### PR TITLE
fix: resolve lint error in feature flag guardrails test

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flag-guardrails.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flag-guardrails.test.ts
@@ -149,12 +149,9 @@ describe('assistant feature flag declaration coverage guard', () => {
         if (!relPath) continue;
         const absPath = join(repoRoot, relPath);
         const content = readFileSync(absPath, 'utf-8');
-        let match: RegExpExecArray | null;
-        while ((match = multilinePattern.exec(content)) !== null) {
+        for (const match of content.matchAll(multilinePattern)) {
           usedKeys.add(match[1]);
         }
-        // Reset lastIndex since we reuse the regex across files
-        multilinePattern.lastIndex = 0;
       }
     }
 


### PR DESCRIPTION
## Summary
- Replace `while ((match = regex.exec(content)) !== null)` with `for (const match of content.matchAll(regex))` to satisfy the `no-restricted-syntax` lint rule banning `!== null`
- Remove the now-unnecessary manual `lastIndex` reset since `matchAll` handles regex state internally

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22472829348/job/65093507650

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
