### PR TITLE
fix: include socket file type in build cleanup find command

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -657,7 +657,7 @@ fi
 # of the distributable app and can break outer-bundle codesign verification.
 rm -f "$MACOS_DIR/.qdrant-initialized"
 rm -rf "$MACOS_DIR/snapshots"
-find "$MACOS_DIR" -maxdepth 1 -type f \
+find "$MACOS_DIR" -maxdepth 1 \( -type f -o -type s \) \
     \( -name "*.pid" -o -name "*.sock" -o -name "*.log" \) \
     -delete
 


### PR DESCRIPTION
Addresses review feedback from PR #10306. Changes find -type f to find \( -type f -o -type s \) so that Unix domain socket files are also cleaned up during the build process.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
