### PR TITLE
fix: preserve persisted overrides for undeclared feature flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,8 +170,8 @@ All assistant API requests from clients, CLI, skills, and user-facing tooling **
 Assistant feature flags are the canonical assistant-scoped flagging mechanism for enabling/disabling assistant behavior across the system. They are declaration-driven and not limited to skills.
 
 - **Canonical key format:** `feature_flags.<flagId>.enabled`. All new code must use this format. The legacy `skills.<id>.enabled` format is still read for backward compatibility but must not be introduced in new code.
-- **Defaults registry:** All declared flags and their default values live in `meta/assistant-feature-flags/assistant-feature-flag-defaults.json`. Only keys declared in this registry participate in assistant feature-flag resolution and UI exposure.
-- **Resolver:** The canonical resolver in `assistant/src/config/assistant-feature-flags.ts` resolves effective flag state by checking (in order): explicit config overrides, legacy config values, and registry defaults.
+- **Defaults registry:** All declared flags and their default values live in `meta/assistant-feature-flags/assistant-feature-flag-defaults.json`. Keys declared in this registry participate in UI exposure and have registry-defined defaults. Undeclared keys still respect persisted config overrides but default to enabled when no override exists.
+- **Resolver:** The canonical resolver in `assistant/src/config/assistant-feature-flags.ts` resolves effective flag state by checking (in order): explicit config overrides, legacy config values, registry defaults (for declared keys), and finally `true` (for undeclared keys with no persisted override).
 - **Gateway API:** The gateway owns the `/v1/feature-flags` REST API for reading and mutating flags. New writes are stored in the `assistantFeatureFlagValues` config section using canonical keys.
 - **Guard tests:** A guard test (`assistant-feature-flag-guard.test.ts`) enforces two invariants:
   1. All feature flag key literals in production code use the canonical `feature_flags.<id>.enabled` format (not the legacy `skills.<id>.enabled` format).

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -319,7 +319,7 @@ The assistant feature-flag resolver (`src/config/assistant-feature-flags.ts`) is
 1. `config.assistantFeatureFlagValues[key]` — new canonical config section, written by the gateway's PATCH endpoint
 2. `config.featureFlags[legacyKey]` — legacy `skills.<id>.enabled` key mapping (backward-compat)
 3. Defaults registry `defaultEnabled` — from `meta/assistant-feature-flags/assistant-feature-flag-defaults.json`
-4. `true` — unknown/undeclared flags default to enabled and are ignored by the flag system
+4. `true` — unknown/undeclared flags with no persisted override default to enabled
 
 **Backward-compat path:** The legacy `featureFlags` config section (key format `skills.<id>.enabled`) is still read as a fallback during resolution. New writes go to `assistantFeatureFlagValues` using the canonical format. The `isSkillFeatureEnabled()` wrapper in `config/skill-state.ts` is deprecated but retained as a thin delegate to `isAssistantSkillEnabled()` for migration compatibility.
 

--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -171,8 +171,9 @@ describe('buildSystemPrompt assistant feature flag filtering', () => {
     const result = buildSystemPrompt();
 
     expect(result).not.toContain(`id="${DECLARED_SKILL_ID}"`);
-    // Undeclared skill IDs are intentionally unaffected by assistant feature flags.
-    expect(result).toContain('id="twitter"');
+    // Twitter is undeclared but also has an explicit persisted override (false),
+    // so it should be hidden too.
+    expect(result).not.toContain('id="twitter"');
   });
 
   test('new assistantFeatureFlagValues takes priority over legacy featureFlags', () => {
@@ -190,13 +191,28 @@ describe('buildSystemPrompt assistant feature flag filtering', () => {
     expect(result).toContain(`id="${DECLARED_SKILL_ID}"`);
   });
 
-  test('undeclared skill flags are ignored', () => {
+  test('persisted overrides for undeclared flags are respected', () => {
     createSkillOnDisk('browser', 'Browser', 'Web browsing automation');
 
     currentConfig = {
       sandbox: { enabled: false, backend: 'native' },
       featureFlags: { 'skills.browser.enabled': false },
       assistantFeatureFlagValues: { 'feature_flags.browser.enabled': false },
+    };
+
+    const result = buildSystemPrompt();
+
+    // Even though 'browser' is not in the defaults registry, the user
+    // explicitly disabled it — that override must be honored.
+    expect(result).not.toContain('id="browser"');
+  });
+
+  test('undeclared flags with no persisted override default to enabled', () => {
+    createSkillOnDisk('browser', 'Browser', 'Web browsing automation');
+
+    currentConfig = {
+      sandbox: { enabled: false, backend: 'native' },
+      featureFlags: {},
     };
 
     const result = buildSystemPrompt();
@@ -237,12 +253,29 @@ describe('isAssistantFeatureFlagEnabled', () => {
     expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(true);
   });
 
-  test('unknown flag defaults to true', () => {
+  test('unknown flag defaults to true when no persisted override', () => {
     const config = {
       featureFlags: {},
     } as any;
 
     expect(isAssistantFeatureFlagEnabled('feature_flags.unknown-skill.enabled', config)).toBe(true);
+  });
+
+  test('undeclared flag respects persisted canonical override', () => {
+    const config = {
+      featureFlags: {},
+      assistantFeatureFlagValues: { 'feature_flags.browser.enabled': false },
+    } as any;
+
+    expect(isAssistantFeatureFlagEnabled('feature_flags.browser.enabled', config)).toBe(false);
+  });
+
+  test('undeclared flag respects persisted legacy override', () => {
+    const config = {
+      featureFlags: { 'skills.browser.enabled': false },
+    } as any;
+
+    expect(isAssistantFeatureFlagEnabled('feature_flags.browser.enabled', config)).toBe(false);
   });
 });
 

--- a/assistant/src/__tests__/skill-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags-integration.test.ts
@@ -164,8 +164,8 @@ describe('buildSystemPrompt feature flag filtering', () => {
 
     const result = buildSystemPrompt();
 
-    // Declared flagged skill is hidden; undeclared keys do not gate skill visibility.
+    // Both are hidden: declared skill via registry, undeclared via persisted override.
     expect(result).not.toContain(`id="${DECLARED_SKILL_ID}"`);
-    expect(result).toContain('id="twitter"');
+    expect(result).not.toContain('id="twitter"');
   });
 });

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -108,11 +108,16 @@ describe('isAssistantSkillEnabled', () => {
     expect(isAssistantSkillEnabled(DECLARED_SKILL_ID, config)).toBe(true);
   });
 
-  test('ignores persisted values for undeclared skills', () => {
+  test('respects persisted overrides for undeclared skills', () => {
     const config = makeConfig({
       featureFlags: { 'skills.browser.enabled': false },
       assistantFeatureFlagValues: { 'feature_flags.browser.enabled': false },
     });
+    expect(isAssistantSkillEnabled('browser', config)).toBe(false);
+  });
+
+  test('undeclared skills with no persisted override default to enabled', () => {
+    const config = makeConfig({ featureFlags: {} });
     expect(isAssistantSkillEnabled('browser', config)).toBe(true);
   });
 });
@@ -142,11 +147,16 @@ describe('isAssistantFeatureFlagEnabled', () => {
     expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(true);
   });
 
-  test('ignores persisted values for undeclared keys', () => {
+  test('respects persisted overrides for undeclared keys', () => {
     const config = makeConfig({
       featureFlags: { 'skills.browser.enabled': false },
       assistantFeatureFlagValues: { 'feature_flags.browser.enabled': false },
     });
+    expect(isAssistantFeatureFlagEnabled('feature_flags.browser.enabled', config)).toBe(false);
+  });
+
+  test('undeclared keys with no persisted override default to enabled', () => {
+    const config = makeConfig({ featureFlags: {} });
     expect(isAssistantFeatureFlagEnabled('feature_flags.browser.enabled', config)).toBe(true);
   });
 });

--- a/assistant/src/__tests__/skill-projection-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-projection-feature-flag.test.ts
@@ -349,7 +349,7 @@ describe('projectSkillTools feature flag enforcement', () => {
     ];
     const prevActive = new Map<string, string>();
 
-    // Declared skill is OFF, twitter is undeclared and remains ON.
+    // Declared skill is OFF, twitter is undeclared with no persisted override so remains ON.
     currentConfig = {
       featureFlags: { [DECLARED_LEGACY_KEY]: false },
     };

--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -9,9 +9,11 @@
  *   2. `config.featureFlags[legacyKey]`           (legacy backward-compat)
  *   3. defaults registry `defaultEnabled`
  *
- * Only declared flags participate in resolution. Undeclared keys are treated
- * as not part of the assistant feature-flag system and always resolve to
- * enabled (`true`) regardless of persisted config values.
+ * For undeclared keys (not in the defaults registry), persisted config
+ * overrides are still respected — if the user explicitly set a value in
+ * `assistantFeatureFlagValues` or `featureFlags`, that value is honored.
+ * Only when no persisted override exists does an undeclared key default
+ * to enabled (`true`).
  *
  * Key format:
  *   Canonical:  `feature_flags.<id>.enabled`
@@ -97,20 +99,14 @@ function canonicalToLegacyKey(canonicalKey: string): string | undefined {
  * Resolve whether an assistant feature flag is enabled.
  *
  * Resolution order:
- *   0. undeclared key -> `true` (ignored by flag system)
  *   1. `config.assistantFeatureFlagValues[key]`  (explicit new-format override)
  *   2. `config.featureFlags[legacyKey]`           (legacy backward-compat)
- *   3. defaults registry `defaultEnabled`
+ *   3. defaults registry `defaultEnabled`         (for declared keys)
+ *   4. `true`                                     (for undeclared keys with no persisted override)
  */
 export function isAssistantFeatureFlagEnabled(key: string, config: AssistantConfig): boolean {
   const defaults = loadDefaultsRegistry();
   const declared = defaults[key];
-
-  // Ignore persisted values for undeclared keys: only declarative flags
-  // defined in the defaults registry are part of the system.
-  if (!declared) {
-    return true;
-  }
 
   // 1. Check new canonical section
   const newValues = (config as AssistantConfigWithFeatureFlags).assistantFeatureFlagValues;
@@ -129,8 +125,13 @@ export function isAssistantFeatureFlagEnabled(key: string, config: AssistantConf
     }
   }
 
-  // 3. Check defaults registry
-  return declared.defaultEnabled;
+  // 3. For declared keys, use the registry default
+  if (declared) {
+    return declared.defaultEnabled;
+  }
+
+  // 4. Undeclared keys with no persisted override default to enabled
+  return true;
 }
 
 /**


### PR DESCRIPTION
Codex P1 feedback on #10295: the resolver returned true for undeclared keys before checking persisted config, silently re-enabling flags users had explicitly disabled. Now checks assistantFeatureFlagValues and legacy featureFlags before defaulting to true for undeclared keys.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
