### PR TITLE
fix: use second-person phrasing in containerized system prompt

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -636,7 +636,7 @@ function buildContainerizedSection(): string {
   return [
     '## Running in a Container — Data Persistence',
     '',
-    `This assistant is running inside a container. Only the directory \`${baseDataDir}\` is mounted to a persistent volume.`,
+    `You are running inside a container. Only the directory \`${baseDataDir}\` is mounted to a persistent volume.`,
     '',
     '**Any new files or data you create MUST be written inside that directory, or they will be lost when the container restarts.**',
     '',


### PR DESCRIPTION
## Summary
- Changes "This assistant is running inside a container" to "You are running inside a container" to be consistent with the second-person style used throughout the rest of the system prompt
- Addresses review feedback from @awlevin on #10201

## Original prompt
address the feedback from aaron in a new worktree from this pr https://github.com/vellum-ai/vellum-assistant/pull/10201

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
