### PR TITLE
fix: check socket responsiveness before deleting during desktop hatch

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -1,6 +1,7 @@
 import { spawn } from "child_process";
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import { createRequire } from "module";
+import { createConnection } from "net";
 import { homedir } from "os";
 import { dirname, join } from "path";
 
@@ -95,6 +96,30 @@ function readWorkspaceIngressPublicBaseUrl(): string | undefined {
   }
 }
 
+/** Try a TCP connect to the Unix socket. Returns true if the handshake
+ *  completes within the timeout — false on connection refused, timeout,
+ *  or missing socket file. */
+function isSocketResponsive(socketPath: string, timeoutMs = 1500): Promise<boolean> {
+  if (!existsSync(socketPath)) return Promise.resolve(false);
+  return new Promise((resolve) => {
+    const socket = createConnection(socketPath);
+    const timer = setTimeout(() => {
+      socket.destroy();
+      resolve(false);
+    }, timeoutMs);
+    socket.on("connect", () => {
+      clearTimeout(timer);
+      socket.destroy();
+      resolve(true);
+    });
+    socket.on("error", () => {
+      clearTimeout(timer);
+      socket.destroy();
+      resolve(false);
+    });
+  });
+}
+
 async function discoverPublicUrl(): Promise<string | undefined> {
   const cloud = process.env.VELLUM_CLOUD;
   if (!cloud || cloud === "local") {
@@ -172,7 +197,15 @@ export async function startLocalDaemon(): Promise<void> {
     }
 
     if (!daemonAlive) {
-      // Remove stale socket so we can detect the fresh one
+      // The PID file was stale or missing, but a daemon with a different PID
+      // may still be listening on the socket (e.g. if the PID file was
+      // overwritten by a crashed restart attempt). Check before deleting.
+      if (await isSocketResponsive(socketFile)) {
+        console.log("   Daemon socket is responsive — skipping restart\n");
+        return;
+      }
+
+      // Socket is unresponsive or missing — safe to clean up and start fresh.
       try { unlinkSync(socketFile); } catch {}
 
       console.log("🔨 Starting daemon...");


### PR DESCRIPTION
## Summary
- Added socket responsiveness check to the desktop app's `startLocalDaemon()` in `cli/src/lib/local.ts`
- When the PID file is stale but the socket is still responsive (a different daemon is serving), skip the restart instead of deleting the socket and orphaning the running daemon
- Mirrors the `isSocketResponsive()` pattern already used in `assistant/src/daemon/daemon-control.ts`

## Original prompt
fix this error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
