### PR TITLE
fix: dismiss only the mark-all toast on deferred seen-signal commit

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -498,7 +498,7 @@ extension AppDelegate {
         let markedIds = threadManager.markAllThreadsSeen()
         guard !markedIds.isEmpty else { return }
         let count = markedIds.count
-        mainWindow?.windowState.showToast(
+        let toastId = mainWindow?.windowState.showToast(
             message: "Marked \(count) thread\(count == 1 ? "" : "s") as seen",
             style: .success,
             primaryAction: VToastAction(label: "Undo") { [weak self] in
@@ -510,7 +510,8 @@ extension AppDelegate {
             }
         )
         threadManager.schedulePendingSeenSignals { [weak self] in
-            self?.mainWindow?.windowState.dismissToast()
+            guard let toastId else { return }
+            self?.mainWindow?.windowState.dismissToast(id: toastId)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -241,8 +241,12 @@ public final class MainWindowState: ObservableObject {
     /// - Parameters:
     ///   - onDismiss: Optional callback invoked when the toast is dismissed
     ///     by the user (via the X button), as opposed to a primary action.
-    func showToast(message: String, style: ToastInfo.Style, primaryAction: VToastAction? = nil, onDismiss: (() -> Void)? = nil) {
-        toastInfo = ToastInfo(message: message, style: style, primaryAction: primaryAction, onDismiss: onDismiss)
+    /// - Returns: The unique ID of the displayed toast, useful for targeted dismissal.
+    @discardableResult
+    func showToast(message: String, style: ToastInfo.Style, primaryAction: VToastAction? = nil, onDismiss: (() -> Void)? = nil) -> UUID {
+        let toast = ToastInfo(message: message, style: style, primaryAction: primaryAction, onDismiss: onDismiss)
+        toastInfo = toast
+        return toast.id
     }
 
     /// Dismiss the currently displayed toast, invoking its onDismiss callback.
@@ -250,6 +254,13 @@ public final class MainWindowState: ObservableObject {
         let callback = toastInfo?.onDismiss
         toastInfo = nil
         callback?()
+    }
+
+    /// Dismiss the toast only if it matches the given ID.
+    /// Prevents deferred callbacks from accidentally dismissing a different toast.
+    func dismissToast(id: UUID) {
+        guard toastInfo?.id == id else { return }
+        dismissToast()
     }
 
     /// Restore the last active panel from UserDefaults
@@ -269,9 +280,18 @@ struct ToastInfo {
         case warning
     }
 
+    let id: UUID
     let message: String
     let style: Style
     let primaryAction: VToastAction?
     /// Called when the toast is dismissed via the X button (not via primary action).
     let onDismiss: (() -> Void)?
+
+    init(message: String, style: Style, primaryAction: VToastAction? = nil, onDismiss: (() -> Void)? = nil) {
+        self.id = UUID()
+        self.message = message
+        self.style = style
+        self.primaryAction = primaryAction
+        self.onDismiss = onDismiss
+    }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1198,7 +1198,7 @@ struct MainWindowView: View {
                     let markedIds = threadManager.markAllThreadsSeen()
                     guard !markedIds.isEmpty else { return }
                     let count = markedIds.count
-                    windowState.showToast(
+                    let toastId = windowState.showToast(
                         message: "Marked \(count) thread\(count == 1 ? "" : "s") as seen",
                         style: .success,
                         primaryAction: VToastAction(label: "Undo") {
@@ -1210,7 +1210,7 @@ struct MainWindowView: View {
                         }
                     )
                     threadManager.schedulePendingSeenSignals {
-                        windowState.dismissToast()
+                        windowState.dismissToast(id: toastId)
                     }
                 },
                 onNewThread: {


### PR DESCRIPTION
Addresses Codex feedback on #10262: instead of calling dismissToast() unconditionally after the 5s undo window, verify that the current toast is still the mark-all toast before dismissing it. This prevents accidentally dismissing a different toast that appeared during the undo window.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
