### PR TITLE
feat: add async keychain variants to avoid blocking the event loop

### DIFF
--- a/assistant/src/security/keychain.ts
+++ b/assistant/src/security/keychain.ts
@@ -4,12 +4,16 @@
  * - macOS: uses the `security` CLI to interact with Keychain
  * - Linux: uses `secret-tool` (libsecret) for GNOME/KDE keyrings
  *
- * All operations are synchronous to match the config loader's sync API.
+ * Sync variants (getKey, setKey, deleteKey) match the config loader's sync API.
+ * Async variants (getKeyAsync, setKeyAsync, deleteKeyAsync) avoid blocking
+ * the event loop and should be preferred for non-startup code paths.
+ *
  * Callers should check `isKeychainAvailable()` before use and fall back
  * to encrypted-at-rest storage when the keychain is not accessible.
  */
 
-import { execFileSync } from 'node:child_process';
+import { execFile, execFileSync } from 'node:child_process';
+import { promisify } from 'node:util';
 
 import { getLogger } from '../util/logger.js';
 import { isLinux,isMacOS } from '../util/platform.js';
@@ -246,6 +250,154 @@ function linuxDeleteKey(account: string): boolean {
       stdio: ['ignore', 'ignore', 'ignore'],
       timeout: 5000,
     });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Async variants — non-blocking alternatives to the sync functions above.
+// Preferred for non-startup code paths to avoid blocking the event loop.
+// ---------------------------------------------------------------------------
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Async version of `getKey` — retrieve a secret without blocking the event loop.
+ * Returns `null` if the key doesn't exist.
+ * Throws on runtime errors (keychain unavailable, locked, etc.).
+ */
+export async function getKeyAsync(account: string): Promise<string | null> {
+  if (deps.isMacOS()) return macosGetKeyAsync(account);
+  if (deps.isLinux()) return linuxGetKeyAsync(account);
+  return null;
+}
+
+/**
+ * Async version of `setKey` — store a secret without blocking the event loop.
+ * Returns true on success, false on failure.
+ */
+export async function setKeyAsync(account: string, value: string): Promise<boolean> {
+  try {
+    if (deps.isMacOS()) return await macosSetKeyAsync(account, value);
+    if (deps.isLinux()) return await linuxSetKeyAsync(account, value);
+    return false;
+  } catch (err) {
+    log.warn({ err, account }, 'Failed to write to keychain');
+    return false;
+  }
+}
+
+/**
+ * Async version of `deleteKey` — delete a secret without blocking the event loop.
+ * Returns true on success, false if not found or on failure.
+ */
+export async function deleteKeyAsync(account: string): Promise<boolean> {
+  try {
+    if (deps.isMacOS()) return await macosDeleteKeyAsync(account);
+    if (deps.isLinux()) return await linuxDeleteKeyAsync(account);
+    return false;
+  } catch (err) {
+    log.debug({ err, account }, 'Failed to delete from keychain');
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Async macOS Keychain
+// ---------------------------------------------------------------------------
+
+async function macosGetKeyAsync(account: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('security', [
+      'find-generic-password',
+      '-s', SERVICE_NAME,
+      '-a', account,
+      '-w',
+    ], { timeout: 5000 });
+    return stdout.replace(/\n$/, '') || null;
+  } catch (err: unknown) {
+    // Exit code 44 = item not found — return null.
+    if (err && typeof err === 'object' && 'code' in err && (err as { code: number }).code === 44) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+async function macosSetKeyAsync(account: string, value: string): Promise<boolean> {
+  try {
+    await execFileAsync('security', [
+      'add-generic-password',
+      '-s', SERVICE_NAME,
+      '-a', account,
+      '-w', value,
+      '-U',
+    ], { timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function macosDeleteKeyAsync(account: string): Promise<boolean> {
+  try {
+    await execFileAsync('security', [
+      'delete-generic-password',
+      '-s', SERVICE_NAME,
+      '-a', account,
+    ], { timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Async Linux via `secret-tool`
+// ---------------------------------------------------------------------------
+
+async function linuxGetKeyAsync(account: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('secret-tool', [
+      'lookup',
+      'service', SERVICE_NAME,
+      'account', account,
+    ], { timeout: 5000 });
+    return stdout.replace(/\n$/, '') || null;
+  } catch (err: unknown) {
+    if (err && typeof err === 'object' && 'code' in err && (err as { code: number }).code === 1) {
+      const stderr = String((err as { stderr?: unknown }).stderr ?? '').trim();
+      if (stderr.length > 0) throw err;
+      return null;
+    }
+    throw err;
+  }
+}
+
+async function linuxSetKeyAsync(account: string, value: string): Promise<boolean> {
+  // secret-tool reads the secret from stdin
+  return new Promise<boolean>((resolve) => {
+    const child = execFile('secret-tool', [
+      'store',
+      '--label', `${SERVICE_NAME}: ${account}`,
+      'service', SERVICE_NAME,
+      'account', account,
+    ], { timeout: 5000 }, (err) => {
+      resolve(!err);
+    });
+    child.stdin?.end(value);
+  });
+}
+
+async function linuxDeleteKeyAsync(account: string): Promise<boolean> {
+  try {
+    await execFileAsync('secret-tool', [
+      'clear',
+      'service', SERVICE_NAME,
+      'account', account,
+    ], { timeout: 5000 });
     return true;
   } catch {
     return false;

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -167,6 +167,90 @@ export function isDowngradedFromKeychain(): boolean {
   return downgradedFromKeychain;
 }
 
+// ---------------------------------------------------------------------------
+// Async variants — non-blocking alternatives that avoid blocking the event
+// loop during keychain operations. Preferred for non-startup code paths.
+// ---------------------------------------------------------------------------
+
+/**
+ * Async version of `getSecureKey` — retrieve a secret without blocking.
+ */
+export async function getSecureKeyAsync(account: string): Promise<string | undefined> {
+  const backend = getBackend();
+  if (backend === 'keychain') {
+    try {
+      return (await keychain.getKeyAsync(account)) ?? undefined;
+    } catch {
+      log.warn('Keychain read failed at runtime, falling back to encrypted file storage');
+      resolvedBackend = 'encrypted';
+      downgradedFromKeychain = true;
+      return encryptedStore.getKey(account);
+    }
+  }
+  if (backend === 'encrypted') {
+    const value = encryptedStore.getKey(account);
+    if (value === undefined && downgradedFromKeychain) {
+      try {
+        return (await keychain.getKeyAsync(account)) ?? undefined;
+      } catch {
+        return undefined;
+      }
+    }
+    return value;
+  }
+  return undefined;
+}
+
+/**
+ * Async version of `setSecureKey` — store a secret without blocking.
+ */
+export async function setSecureKeyAsync(account: string, value: string): Promise<boolean> {
+  const backend = getBackend();
+  if (backend === 'encrypted') return encryptedStore.setKey(account, value);
+  if (backend !== 'keychain') return false;
+
+  const result = await keychain.setKeyAsync(account, value);
+  if (result === false) {
+    log.warn('Keychain operation failed at runtime, falling back to encrypted file storage');
+    resolvedBackend = 'encrypted';
+    downgradedFromKeychain = true;
+    return encryptedStore.setKey(account, value);
+  }
+  return result;
+}
+
+/**
+ * Async version of `deleteSecureKey` — delete a secret without blocking.
+ */
+export async function deleteSecureKeyAsync(account: string): Promise<boolean> {
+  const backend = getBackend();
+  if (backend === 'encrypted') {
+    const result = encryptedStore.deleteKey(account);
+    if (downgradedFromKeychain) {
+      await keychain.deleteKeyAsync(account); // best-effort
+    }
+    return result;
+  }
+  if (backend !== 'keychain') return false;
+
+  try {
+    if ((await keychain.getKeyAsync(account)) == null) {
+      return false;
+    }
+  } catch {
+    // fall through
+  }
+
+  const result = await keychain.deleteKeyAsync(account);
+  if (result === false) {
+    log.warn('Keychain operation failed at runtime, falling back to encrypted file storage');
+    resolvedBackend = 'encrypted';
+    downgradedFromKeychain = true;
+    return encryptedStore.deleteKey(account);
+  }
+  return result;
+}
+
 /** @internal Test-only: reset the cached backend so it's re-evaluated. */
 export function _resetBackend(): void {
   resolvedBackend = undefined;


### PR DESCRIPTION
## Summary
- Add async variants (`getKeyAsync`, `setKeyAsync`, `deleteKeyAsync`) to `keychain.ts` using `child_process.execFile` (non-blocking)
- Mirror async variants in `secure-keys.ts` (`getSecureKeyAsync`, `setSecureKeyAsync`, `deleteSecureKeyAsync`) with the same fallback semantics
- Existing sync API is unchanged — callers can be migrated incrementally

## Original prompt
all of these in separate PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
