### PR TITLE
Add VInlineActionField design system component for inline input-action groups

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -297,16 +297,9 @@ struct SettingsPanel: View {
                         VInfoTooltip("Get your API key at console.anthropic.com")
                     }
 
-                    HStack(spacing: VSpacing.sm) {
-                        SecureField("This is your private generated key", text: $apiKeyText)
-                            .vInputStyle()
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textPrimary)
-
-                        VButton(label: "Save", style: .primary) {
-                            store.saveAPIKey(apiKeyText)
-                            apiKeyText = ""
-                        }
+                    VInlineActionField(text: $apiKeyText, placeholder: "This is your private generated key", isSecure: true) {
+                        store.saveAPIKey(apiKeyText)
+                        apiKeyText = ""
                     }
 
                     HStack(spacing: 0) {
@@ -409,16 +402,9 @@ struct SettingsPanel: View {
                         VInfoTooltip("Get your API key at perplexity.ai/settings/api")
                     }
 
-                    HStack(spacing: VSpacing.sm) {
-                        SecureField("Your Perplexity API key", text: $perplexityKeyText)
-                            .vInputStyle()
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textPrimary)
-
-                        VButton(label: "Save", style: .primary) {
-                            store.savePerplexityKey(perplexityKeyText)
-                            perplexityKeyText = ""
-                        }
+                    VInlineActionField(text: $perplexityKeyText, placeholder: "Your Perplexity API key", isSecure: true) {
+                        store.savePerplexityKey(perplexityKeyText)
+                        perplexityKeyText = ""
                     }
 
                     HStack(spacing: 0) {
@@ -465,16 +451,9 @@ struct SettingsPanel: View {
                         VInfoTooltip("Get your API key at brave.com/search/api")
                     }
 
-                    HStack(spacing: VSpacing.sm) {
-                        SecureField("Your Brave Search API key", text: $braveKeyText)
-                            .vInputStyle()
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textPrimary)
-
-                        VButton(label: "Save", style: .primary) {
-                            store.saveBraveKey(braveKeyText)
-                            braveKeyText = ""
-                        }
+                    VInlineActionField(text: $braveKeyText, placeholder: "Your Brave Search API key", isSecure: true) {
+                        store.saveBraveKey(braveKeyText)
+                        braveKeyText = ""
                     }
 
                     HStack(spacing: 0) {
@@ -539,16 +518,9 @@ struct SettingsPanel: View {
                         VInfoTooltip("Get your API key at aistudio.google.com/apikey")
                     }
 
-                    HStack(spacing: VSpacing.sm) {
-                        SecureField("Your Gemini API key", text: $imageGenKeyText)
-                            .vInputStyle()
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textPrimary)
-
-                        VButton(label: "Save", style: .primary) {
-                            store.saveImageGenKey(imageGenKeyText)
-                            imageGenKeyText = ""
-                        }
+                    VInlineActionField(text: $imageGenKeyText, placeholder: "Your Gemini API key", isSecure: true) {
+                        store.saveImageGenKey(imageGenKeyText)
+                        imageGenKeyText = ""
                     }
 
                     HStack(spacing: 0) {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -53,9 +53,6 @@ struct SettingsChannelsTab: View {
     // Outbound guardian verification destination input (keyed by channel)
     @State private var guardianDestinationText: [String: String] = [:]
 
-    // Hover state for guardian send button (keyed by channel)
-    @State private var guardianSendHovered: [String: Bool] = [:]
-
     // Outbound verification code copy state (tracks which channel's code was just copied)
     @State private var outboundCodeCopiedChannel: String?
 
@@ -1241,52 +1238,9 @@ struct SettingsChannelsTab: View {
             HStack(spacing: VSpacing.sm) {
                 guardianLabel
 
-                HStack(spacing: 0) {
-                    TextField(placeholder, text: destinationBinding)
-                        .textFieldStyle(.plain)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
-                        .padding(.leading, VSpacing.md)
-                        .padding(.vertical, VSpacing.md)
-                        .onSubmit {
-                            if !destination.isEmpty {
-                                store.startOutboundGuardianVerification(channel: channel, destination: destination)
-                            }
-                        }
-
-                    Button {
-                        store.startOutboundGuardianVerification(channel: channel, destination: destination)
-                    } label: {
-                        let isHovered = guardianSendHovered[channel] ?? false
-                        Text("Send")
-                            .font(VFont.captionMedium)
-                            .foregroundColor(destination.isEmpty ? VColor.textMuted : .white)
-                            .padding(.horizontal, VSpacing.md)
-                            .padding(.vertical, VSpacing.buttonV)
-                            .background(
-                                destination.isEmpty
-                                    ? VColor.surfaceBorder.opacity(0.5)
-                                    : (isHovered ? VColor.buttonPrimaryHover : VColor.buttonPrimary)
-                            )
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                            .animation(VAnimation.fast, value: isHovered)
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(destination.isEmpty)
-                    .onHover { hovering in
-                        guardianSendHovered[channel] = destination.isEmpty ? false : hovering
-                        if !destination.isEmpty {
-                            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                        }
-                    }
-                    .padding(.trailing, VSpacing.sm)
+                VInlineActionField(text: destinationBinding, placeholder: placeholder, actionLabel: "Send") {
+                    store.startOutboundGuardianVerification(channel: channel, destination: destination)
                 }
-                .background(VColor.inputBackground)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(VColor.surfaceBorder, lineWidth: 1)
-                )
                 .frame(maxWidth: 360)
 
                 Spacer()

--- a/clients/shared/DesignSystem/Core/Inputs/VInlineActionField.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VInlineActionField.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
+
+/// An input field with an inline action button (e.g., Save, Send) inside a shared container.
+/// The button sits on the right edge of the field, creating a cohesive input-action group.
+///
+/// Usage:
+/// ```swift
+/// VInlineActionField(text: $apiKey, placeholder: "Your API key", isSecure: true) {
+///     store.saveKey(apiKey)
+/// }
+/// ```
+public struct VInlineActionField: View {
+    @Binding public var text: String
+    public let placeholder: String
+    public var actionLabel: String
+    public var isSecure: Bool
+    public let action: () -> Void
+
+    @State private var isHovered = false
+
+    public init(
+        text: Binding<String>,
+        placeholder: String,
+        actionLabel: String = "Save",
+        isSecure: Bool = false,
+        action: @escaping () -> Void
+    ) {
+        self._text = text
+        self.placeholder = placeholder
+        self.actionLabel = actionLabel
+        self.isSecure = isSecure
+        self.action = action
+    }
+
+    private var isEmpty: Bool {
+        text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    public var body: some View {
+        HStack(spacing: 0) {
+            inputField
+                .padding(.leading, VSpacing.md)
+                .padding(.vertical, VSpacing.md)
+                .onSubmit {
+                    if !isEmpty { action() }
+                }
+
+            Button {
+                if !isEmpty { action() }
+            } label: {
+                Text(actionLabel)
+                    .font(VFont.captionMedium)
+                    .foregroundColor(isEmpty ? VColor.textMuted : .white)
+                    .padding(.horizontal, VSpacing.md)
+                    .padding(.vertical, VSpacing.buttonV)
+                    .background(
+                        isEmpty
+                            ? VColor.surfaceBorder.opacity(0.5)
+                            : (isHovered ? VColor.buttonPrimaryHover : VColor.buttonPrimary)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                    .animation(VAnimation.fast, value: isHovered)
+            }
+            .buttonStyle(.plain)
+            .disabled(isEmpty)
+            .onHover { hovering in
+                isHovered = isEmpty ? false : hovering
+                #if os(macOS)
+                if !isEmpty {
+                    if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                }
+                #endif
+            }
+            .padding(.trailing, VSpacing.sm)
+        }
+        .background(VColor.inputBackground)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+    }
+
+    @ViewBuilder
+    private var inputField: some View {
+        if isSecure {
+            SecureField(placeholder, text: $text)
+                .textFieldStyle(.plain)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+        } else {
+            TextField(placeholder, text: $text)
+                .textFieldStyle(.plain)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+        }
+    }
+}
+
+#if DEBUG
+struct VInlineActionField_Preview: PreviewProvider {
+    static var previews: some View {
+        VInlineActionFieldPreviewWrapper()
+            .frame(width: 450, height: 200)
+            .previewDisplayName("VInlineActionField")
+    }
+}
+
+private struct VInlineActionFieldPreviewWrapper: View {
+    @State private var text = ""
+    @State private var secureText = ""
+
+    var body: some View {
+        ZStack {
+            VColor.background.ignoresSafeArea()
+            VStack(spacing: 16) {
+                VInlineActionField(text: $text, placeholder: "Enter a value") {}
+                VInlineActionField(text: $secureText, placeholder: "Your API key", isSecure: true) {}
+                VInlineActionField(text: $text, placeholder: "@username or chat ID", actionLabel: "Send") {}
+            }
+            .padding()
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- New `VInlineActionField` component in `DesignSystem/Core/Inputs/` — a text field with an embedded action button (supports secure fields, custom action labels, hover state, Enter-to-submit)
- Replaces the separate `SecureField` + `VButton("Save")` pattern in all 4 API key sections (Anthropic, Perplexity, Brave Search, Gemini) on the Models & Services settings tab
- Refactors the guardian verification destination input in SettingsChannelsTab to use the same component, removing ~45 lines of hand-rolled inline button code

## Original prompt
lets update these to use that same inline Save button. Feel free to make a reusable component in our design system if helpful

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
