### PR TITLE
fix: strengthen feature flag guard test coverage

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flag-guard.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flag-guard.test.ts
@@ -54,10 +54,12 @@ const LEGACY_KEY_ALLOWLIST = new Set([
 function isTestFile(filePath: string): boolean {
   return (
     filePath.includes('/__tests__/') ||
+    filePath.includes('/Tests/') ||
     filePath.endsWith('.test.ts') ||
     filePath.endsWith('.test.js') ||
     filePath.endsWith('.spec.ts') ||
-    filePath.endsWith('.spec.js')
+    filePath.endsWith('.spec.js') ||
+    filePath.endsWith('Tests.swift')
   );
 }
 
@@ -68,14 +70,14 @@ function isTestFile(filePath: string): boolean {
 describe('assistant feature flag guard', () => {
   test('no production files use legacy skills.<id>.enabled key format outside allowlist', () => {
     // Search for the legacy key pattern in string literals across the codebase.
-    // The pattern matches quoted strings like 'skills.browser.enabled' or
-    // "skills.browser.enabled".
-    const pattern = `['"]skills\\.[a-z][a-z0-9._-]*\\.enabled['"]`;
+    // The pattern matches quoted strings like 'skills.browser.enabled',
+    // "skills.browser.enabled", or `skills.browser.enabled`.
+    const pattern = `['"\`]skills\\.[a-z][a-z0-9._-]*\\.enabled['"\`]`;
 
     let grepOutput = '';
     try {
       grepOutput = execSync(
-        `git grep -lE ${JSON.stringify(pattern)} -- '*.ts' '*.js' '*.swift'`,
+        `git grep -lE ${JSON.stringify(pattern)} -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.swift'`,
         { encoding: 'utf-8', cwd: getRepoRoot() },
       ).trim();
     } catch (err) {


### PR DESCRIPTION
Address review feedback on PR #10255:
- Include *.tsx/*.jsx files in legacy-key guard scan
- Match template-literal (backtick) legacy keys in guard regex
- Add Swift test file pattern recognition to isTestFile
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
