### PR TITLE
perf: reduce browser PiP CPU overhead

### DIFF
--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -509,10 +509,10 @@ class BrowserManager {
     this.cdpSessions.set(sessionId, cdp);
     this.screencastCallbacks.set(sessionId, onFrame);
 
-    // Throttle frame delivery to ~8fps max to avoid flooding IPC and the client.
-    // CDP still encodes fewer frames thanks to everyNthFrame:2, but on heavy
-    // pages Chrome can still produce bursts faster than the UI can consume.
-    const MIN_FRAME_INTERVAL_MS = 125;
+    // Throttle frame delivery to ~4fps max to avoid flooding IPC and the client.
+    // This materially reduces CPU on heavy pages (e.g. cloud consoles) while
+    // still keeping enough visual continuity for guided browser actions.
+    const MIN_FRAME_INTERVAL_MS = 250;
     let lastFrameTime = 0;
 
     cdp.on('Page.screencastFrame', (params) => {
@@ -527,9 +527,9 @@ class BrowserManager {
 
     await cdp.send('Page.startScreencast', {
       format: 'jpeg',
-      quality: 50,
-      maxWidth: 1280,
-      maxHeight: 960,
+      quality: 40,
+      maxWidth: 1024,
+      maxHeight: 768,
       everyNthFrame: 2,
     });
   }

--- a/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPManager.swift
+++ b/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPManager.swift
@@ -30,6 +30,8 @@ final class BrowserPiPManager: ObservableObject {
     private var moveObserver: Any?
     private var resizeObserver: Any?
     private let decodeQueue = DispatchQueue(label: "browser-pip-frame-decode")
+    private var isDecodingFrame = false
+    private var pendingFrameBase64: String?
     weak var daemonClient: DaemonClient?
 
     // Saved position
@@ -175,21 +177,50 @@ final class BrowserPiPManager: ObservableObject {
         currentFrame = nil
         isInteractive = false
         handoffMessage = nil
+        pendingFrameBase64 = nil
+        isDecodingFrame = false
 
         log.info("Dismissed browser PiP panel")
     }
 
     private func decodeFrame(_ base64: String) {
+        if isDecodingFrame {
+            pendingFrameBase64 = base64
+            return
+        }
+        startFrameDecode(base64)
+    }
+
+    private func startFrameDecode(_ base64: String) {
+        isDecodingFrame = true
         decodeQueue.async { [weak self] in
+            guard let self else { return }
             guard let data = Data(base64Encoded: base64),
-                  let image = NSImage(data: data) else { return }
-            DispatchQueue.main.async {
-                self?.currentFrame = image
-                if image.size.width > 0 && image.size.height > 0 {
-                    self?.frameSize = image.size
+                  let image = NSImage(data: data) else {
+                DispatchQueue.main.async { [weak self] in
+                    self?.finishFrameDecode()
                 }
+                return
+            }
+            DispatchQueue.main.async {
+                guard self.isVisible else {
+                    self.finishFrameDecode()
+                    return
+                }
+                self.currentFrame = image
+                if image.size.width > 0 && image.size.height > 0 {
+                    self.frameSize = image.size
+                }
+                self.finishFrameDecode()
             }
         }
+    }
+
+    private func finishFrameDecode() {
+        isDecodingFrame = false
+        guard let next = pendingFrameBase64 else { return }
+        pendingFrameBase64 = nil
+        startFrameDecode(next)
     }
 
     private func scheduleActionTextClear() {


### PR DESCRIPTION
## Summary

- Reduces screencast frame rate from ~8fps to ~4fps, resolution from 1280×960 to 1024×768, and JPEG quality from 50 to 40 to cut IPC bandwidth and encoding cost on heavy pages.
- Adds frame decode coalescing in the macOS BrowserPiPManager: if a new frame arrives while one is still being decoded, only the latest frame is kept — intermediates are dropped, preventing decode queue buildup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
