### PR TITLE
Adopt VInlineActionField for ElevenLabs API key input

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -484,12 +484,7 @@ struct VoiceSettingsView: View {
                     }
                 }
             } else {
-                SecureField("Your ElevenLabs API key", text: $elevenLabsKeyText)
-                    .vInputStyle()
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textPrimary)
-
-                VButton(label: "Save", style: .primary) {
+                VInlineActionField(text: $elevenLabsKeyText, placeholder: "Your ElevenLabs API key", isSecure: true) {
                     store.saveElevenLabsKey(elevenLabsKeyText)
                     elevenLabsKeyText = ""
                 }


### PR DESCRIPTION
## Summary
- Replace separate SecureField + VButton with VInlineActionField(isSecure: true) for the ElevenLabs API key entry in VoiceSettingsView

## Original prompt
yes do it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
