### PR TITLE
fix: use wide ps output in isVellumDaemonProcess to prevent truncation

### DIFF
--- a/assistant/src/daemon/daemon-control.ts
+++ b/assistant/src/daemon/daemon-control.ts
@@ -106,7 +106,7 @@ function isProcessRunning(pid: number): boolean {
  */
 function isVellumDaemonProcess(pid: number): boolean {
   try {
-    const cmd = execSync(`ps -p ${pid} -o command=`, {
+    const cmd = execSync(`ps -ww -p ${pid} -o command=`, {
       encoding: 'utf-8',
       timeout: 3000,
       stdio: ['ignore', 'pipe', 'ignore'],


### PR DESCRIPTION
Addresses review feedback from PR #10121. Adds -ww flag to the ps command in isVellumDaemonProcess to prevent output truncation on long command lines, which could cause a healthy daemon to be misidentified as non-vellum.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
