### PR TITLE
Fix gateway feature-flag defaults fallback

### DIFF
--- a/gateway/src/__tests__/feature-flag-defaults-sync.test.ts
+++ b/gateway/src/__tests__/feature-flag-defaults-sync.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+describe("assistant feature flag defaults registry sync", () => {
+  test("gateway bundled defaults copy matches canonical meta copy", () => {
+    const repoRoot = join(process.cwd(), "..");
+    const canonicalPath = join(repoRoot, "meta", "assistant-feature-flags", "assistant-feature-flag-defaults.json");
+    const bundledPath = join(process.cwd(), "src", "assistant-feature-flag-defaults.json");
+
+    const canonical = readFileSync(canonicalPath, "utf-8");
+    const bundled = readFileSync(bundledPath, "utf-8");
+
+    expect(bundled, [
+      "The bundled copy at gateway/src/assistant-feature-flag-defaults.json",
+      "is out of sync with the canonical copy at meta/assistant-feature-flags/assistant-feature-flag-defaults.json.",
+      "",
+      "To fix: copy the canonical file over the bundled one:",
+      "  cp meta/assistant-feature-flags/assistant-feature-flag-defaults.json gateway/src/assistant-feature-flag-defaults.json",
+    ].join("\n")).toBe(canonical);
+  });
+});

--- a/gateway/src/assistant-feature-flag-defaults.json
+++ b/gateway/src/assistant-feature-flag-defaults.json
@@ -1,0 +1,10 @@
+{
+  "feature_flags.hatch-new-assistant.enabled": {
+    "defaultEnabled": true,
+    "description": "Show Hatch New Assistant action in Settings > Account"
+  },
+  "feature_flags.sms.enabled": {
+    "defaultEnabled": true,
+    "description": "Show SMS setup in Settings > Connect and enable the SMS setup skill"
+  }
+}

--- a/gateway/src/feature-flag-defaults.ts
+++ b/gateway/src/feature-flag-defaults.ts
@@ -19,19 +19,26 @@ const REGISTRY_RELATIVE = join("meta", "assistant-feature-flags", REGISTRY_FILEN
 /**
  * Resolve the path to the defaults registry JSON file.
  *
- * The file lives at `meta/assistant-feature-flags/assistant-feature-flag-defaults.json`
- * relative to the repository root. We try several candidate locations so the
- * lookup works both in the monorepo dev layout and in Docker (where only
- * the gateway directory is copied to `/app`).
+ * The canonical file lives at
+ * `meta/assistant-feature-flags/assistant-feature-flag-defaults.json`
+ * relative to the repository root. We also keep a bundled copy at
+ * `gateway/src/assistant-feature-flag-defaults.json` so gateway-only layouts
+ * can still resolve defaults without the repo-root `meta/` tree.
+ *
+ * We try several candidate locations so lookup works in monorepo dev,
+ * gateway-only Docker, and explicit test overrides.
  *
  * Candidate order:
  *   1. `FEATURE_FLAG_DEFAULTS_PATH` env var (explicit override)
- *   2. Monorepo layout: walk up two levels from gateway/src/
- *   3. Docker / gateway-only layout: adjacent to gateway src (`<root>/meta/...`)
- *   4. cwd-based fallback
+ *   2. Bundled copy adjacent to gateway source (`gateway/src/<file>`)
+ *   3. Monorepo layout: walk up two levels from gateway/src/
+ *   4. Docker / gateway-only layout: adjacent to gateway src (`<root>/meta/...`)
+ *   5. cwd-based fallback
  */
 function getRegistryCandidates(): string[] {
   const candidates: string[] = [];
+
+  const srcDir = import.meta.dirname ?? new URL(".", import.meta.url).pathname;
 
   // 1. Explicit env override
   const envPath = process.env.FEATURE_FLAG_DEFAULTS_PATH?.trim();
@@ -39,17 +46,19 @@ function getRegistryCandidates(): string[] {
     candidates.push(envPath);
   }
 
-  // 2. Monorepo layout: gateway/src -> repo root is ../../
-  const srcDir = import.meta.dirname ?? new URL(".", import.meta.url).pathname;
+  // 2. Bundled gateway-local copy
+  candidates.push(join(srcDir, REGISTRY_FILENAME));
+
+  // 3. Monorepo layout: gateway/src -> repo root is ../../
   const repoRoot = join(srcDir, "..", "..");
   candidates.push(join(repoRoot, REGISTRY_RELATIVE));
 
-  // 3. Docker layout: the gateway Dockerfile copies the gateway dir to /app,
+  // 4. Docker layout: the gateway Dockerfile copies the gateway dir to /app,
   //    so the meta dir (if mounted or copied) may be under /app/../meta or a
   //    sibling directory. Also check one level up from srcDir (gateway root).
   candidates.push(join(srcDir, "..", REGISTRY_RELATIVE));
 
-  // 4. cwd-based fallback
+  // 5. cwd-based fallback
   candidates.push(join(process.cwd(), REGISTRY_RELATIVE));
 
   return candidates;


### PR DESCRIPTION
## Summary
- fixes empty assistant feature flag lists when gateway cannot resolve `meta/assistant-feature-flags/assistant-feature-flag-defaults.json`
- adds a bundled gateway-local defaults copy at `gateway/src/assistant-feature-flag-defaults.json`
- updates defaults loader candidate order to check bundled copy before monorepo/meta paths
- adds a sync guard test to ensure gateway bundled defaults stay identical to canonical `meta/` defaults

## Why
In gateway-only or packaged layouts, the repo-root `meta/` directory may be unavailable. When that happened, `GET /v1/feature-flags` returned an empty set, causing the UI to show **"No assistant feature flags available."** even when flags are declared.

## Validation
- `cd gateway && export PATH="$HOME/.bun/bin:$PATH" && bun test src/__tests__/feature-flag-defaults-sync.test.ts src/__tests__/feature-flags-route.test.ts src/feature-flags-auth.test.ts`
- `cd gateway && export PATH="$HOME/.bun/bin:$PATH" && bunx tsc --noEmit`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
