### PR TITLE
perf: turn off coverage in CI

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -43,46 +43,8 @@ jobs:
       - name: Lint
         run: bun run lint
 
-      - name: Test with coverage
-        run: bun run test:coverage
-        env:
-          EXCLUDE_EXPERIMENTAL: 'true'
-
-      - name: Coverage summary
-        if: success()
-        run: |
-          LCOV="coverage/lcov.info"
-          if [[ ! -s "${LCOV}" ]]; then
-            echo "No coverage data found"
-            exit 0
-          fi
-
-          # Parse lcov: count lines found (LF) and lines hit (LH)
-          TOTAL_LF=0
-          TOTAL_LH=0
-          while IFS= read -r line; do
-            case "${line}" in
-              LF:*) TOTAL_LF=$(( TOTAL_LF + ${line#LF:} )) ;;
-              LH:*) TOTAL_LH=$(( TOTAL_LH + ${line#LH:} )) ;;
-            esac
-          done < "${LCOV}"
-
-          if [[ ${TOTAL_LF} -gt 0 ]]; then
-            PCT=$(( TOTAL_LH * 100 / TOTAL_LF ))
-            echo "Line coverage: ${TOTAL_LH}/${TOTAL_LF} (${PCT}%)"
-            echo "### Code Coverage: ${PCT}%" >> "${GITHUB_STEP_SUMMARY}"
-            echo "${TOTAL_LH} of ${TOTAL_LF} lines covered" >> "${GITHUB_STEP_SUMMARY}"
-          else
-            echo "No line data in coverage report"
-          fi
-
-      - name: Upload coverage report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-report
-          path: assistant/coverage/lcov.info
-          retention-days: 30
+      - name: Test
+        run: bun run test:stable
 
       - name: Track consecutive failures
         if: always()


### PR DESCRIPTION
## Summary
- Switch CI test step from `test:coverage` to `test:stable` (no coverage instrumentation)
- Remove the coverage summary step and coverage artifact upload
- Coverage adds ~30-50% overhead per test file, and the lcov merge step adds further time. With 444 test files and only 2 workers on `ubuntu-latest`, this was causing the job to exceed the 15-minute timeout.

## Original prompt
turn off coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
