### PR TITLE
perf: build arm64-only in CI macOS build (skip x86_64)

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -83,13 +83,14 @@ jobs:
 
       - name: Build binaries
         working-directory: clients/macos
-        run: ./build.sh binaries --universal
+        run: ./build.sh binaries
 
       - name: Build release .app
         working-directory: clients/macos
         run: |
           SIGN_IDENTITY="Developer ID Application" \
           SKIP_CLEAN=1 \
+          RELEASE_ARCH_FLAGS="--arch arm64" \
           ./build.sh release
           ls -la "dist/Vellum.app"
 

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -256,7 +256,7 @@ CONFIG="debug"
 SWIFT_FLAGS=""
 if [ "$CMD" = "release" ]; then
     CONFIG="release"
-    SWIFT_FLAGS="-c release --arch arm64 --arch x86_64"
+    SWIFT_FLAGS="-c release ${RELEASE_ARCH_FLAGS:---arch arm64 --arch x86_64}"
     if [ "${SKIP_CLEAN:-}" = "1" ]; then
         echo "Release build: skipping .build clean (SKIP_CLEAN=1, using cached artifacts)"
         rm -rf "$SCRIPT_DIR/dist"


### PR DESCRIPTION
## Summary
- Add `RELEASE_ARCH_FLAGS` env var to `build.sh` to allow overriding the default `--arch arm64 --arch x86_64` for release builds
- Set `RELEASE_ARCH_FLAGS="--arch arm64"` in CI workflow to skip x86_64 cross-compilation
- Also skip `--universal` flag for Bun binary builds in CI (arm64-only)
- This halves Swift compilation time since it no longer compiles 249 source files for two architectures

## Original prompt
Build arm64-only for CI validation to halve compile time. Reserve universal builds for the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
