### PR TITLE
fix: block Advanced deep links when dev mode is disabled

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -131,13 +131,17 @@ struct SettingsPanel: View {
             setupIntegrationCallbacks()
             try? daemonClient?.sendIntegrationList()
             if let pending = store.pendingSettingsTab {
-                selectedTab = pending
+                if pending != .advanced || store.isDevMode {
+                    selectedTab = pending
+                }
                 store.pendingSettingsTab = nil
             }
         }
         .onChange(of: store.pendingSettingsTab) { _, newTab in
             if let tab = newTab {
-                selectedTab = tab
+                if tab != .advanced || store.isDevMode {
+                    selectedTab = tab
+                }
                 store.pendingSettingsTab = nil
             }
         }
@@ -181,6 +185,7 @@ struct SettingsPanel: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .navigateToSettingsTab)) { notification in
             if let tab = notification.object as? SettingsTab {
+                if tab == .advanced && !store.isDevMode { return }
                 selectedTab = tab
             }
         }
@@ -252,7 +257,11 @@ struct SettingsPanel: View {
         case .parental:
             permissionsContent
         case .advanced:
-            SettingsAdvancedDevTab(store: store, daemonClient: daemonClient)
+            if store.isDevMode {
+                SettingsAdvancedDevTab(store: store, daemonClient: daemonClient)
+            } else {
+                SettingsAccountTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose)
+            }
         }
     }
 


### PR DESCRIPTION
Addresses review feedback on #10110:\n- Block Advanced tab deep links when dev mode is disabled\n- Verify and ensure the legacy mapper correctly gates developer-only tab access\n\nThe original PR (#10110) added a dev mode guard to `fromLegacyRawValue`, but three other navigation paths were ungated:\n1. `navigateToSettingsTab` NotificationCenter handler — could set selectedTab to .advanced without checking dev mode\n2. `pendingSettingsTab` onAppear/onChange consumers — applied the tab unconditionally (the setter was gated, but defense-in-depth was missing)\n3. `selectedTabContent` view — would render Advanced content even if .advanced was somehow set as selectedTab with dev mode off\n\nAll three paths now check `store.isDevMode` before allowing navigation to the Advanced tab.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
