### PR TITLE
M6: Deterministic guardian thread affinity per call session

### DIFF
--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -515,4 +515,128 @@ describe('guardian-dispatch', () => {
     const secondPayload = (emitCalls[0] as Record<string, unknown>).contextPayload as Record<string, unknown>;
     expect(secondPayload.activeGuardianRequestCount).toBe(2);
   });
+
+  test('second guardian question in same call session passes conversationAffinityHint with first conversation ID', async () => {
+    const convId = 'conv-dispatch-affinity-1';
+    ensureConversation(convId);
+
+    const sharedConversationId = 'conv-affinity-guardian';
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15550002222',
+    });
+
+    // First dispatch — no affinity hint expected (no prior delivery exists)
+    const pq1 = createPendingQuestion(session.id, 'First question');
+    mockEmitResult = {
+      signalId: 'sig-affinity-1',
+      deduplicated: false,
+      dispatched: true,
+      reason: 'ok',
+      deliveryResults: [
+        {
+          channel: 'vellum',
+          destination: 'vellum',
+          status: 'sent',
+          conversationId: sharedConversationId,
+        },
+      ],
+    };
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: 'self',
+      pendingQuestion: pq1,
+    });
+
+    const firstParams = emitCalls[0] as Record<string, unknown>;
+    // First dispatch should not have an affinity hint
+    expect(firstParams.conversationAffinityHint).toBeUndefined();
+
+    // Second dispatch — should carry the affinity hint from the first delivery
+    emitCalls.length = 0;
+    const pq2 = createPendingQuestion(session.id, 'Second question');
+    mockEmitResult = {
+      signalId: 'sig-affinity-2',
+      deduplicated: false,
+      dispatched: true,
+      reason: 'ok',
+      deliveryResults: [
+        {
+          channel: 'vellum',
+          destination: 'vellum',
+          status: 'sent',
+          conversationId: sharedConversationId,
+        },
+      ],
+    };
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: 'self',
+      pendingQuestion: pq2,
+    });
+
+    const secondParams = emitCalls[0] as Record<string, unknown>;
+    expect(secondParams.conversationAffinityHint).toEqual({
+      vellum: sharedConversationId,
+    });
+  });
+
+  test('third guardian question in same call session also carries affinity hint', async () => {
+    const convId = 'conv-dispatch-affinity-2';
+    ensureConversation(convId);
+
+    const sharedConversationId = 'conv-affinity-triple';
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15550002222',
+    });
+
+    // Dispatch three guardian questions in the same call session
+    for (let i = 0; i < 3; i++) {
+      emitCalls.length = 0;
+      const pq = createPendingQuestion(session.id, `Question ${i + 1}`);
+      mockEmitResult = {
+        signalId: `sig-triple-${i}`,
+        deduplicated: false,
+        dispatched: true,
+        reason: 'ok',
+        deliveryResults: [
+          {
+            channel: 'vellum',
+            destination: 'vellum',
+            status: 'sent',
+            conversationId: sharedConversationId,
+          },
+        ],
+      };
+
+      await dispatchGuardianQuestion({
+        callSessionId: session.id,
+        conversationId: convId,
+        assistantId: 'self',
+        pendingQuestion: pq,
+      });
+
+      const params = emitCalls[0] as Record<string, unknown>;
+      if (i === 0) {
+        // First dispatch — no affinity hint
+        expect(params.conversationAffinityHint).toBeUndefined();
+      } else {
+        // Subsequent dispatches — affinity hint points to the shared conversation
+        expect(params.conversationAffinityHint).toEqual({
+          vellum: sharedConversationId,
+        });
+      }
+    }
+  });
 });

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -23,6 +23,11 @@ import type { CallPendingQuestion } from './types.js';
 
 const log = getLogger('guardian-dispatch');
 
+// Per-callSessionId serialization lock. Ensures that concurrent dispatches for
+// the same call session are serialized so the second dispatch always sees the
+// delivery row (and thus the guardian conversation ID) persisted by the first.
+const pendingDispatches = new Map<string, Promise<void>>();
+
 export interface GuardianDispatchParams {
   callSessionId: string;
   conversationId: string;
@@ -48,6 +53,31 @@ function applyDeliveryStatus(deliveryId: string, result: NotificationDeliveryRes
  * Fire-and-forget: errors are logged but do not propagate.
  */
 export async function dispatchGuardianQuestion(params: GuardianDispatchParams): Promise<void> {
+  const { callSessionId } = params;
+
+  // Serialize concurrent dispatches for the same call session so the second
+  // dispatch always sees the guardian conversation ID persisted by the first.
+  const preceding = pendingDispatches.get(callSessionId);
+  const current = (preceding ?? Promise.resolve()).then(() =>
+    dispatchGuardianQuestionInner(params),
+  );
+  // Store a suppressed-error variant so the chain never rejects, and keep
+  // a stable reference for the cleanup identity check below.
+  const suppressed = current.catch(() => {});
+  pendingDispatches.set(callSessionId, suppressed);
+
+  try {
+    await current;
+  } finally {
+    // Clean up the map entry only if it still points to our promise, to avoid
+    // removing a later dispatch's entry.
+    if (pendingDispatches.get(callSessionId) === suppressed) {
+      pendingDispatches.delete(callSessionId);
+    }
+  }
+}
+
+async function dispatchGuardianQuestionInner(params: GuardianDispatchParams): Promise<void> {
   const {
     callSessionId,
     conversationId,

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -12,6 +12,7 @@ import {
   countPendingRequestsByCallSessionId,
   createGuardianActionDelivery,
   createGuardianActionRequest,
+  getGuardianConversationIdForCallSession,
   updateDeliveryStatus,
 } from '../memory/guardian-action-store.js';
 import { emitNotificationSignal } from '../notifications/emit-signal.js';
@@ -84,6 +85,22 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
     // in the same call session.
     const activeGuardianRequestCount = countPendingRequestsByCallSessionId(callSessionId);
 
+    // Look up the vellum conversation used for the first guardian question
+    // in this call session. When found, pass it as an affinity hint so the
+    // notification pipeline deterministically routes to the same conversation
+    // instead of letting the LLM choose a different thread.
+    const existingGuardianConversationId = getGuardianConversationIdForCallSession(callSessionId);
+    const conversationAffinityHint = existingGuardianConversationId
+      ? { vellum: existingGuardianConversationId }
+      : undefined;
+
+    if (existingGuardianConversationId) {
+      log.info(
+        { callSessionId, existingGuardianConversationId },
+        'Found existing guardian conversation for call session — enforcing thread affinity',
+      );
+    }
+
     // Route through the canonical notification pipeline. The paired vellum
     // conversation from this pipeline is the canonical guardian thread.
     let vellumDeliveryId: string | null = null;
@@ -107,6 +124,7 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
         pendingQuestionId: pendingQuestion.id,
         activeGuardianRequestCount,
       },
+      conversationAffinityHint,
       dedupeKey: `guardian:${request.id}`,
       onThreadCreated: (info) => {
         if (info.sourceEventName !== 'guardian.question' || vellumDeliveryId) return;

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -7,7 +7,7 @@
  * answer resolves the request and all other deliveries are marked answered.
  */
 
-import { and, count, desc, eq, inArray, lt } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, isNotNull, lt } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
 import { getLogger } from '../util/logger.js';
@@ -244,6 +244,45 @@ export function countPendingRequestsByCallSessionId(callSessionId: string): numb
     )
     .get();
   return row?.count ?? 0;
+}
+
+/**
+ * Look up the vellum conversation ID used for the first guardian question
+ * delivery in a given call session. Returns the conversation ID when one
+ * exists, or null if no vellum delivery has been recorded yet.
+ *
+ * Used by guardian-dispatch to enforce deterministic thread affinity:
+ * all guardian questions within the same call session should route to
+ * the same vellum conversation.
+ */
+export function getGuardianConversationIdForCallSession(callSessionId: string): string | null {
+  try {
+    const db = getDb();
+    const row = db
+      .select({ conversationId: guardianActionDeliveries.destinationConversationId })
+      .from(guardianActionDeliveries)
+      .innerJoin(
+        guardianActionRequests,
+        eq(guardianActionDeliveries.requestId, guardianActionRequests.id),
+      )
+      .where(
+        and(
+          eq(guardianActionRequests.callSessionId, callSessionId),
+          eq(guardianActionDeliveries.destinationChannel, 'vellum'),
+          isNotNull(guardianActionDeliveries.destinationConversationId),
+        ),
+      )
+      .orderBy(guardianActionDeliveries.createdAt)
+      .limit(1)
+      .get();
+    return row?.conversationId ?? null;
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('no such table')) {
+      log.warn({ err }, 'guardian tables not yet created');
+      return null;
+    }
+    throw err;
+  }
 }
 
 /**

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -443,7 +443,8 @@ export async function evaluateSignal(
   const provider = getConfiguredProvider();
   if (!provider) {
     log.warn('Configured provider unavailable for notification decision, using fallback');
-    const decision = buildFallbackDecision(signal, availableChannels);
+    let decision = buildFallbackDecision(signal, availableChannels);
+    decision = enforceConversationAffinity(decision, signal.conversationAffinityHint);
     decision.persistedDecisionId = persistDecision(signal, decision);
     return decision;
   }
@@ -457,6 +458,7 @@ export async function evaluateSignal(
     decision = buildFallbackDecision(signal, availableChannels);
   }
 
+  decision = enforceConversationAffinity(decision, signal.conversationAffinityHint);
   decision.persistedDecisionId = persistDecision(signal, decision);
 
   return decision;
@@ -589,6 +591,50 @@ export function enforceRoutingIntent(
   }
 
   return decision;
+}
+
+// ── Conversation affinity enforcement ───────────────────────────────────
+
+/**
+ * Enforce conversation affinity on a decision.
+ *
+ * When the signal carries a conversationAffinityHint (per-channel map of
+ * conversationId), override the decision's threadActions for those channels
+ * to `reuse_existing` with the hinted conversationId. This is a
+ * deterministic post-decision guard that prevents the LLM from routing
+ * guardian questions for the same call session to different conversations.
+ */
+export function enforceConversationAffinity(
+  decision: NotificationDecision,
+  affinityHint: Partial<Record<string, string>> | undefined,
+): NotificationDecision {
+  if (!affinityHint) return decision;
+
+  const entries = Object.entries(affinityHint).filter(
+    ([, conversationId]) => typeof conversationId === 'string' && conversationId.length > 0,
+  );
+  if (entries.length === 0) return decision;
+
+  const enforced = { ...decision };
+  const threadActions: Partial<Record<NotificationChannel, ThreadAction>> = {
+    ...(decision.threadActions ?? {}),
+  };
+
+  for (const [channel, conversationId] of entries) {
+    threadActions[channel as NotificationChannel] = {
+      action: 'reuse_existing',
+      conversationId: conversationId!,
+    };
+  }
+
+  enforced.threadActions = threadActions;
+
+  log.info(
+    { affinityHint },
+    'Conversation affinity enforcement: overrode threadActions for hinted channels',
+  );
+
+  return enforced;
 }
 
 // ── Persistence ────────────────────────────────────────────────────────

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -133,6 +133,12 @@ export interface EmitSignalParams {
   routingIntent?: RoutingIntent;
   /** Free-form hints from the source for the decision engine. */
   routingHints?: Record<string, unknown>;
+  /**
+   * Per-channel conversation affinity hint. Forces the decision engine to
+   * reuse the specified conversation for the given channel(s), bypassing
+   * LLM thread-routing judgment. Keyed by channel name, value is conversationId.
+   */
+  conversationAffinityHint?: Partial<Record<string, string>>;
   /** Optional deduplication key. */
   dedupeKey?: string;
   /**
@@ -177,6 +183,7 @@ export async function emitNotificationSignal(params: EmitSignalParams): Promise<
     attentionHints: params.attentionHints,
     routingIntent: params.routingIntent,
     routingHints: params.routingHints,
+    conversationAffinityHint: params.conversationAffinityHint,
   };
 
   try {

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -27,4 +27,11 @@ export interface NotificationSignal {
   routingIntent?: RoutingIntent;
   /** Free-form hints from the source for the decision engine (e.g. preferred channels). */
   routingHints?: Record<string, unknown>;
+  /**
+   * Per-channel conversation affinity hint. When set, the decision engine
+   * must force thread reuse to the specified conversation for that channel,
+   * bypassing LLM judgment. Used to enforce deterministic guardian thread
+   * affinity within a call session.
+   */
+  conversationAffinityHint?: Partial<Record<string, string>>;
 }


### PR DESCRIPTION
Part of #10276. Ensures all guardian.question deliveries for one call stay on the same guardian conversation. Adds affinity target lookup in guardian-dispatch, wires conversationAffinityHint through the notification signal context, and honors it in the decision engine routing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
