### PR TITLE
M3: macOS client rename + settings split

### DIFF
--- a/clients/README.md
+++ b/clients/README.md
@@ -44,7 +44,7 @@ clients/
     types that need Swift-specific logic (e.g. typed enums, polymorphic `AnyCodable` data)
 - **Shared chat features** (`ChatViewModel`, `ChatMessage`, `MessageBubbleView`, `InputBarView`, `AttachmentStripView`, `MarkdownRenderer`, `CurrentStepIndicator`, inline widgets)
 - **Design system** (`VColor`, `VFont`, `VSpacing`, `VRadius`, `VShadow`, `VAnimation`, and all `V`-prefixed components)
-- **Shared utilities** (`APIKeyManager` for Keychain credential storage, `PermissionManager`, `FeatureFlagManager`)
+- **Shared utilities** (`APIKeyManager` for Keychain credential storage, `PermissionManager`, `MacOSClientFeatureFlagManager`)
 - **Shared app utilities** (signing identity management)
 
 **Dependencies**: None (only system frameworks: Network, Security)

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -216,8 +216,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         UserDefaults.standard.removeObject(forKey: "NSWindow Frame com_apple_SwiftUI_Settings_window")
 
 
-        if let envPath = FeatureFlagManager.findRepoEnvFile() {
-            FeatureFlagManager.shared.loadFromFile(at: envPath)
+        if let envPath = MacOSClientFeatureFlagManager.findRepoEnvFile() {
+            MacOSClientFeatureFlagManager.shared.loadFromFile(at: envPath)
         }
 
         applyThemePreference()
@@ -908,7 +908,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
         guard let assistant, assistant.isRemote, let runtimeUrl = assistant.runtimeUrl else {
             // Local assistant or no assistant.
-            if FeatureFlagManager.shared.isEnabled(.localHttpEnabled) {
+            if MacOSClientFeatureFlagManager.shared.isEnabled(.localHttpEnabled) {
                 // Use HTTP transport for the local daemon instead of IPC.
                 // Bearer token is nil; resolved lazily at connect time.
                 let portString = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "7821"

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -39,7 +39,7 @@ struct APIKeyStepView: View {
     @FocusState private var keyFieldFocused: Bool
 
     private var userHostedEnabled: Bool {
-        FeatureFlagManager.shared.isEnabled(.userHostedEnabled)
+        MacOSClientFeatureFlagManager.shared.isEnabled(.userHostedEnabled)
     }
 
     var body: some View {
@@ -337,6 +337,6 @@ struct APIKeyStepView: View {
     }
     .frame(width: 460, height: 620)
     .onAppear {
-        FeatureFlagManager.shared.setOverride(.userHostedEnabled, enabled: true)
+        MacOSClientFeatureFlagManager.shared.setOverride(.userHostedEnabled, enabled: true)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
@@ -6,7 +6,7 @@ struct ModelSelectionStepView: View {
     @Bindable var state: OnboardingState
 
     private var userHostedEnabled: Bool {
-        FeatureFlagManager.shared.isEnabled(.userHostedEnabled)
+        MacOSClientFeatureFlagManager.shared.isEnabled(.userHostedEnabled)
     }
 
     @State private var showTitle = false

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -76,7 +76,7 @@ final class OnboardingState {
     }
 
     var userHostedEnabled: Bool {
-        FeatureFlagManager.shared.isEnabled(.userHostedEnabled)
+        MacOSClientFeatureFlagManager.shared.isEnabled(.userHostedEnabled)
     }
 
     /// Continuous crack progress (0.0–1.0) derived from step and permission state.
@@ -139,7 +139,7 @@ final class OnboardingState {
         // from reopening legacy permission-request steps.
         // When userHostedEnabled is on and a cloud provider is selected, the flow
         // has 3 steps (0–2); otherwise it stays at 2 steps (0–1).
-        let hasCloudStep = FeatureFlagManager.shared.isEnabled(.userHostedEnabled) && cloudProvider != "local"
+        let hasCloudStep = MacOSClientFeatureFlagManager.shared.isEnabled(.userHostedEnabled) && cloudProvider != "local"
         let maxStep = onboardingVariant == .firstMeeting ? 4 : (hasCloudStep ? 2 : 1)
         if currentStep > maxStep {
             currentStep = maxStep

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -24,10 +24,12 @@ struct SettingsAccountTab: View {
     @State private var devModeTapCount: Int = 0
     @State private var devModeMessage: String?
 
-    private static let hatchNewAssistantSkillFlagKeys: [String] = [
-        "skills.hatch_new_assistant.enabled",
-        "skills.hatch-new-assistant.enabled"
-    ]
+    /// Whether the hatch new assistant feature flag is enabled.
+    /// Defaults to `true` until the gateway responds. Once the gateway response
+    /// arrives, this reflects the value of `feature_flags.hatch-new-assistant.enabled`.
+    @State private var isHatchFlagEnabled: Bool = true
+
+    private static let hatchFlagKey = "feature_flags.hatch-new-assistant.enabled"
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
@@ -53,6 +55,7 @@ struct SettingsAccountTab: View {
                     remoteIdentity = await daemonClient?.fetchRemoteIdentity()
                 }
             }
+            Task { await loadHatchFlag() }
         }
         .onChange(of: store.platformBaseUrl) { _, newValue in
             if !isPlatformUrlFocused {
@@ -384,22 +387,41 @@ struct SettingsAccountTab: View {
 
     // MARK: - Hatch New Assistant
 
-    private var isHatchNewAssistantEnabled: Bool {
-        let config = WorkspaceConfigIO.read()
-        guard let featureFlags = config["featureFlags"] as? [String: Any] else {
-            return true
-        }
-        for key in Self.hatchNewAssistantSkillFlagKeys {
-            if let enabled = featureFlags[key] as? Bool {
-                return enabled
+    /// Fetch the hatch-new-assistant flag from the gateway API.
+    /// Falls back to the local workspace config if the gateway is unreachable.
+    private func loadHatchFlag() async {
+        if let dc = daemonClient {
+            do {
+                let flags = try await dc.fetchAssistantFeatureFlags()
+                if let match = flags.first(where: { $0.key == Self.hatchFlagKey }) {
+                    isHatchFlagEnabled = match.enabled
+                    return
+                }
+            } catch {
+                // Gateway unreachable — fall through to local config fallback
             }
         }
-        return true
+
+        // Fallback: read from local workspace config (legacy path)
+        let config = WorkspaceConfigIO.read()
+        if let featureFlags = config["featureFlags"] as? [String: Any] {
+            let legacyKeys = [
+                "skills.hatch_new_assistant.enabled",
+                "skills.hatch-new-assistant.enabled"
+            ]
+            for key in legacyKeys {
+                if let enabled = featureFlags[key] as? Bool {
+                    isHatchFlagEnabled = enabled
+                    return
+                }
+            }
+        }
+        isHatchFlagEnabled = true
     }
 
     @ViewBuilder
     private var hatchNewAssistantSection: some View {
-        if isHatchNewAssistantEnabled {
+        if isHatchFlagEnabled {
             VStack(alignment: .leading, spacing: VSpacing.md) {
                 Text("Hatch New Assistant")
                     .font(VFont.sectionTitle)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
@@ -8,7 +8,10 @@ struct SettingsAdvancedDevTab: View {
     @ObservedObject var store: SettingsStore
     var daemonClient: DaemonClient?
 
-    @State private var flagStates: [(flag: FeatureFlag, enabled: Bool)] = []
+    @State private var macOSFlagStates: [(flag: MacOSClientFeatureFlag, enabled: Bool)] = []
+    @State private var assistantFlags: [DaemonClient.AssistantFeatureFlagEntry] = []
+    @State private var assistantFlagsLoading = false
+    @State private var assistantFlagsError: String?
     @State private var showingEnvVars = false
     @State private var appEnvVars: [(String, String)] = []
     @State private var daemonEnvVars: [(String, String)] = []
@@ -21,19 +24,23 @@ struct SettingsAdvancedDevTab: View {
                 ToolPermissionTesterView(model: model)
             }
 
-            // Feature Flags
-            featureFlagSection
+            // Assistant Feature Flags (gateway-backed)
+            assistantFeatureFlagSection
+
+            // macOS Feature Flags (local-only)
+            macOSFeatureFlagSection
 
             // Developer section (env vars)
             developerSection
         }
         .onAppear {
-            flagStates = FeatureFlag.allCases.map { flag in
-                (flag: flag, enabled: FeatureFlagManager.shared.isEnabled(flag))
+            macOSFlagStates = MacOSClientFeatureFlag.allCases.map { flag in
+                (flag: flag, enabled: MacOSClientFeatureFlagManager.shared.isEnabled(flag))
             }
             if testerModel == nil, let dc = daemonClient {
                 testerModel = ToolPermissionTesterModel(daemonClient: dc)
             }
+            loadAssistantFlags()
         }
         .sheet(isPresented: $showingEnvVars) {
             SettingsPanelEnvVarsSheet(appEnvVars: appEnvVars, daemonEnvVars: daemonEnvVars)
@@ -43,20 +50,95 @@ struct SettingsAdvancedDevTab: View {
         }
     }
 
-    // MARK: - Feature Flags
+    // MARK: - Assistant Feature Flags
 
-    private var featureFlagSection: some View {
+    private func loadAssistantFlags() {
+        guard let dc = daemonClient else { return }
+        assistantFlagsLoading = true
+        assistantFlagsError = nil
+        Task {
+            do {
+                let flags = try await dc.fetchAssistantFeatureFlags()
+                assistantFlags = flags
+            } catch {
+                assistantFlagsError = error.localizedDescription
+            }
+            assistantFlagsLoading = false
+        }
+    }
+
+    private var assistantFeatureFlagSection: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Feature Flags")
+            Text("Assistant Feature Flags")
                 .font(VFont.sectionTitle)
                 .foregroundColor(VColor.textPrimary)
 
-            ForEach(Array(flagStates.enumerated()), id: \.element.flag) { index, entry in
+            if assistantFlagsLoading {
+                HStack(spacing: VSpacing.sm) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Loading...")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+            } else if let error = assistantFlagsError {
+                Text(error)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
+            } else if assistantFlags.isEmpty {
+                Text("No assistant feature flags available.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            } else {
+                ForEach(Array(assistantFlags.enumerated()), id: \.element.key) { index, entry in
+                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                        Toggle(entry.key, isOn: Binding(
+                            get: { assistantFlags[index].enabled },
+                            set: { newValue in
+                                let flagKey = assistantFlags[index].key
+                                assistantFlags[index] = DaemonClient.AssistantFeatureFlagEntry(
+                                    key: flagKey,
+                                    enabled: newValue,
+                                    defaultEnabled: assistantFlags[index].defaultEnabled,
+                                    description: assistantFlags[index].description
+                                )
+                                Task {
+                                    try? await daemonClient?.setFeatureFlag(key: flagKey, enabled: newValue)
+                                }
+                            }
+                        ))
+                        .toggleStyle(.switch)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+
+                        if !entry.description.isEmpty {
+                            Text(entry.description)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(VSpacing.lg)
+        .vCard(background: VColor.surfaceSubtle)
+    }
+
+    // MARK: - macOS Feature Flags
+
+    private var macOSFeatureFlagSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("macOS Feature Flags")
+                .font(VFont.sectionTitle)
+                .foregroundColor(VColor.textPrimary)
+
+            ForEach(Array(macOSFlagStates.enumerated()), id: \.element.flag) { index, entry in
                 Toggle(entry.flag.displayName, isOn: Binding(
-                    get: { flagStates[index].enabled },
+                    get: { macOSFlagStates[index].enabled },
                     set: { newValue in
-                        flagStates[index].enabled = newValue
-                        FeatureFlagManager.shared.setOverride(entry.flag, enabled: newValue)
+                        macOSFlagStates[index].enabled = newValue
+                        MacOSClientFeatureFlagManager.shared.setOverride(entry.flag, enabled: newValue)
                     }
                 ))
                 .toggleStyle(.switch)

--- a/clients/macos/vellum-assistantTests/FeatureFlagManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/FeatureFlagManagerTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import VellumAssistantShared
 
-final class FeatureFlagManagerTests: XCTestCase {
+final class MacOSClientFeatureFlagManagerTests: XCTestCase {
 
     /// Tests that a flag set to "true" is enabled.
     func testFlagSetToTrue() {
@@ -9,7 +9,7 @@ final class FeatureFlagManagerTests: XCTestCase {
         let env = ["VELLUM_FLAG_MY_FEATURE": "true"]
 
         // WHEN we create a manager from that environment
-        let manager = FeatureFlagManager(environment: env)
+        let manager = MacOSClientFeatureFlagManager(environment: env)
 
         // THEN the flag is enabled
         XCTAssertTrue(manager.isEnabled("my_feature"))
@@ -21,7 +21,7 @@ final class FeatureFlagManagerTests: XCTestCase {
         let env = ["VELLUM_FLAG_DARK_MODE": "1"]
 
         // WHEN we create a manager from that environment
-        let manager = FeatureFlagManager(environment: env)
+        let manager = MacOSClientFeatureFlagManager(environment: env)
 
         // THEN the flag is enabled
         XCTAssertTrue(manager.isEnabled("dark_mode"))
@@ -33,7 +33,7 @@ final class FeatureFlagManagerTests: XCTestCase {
         let env = ["VELLUM_FLAG_BETA": "yes"]
 
         // WHEN we create a manager from that environment
-        let manager = FeatureFlagManager(environment: env)
+        let manager = MacOSClientFeatureFlagManager(environment: env)
 
         // THEN the flag is enabled
         XCTAssertTrue(manager.isEnabled("beta"))
@@ -45,7 +45,7 @@ final class FeatureFlagManagerTests: XCTestCase {
         let env = ["VELLUM_FLAG_VERBOSE": "on"]
 
         // WHEN we create a manager from that environment
-        let manager = FeatureFlagManager(environment: env)
+        let manager = MacOSClientFeatureFlagManager(environment: env)
 
         // THEN the flag is enabled
         XCTAssertTrue(manager.isEnabled("verbose"))
@@ -57,7 +57,7 @@ final class FeatureFlagManagerTests: XCTestCase {
         let env = ["VELLUM_FLAG_DISABLED": "false"]
 
         // WHEN we create a manager from that environment
-        let manager = FeatureFlagManager(environment: env)
+        let manager = MacOSClientFeatureFlagManager(environment: env)
 
         // THEN the flag is disabled
         XCTAssertFalse(manager.isEnabled("disabled"))
@@ -69,7 +69,7 @@ final class FeatureFlagManagerTests: XCTestCase {
         let env = ["VELLUM_FLAG_OFF": "0"]
 
         // WHEN we create a manager from that environment
-        let manager = FeatureFlagManager(environment: env)
+        let manager = MacOSClientFeatureFlagManager(environment: env)
 
         // THEN the flag is disabled
         XCTAssertFalse(manager.isEnabled("off"))
@@ -81,7 +81,7 @@ final class FeatureFlagManagerTests: XCTestCase {
         let env: [String: String] = [:]
 
         // WHEN we create a manager and query a nonexistent flag
-        let manager = FeatureFlagManager(environment: env)
+        let manager = MacOSClientFeatureFlagManager(environment: env)
 
         // THEN the flag is disabled
         XCTAssertFalse(manager.isEnabled("nonexistent"))
@@ -93,7 +93,7 @@ final class FeatureFlagManagerTests: XCTestCase {
         let env = ["VELLUM_FLAG_MY_FEATURE": "true"]
 
         // WHEN we create a manager from that environment
-        let manager = FeatureFlagManager(environment: env)
+        let manager = MacOSClientFeatureFlagManager(environment: env)
 
         // THEN the flag is found regardless of query casing
         XCTAssertTrue(manager.isEnabled("MY_FEATURE"))
@@ -112,7 +112,7 @@ final class FeatureFlagManagerTests: XCTestCase {
         ]
 
         // WHEN we create a manager from that environment
-        let manager = FeatureFlagManager(environment: env)
+        let manager = MacOSClientFeatureFlagManager(environment: env)
 
         // THEN only the VELLUM_FLAG_ variable is loaded
         XCTAssertEqual(manager.allFlags().count, 1)
@@ -131,7 +131,7 @@ final class FeatureFlagManagerTests: XCTestCase {
         ]
 
         // WHEN we create a manager from that environment
-        let manager = FeatureFlagManager(environment: env)
+        let manager = MacOSClientFeatureFlagManager(environment: env)
 
         // THEN each flag has its correct value
         XCTAssertTrue(manager.isEnabled("alpha"))
@@ -145,7 +145,7 @@ final class FeatureFlagManagerTests: XCTestCase {
     /// Tests that setOverride can enable a flag that was not in the environment.
     func testSetOverrideAddsFlag() {
         // GIVEN a manager with no flags
-        let manager = FeatureFlagManager(environment: [:])
+        let manager = MacOSClientFeatureFlagManager(environment: [:])
 
         // WHEN we set an override
         manager.setOverride("new_flag", enabled: true)
@@ -158,7 +158,7 @@ final class FeatureFlagManagerTests: XCTestCase {
     func testSetOverrideChangesExistingFlag() {
         // GIVEN a manager with a disabled flag
         let env = ["VELLUM_FLAG_FEATURE": "false"]
-        let manager = FeatureFlagManager(environment: env)
+        let manager = MacOSClientFeatureFlagManager(environment: env)
 
         // WHEN we override it to enabled
         manager.setOverride("feature", enabled: true)
@@ -171,7 +171,7 @@ final class FeatureFlagManagerTests: XCTestCase {
     func testRemoveOverride() {
         // GIVEN a manager with a flag enabled
         let env = ["VELLUM_FLAG_TEMP": "true"]
-        let manager = FeatureFlagManager(environment: env)
+        let manager = MacOSClientFeatureFlagManager(environment: env)
 
         // WHEN we remove the override
         manager.removeOverride("temp")
@@ -186,7 +186,7 @@ final class FeatureFlagManagerTests: XCTestCase {
         let env = ["VELLUM_FLAG_": "true"]
 
         // WHEN we create a manager from that environment
-        let manager = FeatureFlagManager(environment: env)
+        let manager = MacOSClientFeatureFlagManager(environment: env)
 
         // THEN no flags are loaded
         XCTAssertEqual(manager.allFlags().count, 0)
@@ -198,7 +198,7 @@ final class FeatureFlagManagerTests: XCTestCase {
         let env = ["VELLUM_FLAG_PADDED": "  true  "]
 
         // WHEN we create a manager from that environment
-        let manager = FeatureFlagManager(environment: env)
+        let manager = MacOSClientFeatureFlagManager(environment: env)
 
         // THEN the flag is correctly parsed as enabled
         XCTAssertTrue(manager.isEnabled("padded"))
@@ -210,7 +210,7 @@ final class FeatureFlagManagerTests: XCTestCase {
         let env = ["VELLUM_FLAG_DARK_MODE": "1"]
 
         // WHEN we create a manager from that environment
-        let manager = FeatureFlagManager(environment: env)
+        let manager = MacOSClientFeatureFlagManager(environment: env)
 
         // THEN the flag is accessible via the camelCase string directly
         XCTAssertTrue(manager.isEnabled("darkMode"))
@@ -225,7 +225,7 @@ final class FeatureFlagManagerTests: XCTestCase {
         let env = ["VELLUM_FLAG_DARK_MODE": "true"]
 
         // WHEN we create a manager from that environment
-        let manager = FeatureFlagManager(environment: env)
+        let manager = MacOSClientFeatureFlagManager(environment: env)
 
         // THEN various casings all resolve to the same flag
         XCTAssertTrue(manager.isEnabled("DARK_MODE"))

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1533,6 +1533,74 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     // MARK: - Feature Flags
 
+    /// A single assistant feature flag entry returned by `GET /v1/feature-flags`.
+    public struct AssistantFeatureFlagEntry: Decodable, Identifiable {
+        public let key: String
+        public let enabled: Bool
+        public let defaultEnabled: Bool
+        public let description: String
+
+        public var id: String { key }
+
+        public init(key: String, enabled: Bool, defaultEnabled: Bool, description: String) {
+            self.key = key
+            self.enabled = enabled
+            self.defaultEnabled = defaultEnabled
+            self.description = description
+        }
+    }
+
+    /// Response shape for `GET /v1/feature-flags`.
+    private struct AssistantFeatureFlagsResponse: Decodable {
+        let flags: [AssistantFeatureFlagEntry]
+    }
+
+    /// Fetch all assistant feature flags from the gateway's `GET /v1/feature-flags` endpoint.
+    /// Uses the runtime bearer token or feature-flag token for auth.
+    ///
+    /// Routing logic mirrors `setFeatureFlag`: remote mode delegates to `httpTransport`,
+    /// local mode calls the gateway directly on port 7830.
+    public func fetchAssistantFeatureFlags() async throws -> [AssistantFeatureFlagEntry] {
+        let token: String
+        if let ffToken = config.featureFlagToken, !ffToken.isEmpty {
+            token = ffToken
+        } else {
+            throw FeatureFlagError.missingToken
+        }
+
+        #if os(macOS)
+        if let httpTransport = self.httpTransport, !Self.isLocalBaseURL(httpTransport.baseURL) {
+            return try await httpTransport.fetchAssistantFeatureFlags(featureFlagToken: token)
+        }
+
+        let gatewayPort = ProcessInfo.processInfo.environment["GATEWAY_PORT"]
+            .flatMap(Int.init) ?? 7830
+        let baseURL = "http://127.0.0.1:\(gatewayPort)"
+        guard let url = URL(string: "\(baseURL)/v1/feature-flags") else {
+            throw FeatureFlagError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+            throw FeatureFlagError.requestFailed(statusCode)
+        }
+
+        let decoded = try JSONDecoder().decode(AssistantFeatureFlagsResponse.self, from: data)
+        return decoded.flags
+        #else
+        guard let httpTransport else {
+            throw FeatureFlagError.requestFailed(0)
+        }
+        return try await httpTransport.fetchAssistantFeatureFlags(featureFlagToken: token)
+        #endif
+    }
+
     /// Toggle a feature flag via the gateway's PATCH /v1/feature-flags/:flagKey endpoint.
     /// Uses the dedicated feature-flag token (not the runtime bearer token) for auth.
     ///

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -627,6 +627,41 @@ final class HTTPTransport {
         log.info("Feature flag '\(key)' set to \(enabled)")
     }
 
+    /// Fetch all assistant feature flags from the gateway's `GET /v1/feature-flags` endpoint.
+    func fetchAssistantFeatureFlags(featureFlagToken: String) async throws -> [DaemonClient.AssistantFeatureFlagEntry] {
+        guard let url = URL(string: "\(baseURL)/v1/feature-flags") else {
+            throw HTTPTransportError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(featureFlagToken)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw HTTPTransportError.healthCheckFailed
+        }
+
+        if http.statusCode == 401 {
+            log.error("Feature flags GET failed: authentication error (401)")
+            throw HTTPTransportError.healthCheckFailed
+        }
+
+        guard (200..<300).contains(http.statusCode) else {
+            let errorBody = String(data: data, encoding: .utf8) ?? "unknown"
+            log.error("Feature flags GET failed (\(http.statusCode)): \(errorBody)")
+            throw HTTPTransportError.healthCheckFailed
+        }
+
+        struct FlagsResponse: Decodable {
+            let flags: [DaemonClient.AssistantFeatureFlagEntry]
+        }
+
+        let decoded = try JSONDecoder().decode(FlagsResponse.self, from: data)
+        return decoded.flags
+    }
+
     // MARK: - Remote Identity
 
     /// Fetch identity info from the remote daemon's `GET /v1/identity` endpoint.

--- a/clients/shared/Utilities/MacOSClientFeatureFlagManager.swift
+++ b/clients/shared/Utilities/MacOSClientFeatureFlagManager.swift
@@ -2,7 +2,7 @@ import Foundation
 
 private let flagPrefix = "VELLUM_FLAG_"
 
-public enum FeatureFlag: String, CaseIterable {
+public enum MacOSClientFeatureFlag: String, CaseIterable {
     case userHostedEnabled = "user_hosted_enabled"
     case localHttpEnabled = "local_http_enabled"
 
@@ -14,8 +14,8 @@ public enum FeatureFlag: String, CaseIterable {
     }
 }
 
-public final class FeatureFlagManager: @unchecked Sendable {
-    public static let shared = FeatureFlagManager()
+public final class MacOSClientFeatureFlagManager: @unchecked Sendable {
+    public static let shared = MacOSClientFeatureFlagManager()
 
     private let lock = NSLock()
     private var flags: [String: Bool]
@@ -37,7 +37,7 @@ public final class FeatureFlagManager: @unchecked Sendable {
         return flags[Self.normalize(flag)] ?? false
     }
 
-    public func isEnabled(_ flag: FeatureFlag) -> Bool {
+    public func isEnabled(_ flag: MacOSClientFeatureFlag) -> Bool {
         isEnabled(flag.rawValue)
     }
 
@@ -53,7 +53,7 @@ public final class FeatureFlagManager: @unchecked Sendable {
         flags[Self.normalize(flag)] = enabled
     }
 
-    public func setOverride(_ flag: FeatureFlag, enabled: Bool) {
+    public func setOverride(_ flag: MacOSClientFeatureFlag, enabled: Bool) {
         setOverride(flag.rawValue, enabled: enabled)
     }
 
@@ -63,7 +63,7 @@ public final class FeatureFlagManager: @unchecked Sendable {
         flags.removeValue(forKey: Self.normalize(flag))
     }
 
-    public func removeOverride(_ flag: FeatureFlag) {
+    public func removeOverride(_ flag: MacOSClientFeatureFlag) {
         removeOverride(flag.rawValue)
     }
 


### PR DESCRIPTION
Part of #10215 (Assistant Feature Flags Canonicalization). Closes #10218.\n\n- Rename FeatureFlagManager -> MacOSClientFeatureFlagManager\n- Split settings into Assistant Feature Flags (gateway-backed) and macOS Feature Flags (local-only)\n- Add DaemonClient support for fetching/setting assistant feature flags via gateway API\n- Gate Hatch UI behind feature_flags.hatch_new_assistant.enabled
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
