### PR TITLE
M3: Build Mac chat UI for guardian approval prompts

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -121,6 +121,9 @@ struct ChatContentView: View {
                                     onRegenerate: isLastAssistant ? { viewModel.regenerateLastMessage() } : nil,
                                     onAlwaysAllow: { requestId, selectedPattern, selectedScope, decision in
                                         viewModel.respondToAlwaysAllow(requestId: requestId, selectedPattern: selectedPattern, selectedScope: selectedScope, decision: decision)
+                                    },
+                                    onGuardianAction: { requestId, action in
+                                        viewModel.submitGuardianDecision(requestId: requestId, action: action)
                                     }
                                 )
                                 .id(message.id)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -37,6 +37,7 @@ struct ChatView: View {
     let onConfirmationAllow: (String) -> Void
     let onConfirmationDeny: (String) -> Void
     let onAlwaysAllow: (String, String, String, String) -> Void
+    var onGuardianAction: ((String, String) -> Void)?
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
     let sessionError: SessionError?
     let onRetry: () -> Void
@@ -187,6 +188,7 @@ struct ChatView: View {
                             onConfirmationDeny: onConfirmationDeny,
                             onAlwaysAllow: onAlwaysAllow,
                             onSurfaceAction: onSurfaceAction,
+                            onGuardianAction: onGuardianAction,
                             onDismissDocumentWidget: onDismissDocumentWidget,
                             onReportMessage: onReportMessage,
                             mediaEmbedSettings: mediaEmbedSettings,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -14,6 +14,8 @@ struct MessageListView: View {
     let onConfirmationDeny: (String) -> Void
     let onAlwaysAllow: (String, String, String, String) -> Void
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
+    /// Called when a guardian decision action button is clicked: (requestId, action).
+    var onGuardianAction: ((String, String) -> Void)?
     let onDismissDocumentWidget: ((String) -> Void)?
     let onReportMessage: ((String?) -> Void)?
     let mediaEmbedSettings: MediaEmbedResolverSettings?
@@ -189,6 +191,15 @@ struct MessageListView: View {
                             CommandListBubble()
                                 .id(message.id)
                                 .transition(.opacity)
+                        } else if let guardianDecision = message.guardianDecision {
+                            GuardianDecisionBubble(
+                                decision: guardianDecision,
+                                onAction: { requestId, action in
+                                    onGuardianAction?(requestId, action)
+                                }
+                            )
+                            .id(message.id)
+                            .transition(.opacity)
                         } else {
                             let nextIsPendingConfirmation = index + 1 < displayMessages.count
                                 && displayMessages[index + 1].confirmation?.state == .pending

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -722,6 +722,7 @@ struct ActiveChatViewWrapper: View {
             onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
             onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") },
             onAlwaysAllow: { requestId, selectedPattern, selectedScope, decision in viewModel.respondToAlwaysAllow(requestId: requestId, selectedPattern: selectedPattern, selectedScope: selectedScope, decision: decision) },
+            onGuardianAction: { requestId, action in viewModel.submitGuardianDecision(requestId: requestId, action: action) },
             onSurfaceAction: { surfaceId, actionId, data in viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data) },
             sessionError: viewModel.sessionError,
             onRetry: { viewModel.retryAfterSessionError() },

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1416,6 +1416,48 @@ public struct ChatAttachment: Identifiable {
     #endif
 }
 
+/// Tracks the state of a guardian decision prompt displayed in chat.
+public enum GuardianDecisionState: Equatable {
+    case pending
+    case resolved(action: String)
+    case stale
+}
+
+/// Data for a guardian decision prompt message displayed in chat.
+/// Populated from `GuardianDecisionPromptWire` returned by the daemon.
+public struct GuardianDecisionData: Equatable {
+    public let requestId: String
+    public let requestCode: String
+    public let questionText: String
+    public let toolName: String?
+    public let actions: [GuardianActionOption]
+    public let conversationId: String
+    public var state: GuardianDecisionState = .pending
+    /// True while waiting for the server to acknowledge a button click.
+    public var isSubmitting: Bool = false
+
+    public init(requestId: String, requestCode: String, questionText: String, toolName: String?, actions: [GuardianActionOption], conversationId: String, state: GuardianDecisionState = .pending) {
+        self.requestId = requestId
+        self.requestCode = requestCode
+        self.questionText = questionText
+        self.toolName = toolName
+        self.actions = actions
+        self.conversationId = conversationId
+        self.state = state
+    }
+
+    /// Build from the wire type returned by the daemon HTTP API.
+    public init(from wire: GuardianDecisionPromptWire) {
+        self.requestId = wire.requestId
+        self.requestCode = wire.requestCode
+        self.questionText = wire.questionText
+        self.toolName = wire.toolName
+        self.actions = wire.actions
+        self.conversationId = wire.conversationId
+        self.state = wire.state == "resolved" ? .stale : .pending
+    }
+}
+
 public struct ModelPickerData: Equatable {
     public init() {}
 }
@@ -1505,6 +1547,8 @@ public struct ChatMessage: Identifiable, Equatable {
         && lhs.attachments.count == rhs.attachments.count
         && lhs.inlineSurfaces.count == rhs.inlineSurfaces.count
         && lhs.confirmation?.state == rhs.confirmation?.state
+        && lhs.guardianDecision?.state == rhs.guardianDecision?.state
+        && lhs.guardianDecision?.isSubmitting == rhs.guardianDecision?.isSubmitting
         && lhs.isSubagentNotification == rhs.isSubagentNotification
         && lhs.isContentStripped == rhs.isContentStripped
         && lhs.streamingCodePreview == rhs.streamingCodePreview
@@ -1518,6 +1562,8 @@ public struct ChatMessage: Identifiable, Equatable {
     public var status: ChatMessageStatus
     /// Non-nil when this message is an inline tool confirmation request.
     public var confirmation: ToolConfirmationData?
+    /// Non-nil when this message is a guardian decision prompt.
+    public var guardianDecision: GuardianDecisionData?
     public var skillInvocation: SkillInvocationData?
     public var modelPicker: ModelPickerData?
     public var modelList: ModelListData?
@@ -1554,7 +1600,7 @@ public struct ChatMessage: Identifiable, Equatable {
         textSegments.joined()
     }
 
-    public init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, skillInvocation: SkillInvocationData? = nil, attachments: [ChatAttachment] = [], toolCalls: [ToolCallData] = [], inlineSurfaces: [InlineSurfaceData] = [], isError: Bool = false) {
+    public init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, guardianDecision: GuardianDecisionData? = nil, skillInvocation: SkillInvocationData? = nil, attachments: [ChatAttachment] = [], toolCalls: [ToolCallData] = [], inlineSurfaces: [InlineSurfaceData] = [], isError: Bool = false) {
         self.id = id
         self.role = role
         self.textSegments = text.isEmpty ? [] : [text]
@@ -1563,6 +1609,7 @@ public struct ChatMessage: Identifiable, Equatable {
         self.isStreaming = isStreaming
         self.status = status
         self.confirmation = confirmation
+        self.guardianDecision = guardianDecision
         self.skillInvocation = skillInvocation
         self.attachments = attachments
         self.toolCalls = toolCalls

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -455,6 +455,9 @@ extension ChatViewModel {
                 onSessionCreated?(info.sessionId)
                 log.info("Chat session created: \(info.sessionId)")
 
+                // Fetch pending guardian prompts for this conversation
+                refreshGuardianPrompts()
+
                 // Send the queued user message, or finalize a message-less
                 // session create by clearing the bootstrap sending state.
                 if let pending = pendingUserMessage {
@@ -688,6 +691,8 @@ extension ChatViewModel {
                 }
             }
             dispatchPendingSendDirect()
+            // Refresh guardian prompts on message completion (cheap consistency check)
+            refreshGuardianPrompts()
             // Skip follow-up suggestions for workspace refinements
             if !isSending && !wasRefinement {
                 fetchSuggestion()
@@ -1515,6 +1520,12 @@ extension ChatViewModel {
             let degraded = status.enabled && status.degraded
             isMemoryDegraded = degraded
             memoryDegradedReason = degraded ? status.reason : nil
+
+        case .guardianActionsPendingResponse(let response):
+            handleGuardianActionsPendingResponse(response)
+
+        case .guardianActionDecisionResponse(let response):
+            handleGuardianActionDecisionResponse(response)
 
         default:
             break

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -262,6 +262,10 @@ public final class ChatViewModel: ObservableObject {
 
     public let subagentDetailStore = SubagentDetailStore()
     let daemonClient: any DaemonClientProtocol
+    /// Tracks the action submitted for each guardian decision requestId so the
+    /// response handler can display the correct resolved state (the server does
+    /// not echo back the action in its acknowledgement).
+    private var pendingGuardianActions: [String: String] = [:]
     public var sessionId: String? {
         didSet {
             // If the daemon reconnected before this VM had a session ID, a deferred
@@ -2360,6 +2364,10 @@ public final class ChatViewModel: ObservableObject {
     /// Submit a guardian action decision for a given request.
     /// Marks the prompt as submitting immediately for responsive UI.
     public func submitGuardianDecision(requestId: String, action: String) {
+        // Track the submitted action so the response handler can display the
+        // correct resolved state (the server acknowledgement omits the action).
+        pendingGuardianActions[requestId] = action
+
         // Mark as submitting in the UI
         if let idx = messages.firstIndex(where: { $0.guardianDecision?.requestId == requestId }) {
             messages[idx].guardianDecision?.isSubmitting = true
@@ -2370,6 +2378,7 @@ public final class ChatViewModel: ObservableObject {
             try daemonClient.send(GuardianActionDecisionMessage(requestId: requestId, action: action, conversationId: conversationId))
         } catch {
             log.error("Failed to submit guardian decision: \(error)")
+            pendingGuardianActions.removeValue(forKey: requestId)
             // Revert submitting state on failure
             if let idx = messages.firstIndex(where: { $0.guardianDecision?.requestId == requestId }) {
                 messages[idx].guardianDecision?.isSubmitting = false
@@ -2380,7 +2389,14 @@ public final class ChatViewModel: ObservableObject {
     /// Process the server's response to a guardian actions pending request.
     /// Inserts new prompts, updates existing ones, and marks absent ones as stale.
     func handleGuardianActionsPendingResponse(_ response: GuardianActionsPendingResponseMessage) {
-        let incomingIds = Set(response.prompts.map(\.requestId))
+        // Only process prompts that belong to this conversation
+        guard let myConversationId = sessionId,
+              response.prompts.contains(where: { $0.conversationId == myConversationId }) else {
+            return
+        }
+
+        let relevantPrompts = response.prompts.filter { $0.conversationId == myConversationId }
+        let incomingIds = Set(relevantPrompts.map(\.requestId))
 
         // Mark existing guardian messages not in the response as stale
         for i in messages.indices {
@@ -2394,7 +2410,7 @@ public final class ChatViewModel: ObservableObject {
 
         let existingIds = Set(messages.compactMap { $0.guardianDecision?.requestId })
 
-        for wire in response.prompts {
+        for wire in relevantPrompts {
             if existingIds.contains(wire.requestId) {
                 // Update existing message
                 if let idx = messages.firstIndex(where: { $0.guardianDecision?.requestId == wire.requestId }) {
@@ -2423,12 +2439,15 @@ public final class ChatViewModel: ObservableObject {
     func handleGuardianActionDecisionResponse(_ response: GuardianActionDecisionResponseMessage) {
         guard let requestId = response.requestId else { return }
 
+        let submittedAction = pendingGuardianActions.removeValue(forKey: requestId)
+
         if let idx = messages.firstIndex(where: { $0.guardianDecision?.requestId == requestId }) {
             messages[idx].guardianDecision?.isSubmitting = false
             if response.applied {
-                // The decision was applied; the prompt will be removed on next refresh.
-                // Mark resolved with the action from the response.
-                messages[idx].guardianDecision?.state = .resolved(action: response.reason ?? "approved")
+                // Use the locally tracked action since the server acknowledgement
+                // does not echo back the action that was submitted.
+                let resolvedAction = submittedAction ?? response.reason ?? "approved"
+                messages[idx].guardianDecision?.state = .resolved(action: resolvedAction)
             } else {
                 // Stale: someone else already resolved this prompt.
                 messages[idx].guardianDecision?.state = .stale

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2313,6 +2313,8 @@ public final class ChatViewModel: ObservableObject {
         // Surfaces are now included directly in the history response and populated above
         // Strip heavy data from old messages after a (potentially large) history load.
         trimOldMessagesIfNeeded()
+        // Fetch pending guardian prompts when history loads (thread open/restore)
+        refreshGuardianPrompts()
     }
 
     deinit {
@@ -2338,6 +2340,103 @@ public final class ChatViewModel: ObservableObject {
     /// Delegates to ChatErrorManager so the logic lives in one place.
     static func connectionDiagnosticHint(for error: Error) -> String? {
         ChatErrorManager.connectionDiagnosticHint(for: error)
+    }
+
+    // MARK: - Guardian Decision Prompts
+
+    /// Fetch pending guardian prompts for the current conversation and insert
+    /// them into the message list. Existing guardian messages for the same
+    /// requestId are updated rather than duplicated; resolved prompts not in
+    /// the response are marked stale.
+    public func refreshGuardianPrompts() {
+        guard let conversationId = sessionId else { return }
+        do {
+            try daemonClient.send(GuardianActionsPendingRequestMessage(conversationId: conversationId))
+        } catch {
+            log.error("Failed to request pending guardian prompts: \(error)")
+        }
+    }
+
+    /// Submit a guardian action decision for a given request.
+    /// Marks the prompt as submitting immediately for responsive UI.
+    public func submitGuardianDecision(requestId: String, action: String) {
+        // Mark as submitting in the UI
+        if let idx = messages.firstIndex(where: { $0.guardianDecision?.requestId == requestId }) {
+            messages[idx].guardianDecision?.isSubmitting = true
+        }
+
+        let conversationId = sessionId
+        do {
+            try daemonClient.send(GuardianActionDecisionMessage(requestId: requestId, action: action, conversationId: conversationId))
+        } catch {
+            log.error("Failed to submit guardian decision: \(error)")
+            // Revert submitting state on failure
+            if let idx = messages.firstIndex(where: { $0.guardianDecision?.requestId == requestId }) {
+                messages[idx].guardianDecision?.isSubmitting = false
+            }
+        }
+    }
+
+    /// Process the server's response to a guardian actions pending request.
+    /// Inserts new prompts, updates existing ones, and marks absent ones as stale.
+    func handleGuardianActionsPendingResponse(_ response: GuardianActionsPendingResponseMessage) {
+        let incomingIds = Set(response.prompts.map(\.requestId))
+
+        // Mark existing guardian messages not in the response as stale
+        for i in messages.indices {
+            if let gd = messages[i].guardianDecision,
+               case .pending = gd.state,
+               !incomingIds.contains(gd.requestId) {
+                messages[i].guardianDecision?.state = .stale
+                messages[i].guardianDecision?.isSubmitting = false
+            }
+        }
+
+        let existingIds = Set(messages.compactMap { $0.guardianDecision?.requestId })
+
+        for wire in response.prompts {
+            if existingIds.contains(wire.requestId) {
+                // Update existing message
+                if let idx = messages.firstIndex(where: { $0.guardianDecision?.requestId == wire.requestId }) {
+                    let newData = GuardianDecisionData(from: wire)
+                    // Preserve submitting state if still waiting
+                    let wasSubmitting = messages[idx].guardianDecision?.isSubmitting ?? false
+                    messages[idx].guardianDecision = newData
+                    if wasSubmitting && newData.state == .pending {
+                        messages[idx].guardianDecision?.isSubmitting = true
+                    }
+                }
+            } else {
+                // Insert new guardian prompt as an assistant message
+                let data = GuardianDecisionData(from: wire)
+                let msg = ChatMessage(
+                    role: .assistant,
+                    text: "",
+                    guardianDecision: data
+                )
+                messages.append(msg)
+            }
+        }
+    }
+
+    /// Process the server's response to a guardian action decision submission.
+    func handleGuardianActionDecisionResponse(_ response: GuardianActionDecisionResponseMessage) {
+        guard let requestId = response.requestId else { return }
+
+        if let idx = messages.firstIndex(where: { $0.guardianDecision?.requestId == requestId }) {
+            messages[idx].guardianDecision?.isSubmitting = false
+            if response.applied {
+                // The decision was applied; the prompt will be removed on next refresh.
+                // Mark resolved with the action from the response.
+                messages[idx].guardianDecision?.state = .resolved(action: response.reason ?? "approved")
+            } else {
+                // Stale: someone else already resolved this prompt.
+                messages[idx].guardianDecision?.state = .stale
+            }
+        }
+
+        // Re-fetch pending prompts to get the updated list
+        refreshGuardianPrompts()
     }
 
     // MARK: - PTT metadata

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2413,6 +2413,11 @@ public final class ChatViewModel: ObservableObject {
             if existingIds.contains(wire.requestId) {
                 // Update existing message
                 if let idx = messages.firstIndex(where: { $0.guardianDecision?.requestId == wire.requestId }) {
+                    // Don't overwrite a locally-resolved state with a stale state
+                    // from the server — the local resolved state carries the action label.
+                    if case .resolved = messages[idx].guardianDecision?.state {
+                        continue
+                    }
                     let newData = GuardianDecisionData(from: wire)
                     // Preserve submitting state if still waiting
                     let wasSubmitting = messages[idx].guardianDecision?.isSubmitting ?? false

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2390,8 +2390,7 @@ public final class ChatViewModel: ObservableObject {
     /// Inserts new prompts, updates existing ones, and marks absent ones as stale.
     func handleGuardianActionsPendingResponse(_ response: GuardianActionsPendingResponseMessage) {
         // Only process prompts that belong to this conversation
-        guard let myConversationId = sessionId,
-              response.prompts.contains(where: { $0.conversationId == myConversationId }) else {
+        guard let myConversationId = sessionId else {
             return
         }
 

--- a/clients/shared/Features/Chat/GuardianDecisionBubble.swift
+++ b/clients/shared/Features/Chat/GuardianDecisionBubble.swift
@@ -1,0 +1,225 @@
+import SwiftUI
+
+/// Renders a guardian decision prompt with actionable buttons in the chat UI.
+/// Follows the same card styling pattern as `ToolConfirmationBubble`.
+public struct GuardianDecisionBubble: View {
+    public let decision: GuardianDecisionData
+    public let onAction: (String, String) -> Void
+
+    public init(decision: GuardianDecisionData, onAction: @escaping (String, String) -> Void) {
+        self.decision = decision
+        self.onAction = onAction
+    }
+
+    private var isPending: Bool {
+        if case .pending = decision.state { return true }
+        return false
+    }
+
+    public var body: some View {
+        if isPending {
+            pendingContent
+        } else {
+            collapsedContent
+        }
+    }
+
+    // MARK: - Pending (actionable)
+
+    @ViewBuilder
+    private var pendingContent: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            // Header
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: "shield.lefthalf.filled")
+                    .font(.system(size: 14))
+                    .foregroundColor(VColor.warning)
+
+                Text("Guardian Approval Required")
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.textSecondary)
+            }
+
+            // Question text
+            Text(decision.questionText)
+                .font(VFont.bodyBold)
+                .foregroundColor(VColor.textPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            // Tool name
+            if let toolName = decision.toolName, !toolName.isEmpty {
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "wrench")
+                        .font(.system(size: 10))
+                        .foregroundColor(VColor.textMuted)
+                    Text(toolName)
+                        .font(VFont.monoSmall)
+                        .foregroundColor(VColor.textSecondary)
+                }
+            }
+
+            // Request code reference
+            if !decision.requestCode.isEmpty {
+                HStack(spacing: VSpacing.xs) {
+                    Text("Ref:")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    Text(decision.requestCode)
+                        .font(VFont.monoSmall)
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
+
+            // Action buttons
+            HStack(spacing: VSpacing.xs) {
+                ForEach(decision.actions, id: \.action) { actionOption in
+                    actionButton(actionOption)
+                }
+                Spacer()
+            }
+            .opacity(decision.isSubmitting ? 0.5 : 1.0)
+            .allowsHitTesting(!decision.isSubmitting)
+
+            if decision.isSubmitting {
+                HStack(spacing: VSpacing.xs) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Submitting...")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
+        }
+        .padding(VSpacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.surface)
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(VColor.warning.opacity(0.3), lineWidth: 1)
+                )
+        )
+    }
+
+    // MARK: - Collapsed (resolved or stale)
+
+    @ViewBuilder
+    private var collapsedContent: some View {
+        HStack(spacing: VSpacing.sm) {
+            Group {
+                switch decision.state {
+                case .resolved(let action):
+                    if action == "deny" {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(VColor.error)
+                    } else {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(VColor.success)
+                    }
+                case .stale:
+                    Image(systemName: "clock.fill")
+                        .foregroundColor(VColor.textMuted)
+                case .pending:
+                    EmptyView()
+                }
+            }
+            .font(.system(size: 12))
+
+            Text(resolvedLabel)
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+
+            Spacer()
+        }
+    }
+
+    private var resolvedLabel: String {
+        switch decision.state {
+        case .resolved(let action):
+            let actionLabel = decision.actions.first(where: { $0.action == action })?.label ?? action
+            return "Guardian: \(actionLabel)"
+        case .stale:
+            return "Guardian: already resolved"
+        case .pending:
+            return ""
+        }
+    }
+
+    // MARK: - Action Button
+
+    @ViewBuilder
+    private func actionButton(_ actionOption: GuardianActionOption) -> some View {
+        let isPrimary = actionOption.action == "approve" || actionOption.action == "allow"
+        let isDanger = actionOption.action == "deny" || actionOption.action == "reject"
+
+        Button {
+            onAction(decision.requestId, actionOption.action)
+        } label: {
+            Text(actionOption.label)
+                .font(VFont.caption)
+                .foregroundColor(isPrimary ? .white : isDanger ? VColor.error : VColor.textSecondary)
+                .padding(.horizontal, VSpacing.sm)
+                .padding(.vertical, VSpacing.xxs + 1)
+                .background(isPrimary ? VColor.buttonPrimary : Color.clear)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.sm)
+                        .stroke(isPrimary ? Color.clear : isDanger ? VColor.error.opacity(0.5) : VColor.surfaceBorder, lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(actionOption.label)
+    }
+}
+
+#if DEBUG
+#Preview("GuardianDecisionBubble") {
+    VStack(spacing: VSpacing.lg) {
+        // Pending with actions
+        GuardianDecisionBubble(
+            decision: GuardianDecisionData(
+                requestId: "req-1",
+                requestCode: "GRD-A1B2",
+                questionText: "Allow running a shell command on the host?",
+                toolName: "host_bash",
+                actions: [
+                    GuardianActionOption(action: "approve", label: "Approve"),
+                    GuardianActionOption(action: "deny", label: "Deny"),
+                ],
+                conversationId: "conv-1"
+            ),
+            onAction: { _, _ in }
+        )
+
+        // Resolved (approved)
+        GuardianDecisionBubble(
+            decision: GuardianDecisionData(
+                requestId: "req-2",
+                requestCode: "GRD-C3D4",
+                questionText: "Allow writing to config file?",
+                toolName: "file_write",
+                actions: [],
+                conversationId: "conv-1",
+                state: .resolved(action: "approve")
+            ),
+            onAction: { _, _ in }
+        )
+
+        // Stale
+        GuardianDecisionBubble(
+            decision: GuardianDecisionData(
+                requestId: "req-3",
+                requestCode: "GRD-E5F6",
+                questionText: "Allow web fetch?",
+                toolName: "web_fetch",
+                actions: [],
+                conversationId: "conv-1",
+                state: .stale
+            ),
+            onAction: { _, _ in }
+        )
+    }
+    .padding(VSpacing.xl)
+    .background(VColor.background)
+}
+#endif

--- a/clients/shared/Features/Chat/GuardianDecisionBubble.swift
+++ b/clients/shared/Features/Chat/GuardianDecisionBubble.swift
@@ -109,7 +109,7 @@ public struct GuardianDecisionBubble: View {
             Group {
                 switch decision.state {
                 case .resolved(let action):
-                    if action == "deny" {
+                    if action == "deny" || action == "reject" {
                         Image(systemName: "xmark.circle.fill")
                             .foregroundColor(VColor.error)
                     } else {
@@ -149,7 +149,7 @@ public struct GuardianDecisionBubble: View {
 
     @ViewBuilder
     private func actionButton(_ actionOption: GuardianActionOption) -> some View {
-        let isPrimary = actionOption.action == "approve" || actionOption.action == "allow"
+        let isPrimary = actionOption.action.hasPrefix("approve") || actionOption.action == "allow"
         let isDanger = actionOption.action == "deny" || actionOption.action == "reject"
 
         Button {

--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -14,19 +14,23 @@ public struct MessageBubbleView: View {
     /// for the last assistant message. Pass nil when generation is in-flight.
     public let onRegenerate: (() -> Void)?
     public let onAlwaysAllow: ((String, String, String, String) -> Void)?
+    /// Called when a guardian decision action button is clicked: (requestId, action).
+    public let onGuardianAction: ((String, String) -> Void)?
 
     public init(
         message: ChatMessage,
         onConfirmationResponse: ((String, String) -> Void)?,
         onSurfaceAction: ((String, String, [String: AnyCodable]?) -> Void)?,
         onRegenerate: (() -> Void)?,
-        onAlwaysAllow: ((String, String, String, String) -> Void)? = nil
+        onAlwaysAllow: ((String, String, String, String) -> Void)? = nil,
+        onGuardianAction: ((String, String) -> Void)? = nil
     ) {
         self.message = message
         self.onConfirmationResponse = onConfirmationResponse
         self.onSurfaceAction = onSurfaceAction
         self.onRegenerate = onRegenerate
         self.onAlwaysAllow = onAlwaysAllow
+        self.onGuardianAction = onGuardianAction
     }
 
     public var body: some View {
@@ -48,6 +52,13 @@ public struct MessageBubbleView: View {
                         },
                         onAlwaysAllow: { requestId, pattern, scope, decision in
                             onAlwaysAllow?(requestId, pattern, scope, decision)
+                        }
+                    )
+                } else if let guardianDecision = message.guardianDecision {
+                    GuardianDecisionBubble(
+                        decision: guardianDecision,
+                        onAction: { requestId, action in
+                            onGuardianAction?(requestId, action)
                         }
                     )
                 } else if message.role == .assistant && hasInterleavedContent {

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -3026,9 +3026,14 @@ public struct ApprovedDevicesClearMessage: Encodable, Sendable {
 // MARK: - Guardian Action Messages
 
 /// A single action button a guardian can press.
-public struct GuardianActionOption: Decodable, Sendable {
+public struct GuardianActionOption: Decodable, Sendable, Equatable {
     public let action: String
     public let label: String
+
+    public init(action: String, label: String) {
+        self.action = action
+        self.label = label
+    }
 }
 
 /// A pending guardian decision prompt.


### PR DESCRIPTION
Add GuardianDecisionBubble SwiftUI view, extend ChatMessage model for guardian prompts, integrate pending prompt fetch/refresh in ChatViewModel, and wire action button clicks through HTTPDaemonClient. Part of #10341.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
