### PR TITLE
fix: restore unconditional tooltip height for selection and secret input

### DIFF
--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -991,9 +991,9 @@ function ChatApp({
   const showTooltip = inputFocused && inputValue.length === 0;
   const tooltipHeight = showTooltip ? tooltipBubbleHeight : 0;
   const bottomHeight = selection
-    ? selection.options.length + 3 + tooltipHeight
+    ? selection.options.length + 3 + tooltipBubbleHeight
     : secretInput
-      ? 5 + tooltipHeight
+      ? 5 + tooltipBubbleHeight
       : spinnerText
         ? 4
         : 3 + tooltipHeight;


### PR DESCRIPTION
PR #10270 changed the tooltip height to be conditional on showTooltip for all branches, but selection and secretInput branches always render their own visible tooltips while inputFocused is false. Restore unconditional tooltipBubbleHeight for those branches, keeping conditional tooltipHeight only for the default main input branch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
