### PR TITLE
fix: add --with-deps to playwright install for CI system dependencies

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install Chromium
         working-directory: playwright
-        run: bunx playwright install chromium
+        run: bunx playwright install --with-deps chromium
 
       - name: Run headless browser tests
         working-directory: playwright


### PR DESCRIPTION
Addresses review feedback from PR #10294. Adds the --with-deps flag to the playwright install command in CI so that required system libraries are installed on Ubuntu runners.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
