### PR TITLE
fix: gate deferred seen check on app activation state

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -748,7 +748,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// or switches back to the app) so that a pre-selected unread thread is
     /// marked seen without requiring a thread switch.
     func markActiveThreadSeenIfNeeded() {
-        guard !isRestoringThreads,
+        guard NSApp.isActive,
+              !isRestoringThreads,
               let activeId = activeThreadId,
               let idx = threads.firstIndex(where: { $0.id == activeId }),
               threads[idx].hasUnseenLatestAssistantMessage else { return }


### PR DESCRIPTION
Codex P2 feedback on #10297: markActiveThreadSeenIfNeeded() didn't check whether the app was actually foregrounded. During cold launch of this menu bar app, the deferred call from restoreLastActiveThread() could mark messages as seen before the user opens the popover. Added NSApp.isActive guard.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
