### PR TITLE
perf: enable SPM incremental compilation in CI macOS build

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -89,6 +89,7 @@ jobs:
         working-directory: clients/macos
         run: |
           SIGN_IDENTITY="Developer ID Application" \
+          SKIP_CLEAN=1 \
           ./build.sh release
           ls -la "dist/Vellum.app"
 


### PR DESCRIPTION
## Summary
- Set `SKIP_CLEAN=1` in CI macOS build workflow for the release build step
- Previously the SPM cache (~517MB) was restored then immediately deleted by `build.sh release`, forcing a full recompile every time (~8 min)
- With this change, SPM incremental compilation uses the cached `.build` artifacts, only recompiling changed files

## Original prompt
Set SKIP_CLEAN=1 in the CI macOS build workflow for the "Build release .app" step. This enables SPM incremental compilation by not deleting the cached .build directory. In CI, the checkout is always clean so there are no stale artifacts to worry about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
