### PR TITLE
fix: restore PID tracking before returning on responsive socket

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -1,4 +1,4 @@
-import { spawn } from "child_process";
+import { execSync, spawn } from "child_process";
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import { createRequire } from "module";
 import { createConnection } from "net";
@@ -196,6 +196,27 @@ function readWorkspaceIngressPublicBaseUrl(): string | undefined {
   }
 }
 
+/** Use lsof to discover the PID of the process listening on a Unix socket.
+ *  Returns the PID if found, undefined otherwise. */
+function findSocketOwnerPid(socketPath: string): number | undefined {
+  try {
+    const output = execSync(`lsof -U -a -F p -- ${JSON.stringify(socketPath)}`, {
+      encoding: "utf-8",
+      timeout: 3000,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    // lsof -F p outputs lines like "p1234" — extract the first PID
+    const match = output.match(/^p(\d+)/m);
+    if (match) {
+      const pid = parseInt(match[1], 10);
+      if (!isNaN(pid)) return pid;
+    }
+  } catch {
+    // lsof not available or failed — cannot recover PID
+  }
+  return undefined;
+}
+
 /** Try a TCP connect to the Unix socket. Returns true if the handshake
  *  completes within the timeout — false on connection refused, timeout,
  *  or missing socket file. */
@@ -301,7 +322,15 @@ export async function startLocalDaemon(): Promise<void> {
       // may still be listening on the socket (e.g. if the PID file was
       // overwritten by a crashed restart attempt). Check before deleting.
       if (await isSocketResponsive(socketFile)) {
-        console.log("   Daemon socket is responsive — skipping restart\n");
+        // Restore PID tracking so lifecycle commands (sleep, retire,
+        // stopLocalProcesses) can manage this daemon process.
+        const ownerPid = findSocketOwnerPid(socketFile);
+        if (ownerPid) {
+          writeFileSync(pidFile, String(ownerPid), "utf-8");
+          console.log(`   Daemon socket is responsive (pid ${ownerPid}) — skipping restart\n`);
+        } else {
+          console.log("   Daemon socket is responsive — skipping restart\n");
+        }
         return;
       }
 


### PR DESCRIPTION
Addresses review feedback from PR #10256. Ensures PID tracking is preserved when a responsive socket is found, preventing orphaned daemon processes.

When the PID file is stale/missing but the daemon socket is still responsive, we now use lsof to discover the owning process PID and write it back to the PID file before returning. This ensures lifecycle commands (sleep, retire, stopLocalProcesses) can still manage the daemon.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
