### PR TITLE
feat: add custom Tooltip component with 1s delay for contextual help

### DIFF
--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -11,6 +11,7 @@ import { callDoctorDaemon, type ChatLogEntry } from "../lib/doctor-client";
 import { checkHealth } from "../lib/health-check";
 import { statusEmoji, withStatusEmoji } from "../lib/status-emoji";
 import TextInput from "./TextInput";
+import { Tooltip } from "./Tooltip";
 
 export const ANSI = {
   reset: "\x1b[0m",
@@ -682,7 +683,9 @@ function DefaultMainScreen({
       </Box>
       <Text dimColor>{"─".repeat(totalWidth)}</Text>
       <Text> </Text>
-      <Text dimColor> ? for shortcuts</Text>
+      <Tooltip text="Type ? or /help for available commands" delay={1000}>
+        <Text dimColor> ? for shortcuts</Text>
+      </Tooltip>
       <Text> </Text>
     </Box>
   );
@@ -841,7 +844,7 @@ function SelectionWindow({
         );
       })}
       <Text>{"\u2514" + "\u2500".repeat(windowWidth - 2) + "\u2518"}</Text>
-      <Text dimColor>{"  \u2191/\u2193 navigate  Enter select  Esc cancel"}</Text>
+      <Tooltip text="\u2191/\u2193 navigate  Enter select  Esc cancel" delay={1000} />
     </Box>
   );
 }
@@ -901,7 +904,7 @@ function SecretInputWindow({
         {"\u2502"}
       </Text>
       <Text>{"\u2514" + "\u2500".repeat(windowWidth - 2) + "\u2518"}</Text>
-      <Text dimColor>{"  Enter submit  Esc cancel"}</Text>
+      <Tooltip text="Enter submit  Esc cancel" delay={1000} />
     </Box>
   );
 }
@@ -1814,6 +1817,12 @@ function ChatApp({
 
       {!selection && !secretInput ? (
         <Box flexDirection="column">
+          <Tooltip
+            text="Type a message or /help for commands"
+            visible={inputFocused && inputValue.length === 0}
+            position="above"
+            delay={1000}
+          />
           <Text dimColor>{"\u2500".repeat(terminalColumns)}</Text>
           <Box paddingLeft={1}>
             <Text color="green" bold>

--- a/cli/src/components/Tooltip.tsx
+++ b/cli/src/components/Tooltip.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState, type ReactElement, type ReactNode } from "react";
+import { Box, Text } from "ink";
+
+export interface TooltipProps {
+  /** The tooltip text to display */
+  text: string;
+  /** Whether the tooltip trigger condition is active. When true, starts the delay timer. */
+  visible?: boolean;
+  /** Position relative to children: "above" or "below" */
+  position?: "above" | "below";
+  /** Delay in ms before showing the tooltip (default: 1000) */
+  delay?: number;
+  /** Children to wrap */
+  children?: ReactNode;
+}
+
+/**
+ * A Codex-style tooltip component for Ink terminal UI.
+ *
+ * Wraps children and shows a styled tooltip bubble (rounded border, bold text)
+ * after a configurable delay when `visible` is true.
+ *
+ * Usage:
+ *   <Tooltip text="Attach files" visible={isFocused}>
+ *     <Text>📎</Text>
+ *   </Tooltip>
+ */
+export function Tooltip({
+  text,
+  visible = true,
+  position = "below",
+  delay = 1000,
+  children,
+}: TooltipProps): ReactElement {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    if (!visible) {
+      setShow(false);
+      return;
+    }
+
+    const timer = setTimeout(() => setShow(true), delay);
+    return () => clearTimeout(timer);
+  }, [visible, delay]);
+
+  const bubble = show ? (
+    <Box borderStyle="round" borderColor="gray" alignSelf="flex-start">
+      <Text bold> {text} </Text>
+    </Box>
+  ) : null;
+
+  if (!children) {
+    return bubble ?? <Text />;
+  }
+
+  return (
+    <Box flexDirection="column">
+      {position === "above" && bubble}
+      {children}
+      {position === "below" && bubble}
+    </Box>
+  );
+}
+
+export default Tooltip;


### PR DESCRIPTION
## Summary
- Add new `Tooltip` component (`cli/src/components/Tooltip.tsx`) with Codex-style rounded border, bold text, configurable delay (default 1s), and above/below positioning
- Replace all inline `dimColor` hint text with `Tooltip` instances: welcome screen shortcuts hint, SelectionWindow navigation hints, SecretInputWindow submit hints
- Add contextual tooltip above the input bar that appears after 1s when the input is empty and focused

## Original prompt
Help me design our own custom tooltip component that we can use to show help text on hover rather than relying on macos system default. Lets model ours after codex's which I've attached a screenshot example of. Once we've made this new component, lets use it everywhere where we currently rely on native tooltips. Lets use a default delay of 1 second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
