### PR TITLE
M3: Fix authorization order in pre-exec gate

### DIFF
--- a/assistant/src/__tests__/tool-approval-handler.test.ts
+++ b/assistant/src/__tests__/tool-approval-handler.test.ts
@@ -1,0 +1,350 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'tool-approval-handler-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  isDebug: () => false,
+  truncateForLog: (value: string) => value,
+}));
+
+// Mock parental controls — no tools blocked by default
+mock.module('../security/parental-control-store.js', () => ({
+  isToolBlocked: () => false,
+}));
+
+// Mock guardian control-plane policy — not targeting control-plane by default
+mock.module('../tools/guardian-control-plane-policy.js', () => ({
+  enforceGuardianOnlyPolicy: () => ({ denied: false }),
+}));
+
+// Mock task run rules — no task run rules by default
+mock.module('../tasks/ephemeral-permissions.js', () => ({
+  getTaskRunRules: () => [],
+}));
+
+// Mock tool registry — return a fake tool for 'bash'
+const fakeTool = {
+  name: 'bash',
+  description: 'Run a shell command',
+  category: 'shell',
+  defaultRiskLevel: 'high',
+  getDefinition: () => ({ name: 'bash', description: 'Run a shell command', input_schema: {} }),
+  execute: async () => ({ content: 'ok', isError: false }),
+};
+
+mock.module('../tools/registry.js', () => ({
+  getTool: (name: string) => (name === 'bash' ? fakeTool : undefined),
+  getAllTools: () => [fakeTool],
+}));
+
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { scopedApprovalGrants } from '../memory/schema.js';
+import { mintGrantFromDecision, type MintGrantParams } from '../approvals/approval-primitive.js';
+import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
+import { ToolApprovalHandler } from '../tools/tool-approval-handler.js';
+import type { ToolContext, ToolLifecycleEvent } from '../tools/types.js';
+
+initializeDb();
+
+function clearTables(): void {
+  const db = getDb();
+  db.delete(scopedApprovalGrants).run();
+}
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mintParams(overrides: Partial<MintGrantParams> = {}): MintGrantParams {
+  const futureExpiry = new Date(Date.now() + 60_000).toISOString();
+  return {
+    assistantId: 'self',
+    scopeMode: 'tool_signature',
+    requestChannel: 'telegram',
+    decisionChannel: 'telegram',
+    expiresAt: futureExpiry,
+    ...overrides,
+  };
+}
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: testDir,
+    sessionId: 'session-1',
+    conversationId: 'conv-1',
+    assistantId: 'self',
+    requestId: 'req-1',
+    guardianActorRole: 'non-guardian',
+    ...overrides,
+  };
+}
+
+// ===========================================================================
+// TESTS
+// ===========================================================================
+
+describe('ToolApprovalHandler / pre-exec gate grant check', () => {
+  const handler = new ToolApprovalHandler();
+  const events: ToolLifecycleEvent[] = [];
+  const emitLifecycleEvent = (event: ToolLifecycleEvent) => { events.push(event); };
+
+  beforeEach(() => {
+    clearTables();
+    events.length = 0;
+  });
+
+  test('untrusted actor + matching tool_signature grant -> allow', () => {
+    const toolName = 'bash';
+    const input = { command: 'ls -la' };
+    const digest = computeToolApprovalDigest(toolName, input);
+
+    // Mint a grant that matches the invocation
+    const mintResult = mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'tool_signature',
+        toolName,
+        inputDigest: digest,
+      }),
+    );
+    expect(mintResult.ok).toBe(true);
+
+    const context = makeContext({ guardianActorRole: 'non-guardian' });
+    const result = handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+
+    expect(result.allowed).toBe(true);
+    // No permission_denied events should have been emitted
+    const deniedEvents = events.filter((e) => e.type === 'permission_denied');
+    expect(deniedEvents.length).toBe(0);
+  });
+
+  test('untrusted actor + no matching grant -> deny with guardian_approval_required', () => {
+    const toolName = 'bash';
+    const input = { command: 'rm -rf /' };
+
+    const context = makeContext({ guardianActorRole: 'non-guardian' });
+    const result = handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+
+    expect(result.allowed).toBe(false);
+    if (result.allowed) return;
+    expect(result.result.isError).toBe(true);
+    expect(result.result.content).toContain('guardian approval');
+
+    // A permission_denied event should have been emitted
+    const deniedEvents = events.filter((e) => e.type === 'permission_denied');
+    expect(deniedEvents.length).toBe(1);
+  });
+
+  test('unverified_channel actor + matching grant -> allow', () => {
+    const toolName = 'bash';
+    const input = { command: 'echo hello' };
+    const digest = computeToolApprovalDigest(toolName, input);
+
+    mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'tool_signature',
+        toolName,
+        inputDigest: digest,
+      }),
+    );
+
+    const context = makeContext({ guardianActorRole: 'unverified_channel' });
+    const result = handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+
+    expect(result.allowed).toBe(true);
+  });
+
+  test('unverified_channel actor + no grant -> deny', () => {
+    const toolName = 'bash';
+    const input = { command: 'deploy' };
+
+    const context = makeContext({ guardianActorRole: 'unverified_channel' });
+    const result = handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+
+    expect(result.allowed).toBe(false);
+    if (result.allowed) return;
+    expect(result.result.content).toContain('verified channel identity');
+  });
+
+  test('grant is one-time: second invocation with same input denied', () => {
+    const toolName = 'bash';
+    const input = { command: 'ls' };
+    const digest = computeToolApprovalDigest(toolName, input);
+
+    mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'tool_signature',
+        toolName,
+        inputDigest: digest,
+      }),
+    );
+
+    const context = makeContext({ guardianActorRole: 'non-guardian' });
+
+    // First invocation — should consume the grant and allow
+    const first = handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+    expect(first.allowed).toBe(true);
+
+    // Second invocation — grant already consumed, should deny
+    const second = handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+    expect(second.allowed).toBe(false);
+  });
+
+  test('grant with mismatched input digest -> deny', () => {
+    const toolName = 'bash';
+    const grantInput = { command: 'ls' };
+    const invokeInput = { command: 'rm -rf /' };
+    const grantDigest = computeToolApprovalDigest(toolName, grantInput);
+
+    mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'tool_signature',
+        toolName,
+        inputDigest: grantDigest,
+      }),
+    );
+
+    const context = makeContext({ guardianActorRole: 'non-guardian' });
+    const result = handler.checkPreExecutionGates(
+      toolName, invokeInput, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+
+    expect(result.allowed).toBe(false);
+  });
+
+  test('expired grant -> deny', () => {
+    const toolName = 'bash';
+    const input = { command: 'ls' };
+    const digest = computeToolApprovalDigest(toolName, input);
+    const pastExpiry = new Date(Date.now() - 60_000).toISOString();
+
+    mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'tool_signature',
+        toolName,
+        inputDigest: digest,
+        expiresAt: pastExpiry,
+      }),
+    );
+
+    const context = makeContext({ guardianActorRole: 'non-guardian' });
+    const result = handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+
+    expect(result.allowed).toBe(false);
+  });
+
+  test('guardian actor bypasses grant check entirely (no grant needed)', () => {
+    const toolName = 'bash';
+    const input = { command: 'deploy' };
+
+    // No grants minted at all
+    const context = makeContext({ guardianActorRole: 'guardian' });
+    const result = handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+
+    // Guardian should pass through — the untrusted gate is not triggered
+    expect(result.allowed).toBe(true);
+  });
+
+  test('undefined actor role (desktop/trusted) bypasses grant check', () => {
+    const toolName = 'bash';
+    const input = { command: 'deploy' };
+
+    const context = makeContext({ guardianActorRole: undefined });
+    const result = handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+
+    expect(result.allowed).toBe(true);
+  });
+
+  test('grant with matching request_id scope -> allow', () => {
+    const toolName = 'bash';
+    const input = { command: 'ls' };
+
+    mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'request_id',
+        requestId: 'req-1',
+      }),
+    );
+
+    const context = makeContext({ guardianActorRole: 'non-guardian', requestId: 'req-1' });
+    const result = handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+
+    expect(result.allowed).toBe(true);
+  });
+
+  test('grant with context fields (conversationId) must match', () => {
+    const toolName = 'bash';
+    const input = { command: 'ls' };
+    const digest = computeToolApprovalDigest(toolName, input);
+
+    mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'tool_signature',
+        toolName,
+        inputDigest: digest,
+        conversationId: 'conv-other',
+      }),
+    );
+
+    // Context conversationId does not match the grant's conversationId
+    const context = makeContext({
+      guardianActorRole: 'non-guardian',
+      conversationId: 'conv-1',
+    });
+    const result = handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+
+    expect(result.allowed).toBe(false);
+  });
+});

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -307,6 +307,7 @@ export async function startVoiceTurn(opts: VoiceTurnOptions): Promise<VoiceTurnH
     strictSideEffects,
   };
   session.setAssistantId(opts.assistantId ?? 'self');
+  session.callSessionId = opts.callSessionId;
   session.setGuardianContext(opts.guardianContext ?? null);
   session.setCommandIntent(null);
   session.setTurnChannelContext({
@@ -429,6 +430,7 @@ export async function startVoiceTurn(opts: VoiceTurnOptions): Promise<VoiceTurnH
     session.setCommandIntent(null);
     session.setAssistantId('self');
     session.setVoiceCallControlPrompt(null);
+    session.callSessionId = undefined;
     // Reset the session's client callback to a no-op so the stale
     // closure doesn't intercept events from future turns on the same session.
     session.updateClient(() => {}, true);

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -58,6 +58,8 @@ export interface ToolSetupContext extends SurfaceSessionContext {
   taskRunId?: string;
   /** Guardian runtime context for the session — actorRole is propagated into ToolContext for control-plane policy enforcement. */
   guardianContext?: GuardianRuntimeContext;
+  /** Voice/call session ID, if the session originates from a call. Propagated into ToolContext for scoped grant consumption. */
+  callSessionId?: string;
 }
 
 // ── buildToolDefinitions ─────────────────────────────────────────────
@@ -109,6 +111,9 @@ export function createToolExecutor(
       requestId: ctx.currentRequestId,
       taskRunId: ctx.taskRunId,
       guardianActorRole: ctx.guardianContext?.actorRole,
+      executionChannel: ctx.guardianContext?.sourceChannel,
+      callSessionId: ctx.callSessionId,
+      requesterExternalUserId: ctx.guardianContext?.requesterExternalUserId,
       onOutput,
       signal: ctx.abortController?.signal,
       sandboxOverride: ctx.sandboxOverride,

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -134,6 +134,7 @@ export class Session {
   /** @internal */ hasNoClient = false;
   /** @internal */ headlessLock = false;
   /** @internal */ taskRunId?: string;
+  /** @internal */ callSessionId?: string;
   /** @internal */ readonly queue = new MessageQueue();
   /** @internal */ currentActiveSurfaceId?: string;
   /** @internal */ currentPage?: string;

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -70,24 +70,29 @@ export class ToolExecutor {
     const tool = gateResult.tool;
 
     try {
-      // Check permissions via the extracted PermissionChecker
-      const permResult = await this.permissionChecker.checkPermission(
-        name,
-        input,
-        tool,
-        context,
-        executionTarget,
-        (event) => emitLifecycleEvent(context, event),
-        sanitizeToolInput,
-        startTime,
-        computePreviewDiff,
-      );
+      // A consumed scoped grant is a complete authorization — skip the
+      // interactive permission/prompt flow so non-interactive sessions
+      // don't auto-deny prompt-gated tools and burn the one-time grant.
+      if (!gateResult.grantConsumed) {
+        // Check permissions via the extracted PermissionChecker
+        const permResult = await this.permissionChecker.checkPermission(
+          name,
+          input,
+          tool,
+          context,
+          executionTarget,
+          (event) => emitLifecycleEvent(context, event),
+          sanitizeToolInput,
+          startTime,
+          computePreviewDiff,
+        );
 
-      riskLevel = permResult.riskLevel;
-      decision = permResult.decision;
+        riskLevel = permResult.riskLevel;
+        decision = permResult.decision;
 
-      if (!permResult.allowed) {
-        return { content: permResult.content, isError: true };
+        if (!permResult.allowed) {
+          return { content: permResult.content, isError: true };
+        }
       }
 
       const hookResult = await getHookManager().trigger('pre-tool-execute', {

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -1,4 +1,6 @@
+import { consumeGrantForInvocation } from '../approvals/approval-primitive.js';
 import { isToolBlocked } from '../security/parental-control-store.js';
+import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
 import { getTaskRunRules } from '../tasks/ephemeral-permissions.js';
 import { getLogger } from '../util/logger.js';
 import { enforceGuardianOnlyPolicy } from './guardian-control-plane-policy.js';
@@ -137,38 +139,64 @@ export class ToolApprovalHandler {
       return { allowed: false, result: { content: guardianCheck.reason!, isError: true } };
     }
 
-    // Untrusted actors cannot execute host tools or side-effect tools directly.
-    // They must go through guardian approval mediation instead of obtaining
-    // privileged execution in-band.
+    // Untrusted actors cannot execute host tools or side-effect tools directly
+    // unless a valid scoped grant exists for this exact invocation.
+    // Check for a matching grant FIRST; only deny if no grant matches.
     if (
       isUntrustedGuardianActorRole(context.guardianActorRole)
       && requiresGuardianApprovalForActor(name, input, executionTarget)
     ) {
-      const reason = guardianApprovalDeniedMessage(context.guardianActorRole, name);
-      log.warn({
-        toolName: name,
-        sessionId: context.sessionId,
-        conversationId: context.conversationId,
-        actorRole: context.guardianActorRole,
-        executionTarget,
-        reason: 'guardian_approval_required',
-      }, 'Guardian approval gate blocked untrusted actor tool invocation');
-      const durationMs = Date.now() - startTime;
-      emitLifecycleEvent({
-        type: 'permission_denied',
-        toolName: name,
-        executionTarget,
-        input,
-        workingDir: context.workingDir,
-        sessionId: context.sessionId,
-        conversationId: context.conversationId,
+      const inputDigest = computeToolApprovalDigest(name, input);
+      const grantResult = consumeGrantForInvocation({
         requestId: context.requestId,
-        riskLevel,
-        decision: 'deny',
-        reason,
-        durationMs,
+        toolName: name,
+        inputDigest,
+        consumingRequestId: context.requestId ?? `preexec-${context.sessionId}-${Date.now()}`,
+        assistantId: context.assistantId ?? 'self',
+        executionChannel: context.executionChannel,
+        conversationId: context.conversationId,
+        callSessionId: context.callSessionId,
+        requesterExternalUserId: context.requesterExternalUserId,
       });
-      return { allowed: false, result: { content: reason, isError: true } };
+
+      if (grantResult.ok) {
+        log.info({
+          toolName: name,
+          sessionId: context.sessionId,
+          conversationId: context.conversationId,
+          actorRole: context.guardianActorRole,
+          executionTarget,
+          grantId: grantResult.grant.id,
+        }, 'Scoped grant consumed — allowing untrusted actor tool invocation');
+        // Grant consumed: fall through to remaining gates and normal execution
+      } else {
+        const reason = guardianApprovalDeniedMessage(context.guardianActorRole, name);
+        log.warn({
+          toolName: name,
+          sessionId: context.sessionId,
+          conversationId: context.conversationId,
+          actorRole: context.guardianActorRole,
+          executionTarget,
+          reason: 'guardian_approval_required',
+          grantMissReason: grantResult.reason,
+        }, 'Guardian approval gate blocked untrusted actor tool invocation (no matching grant)');
+        const durationMs = Date.now() - startTime;
+        emitLifecycleEvent({
+          type: 'permission_denied',
+          toolName: name,
+          executionTarget,
+          input,
+          workingDir: context.workingDir,
+          sessionId: context.sessionId,
+          conversationId: context.conversationId,
+          requestId: context.requestId,
+          riskLevel,
+          decision: 'deny',
+          reason,
+          durationMs,
+        });
+        return { allowed: false, result: { content: reason, isError: true } };
+      }
     }
 
     // Gate tools not active for the current turn

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -36,7 +36,7 @@ function guardianApprovalDeniedMessage(
 }
 
 export type PreExecutionGateResult =
-  | { allowed: true; tool: Tool }
+  | { allowed: true; tool: Tool; grantConsumed?: boolean }
   | { allowed: false; result: ToolExecutionResult };
 
 /**
@@ -168,7 +168,36 @@ export class ToolApprovalHandler {
           executionTarget,
           grantId: grantResult.grant.id,
         }, 'Scoped grant consumed — allowing untrusted actor tool invocation');
-        // Grant consumed: fall through to remaining gates and normal execution
+
+        // Resolve the tool from the registry before returning. A consumed
+        // scoped grant is a complete authorization — the executor must skip
+        // the interactive permission/prompt flow entirely, otherwise
+        // non-interactive sessions (isInteractive: false) would auto-deny
+        // prompt-gated tools and burn the one-time grant.
+        const grantedTool = getTool(name);
+        if (!grantedTool) {
+          const available = getAllTools().filter((t) => t.executionMode !== 'proxy' || context.proxyToolResolver).map((t) => t.name).sort().join(', ');
+          const msg = `Unknown tool: ${name}. Available tools: ${available}`;
+          const durationMs = Date.now() - startTime;
+          emitLifecycleEvent({
+            type: 'error',
+            toolName: name,
+            executionTarget,
+            input,
+            workingDir: context.workingDir,
+            sessionId: context.sessionId,
+            conversationId: context.conversationId,
+            requestId: context.requestId,
+            riskLevel,
+            decision: 'error',
+            durationMs,
+            errorMessage: msg,
+            isExpected: true,
+            errorCategory: 'tool_failure',
+          });
+          return { allowed: false, result: { content: msg, isError: true } };
+        }
+        return { allowed: true, tool: grantedTool, grantConsumed: true };
       } else {
         const reason = guardianApprovalDeniedMessage(context.guardianActorRole, name);
         log.warn({

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -138,6 +138,12 @@ export interface ToolContext {
   principal?: string;
   /** Guardian actor role for the session — used by the guardian control-plane policy gate. */
   guardianActorRole?: 'guardian' | 'non-guardian' | 'unverified_channel';
+  /** Channel through which the tool invocation originates (e.g. 'telegram', 'voice'). Used for scoped grant consumption. */
+  executionChannel?: string;
+  /** Voice/call session ID, if the invocation originates from a call. Used for scoped grant consumption. */
+  callSessionId?: string;
+  /** External user ID of the requester (non-guardian actor). Used for scoped grant consumption. */
+  requesterExternalUserId?: string;
 }
 
 export interface DiffInfo {


### PR DESCRIPTION
Part of #10276. Fixes Incident B: the pre-exec gate now attempts consumeGrantForInvocation before denying with guardian_approval_required. Adds executionChannel, callSessionId, requesterExternalUserId to ToolContext. Untrusted actors with a valid scoped grant can now execute privileged tools. Includes unit tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
