### PR TITLE
fix: resolve 8 lint errors breaking CI

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -8,7 +8,7 @@
  *   - Legacy keys/section still read (backward compat)
  *   - New assistantFeatureFlagValues takes priority over legacy featureFlags
  */
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -113,7 +113,7 @@ function createSkillOnDisk(id: string, name: string, description: string): void 
     `---\nname: "${name}"\ndescription: "${description}"\n---\n\nInstructions for ${id}.\n`,
   );
   const indexPath = join(skillsDir, 'SKILLS.md');
-  const existing = existsSync(indexPath) ? require('node:fs').readFileSync(indexPath, 'utf-8') : '';
+  const existing = existsSync(indexPath) ? readFileSync(indexPath, 'utf-8') : '';
   writeFileSync(indexPath, existing + `- ${id}\n`);
 }
 

--- a/assistant/src/__tests__/skill-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags-integration.test.ts
@@ -2,7 +2,7 @@
  * Integration tests for skill feature flag enforcement at system prompt,
  * skill_load, and session-skill-tools projection layers.
  */
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -107,7 +107,7 @@ function createSkillOnDisk(id: string, name: string, description: string): void 
   );
   // Ensure SKILLS.md index references the skill
   const indexPath = join(skillsDir, 'SKILLS.md');
-  const existing = existsSync(indexPath) ? require('node:fs').readFileSync(indexPath, 'utf-8') : '';
+  const existing = existsSync(indexPath) ? readFileSync(indexPath, 'utf-8') : '';
   writeFileSync(indexPath, existing + `- ${id}\n`);
 }
 

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'bun:test';
 
+import { isAssistantFeatureFlagEnabled, isAssistantSkillEnabled } from '../config/assistant-feature-flags.js';
 import type { AssistantConfig } from '../config/schema.js';
 import { isSkillFeatureEnabled, resolveSkillStates } from '../config/skill-state.js';
-import { isAssistantFeatureFlagEnabled, isAssistantSkillEnabled } from '../config/assistant-feature-flags.js';
 import type { SkillSummary } from '../config/skills.js';
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/config/skill-state.ts
+++ b/assistant/src/config/skill-state.ts
@@ -1,5 +1,5 @@
-import type { AssistantConfig, SkillEntryConfig } from './schema.js';
 import { isAssistantSkillEnabled } from './assistant-feature-flags.js';
+import type { AssistantConfig, SkillEntryConfig } from './schema.js';
 import type { SkillSummary } from './skills.js';
 import { checkSkillRequirements } from './skills.js';
 

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -6,9 +6,9 @@ import { getParentalControlSettings } from '../security/parental-control-store.j
 import { listCredentialMetadata } from '../tools/credentials/metadata-store.js';
 import { getLogger } from '../util/logger.js';
 import { getWorkspaceDir, getWorkspacePromptPath, isMacOS } from '../util/platform.js';
+import { isAssistantSkillEnabled } from './assistant-feature-flags.js';
 import { getBaseDataDir, getIsContainerized } from './env-registry.js';
 import { getConfig } from './loader.js';
-import { isAssistantSkillEnabled } from './assistant-feature-flags.js';
 import { loadSkillCatalog, type SkillSummary } from './skills.js';
 import { resolveUserReference } from './user-reference.js';
 

--- a/assistant/src/daemon/session-skill-tools.ts
+++ b/assistant/src/daemon/session-skill-tools.ts
@@ -11,8 +11,8 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { getConfig } from '../config/loader.js';
 import { isAssistantSkillEnabled } from '../config/assistant-feature-flags.js';
+import { getConfig } from '../config/loader.js';
 import type { SkillSummary, SkillToolManifest } from '../config/skills.js';
 import { loadSkillCatalog } from '../config/skills.js';
 import type { Message, ToolDefinition } from '../providers/types.js';

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -6,6 +6,7 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 
 import type { ServerWebSocket } from 'bun';
@@ -240,7 +241,7 @@ export class RuntimeHttpServer {
   /** Read the feature-flag client token from disk so it can be included in pairing approval responses. */
   private readFeatureFlagToken(): string | undefined {
     try {
-      const baseDir = process.env.BASE_DATA_DIR?.trim() || require('node:os').homedir();
+      const baseDir = process.env.BASE_DATA_DIR?.trim() || homedir();
       const tokenPath = join(baseDir, '.vellum', 'feature-flag-token');
       const token = readFileSync(tokenPath, 'utf-8').trim();
       return token || undefined;

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -1,5 +1,5 @@
-import { getConfig } from '../../config/loader.js';
 import { isAssistantSkillEnabled } from '../../config/assistant-feature-flags.js';
+import { getConfig } from '../../config/loader.js';
 import type { SkillSummary } from '../../config/skills.js';
 import { loadSkillBySelector, loadSkillCatalog } from '../../config/skills.js';
 import { RiskLevel } from '../../permissions/types.js';


### PR DESCRIPTION
## Summary
- Auto-fix 5 import sorting violations (`simple-import-sort/imports`)
- Replace 3 `require()` calls with proper ESM imports (`@typescript-eslint/no-require-imports`)

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22471204872/job/65088370313

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
