### PR TITLE
fix: restrict encrypted store recovery to actual corruption, not transient I/O errors

### DIFF
--- a/assistant/src/security/encrypted-store.ts
+++ b/assistant/src/security/encrypted-store.ts
@@ -96,13 +96,17 @@ function deriveKey(salt: Buffer): Buffer {
  * Read result: distinguishes "file missing" from "file corrupt/unreadable".
  * - `null`: file does not exist or was corrupt (backed up and removed)
  * - `StoreFile`: successfully parsed
+ * - throws: transient I/O error from readFileSync (EACCES, EMFILE, EIO, etc.)
  */
 function readStore(): StoreFile | null {
   const path = getStorePath();
   if (!pathExists(path)) return null;
 
+  // Read outside the parse try/catch so transient filesystem errors (EACCES,
+  // EMFILE, EIO) propagate to callers instead of triggering corruption recovery.
+  const raw = readFileSync(path, 'utf-8');
+
   try {
-    const raw = readFileSync(path, 'utf-8');
     const parsed = JSON.parse(raw);
     if (parsed.version !== 1 || typeof parsed.salt !== 'string' || typeof parsed.entries !== 'object') {
       throw new Error('Encrypted store has invalid format');


### PR DESCRIPTION
Addresses review feedback from PR #10293. Separates filesystem I/O errors from JSON parse/format errors in readStore(), so only actual corruption triggers the backup-and-reset path. Transient I/O errors are re-thrown to callers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
