### PR TITLE
Unify search bars with shared VSearchBar component

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -274,39 +274,43 @@ struct AgentPanelContent: View {
         ) < 7 * 86400
 
         return VStack(alignment: .leading, spacing: VSpacing.sm) {
-            HStack(spacing: VSpacing.md) {
-                // Tappable area: icon + name + description
-                HStack(spacing: VSpacing.md) {
-                    Image(systemName: skill.isVellum ? "v.square.fill" : "shippingbox.fill")
-                        .font(.system(size: 16))
-                        .foregroundColor(skill.isVellum ? VColor.accent : VColor.textMuted)
-                        .frame(width: 24)
+            HStack(alignment: .top, spacing: VSpacing.md) {
+                Image(systemName: skill.isVellum ? "v.square.fill" : "shippingbox.fill")
+                    .font(.system(size: 16))
+                    .foregroundColor(skill.isVellum ? VColor.accent : VColor.textMuted)
+                    .frame(width: 24)
 
-                    VStack(alignment: .leading, spacing: 2) {
-                        HStack(spacing: VSpacing.sm) {
-                            Text(skill.name)
-                                .font(VFont.bodyBold)
-                                .foregroundColor(VColor.textPrimary)
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text(skill.name)
+                        .font(VFont.bodyBold)
+                        .foregroundColor(VColor.textPrimary)
 
-                            if skill.isVellum {
-                                Text("VELLUM")
-                                    .font(VFont.small)
-                                    .foregroundColor(VColor.accent)
-                            } else if isNew {
-                                Text("NEW")
-                                    .font(VFont.small)
-                                    .foregroundColor(Amber._500)
-                            }
+                    Text(skill.description)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                        .lineLimit(2)
+
+                    // Pill badges row
+                    HStack(spacing: VSpacing.xs) {
+                        if skill.isVellum {
+                            VSkillTypePill(type: .core)
+                        } else if isAlreadyInstalled {
+                            VSkillTypePill(type: .installed)
                         }
 
-                        Text(skill.description)
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-                            .lineLimit(2)
+                        if isNew {
+                            VSkillTypePill(type: .custom(
+                                label: "New",
+                                icon: "sparkles",
+                                foreground: Amber._500,
+                                background: Amber._500.opacity(0.15)
+                            ))
+                        }
                     }
+                    .padding(.top, VSpacing.xxs)
                 }
 
-                Spacer()
+                Spacer(minLength: VSpacing.lg)
 
                 if isAlreadyInstalled {
                     Text("Installed")
@@ -881,34 +885,28 @@ struct AgentPanelContent: View {
             HStack(alignment: .top, spacing: VSpacing.md) {
                 skillIcon(skill.emoji)
 
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack(spacing: VSpacing.sm) {
-                        Text(skill.name)
-                            .font(VFont.bodyBold)
-                            .foregroundColor(VColor.textPrimary)
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text(skill.name)
+                        .font(VFont.bodyBold)
+                        .foregroundColor(VColor.textPrimary)
 
-                        // Source badge capsule
-                        Text(sourceLabel(skill.source))
-                            .font(VFont.small)
-                            .foregroundColor(sourceBadgeColor(skill.source))
-                            .padding(.horizontal, VSpacing.sm)
-                            .padding(.vertical, 2)
-                            .background(
-                                Capsule()
-                                    .fill(sourceBadgeColor(skill.source).opacity(0.15))
-                            )
+                    Text(skill.description)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                        .lineLimit(2)
+
+                    // Pill badges row
+                    HStack(spacing: VSpacing.xs) {
+                        VSkillTypePill(source: skill.source)
 
                         // Provenance badge
-                        if let label = provenanceLabel(skill) {
-                            Text(label)
-                                .font(VFont.small)
-                                .foregroundColor(provenanceBadgeColor(skill))
-                                .padding(.horizontal, VSpacing.sm)
-                                .padding(.vertical, 2)
-                                .background(
-                                    Capsule()
-                                        .fill(provenanceBadgeColor(skill).opacity(0.15))
-                                )
+                        if let provenance = skill.provenance, let label = provenanceLabel(skill) {
+                            VSkillTypePill(type: .custom(
+                                label: label,
+                                icon: provenance.kind == "first-party" ? "checkmark.seal.fill" : "person.fill",
+                                foreground: provenanceBadgeColor(skill),
+                                background: provenanceBadgeColor(skill).opacity(0.15)
+                            ))
                         }
 
                         if skill.updateAvailable {
@@ -917,11 +915,7 @@ struct AgentPanelContent: View {
                                 .foregroundColor(Amber._500)
                         }
                     }
-
-                    Text(skill.description)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
-                        .lineLimit(2)
+                    .padding(.top, VSpacing.xxs)
 
                     // Source link for third-party skills
                     if let provenance = skill.provenance,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -46,29 +46,8 @@ struct AgentPanelContent: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Global search bar
-            HStack(spacing: VSpacing.sm) {
-                Image(systemName: "magnifyingglass")
-                    .font(.system(size: 12))
-                    .foregroundColor(VColor.textMuted)
-
-                TextField("Search skills...", text: $globalSkillSearchQuery)
-                    .textFieldStyle(.plain)
-                    .font(VFont.mono)
-                    .foregroundColor(VColor.textPrimary)
-
-                if !globalSkillSearchQuery.isEmpty {
-                    Button(action: { globalSkillSearchQuery = "" }) {
-                        Image(systemName: "xmark.circle.fill")
-                            .font(.system(size: 12))
-                            .foregroundColor(VColor.textMuted)
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-            .padding(VSpacing.md)
-            .background(VColor.backgroundSubtle)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .padding(.bottom, VSpacing.lg)
+            VSearchBar(placeholder: "Search skills...", text: $globalSkillSearchQuery)
+                .padding(.bottom, VSpacing.lg)
 
             // Tab bar — hidden when locked to a single tab via visibleTab
             if visibleTab == nil {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -45,9 +45,11 @@ struct AgentPanelContent: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Global search bar
-            VSearchBar(placeholder: "Search skills...", text: $globalSkillSearchQuery)
-                .padding(.bottom, VSpacing.lg)
+            // Search bar for available skills tab (installed tab has its own in the right panel)
+            if (visibleTab ?? selectedTab) == .available {
+                VSearchBar(placeholder: "Search skills...", text: $globalSkillSearchQuery)
+                    .padding(.bottom, VSpacing.lg)
+            }
 
             // Tab bar — hidden when locked to a single tab via visibleTab
             if visibleTab == nil {
@@ -862,6 +864,8 @@ struct AgentPanelContent: View {
                 categorySidebar
 
                 VStack(spacing: VSpacing.md) {
+                    VSearchBar(placeholder: "Search skills", text: $globalSkillSearchQuery)
+
                     if categoryFilteredSkills.isEmpty {
                         VEmptyState(
                             title: "No skills in this category",
@@ -881,7 +885,10 @@ struct AgentPanelContent: View {
     }
 
     private func skillCard(_ skill: SkillInfo) -> some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
+        let isExpanded = expandedDetailSkillId == skill.id
+
+        return VStack(alignment: .leading, spacing: 0) {
+            // Top row: icon + info + remove button
             HStack(alignment: .top, spacing: VSpacing.md) {
                 skillIcon(skill.emoji)
 
@@ -895,98 +902,63 @@ struct AgentPanelContent: View {
                         .foregroundColor(VColor.textMuted)
                         .lineLimit(2)
 
-                    // Pill badges row
-                    HStack(spacing: VSpacing.xs) {
-                        VSkillTypePill(source: skill.source)
-
-                        // Provenance badge
-                        if let provenance = skill.provenance, let label = provenanceLabel(skill) {
-                            VSkillTypePill(type: .custom(
-                                label: label,
-                                icon: provenance.kind == "first-party" ? "checkmark.seal.fill" : "person.fill",
-                                foreground: provenanceBadgeColor(skill),
-                                background: provenanceBadgeColor(skill).opacity(0.15)
-                            ))
-                        }
-
-                        if skill.updateAvailable {
-                            Text("UPDATE")
-                                .font(VFont.small)
-                                .foregroundColor(Amber._500)
-                        }
-                    }
-                    .padding(.top, VSpacing.xxs)
-
-                    // Source link for third-party skills
-                    if let provenance = skill.provenance,
-                       provenance.kind == "third-party",
-                       let urlString = provenance.sourceUrl,
-                       let url = URL(string: urlString) {
-                        Link(destination: url) {
-                            HStack(spacing: 3) {
-                                Image(systemName: "arrow.up.right.square")
-                                    .font(.system(size: 9))
-                                Text("View on \(provenance.provider ?? "source")")
-                                    .font(VFont.small)
-                            }
-                            .foregroundColor(VColor.textMuted)
-                        }
-                        .buttonStyle(.plain)
-                    }
+                    VSkillTypePill(source: skill.source)
+                        .padding(.top, VSpacing.xxs)
                 }
 
                 Spacer(minLength: VSpacing.lg)
 
-                // Remove button for managed skills only
-                if skill.source == "managed" {
-                    Button {
-                        skillToDelete = skill
-                    } label: {
-                        HStack(spacing: VSpacing.xs) {
-                            Image(systemName: "trash")
-                                .font(.system(size: 11))
-                            Text("Remove")
-                                .font(VFont.caption)
-                        }
+                // Remove button
+                Button {
+                    skillToDelete = skill
+                } label: {
+                    Text("Remove")
+                        .font(VFont.caption)
                         .foregroundColor(Danger._500)
                         .padding(.horizontal, VSpacing.md)
                         .padding(.vertical, VSpacing.xs)
                         .background(
                             RoundedRectangle(cornerRadius: VRadius.sm)
-                                .fill(Danger._500.opacity(0.1))
+                                .strokeBorder(Danger._500, lineWidth: 1)
                         )
-                    }
-                    .buttonStyle(.plain)
                 }
+                .buttonStyle(.plain)
             }
 
-            // Expandable details disclosure
-            DisclosureGroup(
-                isExpanded: Binding(
-                    get: { expandedDetailSkillId == skill.id },
-                    set: { isExpanded in
-                        withAnimation(VAnimation.fast) {
-                            if isExpanded {
-                                expandedDetailSkillId = skill.id
-                                skillsManager.fetchSkillBody(skillId: skill.id)
-                            } else {
-                                expandedDetailSkillId = nil
-                            }
-                        }
+            // Details toggle — full row is clickable
+            Button {
+                withAnimation(VAnimation.fast) {
+                    if isExpanded {
+                        expandedDetailSkillId = nil
+                    } else {
+                        expandedDetailSkillId = skill.id
+                        skillsManager.fetchSkillBody(skillId: skill.id)
                     }
-                )
-            ) {
+                }
+            } label: {
+                HStack {
+                    Spacer()
+                    Text("Details")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 10))
+                        .foregroundColor(VColor.textMuted)
+                        .rotationEffect(.degrees(isExpanded ? 180 : 0))
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .padding(.top, VSpacing.sm)
+
+            // Expanded details content
+            if isExpanded {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     skillBody(for: skill.id)
                 }
                 .padding(.top, VSpacing.sm)
                 .frame(maxWidth: .infinity, alignment: .leading)
-            } label: {
-                Text("Details")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
             }
-            .padding(.leading, 24 + VSpacing.md)
         }
         .padding(VSpacing.lg)
         .contentShape(Rectangle())

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -60,42 +60,7 @@ struct AppsGridView: View {
     // MARK: - Search Bar
 
     private var searchBar: some View {
-        GeometryReader { geometry in
-            HStack {
-                Spacer()
-                HStack(spacing: VSpacing.sm) {
-                    Image(systemName: "magnifyingglass")
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(VColor.textMuted)
-
-                    TextField("Search apps...", text: $searchText)
-                        .textFieldStyle(.plain)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
-
-                    if !searchText.isEmpty {
-                        Button(action: { searchText = "" }) {
-                            Image(systemName: "xmark.circle.fill")
-                                .font(.system(size: 12))
-                                .foregroundColor(VColor.textMuted)
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel("Clear search")
-                    }
-                }
-                .padding(.horizontal, VSpacing.lg)
-                .padding(.vertical, VSpacing.sm)
-                .background(VColor.surface)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.pill)
-                        .stroke(VColor.surfaceBorder, lineWidth: 1)
-                )
-                .frame(maxWidth: geometry.size.width * 0.6)
-                Spacer()
-            }
-        }
-        .frame(height: 36)
+        VSearchBar(placeholder: "Search apps...", text: $searchText)
     }
 
     // MARK: - Sections

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -901,6 +901,10 @@ struct ConstellationView: View {
                 height: panOffset.height + dragOffset.height
             )
             ZStack {
+                // Static dotted grid (unaffected by zoom/pan)
+                DottedGridBackground()
+                    .allowsHitTesting(false)
+
                 canvas(size: proxy.size)
                     .scaleEffect(zoomScale)
                     .offset(totalOffset)
@@ -1153,6 +1157,36 @@ struct ConstellationView: View {
                     .spring(response: 0.5, dampingFraction: 0.7).delay(0.05),
                     value: phase
                 )
+        }
+    }
+}
+
+// MARK: - Dotted Grid Background
+
+private struct DottedGridBackground: View {
+    let spacing: CGFloat = 24
+    let dotRadius: CGFloat = 1.5
+
+    var body: some View {
+        Canvas { context, size in
+            let cols = Int(size.width / spacing) + 1
+            let rows = Int(size.height / spacing) + 1
+            for row in 0..<rows {
+                for col in 0..<cols {
+                    let x = CGFloat(col) * spacing
+                    let y = CGFloat(row) * spacing
+                    let rect = CGRect(
+                        x: x - dotRadius,
+                        y: y - dotRadius,
+                        width: dotRadius * 2,
+                        height: dotRadius * 2
+                    )
+                    context.fill(
+                        Path(ellipseIn: rect),
+                        with: .color(VColor.textMuted.opacity(0.2))
+                    )
+                }
+            }
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -24,45 +24,55 @@ struct IdentityPanel: View {
         HStack(alignment: .top, spacing: 0) {
             // Left sidebar: title, avatar, ID card — hidden in fullscreen
             if !isFullscreen {
-                VStack(alignment: .leading, spacing: 0) {
-                    // Header
-                    Text("Identity")
-                        .font(VFont.panelTitle)
-                        .foregroundColor(VColor.textPrimary)
-                        .padding(.bottom, VSpacing.lg)
-
-                    // Card wrapping avatar + ID fields
+                VStack(spacing: 0) {
                     VStack(spacing: 0) {
-                        // Avatar image or initial-letter fallback (full-size for identity display)
+                        // "I'm [name]!" heading
+                        Text("I'm \(remoteIdentity?.name.nilIfEmpty ?? identity?.name ?? lockfileAssistant?.assistantId ?? "Unknown")!")
+                            .font(.system(size: 22, weight: .regular, design: .rounded))
+                            .foregroundColor(Color(hex: 0x4A4A46))
+                            .multilineTextAlignment(.center)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .padding(.top, VSpacing.xxl)
+                            .padding(.horizontal, VSpacing.lg)
+
+                        Spacer()
+
+                        // Large centered avatar
                         Image(nsImage: appearance.fullAvatarImage)
                             .resizable()
                             .aspectRatio(contentMode: .fill)
-                            .frame(width: 120, height: 120)
+                            .frame(width: 180, height: 180)
                             .clipShape(Circle())
-                            .overlay(
-                                Circle()
-                                    .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
-                            )
                             .frame(maxWidth: .infinity, alignment: .center)
-                            .padding(.top, VSpacing.lg)
 
-                        // Edit Avatar CTA — switches to chat and pre-fills composer
-                        VButton(label: "Edit Avatar", style: .secondary, isFullWidth: true, action: onEditAvatar)
-                            .padding(.top, VSpacing.sm)
+                        Spacer()
+
+                        // Update Avatar button
+                        VButton(label: "Update Avatar", style: .secondary, action: onEditAvatar)
                             .padding(.horizontal, VSpacing.lg)
-                            .padding(.bottom, VSpacing.lg)
+                            .padding(.bottom, VSpacing.xl)
 
-                        // ID card fields
-                        ScrollView {
-                            idCardSection(identity: identity, remoteIdentity: remoteIdentity)
-                                .padding(.horizontal, VSpacing.lg)
-                                .padding(.bottom, VSpacing.lg)
+                        // Divider
+                        Rectangle()
+                            .fill(Color(hex: 0xF5F3EB))
+                            .frame(height: 2)
+
+                        // Role + Hatched date
+                        VStack(alignment: .leading, spacing: VSpacing.lg) {
+                            let role = remoteIdentity?.role.nilIfEmpty ?? identity?.role
+                            if let role, !role.isEmpty {
+                                identityInfoRow(label: "Role", value: role)
+                            }
+                            if let date = metadata?.createdAt {
+                                identityInfoRow(label: "Hatched", value: formatHatchedDate(date))
+                            }
                         }
+                        .padding(.horizontal, VSpacing.lg)
+                        .padding(.vertical, VSpacing.lg)
                     }
-                    .background(VColor.backgroundSubtle)
+                    .frame(maxHeight: .infinity)
+                    .background(Color(hex: 0xE8E6DA))
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-
-                    Spacer()
                 }
                 .frame(width: sidebarWidth)
                 .padding(.leading, panelPadding)
@@ -206,6 +216,23 @@ struct IdentityPanel: View {
                     .textSelection(.enabled)
             }
         }
+    }
+
+    private func identityInfoRow(label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+            Text(label)
+                .font(VFont.caption)
+                .foregroundColor(Color(hex: 0x6B6B5E))
+            Text(value)
+                .font(VFont.caption)
+                .foregroundColor(Color(hex: 0x3D3D35))
+        }
+    }
+
+    private func formatHatchedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "d MMM yyyy"
+        return formatter.string(from: date)
     }
 
     private func formatDate(_ date: Date) -> String {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -30,11 +30,11 @@ struct IntelligencePanel: View {
                         .foregroundColor(VColor.textPrimary)
                     Spacer()
                 }
-                .padding(.top, VSpacing.xxl)
-                .padding(.bottom, VSpacing.xl)
+                .padding(.top, VSpacing.xl)
+                .padding(.bottom, VSpacing.md)
+                .padding(.horizontal, VSpacing.xxl)
 
                 Divider().background(VColor.surfaceBorder)
-                    .padding(.bottom, VSpacing.xl)
 
                 // Tab bar
                 VStack(spacing: 0) {
@@ -44,13 +44,13 @@ struct IntelligencePanel: View {
                         }
                         Spacer()
                     }
+                    .padding(.horizontal, VSpacing.xxl)
 
                     Divider().background(VColor.surfaceBorder)
                 }
-                .padding(.bottom, VSpacing.lg)
+                .padding(.top, VSpacing.md)
+                .padding(.bottom, VSpacing.md)
             }
-            .frame(maxWidth: maxContentWidth)
-            .padding(.horizontal, VSpacing.xxl)
             .frame(maxWidth: .infinity, alignment: .leading)
 
             // Tab content — each tab manages its own scrolling

--- a/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+/// A pill badge indicating the type/source of a skill (Core, Installed, Created).
+public struct VSkillTypePill: View {
+    public enum SkillType {
+        case core
+        case installed
+        case created
+        case extra
+        case custom(label: String, icon: String, foreground: Color, background: Color)
+
+        var label: String {
+            switch self {
+            case .core: return "Core"
+            case .installed: return "Installed"
+            case .created: return "Created"
+            case .extra: return "Extra"
+            case .custom(let label, _, _, _): return label
+            }
+        }
+
+        var icon: String {
+            switch self {
+            case .core: return "building.2.fill"
+            case .installed: return "checkmark.circle.fill"
+            case .created: return "sparkles"
+            case .extra: return "puzzlepiece.fill"
+            case .custom(_, let icon, _, _): return icon
+            }
+        }
+
+        var foregroundColor: Color {
+            switch self {
+            case .core: return Color(hex: 0x4A4A3E)
+            case .installed: return Color(hex: 0x3A6B3A)
+            case .created: return Color(hex: 0x3A4A6B)
+            case .extra: return Color(hex: 0x6B6B5E)
+            case .custom(_, _, let fg, _): return fg
+            }
+        }
+
+        var backgroundColor: Color {
+            switch self {
+            case .core: return Color(hex: 0xDDDBCE)
+            case .installed: return Color(hex: 0xD4E8D4)
+            case .created: return Color(hex: 0xD4DCE8)
+            case .extra: return Color(hex: 0xDDDBCE)
+            case .custom(_, _, _, let bg): return bg
+            }
+        }
+    }
+
+    public let type: SkillType
+
+    public init(type: SkillType) {
+        self.type = type
+    }
+
+    /// Convenience initializer from a skill source string.
+    public init(source: String) {
+        switch source {
+        case "bundled":
+            self.type = .core
+        case "managed", "clawhub":
+            self.type = .installed
+        case "workspace":
+            self.type = .created
+        case "extra":
+            self.type = .extra
+        default:
+            self.type = .custom(
+                label: source.replacingOccurrences(of: "-", with: " ").capitalized,
+                icon: "puzzlepiece.fill",
+                foreground: Color(hex: 0x6B6B5E),
+                background: Color(hex: 0xDDDBCE)
+            )
+        }
+    }
+
+    public var body: some View {
+        HStack(spacing: VSpacing.xs) {
+            Image(systemName: type.icon)
+                .font(.system(size: 10, weight: .medium))
+            Text(type.label)
+                .font(VFont.caption)
+        }
+        .foregroundColor(type.foregroundColor)
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.xs)
+        .background(
+            Capsule()
+                .fill(type.backgroundColor)
+        )
+    }
+}

--- a/clients/shared/DesignSystem/Core/Inputs/VSearchBar.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VSearchBar.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+public struct VSearchBar: View {
+    public let placeholder: String
+    @Binding public var text: String
+
+    public init(placeholder: String = "Search...", text: Binding<String>) {
+        self.placeholder = placeholder
+        self._text = text
+    }
+
+    public var body: some View {
+        HStack(spacing: VSpacing.sm) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(VColor.textMuted)
+
+            TextField(placeholder, text: $text)
+                .textFieldStyle(.plain)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+
+            if !text.isEmpty {
+                Button(action: { text = "" }) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 12))
+                        .foregroundColor(VColor.textMuted)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(VSpacing.md)
+        .background(Color(hex: 0xE8E6DA))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+    }
+}

--- a/clients/shared/DesignSystem/Core/Inputs/VSearchBar.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VSearchBar.swift
@@ -31,7 +31,7 @@ public struct VSearchBar: View {
             }
         }
         .padding(VSpacing.md)
-        .background(Color(hex: 0xE8E6DA))
+        .background(VColor.inputBackground)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
     }
 }


### PR DESCRIPTION
## Summary
- Added a shared `VSearchBar` component to the design system (`DesignSystem/Core/Inputs/VSearchBar.swift`) with `#E8E6DA` background, magnifying glass icon, and clear button
- Replaced the custom search bar in **AgentPanel** (Intelligence tab - Installed/Community Skills) with `VSearchBar`
- Replaced the custom search bar in **AppsGridView** (Things tab) with `VSearchBar`

## Test plan
- [ ] Open Intelligence tab > Installed Skills — verify search bar has warm beige background, filters skills correctly, clear button works
- [ ] Open Intelligence tab > Community Skills — verify same search bar works across tabs
- [ ] Open Things tab — verify search bar matches the same style, filters apps correctly

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
