### PR TITLE
fix: restore null check in voice-config value validation

### DIFF
--- a/assistant/src/tools/system/voice-config.ts
+++ b/assistant/src/tools/system/voice-config.ts
@@ -117,7 +117,7 @@ export class VoiceConfigUpdateTool implements Tool {
       };
     }
 
-    if (value === undefined) {
+    if (value === undefined || value === null) {
       return {
         content: `Error: "value" is required for setting "${setting}".`,
         isError: true,


### PR DESCRIPTION
Addresses review feedback from PR #10192. Restores the null check that was removed, ensuring LLM-supplied null values are properly caught by the value-required guard instead of falling through to type validation with confusing error messages.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
