### PR TITLE
M1: Shared Invite Core Hardening (#10358)

### DIFF
--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -1,0 +1,222 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'invite-redemption-service-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { getSqlite, initializeDb, resetDb } from '../memory/db.js';
+import { createInvite } from '../memory/ingress-invite-store.js';
+import { upsertMember } from '../memory/ingress-member-store.js';
+import { redeemInvite, type InviteRedemptionOutcome } from '../runtime/invite-redemption-service.js';
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+function resetTables() {
+  getSqlite().run('DELETE FROM assistant_ingress_members');
+  getSqlite().run('DELETE FROM assistant_ingress_invites');
+}
+
+describe('invite-redemption-service', () => {
+  beforeEach(resetTables);
+
+  test('redeems a valid invite and returns typed outcome', () => {
+    const { rawToken, invite } = createInvite({ sourceChannel: 'telegram', maxUses: 1 });
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+    });
+
+    expect(outcome.ok).toBe(true);
+    expect(outcome).toEqual({
+      ok: true,
+      type: 'redeemed',
+      memberId: expect.any(String),
+      inviteId: invite.id,
+    });
+  });
+
+  test('returns invalid_token for a bogus token', () => {
+    const outcome = redeemInvite({
+      rawToken: 'totally-bogus-token',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: 'invalid_token' });
+  });
+
+  test('returns expired for an expired invite', () => {
+    // Create an invite that expired 1 ms ago
+    const { rawToken } = createInvite({
+      sourceChannel: 'telegram',
+      maxUses: 1,
+      expiresInMs: -1,
+    });
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: 'expired' });
+  });
+
+  test('returns revoked for a revoked invite', () => {
+    const { revokeInvite: revokeStoreFn } = require('../memory/ingress-invite-store.js') as typeof import('../memory/ingress-invite-store.js');
+
+    const { rawToken, invite } = createInvite({
+      sourceChannel: 'telegram',
+      maxUses: 1,
+    });
+    revokeStoreFn(invite.id);
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: 'revoked' });
+  });
+
+  test('returns max_uses_reached when invite is fully consumed', () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 1 });
+
+    // First redemption should succeed
+    const first = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+    });
+    expect(first.ok).toBe(true);
+
+    // Second attempt should fail — the invite is now fully redeemed
+    const second = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'user-2',
+    });
+
+    expect(second).toEqual({ ok: false, reason: 'max_uses_reached' });
+  });
+
+  test('returns channel_mismatch when redeeming on wrong channel', () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 1 });
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'sms',
+      externalUserId: 'user-1',
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: 'channel_mismatch' });
+  });
+
+  test('returns missing_identity when no externalUserId or externalChatId', () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 1 });
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: 'missing_identity' });
+  });
+
+  test('returns already_member when user is already an active member', () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 5 });
+
+    // Pre-create an active member
+    upsertMember({
+      sourceChannel: 'telegram',
+      externalUserId: 'existing-user',
+      status: 'active',
+    });
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'existing-user',
+    });
+
+    expect(outcome.ok).toBe(true);
+    expect((outcome as Extract<InviteRedemptionOutcome, { type: 'already_member' }>).type).toBe('already_member');
+    expect((outcome as Extract<InviteRedemptionOutcome, { type: 'already_member' }>).memberId).toEqual(expect.any(String));
+  });
+
+  test('does not return already_member for a revoked member', () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 5 });
+
+    // Pre-create a revoked member
+    const member = upsertMember({
+      sourceChannel: 'telegram',
+      externalUserId: 'revoked-user',
+      status: 'revoked',
+    });
+    expect(member.status).toBe('revoked');
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'revoked-user',
+    });
+
+    // Should redeem, not return already_member
+    expect(outcome.ok).toBe(true);
+    expect((outcome as Extract<InviteRedemptionOutcome, { type: 'redeemed' }>).type).toBe('redeemed');
+  });
+
+  test('raw token is not present in the outcome object', () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 1 });
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+    });
+
+    // Verify the raw token does not appear anywhere in the serialized outcome
+    const serialized = JSON.stringify(outcome);
+    expect(serialized).not.toContain(rawToken);
+  });
+
+  test('channel enforcement blocks cross-channel redemption (voice invite via slack)', () => {
+    const { rawToken } = createInvite({ sourceChannel: 'voice', maxUses: 1 });
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'slack',
+      externalUserId: 'user-1',
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: 'channel_mismatch' });
+  });
+});

--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -219,4 +219,71 @@ describe('invite-redemption-service', () => {
 
     expect(outcome).toEqual({ ok: false, reason: 'channel_mismatch' });
   });
+
+  test('returns invalid_token for an active member with a bogus token (no membership probing)', () => {
+    // Pre-create an active member
+    upsertMember({
+      sourceChannel: 'telegram',
+      externalUserId: 'probed-user',
+      status: 'active',
+    });
+
+    // Attempt to redeem with a bogus token — must NOT leak membership status
+    const outcome = redeemInvite({
+      rawToken: 'completely-bogus-token',
+      sourceChannel: 'telegram',
+      externalUserId: 'probed-user',
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: 'invalid_token' });
+  });
+
+  test('returns expired for an active member with an expired invite token', () => {
+    // Create an expired invite
+    const { rawToken } = createInvite({
+      sourceChannel: 'telegram',
+      maxUses: 5,
+      expiresInMs: -1,
+    });
+
+    // Pre-create an active member
+    upsertMember({
+      sourceChannel: 'telegram',
+      externalUserId: 'expired-token-user',
+      status: 'active',
+    });
+
+    // Expired token must return expired, not already_member
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'expired-token-user',
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: 'expired' });
+  });
+
+  test('returns channel_mismatch for an active member with a valid token for a different channel', () => {
+    // Create an invite for SMS
+    const { rawToken } = createInvite({
+      sourceChannel: 'sms',
+      maxUses: 5,
+    });
+
+    // Pre-create an active member on telegram
+    upsertMember({
+      sourceChannel: 'telegram',
+      externalUserId: 'cross-channel-user',
+      status: 'active',
+    });
+
+    // Valid token for wrong channel must return channel_mismatch, not already_member
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'cross-channel-user',
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: 'channel_mismatch' });
+  });
 });

--- a/assistant/src/memory/ingress-invite-store.ts
+++ b/assistant/src/memory/ingress-invite-store.ts
@@ -66,7 +66,7 @@ const DEFAULT_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 // Helpers
 // ---------------------------------------------------------------------------
 
-function hashToken(rawToken: string): string {
+export function hashToken(rawToken: string): string {
   return createHash('sha256').update(rawToken).digest('hex');
 }
 

--- a/assistant/src/memory/ingress-invite-store.ts
+++ b/assistant/src/memory/ingress-invite-store.ts
@@ -330,6 +330,30 @@ export function redeemInvite(params: {
 }
 
 // ---------------------------------------------------------------------------
+// markInviteExpired
+// ---------------------------------------------------------------------------
+
+/**
+ * Transition an invite's status to 'expired' in storage. This is safe to call
+ * even if the invite is already expired — the WHERE clause scopes the update
+ * to 'active' rows so it becomes a no-op in that case.
+ */
+export function markInviteExpired(inviteId: string): void {
+  const db = getDb();
+  const now = Date.now();
+
+  db.update(assistantIngressInvites)
+    .set({ status: 'expired', updatedAt: now })
+    .where(
+      and(
+        eq(assistantIngressInvites.id, inviteId),
+        eq(assistantIngressInvites.status, 'active'),
+      ),
+    )
+    .run();
+}
+
+// ---------------------------------------------------------------------------
 // findByTokenHash
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/memory/ingress-invite-store.ts
+++ b/assistant/src/memory/ingress-invite-store.ts
@@ -268,6 +268,12 @@ export function redeemInvite(params: {
     return { error: 'invite_max_uses_reached' };
   }
 
+  // Enforce channel-scoped redemption: when the caller specifies a channel, it
+  // must match the channel the invite was created for.
+  if (params.sourceChannel && params.sourceChannel !== invite.sourceChannel) {
+    return { error: 'invite_channel_mismatch' };
+  }
+
   const newUseCount = invite.useCount + 1;
   const newStatus = newUseCount >= invite.maxUses ? 'redeemed' : 'active';
 

--- a/assistant/src/runtime/ingress-service.ts
+++ b/assistant/src/runtime/ingress-service.ts
@@ -22,6 +22,10 @@ import {
   revokeMember,
   upsertMember,
 } from '../memory/ingress-member-store.js';
+import {
+  redeemInvite as redeemInviteTyped,
+  type InviteRedemptionOutcome,
+} from './invite-redemption-service.js';
 
 // ---------------------------------------------------------------------------
 // Response shapes — used by both HTTP routes and IPC handlers
@@ -161,6 +165,24 @@ export function redeemIngressInvite(params: {
     return { ok: false, error: result.error };
   }
   return { ok: true, data: inviteToResponse(result.invite) };
+}
+
+// ---------------------------------------------------------------------------
+// Typed invite redemption — preferred entry point for new callers
+// ---------------------------------------------------------------------------
+
+export { type InviteRedemptionOutcome } from './invite-redemption-service.js';
+
+export function redeemIngressInviteTyped(params: {
+  rawToken: string;
+  sourceChannel: string;
+  externalUserId?: string;
+  externalChatId?: string;
+  displayName?: string;
+  username?: string;
+  assistantId?: string;
+}): InviteRedemptionOutcome {
+  return redeemInviteTyped(params);
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -8,7 +8,7 @@
  */
 
 import { findMember } from '../memory/ingress-member-store.js';
-import { redeemInvite as storeRedeemInvite } from '../memory/ingress-invite-store.js';
+import { findByTokenHash, hashToken, redeemInvite as storeRedeemInvite } from '../memory/ingress-invite-store.js';
 
 // ---------------------------------------------------------------------------
 // Outcome type
@@ -51,7 +51,37 @@ export function redeemInvite(params: {
     return { ok: false, reason: 'missing_identity' };
   }
 
-  // Check if the caller is already a member on this channel
+  // Validate the invite token before any membership checks to prevent
+  // membership-status probing with arbitrary tokens.
+  const tokenHash = hashToken(rawToken);
+  const invite = findByTokenHash(tokenHash);
+
+  if (!invite) {
+    return { ok: false, reason: 'invalid_token' };
+  }
+
+  if (invite.status !== 'active') {
+    const mapped = STORE_ERROR_TO_REASON[`invite_${invite.status}`];
+    if (mapped) return mapped;
+    return { ok: false, reason: 'invalid_token' };
+  }
+
+  if (invite.expiresAt <= Date.now()) {
+    return { ok: false, reason: 'expired' };
+  }
+
+  if (invite.useCount >= invite.maxUses) {
+    return { ok: false, reason: 'max_uses_reached' };
+  }
+
+  // Enforce channel match: the token must belong to the channel the caller
+  // is redeeming from.
+  if (sourceChannel !== invite.sourceChannel) {
+    return { ok: false, reason: 'channel_mismatch' };
+  }
+
+  // Token is valid — now safe to check existing membership without leaking
+  // membership status to callers with bogus tokens.
   const existingMember = findMember({
     assistantId,
     sourceChannel,

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -83,7 +83,7 @@ export function redeemInvite(params: {
   // Token is valid — now safe to check existing membership without leaking
   // membership status to callers with bogus tokens.
   const existingMember = findMember({
-    assistantId,
+    assistantId: assistantId ?? invite.assistantId,
     sourceChannel,
     externalUserId,
     externalChatId,

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -8,7 +8,7 @@
  */
 
 import { findMember } from '../memory/ingress-member-store.js';
-import { findByTokenHash, hashToken, redeemInvite as storeRedeemInvite } from '../memory/ingress-invite-store.js';
+import { findByTokenHash, hashToken, markInviteExpired, redeemInvite as storeRedeemInvite } from '../memory/ingress-invite-store.js';
 
 // ---------------------------------------------------------------------------
 // Outcome type
@@ -67,6 +67,7 @@ export function redeemInvite(params: {
   }
 
   if (invite.expiresAt <= Date.now()) {
+    markInviteExpired(invite.id);
     return { ok: false, reason: 'expired' };
   }
 

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -1,0 +1,91 @@
+/**
+ * Typed invite redemption engine.
+ *
+ * Wraps the low-level invite store primitives with channel-scoped enforcement
+ * and a discriminated-union outcome type so callers can handle every case
+ * deterministically. The raw token is accepted as input but is never logged,
+ * persisted, or returned in the outcome.
+ */
+
+import { findMember } from '../memory/ingress-member-store.js';
+import { redeemInvite as storeRedeemInvite } from '../memory/ingress-invite-store.js';
+
+// ---------------------------------------------------------------------------
+// Outcome type
+// ---------------------------------------------------------------------------
+
+export type InviteRedemptionOutcome =
+  | { ok: true; type: 'redeemed'; memberId: string; inviteId: string }
+  | { ok: true; type: 'already_member'; memberId: string }
+  | { ok: false; reason: 'invalid_token' | 'expired' | 'revoked' | 'max_uses_reached' | 'channel_mismatch' | 'missing_identity' };
+
+// ---------------------------------------------------------------------------
+// Error-string to typed-reason mapping
+// ---------------------------------------------------------------------------
+
+const STORE_ERROR_TO_REASON: Record<string, InviteRedemptionOutcome & { ok: false } | undefined> = {
+  invite_not_found: { ok: false, reason: 'invalid_token' },
+  invite_expired: { ok: false, reason: 'expired' },
+  invite_revoked: { ok: false, reason: 'revoked' },
+  invite_redeemed: { ok: false, reason: 'max_uses_reached' },
+  invite_max_uses_reached: { ok: false, reason: 'max_uses_reached' },
+  invite_channel_mismatch: { ok: false, reason: 'channel_mismatch' },
+};
+
+// ---------------------------------------------------------------------------
+// redeemInvite
+// ---------------------------------------------------------------------------
+
+export function redeemInvite(params: {
+  rawToken: string;
+  sourceChannel: string;
+  externalUserId?: string;
+  externalChatId?: string;
+  displayName?: string;
+  username?: string;
+  assistantId?: string;
+}): InviteRedemptionOutcome {
+  const { rawToken, sourceChannel, externalUserId, externalChatId, displayName, username, assistantId } = params;
+
+  if (!externalUserId && !externalChatId) {
+    return { ok: false, reason: 'missing_identity' };
+  }
+
+  // Check if the caller is already a member on this channel
+  const existingMember = findMember({
+    assistantId,
+    sourceChannel,
+    externalUserId,
+    externalChatId,
+  });
+
+  if (existingMember && existingMember.status === 'active') {
+    return { ok: true, type: 'already_member', memberId: existingMember.id };
+  }
+
+  // Delegate to the store-level redeem which handles token lookup, expiry,
+  // use-count, and transactional member creation. Channel enforcement is
+  // applied by passing sourceChannel so the store checks it.
+  const result = storeRedeemInvite({
+    rawToken,
+    sourceChannel,
+    externalUserId,
+    externalChatId,
+    displayName,
+    username,
+  });
+
+  if ('error' in result) {
+    const mapped = STORE_ERROR_TO_REASON[result.error];
+    if (mapped) return mapped;
+    // Fallback for any unrecognized store error
+    return { ok: false, reason: 'invalid_token' };
+  }
+
+  return {
+    ok: true,
+    type: 'redeemed',
+    memberId: result.member.id,
+    inviteId: result.invite.id,
+  };
+}


### PR DESCRIPTION
Add invite-redemption-service.ts with typed InviteRedemptionOutcome, enforce channel-match in redemption path, keep existing HTTP contracts backward-compatible. Part of #10357.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
