### PR TITLE
feat: full untruncated diffs and inputs in tool confirmation prompts

### DIFF
--- a/assistant/src/__tests__/cli.test.ts
+++ b/assistant/src/__tests__/cli.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect,test } from 'bun:test';
 
-import { sanitizeUrlForDisplay } from '../cli.js';
+import {
+  formatConfirmationCommandPreview,
+  formatConfirmationInputLines,
+  sanitizeUrlForDisplay,
+} from '../cli.js';
 
 describe('sanitizeUrlForDisplay', () => {
   test('removes userinfo from absolute URLs', () => {
@@ -23,5 +27,42 @@ describe('sanitizeUrlForDisplay', () => {
     const rawValue = `not-a-url //${userinfo}@example.com`;
 
     expect(sanitizeUrlForDisplay(rawValue)).toBe('not-a-url //[REDACTED]@example.com');
+  });
+});
+
+describe('formatConfirmationInputLines', () => {
+  test('preserves full old_string and new_string values without truncation', () => {
+    const oldString = 'old '.repeat(120);
+    const newString = 'new '.repeat(120);
+    const lines = formatConfirmationInputLines({
+      old_string: oldString,
+      new_string: newString,
+    });
+
+    expect(lines).toContain(`old_string: ${oldString}`);
+    expect(lines).toContain(`new_string: ${newString}`);
+    expect(lines.some((line) => line.includes('...'))).toBe(false);
+  });
+
+  test('preserves multiline values', () => {
+    const lines = formatConfirmationInputLines({
+      old_string: 'line1\nline2\nline3',
+    });
+
+    expect(lines).toEqual([
+      'old_string: line1',
+      '  line2',
+      '  line3',
+    ]);
+  });
+});
+
+describe('formatConfirmationCommandPreview', () => {
+  test('shows concise file_edit preview', () => {
+    const preview = formatConfirmationCommandPreview({
+      toolName: 'file_edit',
+      input: { path: '/tmp/sample.txt' },
+    });
+    expect(preview).toBe('edit /tmp/sample.txt');
   });
 });

--- a/assistant/src/__tests__/diff.test.ts
+++ b/assistant/src/__tests__/diff.test.ts
@@ -91,6 +91,18 @@ describe('formatDiff', () => {
     expect(result).toContain('-old content');
     expect(result).toContain('-line 2');
   });
+
+  test('uses a full fallback diff for oversized files without truncation markers', () => {
+    const old = Array.from({ length: 6 }, (_, i) => `old-${i + 1}`).join('\n');
+    const updated = Array.from({ length: 6 }, (_, i) => (i === 3 ? 'new-4' : `old-${i + 1}`)).join('\n');
+    const result = stripAnsi(formatDiff(old, updated, 'oversized.ts', { maxExactLines: 2 }));
+
+    expect(result).toContain('--- a/oversized.ts');
+    expect(result).toContain('+++ b/oversized.ts');
+    expect(result).toContain('-old-4');
+    expect(result).toContain('+new-4');
+    expect(result).not.toContain('Diff too large to display');
+  });
 });
 
 describe('formatNewFileDiff', () => {
@@ -117,6 +129,16 @@ describe('formatNewFileDiff', () => {
   test('does not truncate short files', () => {
     const content = 'a\nb\nc';
     const result = stripAnsi(formatNewFileDiff(content, 'small.ts'));
+    expect(result).not.toContain('more lines');
+  });
+
+  test('allows unbounded output when maxLines is null', () => {
+    const lines = Array.from({ length: 50 }, (_, i) => `line${i + 1}`);
+    const content = lines.join('\n');
+    const result = stripAnsi(formatNewFileDiff(content, 'all-lines.ts', null));
+
+    expect(result).toContain('+line1');
+    expect(result).toContain('+line50');
     expect(result).not.toContain('more lines');
   });
 });

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -43,6 +43,72 @@ export function sanitizeUrlForDisplay(rawUrl: unknown): string {
   }
 }
 
+function stringifyConfirmationInputValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (value == null) return 'null';
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function formatConfirmationInputLines(input: Record<string, unknown>): string[] {
+  const lines: string[] = [];
+  for (const key of Object.keys(input).sort()) {
+    const rawValue = input[key];
+    const value = key.toLowerCase().includes('url') && typeof rawValue === 'string'
+      ? sanitizeUrlForDisplay(rawValue)
+      : rawValue;
+    const rendered = stringifyConfirmationInputValue(value);
+    const renderedLines = rendered.split('\n');
+    if (renderedLines.length === 0) {
+      lines.push(`${key}:`);
+      continue;
+    }
+    lines.push(`${key}: ${renderedLines[0]}`);
+    for (const continuation of renderedLines.slice(1)) {
+      lines.push(`  ${continuation}`);
+    }
+  }
+  return lines;
+}
+
+export function formatConfirmationCommandPreview(req: Pick<ConfirmationRequest, 'toolName' | 'input'>): string {
+  if (req.toolName === 'bash' || req.toolName === 'host_bash') {
+    return String(req.input.command ?? '');
+  }
+  if (req.toolName === 'file_read' || req.toolName === 'host_file_read') {
+    return `read ${req.input.path ?? ''}`;
+  }
+  if (req.toolName === 'file_write' || req.toolName === 'host_file_write') {
+    return `write ${req.input.path ?? ''}`;
+  }
+  if (req.toolName === 'file_edit' || req.toolName === 'host_file_edit') {
+    return `edit ${req.input.path ?? ''}`;
+  }
+  if (req.toolName === 'web_fetch') {
+    return `fetch ${sanitizeUrlForDisplay(req.input.url ?? '')}`;
+  }
+  if (req.toolName === 'browser_navigate') {
+    return `navigate ${sanitizeUrlForDisplay(req.input.url ?? '')}`;
+  }
+  if (req.toolName === 'browser_close') {
+    return req.input.close_all_pages ? 'close all browser pages' : 'close browser page';
+  }
+  if (req.toolName === 'browser_click') {
+    return `click ${req.input.element_id ?? req.input.selector ?? ''}`;
+  }
+  if (req.toolName === 'browser_type') {
+    return `type into ${req.input.element_id ?? req.input.selector ?? ''}`;
+  }
+  if (req.toolName === 'browser_press_key') {
+    return `press "${req.input.key ?? ''}"`;
+  }
+  return req.toolName;
+}
+
 
 export async function startCli(): Promise<void> {
   const socketPath = getSocketPath();
@@ -138,48 +204,24 @@ export async function startCli(): Promise<void> {
     return false;
   }
 
-  function formatCommandPreview(req: ConfirmationRequest): string {
-    if (req.toolName === 'bash') {
-      return String(req.input.command ?? '');
-    }
-    if (req.toolName === 'file_read') {
-      return `read ${req.input.path ?? ''}`;
-    }
-    if (req.toolName === 'file_write') {
-      return `write ${req.input.path ?? ''}`;
-    }
-    if (req.toolName === 'web_fetch') {
-      return `fetch ${sanitizeUrlForDisplay(req.input.url ?? '')}`;
-    }
-    if (req.toolName === 'browser_navigate') {
-      return `navigate ${sanitizeUrlForDisplay(req.input.url ?? '')}`;
-    }
-    if (req.toolName === 'browser_close') {
-      return req.input.close_all_pages ? 'close all browser pages' : 'close browser page';
-    }
-    if (req.toolName === 'browser_click') {
-      return `click ${req.input.element_id ?? req.input.selector ?? ''}`;
-    }
-    if (req.toolName === 'browser_type') {
-      return `type into ${req.input.element_id ?? req.input.selector ?? ''}`;
-    }
-    if (req.toolName === 'browser_press_key') {
-      return `press "${req.input.key ?? ''}"`;
-    }
-    return `${req.toolName}: ${truncate(JSON.stringify(req.input), 80)}`;
-  }
-
   function renderConfirmationPrompt(req: ConfirmationRequest): void {
-    const preview = formatCommandPreview(req);
+    const preview = formatConfirmationCommandPreview(req);
+    const inputLines = formatConfirmationInputLines(req.input);
     process.stdout.write('\n');
     process.stdout.write(`\u250C ${req.toolName}: ${preview}\n`);
     process.stdout.write(`\u2502 Risk: ${req.riskLevel}${req.sandboxed ? '  [sandboxed]' : ''}\n`);
     if (req.executionTarget) {
       process.stdout.write(`\u2502 Target: ${req.executionTarget}\n`);
     }
+    if (inputLines.length > 0) {
+      process.stdout.write(`\u2502\n`);
+      for (const line of inputLines) {
+        process.stdout.write(`\u2502 ${line}\n`);
+      }
+    }
     if (req.diff) {
       const diffOutput = req.diff.isNewFile
-        ? formatNewFileDiff(req.diff.newContent, req.diff.filePath)
+        ? formatNewFileDiff(req.diff.newContent, req.diff.filePath, null)
         : formatDiff(req.diff.oldContent, req.diff.newContent, req.diff.filePath);
       if (diffOutput) {
         process.stdout.write(`\u2502\n`);
@@ -506,7 +548,7 @@ export async function startCli(): Promise<void> {
         toolStreaming = false;
         if (msg.diff) {
           const diffOutput = msg.diff.isNewFile
-            ? formatNewFileDiff(msg.diff.newContent, msg.diff.filePath)
+            ? formatNewFileDiff(msg.diff.newContent, msg.diff.filePath, null)
             : formatDiff(msg.diff.oldContent, msg.diff.newContent, msg.diff.filePath);
           if (diffOutput) {
             process.stdout.write(diffOutput);

--- a/assistant/src/util/diff.ts
+++ b/assistant/src/util/diff.ts
@@ -54,7 +54,7 @@ interface Hunk {
 }
 
 const CONTEXT_LINES = 3;
-const MAX_DIFF_LINES = 1000;
+const DEFAULT_MAX_EXACT_DIFF_LINES = 1000;
 
 /**
  * Group diff entries into hunks with surrounding context lines.
@@ -108,24 +108,44 @@ const CYAN = '\x1b[36m';
 const DIM = '\x1b[2m';
 const RESET = '\x1b[0m';
 
+export interface FormatDiffOptions {
+  maxExactLines?: number;
+}
+
+function formatLargeDiffFallback(oldLines: string[], newLines: string[], filePath: string): string {
+  let output = `${DIM}--- a/${filePath}${RESET}\n`;
+  output += `${DIM}+++ b/${filePath}${RESET}\n`;
+  output += `${CYAN}@@ -1,${oldLines.length} +1,${newLines.length} @@${RESET}\n`;
+
+  for (const line of oldLines) {
+    output += `${RED}-${line}${RESET}\n`;
+  }
+  for (const line of newLines) {
+    output += `${GREEN}+${line}${RESET}\n`;
+  }
+
+  return output;
+}
+
 /**
  * Format a colored unified diff from old and new file content.
  * Returns an empty string if the contents are identical.
  */
-export function formatDiff(oldContent: string, newContent: string, filePath: string): string {
+export function formatDiff(
+  oldContent: string,
+  newContent: string,
+  filePath: string,
+  options: FormatDiffOptions = {},
+): string {
   if (oldContent === newContent) return '';
 
   const oldLines = oldContent.split('\n');
   const newLines = newContent.split('\n');
+  const maxExactLines = options.maxExactLines ?? DEFAULT_MAX_EXACT_DIFF_LINES;
 
   // Guard against quadratic blowup on large files
-  if (oldLines.length > MAX_DIFF_LINES || newLines.length > MAX_DIFF_LINES) {
-    const removed = oldLines.length;
-    const added = newLines.length;
-    let output = `${DIM}--- a/${filePath}${RESET}\n`;
-    output += `${DIM}+++ b/${filePath}${RESET}\n`;
-    output += `${DIM}[Diff too large to display: ${removed} lines → ${added} lines]${RESET}\n`;
-    return output;
+  if (oldLines.length > maxExactLines || newLines.length > maxExactLines) {
+    return formatLargeDiffFallback(oldLines, newLines, filePath);
   }
 
   const entries = computeLineDiff(oldLines, newLines);
@@ -159,11 +179,14 @@ export function formatDiff(oldContent: string, newContent: string, filePath: str
 /**
  * Format a "new file" diff (everything is added).
  * Truncates to maxLines to avoid flooding the terminal.
+ * Pass `null` for unbounded output.
  */
-export function formatNewFileDiff(content: string, filePath: string, maxLines = 20): string {
+export function formatNewFileDiff(content: string, filePath: string, maxLines: number | null = 20): string {
   const lines = content.split('\n');
-  const truncated = lines.length > maxLines;
-  const displayLines = truncated ? lines.slice(0, maxLines) : lines;
+  const shouldTruncate = typeof maxLines === 'number' && Number.isFinite(maxLines);
+  const boundedMaxLines = shouldTruncate ? Math.max(0, Math.floor(maxLines)) : lines.length;
+  const truncated = lines.length > boundedMaxLines;
+  const displayLines = truncated ? lines.slice(0, boundedMaxLines) : lines;
 
   let output = `${DIM}--- /dev/null${RESET}\n`;
   output += `${DIM}+++ b/${filePath}${RESET}\n`;
@@ -174,7 +197,7 @@ export function formatNewFileDiff(content: string, filePath: string, maxLines = 
   }
 
   if (truncated) {
-    output += `${DIM}... ${lines.length - maxLines} more lines${RESET}\n`;
+    output += `${DIM}... ${lines.length - boundedMaxLines} more lines${RESET}\n`;
   }
 
   return output;

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -138,7 +138,7 @@ public struct ToolConfirmationData: Equatable {
             guard let value = input[key]?.value else { return nil }
             let formatted: String
             if let str = value as? String {
-                formatted = str.count > 120 ? String(str.prefix(117)) + "..." : str
+                formatted = str
             } else if let bool = value as? Bool {
                 formatted = bool ? "true" : "false"
             } else if let num = value as? Int {
@@ -151,6 +151,171 @@ public struct ToolConfirmationData: Equatable {
             return "\(key): \(formatted)"
         }
         return lines.joined(separator: "\n")
+    }
+
+    /// Unified diff preview for file change confirmations.
+    /// Uses an exact LCS diff for typical file sizes and a full, non-truncating
+    /// linear fallback for very large inputs.
+    public var unifiedDiffPreview: String? {
+        guard let diff else { return nil }
+        return Self.buildUnifiedDiff(
+            oldContent: diff.oldContent,
+            newContent: diff.newContent,
+            filePath: diff.filePath
+        )
+    }
+
+    private static let diffContextLines = 3
+    private static let maxExactDiffLines = 1000
+
+    private enum DiffEntryType {
+        case same
+        case add
+        case remove
+    }
+
+    private struct DiffEntry {
+        let type: DiffEntryType
+        let line: String
+    }
+
+    private struct DiffHunk {
+        let oldStart: Int
+        let oldCount: Int
+        let newStart: Int
+        let newCount: Int
+        let lines: [DiffEntry]
+    }
+
+    private static func buildUnifiedDiff(oldContent: String, newContent: String, filePath: String) -> String {
+        if oldContent == newContent { return "" }
+
+        let oldLines = oldContent.components(separatedBy: "\n")
+        let newLines = newContent.components(separatedBy: "\n")
+
+        if oldLines.count > maxExactDiffLines || newLines.count > maxExactDiffLines {
+            return buildLargeUnifiedDiff(oldLines: oldLines, newLines: newLines, filePath: filePath)
+        }
+
+        let entries = computeLineDiff(oldLines: oldLines, newLines: newLines)
+        let hunks = buildHunks(entries: entries)
+        if hunks.isEmpty { return "" }
+
+        var output = "--- a/\(filePath)\n"
+        output += "+++ b/\(filePath)\n"
+        for hunk in hunks {
+            output += "@@ -\(hunk.oldStart),\(hunk.oldCount) +\(hunk.newStart),\(hunk.newCount) @@\n"
+            for entry in hunk.lines {
+                switch entry.type {
+                case .same:
+                    output += " \(entry.line)\n"
+                case .remove:
+                    output += "-\(entry.line)\n"
+                case .add:
+                    output += "+\(entry.line)\n"
+                }
+            }
+        }
+        return output
+    }
+
+    private static func buildLargeUnifiedDiff(oldLines: [String], newLines: [String], filePath: String) -> String {
+        var output = "--- a/\(filePath)\n"
+        output += "+++ b/\(filePath)\n"
+        output += "@@ -1,\(oldLines.count) +1,\(newLines.count) @@\n"
+        for line in oldLines {
+            output += "-\(line)\n"
+        }
+        for line in newLines {
+            output += "+\(line)\n"
+        }
+        return output
+    }
+
+    private static func computeLineDiff(oldLines: [String], newLines: [String]) -> [DiffEntry] {
+        let m = oldLines.count
+        let n = newLines.count
+
+        var dp = Array(repeating: Array(repeating: 0, count: n + 1), count: m + 1)
+        if m > 0 && n > 0 {
+            for i in 1...m {
+                for j in 1...n {
+                    if oldLines[i - 1] == newLines[j - 1] {
+                        dp[i][j] = dp[i - 1][j - 1] + 1
+                    } else {
+                        dp[i][j] = max(dp[i - 1][j], dp[i][j - 1])
+                    }
+                }
+            }
+        }
+
+        var reversed: [DiffEntry] = []
+        var i = m
+        var j = n
+        while i > 0 || j > 0 {
+            if i > 0, j > 0, oldLines[i - 1] == newLines[j - 1] {
+                reversed.append(DiffEntry(type: .same, line: oldLines[i - 1]))
+                i -= 1
+                j -= 1
+            } else if j > 0, (i == 0 || dp[i][j - 1] >= dp[i - 1][j]) {
+                reversed.append(DiffEntry(type: .add, line: newLines[j - 1]))
+                j -= 1
+            } else if i > 0 {
+                reversed.append(DiffEntry(type: .remove, line: oldLines[i - 1]))
+                i -= 1
+            }
+        }
+
+        return Array(reversed.reversed())
+    }
+
+    private static func buildHunks(entries: [DiffEntry]) -> [DiffHunk] {
+        var changeRanges: [(start: Int, end: Int)] = []
+        for i in entries.indices {
+            if entries[i].type != .same {
+                if !changeRanges.isEmpty,
+                   i - changeRanges[changeRanges.count - 1].end <= diffContextLines * 2 {
+                    changeRanges[changeRanges.count - 1].end = i + 1
+                } else {
+                    changeRanges.append((start: i, end: i + 1))
+                }
+            }
+        }
+
+        var hunks: [DiffHunk] = []
+        for range in changeRanges {
+            let contextStart = max(0, range.start - diffContextLines)
+            let contextEnd = min(entries.count, range.end + diffContextLines)
+            let hunkEntries = Array(entries[contextStart..<contextEnd])
+
+            var oldLine = 1
+            var newLine = 1
+            if contextStart > 0 {
+                for idx in 0..<contextStart {
+                    let entry = entries[idx]
+                    if entry.type == .same || entry.type == .remove { oldLine += 1 }
+                    if entry.type == .same || entry.type == .add { newLine += 1 }
+                }
+            }
+
+            var oldCount = 0
+            var newCount = 0
+            for entry in hunkEntries {
+                if entry.type == .same || entry.type == .remove { oldCount += 1 }
+                if entry.type == .same || entry.type == .add { newCount += 1 }
+            }
+
+            hunks.append(
+                DiffHunk(
+                    oldStart: oldLine,
+                    oldCount: oldCount,
+                    newStart: newLine,
+                    newCount: newCount,
+                    lines: hunkEntries
+                )
+            )
+        }
+        return hunks
     }
 
     /// Human-readable preview of the tool input (e.g. the bash command or file path).

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -299,17 +299,25 @@ public struct ToolConfirmationBubble: View {
 
     @ViewBuilder
     private func inlinePreview(_ preview: String) -> some View {
-        Text(preview)
-            .font(VFont.monoSmall)
-            .foregroundColor(VColor.textSecondary)
-            .fixedSize(horizontal: false, vertical: true)
-            .textSelection(.enabled)
-            .padding(VSpacing.sm)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.sm)
-                    .fill(VColor.backgroundSubtle)
-            )
+        codePreviewBlock(preview, maxHeight: 220)
+    }
+
+    @ViewBuilder
+    private func codePreviewBlock(_ content: String, maxHeight: CGFloat) -> some View {
+        ScrollView {
+            Text(content)
+                .font(VFont.monoSmall)
+                .foregroundColor(VColor.textSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .textSelection(.enabled)
+        }
+        .frame(maxHeight: maxHeight)
+        .padding(VSpacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .fill(VColor.backgroundSubtle)
+        )
     }
 
     // MARK: - Description Text
@@ -345,22 +353,15 @@ public struct ToolConfirmationBubble: View {
             .accessibilityLabel(showDiff ? "Hide diff" : "View diff")
 
             if showDiff, let diffInfo = confirmation.diff {
+                let computedDiff = confirmation.unifiedDiffPreview ?? ""
+                let diffBody = computedDiff.isEmpty ? diffInfo.newContent : computedDiff
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text(diffInfo.filePath)
                         .font(VFont.monoSmall)
                         .foregroundColor(VColor.textMuted)
 
-                    Text(diffInfo.newContent)
-                        .font(VFont.mono)
-                        .foregroundColor(VColor.textSecondary)
-                        .lineLimit(10)
+                    codePreviewBlock(diffBody, maxHeight: 260)
                 }
-                .padding(VSpacing.sm)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.sm)
-                        .fill(VColor.backgroundSubtle)
-                )
                 .textSelection(.enabled)
                 .transition(.opacity.combined(with: .move(edge: .top)))
             }

--- a/clients/shared/Tests/ToolConfirmationDataTests.swift
+++ b/clients/shared/Tests/ToolConfirmationDataTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import VellumAssistantShared
+
+final class ToolConfirmationDataTests: XCTestCase {
+    func testFullInputPreviewDoesNotTruncateLongStrings() {
+        let oldString = String(repeating: "old-", count: 80)
+        let newString = String(repeating: "new-", count: 80)
+        let confirmation = ToolConfirmationData(
+            requestId: "req-1",
+            toolName: "file_edit",
+            input: [
+                "path": AnyCodable("/tmp/sample.txt"),
+                "old_string": AnyCodable(oldString),
+                "new_string": AnyCodable(newString),
+            ],
+            riskLevel: "medium"
+        )
+
+        let preview = confirmation.fullInputPreview
+        XCTAssertTrue(preview.contains("old_string: \(oldString)"))
+        XCTAssertTrue(preview.contains("new_string: \(newString)"))
+        XCTAssertFalse(preview.contains("old_string: \(String(oldString.prefix(117)))..."))
+        XCTAssertFalse(preview.contains("new_string: \(String(newString.prefix(117)))..."))
+    }
+
+    func testUnifiedDiffPreviewShowsReplacedLines() {
+        let diff = IPCConfirmationRequestDiff(
+            filePath: "/tmp/test.txt",
+            oldContent: "line1\nline2\nline3",
+            newContent: "line1\nline2-updated\nline3",
+            isNewFile: false
+        )
+        let confirmation = ToolConfirmationData(
+            requestId: "req-2",
+            toolName: "file_edit",
+            input: [:],
+            riskLevel: "medium",
+            diff: diff
+        )
+
+        let rendered = confirmation.unifiedDiffPreview ?? ""
+        XCTAssertTrue(rendered.contains("--- a//tmp/test.txt"))
+        XCTAssertTrue(rendered.contains("+++ b//tmp/test.txt"))
+        XCTAssertTrue(rendered.contains("-line2"))
+        XCTAssertTrue(rendered.contains("+line2-updated"))
+    }
+
+    func testUnifiedDiffPreviewSupportsMultipleHunks() {
+        let oldLines = (1...20).map { "line\($0)" }
+        var newLines = oldLines
+        newLines[2] = "CHANGED_A"
+        newLines[17] = "CHANGED_B"
+
+        let diff = IPCConfirmationRequestDiff(
+            filePath: "/tmp/multi.txt",
+            oldContent: oldLines.joined(separator: "\n"),
+            newContent: newLines.joined(separator: "\n"),
+            isNewFile: false
+        )
+        let confirmation = ToolConfirmationData(
+            requestId: "req-3",
+            toolName: "file_edit",
+            input: [:],
+            riskLevel: "medium",
+            diff: diff
+        )
+
+        let rendered = confirmation.unifiedDiffPreview ?? ""
+        XCTAssertTrue(rendered.contains("-line3"))
+        XCTAssertTrue(rendered.contains("+CHANGED_A"))
+        XCTAssertTrue(rendered.contains("-line18"))
+        XCTAssertTrue(rendered.contains("+CHANGED_B"))
+        let hunkHeaderCount = rendered.components(separatedBy: "@@ -").count - 1
+        XCTAssertGreaterThanOrEqual(hunkHeaderCount, 2)
+    }
+
+    func testUnifiedDiffPreviewLargeFallbackIsNotTruncated() {
+        let oldLines = (1...1005).map { "line\($0)" }
+        var newLines = oldLines
+        newLines[500] = "line501-updated"
+
+        let diff = IPCConfirmationRequestDiff(
+            filePath: "/tmp/large.txt",
+            oldContent: oldLines.joined(separator: "\n"),
+            newContent: newLines.joined(separator: "\n"),
+            isNewFile: false
+        )
+        let confirmation = ToolConfirmationData(
+            requestId: "req-4",
+            toolName: "file_edit",
+            input: [:],
+            riskLevel: "high",
+            diff: diff
+        )
+
+        let rendered = confirmation.unifiedDiffPreview ?? ""
+        XCTAssertFalse(rendered.contains("Diff too large"))
+        XCTAssertTrue(rendered.contains("-line501"))
+        XCTAssertTrue(rendered.contains("+line501-updated"))
+        XCTAssertTrue(rendered.contains("-line1005"))
+        XCTAssertTrue(rendered.contains("+line1005"))
+    }
+}


### PR DESCRIPTION
## Summary

- Remove 120-char string truncation from tool confirmation input previews (CLI + Swift) so users see the complete `old_string`/`new_string` values
- Replace the "Diff too large to display" placeholder with a full linear fallback diff that shows all removed/added lines
- Add LCS-based unified diff computation to the Swift client (`ToolConfirmationData.unifiedDiffPreview`) so native confirmation bubbles render proper diffs instead of raw `newContent`
- Wrap inline previews and diff blocks in scrollable containers with max height bounds to avoid layout blowout
- Extract `formatConfirmationInputLines` and `formatConfirmationCommandPreview` as exported, testable functions
- Add tests for CLI formatting helpers, diff fallback behavior, and Swift diff engine (single hunk, multi-hunk, large file fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
