### PR TITLE
fix: update missed test assertion for undeclared flag override behavior

### DIFF
--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -232,7 +232,7 @@ describe('resolveSkillStates with feature flags', () => {
     expect(resolved.length).toBe(0);
   });
 
-  test('multiple skills with mixed flags', () => {
+  test('multiple skills with mixed flags — persisted overrides respected for undeclared skills', () => {
     const catalog = [
       makeSkill(DECLARED_SKILL_ID),
       makeSkill('twitter'),
@@ -248,7 +248,9 @@ describe('resolveSkillStates with feature flags', () => {
     const resolved = resolveSkillStates(catalog, config);
     const ids = resolved.map((r) => r.summary.id);
 
-    expect(ids).toEqual(['twitter', 'deploy']);
+    // Both declared (hatch-new-assistant) and undeclared (deploy) skills with
+    // persisted false overrides are filtered out; only twitter remains.
+    expect(ids).toEqual(['twitter']);
   });
 
   test('skill-to-flag override applies to skill state resolution', () => {


### PR DESCRIPTION
Updates the 'multiple skills with mixed flags' test in skill-feature-flags.test.ts to match the new resolver behavior from PR #10301. The test previously expected undeclared skills with persisted false overrides to remain enabled, but the new logic correctly respects those overrides.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
