### PR TITLE
Adopt VInlineActionField for remaining settings input fields

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -10,7 +10,6 @@ struct GatewaySettingsCard: View {
     var daemonClient: DaemonClient?
 
     @State private var gatewayUrlText: String = ""
-    @FocusState private var isGatewayUrlFocused: Bool
     @State private var gatewayTargetCopied: Bool = false
 
     var body: some View {
@@ -28,14 +27,7 @@ struct GatewaySettingsCard: View {
             gatewayUrlText = store.ingressPublicBaseUrl
         }
         .onChange(of: store.ingressPublicBaseUrl) { _, newValue in
-            if !isGatewayUrlFocused {
-                gatewayUrlText = newValue
-            }
-        }
-        .onChange(of: isGatewayUrlFocused) { _, focused in
-            if !focused {
-                gatewayUrlText = store.ingressPublicBaseUrl
-            }
+            gatewayUrlText = newValue
         }
         .onChange(of: store.ingressConfigLoaded) { _, loaded in
             guard loaded else { return }
@@ -113,16 +105,8 @@ struct GatewaySettingsCard: View {
                     .foregroundColor(VColor.textSecondary)
             }
 
-            HStack(spacing: VSpacing.sm) {
-                TextField("https://your-tunnel.example.com", text: $gatewayUrlText)
-                    .focused($isGatewayUrlFocused)
-                    .vInputStyle()
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textPrimary)
-
-                VButton(label: "Save", style: .primary) {
-                    store.saveIngressPublicBaseUrl(gatewayUrlText)
-                }
+            VInlineActionField(text: $gatewayUrlText, placeholder: "https://your-tunnel.example.com") {
+                store.saveIngressPublicBaseUrl(gatewayUrlText)
             }
 
             // Tunnel connection status (checks public URL)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -12,7 +12,6 @@ struct SettingsAccountTab: View {
 
     // -- Account / Vellum section state --
     @State private var platformUrlText: String = ""
-    @FocusState private var isPlatformUrlFocused: Bool
 
     // -- Assistant Info state (from SettingsAdvancedTab) --
     @State private var showingRetireConfirmation: Bool = false
@@ -59,14 +58,7 @@ struct SettingsAccountTab: View {
             Task { await loadHatchFlag() }
         }
         .onChange(of: store.platformBaseUrl) { _, newValue in
-            if !isPlatformUrlFocused {
-                platformUrlText = newValue
-            }
-        }
-        .onChange(of: isPlatformUrlFocused) { _, focused in
-            if !focused {
-                platformUrlText = store.platformBaseUrl
-            }
+            platformUrlText = newValue
         }
         .alert("Retire Assistant", isPresented: $showingRetireConfirmation) {
             Button("Cancel", role: .cancel) {}
@@ -117,19 +109,9 @@ struct SettingsAccountTab: View {
                     .font(VFont.caption)
                     .foregroundColor(VColor.textSecondary)
 
-                HStack(spacing: VSpacing.sm) {
-                    TextField("https://platform.vellum.ai", text: $platformUrlText)
-                        .focused($isPlatformUrlFocused)
-                        .vInputStyle()
-                        .font(VFont.mono)
-                        .onSubmit {
-                            store.savePlatformBaseUrl(platformUrlText)
-                            Task { await store.checkVellumPlatform() }
-                        }
-                    VButton(label: "Save", style: .primary) {
-                        store.savePlatformBaseUrl(platformUrlText)
-                        Task { await store.checkVellumPlatform() }
-                    }
+                VInlineActionField(text: $platformUrlText, placeholder: "https://platform.vellum.ai") {
+                    store.savePlatformBaseUrl(platformUrlText)
+                    Task { await store.checkVellumPlatform() }
                 }
             }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -191,19 +191,14 @@ struct SettingsAppearanceTab: View {
                         .font(VFont.bodyBold)
                         .foregroundColor(VColor.textSecondary)
 
-                    HStack(spacing: VSpacing.sm) {
-                        TextField("Add domain (e.g. example.com)", text: $newAllowlistDomain)
-                            .vInputStyle()
-
-                        VButton(label: "Add", style: .primary) {
-                            let domain = newAllowlistDomain
-                                .trimmingCharacters(in: .whitespacesAndNewlines)
-                            guard !domain.isEmpty else { return }
-                            var domains = store.mediaEmbedVideoAllowlistDomains
-                            domains.append(domain)
-                            store.setMediaEmbedVideoAllowlistDomains(domains)
-                            newAllowlistDomain = ""
-                        }
+                    VInlineActionField(text: $newAllowlistDomain, placeholder: "Add domain (e.g. example.com)", actionLabel: "Add") {
+                        let domain = newAllowlistDomain
+                            .trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard !domain.isEmpty else { return }
+                        var domains = store.mediaEmbedVideoAllowlistDomains
+                        domains.append(domain)
+                        store.setMediaEmbedVideoAllowlistDomains(domains)
+                        newAllowlistDomain = ""
                     }
 
                     ForEach(store.mediaEmbedVideoAllowlistDomains, id: \.self) { domain in


### PR DESCRIPTION
## Summary
- Replace separate TextField + VButton combos with VInlineActionField in Platform URL (Account settings), Gateway URL (Gateway settings), and Video Domain Allowlist (Appearance settings)
- Remove now-unnecessary @FocusState properties and focus-tracking onChange handlers
- Consistent inline input-action styling across all settings fields

## Original prompt
lets use that same new component for Platform URL and Gateway URL here as well as the Video Domain Allowlist here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
