### PR TITLE
M1: Introduce Unified Registry + Loaders

### DIFF
--- a/assistant/src/config/__tests__/feature-flag-registry-guard.test.ts
+++ b/assistant/src/config/__tests__/feature-flag-registry-guard.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Validation guard tests for the unified feature flag registry.
+ *
+ * Ensures structural invariants hold so that both the TS and Swift loaders
+ * can safely consume the registry without runtime surprises.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, test } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getRepoRoot(): string {
+  return join(process.cwd(), '..');
+}
+
+function getRegistryPath(): string {
+  return join(getRepoRoot(), 'meta', 'feature-flags', 'feature-flag-registry.json');
+}
+
+function loadRegistry(): Record<string, unknown> {
+  const raw = readFileSync(getRegistryPath(), 'utf-8');
+  return JSON.parse(raw);
+}
+
+const VALID_SCOPES = new Set(['assistant', 'macos']);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('unified feature flag registry guard', () => {
+  const registry = loadRegistry();
+  const flags = registry.flags as Record<string, unknown>[];
+
+  // -----------------------------------------------------------------------
+  // version
+  // -----------------------------------------------------------------------
+
+  test('version is a positive integer', () => {
+    expect(typeof registry.version).toBe('number');
+    expect(Number.isInteger(registry.version)).toBe(true);
+    expect(registry.version as number).toBeGreaterThan(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // required fields and types
+  // -----------------------------------------------------------------------
+
+  test('all flags have required fields with correct types', () => {
+    const violations: string[] = [];
+
+    for (let i = 0; i < flags.length; i++) {
+      const flag = flags[i];
+      const prefix = `flags[${i}]`;
+
+      if (typeof flag !== 'object' || flag === null || Array.isArray(flag)) {
+        violations.push(`${prefix}: entry is not an object`);
+        continue;
+      }
+
+      if (typeof flag.id !== 'string' || flag.id.length === 0) {
+        violations.push(`${prefix}: missing or non-string 'id'`);
+      }
+      if (typeof flag.scope !== 'string' || flag.scope.length === 0) {
+        violations.push(`${prefix}: missing or non-string 'scope'`);
+      }
+      if (typeof flag.key !== 'string' || flag.key.length === 0) {
+        violations.push(`${prefix}: missing or non-string 'key'`);
+      }
+      if (typeof flag.label !== 'string' || flag.label.length === 0) {
+        violations.push(`${prefix}: missing or non-string 'label'`);
+      }
+      if (typeof flag.description !== 'string' || flag.description.length === 0) {
+        violations.push(`${prefix}: missing or non-string 'description'`);
+      }
+      if (typeof flag.defaultEnabled !== 'boolean') {
+        violations.push(`${prefix}: missing or non-boolean 'defaultEnabled'`);
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        'Found flags with missing or incorrectly-typed required fields.',
+        '',
+        'Violations:',
+        ...violations.map((v) => `  - ${v}`),
+      ].join('\n');
+
+      expect(violations, message).toEqual([]);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // unique ids
+  // -----------------------------------------------------------------------
+
+  test('all id values are unique', () => {
+    const seen = new Set<string>();
+    const duplicates: string[] = [];
+
+    for (const flag of flags) {
+      const id = flag.id as string;
+      if (seen.has(id)) {
+        duplicates.push(id);
+      }
+      seen.add(id);
+    }
+
+    if (duplicates.length > 0) {
+      const message = [
+        'Found duplicate flag id values in the registry.',
+        '',
+        'Duplicates:',
+        ...duplicates.map((d) => `  - ${d}`),
+      ].join('\n');
+
+      expect(duplicates, message).toEqual([]);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // unique keys
+  // -----------------------------------------------------------------------
+
+  test('all key values are unique', () => {
+    const seen = new Set<string>();
+    const duplicates: string[] = [];
+
+    for (const flag of flags) {
+      const key = flag.key as string;
+      if (seen.has(key)) {
+        duplicates.push(key);
+      }
+      seen.add(key);
+    }
+
+    if (duplicates.length > 0) {
+      const message = [
+        'Found duplicate flag key values in the registry.',
+        '',
+        'Duplicates:',
+        ...duplicates.map((d) => `  - ${d}`),
+      ].join('\n');
+
+      expect(duplicates, message).toEqual([]);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // valid scopes
+  // -----------------------------------------------------------------------
+
+  test('all scope values are valid', () => {
+    const violations: string[] = [];
+
+    for (const flag of flags) {
+      const scope = flag.scope as string;
+      if (!VALID_SCOPES.has(scope)) {
+        violations.push(`flag '${flag.id}' has invalid scope '${scope}' (expected 'assistant' or 'macos')`);
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        'Found flags with invalid scope values.',
+        '',
+        'Violations:',
+        ...violations.map((v) => `  - ${v}`),
+      ].join('\n');
+
+      expect(violations, message).toEqual([]);
+    }
+  });
+});

--- a/clients/shared/Utilities/FeatureFlagRegistry.swift
+++ b/clients/shared/Utilities/FeatureFlagRegistry.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+// MARK: - Types
+
+/// Scope of a feature flag — determines which platform consumes it.
+public enum FeatureFlagScope: String, Decodable {
+    case assistant
+    case macos
+}
+
+/// A single entry in the unified feature flag registry.
+public struct FeatureFlagDefinition: Decodable {
+    public let id: String
+    public let scope: FeatureFlagScope
+    public let key: String
+    public let label: String
+    public let description: String
+    public let defaultEnabled: Bool
+}
+
+/// Top-level schema for `feature-flag-registry.json`.
+public struct FeatureFlagRegistry: Decodable {
+    public let version: Int
+    public let flags: [FeatureFlagDefinition]
+
+    // MARK: - Scope filters
+
+    /// Return only flags with `scope == .macos`.
+    public func macosScopeFlags() -> [FeatureFlagDefinition] {
+        flags.filter { $0.scope == .macos }
+    }
+
+    /// Return only flags with `scope == .assistant`.
+    public func assistantScopeFlags() -> [FeatureFlagDefinition] {
+        flags.filter { $0.scope == .assistant }
+    }
+}
+
+// MARK: - Loader
+
+/// Load the unified feature flag registry from the app bundle's Resources.
+///
+/// The `feature-flag-registry.json` file must be included in the target's
+/// "Copy Bundle Resources" build phase so it appears in `Bundle.main`.
+public func loadFeatureFlagRegistry() -> FeatureFlagRegistry? {
+    guard let url = Bundle.main.url(forResource: "feature-flag-registry", withExtension: "json") else {
+        return nil
+    }
+    guard let data = try? Data(contentsOf: url) else {
+        return nil
+    }
+    return try? JSONDecoder().decode(FeatureFlagRegistry.self, from: data)
+}

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -1,0 +1,37 @@
+{
+  "version": 1,
+  "flags": [
+    {
+      "id": "sms",
+      "scope": "assistant",
+      "key": "feature_flags.sms.enabled",
+      "label": "SMS",
+      "description": "Show SMS setup in Settings > Connect and enable the SMS setup skill",
+      "defaultEnabled": true
+    },
+    {
+      "id": "hatch-new-assistant",
+      "scope": "assistant",
+      "key": "feature_flags.hatch-new-assistant.enabled",
+      "label": "Hatch New Assistant",
+      "description": "Show Hatch New Assistant action in Settings > Account",
+      "defaultEnabled": true
+    },
+    {
+      "id": "user-hosted-enabled",
+      "scope": "macos",
+      "key": "user_hosted_enabled",
+      "label": "User Hosted Enabled",
+      "description": "Enable user-hosted onboarding flow",
+      "defaultEnabled": false
+    },
+    {
+      "id": "local-http-enabled",
+      "scope": "macos",
+      "key": "local_http_enabled",
+      "label": "Local HTTP Enabled",
+      "description": "Enable local HTTP transport mode in macOS app",
+      "defaultEnabled": false
+    }
+  ]
+}

--- a/meta/feature-flags/loader.ts
+++ b/meta/feature-flags/loader.ts
@@ -1,0 +1,61 @@
+/**
+ * Unified feature flag registry loader.
+ *
+ * Reads the canonical `feature-flag-registry.json` and provides typed access
+ * to the full registry as well as scope-filtered subsets.
+ *
+ * This loader is intended for use by both the assistant and gateway packages.
+ */
+
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type FeatureFlagScope = 'assistant' | 'macos';
+
+export interface FeatureFlagDefinition {
+  id: string;
+  scope: FeatureFlagScope;
+  key: string;
+  label: string;
+  description: string;
+  defaultEnabled: boolean;
+}
+
+export interface FeatureFlagRegistry {
+  version: number;
+  flags: FeatureFlagDefinition[];
+}
+
+// ---------------------------------------------------------------------------
+// Loader
+// ---------------------------------------------------------------------------
+
+/**
+ * Load and parse the unified feature flag registry from disk.
+ *
+ * Resolves the JSON path relative to *this* file so the loader works
+ * regardless of the caller's working directory.
+ */
+export async function loadFeatureFlagRegistry(): Promise<FeatureFlagRegistry> {
+  const registryPath = join(import.meta.dirname ?? __dirname, 'feature-flag-registry.json');
+  const raw = await readFile(registryPath, 'utf-8');
+  return JSON.parse(raw) as FeatureFlagRegistry;
+}
+
+// ---------------------------------------------------------------------------
+// Scope filters
+// ---------------------------------------------------------------------------
+
+/** Return only flags with `scope === 'assistant'`. */
+export function getAssistantScopeFlags(registry: FeatureFlagRegistry): FeatureFlagDefinition[] {
+  return registry.flags.filter((f) => f.scope === 'assistant');
+}
+
+/** Return only flags with `scope === 'macos'`. */
+export function getMacosScopeFlags(registry: FeatureFlagRegistry): FeatureFlagDefinition[] {
+  return registry.flags.filter((f) => f.scope === 'macos');
+}


### PR DESCRIPTION
Adds the unified feature flag registry at meta/feature-flags/feature-flag-registry.json containing both assistant-scope and macos-scope flags. Includes TS loader/types and Swift loader/model for consuming the registry, plus validation guard tests enforcing uniqueness, valid scopes, and required fields. No existing runtime behavior is changed. Part of #10348.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
