### PR TITLE
fix: suppress Sparkle auto-update prompt on first launch

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -552,6 +552,8 @@ cat > "$CONTENTS/Info.plist" <<PLIST
     <string>https://github.com/vellum-ai/velly/releases/latest/download/appcast.xml</string>
     <key>SUPublicEDKey</key>
     <string>${SU_PUBLIC_ED_KEY:-}</string>
+    <key>SUEnableAutomaticChecks</key>
+    <true/>
     <key>SUAutomaticallyUpdate</key>
     <true/>
     <key>CFBundleIconName</key>


### PR DESCRIPTION
## Summary
- Adds `SUEnableAutomaticChecks=true` to the generated Info.plist
- Sparkle was showing a "Check for updates automatically?" dialog on every new installation because this key was missing
- `SUAutomaticallyUpdate` (silent install) was already set, but `SUEnableAutomaticChecks` (opt-in to checking) was not

## Test plan
- [ ] Fresh install of the .app no longer shows the update permission dialog
- [ ] Auto-updates still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
