### PR TITLE
fix: defer seen IPC signals for undo support and change mark-all-seen shortcut

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -60,9 +60,9 @@ extension AppDelegate {
         let markAllSeenItem = NSMenuItem(
             title: "Mark All Threads as Seen",
             action: #selector(markAllThreadsSeen),
-            keyEquivalent: "\u{1b}" // Escape key
+            keyEquivalent: "k"
         )
-        markAllSeenItem.keyEquivalentModifierMask = .shift
+        markAllSeenItem.keyEquivalentModifierMask = [.command, .shift]
         markAllSeenItem.target = self
         fileMenu.addItem(markAllSeenItem)
 
@@ -500,12 +500,16 @@ extension AppDelegate {
         let markedIds = threadManager.markAllThreadsSeen()
         guard !markedIds.isEmpty else { return }
         let count = markedIds.count
+        threadManager.schedulePendingSeenSignals()
         mainWindow?.windowState.showToast(
             message: "Marked \(count) thread\(count == 1 ? "" : "s") as seen",
             style: .success,
             primaryAction: VToastAction(label: "Undo") { [weak self] in
                 self?.mainWindow?.threadManager.restoreUnseen(threadIds: markedIds)
                 self?.mainWindow?.windowState.dismissToast()
+            },
+            onDismiss: { [weak self] in
+                self?.mainWindow?.threadManager.commitPendingSeenSignals()
             }
         )
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -238,13 +238,18 @@ public final class MainWindowState: ObservableObject {
     }
 
     /// Show a toast notification in the main window.
-    func showToast(message: String, style: ToastInfo.Style, primaryAction: VToastAction? = nil) {
-        toastInfo = ToastInfo(message: message, style: style, primaryAction: primaryAction)
+    /// - Parameters:
+    ///   - onDismiss: Optional callback invoked when the toast is dismissed
+    ///     by the user (via the X button), as opposed to a primary action.
+    func showToast(message: String, style: ToastInfo.Style, primaryAction: VToastAction? = nil, onDismiss: (() -> Void)? = nil) {
+        toastInfo = ToastInfo(message: message, style: style, primaryAction: primaryAction, onDismiss: onDismiss)
     }
 
-    /// Dismiss the currently displayed toast.
+    /// Dismiss the currently displayed toast, invoking its onDismiss callback.
     func dismissToast() {
+        let callback = toastInfo?.onDismiss
         toastInfo = nil
+        callback?()
     }
 
     /// Restore the last active panel from UserDefaults
@@ -267,4 +272,6 @@ struct ToastInfo {
     let message: String
     let style: Style
     let primaryAction: VToastAction?
+    /// Called when the toast is dismissed via the X button (not via primary action).
+    let onDismiss: (() -> Void)?
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1195,12 +1195,16 @@ struct MainWindowView: View {
                     let markedIds = threadManager.markAllThreadsSeen()
                     guard !markedIds.isEmpty else { return }
                     let count = markedIds.count
+                    threadManager.schedulePendingSeenSignals()
                     windowState.showToast(
                         message: "Marked \(count) thread\(count == 1 ? "" : "s") as seen",
                         style: .success,
                         primaryAction: VToastAction(label: "Undo") {
                             threadManager.restoreUnseen(threadIds: markedIds)
                             windowState.dismissToast()
+                        },
+                        onDismiss: {
+                            threadManager.commitPendingSeenSignals()
                         }
                     )
                 },

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -86,6 +86,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     @Published private(set) var threadInteractionStates: [UUID: ThreadInteractionState] = [:]
     /// Subscriptions to per-thread interaction-state changes.
     private var interactionStateCancellables: [UUID: Set<AnyCancellable>] = [:]
+    /// Session IDs whose seen signals are deferred pending undo expiration.
+    private var pendingSeenSessionIds: [String] = []
+    /// Task that auto-commits deferred seen signals after the undo window.
+    private var pendingSeenSignalTask: Task<Void, Never>?
 
     /// Threads that are not archived — used by the UI to populate the sidebar.
     /// Sorted: pinned first (by pinnedOrder ascending), then unpinned by lastInteractedAt descending.
@@ -751,12 +755,15 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
     }
 
-    /// Mark all visible (non-archived, non-private) threads as seen and emit
-    /// IPC signals for each. Returns the IDs of threads that were actually
-    /// marked, so the caller can offer an undo action.
+    /// Mark all visible (non-archived, non-private) threads as seen locally.
+    /// IPC signals are NOT sent immediately — call `commitPendingSeenSignals()`
+    /// after the undo window expires, or `cancelPendingSeenSignals()` if the
+    /// user clicks Undo. Returns the IDs of threads that were actually marked.
     @discardableResult
     internal func markAllThreadsSeen() -> [UUID] {
+        cancelPendingSeenSignals()
         var markedIds: [UUID] = []
+        var sessionIds: [String] = []
         for idx in threads.indices {
             guard !threads[idx].isArchived,
                   threads[idx].kind != .private,
@@ -764,14 +771,51 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             threads[idx].hasUnseenLatestAssistantMessage = false
             markedIds.append(threads[idx].id)
             if let sessionId = threads[idx].sessionId {
-                emitConversationSeenSignal(conversationId: sessionId)
+                sessionIds.append(sessionId)
             }
+        }
+        if !sessionIds.isEmpty {
+            pendingSeenSessionIds = sessionIds
         }
         return markedIds
     }
 
-    /// Restore the unseen flag for the given thread IDs (used by undo).
+    /// Send the deferred IPC seen signals that were collected by
+    /// `markAllThreadsSeen()`. Called when the undo window expires
+    /// (toast dismissed or auto-dismiss timer fires).
+    internal func commitPendingSeenSignals() {
+        let sessionIds = pendingSeenSessionIds
+        pendingSeenSessionIds = []
+        pendingSeenSignalTask?.cancel()
+        pendingSeenSignalTask = nil
+        for sessionId in sessionIds {
+            emitConversationSeenSignal(conversationId: sessionId)
+        }
+    }
+
+    /// Cancel any pending IPC seen signals (user clicked Undo).
+    internal func cancelPendingSeenSignals() {
+        pendingSeenSessionIds = []
+        pendingSeenSignalTask?.cancel()
+        pendingSeenSignalTask = nil
+    }
+
+    /// Schedule deferred IPC seen signals to fire after a delay.
+    /// If the user clicks Undo before the delay, call
+    /// `cancelPendingSeenSignals()` to prevent them from sending.
+    internal func schedulePendingSeenSignals(delay: TimeInterval = 5.0) {
+        pendingSeenSignalTask?.cancel()
+        pendingSeenSignalTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            self?.commitPendingSeenSignals()
+        }
+    }
+
+    /// Restore the unseen flag for the given thread IDs and cancel any
+    /// pending IPC seen signals (used by undo).
     internal func restoreUnseen(threadIds: [UUID]) {
+        cancelPendingSeenSignals()
         for id in threadIds {
             if let idx = threads.firstIndex(where: { $0.id == id }) {
                 threads[idx].hasUnseenLatestAssistantMessage = true


### PR DESCRIPTION
Addresses review feedback on #10161:\n- Defer conversation_seen_signal IPC messages until undo window expires\n- Cancel pending IPC sends when user clicks Undo\n- Change keyboard shortcut from Shift+Escape to avoid conflict with global Escape monitor
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
