### PR TITLE
fix: propagate screencast dimensions across all coordinate math

### DIFF
--- a/assistant/src/daemon/handlers/browser.ts
+++ b/assistant/src/daemon/handlers/browser.ts
@@ -1,4 +1,4 @@
-import { browserManager } from '../../tools/browser/browser-manager.js';
+import { browserManager, SCREENCAST_WIDTH, SCREENCAST_HEIGHT } from '../../tools/browser/browser-manager.js';
 import { defineHandlers,log } from './shared.js';
 
 export const browserHandlers = defineHandlers({
@@ -10,7 +10,7 @@ export const browserHandlers = defineHandlers({
     try {
       const page = await browserManager.getOrCreateSessionPage(msg.sessionId);
       const viewport = await page.evaluate('(() => ({ vw: window.innerWidth, vh: window.innerHeight }))()') as { vw: number; vh: number };
-      const scale = Math.min(1280 / viewport.vw, 960 / viewport.vh);
+      const scale = Math.min(SCREENCAST_WIDTH / viewport.vw, SCREENCAST_HEIGHT / viewport.vh);
       const pageX = msg.x / scale;
       const pageY = msg.y / scale;
       const options: Record<string, unknown> = {};

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -12,7 +12,7 @@ import {
 import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { detectAuthChallenge, detectCaptchaChallenge, formatAuthChallenge } from './auth-detector.js';
 import type { PageResponse,RouteHandler } from './browser-manager.js';
-import { browserManager } from './browser-manager.js';
+import { browserManager, SCREENCAST_WIDTH, SCREENCAST_HEIGHT } from './browser-manager.js';
 import {
   ensureScreencast,
   getElementBounds,
@@ -770,7 +770,7 @@ export async function executeBrowserScroll(
       if (bounds) {
         // Convert screencast coords back to page coords for mouse.move
         const result = await page.evaluate(`(() => ({ vw: window.innerWidth, vh: window.innerHeight }))()`) as { vw: number; vh: number };
-        const scale = Math.min(1280 / result.vw, 960 / result.vh);
+        const scale = Math.min(SCREENCAST_WIDTH / result.vw, SCREENCAST_HEIGHT / result.vh);
         const pageX = (bounds.x + bounds.w / 2) / scale;
         const pageY = (bounds.y + bounds.h / 2) / scale;
         await page.mouse.move(pageX, pageY);

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -10,6 +10,11 @@ import { checkBrowserRuntime } from './runtime-check.js';
 
 const log = getLogger('browser-manager');
 
+// Screencast capture dimensions — used by coordinate math across the browser module
+// to map between page coordinates and screencast-frame coordinates.
+export const SCREENCAST_WIDTH = 800;
+export const SCREENCAST_HEIGHT = 600;
+
 function getDownloadsDir(): string {
   const dir = join(getDataDir(), 'browser-downloads');
   mkdirSync(dir, { recursive: true });
@@ -521,8 +526,8 @@ class BrowserManager {
     await cdp.send('Page.startScreencast', {
       format: 'jpeg',
       quality: 30,
-      maxWidth: 800,
-      maxHeight: 600,
+      maxWidth: SCREENCAST_WIDTH,
+      maxHeight: SCREENCAST_HEIGHT,
       everyNthFrame: 4,
     });
   }

--- a/assistant/src/tools/browser/browser-screencast.ts
+++ b/assistant/src/tools/browser/browser-screencast.ts
@@ -1,7 +1,7 @@
 import { v4 as uuid } from 'uuid';
 
 import type { BrowserFrame, BrowserViewSurfaceData, ServerMessage } from '../../daemon/ipc-contract.js';
-import { browserManager } from './browser-manager.js';
+import { browserManager, SCREENCAST_WIDTH, SCREENCAST_HEIGHT } from './browser-manager.js';
 
 // Track active screencast sessions
 const activeScreencasts = new Map<string, { surfaceId: string }>();
@@ -161,7 +161,7 @@ export async function getElementBounds(
       })()
     `) as { x: number; y: number; w: number; h: number; vw: number; vh: number } | null;
     if (!result) return null;
-    const scale = Math.min(1280 / result.vw, 960 / result.vh);
+    const scale = Math.min(SCREENCAST_WIDTH / result.vw, SCREENCAST_HEIGHT / result.vh);
     return {
       x: result.x * scale,
       y: result.y * scale,


### PR DESCRIPTION
Addresses review feedback from PR #10310. Replaces hardcoded 1280x960 values with shared SCREENCAST_WIDTH/SCREENCAST_HEIGHT constants (800x600) in browser-screencast.ts, browser-execution.ts, and browser.ts handler. The coordinate math now stays in sync with the actual screencast capture dimensions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
