### PR TITLE
Add SMS assistant feature flag for skill + Connect UI

### DIFF
--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -8,6 +8,9 @@ import type { SkillSummary } from '../config/skills.js';
 const DECLARED_FLAG_KEY = 'feature_flags.hatch-new-assistant.enabled';
 const DECLARED_LEGACY_KEY = 'skills.hatch-new-assistant.enabled';
 const DECLARED_SKILL_ID = 'hatch-new-assistant';
+const SMS_FLAG_KEY = 'feature_flags.sms.enabled';
+const SMS_LEGACY_KEY = 'skills.sms.enabled';
+const SMS_SKILL_ID = 'sms-setup';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -114,6 +117,19 @@ describe('isAssistantSkillEnabled', () => {
       assistantFeatureFlagValues: { 'feature_flags.browser.enabled': false },
     });
     expect(isAssistantSkillEnabled('browser', config)).toBe(true);
+  });
+
+  test('supports skill-to-flag override keys (skill id does not need to match flag id)', () => {
+    const config = makeConfig({
+      featureFlags: {
+        [SMS_LEGACY_KEY]: false,
+        'skills.sms-setup.enabled': true,
+      },
+      assistantFeatureFlagValues: {
+        [SMS_FLAG_KEY]: false,
+      },
+    });
+    expect(isAssistantSkillEnabled(SMS_SKILL_ID, config)).toBe(false);
   });
 });
 
@@ -227,5 +243,18 @@ describe('resolveSkillStates with feature flags', () => {
     const ids = resolved.map((r) => r.summary.id);
 
     expect(ids).toEqual(['twitter', 'deploy']);
+  });
+
+  test('skill-to-flag override applies to skill state resolution', () => {
+    const catalog = [makeSkill(SMS_SKILL_ID)];
+    const config = makeConfig({
+      featureFlags: {
+        [SMS_LEGACY_KEY]: false,
+        'skills.sms-setup.enabled': true,
+      },
+    });
+
+    const resolved = resolveSkillStates(catalog, config);
+    expect(resolved).toHaveLength(0);
   });
 });

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -9,7 +9,6 @@ const DECLARED_FLAG_KEY = 'feature_flags.hatch-new-assistant.enabled';
 const DECLARED_LEGACY_KEY = 'skills.hatch-new-assistant.enabled';
 const DECLARED_SKILL_ID = 'hatch-new-assistant';
 const SMS_FLAG_KEY = 'feature_flags.sms.enabled';
-const SMS_LEGACY_KEY = 'skills.sms.enabled';
 const SMS_SKILL_ID = 'sms-setup';
 
 // ---------------------------------------------------------------------------
@@ -121,12 +120,9 @@ describe('isAssistantSkillEnabled', () => {
 
   test('supports skill-to-flag override keys (skill id does not need to match flag id)', () => {
     const config = makeConfig({
-      featureFlags: {
-        [SMS_LEGACY_KEY]: false,
-        'skills.sms-setup.enabled': true,
-      },
       assistantFeatureFlagValues: {
         [SMS_FLAG_KEY]: false,
+        'feature_flags.sms-setup.enabled': true,
       },
     });
     expect(isAssistantSkillEnabled(SMS_SKILL_ID, config)).toBe(false);
@@ -248,9 +244,9 @@ describe('resolveSkillStates with feature flags', () => {
   test('skill-to-flag override applies to skill state resolution', () => {
     const catalog = [makeSkill(SMS_SKILL_ID)];
     const config = makeConfig({
-      featureFlags: {
-        [SMS_LEGACY_KEY]: false,
-        'skills.sms-setup.enabled': true,
+      assistantFeatureFlagValues: {
+        [SMS_FLAG_KEY]: false,
+        'feature_flags.sms-setup.enabled': true,
       },
     });
 

--- a/assistant/src/config/assistant-feature-flag-defaults.json
+++ b/assistant/src/config/assistant-feature-flag-defaults.json
@@ -2,5 +2,9 @@
   "feature_flags.hatch-new-assistant.enabled": {
     "defaultEnabled": true,
     "description": "Show Hatch New Assistant action in Settings > Account"
+  },
+  "feature_flags.sms.enabled": {
+    "defaultEnabled": true,
+    "description": "Show SMS setup in Settings > Connect and enable the SMS setup skill"
   }
 }

--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -89,6 +89,14 @@ function canonicalToLegacyKey(canonicalKey: string): string | undefined {
   return `skills.${match[1]}.enabled`;
 }
 
+/**
+ * Optional skill-to-flag overrides. This lets a skill be gated by a flag whose
+ * key does not have to match the skill ID.
+ */
+const SKILL_FLAG_KEY_OVERRIDES: Record<string, string> = {
+  'sms-setup': 'feature_flags.sms.enabled',
+};
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -136,10 +144,14 @@ export function isAssistantFeatureFlagEnabled(key: string, config: AssistantConf
 /**
  * Convenience: check whether a skill is enabled by its skill ID.
  *
- * Translates the skill ID to the canonical key format
- * `feature_flags.<skillId>.enabled` and delegates to the full resolver.
+ * Uses a skill-specific override key when one is declared; otherwise
+ * falls back to `feature_flags.<skillId>.enabled`.
  */
 export function isAssistantSkillEnabled(skillId: string, config: AssistantConfig): boolean {
+  const overrideKey = SKILL_FLAG_KEY_OVERRIDES[skillId];
+  if (overrideKey) {
+    return isAssistantFeatureFlagEnabled(overrideKey, config);
+  }
   return isAssistantFeatureFlagEnabled(`feature_flags.${skillId}.enabled`, config);
 }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -9,6 +9,7 @@ import VellumAssistantShared
 struct SettingsChannelsTab: View {
     @ObservedObject var store: SettingsStore
     var daemonClient: DaemonClient?
+    private static let smsFeatureFlagKey = "feature_flags.sms.enabled"
 
     @State private var bearerToken: String = ""
     @State private var tokenRevealed: Bool = false
@@ -16,6 +17,7 @@ struct SettingsChannelsTab: View {
     @State private var showingPairingQR: Bool = false
     @State private var showingRegenerateConfirmation: Bool = false
     @State private var advancedExpanded: Bool = false
+    @State private var isSmsFeatureEnabled: Bool = true
 
     // Telegram credential entry
     @State private var telegramBotTokenText = ""
@@ -72,10 +74,15 @@ struct SettingsChannelsTab: View {
             store.refreshApprovedDevices()
             refreshBearerToken()
             store.refreshChannelGuardianStatus(channel: "telegram")
-            store.refreshChannelGuardianStatus(channel: "sms")
             store.refreshChannelGuardianStatus(channel: "voice")
             store.refreshTelegramApprovedMembers()
             store.fetchSlackChannelConfig()
+            Task {
+                await loadSmsFeatureFlag()
+                if isSmsFeatureEnabled {
+                    store.refreshChannelGuardianStatus(channel: "sms")
+                }
+            }
         }
         .onChange(of: store.twilioHasCredentials) { _, hasCredentials in
             if !hasCredentials {
@@ -189,7 +196,9 @@ struct SettingsChannelsTab: View {
             telegramCard
             slackChannelCard
             voiceCard
-            twilioCard
+            if isSmsFeatureEnabled {
+                twilioCard
+            }
             emailCard
         }
     }
@@ -1707,6 +1716,32 @@ struct SettingsChannelsTab: View {
 
 
     // MARK: - Token Helpers
+
+    private func loadSmsFeatureFlag() async {
+        // Primary source: gateway feature-flags API.
+        if let daemonClient {
+            do {
+                let flags = try await daemonClient.getFeatureFlags()
+                if let smsFlag = flags.first(where: { $0.key == Self.smsFeatureFlagKey }) {
+                    isSmsFeatureEnabled = smsFlag.enabled
+                    return
+                }
+            } catch {
+                // Fall through to local config fallback.
+            }
+        }
+
+        // Fallback: local workspace config values.
+        let config = WorkspaceConfigIO.read()
+        if let canonicalFlags = config["assistantFeatureFlagValues"] as? [String: Bool],
+           let enabled = canonicalFlags[Self.smsFeatureFlagKey] {
+            isSmsFeatureEnabled = enabled
+            return
+        }
+
+        // No legacy `skills.*` fallback in new production code. If canonical
+        // values are absent, keep the default enabled behavior.
+    }
 
     private func refreshBearerToken() {
         bearerToken = readHttpToken() ?? ""

--- a/meta/assistant-feature-flags/assistant-feature-flag-defaults.json
+++ b/meta/assistant-feature-flags/assistant-feature-flag-defaults.json
@@ -2,5 +2,9 @@
   "feature_flags.hatch-new-assistant.enabled": {
     "defaultEnabled": true,
     "description": "Show Hatch New Assistant action in Settings > Account"
+  },
+  "feature_flags.sms.enabled": {
+    "defaultEnabled": true,
+    "description": "Show SMS setup in Settings > Connect and enable the SMS setup skill"
   }
 }


### PR DESCRIPTION
## Summary
- adds a new declarative assistant feature flag: `feature_flags.sms.enabled`
- gates the SMS setup skill behind this flag while avoiding skill-id naming requirements
  - explicit resolver override maps `sms-setup` -> `feature_flags.sms.enabled`
- hides the SMS section in Settings > Connect when the flag is OFF
  - Connect tab loads assistant flags from gateway (`getFeatureFlags`) and falls back to local canonical config values

## Behavior
- When `feature_flags.sms.enabled = false`:
  - `sms-setup` skill is unavailable to the assistant (`isAssistantSkillEnabled` returns false)
  - SMS card is hidden from Settings > Connect
- When `true` (default): existing behavior remains

## Validation
- `cd assistant && export PATH="$HOME/.bun/bin:$PATH" && bun test src/__tests__/skill-feature-flags.test.ts src/__tests__/assistant-feature-flag-guard.test.ts src/__tests__/assistant-feature-flag-guardrails.test.ts src/__tests__/skill-load-feature-flag.test.ts src/__tests__/skill-projection-feature-flag.test.ts`
- `cd assistant && export PATH="$HOME/.bun/bin:$PATH" && bunx tsc --noEmit`
- `cd gateway && export PATH="$HOME/.bun/bin:$PATH" && bun test src/__tests__/feature-flags-route.test.ts src/feature-flags-auth.test.ts`
- `cd gateway && export PATH="$HOME/.bun/bin:$PATH" && bunx tsc --noEmit`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
