### PR TITLE
fix: portable date parsing and pre-sweep heartbeat refresh for blitz registry

### DIFF
--- a/.claude/commands/blitz.md
+++ b/.claude/commands/blitz.md
@@ -38,11 +38,25 @@ Register this blitz run in `.private/ACTIVE_BLITZ.md` so that standalone `/check
 
 Read and follow `.claude/phases/plan-and-spec.md`. For blitz mode, remove the `<EXTRA_EPIC_FIELDS>` placeholder entirely (no feature branch field).
 
+**Update the blitz heartbeat** after planning completes to prevent the entry from going stale during long-running phases:
+```bash
+grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp 2>/dev/null || true
+echo "<namespace> blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp
+mv .private/ACTIVE_BLITZ.md.tmp .private/ACTIVE_BLITZ.md
+```
+
 ## Phase 3: Populate TODO.md
 
 Read and follow `.claude/phases/populate-todo.md`.
 
 ## Phase 4: Swarm
+
+**Update the blitz heartbeat** before starting the swarm:
+```bash
+grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp 2>/dev/null || true
+echo "<namespace> blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp
+mv .private/ACTIVE_BLITZ.md.tmp .private/ACTIVE_BLITZ.md
+```
 
 Read and follow the instructions in `.claude/commands/swarm.md` with these modifications:
 
@@ -65,6 +79,13 @@ gh issue close <issue-number>
 ## Phase 4.5: Review and Merge
 
 **This phase only runs when `--skip-reviews` is NOT set (the default).**
+
+**Update the blitz heartbeat** before starting the review-and-merge phase:
+```bash
+grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp 2>/dev/null || true
+echo "<namespace> blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp
+mv .private/ACTIVE_BLITZ.md.tmp .private/ACTIVE_BLITZ.md
+```
 
 After the swarm phase completes, all milestone PRs are open but unmerged. This phase runs a per-PR feedback loop on each one — addressing review feedback by pushing fixes directly to the PR branch — before merging to main.
 

--- a/.claude/commands/check-reviews.md
+++ b/.claude/commands/check-reviews.md
@@ -26,10 +26,11 @@ If neither `--namespace` nor `--force` was provided:
    ```
    Example: `approval-conv-flow safe-blitz 2026-02-26T10:00:00Z`
 
-3. For each entry, check if the heartbeat is stale (older than 30 minutes):
+3. For each entry, check if the heartbeat is stale (older than 30 minutes). Use portable date parsing that works on both macOS (BSD) and Linux (GNU):
    ```bash
    HEARTBEAT="<heartbeat-timestamp>"
-   HEARTBEAT_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$HEARTBEAT" "+%s" 2>/dev/null)
+   # Portable: try BSD date first, fall back to GNU date
+   HEARTBEAT_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$HEARTBEAT" "+%s" 2>/dev/null || date -d "$HEARTBEAT" "+%s" 2>/dev/null)
    NOW_EPOCH=$(date "+%s")
    AGE=$(( NOW_EPOCH - HEARTBEAT_EPOCH ))
    ```

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -66,6 +66,13 @@ Read and follow `.claude/phases/plan-and-spec.md`. For safe-blitz mode, replace 
 
 **Skip the approval step** (step 5 in plan-and-spec.md). Do NOT pause for user confirmation after creating the plan. Instead, log a summary of the plan (project issue link, milestone list, feature branch name) and proceed directly to the next phase. Safe-blitz already has review gates on every milestone PR and a final PR into main, so an upfront approval is unnecessary.
 
+**Update the blitz heartbeat** after planning completes to prevent the entry from going stale during long-running phases:
+```bash
+grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp 2>/dev/null || true
+echo "<namespace> safe-blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp
+mv .private/ACTIVE_BLITZ.md.tmp .private/ACTIVE_BLITZ.md
+```
+
 ## Phase 3: Prepare Milestone List
 
 Do NOT use `.claude/phases/populate-todo.md` here. Instead, maintain an internal ordered list of milestones (M1, M2, ..., MN) with their titles and GitHub issue numbers. These milestones will be executed **one at a time** in Phase 4 — do NOT write them all to TODO.md at once.
@@ -185,6 +192,13 @@ Address the review feedback on PR #<milestone-pr-number> (<milestone-pr-url>):
 ### For each milestone (in order):
 
 #### 4a. Add to TODO.md and execute
+
+**Update the blitz heartbeat** before each milestone execution to prevent the entry from going stale:
+```bash
+grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp 2>/dev/null || true
+echo "<namespace> safe-blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp
+mv .private/ACTIVE_BLITZ.md.tmp .private/ACTIVE_BLITZ.md
+```
 
 1. Prepend this single milestone item to `.private/TODO.md` (preserve existing items) with the namespace prefix:
    ```


### PR DESCRIPTION
Addresses review feedback on #10108:\n- Use portable date parsing that works on both macOS and Linux\n- Add heartbeat refresh during pre-sweep phases (planning, swarm, review)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
