### PR TITLE
fix: add guardian_pending_disambiguation to ALL_SCENARIOS test array

### DIFF
--- a/assistant/src/__tests__/guardian-action-copy-generator.test.ts
+++ b/assistant/src/__tests__/guardian-action-copy-generator.test.ts
@@ -23,6 +23,7 @@ const ALL_SCENARIOS: GuardianActionMessageScenario[] = [
   'guardian_followup_failed',
   'guardian_followup_declined_ack',
   'guardian_followup_clarification',
+  'guardian_pending_disambiguation',
   'guardian_expired_disambiguation',
   'guardian_followup_disambiguation',
   'guardian_stale_answered',


### PR DESCRIPTION
Addresses Devin feedback on #10315. Adds the missing guardian_pending_disambiguation scenario to the exhaustive test array in guardian-action-copy-generator.test.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
