### PR TITLE
fix: share token regeneration state between Account and Channels tabs

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -63,10 +63,6 @@ struct SettingsChannelsTab: View {
     // Shared label column width for channelStatusRow and guardianLabel alignment
     private let labelColumnWidth: CGFloat = 140
 
-    // Token regeneration state
-    @State private var isRegeneratingToken: Bool = false
-
-
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
             connectionsSection
@@ -1665,7 +1661,7 @@ struct SettingsChannelsTab: View {
         let hasGateway = !store.resolvedIosGatewayUrl.isEmpty || LANIPHelper.currentLANAddress() != nil
         let hasToken = !bearerToken.isEmpty
 
-        if isRegeneratingToken {
+        if store.isRegeneratingToken {
             HStack(spacing: VSpacing.sm) {
                 mobilePairingLabel
                 ProgressView()
@@ -1730,7 +1726,7 @@ struct SettingsChannelsTab: View {
         bearerToken = newToken
         // Kill the daemon so the health monitor restarts it with the new token.
         // The daemon only reads the token at startup, so a restart is required.
-        isRegeneratingToken = true
+        store.isRegeneratingToken = true
         let pidPath = resolvePidPath()
         if let pidStr = try? String(contentsOfFile: pidPath, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines),
            let pid = Int32(pidStr) {
@@ -1742,7 +1738,7 @@ struct SettingsChannelsTab: View {
                 ? String(store.localGatewayTarget.dropLast())
                 : store.localGatewayTarget
             guard let url = URL(string: "\(base)/v1/health") else {
-                isRegeneratingToken = false
+                store.isRegeneratingToken = false
                 return
             }
             var request = URLRequest(url: url)
@@ -1752,11 +1748,11 @@ struct SettingsChannelsTab: View {
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
                 if let (_, response) = try? await URLSession.shared.data(for: request),
                    let http = response as? HTTPURLResponse, http.statusCode == 200 {
-                    isRegeneratingToken = false
+                    store.isRegeneratingToken = false
                     return
                 }
             }
-            isRegeneratingToken = false
+            store.isRegeneratingToken = false
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -215,6 +215,15 @@ public final class SettingsStore: ObservableObject {
     @Published var isCheckingTunnel: Bool = false
     @Published var tunnelLastChecked: Date?
 
+    // MARK: - Token Regeneration State
+
+    /// Shared across Account and Channels tabs so both views know when the
+    /// daemon is restarting after a bearer token regeneration. Without this,
+    /// switching to Channels immediately after regenerating in Account could
+    /// cause PairingQRCodeSheet to read the new token while the daemon is
+    /// still running on the old one, leading to transient pairing failures.
+    @Published var isRegeneratingToken: Bool = false
+
     @Published var vellumPlatformReachable: Bool?
     @Published var vellumPlatformError: String?
     @Published var isCheckingVellumPlatform: Bool = false


### PR DESCRIPTION
Addresses review feedback on #10170:\n- Lift isRegeneratingToken state up so both Account and Channels tabs share it\n- Prevents transient pairing failures when regenerating token in Account then switching to Channels
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
