### PR TITLE
fix: auto-retry failed messages and clear error banner on daemon reconnect

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -800,6 +800,17 @@ public final class ChatViewModel: ObservableObject {
                         }
                     }
                 }
+                // Auto-retry a failed message on reconnect so the user doesn't
+                // have to manually click "Retry" after a transient daemon crash.
+                if let self, self.isConnectionError, self.lastFailedMessageText != nil {
+                    self.retryLastMessage()
+                } else if let self, self.isConnectionError {
+                    // No message to retry, but clear the stale error banner
+                    self.errorText = nil
+                    self.lastFailedSendError = nil
+                    self.connectionDiagnosticHint = nil
+                }
+
                 // If we already have a session ID, flush immediately. Otherwise
                 // defer: sessionId's didSet will trigger flushOfflineQueue() once
                 // the session is restored from history (cold-start reconnect case).


### PR DESCRIPTION
## Summary
- On `daemonDidReconnect`, auto-retry the last failed message if the error was a connection error
- If no message to retry, clear stale connection error banner (errorText, lastFailedSendError, connectionDiagnosticHint)
- Eliminates the need for users to manually click Retry after a transient daemon crash

## Original prompt
all of these in separate PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
