### PR TITLE
fix: only subtract tooltip height when tooltip is visible

### DIFF
--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -988,13 +988,15 @@ function ChatApp({
   const terminalColumns = stdout.columns || 80;
   const headerHeight = calculateHeaderHeight(species);
   const tooltipBubbleHeight = 3;
+  const showTooltip = inputFocused && inputValue.length === 0;
+  const tooltipHeight = showTooltip ? tooltipBubbleHeight : 0;
   const bottomHeight = selection
-    ? selection.options.length + 3 + tooltipBubbleHeight
+    ? selection.options.length + 3 + tooltipHeight
     : secretInput
-      ? 5 + tooltipBubbleHeight
+      ? 5 + tooltipHeight
       : spinnerText
         ? 4
-        : 3 + tooltipBubbleHeight;
+        : 3 + tooltipHeight;
   const availableRows = Math.max(3, terminalRows - headerHeight - bottomHeight);
 
   const addMessage = useCallback((msg: RuntimeMessage) => {


### PR DESCRIPTION
Address review feedback on PR #10258:
- Only add tooltipBubbleHeight to bottomHeight when the tooltip is actually visible (inputFocused && empty input)
- Prevents wasting 3 terminal rows when the tooltip is hidden
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
