### PR TITLE
fix: preserve startup retries when daemon socket is temporarily absent

### DIFF
--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -68,12 +68,12 @@ extension DaemonClient {
                         throw NWError.posix(.ECONNREFUSED)
                     }
                 } else {
-                    // Socket file doesn't exist — fail fast with ENOENT instead of
-                    // letting NWConnection hang until the connect timeout (ETIMEDOUT).
-                    log.warning("Daemon socket not found at \(path, privacy: .public)")
-                    isConnecting = false
+                    // Socket doesn't exist yet — notify the health monitor so it
+                    // can trigger a daemon restart, but don't hard-fail. Let
+                    // NWConnection proceed; the 5s connect timeout gives the daemon
+                    // a grace period to create the socket during startup.
+                    log.warning("Daemon socket not found at \(path, privacy: .public) — proceeding with connect timeout")
                     NotificationCenter.default.post(name: .daemonSocketNotFound, object: self)
-                    throw NWError.posix(.ENOENT)
                 }
             }
 


### PR DESCRIPTION
Addresses review feedback from PR #10254. Instead of hard-failing with ENOENT when the socket doesn't exist yet, let NWConnection proceed with its 5s connect timeout — this preserves the grace period for late socket creation during daemon startup. The daemonSocketNotFound notification is kept so the health monitor can still trigger an immediate restart.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
