### PR TITLE
perf: throttle browser screencast to reduce CPU usage

### DIFF
--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -509,17 +509,28 @@ class BrowserManager {
     this.cdpSessions.set(sessionId, cdp);
     this.screencastCallbacks.set(sessionId, onFrame);
 
+    // Throttle frame delivery to ~8fps max to avoid flooding IPC and the client.
+    // CDP still encodes fewer frames thanks to everyNthFrame:2, but on heavy
+    // pages Chrome can still produce bursts faster than the UI can consume.
+    const MIN_FRAME_INTERVAL_MS = 125;
+    let lastFrameTime = 0;
+
     cdp.on('Page.screencastFrame', (params) => {
-      onFrame({ data: params.data as string, metadata: params.metadata as ScreencastFrameMetadata });
+      const now = Date.now();
+      if (now - lastFrameTime >= MIN_FRAME_INTERVAL_MS) {
+        lastFrameTime = now;
+        onFrame({ data: params.data as string, metadata: params.metadata as ScreencastFrameMetadata });
+      }
+      // Always ack so CDP continues delivering frames (otherwise it stalls)
       silentlyWithLog(cdp.send('Page.screencastFrameAck', { sessionId: params.sessionId }), 'screencast frame ack');
     });
 
     await cdp.send('Page.startScreencast', {
       format: 'jpeg',
-      quality: 60,
+      quality: 50,
       maxWidth: 1280,
       maxHeight: 960,
-      everyNthFrame: 1,
+      everyNthFrame: 2,
     });
   }
 


### PR DESCRIPTION
## Summary

- Reduce CDP screencast `everyNthFrame` from 1→2, halving Chrome's JPEG encoding workload (root cause of 104% CPU on Chrome Helper)
- Lower screencast JPEG quality from 60→50 for PiP preview (model-facing `browser_screenshot` still uses quality 80)
- Add 125ms server-side frame throttle (~8fps cap) to prevent IPC flooding on heavy pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
