### PR TITLE
M2: Move all grant producers to primitive

### DIFF
--- a/assistant/src/runtime/guardian-action-grant-minter.ts
+++ b/assistant/src/runtime/guardian-action-grant-minter.ts
@@ -7,8 +7,8 @@
  * consistently regardless of which channel the guardian answers on.
  */
 
+import { mintGrantFromDecision } from '../approvals/approval-primitive.js';
 import type { GuardianActionRequest } from '../memory/guardian-action-store.js';
-import { createScopedApprovalGrant } from '../memory/scoped-approval-grants.js';
 import { getLogger } from '../util/logger.js';
 import { parseApprovalDecision } from './channel-approval-parser.js';
 
@@ -63,21 +63,21 @@ export function tryMintGuardianActionGrant(params: {
     return;
   }
 
-  try {
-    createScopedApprovalGrant({
-      assistantId: resolvedRequest.assistantId,
-      scopeMode: 'tool_signature',
-      toolName: resolvedRequest.toolName,
-      inputDigest: resolvedRequest.inputDigest,
-      requestChannel: resolvedRequest.sourceChannel,
-      decisionChannel,
-      executionChannel: null,
-      conversationId: resolvedRequest.sourceConversationId,
-      callSessionId: resolvedRequest.callSessionId,
-      guardianExternalUserId: guardianExternalUserId ?? null,
-      expiresAt: new Date(Date.now() + GUARDIAN_ACTION_GRANT_TTL_MS).toISOString(),
-    });
+  const result = mintGrantFromDecision({
+    assistantId: resolvedRequest.assistantId,
+    scopeMode: 'tool_signature',
+    toolName: resolvedRequest.toolName,
+    inputDigest: resolvedRequest.inputDigest,
+    requestChannel: resolvedRequest.sourceChannel,
+    decisionChannel,
+    executionChannel: null,
+    conversationId: resolvedRequest.sourceConversationId,
+    callSessionId: resolvedRequest.callSessionId,
+    guardianExternalUserId: guardianExternalUserId ?? null,
+    expiresAt: new Date(Date.now() + GUARDIAN_ACTION_GRANT_TTL_MS).toISOString(),
+  });
 
+  if (result.ok) {
     log.info(
       {
         event: 'guardian_action_grant_minted',
@@ -88,9 +88,9 @@ export function tryMintGuardianActionGrant(params: {
       },
       'Minted scoped approval grant for guardian-action answer resolution',
     );
-  } catch (err) {
+  } else {
     log.error(
-      { err, toolName: resolvedRequest.toolName, requestId: resolvedRequest.id },
+      { reason: result.reason, toolName: resolvedRequest.toolName, requestId: resolvedRequest.id },
       'Failed to mint scoped approval grant for guardian-action (non-fatal)',
     );
   }

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -81,7 +81,16 @@ function tryMintToolApprovalGrant(params: {
     return;
   }
 
-  const inputDigest = computeToolApprovalDigest(approvalInfo.toolName, approvalInfo.input);
+  let inputDigest: string;
+  try {
+    inputDigest = computeToolApprovalDigest(approvalInfo.toolName, approvalInfo.input);
+  } catch (err) {
+    log.error(
+      { err, toolName: approvalInfo.toolName, conversationId: approval.conversationId },
+      'Failed to compute tool approval digest for grant minting (non-fatal)',
+    );
+    return;
+  }
 
   const result = mintGrantFromDecision({
     assistantId: approval.assistantId,

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -2,6 +2,7 @@
  * Approval interception: checks for pending approvals and handles inbound
  * messages as decisions, reminders, or conversational follow-ups.
  */
+import { mintGrantFromDecision } from '../../approvals/approval-primitive.js';
 import type { ChannelId } from '../../channels/types.js';
 import {
   getAllPendingApprovalsByGuardianChat,
@@ -11,7 +12,6 @@ import {
   type GuardianApprovalRequest,
   updateApprovalDecision,
 } from '../../memory/channel-guardian-store.js';
-import { createScopedApprovalGrant } from '../../memory/scoped-approval-grants.js';
 import { emitNotificationSignal } from '../../notifications/emit-signal.js';
 import { computeToolApprovalDigest } from '../../security/tool-approval-digest.js';
 import { getLogger } from '../../util/logger.js';
@@ -81,31 +81,31 @@ function tryMintToolApprovalGrant(params: {
     return;
   }
 
-  try {
-    const inputDigest = computeToolApprovalDigest(approvalInfo.toolName, approvalInfo.input);
+  const inputDigest = computeToolApprovalDigest(approvalInfo.toolName, approvalInfo.input);
 
-    createScopedApprovalGrant({
-      assistantId: approval.assistantId,
-      scopeMode: 'tool_signature',
-      toolName: approvalInfo.toolName,
-      inputDigest,
-      requestChannel: approval.channel,
-      decisionChannel,
-      executionChannel: null,
-      conversationId: approval.conversationId,
-      callSessionId: null,
-      guardianExternalUserId,
-      requesterExternalUserId: approval.requesterExternalUserId,
-      expiresAt: new Date(Date.now() + GRANT_TTL_MS).toISOString(),
-    });
+  const result = mintGrantFromDecision({
+    assistantId: approval.assistantId,
+    scopeMode: 'tool_signature',
+    toolName: approvalInfo.toolName,
+    inputDigest,
+    requestChannel: approval.channel,
+    decisionChannel,
+    executionChannel: null,
+    conversationId: approval.conversationId,
+    callSessionId: null,
+    guardianExternalUserId,
+    requesterExternalUserId: approval.requesterExternalUserId,
+    expiresAt: new Date(Date.now() + GRANT_TTL_MS).toISOString(),
+  });
 
+  if (result.ok) {
     log.info(
       { toolName: approvalInfo.toolName, conversationId: approval.conversationId },
       'Minted scoped approval grant for guardian tool-approval decision',
     );
-  } catch (err) {
+  } else {
     log.error(
-      { err, toolName: approvalInfo.toolName, conversationId: approval.conversationId },
+      { reason: result.reason, toolName: approvalInfo.toolName, conversationId: approval.conversationId },
       'Failed to mint scoped approval grant (non-fatal)',
     );
   }


### PR DESCRIPTION
Part of #10276. Migrates guardian-action-grant-minter.ts and guardian-approval-interception.ts from direct createScopedApprovalGrant calls to mintGrantFromDecision via the unified approval primitive. Preserves all existing identity checks, stale handling, and natural-language paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
