### PR TITLE
fix: avoid sync backend detection in async secure-key methods

### DIFF
--- a/assistant/src/security/keychain.ts
+++ b/assistant/src/security/keychain.ts
@@ -19,6 +19,7 @@ import { getLogger } from '../util/logger.js';
 import { isLinux,isMacOS } from '../util/platform.js';
 
 const log = getLogger('keychain');
+const execFileAsync = promisify(execFile);
 
 const SERVICE_NAME = 'vellum-assistant';
 
@@ -60,6 +61,29 @@ export function isKeychainAvailable(): boolean {
       // Verify `secret-tool` exists
       deps.execFileSync('which', ['secret-tool'], {
         stdio: ['ignore', 'ignore', 'ignore'],
+        timeout: 5000,
+      });
+      return true;
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/** Async version of `isKeychainAvailable` — probes without blocking the event loop. */
+export async function isKeychainAvailableAsync(): Promise<boolean> {
+  try {
+    if (deps.isMacOS()) {
+      await execFileAsync('security', ['list-keychains'], {
+        timeout: 5000,
+      });
+      return true;
+    }
+
+    if (deps.isLinux()) {
+      await execFileAsync('which', ['secret-tool'], {
         timeout: 5000,
       });
       return true;
@@ -260,8 +284,6 @@ function linuxDeleteKey(account: string): boolean {
 // Async variants — non-blocking alternatives to the sync functions above.
 // Preferred for non-startup code paths to avoid blocking the event loop.
 // ---------------------------------------------------------------------------
-
-const execFileAsync = promisify(execFile);
 
 /**
  * Async version of `getKey` — retrieve a secret without blocking the event loop.

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -30,6 +30,19 @@ function getBackend(): Backend {
   return resolvedBackend;
 }
 
+async function getBackendAsync(): Promise<Backend> {
+  if (resolvedBackend !== undefined) return resolvedBackend;
+
+  if (await keychain.isKeychainAvailableAsync()) {
+    log.debug('Using OS keychain for secure key storage');
+    resolvedBackend = 'keychain';
+  } else {
+    log.debug('OS keychain unavailable, using encrypted file storage');
+    resolvedBackend = 'encrypted';
+  }
+  return resolvedBackend;
+}
+
 /**
  * Try a keychain operation; on failure, permanently downgrade to encrypted
  * backend and retry. This handles systems where the keychain CLI exists
@@ -176,7 +189,7 @@ export function isDowngradedFromKeychain(): boolean {
  * Async version of `getSecureKey` — retrieve a secret without blocking.
  */
 export async function getSecureKeyAsync(account: string): Promise<string | undefined> {
-  const backend = getBackend();
+  const backend = await getBackendAsync();
   if (backend === 'keychain') {
     try {
       return (await keychain.getKeyAsync(account)) ?? undefined;
@@ -205,7 +218,7 @@ export async function getSecureKeyAsync(account: string): Promise<string | undef
  * Async version of `setSecureKey` — store a secret without blocking.
  */
 export async function setSecureKeyAsync(account: string, value: string): Promise<boolean> {
-  const backend = getBackend();
+  const backend = await getBackendAsync();
   if (backend === 'encrypted') return encryptedStore.setKey(account, value);
   if (backend !== 'keychain') return false;
 
@@ -223,7 +236,7 @@ export async function setSecureKeyAsync(account: string, value: string): Promise
  * Async version of `deleteSecureKey` — delete a secret without blocking.
  */
 export async function deleteSecureKeyAsync(account: string): Promise<boolean> {
-  const backend = getBackend();
+  const backend = await getBackendAsync();
   if (backend === 'encrypted') {
     const result = encryptedStore.deleteKey(account);
     if (downgradedFromKeychain) {


### PR DESCRIPTION
Addresses review feedback from PR #10290. Makes backend detection async for the async secure-key API paths to avoid blocking the event loop on first call.

Changes:
- Added `isKeychainAvailableAsync()` to `keychain.ts` using async `execFile` instead of `execFileSync`
- Added `getBackendAsync()` to `secure-keys.ts` that uses the async availability check
- Updated `getSecureKeyAsync`, `setSecureKeyAsync`, and `deleteSecureKeyAsync` to use `getBackendAsync()` instead of the sync `getBackend()`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
