### PR TITLE
fix: trigger immediate daemon restart when socket not found

### DIFF
--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -73,6 +73,7 @@ final class AssistantCli {
     var onDaemonRestarted: (() -> Void)?
 
     private var healthCheckTask: Task<Void, Never>?
+    private var socketNotFoundObserver: NSObjectProtocol?
 
     /// Set to `true` during an intentional stop to prevent the health monitor
     /// from restarting the daemon.
@@ -317,12 +318,31 @@ final class AssistantCli {
                 }
             }
         }
+
+        // Trigger an immediate restart when the client detects the socket is
+        // missing (ENOENT) instead of waiting for the next 5-second health check.
+        socketNotFoundObserver = NotificationCenter.default.addObserver(
+            forName: .daemonSocketNotFound,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self, !self.isStopping else { return }
+                guard self.isDaemonAlive() == false else { return }
+                log.warning("Socket not found notification — attempting immediate restart")
+                await self.restartDaemon()
+            }
+        }
     }
 
     /// Stop the health monitor.
     func stopMonitoring() {
         healthCheckTask?.cancel()
         healthCheckTask = nil
+        if let observer = socketNotFoundObserver {
+            NotificationCenter.default.removeObserver(observer)
+            socketNotFoundObserver = nil
+        }
     }
 
     // MARK: - Remote Hatch (pass-through to CLI)

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -145,6 +145,11 @@ public protocol DaemonClientProtocol {
 extension Notification.Name {
     /// Posted by `DaemonClient` on the main actor immediately after `isConnected` transitions to `true`.
     public static let daemonDidReconnect = Notification.Name("daemonDidReconnect")
+
+    /// Posted when a connection attempt fails because the daemon socket does not exist (ENOENT).
+    /// The health monitor observes this to trigger an immediate restart instead of waiting
+    /// for the next periodic health check.
+    public static let daemonSocketNotFound = Notification.Name("daemonSocketNotFound")
 }
 
 /// Platform-agnostic client for communicating with the Vellum daemon.

--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -72,6 +72,7 @@ extension DaemonClient {
                     // letting NWConnection hang until the connect timeout (ETIMEDOUT).
                     log.warning("Daemon socket not found at \(path, privacy: .public)")
                     isConnecting = false
+                    NotificationCenter.default.post(name: .daemonSocketNotFound, object: self)
                     throw NWError.posix(.ENOENT)
                 }
             }


### PR DESCRIPTION
## Summary
- Add `daemonSocketNotFound` notification posted from DaemonConnection when ENOENT is detected
- AssistantCli observes this notification and triggers an immediate `restartDaemon()` call
- Eliminates up to 5 seconds of unnecessary delay between daemon crash and restart attempt

## Original prompt
all of these in separate PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
