### PR TITLE
perf: run macOS tests in parallel with release build

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -9,7 +9,7 @@ on:
       - '.github/workflows/ci-main-macos.yaml'
 
 jobs:
-  build-check:
+  build:
     name: macOS Build
     runs-on: macos-14
     timeout-minutes: 15
@@ -86,10 +86,6 @@ jobs:
           codesign --verify --deep --strict "dist/Vellum.app"
           echo "Code signature verified"
 
-      - name: Run tests
-        working-directory: clients/macos
-        run: ./build.sh test
-
       - name: Cleanup keychain
         if: always()
         run: |
@@ -130,3 +126,27 @@ jobs:
           fi
 
           echo "Consecutive failures on main: $CONSECUTIVE"
+
+  test:
+    name: macOS Tests
+    runs-on: macos-14
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+
+      - name: Cache SPM build artifacts
+        uses: actions/cache@v4
+        with:
+          path: clients/.build
+          key: macos-spm-${{ hashFiles('clients/Package.resolved') }}-${{ hashFiles('clients/**/*.swift') }}
+          restore-keys: |
+            macos-spm-${{ hashFiles('clients/Package.resolved') }}-
+            macos-spm-
+
+      - name: Run tests
+        working-directory: clients/macos
+        run: ./build.sh test


### PR DESCRIPTION
## Summary
- Split the single `build-check` job into two parallel jobs: `build` (release .app) and `test` (swift test)
- Tests use debug config and don't need the release binary, code signing, or Bun binaries
- The test job only needs Xcode and SPM cache — no keychain, no Bun
- Saves ~2.5 min of wall-clock time since tests run concurrently with the build

## Original prompt
Run tests in parallel with the release build as a separate CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
