### PR TITLE
fix: mark active thread as seen when app becomes active

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -662,6 +662,9 @@ struct MainWindowView: View {
         .onReceive(daemonClient.$isConnected) { _ in
             windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected)
         }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            threadManager.markActiveThreadSeenIfNeeded()
+        }
         .onChange(of: selectedThreadId) { _, newId in
             if let newId = newId {
                 threadManager.selectThread(id: newId)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -743,6 +743,18 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
     }
 
+    /// If the active thread has an unseen assistant message, mark it as seen.
+    /// Called when the app becomes active (e.g. user clicks the menu bar icon
+    /// or switches back to the app) so that a pre-selected unread thread is
+    /// marked seen without requiring a thread switch.
+    func markActiveThreadSeenIfNeeded() {
+        guard !isRestoringThreads,
+              let activeId = activeThreadId,
+              let idx = threads.firstIndex(where: { $0.id == activeId }),
+              threads[idx].hasUnseenLatestAssistantMessage else { return }
+        markConversationSeen(threadId: activeId)
+    }
+
     /// Clear the local unseen flag and notify the daemon that the conversation
     /// has been seen. Use this from call-sites that bypass `selectThread` (e.g.
     /// deep-link navigation in `openConversationThread`) where the `id != previousActiveId`


### PR DESCRIPTION
## Summary
- Add `markActiveThreadSeenIfNeeded()` to ThreadManager — if the active thread has `hasUnseenLatestAssistantMessage`, marks it seen and sends the IPC signal
- Listen for `NSApplication.didBecomeActiveNotification` in MainWindowView to call it when the app gains focus
- Fixes the case where opening the app with an already-selected unread thread (or returning from background) leaves the thread permanently marked unseen

## Original prompt
Mark active thread as seen when app becomes active — fix for pre-selected unread threads not transitioning to seen state on app launch/focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
