### PR TITLE
fix: prevent dual-control-mode conflicts and reduce browser CPU overhead

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -312,12 +312,47 @@ export class AgentLoop {
           break;
         }
 
+        // Guard against dual-control-mode conflicts in a single turn.
+        // If the model escalates to foreground computer control, browser_* tools
+        // in the same response create competing browser sessions/windows and can
+        // thrash renderer CPU. Reject browser_* calls in that turn.
+        const hasComputerUseEscalation = toolUseBlocks.some(
+          (toolUse) => toolUse.name === 'computer_use_request_control',
+        );
+        const blockedBrowserToolIds = hasComputerUseEscalation
+          ? new Set(
+              toolUseBlocks
+                .filter((toolUse) => toolUse.name.startsWith('browser_'))
+                .map((toolUse) => toolUse.id),
+            )
+          : new Set<string>();
+
+        if (blockedBrowserToolIds.size > 0) {
+          log.warn(
+            {
+              blockedBrowserToolCount: blockedBrowserToolIds.size,
+              toolNames: toolUseBlocks.map((toolUse) => toolUse.name),
+            },
+            'Blocking browser_* tools: computer_use_request_control was requested in same turn',
+          );
+        }
+
         // Execute all tools concurrently for reduced latency.
         // Race against the abort signal so cancellation isn't blocked by
         // stuck tools (e.g. a hung browser navigation).
         const toolExecutionPromise = Promise.all(
           toolUseBlocks.map(async (toolUse) => {
             const toolStart = Date.now();
+
+            if (blockedBrowserToolIds.has(toolUse.id)) {
+              return {
+                toolUse,
+                result: {
+                  content: 'Error: browser_* tools cannot run in the same turn as computer_use_request_control. Continue using the foreground computer-use session only.',
+                  isError: true,
+                },
+              };
+            }
 
             const result = await this.toolExecutor!(toolUse.name, toolUse.input, (chunk) => {
               onEvent({ type: 'tool_output_chunk', toolUseId: toolUse.id, chunk });

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -20,6 +20,7 @@ export type DownloadInfo = { path: string; filename: string };
 
 type BrowserContext = {
   newPage(): Promise<Page>;
+  pages?(): Page[];
   close(): Promise<void>;
 };
 
@@ -253,32 +254,11 @@ class BrowserManager {
           }
         }
 
-        // If a client is connected, launch headed Chromium (minimized) so the user
-        // can interact directly when handoff triggers (e.g. CAPTCHAs).
-        // The window stays offscreen until bringToFront() is called during handoff.
-        const hasSender = !!(invokingSessionId && this.sessionSenders.get(invokingSessionId));
-        if (hasSender && this._browserMode === 'headless') {
-          try {
-            const pw2 = await import('playwright');
-            const headedBrowser = await pw2.chromium.launch({
-              channel: 'chrome',
-              headless: false,
-              args: [
-                '--window-position=-32000,-32000',
-                '--window-size=1,1',
-                '--disable-blink-features=AutomationControlled',
-              ],
-            });
-            const ctx = headedBrowser.contexts()[0] || await headedBrowser.newContext();
-            this.cdpBrowser = headedBrowser as unknown as typeof this.cdpBrowser;
-            this._browserLaunched = true;
-            this.setBrowserMode('cdp');
-            await this.initBrowserCdpSession();
-            log.info('Launched headed Chromium (minimized) for interactive handoff support');
-            return ctx as unknown as BrowserContext;
-          } catch (err2) {
-            log.warn({ err: err2 }, 'Headed Chromium launch failed, falling back to headless');
-          }
+        if (invokingSessionId && this.sessionSenders.get(invokingSessionId) && this._browserMode === 'headless') {
+          log.info(
+            { sessionId: invokingSessionId },
+            'CDP unavailable/declined; staying in headless mode (no visible browser window will be auto-launched)',
+          );
         }
       }
 
@@ -380,7 +360,21 @@ class BrowserManager {
     this.snapshotMaps.delete(sessionId);
     await this.stopScreencast(sessionId);
 
-    const page = await context.newPage();
+    let page: Page | undefined;
+
+    // In connectOverCDP mode, Chrome often starts with a pre-opened blank tab.
+    // Reuse that tab first to avoid spawning an extra visible window/tab that
+    // appears unused to the user.
+    if (this._browserMode === 'cdp' && !this._browserLaunched && typeof context.pages === 'function') {
+      const claimedPages = new Set(this.pages.values());
+      const reusable = context.pages().find((p) => !p.isClosed() && !claimedPages.has(p));
+      if (reusable) {
+        page = reusable;
+        log.debug({ sessionId }, 'Reusing existing CDP page instead of creating a new page');
+      }
+    }
+
+    page ??= await context.newPage();
     this.pages.set(sessionId, page);
     this.rawPages.set(sessionId, page);
 
@@ -509,10 +503,9 @@ class BrowserManager {
     this.cdpSessions.set(sessionId, cdp);
     this.screencastCallbacks.set(sessionId, onFrame);
 
-    // Throttle frame delivery to ~4fps max to avoid flooding IPC and the client.
-    // This materially reduces CPU on heavy pages (e.g. cloud consoles) while
-    // still keeping enough visual continuity for guided browser actions.
-    const MIN_FRAME_INTERVAL_MS = 250;
+    // Keep screencast intentionally low-frequency to avoid Chrome renderer /
+    // WindowServer spikes while users type in interactive auth flows.
+    const MIN_FRAME_INTERVAL_MS = 1000;
     let lastFrameTime = 0;
 
     cdp.on('Page.screencastFrame', (params) => {
@@ -527,10 +520,10 @@ class BrowserManager {
 
     await cdp.send('Page.startScreencast', {
       format: 'jpeg',
-      quality: 40,
-      maxWidth: 1024,
-      maxHeight: 768,
-      everyNthFrame: 2,
+      quality: 30,
+      maxWidth: 800,
+      maxHeight: 600,
+      everyNthFrame: 4,
     });
   }
 


### PR DESCRIPTION
## Summary

- Adds a guard in the agent loop to block `browser_*` tools when `computer_use_request_control` is requested in the same turn, preventing competing browser sessions and CPU thrashing
- Removes auto-launch of headed Chromium for interactive handoff — stays in headless mode with a log message instead of risking a failed headed launch
- Reuses existing CDP blank tabs instead of spawning new visible tabs/windows
- Reduces screencast frame rate from ~4fps to ~1fps and lowers resolution/quality to cut Chrome renderer and WindowServer CPU overhead during interactive auth flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
