### PR TITLE
Redesign identity panel sidebar layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -901,6 +901,10 @@ struct ConstellationView: View {
                 height: panOffset.height + dragOffset.height
             )
             ZStack {
+                // Static dotted grid (unaffected by zoom/pan)
+                DottedGridBackground()
+                    .allowsHitTesting(false)
+
                 canvas(size: proxy.size)
                     .scaleEffect(zoomScale)
                     .offset(totalOffset)
@@ -1153,6 +1157,36 @@ struct ConstellationView: View {
                     .spring(response: 0.5, dampingFraction: 0.7).delay(0.05),
                     value: phase
                 )
+        }
+    }
+}
+
+// MARK: - Dotted Grid Background
+
+private struct DottedGridBackground: View {
+    let spacing: CGFloat = 24
+    let dotRadius: CGFloat = 1.5
+
+    var body: some View {
+        Canvas { context, size in
+            let cols = Int(size.width / spacing) + 1
+            let rows = Int(size.height / spacing) + 1
+            for row in 0..<rows {
+                for col in 0..<cols {
+                    let x = CGFloat(col) * spacing
+                    let y = CGFloat(row) * spacing
+                    let rect = CGRect(
+                        x: x - dotRadius,
+                        y: y - dotRadius,
+                        width: dotRadius * 2,
+                        height: dotRadius * 2
+                    )
+                    context.fill(
+                        Path(ellipseIn: rect),
+                        with: .color(VColor.textMuted.opacity(0.2))
+                    )
+                }
+            }
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -24,45 +24,55 @@ struct IdentityPanel: View {
         HStack(alignment: .top, spacing: 0) {
             // Left sidebar: title, avatar, ID card — hidden in fullscreen
             if !isFullscreen {
-                VStack(alignment: .leading, spacing: 0) {
-                    // Header
-                    Text("Identity")
-                        .font(VFont.panelTitle)
-                        .foregroundColor(VColor.textPrimary)
-                        .padding(.bottom, VSpacing.lg)
-
-                    // Card wrapping avatar + ID fields
+                VStack(spacing: 0) {
                     VStack(spacing: 0) {
-                        // Avatar image or initial-letter fallback (full-size for identity display)
+                        // "I'm [name]!" heading
+                        Text("I'm \(remoteIdentity?.name.nilIfEmpty ?? identity?.name ?? lockfileAssistant?.assistantId ?? "Unknown")!")
+                            .font(.system(size: 22, weight: .regular, design: .rounded))
+                            .foregroundColor(Color(hex: 0x4A4A46))
+                            .multilineTextAlignment(.center)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .padding(.top, VSpacing.xxl)
+                            .padding(.horizontal, VSpacing.lg)
+
+                        Spacer()
+
+                        // Large centered avatar
                         Image(nsImage: appearance.fullAvatarImage)
                             .resizable()
                             .aspectRatio(contentMode: .fill)
-                            .frame(width: 120, height: 120)
+                            .frame(width: 180, height: 180)
                             .clipShape(Circle())
-                            .overlay(
-                                Circle()
-                                    .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
-                            )
                             .frame(maxWidth: .infinity, alignment: .center)
-                            .padding(.top, VSpacing.lg)
 
-                        // Edit Avatar CTA — switches to chat and pre-fills composer
-                        VButton(label: "Edit Avatar", style: .secondary, isFullWidth: true, action: onEditAvatar)
-                            .padding(.top, VSpacing.sm)
+                        Spacer()
+
+                        // Update Avatar button
+                        VButton(label: "Update Avatar", style: .secondary, action: onEditAvatar)
                             .padding(.horizontal, VSpacing.lg)
-                            .padding(.bottom, VSpacing.lg)
+                            .padding(.bottom, VSpacing.xl)
 
-                        // ID card fields
-                        ScrollView {
-                            idCardSection(identity: identity, remoteIdentity: remoteIdentity)
-                                .padding(.horizontal, VSpacing.lg)
-                                .padding(.bottom, VSpacing.lg)
+                        // Divider
+                        Rectangle()
+                            .fill(Color(hex: 0xF5F3EB))
+                            .frame(height: 2)
+
+                        // Role + Hatched date
+                        VStack(alignment: .leading, spacing: VSpacing.lg) {
+                            let role = remoteIdentity?.role.nilIfEmpty ?? identity?.role
+                            if let role, !role.isEmpty {
+                                identityInfoRow(label: "Role", value: role)
+                            }
+                            if let date = metadata?.createdAt {
+                                identityInfoRow(label: "Hatched", value: formatHatchedDate(date))
+                            }
                         }
+                        .padding(.horizontal, VSpacing.lg)
+                        .padding(.vertical, VSpacing.lg)
                     }
-                    .background(VColor.backgroundSubtle)
+                    .frame(maxHeight: .infinity)
+                    .background(Color(hex: 0xE8E6DA))
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-
-                    Spacer()
                 }
                 .frame(width: sidebarWidth)
                 .padding(.leading, panelPadding)
@@ -206,6 +216,23 @@ struct IdentityPanel: View {
                     .textSelection(.enabled)
             }
         }
+    }
+
+    private func identityInfoRow(label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+            Text(label)
+                .font(VFont.caption)
+                .foregroundColor(Color(hex: 0x6B6B5E))
+            Text(value)
+                .font(VFont.caption)
+                .foregroundColor(Color(hex: 0x3D3D35))
+        }
+    }
+
+    private func formatHatchedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "d MMM yyyy"
+        return formatter.string(from: date)
     }
 
     private func formatDate(_ date: Date) -> String {


### PR DESCRIPTION
## Summary
- Redesigned the left sidebar of the Identity tab: centered name heading ("I'm [name]!"), larger circular avatar (180px), "Update Avatar" button using VButton secondary style, and vertical Role/Hatched info section separated by a subtle divider
- Added a static dotted grid background to the constellation/skill graph view that stays fixed during zoom/pan
- Applied warm beige (#E8E6DA) background to the sidebar card with appropriate text colors for the light surface

## Test plan
- [ ] Open Identity tab — verify sidebar shows centered name, circular avatar, Update Avatar button, and Role/Hatched info
- [ ] Zoom and pan the skill graph — verify dotted grid stays fixed in the background
- [ ] Verify long role text wraps properly in the info section

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
