### PR TITLE
Redesign guardian verification input as inline input-action group

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -53,6 +53,9 @@ struct SettingsChannelsTab: View {
     // Outbound guardian verification destination input (keyed by channel)
     @State private var guardianDestinationText: [String: String] = [:]
 
+    // Hover state for guardian send button (keyed by channel)
+    @State private var guardianSendHovered: [String: Bool] = [:]
+
     // Outbound verification code copy state (tracks which channel's code was just copied)
     @State private var outboundCodeCopiedChannel: String?
 
@@ -1238,15 +1241,53 @@ struct SettingsChannelsTab: View {
             HStack(spacing: VSpacing.sm) {
                 guardianLabel
 
-                TextField(placeholder, text: destinationBinding)
-                    .font(VFont.body)
-                    .vInputStyle()
-                    .frame(maxWidth: 200)
+                HStack(spacing: 0) {
+                    TextField(placeholder, text: destinationBinding)
+                        .textFieldStyle(.plain)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                        .padding(.leading, VSpacing.md)
+                        .padding(.vertical, VSpacing.md)
+                        .onSubmit {
+                            if !destination.isEmpty {
+                                store.startOutboundGuardianVerification(channel: channel, destination: destination)
+                            }
+                        }
 
-                VButton(label: "Send verification", style: .secondary) {
-                    store.startOutboundGuardianVerification(channel: channel, destination: destination)
+                    Button {
+                        store.startOutboundGuardianVerification(channel: channel, destination: destination)
+                    } label: {
+                        let isHovered = guardianSendHovered[channel] ?? false
+                        Text("Send")
+                            .font(VFont.captionMedium)
+                            .foregroundColor(destination.isEmpty ? VColor.textMuted : .white)
+                            .padding(.horizontal, VSpacing.md)
+                            .padding(.vertical, VSpacing.buttonV)
+                            .background(
+                                destination.isEmpty
+                                    ? VColor.surfaceBorder.opacity(0.5)
+                                    : (isHovered ? VColor.buttonPrimaryHover : VColor.buttonPrimary)
+                            )
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                            .animation(VAnimation.fast, value: isHovered)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(destination.isEmpty)
+                    .onHover { hovering in
+                        guardianSendHovered[channel] = destination.isEmpty ? false : hovering
+                        if !destination.isEmpty {
+                            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                        }
+                    }
+                    .padding(.trailing, VSpacing.sm)
                 }
-                .disabled(destination.isEmpty)
+                .background(VColor.inputBackground)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(VColor.surfaceBorder, lineWidth: 1)
+                )
+                .frame(maxWidth: 360)
 
                 Spacer()
             }
@@ -1271,6 +1312,12 @@ struct SettingsChannelsTab: View {
                         if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
                     }
                 }
+                .padding(.leading, labelColumnWidth + VSpacing.sm)
+            } else if channel == "voice" || channel == "sms" {
+                Text("This is your personal phone number")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .padding(.leading, labelColumnWidth + VSpacing.sm)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replaces the separate text field + button with a single inline container (shared background, border, and rounded corners) for the guardian verification input
- Adds hover state (color change + pointer cursor) on the Send pill button, and Enter key support on the text field
- Aligns Telegram helper text under the input and adds "This is your personal phone number" helper text for voice and SMS channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
