### PR TITLE
fix: serialize feature-flag config writes to prevent concurrent races

### DIFF
--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -471,4 +471,41 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     const tmpFiles = files.filter((f: string) => f.endsWith(".tmp"));
     expect(tmpFiles.length).toBe(0);
   });
+
+  test("concurrent writes are serialized and no flag change is lost", async () => {
+    writeFileSync(configPath, JSON.stringify({}));
+    const handler = createFeatureFlagsPatchHandler();
+
+    // Fire multiple concurrent PATCH requests at the same time
+    const flagKeys = [
+      "feature_flags.browser.enabled",
+      "feature_flags.twitter.enabled",
+      "feature_flags.guardian-verify-setup.enabled",
+      "feature_flags.hatch-new-assistant.enabled",
+    ];
+
+    const results = await Promise.all(
+      flagKeys.map((key) =>
+        handler(
+          new Request(`http://gateway.test/v1/feature-flags/${key}`, {
+            method: "PATCH",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ enabled: false }),
+          }),
+          key,
+        ),
+      ),
+    );
+
+    // All should succeed
+    for (const res of results) {
+      expect(res.status).toBe(200);
+    }
+
+    // All flags should be persisted — none should be lost to a race
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    for (const key of flagKeys) {
+      expect(config.assistantFeatureFlagValues[key]).toBe(false);
+    }
+  });
 });

--- a/gateway/src/http/routes/feature-flags.ts
+++ b/gateway/src/http/routes/feature-flags.ts
@@ -8,6 +8,12 @@ import { getLogger } from "../../logger.js";
 const log = getLogger("feature-flags");
 
 /**
+ * Serializes config writes so concurrent PATCH requests don't race on
+ * read-modify-write. Each write awaits the previous one before proceeding.
+ */
+let configWriteChain: Promise<void> = Promise.resolve();
+
+/**
  * Only allow keys matching `feature_flags.<flagId>.enabled` for the canonical format.
  * The flagId segment must be a non-empty string of lowercase alphanumeric chars,
  * dots, hyphens, and underscores.
@@ -202,34 +208,42 @@ export function createFeatureFlagsPatchHandler() {
       );
     }
 
-    try {
-      const result = readConfigFile();
-      if (!result.ok) {
-        log.error({ reason: result.reason, detail: result.detail }, "Config file is malformed, refusing to overwrite");
-        return Response.json(
-          { error: "Config file is malformed, cannot safely write" },
-          { status: 500 },
-        );
-      }
+    // Serialize config writes to prevent concurrent read-modify-write races
+    const writeResult = new Promise<Response>((resolve) => {
+      configWriteChain = configWriteChain.then(() => {
+        try {
+          const result = readConfigFile();
+          if (!result.ok) {
+            log.error({ reason: result.reason, detail: result.detail }, "Config file is malformed, refusing to overwrite");
+            resolve(Response.json(
+              { error: "Config file is malformed, cannot safely write" },
+              { status: 500 },
+            ));
+            return;
+          }
 
-      const config = result.data;
+          const config = result.data;
 
-      // Write to the new `assistantFeatureFlagValues` section (NOT the old `featureFlags` section)
-      const existingFlags =
-        config.assistantFeatureFlagValues && typeof config.assistantFeatureFlagValues === "object" && !Array.isArray(config.assistantFeatureFlagValues)
-          ? (config.assistantFeatureFlagValues as Record<string, unknown>)
-          : {};
+          // Write to the new `assistantFeatureFlagValues` section (NOT the old `featureFlags` section)
+          const existingFlags =
+            config.assistantFeatureFlagValues && typeof config.assistantFeatureFlagValues === "object" && !Array.isArray(config.assistantFeatureFlagValues)
+              ? (config.assistantFeatureFlagValues as Record<string, unknown>)
+              : {};
 
-      config.assistantFeatureFlagValues = { ...existingFlags, [flagKey]: enabled };
+          config.assistantFeatureFlagValues = { ...existingFlags, [flagKey]: enabled };
 
-      writeConfigFileAtomic(config);
+          writeConfigFileAtomic(config);
 
-      log.info({ flagKey, enabled }, "Feature flag updated");
+          log.info({ flagKey, enabled }, "Feature flag updated");
 
-      return Response.json({ key: flagKey, enabled });
-    } catch (err) {
-      log.error({ err, flagKey }, "Failed to update feature flag");
-      return Response.json({ error: "Internal server error" }, { status: 500 });
-    }
+          resolve(Response.json({ key: flagKey, enabled }));
+        } catch (err) {
+          log.error({ err, flagKey }, "Failed to update feature flag");
+          resolve(Response.json({ error: "Internal server error" }, { status: 500 }));
+        }
+      });
+    });
+
+    return writeResult;
   };
 }


### PR DESCRIPTION
Addresses review feedback on #10183:
- Serialize feature-flag config writes per process (P2 item #2 from Codex review)

The PATCH handler for feature flags performs a read-modify-write of config.json. Without serialization, concurrent PATCH requests (e.g. toggling multiple skills quickly from UI) could race and cause last-writer-wins, silently dropping flag changes.

This adds a promise-chain serializer (`configWriteChain`) that ensures each write completes before the next one begins. Input validation still runs concurrently — only the critical section (read-modify-write) is serialized.

Other review items (P1 transport host, P2 token preservation, P2 local HTTP fallback, P2 dotted skill IDs) were already addressed in direct pushes to the feature branch before it merged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
