### PR TITLE
fix: polish Guardian Verification text inputs on Channels settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -1231,7 +1231,7 @@ struct SettingsChannelsTab: View {
 
                 TextField(placeholder, text: destinationBinding)
                     .font(VFont.body)
-                    .textFieldStyle(.roundedBorder)
+                    .vInputStyle()
                     .frame(maxWidth: 200)
 
                 VButton(label: "Send verification", style: .secondary) {


### PR DESCRIPTION
## Summary
- Replace `.textFieldStyle(.roundedBorder)` with `.vInputStyle()` on the Guardian Verification text inputs (Telegram, Phone Calling, SMS)
- This applies the design system's consistent padding, background color, corner radius, and border styling instead of the native macOS rounded border

## Original prompt
these three text inputs on the Channels Settings page look kinda wonky. Can you take a design polish pass to them?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
