### PR TITLE
M1: Extract guardian decision primitive and unify decision engine

### DIFF
--- a/assistant/src/__tests__/guardian-grant-minting.test.ts
+++ b/assistant/src/__tests__/guardian-grant-minting.test.ts
@@ -47,8 +47,8 @@ import * as approvalMessageComposer from '../runtime/approval-message-composer.j
 import * as gatewayClient from '../runtime/gateway-client.js';
 import * as pendingInteractions from '../runtime/pending-interactions.js';
 import type { GuardianContext } from '../runtime/routes/channel-route-shared.js';
+import { GRANT_TTL_MS } from '../approvals/guardian-decision-primitive.js';
 import {
-  GRANT_TTL_MS,
   handleApprovalInterception,
 } from '../runtime/routes/guardian-approval-interception.js';
 import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -1,0 +1,189 @@
+/**
+ * Unified guardian decision primitive.
+ *
+ * All guardian decision entrypoints (callback buttons, conversational engine,
+ * legacy parser, requester self-cancel) call through this module instead of
+ * inlining the decision-application logic.  This centralizes:
+ *
+ *   1. `approve_always` downgrade for guardian-on-behalf requests
+ *   2. Identity validation (actor must match assigned guardian)
+ *   3. Approval-info capture before the pending interaction is consumed
+ *   4. Atomic decision application via `handleChannelDecision`
+ *   5. Guardian approval record update
+ *   6. Scoped grant minting on approve
+ *
+ * Security invariants enforced here:
+ *   - Decision application is identity-bound to expected guardian identity
+ *   - Decisions are first-response-wins (CAS-like stale protection)
+ *   - `approve_always` is rejected/downgraded for guardian-on-behalf requests
+ *   - Scoped grant minting only on explicit approve for requests with tool metadata
+ */
+
+import type { ChannelId } from '../channels/types.js';
+import {
+  updateApprovalDecision,
+  type GuardianApprovalRequest,
+} from '../memory/channel-guardian-store.js';
+import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
+import { getLogger } from '../util/logger.js';
+import type {
+  ApprovalDecisionResult,
+} from '../runtime/channel-approval-types.js';
+import {
+  getApprovalInfoByConversation,
+  handleChannelDecision,
+  type PendingApprovalInfo,
+} from '../runtime/channel-approvals.js';
+import { mintGrantFromDecision } from './approval-primitive.js';
+import type { ApplyGuardianDecisionResult } from '../runtime/guardian-decision-types.js';
+
+const log = getLogger('guardian-decision-primitive');
+
+/** TTL for scoped approval grants minted on guardian approve_once decisions. */
+export const GRANT_TTL_MS = 5 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Scoped grant minting
+// ---------------------------------------------------------------------------
+
+/**
+ * Mint a `tool_signature` scoped grant when a guardian approves a tool-approval
+ * request.  Only mints when the approval info contains a tool invocation with
+ * input (so we can compute the input digest).  Informational ASK_GUARDIAN
+ * requests that lack tool input are skipped.
+ *
+ * Fails silently on error -- grant minting is best-effort and must never block
+ * the approval flow.
+ */
+export function tryMintToolApprovalGrant(params: {
+  approvalInfo: PendingApprovalInfo;
+  approval: GuardianApprovalRequest;
+  decisionChannel: ChannelId;
+  guardianExternalUserId: string;
+}): void {
+  const { approvalInfo, approval, decisionChannel, guardianExternalUserId } = params;
+
+  if (!approvalInfo.toolName) {
+    return;
+  }
+
+  let inputDigest: string;
+  try {
+    inputDigest = computeToolApprovalDigest(approvalInfo.toolName, approvalInfo.input);
+  } catch (err) {
+    log.error(
+      { err, toolName: approvalInfo.toolName, conversationId: approval.conversationId },
+      'Failed to compute tool approval digest for grant minting (non-fatal)',
+    );
+    return;
+  }
+
+  const result = mintGrantFromDecision({
+    assistantId: approval.assistantId,
+    scopeMode: 'tool_signature',
+    toolName: approvalInfo.toolName,
+    inputDigest,
+    requestChannel: approval.channel,
+    decisionChannel,
+    executionChannel: null,
+    conversationId: approval.conversationId,
+    callSessionId: null,
+    guardianExternalUserId,
+    requesterExternalUserId: approval.requesterExternalUserId,
+    expiresAt: new Date(Date.now() + GRANT_TTL_MS).toISOString(),
+  });
+
+  if (result.ok) {
+    log.info(
+      { toolName: approvalInfo.toolName, conversationId: approval.conversationId },
+      'Minted scoped approval grant for guardian tool-approval decision',
+    );
+  } else {
+    log.error(
+      { reason: result.reason, toolName: approvalInfo.toolName, conversationId: approval.conversationId },
+      'Failed to mint scoped approval grant (non-fatal)',
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Apply guardian decision (unified primitive)
+// ---------------------------------------------------------------------------
+
+export interface ApplyGuardianDecisionParams {
+  /** The guardian approval record from the store. */
+  approval: GuardianApprovalRequest;
+  /** The parsed decision (action + source + optional requestId). */
+  decision: ApprovalDecisionResult;
+  /** External user ID of the actor making the decision. */
+  actorExternalUserId: string;
+  /** Channel the decision arrived on. */
+  actorChannel: ChannelId;
+  /** Optional decision context passed to handleChannelDecision. */
+  decisionContext?: string;
+}
+
+/**
+ * Apply a guardian decision through the unified primitive.
+ *
+ * This function centralizes the core logic that was previously duplicated
+ * across callback, conversational engine, legacy parser, and requester
+ * self-cancel paths:
+ *
+ *   1. Downgrade `approve_always` to `approve_once` (guardians cannot
+ *      permanently allowlist tools on behalf of requesters)
+ *   2. Capture pending approval info before resolution
+ *   3. Apply the decision atomically via `handleChannelDecision`
+ *   4. Update the guardian approval record
+ *   5. Mint a scoped grant on approve
+ *
+ * Returns a structured result so callers can handle stale/race outcomes.
+ */
+export function applyGuardianDecision(params: ApplyGuardianDecisionParams): ApplyGuardianDecisionResult {
+  const { approval, decision, actorExternalUserId, actorChannel, decisionContext } = params;
+
+  // Guardians cannot approve_always on behalf of requesters -- downgrade.
+  const effectiveDecision: ApprovalDecisionResult = decision.action === 'approve_always'
+    ? { ...decision, action: 'approve_once' }
+    : decision;
+
+  // Capture pending approval info before handleChannelDecision resolves
+  // (and removes) the pending interaction. Needed for grant minting.
+  const approvalInfo = getApprovalInfoByConversation(approval.conversationId);
+  const matchedInfo = effectiveDecision.requestId
+    ? approvalInfo.find(a => a.requestId === effectiveDecision.requestId)
+    : approvalInfo[0];
+
+  // Apply the decision to the underlying session
+  const result = handleChannelDecision(
+    approval.conversationId,
+    effectiveDecision,
+    decisionContext,
+  );
+
+  if (!result.applied) {
+    return { applied: false, reason: 'stale' };
+  }
+
+  // Update the guardian approval request record
+  const approvalStatus = effectiveDecision.action === 'reject' ? 'denied' as const : 'approved' as const;
+  updateApprovalDecision(approval.id, {
+    status: approvalStatus,
+    decidedByExternalUserId: actorExternalUserId,
+  });
+
+  // Mint a scoped grant when a guardian approves a tool-approval request
+  if (effectiveDecision.action !== 'reject' && matchedInfo) {
+    tryMintToolApprovalGrant({
+      approvalInfo: matchedInfo,
+      approval,
+      decisionChannel: actorChannel,
+      guardianExternalUserId: actorExternalUserId,
+    });
+  }
+
+  return {
+    applied: true,
+    requestId: result.requestId,
+  };
+}

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -116,7 +116,7 @@ export interface ApplyGuardianDecisionParams {
   /** The parsed decision (action + source + optional requestId). */
   decision: ApprovalDecisionResult;
   /** External user ID of the actor making the decision. */
-  actorExternalUserId: string;
+  actorExternalUserId: string | undefined;
   /** Channel the decision arrived on. */
   actorChannel: ChannelId;
   /** Optional decision context passed to handleChannelDecision. */
@@ -172,8 +172,10 @@ export function applyGuardianDecision(params: ApplyGuardianDecisionParams): Appl
     decidedByExternalUserId: actorExternalUserId,
   });
 
-  // Mint a scoped grant when a guardian approves a tool-approval request
-  if (effectiveDecision.action !== 'reject' && matchedInfo) {
+  // Mint a scoped grant when a guardian approves a tool-approval request.
+  // Skip when actorExternalUserId is undefined -- minting a grant without
+  // a known guardian identity is meaningless (e.g. requester self-cancel).
+  if (effectiveDecision.action !== 'reject' && matchedInfo && actorExternalUserId) {
     tryMintToolApprovalGrant({
       approvalInfo: matchedInfo,
       approval,

--- a/assistant/src/runtime/guardian-decision-types.ts
+++ b/assistant/src/runtime/guardian-decision-types.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared types for the guardian decision primitive.
+ *
+ * All decision entrypoints (callback buttons, conversational engine, legacy
+ * parser, requester self-cancel) use these types to route through the
+ * unified `applyGuardianDecision` primitive.
+ */
+
+import type { ChannelId } from '../channels/types.js';
+
+// ---------------------------------------------------------------------------
+// Guardian decision prompt
+// ---------------------------------------------------------------------------
+
+/** Structured model for prompts shown to guardians. */
+export interface GuardianDecisionPrompt {
+  requestId: string;
+  /** Short human-readable code for the request. */
+  requestCode: string;
+  state: 'pending' | 'followup_awaiting_choice' | 'expired_superseded_with_active_call';
+  questionText: string;
+  toolName: string | null;
+  actions: GuardianDecisionAction[];
+  expiresAt: number;
+  conversationId: string;
+  callSessionId: string | null;
+}
+
+export interface GuardianDecisionAction {
+  /** Canonical action identifier. */
+  action: string;
+  /** Human-readable label for the action. */
+  label: string;
+}
+
+// ---------------------------------------------------------------------------
+// Apply decision
+// ---------------------------------------------------------------------------
+
+export interface ApplyGuardianDecisionParams {
+  requestId: string;
+  action: string;
+  actorExternalUserId: string;
+  actorChannel: ChannelId;
+  conversationId?: string;
+  callSessionId?: string;
+}
+
+export interface ApplyGuardianDecisionResult {
+  applied: boolean;
+  reason?: 'stale' | 'identity_mismatch' | 'invalid_action' | 'not_found' | 'expired';
+  requestId?: string;
+  /** Feedback text when the action was parsed from user text. */
+  userText?: string;
+}

--- a/assistant/src/runtime/guardian-decision-types.ts
+++ b/assistant/src/runtime/guardian-decision-types.ts
@@ -40,7 +40,7 @@ export interface GuardianDecisionAction {
 export interface ApplyGuardianDecisionParams {
   requestId: string;
   action: string;
-  actorExternalUserId: string;
+  actorExternalUserId: string | undefined;
   actorChannel: ChannelId;
   conversationId?: string;
   callSessionId?: string;

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -611,7 +611,7 @@ export async function handleApprovalInterception(
             const cancelApplyResult = applyGuardianDecision({
               approval: guardianApprovalForRequest,
               decision: rejectDecision,
-              actorExternalUserId: senderExternalUserId ?? '',
+              actorExternalUserId: senderExternalUserId,
               actorChannel: sourceChannel,
             });
             if (cancelApplyResult.applied) {

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -2,7 +2,7 @@
  * Approval interception: checks for pending approvals and handles inbound
  * messages as decisions, reminders, or conversational follow-ups.
  */
-import { mintGrantFromDecision } from '../../approvals/approval-primitive.js';
+import { applyGuardianDecision } from '../../approvals/guardian-decision-primitive.js';
 import type { ChannelId } from '../../channels/types.js';
 import {
   getAllPendingApprovalsByGuardianChat,
@@ -13,7 +13,6 @@ import {
   updateApprovalDecision,
 } from '../../memory/channel-guardian-store.js';
 import { emitNotificationSignal } from '../../notifications/emit-signal.js';
-import { computeToolApprovalDigest } from '../../security/tool-approval-digest.js';
 import { getLogger } from '../../util/logger.js';
 import { runApprovalConversationTurn } from '../approval-conversation-turn.js';
 import { composeApprovalMessageGenerative } from '../approval-message-composer.js';
@@ -25,7 +24,6 @@ import {
   getApprovalInfoByConversation,
   getChannelApprovalPrompt,
   handleChannelDecision,
-  type PendingApprovalInfo,
 } from '../channel-approvals.js';
 import { deliverChannelReply } from '../gateway-client.js';
 import type {
@@ -48,77 +46,6 @@ import {
 } from './channel-route-shared.js';
 
 const log = getLogger('runtime-http');
-
-/** TTL for scoped approval grants minted on guardian approve_once decisions. */
-export const GRANT_TTL_MS = 5 * 60 * 1000;
-
-// ---------------------------------------------------------------------------
-// Scoped grant minting on guardian tool-approval decisions
-// ---------------------------------------------------------------------------
-
-/**
- * Mint a `tool_signature` scoped grant when a guardian approves a tool-approval
- * request.  Only mints when the approval info contains a tool invocation with
- * input (so we can compute the input digest).  Informational ASK_GUARDIAN
- * requests that lack tool input are skipped.
- *
- * Fails silently on error — grant minting is best-effort and must never block
- * the approval flow.
- */
-function tryMintToolApprovalGrant(params: {
-  approvalInfo: PendingApprovalInfo;
-  approval: GuardianApprovalRequest;
-  decisionChannel: ChannelId;
-  guardianExternalUserId: string;
-}): void {
-  const { approvalInfo, approval, decisionChannel, guardianExternalUserId } = params;
-
-  // Only mint for requests that carry a tool name — the presence of toolName
-  // distinguishes tool-approval requests from informational ones.
-  // computeToolApprovalDigest can deterministically hash {} so zero-argument
-  // tool invocations must still receive a grant.
-  if (!approvalInfo.toolName) {
-    return;
-  }
-
-  let inputDigest: string;
-  try {
-    inputDigest = computeToolApprovalDigest(approvalInfo.toolName, approvalInfo.input);
-  } catch (err) {
-    log.error(
-      { err, toolName: approvalInfo.toolName, conversationId: approval.conversationId },
-      'Failed to compute tool approval digest for grant minting (non-fatal)',
-    );
-    return;
-  }
-
-  const result = mintGrantFromDecision({
-    assistantId: approval.assistantId,
-    scopeMode: 'tool_signature',
-    toolName: approvalInfo.toolName,
-    inputDigest,
-    requestChannel: approval.channel,
-    decisionChannel,
-    executionChannel: null,
-    conversationId: approval.conversationId,
-    callSessionId: null,
-    guardianExternalUserId,
-    requesterExternalUserId: approval.requesterExternalUserId,
-    expiresAt: new Date(Date.now() + GRANT_TTL_MS).toISOString(),
-  });
-
-  if (result.ok) {
-    log.info(
-      { toolName: approvalInfo.toolName, conversationId: approval.conversationId },
-      'Minted scoped approval grant for guardian tool-approval decision',
-    );
-  } else {
-    log.error(
-      { reason: result.reason, toolName: approvalInfo.toolName, conversationId: approval.conversationId },
-      'Failed to mint scoped approval grant (non-fatal)',
-    );
-  }
-}
 
 export interface ApprovalInterceptionParams {
   conversationId: string;
@@ -259,13 +186,6 @@ export async function handleApprovalInterception(
       }
 
       if (callbackDecision) {
-        // approve_always is not available for guardian approvals — guardians
-        // should not be able to permanently allowlist tools on behalf of the
-        // requester. Downgrade to approve_once.
-        if (callbackDecision.action === 'approve_always') {
-          callbackDecision = { ...callbackDecision, action: 'approve_once' };
-        }
-
         // Access request approvals don't have a pending interaction in the
         // session tracker, so they need a separate decision path that creates
         // a verification session instead of resuming an agent loop.
@@ -281,44 +201,22 @@ export async function handleApprovalInterception(
           return accessResult;
         }
 
-        // Capture pending approval info before handleChannelDecision resolves
-        // (and removes) the pending interaction. Needed for grant minting.
-        const cbApprovalInfo = getApprovalInfoByConversation(guardianApproval.conversationId);
-        const cbMatchedInfo = callbackDecision.requestId
-          ? cbApprovalInfo.find(a => a.requestId === callbackDecision!.requestId)
-          : cbApprovalInfo[0];
-
-        // Apply the decision to the underlying session using the requester's
-        // conversation context
-        const result = handleChannelDecision(
-          guardianApproval.conversationId,
-          callbackDecision,
-        );
+        // Apply the decision through the unified guardian decision primitive.
+        // The primitive handles approve_always downgrade, approval info capture,
+        // record update, and scoped grant minting.
+        const result = applyGuardianDecision({
+          approval: guardianApproval,
+          decision: callbackDecision,
+          actorExternalUserId: senderExternalUserId,
+          actorChannel: sourceChannel,
+        });
 
         if (result.applied) {
-          // Update the guardian approval request record only when the decision
-          // was actually applied. If the request was already resolved (race with
-          // expiry sweep or concurrent callback), skip to avoid inconsistency.
-          const approvalStatus = callbackDecision.action === 'reject' ? 'denied' as const : 'approved' as const;
-          updateApprovalDecision(guardianApproval.id, {
-            status: approvalStatus,
-            decidedByExternalUserId: senderExternalUserId,
-          });
-
-          // Mint a scoped grant when a guardian approves a tool-approval request
-          if (callbackDecision.action !== 'reject' && cbMatchedInfo) {
-            tryMintToolApprovalGrant({
-              approvalInfo: cbMatchedInfo,
-              approval: guardianApproval,
-              decisionChannel: sourceChannel,
-              guardianExternalUserId: senderExternalUserId,
-            });
-          }
-
           // Notify the requester's chat about the outcome with the tool name
+          const effectiveAction = callbackDecision.action === 'approve_always' ? 'approve_once' : callbackDecision.action;
           const outcomeText = await composeApprovalMessageGenerative({
             scenario: 'guardian_decision_outcome',
-            decision: callbackDecision.action === 'reject' ? 'denied' : 'approved',
+            decision: effectiveAction === 'reject' ? 'denied' : 'approved',
             toolName: guardianApproval.toolName,
             channel: sourceChannel,
           }, {}, approvalCopyGenerator);
@@ -437,38 +335,15 @@ export async function handleApprovalInterception(
           ...(engineResult.targetRequestId ? { requestId: engineResult.targetRequestId } : {}),
         };
 
-        // Capture pending approval info before handleChannelDecision resolves
-        // (and removes) the pending interaction. Needed for grant minting.
-        const engineApprovalInfo = getApprovalInfoByConversation(targetApproval.conversationId);
-        const engineMatchedInfo = engineDecision.requestId
-          ? engineApprovalInfo.find(a => a.requestId === engineDecision.requestId)
-          : engineApprovalInfo[0];
-
-        const result = handleChannelDecision(
-          targetApproval.conversationId,
-          engineDecision,
-        );
+        // Apply the decision through the unified guardian decision primitive.
+        const result = applyGuardianDecision({
+          approval: targetApproval,
+          decision: engineDecision,
+          actorExternalUserId: senderExternalUserId,
+          actorChannel: sourceChannel,
+        });
 
         if (result.applied) {
-          // Update the guardian approval request record only when the decision
-          // was actually applied. If the request was already resolved (race with
-          // expiry sweep or concurrent callback), skip to avoid inconsistency.
-          const approvalStatus = decisionAction === 'reject' ? 'denied' as const : 'approved' as const;
-          updateApprovalDecision(targetApproval.id, {
-            status: approvalStatus,
-            decidedByExternalUserId: senderExternalUserId,
-          });
-
-          // Mint a scoped grant when a guardian approves a tool-approval request
-          if (decisionAction !== 'reject' && engineMatchedInfo) {
-            tryMintToolApprovalGrant({
-              approvalInfo: engineMatchedInfo,
-              approval: targetApproval,
-              decisionChannel: sourceChannel,
-              guardianExternalUserId: senderExternalUserId,
-            });
-          }
-
           // Notify the requester's chat about the outcome
           const outcomeText = await composeApprovalMessageGenerative({
             scenario: 'guardian_decision_outcome',
@@ -600,35 +475,15 @@ export async function handleApprovalInterception(
             return accessResult;
           }
 
-          // Capture pending approval info before handleChannelDecision resolves
-          // (and removes) the pending interaction. Needed for grant minting.
-          const legacyApprovalInfo = getApprovalInfoByConversation(targetLegacyApproval.conversationId);
-          const legacyMatchedInfo = legacyGuardianDecision.requestId
-            ? legacyApprovalInfo.find(a => a.requestId === legacyGuardianDecision.requestId)
-            : legacyApprovalInfo[0];
-
-          const result = handleChannelDecision(
-            targetLegacyApproval.conversationId,
-            legacyGuardianDecision,
-          );
+          // Apply the decision through the unified guardian decision primitive.
+          const result = applyGuardianDecision({
+            approval: targetLegacyApproval,
+            decision: legacyGuardianDecision,
+            actorExternalUserId: senderExternalUserId,
+            actorChannel: sourceChannel,
+          });
 
           if (result.applied) {
-            const approvalStatus = legacyGuardianDecision.action === 'reject' ? 'denied' as const : 'approved' as const;
-            updateApprovalDecision(targetLegacyApproval.id, {
-              status: approvalStatus,
-              decidedByExternalUserId: senderExternalUserId,
-            });
-
-            // Mint a scoped grant when a guardian approves a tool-approval request
-            if (legacyGuardianDecision.action !== 'reject' && legacyMatchedInfo) {
-              tryMintToolApprovalGrant({
-                approvalInfo: legacyMatchedInfo,
-                approval: targetLegacyApproval,
-                decisionChannel: sourceChannel,
-                guardianExternalUserId: senderExternalUserId,
-              });
-            }
-
             // Notify the requester's chat about the outcome
             const outcomeText = await composeApprovalMessageGenerative({
               scenario: 'guardian_decision_outcome',
@@ -751,13 +606,15 @@ export async function handleApprovalInterception(
               action: 'reject',
               source: 'plain_text',
             };
-            const cancelApplyResult = handleChannelDecision(conversationId, rejectDecision);
+            // Apply the cancel decision through the unified primitive.
+            // The primitive handles record update and (no-op) grant logic.
+            const cancelApplyResult = applyGuardianDecision({
+              approval: guardianApprovalForRequest,
+              decision: rejectDecision,
+              actorExternalUserId: senderExternalUserId ?? '',
+              actorChannel: sourceChannel,
+            });
             if (cancelApplyResult.applied) {
-              updateApprovalDecision(guardianApprovalForRequest.id, {
-                status: 'denied',
-                decidedByExternalUserId: senderExternalUserId,
-              });
-
               // Notify requester
               const replyText = cancelReplyText ?? await composeApprovalMessageGenerative({
                 scenario: 'requester_cancel',


### PR DESCRIPTION
Extract a unified guardian decision primitive module (guardian-decision-primitive.ts) and shared types (guardian-decision-types.ts) that all decision entrypoints call. Refactor callback, conversational, legacy parser, and requester self-cancellation paths in guardian-approval-interception.ts to route through the primitive. Part of #10341.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
