### PR TITLE
fix: fail fast when daemon socket file is missing

### DIFF
--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -50,20 +50,30 @@ extension DaemonClient {
                 guard let v = ProcessInfo.processInfo.environment["VELLUM_DAEMON_SOCKET"] else { return false }
                 return !v.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             }()
-            if !isCustomSocket, FileManager.default.fileExists(atPath: path), !Self.isDaemonProcessAlive() {
-                log.warning("Stale daemon socket detected — PID is dead, removing socket at \(path, privacy: .public)")
-                // Only remove the path if it is actually a Unix socket, not a regular file.
-                var isSocket = false
-                if let attrs = try? FileManager.default.attributesOfItem(atPath: path),
-                   let fileType = attrs[.type] as? FileAttributeType,
-                   fileType == .typeSocket {
-                    isSocket = true
+            if !isCustomSocket {
+                if FileManager.default.fileExists(atPath: path) {
+                    if !Self.isDaemonProcessAlive() {
+                        log.warning("Stale daemon socket detected — PID is dead, removing socket at \(path, privacy: .public)")
+                        // Only remove the path if it is actually a Unix socket, not a regular file.
+                        var isSocket = false
+                        if let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+                           let fileType = attrs[.type] as? FileAttributeType,
+                           fileType == .typeSocket {
+                            isSocket = true
+                        }
+                        if isSocket {
+                            try? FileManager.default.removeItem(atPath: path)
+                        }
+                        isConnecting = false
+                        throw NWError.posix(.ECONNREFUSED)
+                    }
+                } else {
+                    // Socket file doesn't exist — fail fast with ENOENT instead of
+                    // letting NWConnection hang until the connect timeout (ETIMEDOUT).
+                    log.warning("Daemon socket not found at \(path, privacy: .public)")
+                    isConnecting = false
+                    throw NWError.posix(.ENOENT)
                 }
-                if isSocket {
-                    try? FileManager.default.removeItem(atPath: path)
-                }
-                isConnecting = false
-                throw NWError.posix(.ECONNREFUSED)
             }
 
             log.info("Connecting to daemon socket at \(path, privacy: .public)")


### PR DESCRIPTION
## Summary
- When the daemon socket file doesn't exist at `~/.vellum/vellum.sock`, the macOS client now fails immediately with `ENOENT` instead of hanging for 5 seconds and timing out with `ETIMEDOUT`
- This surfaces the correct diagnostic hint ("Daemon socket not found — the daemon may not be running") instead of the misleading "Connection timed out" message
- The reconnect loop retries automatically, so there's no loss in resilience

## Original prompt
fix this error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
