### PR TITLE
feat: add LLM fallback classifier to guardian-action grant minter

### DIFF
--- a/assistant/src/__tests__/guardian-action-grant-mint-consume.test.ts
+++ b/assistant/src/__tests__/guardian-action-grant-mint-consume.test.ts
@@ -201,7 +201,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
 
     // Step 3: Mint a scoped grant from the resolved request
     await tryMintGuardianActionGrant({
-      resolvedRequest: resolved!,
+      request: resolved!,
       answerText: 'yes',
       decisionChannel: 'telegram',
       guardianExternalUserId: 'guardian-user-123',
@@ -270,7 +270,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     expect(resolved).not.toBeNull();
 
     await tryMintGuardianActionGrant({
-      resolvedRequest: resolved!,
+      request: resolved!,
       answerText: 'Yes',
       decisionChannel: 'telegram',
     });
@@ -318,7 +318,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     expect(resolved).not.toBeNull();
 
     await tryMintGuardianActionGrant({
-      resolvedRequest: resolved!,
+      request: resolved!,
       answerText: 'Tell them to call back',
       decisionChannel: 'vellum',
     });
@@ -354,7 +354,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
 
     // Mint with decisionChannel: 'vellum' (desktop path)
     await tryMintGuardianActionGrant({
-      resolvedRequest: resolved!,
+      request: resolved!,
       answerText: 'approve',
       decisionChannel: 'vellum',
     });
@@ -393,7 +393,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     expect(resolved).not.toBeNull();
 
     await tryMintGuardianActionGrant({
-      resolvedRequest: resolved!,
+      request: resolved!,
       answerText: 'No',
       decisionChannel: 'telegram',
       guardianExternalUserId: 'guardian-user-456',
@@ -428,7 +428,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     expect(resolved).not.toBeNull();
 
     await tryMintGuardianActionGrant({
-      resolvedRequest: resolved!,
+      request: resolved!,
       answerText: denialWord,
       decisionChannel: 'telegram',
     });
@@ -462,7 +462,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     expect(resolved).not.toBeNull();
 
     await tryMintGuardianActionGrant({
-      resolvedRequest: resolved!,
+      request: resolved!,
       answerText: 'Sure, go ahead and run it',
       decisionChannel: 'telegram',
     });
@@ -496,7 +496,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     expect(resolved).not.toBeNull();
 
     await tryMintGuardianActionGrant({
-      resolvedRequest: resolved!,
+      request: resolved!,
       answerText: approveWord,
       decisionChannel: 'telegram',
     });
@@ -546,7 +546,7 @@ describe('guardian-action grant minter: two-tier classification (deterministic +
     };
 
     await tryMintGuardianActionGrant({
-      resolvedRequest: resolved!,
+      request: resolved!,
       answerText: 'yes',
       decisionChannel: 'telegram',
       approvalConversationGenerator: generatorSpy,
@@ -583,7 +583,7 @@ describe('guardian-action grant minter: two-tier classification (deterministic +
     });
 
     await tryMintGuardianActionGrant({
-      resolvedRequest: resolved!,
+      request: resolved!,
       answerText: 'Sure, go ahead and run it',
       decisionChannel: 'telegram',
       approvalConversationGenerator: mockGenerator,
@@ -620,7 +620,7 @@ describe('guardian-action grant minter: two-tier classification (deterministic +
     });
 
     await tryMintGuardianActionGrant({
-      resolvedRequest: resolved!,
+      request: resolved!,
       answerText: "I'm not sure about this",
       decisionChannel: 'telegram',
       approvalConversationGenerator: mockGenerator,
@@ -655,7 +655,7 @@ describe('guardian-action grant minter: two-tier classification (deterministic +
     };
 
     await tryMintGuardianActionGrant({
-      resolvedRequest: resolved!,
+      request: resolved!,
       answerText: 'Sure, go ahead and run it',
       decisionChannel: 'telegram',
       approvalConversationGenerator: failingGenerator,
@@ -687,11 +687,91 @@ describe('guardian-action grant minter: two-tier classification (deterministic +
 
     // No generator provided — behaves like before, no LLM fallback
     await tryMintGuardianActionGrant({
-      resolvedRequest: resolved!,
+      request: resolved!,
       answerText: 'Sure, go ahead and run it',
       decisionChannel: 'telegram',
     });
 
+    const db = getDb();
+    const grants = db.select().from(scopedApprovalGrants).all();
+    expect(grants.length).toBe(0);
+  });
+
+  test('deterministic "approve always" still mints a one-time grant (normalized to approve_once semantics)', async () => {
+    const inputDigest = computeToolApprovalDigest(TOOL_NAME, TOOL_INPUT);
+
+    const request = createGuardianActionRequest({
+      assistantId: ASSISTANT_ID,
+      kind: 'ask_guardian',
+      sourceChannel: 'voice',
+      sourceConversationId: CONVERSATION_ID,
+      callSessionId: CALL_SESSION_ID,
+      pendingQuestionId: nextPendingQuestionId(),
+      questionText: 'Can I run the command?',
+      expiresAt: Date.now() + 60_000,
+      toolName: TOOL_NAME,
+      inputDigest,
+    });
+
+    const resolved = resolveGuardianActionRequest(request.id, 'approve always', 'telegram');
+    expect(resolved).not.toBeNull();
+
+    // Generator should NOT be called -- deterministic parser matches "approve always"
+    const generatorSpy: ApprovalConversationGenerator = async () => {
+      throw new Error('Generator should not be called for deterministic match');
+    };
+
+    await tryMintGuardianActionGrant({
+      request: resolved!,
+      answerText: 'approve always',
+      decisionChannel: 'telegram',
+      approvalConversationGenerator: generatorSpy,
+    });
+
+    // Grant is minted (approve_always treated as approval), but it is still
+    // a one-time tool_signature grant -- no broader privilege is granted.
+    const db = getDb();
+    const grants = db.select().from(scopedApprovalGrants).all();
+    expect(grants.length).toBe(1);
+    expect(grants[0].scopeMode).toBe('tool_signature');
+  });
+
+  test('LLM fallback allowedActions excludes approve_always (guardian invariant)', async () => {
+    const inputDigest = computeToolApprovalDigest(TOOL_NAME, TOOL_INPUT);
+
+    const request = createGuardianActionRequest({
+      assistantId: ASSISTANT_ID,
+      kind: 'ask_guardian',
+      sourceChannel: 'voice',
+      sourceConversationId: CONVERSATION_ID,
+      callSessionId: CALL_SESSION_ID,
+      pendingQuestionId: nextPendingQuestionId(),
+      questionText: 'Can I run the command?',
+      expiresAt: Date.now() + 60_000,
+      toolName: TOOL_NAME,
+      inputDigest,
+    });
+
+    const resolved = resolveGuardianActionRequest(request.id, 'Sure, go ahead and run it', 'telegram');
+    expect(resolved).not.toBeNull();
+
+    // Generator returns approve_always -- but the allowedActions constraint
+    // in the minter restricts to approve_once/reject, so the approval-
+    // conversation-turn layer will normalize this to keep_pending.
+    const mockGenerator: ApprovalConversationGenerator = async () => ({
+      disposition: 'approve_always',
+      replyText: 'Approved permanently.',
+    });
+
+    await tryMintGuardianActionGrant({
+      request: resolved!,
+      answerText: 'Sure, go ahead and run it',
+      decisionChannel: 'telegram',
+      approvalConversationGenerator: mockGenerator,
+    });
+
+    // No grant -- approve_always is not in LLM fallback allowedActions,
+    // so the disposition gets normalized to keep_pending (fail-closed).
     const db = getDb();
     const grants = db.select().from(scopedApprovalGrants).all();
     expect(grants.length).toBe(0);

--- a/assistant/src/__tests__/guardian-action-grant-mint-consume.test.ts
+++ b/assistant/src/__tests__/guardian-action-grant-mint-consume.test.ts
@@ -59,6 +59,7 @@ import {
 
 const { consumeScopedApprovalGrantByToolSignature } = _internal;
 import { tryMintGuardianActionGrant } from '../runtime/guardian-action-grant-minter.js';
+import type { ApprovalConversationGenerator } from '../runtime/http-types.js';
 import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
 
 initializeDb();
@@ -109,7 +110,7 @@ function ensureFkParents(): void {
   // Pre-create enough pending questions for all tests in a suite run
   PENDING_QUESTION_IDS = [];
   pqIndex = 0;
-  for (let i = 0; i < 10; i++) {
+  for (let i = 0; i < 20; i++) {
     const pq = createPendingQuestion(session.id, `Question ${i}`);
     PENDING_QUESTION_IDS.push(pq.id);
   }
@@ -166,7 +167,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     ensureFkParents();
   });
 
-  test('full flow: resolve guardian action with tool metadata -> mint grant -> voice consume succeeds once', () => {
+  test('full flow: resolve guardian action with tool metadata -> mint grant -> voice consume succeeds once', async () => {
     const inputDigest = computeToolApprovalDigest(TOOL_NAME, TOOL_INPUT);
 
     // Step 1: Create a guardian action request with tool metadata
@@ -199,7 +200,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     expect(resolved!.status).toBe('answered');
 
     // Step 3: Mint a scoped grant from the resolved request
-    tryMintGuardianActionGrant({
+    await tryMintGuardianActionGrant({
       resolvedRequest: resolved!,
       answerText: 'yes',
       decisionChannel: 'telegram',
@@ -249,7 +250,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     expect(secondConsume.grant).toBeNull();
   });
 
-  test('grant minted for one assistantId cannot be consumed by another', () => {
+  test('grant minted for one assistantId cannot be consumed by another', async () => {
     const inputDigest = computeToolApprovalDigest(TOOL_NAME, TOOL_INPUT);
 
     const request = createGuardianActionRequest({
@@ -268,7 +269,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     const resolved = resolveGuardianActionRequest(request.id, 'Yes', 'telegram');
     expect(resolved).not.toBeNull();
 
-    tryMintGuardianActionGrant({
+    await tryMintGuardianActionGrant({
       resolvedRequest: resolved!,
       answerText: 'Yes',
       decisionChannel: 'telegram',
@@ -299,7 +300,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     expect(correctAssistant.ok).toBe(true);
   });
 
-  test('no grant minted when guardian action request lacks tool metadata', () => {
+  test('no grant minted when guardian action request lacks tool metadata', async () => {
     // Create a request without toolName/inputDigest (informational consult)
     const request = createGuardianActionRequest({
       assistantId: ASSISTANT_ID,
@@ -316,7 +317,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     const resolved = resolveGuardianActionRequest(request.id, 'Tell them to call back', 'vellum');
     expect(resolved).not.toBeNull();
 
-    tryMintGuardianActionGrant({
+    await tryMintGuardianActionGrant({
       resolvedRequest: resolved!,
       answerText: 'Tell them to call back',
       decisionChannel: 'vellum',
@@ -331,7 +332,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     expect(grants.length).toBe(0);
   });
 
-  test('grant minted via desktop/vellum channel also consumable by voice', () => {
+  test('grant minted via desktop/vellum channel also consumable by voice', async () => {
     const inputDigest = computeToolApprovalDigest(TOOL_NAME, TOOL_INPUT);
 
     const request = createGuardianActionRequest({
@@ -352,7 +353,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     expect(resolved).not.toBeNull();
 
     // Mint with decisionChannel: 'vellum' (desktop path)
-    tryMintGuardianActionGrant({
+    await tryMintGuardianActionGrant({
       resolvedRequest: resolved!,
       answerText: 'approve',
       decisionChannel: 'vellum',
@@ -371,7 +372,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     expect(consumeResult.ok).toBe(true);
   });
 
-  test('no grant minted when guardian answer is a denial', () => {
+  test('no grant minted when guardian answer is a denial', async () => {
     const inputDigest = computeToolApprovalDigest(TOOL_NAME, TOOL_INPUT);
 
     const request = createGuardianActionRequest({
@@ -391,7 +392,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     const resolved = resolveGuardianActionRequest(request.id, 'No', 'telegram', 'guardian-user-456');
     expect(resolved).not.toBeNull();
 
-    tryMintGuardianActionGrant({
+    await tryMintGuardianActionGrant({
       resolvedRequest: resolved!,
       answerText: 'No',
       decisionChannel: 'telegram',
@@ -407,7 +408,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     expect(grants.length).toBe(0);
   });
 
-  test.each(['no', 'reject', 'deny', 'cancel'])('no grant minted for denial keyword: %s', (denialWord) => {
+  test.each(['no', 'reject', 'deny', 'cancel'])('no grant minted for denial keyword: %s', async (denialWord) => {
     const inputDigest = computeToolApprovalDigest(TOOL_NAME, TOOL_INPUT);
 
     const request = createGuardianActionRequest({
@@ -426,7 +427,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     const resolved = resolveGuardianActionRequest(request.id, denialWord, 'telegram');
     expect(resolved).not.toBeNull();
 
-    tryMintGuardianActionGrant({
+    await tryMintGuardianActionGrant({
       resolvedRequest: resolved!,
       answerText: denialWord,
       decisionChannel: 'telegram',
@@ -440,7 +441,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     expect(grants.length).toBe(0);
   });
 
-  test('no grant minted for unrecognised free-form answer (fail-closed)', () => {
+  test('no grant minted for unrecognised free-form answer without generator (fail-closed)', async () => {
     const inputDigest = computeToolApprovalDigest(TOOL_NAME, TOOL_INPUT);
 
     const request = createGuardianActionRequest({
@@ -460,7 +461,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     const resolved = resolveGuardianActionRequest(request.id, 'Sure, go ahead and run it', 'telegram');
     expect(resolved).not.toBeNull();
 
-    tryMintGuardianActionGrant({
+    await tryMintGuardianActionGrant({
       resolvedRequest: resolved!,
       answerText: 'Sure, go ahead and run it',
       decisionChannel: 'telegram',
@@ -475,7 +476,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     expect(grants.length).toBe(0);
   });
 
-  test.each(['yes', 'approve', 'approve once', 'allow', 'go ahead'])('grant IS minted for approval keyword: %s', (approveWord) => {
+  test.each(['yes', 'approve', 'approve once', 'allow', 'go ahead'])('grant IS minted for approval keyword: %s', async (approveWord) => {
     const inputDigest = computeToolApprovalDigest(TOOL_NAME, TOOL_INPUT);
 
     const request = createGuardianActionRequest({
@@ -494,7 +495,7 @@ describe('guardian-action grant mint -> voice consume integration', () => {
     const resolved = resolveGuardianActionRequest(request.id, approveWord, 'telegram');
     expect(resolved).not.toBeNull();
 
-    tryMintGuardianActionGrant({
+    await tryMintGuardianActionGrant({
       resolvedRequest: resolved!,
       answerText: approveWord,
       decisionChannel: 'telegram',
@@ -507,5 +508,192 @@ describe('guardian-action grant mint -> voice consume integration', () => {
       .all();
     expect(grants.length).toBe(1);
     expect(grants[0].toolName).toBe(TOOL_NAME);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LLM fallback two-tier classification tests
+// ---------------------------------------------------------------------------
+
+describe('guardian-action grant minter: two-tier classification (deterministic + LLM fallback)', () => {
+  beforeEach(() => {
+    clearTables();
+    ensureFkParents();
+  });
+
+  test('deterministic parser works for exact phrases without needing the generator', async () => {
+    const inputDigest = computeToolApprovalDigest(TOOL_NAME, TOOL_INPUT);
+
+    const request = createGuardianActionRequest({
+      assistantId: ASSISTANT_ID,
+      kind: 'ask_guardian',
+      sourceChannel: 'voice',
+      sourceConversationId: CONVERSATION_ID,
+      callSessionId: CALL_SESSION_ID,
+      pendingQuestionId: nextPendingQuestionId(),
+      questionText: 'Can I run the command?',
+      expiresAt: Date.now() + 60_000,
+      toolName: TOOL_NAME,
+      inputDigest,
+    });
+
+    const resolved = resolveGuardianActionRequest(request.id, 'yes', 'telegram');
+    expect(resolved).not.toBeNull();
+
+    // Provide a generator that should NOT be called (deterministic match first)
+    const generatorSpy: ApprovalConversationGenerator = async () => {
+      throw new Error('Generator should not be called for exact phrase match');
+    };
+
+    await tryMintGuardianActionGrant({
+      resolvedRequest: resolved!,
+      answerText: 'yes',
+      decisionChannel: 'telegram',
+      approvalConversationGenerator: generatorSpy,
+    });
+
+    const db = getDb();
+    const grants = db.select().from(scopedApprovalGrants).all();
+    expect(grants.length).toBe(1);
+    expect(grants[0].toolName).toBe(TOOL_NAME);
+  });
+
+  test('free-form approval via LLM fallback mints a grant', async () => {
+    const inputDigest = computeToolApprovalDigest(TOOL_NAME, TOOL_INPUT);
+
+    const request = createGuardianActionRequest({
+      assistantId: ASSISTANT_ID,
+      kind: 'ask_guardian',
+      sourceChannel: 'voice',
+      sourceConversationId: CONVERSATION_ID,
+      callSessionId: CALL_SESSION_ID,
+      pendingQuestionId: nextPendingQuestionId(),
+      questionText: 'Can I run the command?',
+      expiresAt: Date.now() + 60_000,
+      toolName: TOOL_NAME,
+      inputDigest,
+    });
+
+    const resolved = resolveGuardianActionRequest(request.id, 'Sure, go ahead and run it', 'telegram');
+    expect(resolved).not.toBeNull();
+
+    const mockGenerator: ApprovalConversationGenerator = async () => ({
+      disposition: 'approve_once',
+      replyText: 'Approved.',
+    });
+
+    await tryMintGuardianActionGrant({
+      resolvedRequest: resolved!,
+      answerText: 'Sure, go ahead and run it',
+      decisionChannel: 'telegram',
+      approvalConversationGenerator: mockGenerator,
+    });
+
+    const db = getDb();
+    const grants = db.select().from(scopedApprovalGrants).all();
+    expect(grants.length).toBe(1);
+    expect(grants[0].toolName).toBe(TOOL_NAME);
+  });
+
+  test('ambiguous text returns keep_pending from generator, no grant minted', async () => {
+    const inputDigest = computeToolApprovalDigest(TOOL_NAME, TOOL_INPUT);
+
+    const request = createGuardianActionRequest({
+      assistantId: ASSISTANT_ID,
+      kind: 'ask_guardian',
+      sourceChannel: 'voice',
+      sourceConversationId: CONVERSATION_ID,
+      callSessionId: CALL_SESSION_ID,
+      pendingQuestionId: nextPendingQuestionId(),
+      questionText: 'Can I run the command?',
+      expiresAt: Date.now() + 60_000,
+      toolName: TOOL_NAME,
+      inputDigest,
+    });
+
+    const resolved = resolveGuardianActionRequest(request.id, "I'm not sure about this", 'telegram');
+    expect(resolved).not.toBeNull();
+
+    const mockGenerator: ApprovalConversationGenerator = async () => ({
+      disposition: 'keep_pending',
+      replyText: 'Could you clarify?',
+    });
+
+    await tryMintGuardianActionGrant({
+      resolvedRequest: resolved!,
+      answerText: "I'm not sure about this",
+      decisionChannel: 'telegram',
+      approvalConversationGenerator: mockGenerator,
+    });
+
+    const db = getDb();
+    const grants = db.select().from(scopedApprovalGrants).all();
+    expect(grants.length).toBe(0);
+  });
+
+  test('generator failure falls back to no grant (fail-closed)', async () => {
+    const inputDigest = computeToolApprovalDigest(TOOL_NAME, TOOL_INPUT);
+
+    const request = createGuardianActionRequest({
+      assistantId: ASSISTANT_ID,
+      kind: 'ask_guardian',
+      sourceChannel: 'voice',
+      sourceConversationId: CONVERSATION_ID,
+      callSessionId: CALL_SESSION_ID,
+      pendingQuestionId: nextPendingQuestionId(),
+      questionText: 'Can I run the command?',
+      expiresAt: Date.now() + 60_000,
+      toolName: TOOL_NAME,
+      inputDigest,
+    });
+
+    const resolved = resolveGuardianActionRequest(request.id, 'Sure, go ahead and run it', 'telegram');
+    expect(resolved).not.toBeNull();
+
+    const failingGenerator: ApprovalConversationGenerator = async () => {
+      throw new Error('LLM provider unavailable');
+    };
+
+    await tryMintGuardianActionGrant({
+      resolvedRequest: resolved!,
+      answerText: 'Sure, go ahead and run it',
+      decisionChannel: 'telegram',
+      approvalConversationGenerator: failingGenerator,
+    });
+
+    const db = getDb();
+    const grants = db.select().from(scopedApprovalGrants).all();
+    expect(grants.length).toBe(0);
+  });
+
+  test('no generator provided and unrecognised text produces no grant', async () => {
+    const inputDigest = computeToolApprovalDigest(TOOL_NAME, TOOL_INPUT);
+
+    const request = createGuardianActionRequest({
+      assistantId: ASSISTANT_ID,
+      kind: 'ask_guardian',
+      sourceChannel: 'voice',
+      sourceConversationId: CONVERSATION_ID,
+      callSessionId: CALL_SESSION_ID,
+      pendingQuestionId: nextPendingQuestionId(),
+      questionText: 'Can I run the command?',
+      expiresAt: Date.now() + 60_000,
+      toolName: TOOL_NAME,
+      inputDigest,
+    });
+
+    const resolved = resolveGuardianActionRequest(request.id, 'Sure, go ahead and run it', 'telegram');
+    expect(resolved).not.toBeNull();
+
+    // No generator provided — behaves like before, no LLM fallback
+    await tryMintGuardianActionGrant({
+      resolvedRequest: resolved!,
+      answerText: 'Sure, go ahead and run it',
+      decisionChannel: 'telegram',
+    });
+
+    const db = getDb();
+    const grants = db.select().from(scopedApprovalGrants).all();
+    expect(grants.length).toBe(0);
   });
 });

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -57,7 +57,7 @@ import type { ServerMessage } from './ipc-protocol.js';
 import { initializeProvidersAndTools, registerMessagingProviders,registerWatcherProviders } from './providers-setup.js';
 import { seedInterfaceFiles } from './seed-files.js';
 import { DaemonServer } from './server.js';
-import { setGuardianActionCopyGenerator, setGuardianFollowUpConversationGenerator } from './session-process.js';
+import { setApprovalConversationGenerator, setGuardianActionCopyGenerator, setGuardianFollowUpConversationGenerator } from './session-process.js';
 import { initSlashPairingContext } from './session-slash.js';
 import { installShutdownHandlers } from './shutdown-handlers.js';
 
@@ -307,7 +307,11 @@ export async function runDaemon(): Promise<void> {
         server.persistAndProcessMessage(conversationId, content, attachmentIds, options, sourceChannel, sourceInterface),
       interfacesDir: getInterfacesDir(),
       approvalCopyGenerator: createApprovalCopyGenerator(),
-      approvalConversationGenerator: createApprovalConversationGenerator(),
+      approvalConversationGenerator: (() => {
+        const gen = createApprovalConversationGenerator();
+        setApprovalConversationGenerator(gen);
+        return gen;
+      })(),
       guardianActionCopyGenerator: (() => {
         const gen = createGuardianActionCopyGenerator();
         setGuardianActionCopyGenerator(gen);

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -531,7 +531,7 @@ export async function processMessage(
           if ('ok' in answerResult && answerResult.ok) {
             const resolved = resolveGuardianActionRequest(request.id, answerText, 'vellum');
             if (resolved) {
-              await tryMintGuardianActionGrant({ resolvedRequest: request, answerText, decisionChannel: 'vellum', approvalConversationGenerator: _approvalConversationGenerator });
+              await tryMintGuardianActionGrant({ request, answerText, decisionChannel: 'vellum', approvalConversationGenerator: _approvalConversationGenerator });
             }
             const replyText = resolved
               ? 'Your answer has been relayed to the call.'
@@ -629,16 +629,16 @@ export async function processMessage(
                 if ('ok' in remapResult && remapResult.ok) {
                   const resolved = resolveGuardianActionRequest(currentPending.id, answerText, 'vellum');
                   if (resolved) {
-                    await tryMintGuardianActionGrant({ resolvedRequest: currentPending, answerText, decisionChannel: 'vellum', approvalConversationGenerator: _approvalConversationGenerator });
-                    const remapText = await composeGuardianActionMessageGenerative({ scenario: 'guardian_superseded_remap', questionText: currentPending.questionText }, {}, _guardianActionCopyGenerator);
-                    const remapMsg = createAssistantMessage(remapText);
-                    await conversationStore.addMessage(session.conversationId, 'assistant', JSON.stringify(remapMsg.content), guardianChannelMeta);
-                    session.messages.push(remapMsg);
-                    onEvent({ type: 'assistant_text_delta', text: remapText });
-                    onEvent({ type: 'message_complete', sessionId: session.conversationId });
-                    log.info({ supersededRequestId: request.id, remappedToRequestId: currentPending.id }, 'Late approval for superseded request remapped to current pending request');
-                    return persisted.id;
+                    await tryMintGuardianActionGrant({ request: currentPending, answerText, decisionChannel: 'vellum', approvalConversationGenerator: _approvalConversationGenerator });
                   }
+                  const remapText = await composeGuardianActionMessageGenerative({ scenario: 'guardian_superseded_remap', questionText: currentPending.questionText }, {}, _guardianActionCopyGenerator);
+                  const remapMsg = createAssistantMessage(remapText);
+                  await conversationStore.addMessage(session.conversationId, 'assistant', JSON.stringify(remapMsg.content), guardianChannelMeta);
+                  session.messages.push(remapMsg);
+                  onEvent({ type: 'assistant_text_delta', text: remapText });
+                  onEvent({ type: 'message_complete', sessionId: session.conversationId });
+                  log.info({ supersededRequestId: request.id, remappedToRequestId: currentPending.id }, 'Late approval for superseded request remapped to current pending request');
+                  return persisted.id;
                 }
                 log.warn({ callSessionId: currentPending.callSessionId, error: 'error' in remapResult ? remapResult.error : 'unknown' }, 'Superseded remap answerCall failed, falling through to follow-up');
               }

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -34,7 +34,7 @@ import { processGuardianFollowUpTurn } from '../runtime/guardian-action-conversa
 import { executeFollowupAction } from '../runtime/guardian-action-followup-executor.js';
 import { tryMintGuardianActionGrant } from '../runtime/guardian-action-grant-minter.js';
 import { composeGuardianActionMessageGenerative } from '../runtime/guardian-action-message-composer.js';
-import type { GuardianActionCopyGenerator, GuardianFollowUpConversationGenerator } from '../runtime/http-types.js';
+import type { ApprovalConversationGenerator, GuardianActionCopyGenerator, GuardianFollowUpConversationGenerator } from '../runtime/http-types.js';
 import { getLogger } from '../util/logger.js';
 import { resolveGuardianVerificationIntent } from './guardian-verification-intent.js';
 import type { UsageStats } from './ipc-contract.js';
@@ -55,6 +55,7 @@ const log = getLogger('session-process');
 // generator through Session / DaemonServer constructors.
 let _guardianFollowUpGenerator: GuardianFollowUpConversationGenerator | undefined;
 let _guardianActionCopyGenerator: GuardianActionCopyGenerator | undefined;
+let _approvalConversationGenerator: ApprovalConversationGenerator | undefined;
 
 /** Inject the guardian follow-up conversation generator (called from lifecycle.ts). */
 export function setGuardianFollowUpConversationGenerator(gen: GuardianFollowUpConversationGenerator): void {
@@ -64,6 +65,11 @@ export function setGuardianFollowUpConversationGenerator(gen: GuardianFollowUpCo
 /** Inject the guardian action copy generator (called from lifecycle.ts). */
 export function setGuardianActionCopyGenerator(gen: GuardianActionCopyGenerator): void {
   _guardianActionCopyGenerator = gen;
+}
+
+/** Inject the approval conversation generator (called from lifecycle.ts). */
+export function setApprovalConversationGenerator(gen: ApprovalConversationGenerator): void {
+  _approvalConversationGenerator = gen;
 }
 
 /** Build a model_info event with fresh config data. */
@@ -525,7 +531,7 @@ export async function processMessage(
           if ('ok' in answerResult && answerResult.ok) {
             const resolved = resolveGuardianActionRequest(request.id, answerText, 'vellum');
             if (resolved) {
-              tryMintGuardianActionGrant({ resolvedRequest: resolved, answerText, decisionChannel: 'vellum' });
+              await tryMintGuardianActionGrant({ resolvedRequest: resolved, answerText, decisionChannel: 'vellum', approvalConversationGenerator: _approvalConversationGenerator });
             }
             const replyText = resolved
               ? 'Your answer has been relayed to the call.'
@@ -623,7 +629,7 @@ export async function processMessage(
                 if ('ok' in remapResult && remapResult.ok) {
                   const resolved = resolveGuardianActionRequest(currentPending.id, answerText, 'vellum');
                   if (resolved) {
-                    tryMintGuardianActionGrant({ resolvedRequest: resolved, answerText, decisionChannel: 'vellum' });
+                    await tryMintGuardianActionGrant({ resolvedRequest: resolved, answerText, decisionChannel: 'vellum', approvalConversationGenerator: _approvalConversationGenerator });
                   }
                   const remapText = await composeGuardianActionMessageGenerative({ scenario: 'guardian_superseded_remap', questionText: currentPending.questionText }, {}, _guardianActionCopyGenerator);
                   const remapMsg = createAssistantMessage(remapText);

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -526,14 +526,13 @@ export async function processMessage(
           const persisted = await conversationStore.addMessage(session.conversationId, 'user', JSON.stringify(userMsg.content), guardianChannelMeta);
           session.messages.push(userMsg);
 
-          // Mint the grant BEFORE answerCall so the grant exists before the
-          // call controller resumes and the next voice turn tries to consume it.
-          await tryMintGuardianActionGrant({ resolvedRequest: request, answerText, decisionChannel: 'vellum', approvalConversationGenerator: _approvalConversationGenerator });
-
           const answerResult = await answerCall({ callSessionId: request.callSessionId, answer: answerText, pendingQuestionId: request.pendingQuestionId });
 
           if ('ok' in answerResult && answerResult.ok) {
             const resolved = resolveGuardianActionRequest(request.id, answerText, 'vellum');
+            if (resolved) {
+              await tryMintGuardianActionGrant({ resolvedRequest: request, answerText, decisionChannel: 'vellum', approvalConversationGenerator: _approvalConversationGenerator });
+            }
             const replyText = resolved
               ? 'Your answer has been relayed to the call.'
               : await composeGuardianActionMessageGenerative({ scenario: 'guardian_stale_answered' }, {}, _guardianActionCopyGenerator);
@@ -626,13 +625,10 @@ export async function processMessage(
               if (!senderHasDelivery) {
                 log.info({ supersededRequestId: request.id, currentRequestId: currentPending.id, guardianExternalUserId: guardianExtUserId }, 'Superseded remap skipped: sender has no delivery on current pending request');
               } else {
-                // Mint the grant BEFORE answerCall so the grant exists before the
-                // call controller resumes and the next voice turn tries to consume it.
-                await tryMintGuardianActionGrant({ resolvedRequest: currentPending, answerText, decisionChannel: 'vellum', approvalConversationGenerator: _approvalConversationGenerator });
-
                 const remapResult = await answerCall({ callSessionId: currentPending.callSessionId, answer: answerText, pendingQuestionId: currentPending.pendingQuestionId });
                 if ('ok' in remapResult && remapResult.ok) {
                   resolveGuardianActionRequest(currentPending.id, answerText, 'vellum');
+                  await tryMintGuardianActionGrant({ resolvedRequest: currentPending, answerText, decisionChannel: 'vellum', approvalConversationGenerator: _approvalConversationGenerator });
                   const remapText = await composeGuardianActionMessageGenerative({ scenario: 'guardian_superseded_remap', questionText: currentPending.questionText }, {}, _guardianActionCopyGenerator);
                   const remapMsg = createAssistantMessage(remapText);
                   await conversationStore.addMessage(session.conversationId, 'assistant', JSON.stringify(remapMsg.content), guardianChannelMeta);

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -627,16 +627,18 @@ export async function processMessage(
               } else {
                 const remapResult = await answerCall({ callSessionId: currentPending.callSessionId, answer: answerText, pendingQuestionId: currentPending.pendingQuestionId });
                 if ('ok' in remapResult && remapResult.ok) {
-                  resolveGuardianActionRequest(currentPending.id, answerText, 'vellum');
-                  await tryMintGuardianActionGrant({ resolvedRequest: currentPending, answerText, decisionChannel: 'vellum', approvalConversationGenerator: _approvalConversationGenerator });
-                  const remapText = await composeGuardianActionMessageGenerative({ scenario: 'guardian_superseded_remap', questionText: currentPending.questionText }, {}, _guardianActionCopyGenerator);
-                  const remapMsg = createAssistantMessage(remapText);
-                  await conversationStore.addMessage(session.conversationId, 'assistant', JSON.stringify(remapMsg.content), guardianChannelMeta);
-                  session.messages.push(remapMsg);
-                  onEvent({ type: 'assistant_text_delta', text: remapText });
-                  onEvent({ type: 'message_complete', sessionId: session.conversationId });
-                  log.info({ supersededRequestId: request.id, remappedToRequestId: currentPending.id }, 'Late approval for superseded request remapped to current pending request');
-                  return persisted.id;
+                  const resolved = resolveGuardianActionRequest(currentPending.id, answerText, 'vellum');
+                  if (resolved) {
+                    await tryMintGuardianActionGrant({ resolvedRequest: currentPending, answerText, decisionChannel: 'vellum', approvalConversationGenerator: _approvalConversationGenerator });
+                    const remapText = await composeGuardianActionMessageGenerative({ scenario: 'guardian_superseded_remap', questionText: currentPending.questionText }, {}, _guardianActionCopyGenerator);
+                    const remapMsg = createAssistantMessage(remapText);
+                    await conversationStore.addMessage(session.conversationId, 'assistant', JSON.stringify(remapMsg.content), guardianChannelMeta);
+                    session.messages.push(remapMsg);
+                    onEvent({ type: 'assistant_text_delta', text: remapText });
+                    onEvent({ type: 'message_complete', sessionId: session.conversationId });
+                    log.info({ supersededRequestId: request.id, remappedToRequestId: currentPending.id }, 'Late approval for superseded request remapped to current pending request');
+                    return persisted.id;
+                  }
                 }
                 log.warn({ callSessionId: currentPending.callSessionId, error: 'error' in remapResult ? remapResult.error : 'unknown' }, 'Superseded remap answerCall failed, falling through to follow-up');
               }

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -526,13 +526,14 @@ export async function processMessage(
           const persisted = await conversationStore.addMessage(session.conversationId, 'user', JSON.stringify(userMsg.content), guardianChannelMeta);
           session.messages.push(userMsg);
 
+          // Mint the grant BEFORE answerCall so the grant exists before the
+          // call controller resumes and the next voice turn tries to consume it.
+          await tryMintGuardianActionGrant({ resolvedRequest: request, answerText, decisionChannel: 'vellum', approvalConversationGenerator: _approvalConversationGenerator });
+
           const answerResult = await answerCall({ callSessionId: request.callSessionId, answer: answerText, pendingQuestionId: request.pendingQuestionId });
 
           if ('ok' in answerResult && answerResult.ok) {
             const resolved = resolveGuardianActionRequest(request.id, answerText, 'vellum');
-            if (resolved) {
-              await tryMintGuardianActionGrant({ resolvedRequest: resolved, answerText, decisionChannel: 'vellum', approvalConversationGenerator: _approvalConversationGenerator });
-            }
             const replyText = resolved
               ? 'Your answer has been relayed to the call.'
               : await composeGuardianActionMessageGenerative({ scenario: 'guardian_stale_answered' }, {}, _guardianActionCopyGenerator);
@@ -625,12 +626,13 @@ export async function processMessage(
               if (!senderHasDelivery) {
                 log.info({ supersededRequestId: request.id, currentRequestId: currentPending.id, guardianExternalUserId: guardianExtUserId }, 'Superseded remap skipped: sender has no delivery on current pending request');
               } else {
+                // Mint the grant BEFORE answerCall so the grant exists before the
+                // call controller resumes and the next voice turn tries to consume it.
+                await tryMintGuardianActionGrant({ resolvedRequest: currentPending, answerText, decisionChannel: 'vellum', approvalConversationGenerator: _approvalConversationGenerator });
+
                 const remapResult = await answerCall({ callSessionId: currentPending.callSessionId, answer: answerText, pendingQuestionId: currentPending.pendingQuestionId });
                 if ('ok' in remapResult && remapResult.ok) {
-                  const resolved = resolveGuardianActionRequest(currentPending.id, answerText, 'vellum');
-                  if (resolved) {
-                    await tryMintGuardianActionGrant({ resolvedRequest: resolved, answerText, decisionChannel: 'vellum', approvalConversationGenerator: _approvalConversationGenerator });
-                  }
+                  resolveGuardianActionRequest(currentPending.id, answerText, 'vellum');
                   const remapText = await composeGuardianActionMessageGenerative({ scenario: 'guardian_superseded_remap', questionText: currentPending.questionText }, {}, _guardianActionCopyGenerator);
                   const remapMsg = createAssistantMessage(remapText);
                   await conversationStore.addMessage(session.conversationId, 'assistant', JSON.stringify(remapMsg.content), guardianChannelMeta);

--- a/assistant/src/runtime/guardian-action-grant-minter.ts
+++ b/assistant/src/runtime/guardian-action-grant-minter.ts
@@ -61,7 +61,7 @@ export async function tryMintGuardianActionGrant(params: {
       const llmResult = await runApprovalConversationTurn(
         {
           toolName: resolvedRequest.toolName,
-          allowedActions: ['approve_once', 'reject'],
+          allowedActions: ['approve_once', 'approve_always', 'reject'],
           role: 'guardian',
           pendingApprovals: [{ requestId: resolvedRequest.id, toolName: resolvedRequest.toolName }],
           userMessage: answerText,

--- a/assistant/src/runtime/guardian-action-grant-minter.ts
+++ b/assistant/src/runtime/guardian-action-grant-minter.ts
@@ -10,7 +10,9 @@
 import { mintGrantFromDecision } from '../approvals/approval-primitive.js';
 import type { GuardianActionRequest } from '../memory/guardian-action-store.js';
 import { getLogger } from '../util/logger.js';
+import { runApprovalConversationTurn } from './approval-conversation-turn.js';
 import { parseApprovalDecision } from './channel-approval-parser.js';
+import type { ApprovalConversationGenerator } from './http-types.js';
 
 const log = getLogger('guardian-action-grant-minter');
 
@@ -21,20 +23,26 @@ export const GUARDIAN_ACTION_GRANT_TTL_MS = 5 * 60 * 1000;
  * Mint a `tool_signature` scoped grant when a guardian-action request is
  * resolved and the request carries tool metadata (toolName + inputDigest).
  *
+ * Uses two-tier classification:
+ *   1. Deterministic fast path via parseApprovalDecision (exact keyword match).
+ *   2. LLM fallback via runApprovalConversationTurn when the deterministic
+ *      parser returns null and an approvalConversationGenerator is provided.
+ *
  * Skips silently when:
  *   - The resolved request has no toolName/inputDigest (informational consult).
- *   - The guardian's answer is not an explicit approval (fail-closed).
+ *   - The guardian's answer is not classified as approval by either tier (fail-closed).
  *
  * Fails silently on error -- grant minting is best-effort and must never
  * block the guardian-action answer flow.
  */
-export function tryMintGuardianActionGrant(params: {
+export async function tryMintGuardianActionGrant(params: {
   resolvedRequest: GuardianActionRequest;
   answerText: string;
   decisionChannel: string;
   guardianExternalUserId?: string;
-}): void {
-  const { resolvedRequest, answerText, decisionChannel, guardianExternalUserId } = params;
+  approvalConversationGenerator?: ApprovalConversationGenerator;
+}): Promise<void> {
+  const { resolvedRequest, answerText, decisionChannel, guardianExternalUserId, approvalConversationGenerator } = params;
 
   // Only mint for requests that carry tool metadata -- informational
   // ASK_GUARDIAN consults without tool context do not produce grants.
@@ -42,13 +50,55 @@ export function tryMintGuardianActionGrant(params: {
     return;
   }
 
-  // Gate on explicit affirmative guardian decisions (fail-closed).
-  // Only mint when the deterministic parser recognises an approval keyword
-  // ("yes", "approve", "allow", "go ahead", etc.).  Unrecognised text
-  // (e.g. "nope", "don't do that") is treated as non-approval and skipped,
-  // preventing ambiguous answers from producing grants.
+  // Tier 1: Deterministic fast path -- try exact keyword matching first.
   const decision = parseApprovalDecision(answerText);
-  if (decision?.action !== 'approve_once' && decision?.action !== 'approve_always') {
+  let isApproval = decision?.action === 'approve_once' || decision?.action === 'approve_always';
+
+  // Tier 2: LLM fallback -- when the deterministic parser found no match
+  // and a generator is available, delegate to the conversational engine.
+  if (!isApproval && decision === null && approvalConversationGenerator) {
+    try {
+      const llmResult = await runApprovalConversationTurn(
+        {
+          toolName: resolvedRequest.toolName,
+          allowedActions: ['approve_once', 'reject'],
+          role: 'guardian',
+          pendingApprovals: [{ requestId: resolvedRequest.id, toolName: resolvedRequest.toolName }],
+          userMessage: answerText,
+        },
+        approvalConversationGenerator,
+      );
+
+      isApproval = llmResult.disposition === 'approve_once' || llmResult.disposition === 'approve_always';
+
+      log.info(
+        {
+          event: 'guardian_action_grant_llm_fallback',
+          toolName: resolvedRequest.toolName,
+          requestId: resolvedRequest.id,
+          answerText,
+          llmDisposition: llmResult.disposition,
+          matched: isApproval,
+          decisionChannel,
+        },
+        `LLM fallback classifier returned disposition: ${llmResult.disposition}`,
+      );
+    } catch (err) {
+      // Fail-closed: generator errors must not produce grants.
+      log.warn(
+        {
+          event: 'guardian_action_grant_llm_fallback_error',
+          toolName: resolvedRequest.toolName,
+          requestId: resolvedRequest.id,
+          err,
+          decisionChannel,
+        },
+        'LLM fallback classifier threw an error; treating as non-approval (fail-closed)',
+      );
+    }
+  }
+
+  if (!isApproval) {
     log.info(
       {
         event: 'guardian_action_grant_skipped_no_approval',
@@ -58,7 +108,7 @@ export function tryMintGuardianActionGrant(params: {
         parsedAction: decision?.action ?? null,
         decisionChannel,
       },
-      'Skipped grant minting: guardian answer not classified as explicit approval',
+      'Skipped grant minting: guardian answer not classified as approval',
     );
     return;
   }

--- a/assistant/src/runtime/guardian-action-grant-minter.ts
+++ b/assistant/src/runtime/guardian-action-grant-minter.ts
@@ -36,46 +36,53 @@ export const GUARDIAN_ACTION_GRANT_TTL_MS = 5 * 60 * 1000;
  * block the guardian-action answer flow.
  */
 export async function tryMintGuardianActionGrant(params: {
-  resolvedRequest: GuardianActionRequest;
+  request: GuardianActionRequest;
   answerText: string;
   decisionChannel: string;
   guardianExternalUserId?: string;
   approvalConversationGenerator?: ApprovalConversationGenerator;
 }): Promise<void> {
-  const { resolvedRequest, answerText, decisionChannel, guardianExternalUserId, approvalConversationGenerator } = params;
+  const { request, answerText, decisionChannel, guardianExternalUserId, approvalConversationGenerator } = params;
 
   // Only mint for requests that carry tool metadata -- informational
   // ASK_GUARDIAN consults without tool context do not produce grants.
-  if (!resolvedRequest.toolName || !resolvedRequest.inputDigest) {
+  if (!request.toolName || !request.inputDigest) {
     return;
   }
 
   // Tier 1: Deterministic fast path -- try exact keyword matching first.
+  // Guardian-action invariant: grants are always one-time `tool_signature`
+  // scoped.  We treat `approve_always` from the deterministic parser the
+  // same as `approve_once` -- the grant is still single-use.  This keeps
+  // the guardian-action path aligned with the primary approval interception
+  // flow where guardians are limited to approve_once / reject.
   const decision = parseApprovalDecision(answerText);
   let isApproval = decision?.action === 'approve_once' || decision?.action === 'approve_always';
 
   // Tier 2: LLM fallback -- when the deterministic parser found no match
   // and a generator is available, delegate to the conversational engine.
+  // Only allow approve_once (not approve_always) to keep guardian-action
+  // grants strictly one-time and consistent with guardian policy.
   if (!isApproval && decision === null && approvalConversationGenerator) {
     try {
       const llmResult = await runApprovalConversationTurn(
         {
-          toolName: resolvedRequest.toolName,
-          allowedActions: ['approve_once', 'approve_always', 'reject'],
+          toolName: request.toolName,
+          allowedActions: ['approve_once', 'reject'],
           role: 'guardian',
-          pendingApprovals: [{ requestId: resolvedRequest.id, toolName: resolvedRequest.toolName }],
+          pendingApprovals: [{ requestId: request.id, toolName: request.toolName }],
           userMessage: answerText,
         },
         approvalConversationGenerator,
       );
 
-      isApproval = llmResult.disposition === 'approve_once' || llmResult.disposition === 'approve_always';
+      isApproval = llmResult.disposition === 'approve_once';
 
       log.info(
         {
           event: 'guardian_action_grant_llm_fallback',
-          toolName: resolvedRequest.toolName,
-          requestId: resolvedRequest.id,
+          toolName: request.toolName,
+          requestId: request.id,
           answerText,
           llmDisposition: llmResult.disposition,
           matched: isApproval,
@@ -88,8 +95,8 @@ export async function tryMintGuardianActionGrant(params: {
       log.warn(
         {
           event: 'guardian_action_grant_llm_fallback_error',
-          toolName: resolvedRequest.toolName,
-          requestId: resolvedRequest.id,
+          toolName: request.toolName,
+          requestId: request.id,
           err,
           decisionChannel,
         },
@@ -102,8 +109,8 @@ export async function tryMintGuardianActionGrant(params: {
     log.info(
       {
         event: 'guardian_action_grant_skipped_no_approval',
-        toolName: resolvedRequest.toolName,
-        requestId: resolvedRequest.id,
+        toolName: request.toolName,
+        requestId: request.id,
         answerText,
         parsedAction: decision?.action ?? null,
         decisionChannel,
@@ -114,15 +121,15 @@ export async function tryMintGuardianActionGrant(params: {
   }
 
   const result = mintGrantFromDecision({
-    assistantId: resolvedRequest.assistantId,
+    assistantId: request.assistantId,
     scopeMode: 'tool_signature',
-    toolName: resolvedRequest.toolName,
-    inputDigest: resolvedRequest.inputDigest,
-    requestChannel: resolvedRequest.sourceChannel,
+    toolName: request.toolName,
+    inputDigest: request.inputDigest,
+    requestChannel: request.sourceChannel,
     decisionChannel,
     executionChannel: null,
-    conversationId: resolvedRequest.sourceConversationId,
-    callSessionId: resolvedRequest.callSessionId,
+    conversationId: request.sourceConversationId,
+    callSessionId: request.callSessionId,
     guardianExternalUserId: guardianExternalUserId ?? null,
     expiresAt: new Date(Date.now() + GUARDIAN_ACTION_GRANT_TTL_MS).toISOString(),
   });
@@ -131,16 +138,16 @@ export async function tryMintGuardianActionGrant(params: {
     log.info(
       {
         event: 'guardian_action_grant_minted',
-        toolName: resolvedRequest.toolName,
-        requestId: resolvedRequest.id,
-        callSessionId: resolvedRequest.callSessionId,
+        toolName: request.toolName,
+        requestId: request.id,
+        callSessionId: request.callSessionId,
         decisionChannel,
       },
       'Minted scoped approval grant for guardian-action answer resolution',
     );
   } else {
     log.error(
-      { reason: result.reason, toolName: resolvedRequest.toolName, requestId: resolvedRequest.id },
+      { reason: result.reason, toolName: request.toolName, requestId: request.id },
       'Failed to mint scoped approval grant for guardian-action (non-fatal)',
     );
   }

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1105,31 +1105,33 @@ export async function handleChannelInbound(
                 });
 
                 if ('ok' in remapResult && remapResult.ok) {
-                  resolveGuardianActionRequest(currentPending.id, answerText, sourceChannel, body.senderExternalUserId);
+                  const resolved = resolveGuardianActionRequest(currentPending.id, answerText, sourceChannel, body.senderExternalUserId);
 
-                  await tryMintGuardianActionGrant({
-                    resolvedRequest: currentPending,
-                    answerText,
-                    decisionChannel: sourceChannel,
-                    guardianExternalUserId: body.senderExternalUserId,
-                    approvalConversationGenerator,
-                  });
+                  if (resolved) {
+                    await tryMintGuardianActionGrant({
+                      resolvedRequest: currentPending,
+                      answerText,
+                      decisionChannel: sourceChannel,
+                      guardianExternalUserId: body.senderExternalUserId,
+                      approvalConversationGenerator,
+                    });
 
-                  const remapText = await composeGuardianActionMessageGenerative(
-                    { scenario: 'guardian_superseded_remap', questionText: currentPending.questionText },
-                    {},
-                    guardianActionCopyGenerator,
-                  );
-                  try {
-                    await deliverChannelReply(replyCallbackUrl, { chatId: externalChatId, text: remapText, assistantId }, bearerToken);
-                  } catch (err) {
-                    log.error({ err, externalChatId }, 'Failed to deliver superseded remap confirmation');
+                    const remapText = await composeGuardianActionMessageGenerative(
+                      { scenario: 'guardian_superseded_remap', questionText: currentPending.questionText },
+                      {},
+                      guardianActionCopyGenerator,
+                    );
+                    try {
+                      await deliverChannelReply(replyCallbackUrl, { chatId: externalChatId, text: remapText, assistantId }, bearerToken);
+                    } catch (err) {
+                      log.error({ err, externalChatId }, 'Failed to deliver superseded remap confirmation');
+                    }
+                    log.info(
+                      { supersededRequestId: request.id, remappedToRequestId: currentPending.id },
+                      'Late approval for superseded request remapped to current pending request',
+                    );
+                    return Response.json({ accepted: true, duplicate: false, eventId: result.eventId, guardianAnswer: 'superseded_remapped' });
                   }
-                  log.info(
-                    { supersededRequestId: request.id, remappedToRequestId: currentPending.id },
-                    'Late approval for superseded request remapped to current pending request',
-                  );
-                  return Response.json({ accepted: true, duplicate: false, eventId: result.eventId, guardianAnswer: 'superseded_remapped' });
                 }
                 log.warn(
                   { callSessionId: currentPending.callSessionId, error: 'error' in remapResult ? remapResult.error : 'unknown' },

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -964,6 +964,16 @@ export async function handleChannelInbound(
 
         // ── PENDING state handler ──
         if (state === 'pending' && request.status === 'pending') {
+          // Mint the grant BEFORE answerCall so the grant exists before the
+          // call controller resumes and the next voice turn tries to consume it.
+          await tryMintGuardianActionGrant({
+            resolvedRequest: request,
+            answerText,
+            decisionChannel: sourceChannel,
+            guardianExternalUserId: body.senderExternalUserId,
+            approvalConversationGenerator,
+          });
+
           const answerResult = await answerCall({ callSessionId: request.callSessionId, answer: answerText, pendingQuestionId: request.pendingQuestionId });
 
           if (!('ok' in answerResult) || !answerResult.ok) {
@@ -985,13 +995,6 @@ export async function handleChannelInbound(
           const resolved = resolveGuardianActionRequest(request.id, answerText, sourceChannel, body.senderExternalUserId);
 
           if (resolved) {
-            await tryMintGuardianActionGrant({
-              resolvedRequest: resolved,
-              answerText,
-              decisionChannel: sourceChannel,
-              guardianExternalUserId: body.senderExternalUserId,
-              approvalConversationGenerator,
-            });
             return Response.json({ accepted: true, duplicate: false, eventId: result.eventId, guardianAnswer: 'resolved' });
           } else {
             const freshRequest = getGuardianActionRequest(request.id);
@@ -1097,6 +1100,16 @@ export async function handleChannelInbound(
                   'Superseded remap skipped: sender has no delivery on current pending request',
                 );
               } else {
+                // Mint the grant BEFORE answerCall so the grant exists before the
+                // call controller resumes and the next voice turn tries to consume it.
+                await tryMintGuardianActionGrant({
+                  resolvedRequest: currentPending,
+                  answerText,
+                  decisionChannel: sourceChannel,
+                  guardianExternalUserId: body.senderExternalUserId,
+                  approvalConversationGenerator,
+                });
+
                 const remapResult = await answerCall({
                   callSessionId: currentPending.callSessionId,
                   answer: answerText,
@@ -1104,16 +1117,7 @@ export async function handleChannelInbound(
                 });
 
                 if ('ok' in remapResult && remapResult.ok) {
-                  const resolved = resolveGuardianActionRequest(currentPending.id, answerText, sourceChannel, body.senderExternalUserId);
-                  if (resolved) {
-                    await tryMintGuardianActionGrant({
-                      resolvedRequest: resolved,
-                      answerText,
-                      decisionChannel: sourceChannel,
-                      guardianExternalUserId: body.senderExternalUserId,
-                      approvalConversationGenerator,
-                    });
-                  }
+                  resolveGuardianActionRequest(currentPending.id, answerText, sourceChannel, body.senderExternalUserId);
 
                   const remapText = await composeGuardianActionMessageGenerative(
                     { scenario: 'guardian_superseded_remap', questionText: currentPending.questionText },

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -985,11 +985,12 @@ export async function handleChannelInbound(
           const resolved = resolveGuardianActionRequest(request.id, answerText, sourceChannel, body.senderExternalUserId);
 
           if (resolved) {
-            tryMintGuardianActionGrant({
+            await tryMintGuardianActionGrant({
               resolvedRequest: resolved,
               answerText,
               decisionChannel: sourceChannel,
               guardianExternalUserId: body.senderExternalUserId,
+              approvalConversationGenerator,
             });
             return Response.json({ accepted: true, duplicate: false, eventId: result.eventId, guardianAnswer: 'resolved' });
           } else {
@@ -1105,11 +1106,12 @@ export async function handleChannelInbound(
                 if ('ok' in remapResult && remapResult.ok) {
                   const resolved = resolveGuardianActionRequest(currentPending.id, answerText, sourceChannel, body.senderExternalUserId);
                   if (resolved) {
-                    tryMintGuardianActionGrant({
+                    await tryMintGuardianActionGrant({
                       resolvedRequest: resolved,
                       answerText,
                       decisionChannel: sourceChannel,
                       guardianExternalUserId: body.senderExternalUserId,
+                      approvalConversationGenerator,
                     });
                   }
 

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -964,16 +964,6 @@ export async function handleChannelInbound(
 
         // ── PENDING state handler ──
         if (state === 'pending' && request.status === 'pending') {
-          // Mint the grant BEFORE answerCall so the grant exists before the
-          // call controller resumes and the next voice turn tries to consume it.
-          await tryMintGuardianActionGrant({
-            resolvedRequest: request,
-            answerText,
-            decisionChannel: sourceChannel,
-            guardianExternalUserId: body.senderExternalUserId,
-            approvalConversationGenerator,
-          });
-
           const answerResult = await answerCall({ callSessionId: request.callSessionId, answer: answerText, pendingQuestionId: request.pendingQuestionId });
 
           if (!('ok' in answerResult) || !answerResult.ok) {
@@ -995,6 +985,14 @@ export async function handleChannelInbound(
           const resolved = resolveGuardianActionRequest(request.id, answerText, sourceChannel, body.senderExternalUserId);
 
           if (resolved) {
+            await tryMintGuardianActionGrant({
+              resolvedRequest: request,
+              answerText,
+              decisionChannel: sourceChannel,
+              guardianExternalUserId: body.senderExternalUserId,
+              approvalConversationGenerator,
+            });
+
             return Response.json({ accepted: true, duplicate: false, eventId: result.eventId, guardianAnswer: 'resolved' });
           } else {
             const freshRequest = getGuardianActionRequest(request.id);
@@ -1100,16 +1098,6 @@ export async function handleChannelInbound(
                   'Superseded remap skipped: sender has no delivery on current pending request',
                 );
               } else {
-                // Mint the grant BEFORE answerCall so the grant exists before the
-                // call controller resumes and the next voice turn tries to consume it.
-                await tryMintGuardianActionGrant({
-                  resolvedRequest: currentPending,
-                  answerText,
-                  decisionChannel: sourceChannel,
-                  guardianExternalUserId: body.senderExternalUserId,
-                  approvalConversationGenerator,
-                });
-
                 const remapResult = await answerCall({
                   callSessionId: currentPending.callSessionId,
                   answer: answerText,
@@ -1118,6 +1106,14 @@ export async function handleChannelInbound(
 
                 if ('ok' in remapResult && remapResult.ok) {
                   resolveGuardianActionRequest(currentPending.id, answerText, sourceChannel, body.senderExternalUserId);
+
+                  await tryMintGuardianActionGrant({
+                    resolvedRequest: currentPending,
+                    answerText,
+                    decisionChannel: sourceChannel,
+                    guardianExternalUserId: body.senderExternalUserId,
+                    approvalConversationGenerator,
+                  });
 
                   const remapText = await composeGuardianActionMessageGenerative(
                     { scenario: 'guardian_superseded_remap', questionText: currentPending.questionText },

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -986,7 +986,7 @@ export async function handleChannelInbound(
 
           if (resolved) {
             await tryMintGuardianActionGrant({
-              resolvedRequest: request,
+              request,
               answerText,
               decisionChannel: sourceChannel,
               guardianExternalUserId: body.senderExternalUserId,
@@ -1109,29 +1109,29 @@ export async function handleChannelInbound(
 
                   if (resolved) {
                     await tryMintGuardianActionGrant({
-                      resolvedRequest: currentPending,
+                      request: currentPending,
                       answerText,
                       decisionChannel: sourceChannel,
                       guardianExternalUserId: body.senderExternalUserId,
                       approvalConversationGenerator,
                     });
-
-                    const remapText = await composeGuardianActionMessageGenerative(
-                      { scenario: 'guardian_superseded_remap', questionText: currentPending.questionText },
-                      {},
-                      guardianActionCopyGenerator,
-                    );
-                    try {
-                      await deliverChannelReply(replyCallbackUrl, { chatId: externalChatId, text: remapText, assistantId }, bearerToken);
-                    } catch (err) {
-                      log.error({ err, externalChatId }, 'Failed to deliver superseded remap confirmation');
-                    }
-                    log.info(
-                      { supersededRequestId: request.id, remappedToRequestId: currentPending.id },
-                      'Late approval for superseded request remapped to current pending request',
-                    );
-                    return Response.json({ accepted: true, duplicate: false, eventId: result.eventId, guardianAnswer: 'superseded_remapped' });
                   }
+
+                  const remapText = await composeGuardianActionMessageGenerative(
+                    { scenario: 'guardian_superseded_remap', questionText: currentPending.questionText },
+                    {},
+                    guardianActionCopyGenerator,
+                  );
+                  try {
+                    await deliverChannelReply(replyCallbackUrl, { chatId: externalChatId, text: remapText, assistantId }, bearerToken);
+                  } catch (err) {
+                    log.error({ err, externalChatId }, 'Failed to deliver superseded remap confirmation');
+                  }
+                  log.info(
+                    { supersededRequestId: request.id, remappedToRequestId: currentPending.id },
+                    'Late approval for superseded request remapped to current pending request',
+                  );
+                  return Response.json({ accepted: true, duplicate: false, eventId: result.eventId, guardianAnswer: 'superseded_remapped' });
                 }
                 log.warn(
                   { callSessionId: currentPending.callSessionId, error: 'error' in remapResult ? remapResult.error : 'unknown' },


### PR DESCRIPTION
## Summary
- Adds two-tier classification to tryMintGuardianActionGrant: deterministic parseApprovalDecision as fast path, LLM-backed runApprovalConversationTurn as fallback for natural language approvals
- Threads approvalConversationGenerator through both call sites (inbound-message-handler and session-process)
- Adds 5 test cases covering: exact phrase match, free-form LLM approval, ambiguous keep_pending, generator failure (fail-closed), and no-generator fallback

## Original prompt
Thread the existing approvalConversationGenerator into the guardian-action grant minting path as a two-tier classifier with fail-closed semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
