### PR TITLE
fix: clean runtime artifacts and sign loose files in macOS build

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -645,6 +645,15 @@ if [ -d "$XCASSETS" ]; then
         > /dev/null 2>&1 || true
 fi
 
+# Remove transient runtime artifacts that may be written into the app bundle
+# during local dev runs (for example qdrant marker files). These are not part
+# of the distributable app and can break outer-bundle codesign verification.
+rm -f "$MACOS_DIR/.qdrant-initialized"
+rm -rf "$MACOS_DIR/snapshots"
+find "$MACOS_DIR" -maxdepth 1 -type f \
+    \( -name "*.pid" -o -name "*.sock" -o -name "*.log" \) \
+    -delete
+
 # 6. Code sign
 echo "Signing with: $SIGN_IDENTITY"
 
@@ -707,6 +716,21 @@ if [ -d "$MACOS_DIR/node_modules" ]; then
     find "$MACOS_DIR/node_modules" -type f -exec \
         codesign "${NATIVE_SIGN_FLAGS[@]}" {} \;
     echo "Bundled node_modules signed"
+fi
+
+# Sign any additional regular files directly under Contents/MacOS.
+# This protects against future unsigned loose files in incremental dev builds.
+if [ -d "$MACOS_DIR" ]; then
+    EXTRA_FILE_SIGN_FLAGS=(--force --sign "$SIGN_IDENTITY")
+    if [ "$CONFIG" = "release" ] && [ "$SIGN_IDENTITY" != "-" ]; then
+        EXTRA_FILE_SIGN_FLAGS+=(--timestamp --options runtime)
+    fi
+    find "$MACOS_DIR" -maxdepth 1 -type f \
+        ! -name "$BUNDLE_DISPLAY_NAME" \
+        ! -name "vellum-daemon" \
+        ! -name "vellum-cli" \
+        ! -name "vellum-gateway" \
+        -exec codesign "${EXTRA_FILE_SIGN_FLAGS[@]}" {} \;
 fi
 
 # Sign daemon binary with its own entitlements (JIT, network)


### PR DESCRIPTION
## Summary

- Remove transient runtime artifacts (.qdrant-initialized, snapshots/, *.pid, *.sock, *.log) from the app bundle before codesigning to prevent verification failures
- Sign any additional regular files directly under Contents/MacOS (excluding known binaries) as a safety net for future loose files in incremental dev builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
