### PR TITLE
M7: Fix expired late-approval routing semantics

### DIFF
--- a/assistant/src/__tests__/guardian-action-late-reply.test.ts
+++ b/assistant/src/__tests__/guardian-action-late-reply.test.ts
@@ -29,7 +29,8 @@ mock.module('../runtime/gateway-client.js', () => ({
   deliverChannelReply: async () => {},
 }));
 
-import { createCallSession, createPendingQuestion } from '../calls/call-store.js';
+import { isTerminalState } from '../calls/call-state-machine.js';
+import { createCallSession, createPendingQuestion, getCallSession, updateCallSession } from '../calls/call-store.js';
 import { getDb, initializeDb, resetDb } from '../memory/db.js';
 import {
   createGuardianActionDelivery,
@@ -41,8 +42,10 @@ import {
   getFollowupDeliveriesByConversation,
   getGuardianActionRequest,
   getPendingDeliveriesByConversation,
+  getPendingRequestByCallSessionId,
   resolveGuardianActionRequest,
   startFollowupFromExpiredRequest,
+  supersedeGuardianActionRequest,
   updateDeliveryStatus,
 } from '../memory/guardian-action-store.js';
 import { conversations } from '../memory/schema.js';
@@ -420,6 +423,257 @@ describe('guardian-action-late-reply', () => {
       // After stripping the code prefix, the answer text is extracted
       const answerText = userInput.slice(code.length).trim();
       expect(answerText).toBe('the answer is 42');
+    });
+  });
+
+  // ── Superseded late-approval remap semantics ──────────────────────
+
+  describe('superseded late-approval remap', () => {
+    /**
+     * Helper: create two guardian action requests on the same call session.
+     * The first is superseded by the second (which stays pending).
+     * Returns the superseded request, the current pending request, and the call session.
+     */
+    function createSupersededScenario(convId: string, opts?: { chatId?: string; externalUserId?: string; conversationId?: string }) {
+      ensureConversation(convId);
+      const session = createCallSession({
+        conversationId: convId,
+        provider: 'twilio',
+        fromNumber: '+15550001111',
+        toNumber: '+15550002222',
+      });
+      // Keep call in 'initiated' status (non-terminal) — simulates active call
+      const pqOld = createPendingQuestion(session.id, 'What is the old gate code?');
+      const oldRequest = createGuardianActionRequest({
+        kind: 'ask_guardian',
+        sourceChannel: 'voice',
+        sourceConversationId: convId,
+        callSessionId: session.id,
+        pendingQuestionId: pqOld.id,
+        questionText: pqOld.questionText,
+        expiresAt: Date.now() + 60_000,
+        toolName: 'check_gate',
+        inputDigest: 'digest-old',
+      });
+
+      // Create delivery for the old request
+      const deliveryConvId = opts?.conversationId ?? `delivery-conv-${oldRequest.id}`;
+      if (opts?.conversationId) {
+        ensureConversation(opts.conversationId);
+      } else {
+        ensureConversation(deliveryConvId);
+      }
+      const oldDelivery = createGuardianActionDelivery({
+        requestId: oldRequest.id,
+        destinationChannel: 'telegram',
+        destinationChatId: opts?.chatId ?? 'chat-123',
+        destinationExternalUserId: opts?.externalUserId ?? 'user-456',
+        destinationConversationId: deliveryConvId,
+      });
+      updateDeliveryStatus(oldDelivery.id, 'sent');
+
+      // Create the new (current) pending request
+      const pqNew = createPendingQuestion(session.id, 'What is the new gate code?');
+      const newRequest = createGuardianActionRequest({
+        kind: 'ask_guardian',
+        sourceChannel: 'voice',
+        sourceConversationId: convId,
+        callSessionId: session.id,
+        pendingQuestionId: pqNew.id,
+        questionText: pqNew.questionText,
+        expiresAt: Date.now() + 60_000,
+        toolName: 'check_gate',
+        inputDigest: 'digest-new',
+      });
+
+      // Supersede the old request
+      supersedeGuardianActionRequest(oldRequest.id, newRequest.id);
+
+      return {
+        session,
+        supersededRequest: getGuardianActionRequest(oldRequest.id)!,
+        currentRequest: getGuardianActionRequest(newRequest.id)!,
+        oldDelivery,
+        deliveryConvId,
+      };
+    }
+
+    test('superseded request has expired_reason=superseded and links to replacement', () => {
+      const { supersededRequest, currentRequest } = createSupersededScenario('conv-supersede-1');
+
+      expect(supersededRequest.status).toBe('expired');
+      expect(supersededRequest.expiredReason).toBe('superseded');
+      expect(supersededRequest.supersededByRequestId).toBe(currentRequest.id);
+      expect(currentRequest.status).toBe('pending');
+    });
+
+    test('superseded request with active call and pending request is remap-eligible', () => {
+      const { session, supersededRequest, currentRequest } = createSupersededScenario('conv-supersede-2');
+
+      // Call should still be active (non-terminal)
+      const callSession = getCallSession(session.id);
+      expect(callSession).not.toBeNull();
+      expect(isTerminalState(callSession!.status)).toBe(false);
+
+      // Should find current pending request for the same call session
+      const pending = getPendingRequestByCallSessionId(supersededRequest.callSessionId);
+      expect(pending).not.toBeNull();
+      expect(pending!.id).toBe(currentRequest.id);
+
+      // The superseded request is expired with reason 'superseded' and followup_state 'none'
+      expect(supersededRequest.expiredReason).toBe('superseded');
+      expect(supersededRequest.followupState).toBe('none');
+    });
+
+    test('superseded request with completed call is NOT remap-eligible — falls through to follow-up', () => {
+      const { session, supersededRequest } = createSupersededScenario('conv-supersede-3');
+
+      // Transition the call to a terminal state
+      updateCallSession(session.id, { status: 'in_progress' });
+      updateCallSession(session.id, { status: 'completed', endedAt: Date.now() });
+
+      // Call is now terminal
+      const callSession = getCallSession(session.id);
+      expect(callSession).not.toBeNull();
+      expect(isTerminalState(callSession!.status)).toBe(true);
+
+      // Even though expired_reason is 'superseded', the remap should not apply
+      // because the call has ended. The follow-up path should be used instead.
+      expect(supersededRequest.expiredReason).toBe('superseded');
+    });
+
+    test('timeout-expired request is NOT remap-eligible even with active call', () => {
+      const convId = 'conv-timeout-no-remap';
+      ensureConversation(convId);
+      const session = createCallSession({
+        conversationId: convId,
+        provider: 'twilio',
+        fromNumber: '+15550001111',
+        toNumber: '+15550002222',
+      });
+
+      const pq = createPendingQuestion(session.id, 'What is the code?');
+      const request = createGuardianActionRequest({
+        kind: 'ask_guardian',
+        sourceChannel: 'voice',
+        sourceConversationId: convId,
+        callSessionId: session.id,
+        pendingQuestionId: pq.id,
+        questionText: pq.questionText,
+        expiresAt: Date.now() - 10_000,
+      });
+
+      const deliveryConvId = `delivery-conv-${request.id}`;
+      ensureConversation(deliveryConvId);
+      const delivery = createGuardianActionDelivery({
+        requestId: request.id,
+        destinationChannel: 'telegram',
+        destinationChatId: 'chat-timeout',
+        destinationExternalUserId: 'user-timeout',
+        destinationConversationId: deliveryConvId,
+      });
+      updateDeliveryStatus(delivery.id, 'sent');
+
+      // Expire with sweep_timeout (NOT superseded)
+      expireGuardianActionRequest(request.id, 'sweep_timeout');
+
+      const expired = getGuardianActionRequest(request.id)!;
+      expect(expired.expiredReason).toBe('sweep_timeout');
+
+      // Even if the call is active, this should follow the callback/message path
+      // because it's a real timeout, not a supersession
+      const callSession = getCallSession(session.id);
+      expect(callSession).not.toBeNull();
+      expect(isTerminalState(callSession!.status)).toBe(false);
+
+      // startFollowupFromExpiredRequest should work normally for timeouts
+      const followup = startFollowupFromExpiredRequest(request.id, 'late answer');
+      expect(followup).not.toBeNull();
+      expect(followup!.followupState).toBe('awaiting_guardian_choice');
+    });
+
+    test('call_timeout-expired request is NOT remap-eligible', () => {
+      const convId = 'conv-call-timeout-no-remap';
+      ensureConversation(convId);
+      const session = createCallSession({
+        conversationId: convId,
+        provider: 'twilio',
+        fromNumber: '+15550001111',
+        toNumber: '+15550002222',
+      });
+
+      const pq = createPendingQuestion(session.id, 'What is the code?');
+      const request = createGuardianActionRequest({
+        kind: 'ask_guardian',
+        sourceChannel: 'voice',
+        sourceConversationId: convId,
+        callSessionId: session.id,
+        pendingQuestionId: pq.id,
+        questionText: pq.questionText,
+        expiresAt: Date.now() - 10_000,
+      });
+
+      const deliveryConvId = `delivery-conv-${request.id}`;
+      ensureConversation(deliveryConvId);
+      const delivery = createGuardianActionDelivery({
+        requestId: request.id,
+        destinationChannel: 'telegram',
+        destinationChatId: 'chat-call-timeout',
+        destinationExternalUserId: 'user-call-timeout',
+        destinationConversationId: deliveryConvId,
+      });
+      updateDeliveryStatus(delivery.id, 'sent');
+
+      // Expire with call_timeout (NOT superseded)
+      expireGuardianActionRequest(request.id, 'call_timeout');
+
+      const expired = getGuardianActionRequest(request.id)!;
+      expect(expired.expiredReason).toBe('call_timeout');
+
+      // call_timeout should follow the callback/message path regardless
+      const followup = startFollowupFromExpiredRequest(request.id, 'late answer for timeout');
+      expect(followup).not.toBeNull();
+      expect(followup!.followupState).toBe('awaiting_guardian_choice');
+    });
+
+    test('superseded request with no pending replacement falls through to follow-up', () => {
+      const { supersededRequest, currentRequest } = createSupersededScenario('conv-supersede-no-pending');
+
+      // Resolve the current pending request so there's no pending replacement
+      resolveGuardianActionRequest(currentRequest.id, 'answered already', 'telegram');
+
+      // No pending request for this call session anymore
+      const pending = getPendingRequestByCallSessionId(supersededRequest.callSessionId);
+      expect(pending).toBeNull();
+
+      // The superseded request should fall through to follow-up since
+      // there's no pending request to remap to
+      const followup = startFollowupFromExpiredRequest(supersededRequest.id, 'late answer');
+      expect(followup).not.toBeNull();
+      expect(followup!.followupState).toBe('awaiting_guardian_choice');
+    });
+
+    test('composeGuardianActionMessageGenerative produces remap text for superseded scenario', async () => {
+      const { composeGuardianActionMessageGenerative } = await import('../runtime/guardian-action-message-composer.js');
+
+      const text = await composeGuardianActionMessageGenerative({
+        scenario: 'guardian_superseded_remap',
+        questionText: 'What is the new gate code?',
+      });
+
+      // In test mode, the deterministic fallback is used
+      expect(text).toContain('current active request');
+      expect(text).toContain('What is the new gate code?');
+    });
+
+    test('composeGuardianActionMessageGenerative produces remap text without question', async () => {
+      const { composeGuardianActionMessageGenerative } = await import('../runtime/guardian-action-message-composer.js');
+
+      const text = await composeGuardianActionMessageGenerative({
+        scenario: 'guardian_superseded_remap',
+      });
+
+      expect(text).toContain('current active request');
     });
   });
 });

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -17,6 +17,7 @@ import * as conversationStore from '../memory/conversation-store.js';
 import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import {
   finalizeFollowup,
+  getDeliveriesByRequestId,
   getExpiredDeliveriesByConversation,
   getFollowupDeliveriesByConversation,
   getGuardianActionRequest,
@@ -658,6 +659,24 @@ export async function processMessage(
             : null;
 
           if (callStillActive && currentPending) {
+            // Verify the replying guardian has a delivery on the current
+            // pending request. If guardian bindings rotated between requests,
+            // the previous guardian should not resolve the newer request.
+            const currentDeliveries = getDeliveriesByRequestId(currentPending.id);
+            const guardianExtUserId = session.guardianContext?.guardianExternalUserId;
+            const senderHasDelivery = guardianExtUserId
+              && currentDeliveries.some((d) => d.destinationExternalUserId === guardianExtUserId);
+            if (!senderHasDelivery) {
+              log.info(
+                {
+                  supersededRequestId: expiredRequest.id,
+                  currentRequestId: currentPending.id,
+                  guardianExternalUserId: guardianExtUserId,
+                },
+                'Superseded remap skipped: sender has no delivery on current pending request',
+              );
+              // Fall through to the existing callback/message follow-up path
+            } else {
             const remapResult = await answerCall({
               callSessionId: currentPending.callSessionId,
               answer: expiredAnswerText,
@@ -706,6 +725,7 @@ export async function processMessage(
               { callSessionId: currentPending.callSessionId, error: 'error' in remapResult ? remapResult.error : 'unknown' },
               'Superseded remap answerCall failed, falling through to follow-up',
             );
+            } // end else (senderHasDelivery)
           }
           // Call not active or no pending request — fall through to follow-up
         }

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -8,6 +8,8 @@
 
 import { createAssistantMessage,createUserMessage } from '../agent/message-types.js';
 import { answerCall } from '../calls/call-domain.js';
+import { isTerminalState } from '../calls/call-state-machine.js';
+import { getCallSession } from '../calls/call-store.js';
 import type { TurnChannelContext, TurnInterfaceContext } from '../channels/types.js';
 import { parseChannelId, parseInterfaceId } from '../channels/types.js';
 import { getConfig } from '../config/loader.js';
@@ -19,6 +21,7 @@ import {
   getFollowupDeliveriesByConversation,
   getGuardianActionRequest,
   getPendingDeliveriesByConversation,
+  getPendingRequestByCallSessionId,
   progressFollowupState,
   resolveGuardianActionRequest,
   startFollowupFromExpiredRequest,
@@ -642,6 +645,70 @@ export async function processMessage(
           guardianChannelMeta,
         );
         session.messages.push(userMsg);
+
+        // ── Superseded remap: if the request was superseded (not timed out
+        // or disconnected), check whether the call is still active with a
+        // current pending request. If so, remap the late approval to the
+        // current request instead of entering the callback/message follow-up.
+        if (expiredRequest.expiredReason === 'superseded') {
+          const callSession = getCallSession(expiredRequest.callSessionId);
+          const callStillActive = callSession && !isTerminalState(callSession.status);
+          const currentPending = callStillActive
+            ? getPendingRequestByCallSessionId(expiredRequest.callSessionId)
+            : null;
+
+          if (callStillActive && currentPending) {
+            const remapResult = await answerCall({
+              callSessionId: currentPending.callSessionId,
+              answer: expiredAnswerText,
+              pendingQuestionId: currentPending.pendingQuestionId,
+            });
+
+            if ('ok' in remapResult && remapResult.ok) {
+              const resolved = resolveGuardianActionRequest(currentPending.id, expiredAnswerText, 'vellum');
+
+              if (resolved) {
+                tryMintGuardianActionGrant({
+                  resolvedRequest: resolved,
+                  answerText: expiredAnswerText,
+                  decisionChannel: 'vellum',
+                });
+              }
+
+              const remapText = await composeGuardianActionMessageGenerative(
+                {
+                  scenario: 'guardian_superseded_remap',
+                  questionText: currentPending.questionText,
+                },
+                {},
+                _guardianActionCopyGenerator,
+              );
+              const remapMsg = createAssistantMessage(remapText);
+              await conversationStore.addMessage(
+                session.conversationId,
+                'assistant',
+                JSON.stringify(remapMsg.content),
+                guardianChannelMeta,
+              );
+              session.messages.push(remapMsg);
+              onEvent({ type: 'assistant_text_delta', text: remapText });
+              onEvent({ type: 'message_complete', sessionId: session.conversationId });
+
+              log.info(
+                { supersededRequestId: expiredRequest.id, remappedToRequestId: currentPending.id },
+                'Late approval for superseded request remapped to current pending request',
+              );
+
+              return persisted.id;
+            }
+            // answerCall failed — fall through to the normal follow-up path
+            log.warn(
+              { callSessionId: currentPending.callSessionId, error: 'error' in remapResult ? remapResult.error : 'unknown' },
+              'Superseded remap answerCall failed, falling through to follow-up',
+            );
+          }
+          // Call not active or no pending request — fall through to follow-up
+        }
 
         const followupResult = startFollowupFromExpiredRequest(expiredRequest.id, expiredAnswerText);
         if (followupResult) {

--- a/assistant/src/runtime/guardian-action-message-composer.ts
+++ b/assistant/src/runtime/guardian-action-message-composer.ts
@@ -31,6 +31,7 @@ export type GuardianActionMessageScenario =
   | 'guardian_stale_answered'
   | 'guardian_stale_expired'
   | 'guardian_stale_followup'
+  | 'guardian_superseded_remap'
   | 'outbound_message_copy'
   | 'followup_message_sent'
   | 'followup_call_started'
@@ -199,6 +200,11 @@ export function getGuardianActionFallbackMessage(context: GuardianActionMessageC
 
     case 'guardian_stale_followup':
       return 'It looks like this follow-up has already been handled. No further action is needed.';
+
+    case 'guardian_superseded_remap':
+      return context.questionText
+        ? `Got it! Your answer has been applied to the current active request: "${context.questionText}"`
+        : 'Got it! Your answer has been applied to the current active request on the call.';
 
     case 'outbound_message_copy':
       // This SMS is sent TO the original caller relaying the guardian's answer.

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -21,6 +21,7 @@ import * as conversationStore from '../../memory/conversation-store.js';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
 import {
   finalizeFollowup,
+  getDeliveriesByRequestId,
   getExpiredDeliveriesByDestination,
   getFollowupDeliveriesByDestination,
   getGuardianActionRequest,
@@ -1054,6 +1055,23 @@ export async function handleChannelInbound(
                 : null;
 
               if (callStillActive && currentPending) {
+                // Verify the replying guardian has a delivery on the current
+                // pending request. If guardian bindings rotated between requests,
+                // the previous guardian should not resolve the newer request.
+                const currentDeliveries = getDeliveriesByRequestId(currentPending.id);
+                const senderHasDelivery = body.senderExternalUserId
+                  && currentDeliveries.some((d) => d.destinationExternalUserId === body.senderExternalUserId);
+                if (!senderHasDelivery) {
+                  log.info(
+                    {
+                      supersededRequestId: expiredRequest.id,
+                      currentRequestId: currentPending.id,
+                      senderExternalUserId: body.senderExternalUserId,
+                    },
+                    'Superseded remap skipped: sender has no delivery on current pending request',
+                  );
+                  // Fall through to the existing callback/message follow-up path
+                } else {
                 // Remap: deliver the answer to the call targeting the current
                 // pending question, then resolve the current request and mint a grant.
                 const remapResult = await answerCall({
@@ -1114,6 +1132,7 @@ export async function handleChannelInbound(
                   { callSessionId: currentPending.callSessionId, error: 'error' in remapResult ? remapResult.error : 'unknown' },
                   'Superseded remap answerCall failed, falling through to follow-up',
                 );
+                } // end else (senderHasDelivery)
               }
               // Call not active or no pending request — fall through to follow-up
             }

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -4,6 +4,8 @@
  * verification, guardian action answers, and approval interception.
  */
 import { answerCall } from '../../calls/call-domain.js';
+import { isTerminalState } from '../../calls/call-state-machine.js';
+import { getCallSession } from '../../calls/call-store.js';
 import type { ChannelId, InterfaceId } from '../../channels/types.js';
 import { CHANNEL_IDS, INTERFACE_IDS, isChannelId, parseInterfaceId } from '../../channels/types.js';
 import { getGatewayInternalBaseUrl } from '../../config/env.js';
@@ -23,6 +25,7 @@ import {
   getFollowupDeliveriesByDestination,
   getGuardianActionRequest,
   getPendingDeliveriesByDestination,
+  getPendingRequestByCallSessionId,
   progressFollowupState,
   resolveGuardianActionRequest,
   startFollowupFromExpiredRequest,
@@ -1039,6 +1042,82 @@ export async function handleChannelInbound(
           const expiredRequest = getGuardianActionRequest(matchedExpired.requestId);
 
           if (expiredRequest && expiredRequest.status === 'expired' && expiredRequest.followupState === 'none') {
+            // ── Superseded remap: if the request was superseded (not timed out
+            // or disconnected), check whether the call is still active with a
+            // current pending request. If so, remap the late approval to the
+            // current request instead of entering the callback/message follow-up.
+            if (expiredRequest.expiredReason === 'superseded') {
+              const callSession = getCallSession(expiredRequest.callSessionId);
+              const callStillActive = callSession && !isTerminalState(callSession.status);
+              const currentPending = callStillActive
+                ? getPendingRequestByCallSessionId(expiredRequest.callSessionId)
+                : null;
+
+              if (callStillActive && currentPending) {
+                // Remap: deliver the answer to the call targeting the current
+                // pending question, then resolve the current request and mint a grant.
+                const remapResult = await answerCall({
+                  callSessionId: currentPending.callSessionId,
+                  answer: expiredAnswerText,
+                  pendingQuestionId: currentPending.pendingQuestionId,
+                });
+
+                if ('ok' in remapResult && remapResult.ok) {
+                  const resolved = resolveGuardianActionRequest(
+                    currentPending.id,
+                    expiredAnswerText,
+                    sourceChannel,
+                    body.senderExternalUserId,
+                  );
+
+                  if (resolved) {
+                    tryMintGuardianActionGrant({
+                      resolvedRequest: resolved,
+                      answerText: expiredAnswerText,
+                      decisionChannel: sourceChannel,
+                      guardianExternalUserId: body.senderExternalUserId,
+                    });
+                  }
+
+                  const remapText = await composeGuardianActionMessageGenerative(
+                    {
+                      scenario: 'guardian_superseded_remap',
+                      questionText: currentPending.questionText,
+                    },
+                    {},
+                    guardianActionCopyGenerator,
+                  );
+                  try {
+                    await deliverChannelReply(replyCallbackUrl, {
+                      chatId: externalChatId,
+                      text: remapText,
+                      assistantId,
+                    }, bearerToken);
+                  } catch (err) {
+                    log.error({ err, externalChatId }, 'Failed to deliver superseded remap confirmation');
+                  }
+
+                  log.info(
+                    { supersededRequestId: expiredRequest.id, remappedToRequestId: currentPending.id },
+                    'Late approval for superseded request remapped to current pending request',
+                  );
+
+                  return Response.json({
+                    accepted: true,
+                    duplicate: false,
+                    eventId: result.eventId,
+                    guardianAnswer: 'superseded_remapped',
+                  });
+                }
+                // answerCall failed — fall through to the normal follow-up path
+                log.warn(
+                  { callSessionId: currentPending.callSessionId, error: 'error' in remapResult ? remapResult.error : 'unknown' },
+                  'Superseded remap answerCall failed, falling through to follow-up',
+                );
+              }
+              // Call not active or no pending request — fall through to follow-up
+            }
+
             const followupResult = startFollowupFromExpiredRequest(expiredRequest.id, expiredAnswerText);
             if (followupResult) {
               const followupText = await composeGuardianActionMessageGenerative(


### PR DESCRIPTION
Part of #10276. When a guardian approves a superseded request during an active call, the approval is remapped to the current pending request instead of going to callback/message follow-up. Real timeout/disconnect expirations still follow the existing follow-up path. Includes tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
