### PR TITLE
Increase PR review timeout from 3 to 5 min, track unreviewed on timeout

### DIFF
--- a/.claude/commands/blitz.md
+++ b/.claude/commands/blitz.md
@@ -215,7 +215,7 @@ Record the current UTC time as `last_fix_push_time` **after** posting the re-rev
 Log: `"Re-requested reviews from Codex and Devin on PR #<pr-number> (cycle <cycle-counter>/3, commit $LATEST_COMMIT)."`
 
 Wait for fresh reviews: Poll for **new** reviews posted after `last_fix_push_time`:
-- Poll every 60 seconds for up to **3 minutes**.
+- Poll every 60 seconds for up to **5 minutes**.
 - On each poll, run `.claude/check-pr-reviews <pr-number>` to get the full reviewer status (this catches Codex rate-limit responses in issue comments, which raw `pulls/<pr>/reviews` and `pulls/<pr>/comments` endpoints miss). Then check for new activity since `last_fix_push_time` using `gh api`:
   ```bash
   # Get full reviewer status including rate-limit detection from issue comments
@@ -233,7 +233,7 @@ Wait for fresh reviews: Poll for **new** reviews posted after `last_fix_push_tim
   - If aggregate status is `changes_requested`, return to Step 3 (which checks the cycle limit).
   - If aggregate status is `rate_limited`, continue polling (the rate limit response counts as activity but is not actionable yet).
   - If aggregate status is `pending`, continue polling.
-- If **3 minutes** pass with no new reviews, proceed to Step 6. Log: `"No new reviews within 3 minutes after fixes pushed. Proceeding to merge."`
+- If **5 minutes** pass with no new reviews, ensure the PR is tracked in `.private/UNREVIEWED_PRS.md` (add it if not already present), then proceed to Step 6. Log: `"No new reviews within 5 minutes after fixes pushed. Proceeding to merge (PR tracked in UNREVIEWED_PRS.md)."`
 
 #### Step 6: Merge to main
 

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -298,7 +298,7 @@ The `check-pr-reviews` script reports **cumulative** review status — it counts
    Log: `"Re-requested reviews from Codex and Devin on milestone PR #<milestone-pr-number> (cycle <cycle-counter>/3, commit $LATEST_COMMIT)."`
 
 5. **Wait for fresh reviews**: After fixes are pushed, poll for **new** reviews posted after `last_fix_push_time`:
-   - Poll every 60 seconds for up to **3 minutes**.
+   - Poll every 60 seconds for up to **5 minutes**.
    - On each poll, use `gh api` to check for reviews and inline comments posted after `last_fix_push_time`:
      ```bash
      gh api "repos/{owner}/{repo}/pulls/<milestone-pr-number>/reviews" \
@@ -310,9 +310,9 @@ The `check-pr-reviews` script reports **cumulative** review status — it counts
      - If aggregate status is `approved`, proceed to Phase 4c.5.
      - If aggregate status is `changes_requested`, return to step 2 (which checks the cycle limit).
      - If aggregate status is `pending` or `rate_limited`, continue polling.
-   - If **3 minutes** pass with no new reviews (zero new reviews/comments since `last_fix_push_time`), proceed to Phase 4c.5. Log: `"No new reviews within 3 minutes after fixes pushed. Proceeding to merge."`
+   - If **5 minutes** pass with no new reviews (zero new reviews/comments since `last_fix_push_time`), ensure the milestone PR is tracked in `.private/UNREVIEWED_PRS.md` (add it if not already present), then proceed to Phase 4c.5. Log: `"No new reviews within 5 minutes after fixes pushed. Proceeding to merge (PR tracked in UNREVIEWED_PRS.md)."`
 
-Repeat steps 1-5 until the exit condition: either `approved` aggregate status, 3-minute timeout with no new reviews after a fix push, or the cycle counter has reached 3.
+Repeat steps 1-5 until the exit condition: either `approved` aggregate status, 5-minute timeout with no new reviews after a fix push, or the cycle counter has reached 3.
 
 #### 4c.5. Merge milestone PR into feature branch
 


### PR DESCRIPTION
## Summary
- Increased the PR review polling timeout from 3 minutes to 5 minutes in both `safe-blitz.md` and `blitz.md` slash commands
- When merging after a timeout (before reviews arrive), the PR is now explicitly tracked in `.private/UNREVIEWED_PRS.md` so `/check-reviews` can later address any feedback

## Original prompt
Increase the 3-minute timeout in our slash commands that wait for PR feedback to instead be 5 min. If we end up merging after a timeout (and potentially before reviews are left), we should be sure to add to UNREVIEWED_PRS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
