### PR TITLE
M5: Stop request churn + preserve tool scope

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -893,7 +893,7 @@ describe('call-controller', () => {
     controller.destroy();
   });
 
-  test('no duplicate guardian dispatch: second ASK_GUARDIAN supersedes the first consultation', async () => {
+  test('no duplicate guardian dispatch: repeated informational ASK_GUARDIAN coalesces with existing consultation', async () => {
     // Trigger ASK_GUARDIAN to start first consultation
     mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
       ['Let me ask. [ASK_GUARDIAN: Preferred date?]'],
@@ -904,16 +904,17 @@ describe('call-controller', () => {
     const firstQuestionId = controller.getPendingConsultationQuestionId();
     expect(firstQuestionId).not.toBeNull();
 
-    // Model emits another ASK_GUARDIAN in a subsequent turn — supersedes
+    // Model emits another informational ASK_GUARDIAN in a subsequent turn —
+    // should coalesce (same tool scope: both lack tool metadata)
     mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
       ['Actually let me re-check. [ASK_GUARDIAN: Preferred date again?]'],
     ));
     await controller.handleCallerUtterance('Hello?');
 
-    // New consultation should replace the old one
+    // Consultation should be coalesced — same question ID retained
     const secondQuestionId = controller.getPendingConsultationQuestionId();
     expect(secondQuestionId).not.toBeNull();
-    expect(secondQuestionId).not.toBe(firstQuestionId);
+    expect(secondQuestionId).toBe(firstQuestionId);
 
     // The session status should still be waiting_on_user
     const updatedSession = getCallSession(session.id);
@@ -1529,6 +1530,169 @@ describe('call-controller', () => {
     // Response should appear in relay
     const allText = relay.sentTokens.map((t) => t.token).join('');
     expect(allText).toContain('what else can I help with');
+
+    controller.destroy();
+  });
+
+  // ── Consultation coalescing (Incident C) ────────────────────────────
+
+  test('coalescing: repeated identical informational ASK_GUARDIAN does not create a new request', async () => {
+    // Trigger first ASK_GUARDIAN
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Let me ask. [ASK_GUARDIAN: Preferred date?]'],
+    ));
+    const { session, controller } = setupController();
+    await controller.handleCallerUtterance('Schedule please');
+    await new Promise((r) => setTimeout(r, 50));
+
+    const firstQuestionId = controller.getPendingConsultationQuestionId();
+    expect(firstQuestionId).not.toBeNull();
+    const firstRequest = getPendingRequestByCallSessionId(session.id);
+    expect(firstRequest).not.toBeNull();
+
+    // Repeated ASK_GUARDIAN with same informational question (no tool metadata)
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Still checking. [ASK_GUARDIAN: Preferred date?]'],
+    ));
+    await controller.handleCallerUtterance('Hello? Still there?');
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Should coalesce: same consultation ID, same request
+    expect(controller.getPendingConsultationQuestionId()).toBe(firstQuestionId);
+    const currentRequest = getPendingRequestByCallSessionId(session.id);
+    expect(currentRequest).not.toBeNull();
+    expect(currentRequest!.id).toBe(firstRequest!.id);
+    expect(currentRequest!.status).toBe('pending');
+
+    // Coalesce event should be recorded
+    const events = getCallEvents(session.id);
+    const coalesceEvents = events.filter((e) => e.eventType === 'guardian_consult_coalesced');
+    expect(coalesceEvents.length).toBe(1);
+
+    controller.destroy();
+  });
+
+  test('coalescing: repeated ASK_GUARDIAN_APPROVAL with same tool/input does not create a new request', async () => {
+    const approvalPayload = JSON.stringify({
+      question: 'Allow send_email to bob@example.com?',
+      toolName: 'send_email',
+      input: { to: 'bob@example.com', subject: 'Hello' },
+    });
+
+    // First ASK_GUARDIAN_APPROVAL
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      [`Checking. [ASK_GUARDIAN_APPROVAL: ${approvalPayload}]`],
+    ));
+    const { session, controller } = setupController('Send email');
+    await controller.handleCallerUtterance('Send email to Bob');
+    await new Promise((r) => setTimeout(r, 50));
+
+    const firstQuestionId = controller.getPendingConsultationQuestionId();
+    expect(firstQuestionId).not.toBeNull();
+    const firstRequest = getPendingRequestByCallSessionId(session.id);
+    expect(firstRequest).not.toBeNull();
+
+    // Repeated ASK_GUARDIAN_APPROVAL with same tool/input
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      [`Still checking. [ASK_GUARDIAN_APPROVAL: ${approvalPayload}]`],
+    ));
+    await controller.handleCallerUtterance('Can you send it already?');
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Should coalesce: same consultation, same request
+    expect(controller.getPendingConsultationQuestionId()).toBe(firstQuestionId);
+    const currentRequest = getPendingRequestByCallSessionId(session.id);
+    expect(currentRequest!.id).toBe(firstRequest!.id);
+    expect(currentRequest!.status).toBe('pending');
+
+    controller.destroy();
+  });
+
+  test('supersession: materially different tool triggers new request with superseded metadata', async () => {
+    const firstPayload = JSON.stringify({
+      question: 'Allow send_email?',
+      toolName: 'send_email',
+      input: { to: 'bob@example.com' },
+    });
+
+    // First ASK_GUARDIAN_APPROVAL for send_email
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      [`Checking. [ASK_GUARDIAN_APPROVAL: ${firstPayload}]`],
+    ));
+    const { session, controller } = setupController('Process request');
+    await controller.handleCallerUtterance('Send email');
+    await new Promise((r) => setTimeout(r, 50));
+
+    const firstRequest = getPendingRequestByCallSessionId(session.id);
+    expect(firstRequest).not.toBeNull();
+    expect(firstRequest!.toolName).toBe('send_email');
+
+    // Different tool — should supersede
+    const secondPayload = JSON.stringify({
+      question: 'Allow calendar_create?',
+      toolName: 'calendar_create',
+      input: { date: '2026-03-01' },
+    });
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      [`Actually, let me do this. [ASK_GUARDIAN_APPROVAL: ${secondPayload}]`],
+    ));
+    await controller.handleCallerUtterance('Actually, create a calendar event instead');
+    await new Promise((r) => setTimeout(r, 100));
+
+    // New consultation should be active
+    const secondRequest = getPendingRequestByCallSessionId(session.id);
+    expect(secondRequest).not.toBeNull();
+    expect(secondRequest!.id).not.toBe(firstRequest!.id);
+    expect(secondRequest!.toolName).toBe('calendar_create');
+
+    // Old request should be expired with 'superseded' reason
+    const expiredRequest = getGuardianActionRequest(firstRequest!.id);
+    expect(expiredRequest).not.toBeNull();
+    expect(expiredRequest!.status).toBe('expired');
+    expect(expiredRequest!.expiredReason).toBe('superseded');
+    expect(expiredRequest!.supersededByRequestId).toBe(secondRequest!.id);
+    expect(expiredRequest!.supersededAt).not.toBeNull();
+
+    controller.destroy();
+  });
+
+  test('tool metadata continuity: re-ask without structured metadata inherits tool scope from prior consultation', async () => {
+    const approvalPayload = JSON.stringify({
+      question: 'Allow send_email?',
+      toolName: 'send_email',
+      input: { to: 'bob@example.com', subject: 'Hello' },
+    });
+
+    // First ask with structured tool metadata
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      [`Let me check. [ASK_GUARDIAN_APPROVAL: ${approvalPayload}]`],
+    ));
+    const { session, controller } = setupController('Send email');
+    await controller.handleCallerUtterance('Send email to Bob');
+    await new Promise((r) => setTimeout(r, 50));
+
+    const firstRequest = getPendingRequestByCallSessionId(session.id);
+    expect(firstRequest).not.toBeNull();
+    expect(firstRequest!.toolName).toBe('send_email');
+
+    // Re-ask with informational ASK_GUARDIAN (no structured metadata).
+    // Since the tool metadata matches the existing consultation (inherited),
+    // this should coalesce rather than supersede.
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Checking again. [ASK_GUARDIAN: Can I send that email?]'],
+    ));
+    await controller.handleCallerUtterance('Can you hurry up?');
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Should coalesce: the inherited tool metadata matches the existing consultation
+    const currentRequest = getPendingRequestByCallSessionId(session.id);
+    expect(currentRequest!.id).toBe(firstRequest!.id);
+    expect(currentRequest!.status).toBe('pending');
+
+    // Coalesce event should be recorded
+    const events = getCallEvents(session.id);
+    const coalesceEvents = events.filter((e) => e.eventType === 'guardian_consult_coalesced');
+    expect(coalesceEvents.length).toBe(1);
 
     controller.destroy();
   });

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -12,6 +12,7 @@ import { getGatewayInternalBaseUrl } from '../config/env.js';
 import type { ServerMessage } from '../daemon/ipc-contract.js';
 import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
 import {
+  backfillSupersessionMetadata,
   expireGuardianActionRequest,
   getDeliveriesByRequestId,
   getPendingRequestByCallSessionId,
@@ -692,111 +693,62 @@ export class CallController {
           recordCallEvent(this.callSessionId, 'guardian_consult_deferred', { question: questionText });
           // Fall through to normal turn completion (idle + flushPendingInstructions)
         } else {
-          // Cancel any prior pending consultation (superseded by this new one)
+          // Determine the effective tool metadata for this ask. If the new
+          // ask has structured tool metadata, use it; otherwise inherit from
+          // the prior pending consultation (preserves tool scope on re-asks).
+          const effectiveToolMeta = toolApprovalMeta
+            ? { toolName: toolApprovalMeta.toolName, inputDigest: toolApprovalMeta.inputDigest }
+            : this.pendingConsultation?.toolApprovalMeta ?? null;
+
+          // Coalesce repeated identical asks: if a consultation is already
+          // pending for the same tool/action (or same informational question),
+          // avoid churning requests and just keep the existing one.
           if (this.pendingConsultation) {
-            clearTimeout(this.pendingConsultation.timer);
+            const isSameToolAction =
+              effectiveToolMeta && this.pendingConsultation.toolApprovalMeta
+                ? effectiveToolMeta.toolName === this.pendingConsultation.toolApprovalMeta.toolName
+                  && effectiveToolMeta.inputDigest === this.pendingConsultation.toolApprovalMeta.inputDigest
+                : !effectiveToolMeta && !this.pendingConsultation.toolApprovalMeta;
 
-            // Expire the previous consultation's storage records so stale
-            // guardian answers cannot match the old request.
-            expirePendingQuestions(this.callSessionId);
-            const previousRequest = getPendingRequestByCallSessionId(this.callSessionId);
-            if (previousRequest) {
-              expireGuardianActionRequest(previousRequest.id, 'cancelled');
+            if (isSameToolAction) {
+              // Same tool/action — coalesce. Keep the existing consultation
+              // alive and skip creating a new request.
               log.info(
-                { callSessionId: this.callSessionId, requestId: previousRequest.id },
-                'Expired superseded guardian action request',
+                { callSessionId: this.callSessionId, questionId: this.pendingConsultation.questionId },
+                'Coalescing repeated ASK_GUARDIAN — same tool/action already pending',
               );
-            }
+              recordCallEvent(this.callSessionId, 'guardian_consult_coalesced', { question: questionText });
+              // Fall through to normal turn completion (idle + flushPendingInstructions)
+            } else {
+              // Materially different intent — supersede the old consultation.
+              clearTimeout(this.pendingConsultation.timer);
 
-            this.pendingConsultation = null;
-          }
-
-          const pendingQuestion = createPendingQuestion(this.callSessionId, questionText);
-          updateCallSession(this.callSessionId, { status: 'waiting_on_user' });
-          recordCallEvent(this.callSessionId, 'user_question_asked', { question: questionText });
-
-          // Notify the conversation that a question was asked
-          const session = getCallSession(this.callSessionId);
-          if (session) {
-            fireCallQuestionNotifier(session.conversationId, this.callSessionId, questionText);
-
-            // Dispatch guardian action request to all configured channels
-            void dispatchGuardianQuestion({
-              callSessionId: this.callSessionId,
-              conversationId: session.conversationId,
-              assistantId: this.assistantId,
-              pendingQuestion,
-              toolName: toolApprovalMeta?.toolName,
-              inputDigest: toolApprovalMeta?.inputDigest,
-            });
-          }
-
-          // Set a consultation timeout tied to this specific consultation
-          // record, not the global controller state.
-          const consultationTimer = setTimeout(() => {
-            // Only fire if this consultation is still the active one
-            if (!this.pendingConsultation || this.pendingConsultation.questionId !== pendingQuestion.id) return;
-
-            log.info({ callSessionId: this.callSessionId }, 'Guardian consultation timed out');
-
-            // Mark the linked guardian action request as timed out and
-            // send expiry notices to guardian destinations. Deliveries
-            // must be captured before markTimedOutWithReason changes
-            // their status.
-            const pendingActionRequest = getPendingRequestByCallSessionId(this.callSessionId);
-            if (pendingActionRequest) {
-              const deliveries = getDeliveriesByRequestId(pendingActionRequest.id);
-              markTimedOutWithReason(pendingActionRequest.id, 'call_timeout');
-              log.info(
-                { callSessionId: this.callSessionId, requestId: pendingActionRequest.id },
-                'Marked guardian action request as timed out',
-              );
-              void sendGuardianExpiryNotices(
-                deliveries,
-                pendingActionRequest.assistantId,
-                getGatewayInternalBaseUrl(),
-                readHttpToken() ?? undefined,
-              ).catch((err) => {
-                log.error(
-                  { err, callSessionId: this.callSessionId, requestId: pendingActionRequest.id },
-                  'Failed to send guardian action expiry notices after call timeout',
+              // Expire the previous consultation's storage records so stale
+              // guardian answers cannot match the old request.
+              expirePendingQuestions(this.callSessionId);
+              const previousRequest = getPendingRequestByCallSessionId(this.callSessionId);
+              if (previousRequest) {
+                // Immediately expire with 'superseded' reason to prevent
+                // stale answers from resolving the old request.
+                expireGuardianActionRequest(previousRequest.id, 'superseded');
+                log.info(
+                  { callSessionId: this.callSessionId, requestId: previousRequest.id },
+                  'Superseded guardian action request (materially different intent)',
                 );
-              });
+              }
+
+              this.pendingConsultation = null;
+
+              // Dispatch the new consultation with effective tool metadata.
+              // The previous request ID is passed through so the dispatch
+              // can backfill supersession chain metadata (superseded_by_request_id)
+              // once the new request has been created.
+              this.dispatchNewConsultation(questionText, effectiveToolMeta, previousRequest?.id ?? null);
             }
-
-            // Expire pending questions and update call state
-            expirePendingQuestions(this.callSessionId);
-            this.pendingConsultation = null;
-            updateCallSession(this.callSessionId, { status: 'in_progress' });
-            this.guardianUnavailableForCall = true;
-            recordCallEvent(this.callSessionId, 'guardian_consultation_timed_out', { question: questionText });
-
-            // Inject timeout instruction so the model addresses it on the
-            // next turn. If idle, flush immediately; otherwise it merges
-            // into the next turn completion.
-            const timeoutInstruction =
-              `[GUARDIAN_TIMEOUT] Your guardian did not respond in time to your question: "${questionText}". `
-              + `Apologize to the caller for the delay, let them know you were unable to reach your guardian, `
-              + `ask if they would like to leave a message or receive a callback, `
-              + `and ask if there are any other questions you can help with right now.`;
-
-            this.pendingInstructions.push(timeoutInstruction);
-
-            if (this.state === 'idle') {
-              this.resetSilenceTimer();
-              this.flushPendingInstructions();
-            }
-          }, getUserConsultationTimeoutMs());
-
-          this.pendingConsultation = {
-            questionText,
-            questionId: pendingQuestion.id,
-            toolApprovalMeta: toolApprovalMeta
-              ? { toolName: toolApprovalMeta.toolName, inputDigest: toolApprovalMeta.inputDigest }
-              : null,
-            timer: consultationTimer,
-          };
-          // Fall through to normal turn completion (idle + flushPendingInstructions)
+          } else {
+            // No prior consultation — dispatch fresh
+            this.dispatchNewConsultation(questionText, effectiveToolMeta, null);
+          }
         }
       }
 
@@ -904,6 +856,112 @@ export class CallController {
 
   private isCallerGuardian(): boolean {
     return this.guardianContext?.actorRole === 'guardian';
+  }
+
+  /**
+   * Create a new consultation: persist a pending question, dispatch
+   * guardian action request to channels, and start the consultation timer.
+   *
+   * If `supersededRequestId` is provided, backfills the supersession
+   * chain after the new request is created.
+   */
+  private dispatchNewConsultation(
+    questionText: string,
+    effectiveToolMeta: { toolName: string; inputDigest: string } | null,
+    supersededRequestId: string | null,
+  ): void {
+    const pendingQuestion = createPendingQuestion(this.callSessionId, questionText);
+    updateCallSession(this.callSessionId, { status: 'waiting_on_user' });
+    recordCallEvent(this.callSessionId, 'user_question_asked', { question: questionText });
+
+    // Notify the conversation that a question was asked
+    const session = getCallSession(this.callSessionId);
+    if (session) {
+      fireCallQuestionNotifier(session.conversationId, this.callSessionId, questionText);
+
+      // Dispatch guardian action request to all configured channels
+      void dispatchGuardianQuestion({
+        callSessionId: this.callSessionId,
+        conversationId: session.conversationId,
+        assistantId: this.assistantId,
+        pendingQuestion,
+        toolName: effectiveToolMeta?.toolName,
+        inputDigest: effectiveToolMeta?.inputDigest,
+      }).then(() => {
+        // Backfill supersession chain: now that the new request exists in
+        // the store, update the old request's superseded_by_request_id.
+        if (supersededRequestId) {
+          const newRequest = getPendingRequestByCallSessionId(this.callSessionId);
+          if (newRequest) {
+            backfillSupersessionMetadata(supersededRequestId, newRequest.id);
+          }
+        }
+      });
+    }
+
+    // Set a consultation timeout tied to this specific consultation
+    // record, not the global controller state.
+    const consultationTimer = setTimeout(() => {
+      // Only fire if this consultation is still the active one
+      if (!this.pendingConsultation || this.pendingConsultation.questionId !== pendingQuestion.id) return;
+
+      log.info({ callSessionId: this.callSessionId }, 'Guardian consultation timed out');
+
+      // Mark the linked guardian action request as timed out and
+      // send expiry notices to guardian destinations. Deliveries
+      // must be captured before markTimedOutWithReason changes
+      // their status.
+      const pendingActionRequest = getPendingRequestByCallSessionId(this.callSessionId);
+      if (pendingActionRequest) {
+        const deliveries = getDeliveriesByRequestId(pendingActionRequest.id);
+        markTimedOutWithReason(pendingActionRequest.id, 'call_timeout');
+        log.info(
+          { callSessionId: this.callSessionId, requestId: pendingActionRequest.id },
+          'Marked guardian action request as timed out',
+        );
+        void sendGuardianExpiryNotices(
+          deliveries,
+          pendingActionRequest.assistantId,
+          getGatewayInternalBaseUrl(),
+          readHttpToken() ?? undefined,
+        ).catch((err) => {
+          log.error(
+            { err, callSessionId: this.callSessionId, requestId: pendingActionRequest.id },
+            'Failed to send guardian action expiry notices after call timeout',
+          );
+        });
+      }
+
+      // Expire pending questions and update call state
+      expirePendingQuestions(this.callSessionId);
+      this.pendingConsultation = null;
+      updateCallSession(this.callSessionId, { status: 'in_progress' });
+      this.guardianUnavailableForCall = true;
+      recordCallEvent(this.callSessionId, 'guardian_consultation_timed_out', { question: questionText });
+
+      // Inject timeout instruction so the model addresses it on the
+      // next turn. If idle, flush immediately; otherwise it merges
+      // into the next turn completion.
+      const timeoutInstruction =
+        `[GUARDIAN_TIMEOUT] Your guardian did not respond in time to your question: "${questionText}". `
+        + `Apologize to the caller for the delay, let them know you were unable to reach your guardian, `
+        + `ask if they would like to leave a message or receive a callback, `
+        + `and ask if there are any other questions you can help with right now.`;
+
+      this.pendingInstructions.push(timeoutInstruction);
+
+      if (this.state === 'idle') {
+        this.resetSilenceTimer();
+        this.flushPendingInstructions();
+      }
+    }, getUserConsultationTimeoutMs());
+
+    this.pendingConsultation = {
+      questionText,
+      questionId: pendingQuestion.id,
+      toolApprovalMeta: effectiveToolMeta,
+      timer: consultationTimer,
+    };
   }
 
   /**

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -14,6 +14,7 @@ import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.
 import {
   backfillSupersessionMetadata,
   expireGuardianActionRequest,
+  getByPendingQuestionId,
   getDeliveriesByRequestId,
   getPendingRequestByCallSessionId,
   markTimedOutWithReason,
@@ -708,7 +709,8 @@ export class CallController {
               effectiveToolMeta && this.pendingConsultation.toolApprovalMeta
                 ? effectiveToolMeta.toolName === this.pendingConsultation.toolApprovalMeta.toolName
                   && effectiveToolMeta.inputDigest === this.pendingConsultation.toolApprovalMeta.inputDigest
-                : !effectiveToolMeta && !this.pendingConsultation.toolApprovalMeta;
+                : !effectiveToolMeta && !this.pendingConsultation.toolApprovalMeta
+                  && questionText === this.pendingConsultation.questionText;
 
             if (isSameToolAction) {
               // Same tool/action — coalesce. Keep the existing consultation
@@ -880,6 +882,11 @@ export class CallController {
       fireCallQuestionNotifier(session.conversationId, this.callSessionId, questionText);
 
       // Dispatch guardian action request to all configured channels
+      // Capture the pending question ID in a closure for stable lookup
+      // after the async dispatch completes — avoids a racy
+      // getPendingRequestByCallSessionId lookup that could return a
+      // different request if another supersession occurs during the gap.
+      const stablePendingQuestionId = pendingQuestion.id;
       void dispatchGuardianQuestion({
         callSessionId: this.callSessionId,
         conversationId: session.conversationId,
@@ -891,7 +898,7 @@ export class CallController {
         // Backfill supersession chain: now that the new request exists in
         // the store, update the old request's superseded_by_request_id.
         if (supersededRequestId) {
-          const newRequest = getPendingRequestByCallSessionId(this.callSessionId);
+          const newRequest = getByPendingQuestionId(stablePendingQuestionId);
           if (newRequest) {
             backfillSupersessionMetadata(supersededRequestId, newRequest.id);
           }

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -23,6 +23,7 @@ import {
   migrateFkCascadeRebuilds,
   migrateGuardianActionFollowup,
   migrateGuardianActionToolMetadata,
+  migrateGuardianActionSupersession,
   migrateGuardianBootstrapToken,
   migrateGuardianDeliveryConversationIndex,
   migrateGuardianVerificationPurpose,
@@ -106,6 +107,9 @@ export function initializeDb(): void {
 
   // 14c2. Guardian action tool-approval metadata columns (tool_name, input_digest)
   migrateGuardianActionToolMetadata(database);
+
+  // 14c3. Guardian action supersession metadata (superseded_by_request_id, superseded_at) + session lookup index
+  migrateGuardianActionSupersession(database);
 
   // 14d. Index on conversations.thread_type for frequent WHERE filters
   migrateConversationsThreadTypeIndex(database);

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -25,7 +25,7 @@ const log = getLogger('guardian-action-store');
 
 export type GuardianActionRequestStatus = 'pending' | 'answered' | 'expired' | 'cancelled';
 export type GuardianActionDeliveryStatus = 'pending' | 'sent' | 'failed' | 'answered' | 'expired' | 'cancelled';
-export type ExpiredReason = 'call_timeout' | 'sweep_timeout' | 'cancelled';
+export type ExpiredReason = 'call_timeout' | 'sweep_timeout' | 'cancelled' | 'superseded';
 export type FollowupState = 'none' | 'awaiting_guardian_choice' | 'dispatching' | 'completed' | 'declined' | 'failed';
 export type FollowupAction = 'call_back' | 'message_back' | 'decline';
 
@@ -53,6 +53,8 @@ export interface GuardianActionRequest {
   followupCompletedAt: number | null;
   toolName: string | null;
   inputDigest: string | null;
+  supersededByRequestId: string | null;
+  supersededAt: number | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -101,6 +103,8 @@ function rowToRequest(row: typeof guardianActionRequests.$inferSelect): Guardian
     followupCompletedAt: row.followupCompletedAt ?? null,
     toolName: row.toolName ?? null,
     inputDigest: row.inputDigest ?? null,
+    supersededByRequestId: row.supersededByRequestId ?? null,
+    supersededAt: row.supersededAt ?? null,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -172,6 +176,8 @@ export function createGuardianActionRequest(params: {
     followupCompletedAt: null,
     toolName: params.toolName ?? null,
     inputDigest: params.inputDigest ?? null,
+    supersededByRequestId: null,
+    supersededAt: null,
     createdAt: now,
     updatedAt: now,
   };
@@ -308,6 +314,84 @@ export function expireGuardianActionRequest(id: string, reason?: ExpiredReason):
       and(
         eq(guardianActionDeliveries.requestId, id),
         inArray(guardianActionDeliveries.status, ['pending', 'sent']),
+      ),
+    )
+    .run();
+}
+
+/**
+ * Supersede a pending guardian action request: mark it expired with
+ * reason='superseded', record the replacement request ID and timestamp,
+ * and expire its active deliveries.
+ *
+ * Returns the updated request on success, or null if the request was
+ * not in 'pending' status (first-writer-wins).
+ */
+export function supersedeGuardianActionRequest(
+  id: string,
+  supersededByRequestId: string,
+): GuardianActionRequest | null {
+  const db = getDb();
+  const now = Date.now();
+
+  db.update(guardianActionRequests)
+    .set({
+      status: 'expired',
+      expiredReason: 'superseded',
+      supersededByRequestId,
+      supersededAt: now,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(guardianActionRequests.id, id),
+        eq(guardianActionRequests.status, 'pending'),
+      ),
+    )
+    .run();
+
+  if (rawChanges() === 0) return null;
+
+  // Also expire active deliveries
+  db.update(guardianActionDeliveries)
+    .set({ status: 'expired', updatedAt: now })
+    .where(
+      and(
+        eq(guardianActionDeliveries.requestId, id),
+        inArray(guardianActionDeliveries.status, ['pending', 'sent']),
+      ),
+    )
+    .run();
+
+  return getGuardianActionRequest(id);
+}
+
+/**
+ * Backfill supersession metadata on an already-expired request.
+ * Used when the superseding request ID is not known at the time the
+ * original request is expired (e.g., the new request is created
+ * asynchronously via dispatchGuardianQuestion).
+ *
+ * Only updates requests that are already in 'expired' status with
+ * expired_reason='superseded'.
+ */
+export function backfillSupersessionMetadata(
+  id: string,
+  supersededByRequestId: string,
+): void {
+  const db = getDb();
+  const now = Date.now();
+
+  db.update(guardianActionRequests)
+    .set({
+      supersededByRequestId,
+      supersededAt: now,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(guardianActionRequests.id, id),
+        eq(guardianActionRequests.status, 'expired'),
       ),
     )
     .run();

--- a/assistant/src/memory/migrations/035-guardian-action-supersession.ts
+++ b/assistant/src/memory/migrations/035-guardian-action-supersession.ts
@@ -1,0 +1,23 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Add supersession metadata columns to guardian_action_requests and
+ * create an index for efficient pending-request lookups by call session.
+ *
+ * - superseded_by_request_id: links to the request that replaced this one
+ * - superseded_at: timestamp when supersession occurred
+ * - Index (call_session_id, status, created_at DESC) for fast lookups of
+ *   the most recent pending request per call session
+ *
+ * The existing expired_reason column already supports 'superseded' as a
+ * value — this migration adds the structural metadata to track the
+ * supersession chain.
+ */
+export function migrateGuardianActionSupersession(database: DrizzleDb): void {
+  try { database.run(/*sql*/ `ALTER TABLE guardian_action_requests ADD COLUMN superseded_by_request_id TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE guardian_action_requests ADD COLUMN superseded_at INTEGER`); } catch { /* already exists */ }
+
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_action_requests_session_status_created ON guardian_action_requests(call_session_id, status, created_at DESC)`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -36,6 +36,7 @@ export { migrateGuardianDeliveryConversationIndex } from './032-guardian-deliver
 export { migrateNotificationDeliveryThreadDecision } from './032-notification-delivery-thread-decision.js';
 export { createScopedApprovalGrantsTable } from './033-scoped-approval-grants.js';
 export { migrateGuardianActionToolMetadata } from './034-guardian-action-tool-metadata.js';
+export { migrateGuardianActionSupersession } from './035-guardian-action-supersession.js';
 export { createCoreTables } from './100-core-tables.js';
 export { createWatchersAndLogsTables } from './101-watchers-and-logs.js';
 export { addCoreColumns } from './102-alter-table-columns.js';

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -845,9 +845,13 @@ export const guardianActionRequests = sqliteTable('guardian_action_requests', {
   followupCompletedAt: integer('followup_completed_at'),
   toolName: text('tool_name'),                                        // tool identity for tool-approval requests
   inputDigest: text('input_digest'),                                  // canonical SHA-256 digest of tool input
+  supersededByRequestId: text('superseded_by_request_id'),            // links to the request that replaced this one
+  supersededAt: integer('superseded_at'),                             // epoch ms when supersession occurred
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
-});
+}, (table) => [
+  index('idx_guardian_action_requests_session_status_created').on(table.callSessionId, table.status, table.createdAt),
+]);
 
 // ── Guardian Action Deliveries (per-channel delivery tracking) ───────
 


### PR DESCRIPTION
Part of #10276. Implements consultation coalescing to prevent rapid request-code churn from repeated caller utterances. Adds explicit supersession metadata (expired_reason, superseded_by_request_id, superseded_at) to distinguish intentional supersession from timeout/disconnect expirations. Preserves tool metadata continuity across re-asks. Includes schema migration and tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
