### PR TITLE
M1: Introduce unified approval primitive + request adapter

### DIFF
--- a/assistant/src/__tests__/approval-primitive.test.ts
+++ b/assistant/src/__tests__/approval-primitive.test.ts
@@ -1,0 +1,449 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'approval-primitive-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  isDebug: () => false,
+  truncateForLog: (value: string) => value,
+}));
+
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { scopedApprovalGrants } from '../memory/schema.js';
+import {
+  mintGrantFromDecision,
+  consumeGrantForInvocation,
+  type MintGrantParams,
+} from '../approvals/approval-primitive.js';
+import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
+
+initializeDb();
+
+function clearTables(): void {
+  const db = getDb();
+  db.delete(scopedApprovalGrants).run();
+}
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helper to build mint params with sensible defaults
+// ---------------------------------------------------------------------------
+
+function mintParams(overrides: Partial<MintGrantParams> = {}): MintGrantParams {
+  const futureExpiry = new Date(Date.now() + 60_000).toISOString();
+  return {
+    assistantId: 'self',
+    scopeMode: 'request_id',
+    requestChannel: 'telegram',
+    decisionChannel: 'telegram',
+    expiresAt: futureExpiry,
+    ...overrides,
+  };
+}
+
+// ===========================================================================
+// MINT TESTS
+// ===========================================================================
+
+describe('approval-primitive / mintGrantFromDecision', () => {
+  beforeEach(() => clearTables());
+
+  test('mints a request_id scoped grant successfully', () => {
+    const result = mintGrantFromDecision(
+      mintParams({ scopeMode: 'request_id', requestId: 'req-1' }),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.grant.status).toBe('active');
+    expect(result.grant.requestId).toBe('req-1');
+    expect(result.grant.scopeMode).toBe('request_id');
+  });
+
+  test('mints a tool_signature scoped grant successfully', () => {
+    const digest = computeToolApprovalDigest('shell', { command: 'ls' });
+    const result = mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'tool_signature',
+        toolName: 'shell',
+        inputDigest: digest,
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.grant.toolName).toBe('shell');
+    expect(result.grant.inputDigest).toBe(digest);
+    expect(result.grant.scopeMode).toBe('tool_signature');
+  });
+
+  test('rejects request_id scope when requestId is missing', () => {
+    const result = mintGrantFromDecision(
+      mintParams({ scopeMode: 'request_id', requestId: null }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('missing_request_id');
+  });
+
+  test('rejects tool_signature scope when toolName is missing', () => {
+    const result = mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'tool_signature',
+        toolName: null,
+        inputDigest: 'abc123',
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('missing_tool_fields');
+  });
+
+  test('rejects tool_signature scope when inputDigest is missing', () => {
+    const result = mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'tool_signature',
+        toolName: 'shell',
+        inputDigest: null,
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('missing_tool_fields');
+  });
+
+  test('mints grant with full scope context fields', () => {
+    const result = mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'request_id',
+        requestId: 'req-full',
+        conversationId: 'conv-1',
+        callSessionId: 'call-1',
+        requesterExternalUserId: 'user-1',
+        guardianExternalUserId: 'guardian-1',
+        executionChannel: 'voice',
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.grant.conversationId).toBe('conv-1');
+    expect(result.grant.callSessionId).toBe('call-1');
+    expect(result.grant.requesterExternalUserId).toBe('user-1');
+    expect(result.grant.guardianExternalUserId).toBe('guardian-1');
+    expect(result.grant.executionChannel).toBe('voice');
+  });
+});
+
+// ===========================================================================
+// CONSUME TESTS
+// ===========================================================================
+
+describe('approval-primitive / consumeGrantForInvocation', () => {
+  beforeEach(() => clearTables());
+
+  test('consumes a request_id grant when requestId matches', () => {
+    mintGrantFromDecision(mintParams({ scopeMode: 'request_id', requestId: 'req-100' }));
+
+    const result = consumeGrantForInvocation({
+      requestId: 'req-100',
+      toolName: 'shell',
+      inputDigest: computeToolApprovalDigest('shell', { command: 'ls' }),
+      consumingRequestId: 'consumer-1',
+      assistantId: 'self',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.grant.status).toBe('consumed');
+    expect(result.grant.consumedByRequestId).toBe('consumer-1');
+  });
+
+  test('consumes a tool_signature grant when tool+input matches', () => {
+    const digest = computeToolApprovalDigest('shell', { command: 'ls' });
+    mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'tool_signature',
+        toolName: 'shell',
+        inputDigest: digest,
+      }),
+    );
+
+    const result = consumeGrantForInvocation({
+      toolName: 'shell',
+      inputDigest: digest,
+      consumingRequestId: 'consumer-2',
+      assistantId: 'self',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.grant.status).toBe('consumed');
+  });
+
+  test('falls back to tool_signature when request_id does not match', () => {
+    const digest = computeToolApprovalDigest('shell', { command: 'ls' });
+    // Mint a tool_signature grant (not request_id)
+    mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'tool_signature',
+        toolName: 'shell',
+        inputDigest: digest,
+      }),
+    );
+
+    const result = consumeGrantForInvocation({
+      requestId: 'nonexistent-req',
+      toolName: 'shell',
+      inputDigest: digest,
+      consumingRequestId: 'consumer-3',
+      assistantId: 'self',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.grant.scopeMode).toBe('tool_signature');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Consume miss scenarios
+  // ---------------------------------------------------------------------------
+
+  test('miss: no grants exist at all', () => {
+    const result = consumeGrantForInvocation({
+      toolName: 'shell',
+      inputDigest: computeToolApprovalDigest('shell', { command: 'ls' }),
+      consumingRequestId: 'consumer-miss',
+      assistantId: 'self',
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('no_match');
+  });
+
+  test('miss: tool name mismatch', () => {
+    const digest = computeToolApprovalDigest('shell', { command: 'ls' });
+    mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'tool_signature',
+        toolName: 'shell',
+        inputDigest: digest,
+      }),
+    );
+
+    const result = consumeGrantForInvocation({
+      toolName: 'file_write',
+      inputDigest: digest,
+      consumingRequestId: 'consumer-mismatch-tool',
+      assistantId: 'self',
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('no_match');
+  });
+
+  test('miss: input digest mismatch', () => {
+    mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'tool_signature',
+        toolName: 'shell',
+        inputDigest: computeToolApprovalDigest('shell', { command: 'ls' }),
+      }),
+    );
+
+    const result = consumeGrantForInvocation({
+      toolName: 'shell',
+      inputDigest: computeToolApprovalDigest('shell', { command: 'rm -rf /' }),
+      consumingRequestId: 'consumer-mismatch-input',
+      assistantId: 'self',
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('no_match');
+  });
+
+  test('miss: assistant ID mismatch', () => {
+    mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'request_id',
+        requestId: 'req-assist',
+        assistantId: 'assistant-A',
+      }),
+    );
+
+    const result = consumeGrantForInvocation({
+      requestId: 'req-assist',
+      toolName: 'shell',
+      inputDigest: computeToolApprovalDigest('shell', {}),
+      consumingRequestId: 'consumer-assist-mismatch',
+      assistantId: 'assistant-B',
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('no_match');
+  });
+
+  test('miss: grant expired', () => {
+    const pastExpiry = new Date(Date.now() - 60_000).toISOString();
+    mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'request_id',
+        requestId: 'req-expired',
+        expiresAt: pastExpiry,
+      }),
+    );
+
+    const result = consumeGrantForInvocation({
+      requestId: 'req-expired',
+      toolName: 'shell',
+      inputDigest: computeToolApprovalDigest('shell', {}),
+      consumingRequestId: 'consumer-expired',
+      assistantId: 'self',
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('no_match');
+  });
+
+  // ---------------------------------------------------------------------------
+  // One-time consume semantics
+  // ---------------------------------------------------------------------------
+
+  test('one-time consume: second consume of the same grant fails', () => {
+    mintGrantFromDecision(
+      mintParams({ scopeMode: 'request_id', requestId: 'req-once' }),
+    );
+
+    const first = consumeGrantForInvocation({
+      requestId: 'req-once',
+      toolName: 'shell',
+      inputDigest: computeToolApprovalDigest('shell', {}),
+      consumingRequestId: 'consumer-first',
+      assistantId: 'self',
+    });
+    expect(first.ok).toBe(true);
+
+    const second = consumeGrantForInvocation({
+      requestId: 'req-once',
+      toolName: 'shell',
+      inputDigest: computeToolApprovalDigest('shell', {}),
+      consumingRequestId: 'consumer-second',
+      assistantId: 'self',
+    });
+    expect(second.ok).toBe(false);
+    if (second.ok) return;
+    expect(second.reason).toBe('no_match');
+  });
+
+  test('one-time consume: tool_signature grant is consumed only once', () => {
+    const digest = computeToolApprovalDigest('shell', { command: 'deploy' });
+    mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'tool_signature',
+        toolName: 'shell',
+        inputDigest: digest,
+      }),
+    );
+
+    const first = consumeGrantForInvocation({
+      toolName: 'shell',
+      inputDigest: digest,
+      consumingRequestId: 'consumer-sig-first',
+      assistantId: 'self',
+    });
+    expect(first.ok).toBe(true);
+
+    const second = consumeGrantForInvocation({
+      toolName: 'shell',
+      inputDigest: digest,
+      consumingRequestId: 'consumer-sig-second',
+      assistantId: 'self',
+    });
+    expect(second.ok).toBe(false);
+    if (second.ok) return;
+    expect(second.reason).toBe('no_match');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Context-scoped consume
+  // ---------------------------------------------------------------------------
+
+  test('consumes tool_signature grant with matching conversation context', () => {
+    const digest = computeToolApprovalDigest('shell', { command: 'test' });
+    mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'tool_signature',
+        toolName: 'shell',
+        inputDigest: digest,
+        conversationId: 'conv-ctx',
+        callSessionId: 'call-ctx',
+      }),
+    );
+
+    const result = consumeGrantForInvocation({
+      toolName: 'shell',
+      inputDigest: digest,
+      consumingRequestId: 'consumer-ctx',
+      assistantId: 'self',
+      conversationId: 'conv-ctx',
+      callSessionId: 'call-ctx',
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  test('miss: conversation context mismatch on tool_signature grant', () => {
+    const digest = computeToolApprovalDigest('shell', { command: 'test' });
+    mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'tool_signature',
+        toolName: 'shell',
+        inputDigest: digest,
+        conversationId: 'conv-A',
+      }),
+    );
+
+    const result = consumeGrantForInvocation({
+      toolName: 'shell',
+      inputDigest: digest,
+      consumingRequestId: 'consumer-ctx-mismatch',
+      assistantId: 'self',
+      conversationId: 'conv-B',
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('no_match');
+  });
+});

--- a/assistant/src/approvals/approval-primitive.ts
+++ b/assistant/src/approvals/approval-primitive.ts
@@ -1,0 +1,280 @@
+/**
+ * Unified approval primitive for scoped approval grants.
+ *
+ * All producers (voice guardian-action minter, channel guardian approval
+ * interception) and consumers (tool executor grant checks) must go through
+ * this module instead of calling the storage layer directly.  This enforces
+ * all scope constraints in one place and provides structured logging for
+ * mint/consume hit/miss diagnostics.
+ *
+ * Storage remains in `scoped_approval_grants` via the existing CRUD module;
+ * this primitive wraps that layer with a unified API surface.
+ */
+
+import {
+  createScopedApprovalGrant,
+  consumeScopedApprovalGrantByRequestId,
+  consumeScopedApprovalGrantByToolSignature,
+  type ConsumeByRequestIdResult,
+  type ConsumeByToolSignatureResult,
+  type ScopedApprovalGrant,
+} from '../memory/scoped-approval-grants.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('approval-primitive');
+
+// ---------------------------------------------------------------------------
+// Mint
+// ---------------------------------------------------------------------------
+
+export interface MintGrantParams {
+  assistantId: string;
+  scopeMode: 'request_id' | 'tool_signature';
+  requestId?: string | null;
+  toolName?: string | null;
+  inputDigest?: string | null;
+  requestChannel: string;
+  decisionChannel: string;
+  executionChannel?: string | null;
+  conversationId?: string | null;
+  callSessionId?: string | null;
+  requesterExternalUserId?: string | null;
+  guardianExternalUserId?: string | null;
+  expiresAt: string;
+}
+
+export type MintGrantResult =
+  | { ok: true; grant: ScopedApprovalGrant }
+  | { ok: false; reason: 'missing_request_id' | 'missing_tool_fields' | 'storage_error'; error?: unknown };
+
+/**
+ * Mint a scoped approval grant from a guardian decision.
+ *
+ * Validates scope-mode-specific field requirements before delegating to the
+ * storage layer:
+ *   - `request_id` scope requires a non-null `requestId`.
+ *   - `tool_signature` scope requires both `toolName` and `inputDigest`.
+ *
+ * Returns a discriminated result so callers can inspect failure reasons
+ * without catching exceptions.
+ */
+export function mintGrantFromDecision(params: MintGrantParams): MintGrantResult {
+  // Scope-mode field validation
+  if (params.scopeMode === 'request_id' && !params.requestId) {
+    log.warn(
+      {
+        event: 'approval_primitive_mint_rejected',
+        reason: 'missing_request_id',
+        scopeMode: params.scopeMode,
+        assistantId: params.assistantId,
+        requestChannel: params.requestChannel,
+        decisionChannel: params.decisionChannel,
+      },
+      'Mint rejected: request_id scope requires a non-null requestId',
+    );
+    return { ok: false, reason: 'missing_request_id' };
+  }
+
+  if (params.scopeMode === 'tool_signature' && (!params.toolName || !params.inputDigest)) {
+    log.warn(
+      {
+        event: 'approval_primitive_mint_rejected',
+        reason: 'missing_tool_fields',
+        scopeMode: params.scopeMode,
+        toolName: params.toolName ?? null,
+        inputDigest: params.inputDigest ?? null,
+        assistantId: params.assistantId,
+        requestChannel: params.requestChannel,
+        decisionChannel: params.decisionChannel,
+      },
+      'Mint rejected: tool_signature scope requires both toolName and inputDigest',
+    );
+    return { ok: false, reason: 'missing_tool_fields' };
+  }
+
+  try {
+    const grant = createScopedApprovalGrant({
+      assistantId: params.assistantId,
+      scopeMode: params.scopeMode,
+      requestId: params.requestId ?? null,
+      toolName: params.toolName ?? null,
+      inputDigest: params.inputDigest ?? null,
+      requestChannel: params.requestChannel,
+      decisionChannel: params.decisionChannel,
+      executionChannel: params.executionChannel ?? null,
+      conversationId: params.conversationId ?? null,
+      callSessionId: params.callSessionId ?? null,
+      requesterExternalUserId: params.requesterExternalUserId ?? null,
+      guardianExternalUserId: params.guardianExternalUserId ?? null,
+      expiresAt: params.expiresAt,
+    });
+
+    log.info(
+      {
+        event: 'approval_primitive_mint_success',
+        grantId: grant.id,
+        scopeMode: params.scopeMode,
+        toolName: params.toolName ?? null,
+        requestId: params.requestId ?? null,
+        assistantId: params.assistantId,
+        requestChannel: params.requestChannel,
+        decisionChannel: params.decisionChannel,
+        conversationId: params.conversationId ?? null,
+        callSessionId: params.callSessionId ?? null,
+        expiresAt: params.expiresAt,
+      },
+      'Approval grant minted',
+    );
+
+    return { ok: true, grant };
+  } catch (error) {
+    log.error(
+      {
+        event: 'approval_primitive_mint_error',
+        scopeMode: params.scopeMode,
+        toolName: params.toolName ?? null,
+        assistantId: params.assistantId,
+        err: error,
+      },
+      'Failed to mint approval grant (storage error)',
+    );
+    return { ok: false, reason: 'storage_error', error };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Consume
+// ---------------------------------------------------------------------------
+
+export interface ConsumeByRequestIdParams {
+  requestId: string;
+  consumingRequestId: string;
+  assistantId: string;
+  now?: string;
+}
+
+export interface ConsumeByToolSignatureParams {
+  toolName: string;
+  inputDigest: string;
+  consumingRequestId: string;
+  assistantId?: string;
+  executionChannel?: string;
+  conversationId?: string;
+  callSessionId?: string;
+  requesterExternalUserId?: string;
+  now?: string;
+}
+
+export type ConsumeGrantResult =
+  | { ok: true; grant: ScopedApprovalGrant }
+  | { ok: false; reason: 'no_match' | 'scope_mismatch' | 'expired' | 'already_consumed' };
+
+/**
+ * Consume a scoped approval grant for a tool invocation.
+ *
+ * Tries `request_id` mode first when a requestId is provided, then falls
+ * back to `tool_signature` mode.  This mirrors the priority ordering at
+ * the consume site: an exact request-bound grant takes precedence over a
+ * tool-signature grant.
+ *
+ * Returns a discriminated result with structured miss reasons for
+ * diagnostics.
+ */
+export function consumeGrantForInvocation(params: {
+  requestId?: string;
+  toolName: string;
+  inputDigest: string;
+  consumingRequestId: string;
+  assistantId: string;
+  executionChannel?: string;
+  conversationId?: string;
+  callSessionId?: string;
+  requesterExternalUserId?: string;
+  now?: string;
+}): ConsumeGrantResult {
+  // Try request_id mode first when a requestId is provided
+  if (params.requestId) {
+    const reqResult: ConsumeByRequestIdResult = consumeScopedApprovalGrantByRequestId(
+      params.requestId,
+      params.consumingRequestId,
+      params.assistantId,
+      params.now,
+    );
+
+    if (reqResult.ok && reqResult.grant) {
+      log.info(
+        {
+          event: 'approval_primitive_consume_hit',
+          mode: 'request_id',
+          grantId: reqResult.grant.id,
+          requestId: params.requestId,
+          consumingRequestId: params.consumingRequestId,
+          assistantId: params.assistantId,
+          toolName: params.toolName,
+        },
+        'Approval grant consumed via request_id',
+      );
+      return { ok: true, grant: reqResult.grant };
+    }
+
+    log.info(
+      {
+        event: 'approval_primitive_consume_miss',
+        mode: 'request_id',
+        reason: 'no_match',
+        requestId: params.requestId,
+        consumingRequestId: params.consumingRequestId,
+        assistantId: params.assistantId,
+        toolName: params.toolName,
+      },
+      'No request_id grant match, falling through to tool_signature',
+    );
+  }
+
+  // Fall back to tool_signature mode
+  const sigResult: ConsumeByToolSignatureResult = consumeScopedApprovalGrantByToolSignature({
+    toolName: params.toolName,
+    inputDigest: params.inputDigest,
+    consumingRequestId: params.consumingRequestId,
+    assistantId: params.assistantId,
+    executionChannel: params.executionChannel,
+    conversationId: params.conversationId,
+    callSessionId: params.callSessionId,
+    requesterExternalUserId: params.requesterExternalUserId,
+    now: params.now,
+  });
+
+  if (sigResult.ok && sigResult.grant) {
+    log.info(
+      {
+        event: 'approval_primitive_consume_hit',
+        mode: 'tool_signature',
+        grantId: sigResult.grant.id,
+        toolName: params.toolName,
+        consumingRequestId: params.consumingRequestId,
+        assistantId: params.assistantId,
+        conversationId: params.conversationId ?? null,
+        callSessionId: params.callSessionId ?? null,
+      },
+      'Approval grant consumed via tool_signature',
+    );
+    return { ok: true, grant: sigResult.grant };
+  }
+
+  log.info(
+    {
+      event: 'approval_primitive_consume_miss',
+      mode: 'tool_signature',
+      reason: 'no_match',
+      toolName: params.toolName,
+      consumingRequestId: params.consumingRequestId,
+      assistantId: params.assistantId,
+      conversationId: params.conversationId ?? null,
+      callSessionId: params.callSessionId ?? null,
+      executionChannel: params.executionChannel ?? null,
+    },
+    'No tool_signature grant match found',
+  );
+
+  return { ok: false, reason: 'no_match' };
+}

--- a/assistant/src/approvals/request-adapter.ts
+++ b/assistant/src/approvals/request-adapter.ts
@@ -1,0 +1,115 @@
+/**
+ * Request adapter for normalizing approval requests from different channels
+ * into a unified internal shape.
+ *
+ * Two producers currently create approval requests:
+ *   1. Voice guardian actions (ASK_GUARDIAN markers on calls)
+ *   2. Channel guardian approvals (Telegram/SMS tool-approval interception)
+ *
+ * This adapter normalizes both into a single `NormalizedApprovalRequest` so
+ * downstream code (the approval primitive, logging, metrics) can work with
+ * one shape regardless of the originating channel.
+ */
+
+import type { GuardianActionRequest } from '../memory/guardian-action-store.js';
+import type { GuardianApprovalRequest } from '../memory/channel-guardian-store.js';
+
+// ---------------------------------------------------------------------------
+// Normalized shape
+// ---------------------------------------------------------------------------
+
+export interface NormalizedApprovalRequest {
+  /** The assistant this request belongs to. */
+  assistantId: string;
+  /** Unique identifier for this approval request. */
+  requestId: string;
+  /** Channel through which the original tool invocation was requested. */
+  requestChannel: string;
+  /** Channel through which the guardian decision will arrive. */
+  decisionChannel: string;
+  /** Tool name the approval is for (null for informational consults). */
+  toolName: string | null;
+  /** Deterministic digest of the tool invocation input (null when no tool metadata). */
+  inputDigest: string | null;
+  /** Conversation that originated the request. */
+  conversationId: string;
+  /** Voice call session ID (null for non-voice channels). */
+  callSessionId: string | null;
+  /** External user ID of the actor who triggered the tool invocation. */
+  requesterExternalUserId: string | null;
+  /** External user ID of the guardian who will decide. */
+  guardianExternalUserId: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Voice guardian action adapter
+// ---------------------------------------------------------------------------
+
+export interface VoiceGuardianActionContext {
+  /** The guardian action request from the voice call path. */
+  request: GuardianActionRequest;
+  /** Channel the guardian answered on (e.g. 'telegram', 'sms', 'mac'). */
+  decisionChannel: string;
+  /** External user ID of the guardian who answered. */
+  guardianExternalUserId?: string;
+}
+
+/**
+ * Normalize a voice guardian-action request into the unified shape.
+ *
+ * Voice guardian actions originate from the call path (ASK_GUARDIAN markers)
+ * and carry tool metadata in `toolName` / `inputDigest` fields on the
+ * request record.  The `sourceChannel` on the request represents the
+ * requester's channel (the voice call), while `decisionChannel` is the
+ * channel the guardian used to respond.
+ */
+export function normalizeVoiceGuardianAction(ctx: VoiceGuardianActionContext): NormalizedApprovalRequest {
+  return {
+    assistantId: ctx.request.assistantId,
+    requestId: ctx.request.id,
+    requestChannel: ctx.request.sourceChannel,
+    decisionChannel: ctx.decisionChannel,
+    toolName: ctx.request.toolName ?? null,
+    inputDigest: ctx.request.inputDigest ?? null,
+    conversationId: ctx.request.sourceConversationId,
+    callSessionId: ctx.request.callSessionId,
+    requesterExternalUserId: null,
+    guardianExternalUserId: ctx.guardianExternalUserId ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Channel guardian approval adapter
+// ---------------------------------------------------------------------------
+
+export interface ChannelGuardianApprovalContext {
+  /** The channel guardian approval request record. */
+  approval: GuardianApprovalRequest;
+  /** Channel the guardian decision arrived on. */
+  decisionChannel: string;
+  /** Tool invocation input digest (computed externally since the approval
+   *  record does not store raw input). */
+  inputDigest?: string | null;
+}
+
+/**
+ * Normalize a channel guardian approval request into the unified shape.
+ *
+ * Channel guardian approvals originate from Telegram/SMS/WhatsApp tool-use
+ * confirmation flows.  The approval record's `channel` field represents the
+ * requester's channel, and `decisionChannel` is where the guardian responds.
+ */
+export function normalizeChannelGuardianApproval(ctx: ChannelGuardianApprovalContext): NormalizedApprovalRequest {
+  return {
+    assistantId: ctx.approval.assistantId,
+    requestId: ctx.approval.requestId ?? ctx.approval.runId,
+    requestChannel: ctx.approval.channel,
+    decisionChannel: ctx.decisionChannel,
+    toolName: ctx.approval.toolName,
+    inputDigest: ctx.inputDigest ?? null,
+    conversationId: ctx.approval.conversationId,
+    callSessionId: null,
+    requesterExternalUserId: ctx.approval.requesterExternalUserId,
+    guardianExternalUserId: ctx.approval.guardianExternalUserId,
+  };
+}

--- a/assistant/src/approvals/request-adapter.ts
+++ b/assistant/src/approvals/request-adapter.ts
@@ -102,14 +102,14 @@ export interface ChannelGuardianApprovalContext {
 export function normalizeChannelGuardianApproval(ctx: ChannelGuardianApprovalContext): NormalizedApprovalRequest {
   return {
     assistantId: ctx.approval.assistantId,
-    requestId: ctx.approval.requestId ?? ctx.approval.runId,
+    requestId: ctx.approval.requestId ?? ctx.approval.id,
     requestChannel: ctx.approval.channel,
     decisionChannel: ctx.decisionChannel,
     toolName: ctx.approval.toolName,
     inputDigest: ctx.inputDigest ?? null,
     conversationId: ctx.approval.conversationId,
     callSessionId: null,
-    requesterExternalUserId: ctx.approval.requesterExternalUserId,
+    requesterExternalUserId: ctx.approval.requesterExternalUserId || null,
     guardianExternalUserId: ctx.approval.guardianExternalUserId,
   };
 }


### PR DESCRIPTION
Part of #10276. Creates the unified approval primitive (mintGrantFromDecision, consumeGrantForInvocation) and request adapter for normalizing voice/channel guardian requests. Wraps existing scoped-approval-grants storage. Adds structured logging for mint/consume hit/miss reasons. Includes unit tests for mint/consume success, scope mismatches, and one-time consume semantics.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
