### PR TITLE
M4: Docs and guardrails

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -452,6 +452,31 @@ graph TB
     classDef provider fill:#ef5350,stroke:#c62828,color:#fff
 ```
 
+## Assistant Feature Flags
+
+Assistant feature flags are the canonical mechanism for controlling skill availability at runtime. They are separate from macOS client feature flags (which are local-only, stored in UserDefaults, and control client-side UI behavior).
+
+**Separation of concerns:**
+
+| Flag Type | Scope | Storage | Managed By |
+|-----------|-------|---------|------------|
+| Assistant feature flags | Gateway-managed, workspace config | `~/.vellum/workspace/config.json` under `assistantFeatureFlagValues` | Gateway `/v1/feature-flags` API |
+| macOS client feature flags | Local-only, per-device | UserDefaults (plist) | macOS app directly |
+
+**Defaults registry:** All assistant feature flags are declared in `meta/assistant-feature-flags/assistant-feature-flag-defaults.json`. Each entry specifies a `defaultEnabled` value and a human-readable `description`. Flags not declared in the registry default to enabled (open by default).
+
+**Canonical key format:** `feature_flags.<flag_id>.enabled` (e.g., `feature_flags.browser.enabled`). The legacy format `skills.<id>.enabled` is still read from the `featureFlags` config section for backward compatibility but is being phased out.
+
+**Resolution priority:** When determining whether a flag is enabled, the resolver checks (highest priority first):
+1. `config.assistantFeatureFlagValues[key]` (new canonical section)
+2. `config.featureFlags[legacyKey]` (legacy backward-compat mapping)
+3. Defaults registry `defaultEnabled`
+4. `true` (unknown flags are open by default)
+
+**Domain docs:**
+- Assistant-side resolver and enforcement points: [`assistant/ARCHITECTURE.md`](assistant/ARCHITECTURE.md)
+- Gateway defaults loader and REST API: [`gateway/ARCHITECTURE.md`](gateway/ARCHITECTURE.md)
+
 ## Maintenance Rule
 
 When architecture changes, update the relevant domain architecture document(s) above and keep this index aligned.

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -311,18 +311,24 @@ Release-driven update notification system that surfaces release notes to the ass
 
 ### Assistant Feature Flags — Resolver and Enforcement Points
 
-Assistant feature flags allow external clients to disable individual skills at runtime without restarting the daemon. The canonical flag key format is `feature_flags.<flagId>.enabled`. Default values for all declared flags are defined in the shared defaults registry at `meta/assistant-feature-flags/assistant-feature-flag-defaults.json`.
+The assistant feature-flag resolver (`src/config/assistant-feature-flags.ts`) is the canonical module for determining whether an assistant feature flag is enabled. It loads default values from the registry at `meta/assistant-feature-flags/assistant-feature-flag-defaults.json` and resolves the effective state for each flag. Assistant feature flags allow external clients to disable individual skills at runtime without restarting the daemon.
 
-**Resolution order** (highest priority wins):
+**Canonical key format:** `feature_flags.<flag_id>.enabled` (e.g., `feature_flags.browser.enabled`).
 
-1. `config.assistantFeatureFlagValues[key]` — new canonical config section
-2. `config.featureFlags[legacyKey]` — legacy `skills.<id>.enabled` format (backward-compat)
-3. Defaults registry `defaultEnabled` value
-4. `true` (unknown flags default to enabled)
+**Resolution priority** (highest wins):
+1. `config.assistantFeatureFlagValues[key]` — new canonical config section, written by the gateway's PATCH endpoint
+2. `config.featureFlags[legacyKey]` — legacy `skills.<id>.enabled` key mapping (backward-compat)
+3. Defaults registry `defaultEnabled` — from `meta/assistant-feature-flags/assistant-feature-flag-defaults.json`
+4. `true` — unknown flags default to enabled (open by default)
 
-The resolver is implemented in `src/config/assistant-feature-flags.ts`. The convenience function `isAssistantSkillEnabled(skillId, config)` translates a skill ID to the canonical key `feature_flags.<skillId>.enabled` and delegates to the full resolver. The legacy wrapper `isSkillFeatureEnabled()` in `config/skill-state.ts` is deprecated and delegates to `isAssistantSkillEnabled()`.
+**Backward-compat migration path:** The legacy `featureFlags` config section (key format `skills.<id>.enabled`) is still read as a fallback during resolution. New writes go to `assistantFeatureFlagValues` using the canonical format. The `isSkillFeatureEnabled()` wrapper in `config/skill-state.ts` is deprecated but retained as a thin delegate to `isAssistantSkillEnabled()` so existing call sites continue to work during the one-release migration window. A guard test (`assistant-feature-flag-guard.test.ts`) enforces that production code uses the canonical key format and that all referenced flags are declared in the defaults registry.
 
 **Storage:** Flags are persisted in `~/.vellum/workspace/config.json`. New writes go to the `assistantFeatureFlagValues` section (managed by the gateway's `/v1/feature-flags` API — see [`gateway/ARCHITECTURE.md`](../gateway/ARCHITECTURE.md)). The legacy `featureFlags` section is still read for backward compatibility. The daemon's config watcher hot-reloads this file, so flag changes take effect on the next tool resolution or session.
+
+**Public API:**
+- `isAssistantFeatureFlagEnabled(key, config)` — full resolver with the canonical key
+- `isAssistantSkillEnabled(skillId, config)` — convenience wrapper that constructs `feature_flags.<skillId>.enabled` and delegates
+- `isSkillFeatureEnabled(skillId, config)` — deprecated legacy wrapper in `config/skill-state.ts`
 
 **Guarantee:** When an assistant feature flag is OFF, the skill is unavailable everywhere — it cannot appear in client UIs, model context, or runtime tool execution. This is enforced at five independent points:
 
@@ -334,7 +340,7 @@ The resolver is implemented in `src/config/assistant-feature-flags.ts`. The conv
 | **4. Runtime tool projection** | `projectSkillTools()` in `daemon/session-skill-tools.ts` | Even if a skill was previously active in a session (has `<loaded_skill>` markers in history), the per-turn projection drops it when the flag is OFF. Already-registered tools are unregistered. |
 | **5. Included child skills** | `executeSkillLoad()` in `tools/skills/load.ts` | When a parent skill includes children via the `includes` directive, each child is independently checked against its feature flag. Flagged-off children are silently excluded from the loaded skill content. |
 
-The shared gate function `isAssistantSkillEnabled(skillId, config)` in `config/assistant-feature-flags.ts` is used by all five enforcement points (via `skill-state.ts`) for consistency.
+All five enforcement points use `isAssistantSkillEnabled()` from `config/assistant-feature-flags.ts` for consistency.
 
 **Migration path:** The legacy `skills.<id>.enabled` key format is still read from the `featureFlags` config section for backward compatibility. New code must use the canonical `feature_flags.<id>.enabled` format. A guard test (`assistant-feature-flag-guard.test.ts`) enforces that production code uses the canonical key format and that all referenced flags are declared in the defaults registry.
 
@@ -342,12 +348,13 @@ The shared gate function `isAssistantSkillEnabled(skillId, config)` in `config/a
 
 | File | Purpose |
 |------|---------|
-| `src/config/assistant-feature-flags.ts` | Canonical resolver: `isAssistantFeatureFlagEnabled()`, `isAssistantSkillEnabled()`, `getAssistantFeatureFlagDefaults()` |
+| `src/config/assistant-feature-flags.ts` | Canonical resolver: `isAssistantFeatureFlagEnabled()`, `isAssistantSkillEnabled()`, `getAssistantFeatureFlagDefaults()`, registry loader |
 | `src/config/skill-state.ts` | `isSkillFeatureEnabled()` (deprecated wrapper) — delegates to canonical resolver; `resolveSkillStates()` — enforcement point 1 |
 | `src/config/system-prompt.ts` | `appendSkillsCatalog()` — enforcement point 2 |
 | `src/tools/skills/load.ts` | `executeSkillLoad()` — enforcement points 3 and 5 |
 | `src/daemon/session-skill-tools.ts` | `projectSkillTools()` — enforcement point 4 |
-| `src/config/schema.ts` | `featureFlags` field definition in `AssistantConfig` (Zod schema) |
+| `src/config/schema.ts` | `featureFlags` and `assistantFeatureFlagValues` field definitions in `AssistantConfig` (Zod schema) |
+| `src/config/types.ts` | Type definitions for `FeatureFlags` (legacy) and `AssistantFeatureFlagValues` (canonical) |
 | `src/daemon/handlers/skills.ts` | `handleSkillsList()` — uses `resolveSkillStates()` for IPC client responses |
 | `meta/assistant-feature-flags/assistant-feature-flag-defaults.json` | Shared defaults registry (repo root) — all declared flags with default values and descriptions |
 

--- a/assistant/src/__tests__/assistant-feature-flag-guardrails.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flag-guardrails.test.ts
@@ -4,16 +4,16 @@
  * 1. Key format: all feature flag keys used in production code must follow the
  *    canonical `feature_flags.<flag_id>.enabled` format. Any remaining
  *    `skills.<id>.enabled` usage outside of migration/backward-compat code is
- *    flagged.
+ *    flagged — including template literal forms like `skills.${skillId}.enabled`.
  *
- * 2. Declaration coverage: every flag key used in `isAssistantFeatureFlagEnabled`
- *    or `isAssistantSkillEnabled` calls must be declared in the defaults registry
+ * 2. Declaration coverage: every bundled skill and vellum skill must have a
+ *    corresponding `feature_flags.<id>.enabled` entry in the defaults registry
  *    at `meta/assistant-feature-flags/assistant-feature-flag-defaults.json`.
- *    This prevents drift between code and registry.
+ *    This prevents drift between registered skills and the feature flag registry.
  */
 
 import { execSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { describe, expect, test } from 'bun:test';
@@ -63,12 +63,15 @@ describe('assistant feature flag key format guard', () => {
   test('no production TypeScript files use skills.<id>.enabled outside allowlist', () => {
     const repoRoot = getRepoRoot();
 
-    // Search for string literals containing `skills.*.enabled` in .ts files
-    // under assistant/src/ (excluding test files and allowlisted paths)
+    // Search for string literals and template literals containing
+    // `skills.<id>.enabled` or `skills.${...}.enabled` in .ts files
+    // under assistant/src/ (excluding test files and allowlisted paths).
+    // The pattern catches both literal keys (e.g., `skills.foo.enabled`) and
+    // template literal forms (e.g., `skills.${skillId}.enabled`).
     let grepOutput = '';
     try {
       grepOutput = execSync(
-        `git grep -lE "skills\\.[a-z0-9_-]+\\.enabled" -- 'assistant/src/**/*.ts'`,
+        `git grep -lE "skills\\.[a-z0-9_-]+\\.enabled|skills\\.\\$\\{" -- 'assistant/src/**/*.ts'`,
         { encoding: 'utf-8', cwd: repoRoot },
       ).trim();
     } catch (err) {
@@ -109,7 +112,7 @@ describe('assistant feature flag key format guard', () => {
 // ---------------------------------------------------------------------------
 
 describe('assistant feature flag declaration coverage guard', () => {
-  test('all flag keys referenced in isAssistantFeatureFlagEnabled/isAssistantSkillEnabled calls are declared in the defaults registry', () => {
+  test('all bundled and vellum skill IDs have a corresponding entry in the defaults registry', () => {
     const repoRoot = getRepoRoot();
 
     // Load the defaults registry
@@ -119,32 +122,65 @@ describe('assistant feature flag declaration coverage guard', () => {
     );
     const declaredKeys = new Set(Object.keys(registry));
 
-    // Collect skill IDs from isAssistantSkillEnabled calls in production code.
-    // We use git grep with -P (perl regex) for reliable parenthesis handling.
-    const usedKeys = new Set<string>();
+    // Collect all skill IDs from bundled skills and vellum skills.
+    // The runtime passes these IDs dynamically to isAssistantSkillEnabled,
+    // so rather than trying to parse variable names from call sites, we
+    // enumerate the skill directories directly.
+    const allSkillIds = new Set<string>();
 
-    // Extract skill IDs from isAssistantSkillEnabled('<skillId>', ...) in non-test files
-    let skillLines = '';
-    try {
-      skillLines = execSync(
-        `git grep -n "isAssistantSkillEnabled" -- 'assistant/src/**/*.ts' ':!assistant/src/__tests__/**'`,
-        { encoding: 'utf-8', cwd: repoRoot },
-      ).trim();
-    } catch (err) {
-      if ((err as { status?: number }).status !== 1) throw err;
-    }
-
-    if (skillLines) {
-      for (const line of skillLines.split('\n')) {
-        // Match isAssistantSkillEnabled('skillId' or "skillId"
-        const match = line.match(/isAssistantSkillEnabled\(\s*['"]([a-z0-9_-]+)['"]/);
-        if (match) {
-          usedKeys.add(`feature_flags.${match[1]}.enabled`);
-        }
+    // 1. Bundled skills: each subdirectory in bundled-skills/ is a skill ID
+    const bundledSkillsDir = join(repoRoot, 'assistant', 'src', 'config', 'bundled-skills');
+    const bundledEntries = readdirSync(bundledSkillsDir);
+    for (const entry of bundledEntries) {
+      const fullPath = join(bundledSkillsDir, entry);
+      if (statSync(fullPath).isDirectory()) {
+        allSkillIds.add(entry);
       }
     }
 
+    // 2. Vellum skills: read IDs from the catalog.json manifest
+    const catalogPath = join(repoRoot, 'assistant', 'src', 'config', 'vellum-skills', 'catalog.json');
+    const catalog = JSON.parse(readFileSync(catalogPath, 'utf-8'));
+    for (const skill of catalog.skills) {
+      allSkillIds.add(skill.id);
+    }
+
+    // Verify that each skill ID has a corresponding feature flag entry
+    const undeclared: string[] = [];
+    for (const skillId of allSkillIds) {
+      const key = `feature_flags.${skillId}.enabled`;
+      if (!declaredKeys.has(key)) {
+        undeclared.push(key);
+      }
+    }
+
+    if (undeclared.length > 0) {
+      const message = [
+        'Found skill IDs without a corresponding entry in the feature flag defaults registry.',
+        `Registry: meta/assistant-feature-flags/assistant-feature-flag-defaults.json`,
+        '',
+        'Missing entries:',
+        ...undeclared.sort().map((k) => `  - ${k}`),
+        '',
+        'To fix: add the missing key(s) to the defaults registry with a defaultEnabled value and description.',
+      ].join('\n');
+
+      expect(undeclared, message).toEqual([]);
+    }
+  });
+
+  test('all literal flag keys in isAssistantFeatureFlagEnabled calls are declared in the defaults registry', () => {
+    const repoRoot = getRepoRoot();
+
+    // Load the defaults registry
+    const registryPath = join(repoRoot, 'meta', 'assistant-feature-flags', 'assistant-feature-flag-defaults.json');
+    const registry: Record<string, unknown> = JSON.parse(
+      readFileSync(registryPath, 'utf-8'),
+    );
+    const declaredKeys = new Set(Object.keys(registry));
+
     // Extract full keys from isAssistantFeatureFlagEnabled('<key>', ...) in non-test files
+    const usedKeys = new Set<string>();
     let flagLines = '';
     try {
       flagLines = execSync(
@@ -164,11 +200,6 @@ describe('assistant feature flag declaration coverage guard', () => {
         }
       }
     }
-
-    // Filter out the function definitions themselves (export function ...) and
-    // the generic delegation in assistant-feature-flags.ts that uses a
-    // template expression rather than a literal key
-    // e.g. `isAssistantFeatureFlagEnabled(\`feature_flags.${skillId}.enabled\`, config)`
 
     // Check that all used keys are declared in the registry
     const undeclared: string[] = [];

--- a/assistant/src/__tests__/assistant-feature-flag-guardrails.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flag-guardrails.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Guard tests for assistant feature flag conventions:
+ *
+ * 1. Key format: all feature flag keys used in production code must follow the
+ *    canonical `feature_flags.<flag_id>.enabled` format. Any remaining
+ *    `skills.<id>.enabled` usage outside of migration/backward-compat code is
+ *    flagged.
+ *
+ * 2. Declaration coverage: every flag key used in `isAssistantFeatureFlagEnabled`
+ *    or `isAssistantSkillEnabled` calls must be declared in the defaults registry
+ *    at `meta/assistant-feature-flags/assistant-feature-flag-defaults.json`.
+ *    This prevents drift between code and registry.
+ */
+
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, test } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Resolve the repo root from the assistant/ package directory. */
+function getRepoRoot(): string {
+  return join(process.cwd(), '..');
+}
+
+/**
+ * Files allowed to contain `skills.<id>.enabled` string literals because they
+ * are part of the backward-compat / migration layer or are test files
+ * exercising legacy paths.
+ */
+const LEGACY_KEY_ALLOWLIST = new Set([
+  // Canonical resolver: contains the legacy key mapping function
+  'assistant/src/config/assistant-feature-flags.ts',
+  // Legacy wrapper (deprecated, kept for migration)
+  'assistant/src/config/skill-state.ts',
+  // Type definitions documenting the legacy format
+  'assistant/src/config/types.ts',
+  // Gateway feature flags route: reads legacy keys for backward compat
+  'gateway/src/http/routes/feature-flags.ts',
+  // Gateway feature flag defaults loader
+  'gateway/src/feature-flag-defaults.ts',
+]);
+
+function isTestFile(filePath: string): boolean {
+  return (
+    filePath.includes('/__tests__/') ||
+    filePath.endsWith('.test.ts') ||
+    filePath.endsWith('.test.js') ||
+    filePath.endsWith('.spec.ts') ||
+    filePath.endsWith('.spec.js')
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Guard 1: Key format — no stale `skills.<id>.enabled` in production code
+// ---------------------------------------------------------------------------
+
+describe('assistant feature flag key format guard', () => {
+  test('no production TypeScript files use skills.<id>.enabled outside allowlist', () => {
+    const repoRoot = getRepoRoot();
+
+    // Search for string literals containing `skills.*.enabled` in .ts files
+    // under assistant/src/ (excluding test files and allowlisted paths)
+    let grepOutput = '';
+    try {
+      grepOutput = execSync(
+        `git grep -lE "skills\\.[a-z0-9_-]+\\.enabled" -- 'assistant/src/**/*.ts'`,
+        { encoding: 'utf-8', cwd: repoRoot },
+      ).trim();
+    } catch (err) {
+      // Exit code 1 means no matches — happy path
+      if ((err as { status?: number }).status === 1) {
+        return;
+      }
+      throw err;
+    }
+
+    const files = grepOutput.split('\n').filter((f) => f.length > 0);
+    const violations = files.filter((f) => {
+      if (isTestFile(f)) return false;
+      if (LEGACY_KEY_ALLOWLIST.has(f)) return false;
+      return true;
+    });
+
+    if (violations.length > 0) {
+      const message = [
+        'Found production TypeScript files using legacy `skills.<id>.enabled` key format.',
+        'Use the canonical `feature_flags.<id>.enabled` format instead.',
+        'Call `isAssistantSkillEnabled(skillId, config)` which constructs the canonical key automatically.',
+        '',
+        'Violations:',
+        ...violations.map((f) => `  - ${f}`),
+        '',
+        'If this is a legitimate backward-compat path, add it to LEGACY_KEY_ALLOWLIST in',
+        'assistant-feature-flag-guardrails.test.ts.',
+      ].join('\n');
+
+      expect(violations, message).toEqual([]);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guard 2: Declaration coverage — every flag used in code is in the registry
+// ---------------------------------------------------------------------------
+
+describe('assistant feature flag declaration coverage guard', () => {
+  test('all flag keys referenced in isAssistantFeatureFlagEnabled/isAssistantSkillEnabled calls are declared in the defaults registry', () => {
+    const repoRoot = getRepoRoot();
+
+    // Load the defaults registry
+    const registryPath = join(repoRoot, 'meta', 'assistant-feature-flags', 'assistant-feature-flag-defaults.json');
+    const registry: Record<string, unknown> = JSON.parse(
+      readFileSync(registryPath, 'utf-8'),
+    );
+    const declaredKeys = new Set(Object.keys(registry));
+
+    // Collect skill IDs from isAssistantSkillEnabled calls in production code.
+    // We use git grep with -P (perl regex) for reliable parenthesis handling.
+    const usedKeys = new Set<string>();
+
+    // Extract skill IDs from isAssistantSkillEnabled('<skillId>', ...) in non-test files
+    let skillLines = '';
+    try {
+      skillLines = execSync(
+        `git grep -n "isAssistantSkillEnabled" -- 'assistant/src/**/*.ts' ':!assistant/src/__tests__/**'`,
+        { encoding: 'utf-8', cwd: repoRoot },
+      ).trim();
+    } catch (err) {
+      if ((err as { status?: number }).status !== 1) throw err;
+    }
+
+    if (skillLines) {
+      for (const line of skillLines.split('\n')) {
+        // Match isAssistantSkillEnabled('skillId' or "skillId"
+        const match = line.match(/isAssistantSkillEnabled\(\s*['"]([a-z0-9_-]+)['"]/);
+        if (match) {
+          usedKeys.add(`feature_flags.${match[1]}.enabled`);
+        }
+      }
+    }
+
+    // Extract full keys from isAssistantFeatureFlagEnabled('<key>', ...) in non-test files
+    let flagLines = '';
+    try {
+      flagLines = execSync(
+        `git grep -n "isAssistantFeatureFlagEnabled" -- 'assistant/src/**/*.ts' ':!assistant/src/__tests__/**'`,
+        { encoding: 'utf-8', cwd: repoRoot },
+      ).trim();
+    } catch (err) {
+      if ((err as { status?: number }).status !== 1) throw err;
+    }
+
+    if (flagLines) {
+      for (const line of flagLines.split('\n')) {
+        // Match isAssistantFeatureFlagEnabled('key' or "key"
+        const match = line.match(/isAssistantFeatureFlagEnabled\(\s*['"]([^'"]+)['"]/);
+        if (match) {
+          usedKeys.add(match[1]);
+        }
+      }
+    }
+
+    // Filter out the function definitions themselves (export function ...) and
+    // the generic delegation in assistant-feature-flags.ts that uses a
+    // template expression rather than a literal key
+    // e.g. `isAssistantFeatureFlagEnabled(\`feature_flags.${skillId}.enabled\`, config)`
+
+    // Check that all used keys are declared in the registry
+    const undeclared: string[] = [];
+    for (const key of usedKeys) {
+      if (!declaredKeys.has(key)) {
+        undeclared.push(key);
+      }
+    }
+
+    if (undeclared.length > 0) {
+      const message = [
+        'Found feature flag keys used in production code that are NOT declared in the defaults registry.',
+        `Registry: meta/assistant-feature-flags/assistant-feature-flag-defaults.json`,
+        '',
+        'Undeclared keys:',
+        ...undeclared.map((k) => `  - ${k}`),
+        '',
+        'To fix: add the missing key(s) to the defaults registry with a defaultEnabled value and description.',
+      ].join('\n');
+
+      expect(undeclared, message).toEqual([]);
+    }
+  });
+});

--- a/assistant/src/__tests__/assistant-feature-flag-guardrails.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flag-guardrails.test.ts
@@ -65,13 +65,14 @@ describe('assistant feature flag key format guard', () => {
 
     // Search for string literals and template literals containing
     // `skills.<id>.enabled` or `skills.${...}.enabled` in .ts files
-    // under assistant/src/ (excluding test files and allowlisted paths).
-    // The pattern catches both literal keys (e.g., `skills.foo.enabled`) and
-    // template literal forms (e.g., `skills.${skillId}.enabled`).
+    // under assistant/src/ and gateway/src/ (excluding test files and
+    // allowlisted paths). The pattern catches both literal keys
+    // (e.g., `skills.foo.enabled`) and template literal forms
+    // (e.g., `skills.${skillId}.enabled`).
     let grepOutput = '';
     try {
       grepOutput = execSync(
-        `git grep -lE "skills\\.[a-z0-9_-]+\\.enabled|skills\\.\\$\\{" -- 'assistant/src/**/*.ts'`,
+        `git grep -lE "skills\\.[a-z0-9_-]+\\.enabled|skills\\.\\$\\{" -- 'assistant/src/**/*.ts' 'gateway/src/**/*.ts'`,
         { encoding: 'utf-8', cwd: repoRoot },
       ).trim();
     } catch (err) {
@@ -179,25 +180,40 @@ describe('assistant feature flag declaration coverage guard', () => {
     );
     const declaredKeys = new Set(Object.keys(registry));
 
-    // Extract full keys from isAssistantFeatureFlagEnabled('<key>', ...) in non-test files
+    // Extract full keys from isAssistantFeatureFlagEnabled('<key>', ...) calls
+    // in non-test production files. We read each matching file and apply a
+    // multiline regex so that calls split across lines are still caught:
+    //
+    //   isAssistantFeatureFlagEnabled(
+    //     'feature_flags.foo.enabled',
+    //     config,
+    //   )
+    //
     const usedKeys = new Set<string>();
-    let flagLines = '';
+    let matchingFiles = '';
     try {
-      flagLines = execSync(
-        `git grep -n "isAssistantFeatureFlagEnabled" -- 'assistant/src/**/*.ts' ':!assistant/src/__tests__/**'`,
+      matchingFiles = execSync(
+        `git grep -l "isAssistantFeatureFlagEnabled" -- 'assistant/src/**/*.ts' ':!assistant/src/__tests__/**'`,
         { encoding: 'utf-8', cwd: repoRoot },
       ).trim();
     } catch (err) {
       if ((err as { status?: number }).status !== 1) throw err;
     }
 
-    if (flagLines) {
-      for (const line of flagLines.split('\n')) {
-        // Match isAssistantFeatureFlagEnabled('key' or "key"
-        const match = line.match(/isAssistantFeatureFlagEnabled\(\s*['"]([^'"]+)['"]/);
-        if (match) {
+    if (matchingFiles) {
+      // Multiline regex: match the function name, optional whitespace/newlines,
+      // opening paren, optional whitespace/newlines, then a quoted string key.
+      const multilinePattern = /isAssistantFeatureFlagEnabled\(\s*['"]([^'"]+)['"]/g;
+      for (const relPath of matchingFiles.split('\n')) {
+        if (!relPath) continue;
+        const absPath = join(repoRoot, relPath);
+        const content = readFileSync(absPath, 'utf-8');
+        let match: RegExpExecArray | null;
+        while ((match = multilinePattern.exec(content)) !== null) {
           usedKeys.add(match[1]);
         }
+        // Reset lastIndex since we reuse the regex across files
+        multilinePattern.lastIndex = 0;
       }
     }
 

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -33,22 +33,24 @@ Internet
 
 The gateway exposes a REST API for reading and mutating assistant feature flags. Assistant feature flags control which skills are available to the assistant — when a flag is OFF, the corresponding skill is excluded from every exposure surface in the assistant (see [`assistant/ARCHITECTURE.md`](../assistant/ARCHITECTURE.md) for the resolver and enforcement points).
 
-**Endpoints:**
+**Defaults registry loader:** The gateway loads the defaults registry from `meta/assistant-feature-flags/assistant-feature-flag-defaults.json` via `loadFeatureFlagDefaults()` in `gateway/src/feature-flag-defaults.ts`. The registry is loaded once and cached for the lifetime of the process. Invalid entries are skipped with a warning. The `isFlagDeclared()` helper validates that a flag key exists in the registry before allowing writes.
+
+**Endpoints (GET/PATCH contract):**
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/v1/feature-flags` | List all declared assistant feature flags with their effective enabled state |
-| PATCH | `/v1/feature-flags/:key` | Set a single assistant feature flag. Body: `{ "enabled": true\|false }` |
+| GET | `/v1/feature-flags` | List all declared assistant feature flags from the defaults registry, merged with persisted values from workspace config. Returns `{ flags: FeatureFlagEntry[] }` where each entry has `key`, `enabled`, `defaultEnabled`, and `description`. |
+| PATCH | `/v1/feature-flags/:key` | Set a single assistant feature flag. Body: `{ "enabled": true\|false }`. Key must match `feature_flags.<flagId>.enabled` and be declared in the defaults registry. Writes to the `assistantFeatureFlagValues` config section. |
 
 **Defaults registry:** All declared assistant feature flags and their default values are defined in the shared defaults registry at `meta/assistant-feature-flags/assistant-feature-flag-defaults.json`. The gateway loads this registry on startup via `gateway/src/feature-flag-defaults.ts`. The GET endpoint merges persisted overrides with registry defaults to produce the full flag list. The PATCH endpoint validates that the target flag key exists in the registry before accepting a write.
 
 **Flag key format:** The canonical key format is `feature_flags.<flagId>.enabled`. Only keys matching this pattern are accepted by the PATCH endpoint; other patterns are rejected with 400. The legacy `skills.<id>.enabled` format is still read from persisted config for backward compatibility, but new writes always use the canonical format and are stored in the `assistantFeatureFlagValues` config section.
 
-**Storage:** Flag overrides are persisted in `~/.vellum/workspace/config.json`. New writes go to the `assistantFeatureFlagValues` section as a `Record<string, boolean>`. The legacy `featureFlags` section (which used `skills.<id>.enabled` keys) is still read for backward compatibility during GET resolution. The gateway writes atomically (temp file + rename). The daemon's config watcher hot-reloads changes, so flag mutations take effect on the next session or tool resolution without a restart.
+**Storage:** Flag overrides are persisted in `~/.vellum/workspace/config.json`. New writes go to the `assistantFeatureFlagValues` section as a `Record<string, boolean>`. The GET endpoint reads from both `assistantFeatureFlagValues` (priority) and the legacy `featureFlags` section (with key mapping from `skills.<id>.enabled` to canonical format). The gateway writes atomically (temp file + rename). The daemon's config watcher hot-reloads changes, so flag mutations take effect on the next session or tool resolution without a restart.
 
-**Authentication boundary:**
+**Token separation (authentication boundary):**
 
-The assistant feature flags API uses a dedicated token stored at `~/.vellum/feature-flag-token`, separate from the runtime bearer token (`~/.vellum/http-token`). This separation ensures that clients with feature-flag access cannot access runtime endpoints, and vice versa.
+The assistant feature flags API uses a dedicated token (the **feature-flag token**) stored at `~/.vellum/feature-flag-token`, separate from the **runtime token** (`~/.vellum/http-token`). This separation ensures that clients with feature-flag access cannot access runtime endpoints, and vice versa.
 
 | Operation | Accepted tokens |
 |-----------|----------------|
@@ -57,11 +59,13 @@ The assistant feature flags API uses a dedicated token stored at `~/.vellum/feat
 
 The feature-flag token is auto-generated on first gateway startup if the file does not exist. The gateway watches the token file for changes and hot-reloads without restart.
 
+**`assistantFeatureFlagValues` config section:** This is the canonical storage location for assistant feature flag overrides. It is a `Record<string, boolean>` keyed by canonical flag keys (`feature_flags.<id>.enabled`). The gateway's PATCH handler writes exclusively to this section. The daemon's resolver reads it with highest priority, falling back to the legacy `featureFlags` section and then the defaults registry.
+
 **Key source files:**
 
 | File | Purpose |
 |------|---------|
-| `gateway/src/http/routes/feature-flags.ts` | GET and PATCH handlers; config read/write logic; legacy key mapping |
+| `gateway/src/http/routes/feature-flags.ts` | GET and PATCH handlers; config read/write logic; legacy key mapping; key format validation |
 | `gateway/src/feature-flag-defaults.ts` | `loadFeatureFlagDefaults()` — loads the shared defaults registry; `isFlagDeclared()` — validates flag keys |
 | `gateway/src/config.ts` | `readOrGenerateFeatureFlagToken()` — token provisioning; `featureFlagToken` config field |
 | `gateway/src/index.ts` | Route registration, auth enforcement (dual-token for GET, flag-token-only for PATCH), token file watcher |


### PR DESCRIPTION
Update ARCHITECTURE.md files to document canonical assistant feature-flag system. Add guardrail tests for key format validation and declaration coverage. Replace remaining skill feature flag terminology. Part of #10215.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
