### PR TITLE
fix: re-run active-thread seen check after restore

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -956,6 +956,12 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
     /// Restore the last active thread from UserDefaults after session restoration completes
     func restoreLastActiveThread() {
+        // After restoration finishes, re-run the active-thread seen check.
+        // The didBecomeActive notification may have fired while isRestoringThreads
+        // was true, causing markActiveThreadSeenIfNeeded() to no-op. Deferring
+        // ensures the check runs once restoration is complete.
+        defer { markActiveThreadSeenIfNeeded() }
+
         guard restoreRecentThreads else {
             // Clear the flag even if restoration is disabled
             isRestoringThreads = false


### PR DESCRIPTION
Addresses Codex review feedback on #10274: markActiveThreadSeenIfNeeded() exits early while isRestoringThreads is true, but the didBecomeActive notification can fire before restoration finishes on cold launch, leaving the preselected unread thread marked unseen until the next foreground cycle. This adds a defer call to markActiveThreadSeenIfNeeded() in restoreLastActiveThread() so the seen check is retried once restoration completes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
