### PR TITLE
perf: reduce CU overhead and skip memory on tool-result turns

### DIFF
--- a/assistant/src/daemon/session-memory.ts
+++ b/assistant/src/daemon/session-memory.ts
@@ -40,6 +40,16 @@ export interface MemoryPrepareContext {
 }
 
 /**
+ * Returns true when the latest user turn is an internal tool-result-only
+ * message (no user-authored text/image content).
+ */
+function isToolResultOnlyUserTurn(message: Message | undefined): boolean {
+  return message?.role === 'user'
+    && message.content.length > 0
+    && message.content.every((block) => block.type === 'tool_result');
+}
+
+/**
  * Build memory recall, dynamic profile, and conflict gate evaluation
  * for a single agent loop turn. Returns the augmented run messages and
  * metadata for downstream event emission.
@@ -57,6 +67,41 @@ export async function prepareMemoryContext(
   const isTrustedActor = ctx.guardianActorRole === 'guardian' || ctx.guardianActorRole === undefined;
 
   if (!isTrustedActor) {
+    return {
+      runMessages: ctx.messages,
+      recall: {
+        enabled: false,
+        degraded: false,
+        injectedText: '',
+        lexicalHits: 0,
+        semanticHits: 0,
+        recencyHits: 0,
+        entityHits: 0,
+        relationSeedEntityCount: 0,
+        relationTraversedEdgeCount: 0,
+        relationNeighborEntityCount: 0,
+        relationExpandedItemCount: 0,
+        earlyTerminated: false,
+        mergedCount: 0,
+        selectedCount: 0,
+        rerankApplied: false,
+        injectedTokens: 0,
+        latencyMs: 0,
+        topCandidates: [],
+      } as Awaited<ReturnType<typeof buildMemoryRecall>>,
+      dynamicProfile: { text: '' },
+      softConflictInstruction: null,
+      recallInjectionStrategy: 'prepend_user_block',
+      conflictClarification: null,
+    };
+  }
+
+  // Internal tool-result turns (assistant tool loop) should not trigger
+  // memory retrieval/profile injection. Injecting memory here repeats the
+  // same long recall block on every tool step and dramatically inflates
+  // per-step prompt size/latency.
+  const latestMessage = ctx.messages[ctx.messages.length - 1];
+  if (isToolResultOnlyUserTurn(latestMessage)) {
     return {
       runMessages: ctx.messages,
       recall: {

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -431,16 +431,13 @@ final class ComputerUseSession: ObservableObject {
 
         let stepNumber = currentStepNumber + 1
 
-        // Start screenshot capture early (it's async and takes ~100-200ms)
-        // This runs in parallel with AX tree enumeration below
-        // Use Task.detached so it doesn't inherit @MainActor isolation and can truly run concurrently
-        let screenCap = self.screenCapture
-        let screenshotPromise: Task<ScreenCaptureResult?, Never> = Task.detached {
+        func captureScreenshot() async -> ScreenCaptureResult? {
             do {
-                return try await screenCap.captureScreenWithMetadata(maxWidth: 1280, maxHeight: 720)
+                // Keep CU observations lighter to avoid renderer/WindowServer churn
+                // on complex pages while still preserving enough visual fidelity.
+                return try await self.screenCapture.captureScreenWithMetadata(maxWidth: 960, maxHeight: 540)
             } catch {
-                Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "Session")
-                    .error("Screenshot capture failed: \(error)")
+                log.error("Screenshot capture failed: \(error)")
                 return nil
             }
         }
@@ -470,7 +467,6 @@ final class ComputerUseSession: ObservableObject {
                     if restarted {
                         AccessibilityTreeEnumerator.clearEnhancedAXCache()
                         log.info("\(browserName) restarted — re-enumerating")
-                        screenshotPromise.cancel()
                         return await buildObservation(executionResult: executionResult, executionError: executionError)
                     } else {
                         log.error("\(browserName) restart failed — continuing with limited AX tree")
@@ -527,17 +523,15 @@ final class ComputerUseSession: ObservableObject {
 
             // Await the pre-started screenshot if we need it; cancel otherwise
             if shouldCaptureScreenshot(stepNumber: stepNumber, flatElements: flat, lastAction: nil) {
-                let screenshotResult = await screenshotPromise.value
+                let screenshotResult = await captureScreenshot()
                 screenshotData = screenshotResult?.jpegData
                 screenshotMetadata = screenshotResult?.metadata
                 log.info("[\(stepNumber)] Screenshot captured alongside AX tree (\(screenshotData?.count ?? 0) bytes)")
-            } else {
-                screenshotPromise.cancel()
             }
         } else {
-            // No focused window — await pre-started screenshot as last resort
+            // No focused window — capture screenshot as last resort
             log.warning("[\(stepNumber)] No AX tree available — falling back to screenshot")
-            let screenshotResult = await screenshotPromise.value
+            let screenshotResult = await captureScreenshot()
             screenshotData = screenshotResult?.jpegData
             screenshotMetadata = screenshotResult?.metadata
             if screenshotData != nil {


### PR DESCRIPTION
## Summary

- Skip memory retrieval/profile injection on internal tool-result-only user turns (assistant tool loop). Injecting memory on every tool step was repeating the same long recall block and inflating per-step prompt size and latency.
- Reduce Computer Use screenshot resolution from 1280x720 to 960x540 to lower renderer/WindowServer churn on complex pages while still preserving enough visual fidelity.
- Simplify screenshot capture flow by replacing the `Task.detached` parallel pattern with a straightforward `captureScreenshot()` async function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
