### PR TITLE
fix: sanitize namespace in blitz heartbeat temp filenames

### DIFF
--- a/.claude/commands/blitz.md
+++ b/.claude/commands/blitz.md
@@ -40,9 +40,10 @@ Read and follow `.claude/phases/plan-and-spec.md`. For blitz mode, remove the `<
 
 **Update the blitz heartbeat** after planning completes to prevent the entry from going stale during long-running phases:
 ```bash
-grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp.<namespace> 2>/dev/null || true
-echo "<namespace> blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp.<namespace>
-mv .private/ACTIVE_BLITZ.md.tmp.<namespace> .private/ACTIVE_BLITZ.md
+SAFE_NS=$(echo "<namespace>" | tr '/' '-')
+grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS 2>/dev/null || true
+echo "<namespace> blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS
+mv .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS .private/ACTIVE_BLITZ.md
 ```
 
 ## Phase 3: Populate TODO.md
@@ -53,9 +54,10 @@ Read and follow `.claude/phases/populate-todo.md`.
 
 **Update the blitz heartbeat** before starting the swarm:
 ```bash
-grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp.<namespace> 2>/dev/null || true
-echo "<namespace> blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp.<namespace>
-mv .private/ACTIVE_BLITZ.md.tmp.<namespace> .private/ACTIVE_BLITZ.md
+SAFE_NS=$(echo "<namespace>" | tr '/' '-')
+grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS 2>/dev/null || true
+echo "<namespace> blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS
+mv .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS .private/ACTIVE_BLITZ.md
 ```
 
 Read and follow the instructions in `.claude/commands/swarm.md` with these modifications:
@@ -82,9 +84,10 @@ gh issue close <issue-number>
 
 **Update the blitz heartbeat** before starting the review-and-merge phase:
 ```bash
-grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp.<namespace> 2>/dev/null || true
-echo "<namespace> blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp.<namespace>
-mv .private/ACTIVE_BLITZ.md.tmp.<namespace> .private/ACTIVE_BLITZ.md
+SAFE_NS=$(echo "<namespace>" | tr '/' '-')
+grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS 2>/dev/null || true
+echo "<namespace> blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS
+mv .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS .private/ACTIVE_BLITZ.md
 ```
 
 After the swarm phase completes, all milestone PRs are open but unmerged. This phase runs a per-PR feedback loop on each one — addressing review feedback by pushing fixes directly to the PR branch — before merging to main.
@@ -288,9 +291,10 @@ After all PRs are merged, proceed to Phase 5.
 **Update the blitz heartbeat** at the start of each sweep loop iteration to prevent the entry from going stale. Replace the line starting with `<namespace> ` in `.private/ACTIVE_BLITZ.md` with a fresh timestamp:
 ```bash
 # Read, filter out old entry, append fresh entry
-grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp.<namespace> 2>/dev/null || true
-echo "<namespace> blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp.<namespace>
-mv .private/ACTIVE_BLITZ.md.tmp.<namespace> .private/ACTIVE_BLITZ.md
+SAFE_NS=$(echo "<namespace>" | tr '/' '-')
+grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS 2>/dev/null || true
+echo "<namespace> blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS
+mv .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS .private/ACTIVE_BLITZ.md
 ```
 
 Read and follow `.claude/phases/sweep.md`. When it says "back to the Swarm phase", return to Phase 4 above (with the same `--skip-reviews` behavior). When it says "final phase", proceed to Phase 6.
@@ -307,8 +311,9 @@ This phase runs a recursive loop: check reviews → swarm to address feedback �
 
 Remove this blitz's entry from `.private/ACTIVE_BLITZ.md`:
 ```bash
-grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp.<namespace> 2>/dev/null || true
-mv .private/ACTIVE_BLITZ.md.tmp.<namespace> .private/ACTIVE_BLITZ.md
+SAFE_NS=$(echo "<namespace>" | tr '/' '-')
+grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS 2>/dev/null || true
+mv .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS .private/ACTIVE_BLITZ.md
 ```
 If the file is now empty (only blank lines), delete it: `rm -f .private/ACTIVE_BLITZ.md`
 

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -68,9 +68,10 @@ Read and follow `.claude/phases/plan-and-spec.md`. For safe-blitz mode, replace 
 
 **Update the blitz heartbeat** after planning completes to prevent the entry from going stale during long-running phases:
 ```bash
-grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp.<namespace> 2>/dev/null || true
-echo "<namespace> safe-blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp.<namespace>
-mv .private/ACTIVE_BLITZ.md.tmp.<namespace> .private/ACTIVE_BLITZ.md
+SAFE_NS=$(echo "<namespace>" | tr '/' '-')
+grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS 2>/dev/null || true
+echo "<namespace> safe-blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS
+mv .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS .private/ACTIVE_BLITZ.md
 ```
 
 ## Phase 3: Prepare Milestone List
@@ -195,9 +196,10 @@ Address the review feedback on PR #<milestone-pr-number> (<milestone-pr-url>):
 
 **Update the blitz heartbeat** before each milestone execution to prevent the entry from going stale:
 ```bash
-grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp.<namespace> 2>/dev/null || true
-echo "<namespace> safe-blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp.<namespace>
-mv .private/ACTIVE_BLITZ.md.tmp.<namespace> .private/ACTIVE_BLITZ.md
+SAFE_NS=$(echo "<namespace>" | tr '/' '-')
+grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS 2>/dev/null || true
+echo "<namespace> safe-blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS
+mv .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS .private/ACTIVE_BLITZ.md
 ```
 
 1. Prepend this single milestone item to `.private/TODO.md` (preserve existing items) with the namespace prefix:
@@ -236,9 +238,10 @@ mv .private/ACTIVE_BLITZ.md.tmp.<namespace> .private/ACTIVE_BLITZ.md
 
 **Update the blitz heartbeat** before entering the feedback loop (and at the start of each feedback cycle) to prevent the entry from going stale:
 ```bash
-grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp.<namespace> 2>/dev/null || true
-echo "<namespace> safe-blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp.<namespace>
-mv .private/ACTIVE_BLITZ.md.tmp.<namespace> .private/ACTIVE_BLITZ.md
+SAFE_NS=$(echo "<namespace>" | tr '/' '-')
+grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS 2>/dev/null || true
+echo "<namespace> safe-blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS
+mv .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS .private/ACTIVE_BLITZ.md
 ```
 
 Instead of using the full sweep+swarm machinery (which creates new PRs), per-milestone feedback is handled by pushing fixes directly to the milestone PR branch. This is faster and avoids the overhead of creating, reviewing, and merging intermediate feedback PRs.
@@ -476,9 +479,10 @@ Proceed to step 4d.
 
 **Update the blitz heartbeat** at the start of each sweep loop iteration to prevent the entry from going stale:
 ```bash
-grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp.<namespace> 2>/dev/null || true
-echo "<namespace> safe-blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp.<namespace>
-mv .private/ACTIVE_BLITZ.md.tmp.<namespace> .private/ACTIVE_BLITZ.md
+SAFE_NS=$(echo "<namespace>" | tr '/' '-')
+grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS 2>/dev/null || true
+echo "<namespace> safe-blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS
+mv .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS .private/ACTIVE_BLITZ.md
 ```
 
 After all milestones are merged and their individual reviews are clean, run one final recursive sweep on the entire feature branch.
@@ -697,8 +701,9 @@ gh pr checks <final-pr-number> --json name,state,conclusion --jq '.[] | {name: .
 
 Remove this safe-blitz's entry from `.private/ACTIVE_BLITZ.md`:
 ```bash
-grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp.<namespace> 2>/dev/null || true
-mv .private/ACTIVE_BLITZ.md.tmp.<namespace> .private/ACTIVE_BLITZ.md
+SAFE_NS=$(echo "<namespace>" | tr '/' '-')
+grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS 2>/dev/null || true
+mv .private/ACTIVE_BLITZ.md.tmp.$SAFE_NS .private/ACTIVE_BLITZ.md
 ```
 If the file is now empty (only blank lines), delete it: `rm -f .private/ACTIVE_BLITZ.md`
 


### PR DESCRIPTION
Address review feedback on PR #10257:
- Sanitize namespace before using it in temp file names to prevent failures when namespace contains path separators or shell-significant characters
- Uses tr to replace / with - in the temp file suffix only
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
