### PR TITLE
M2: Channel Invite Transport Abstraction + Telegram Adapter (#10360)

### DIFF
--- a/assistant/src/__tests__/channel-invite-transport.test.ts
+++ b/assistant/src/__tests__/channel-invite-transport.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// Mock the credential metadata store so the Telegram adapter can resolve
+// the bot username without touching the filesystem.
+let mockBotUsername: string | undefined = 'test_invite_bot';
+mock.module('../tools/credentials/metadata-store.js', () => ({
+  getCredentialMetadata: (service: string, field: string) => {
+    if (service === 'telegram' && field === 'bot_token' && mockBotUsername) {
+      return { accountInfo: mockBotUsername };
+    }
+    return undefined;
+  },
+  upsertCredentialMetadata: () => {},
+  deleteCredentialMetadata: () => {},
+  listCredentialMetadata: () => [],
+}));
+
+import {
+  _resetRegistry,
+  getTransport,
+  registerTransport,
+  type ChannelInviteTransport,
+  type InviteSharePayload,
+} from '../runtime/channel-invite-transport.js';
+
+// Importing the Telegram module auto-registers the transport
+import { telegramInviteTransport } from '../runtime/channel-invite-transports/telegram.js';
+
+describe('channel-invite-transport', () => {
+  beforeEach(() => {
+    _resetRegistry();
+    mockBotUsername = 'test_invite_bot';
+    // Re-register after reset so Telegram tests work
+    registerTransport(telegramInviteTransport);
+  });
+
+  // =========================================================================
+  // Registry
+  // =========================================================================
+
+  describe('registry', () => {
+    test('returns the Telegram transport for telegram channel', () => {
+      const transport = getTransport('telegram');
+      expect(transport).toBeDefined();
+      expect(transport!.channel).toBe('telegram');
+    });
+
+    test('returns undefined for an unregistered channel', () => {
+      const transport = getTransport('sms');
+      expect(transport).toBeUndefined();
+    });
+
+    test('overwrites a previously registered transport for the same channel', () => {
+      const custom: ChannelInviteTransport = {
+        channel: 'telegram',
+        buildShareableInvite: () => ({ url: 'custom', displayText: 'custom' }),
+        extractInboundToken: () => undefined,
+      };
+      registerTransport(custom);
+      const transport = getTransport('telegram');
+      expect(transport!.buildShareableInvite({ rawToken: 'x', sourceChannel: 'telegram' }).url).toBe('custom');
+    });
+
+    test('_resetRegistry clears all transports', () => {
+      _resetRegistry();
+      expect(getTransport('telegram')).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // Telegram adapter — buildShareableInvite
+  // =========================================================================
+
+  describe('telegram buildShareableInvite', () => {
+    test('produces a valid Telegram deep link', () => {
+      const result = telegramInviteTransport.buildShareableInvite({
+        rawToken: 'abc123_test-token',
+        sourceChannel: 'telegram',
+      });
+
+      expect(result.url).toBe('https://t.me/test_invite_bot?start=iv_abc123_test-token');
+      expect(result.displayText).toContain('https://t.me/test_invite_bot?start=iv_abc123_test-token');
+    });
+
+    test('deep link is deterministic for the same token', () => {
+      const a = telegramInviteTransport.buildShareableInvite({ rawToken: 'tok1', sourceChannel: 'telegram' });
+      const b = telegramInviteTransport.buildShareableInvite({ rawToken: 'tok1', sourceChannel: 'telegram' });
+      expect(a.url).toBe(b.url);
+      expect(a.displayText).toBe(b.displayText);
+    });
+
+    test('uses the configured bot username', () => {
+      mockBotUsername = 'my_custom_bot';
+      const result = telegramInviteTransport.buildShareableInvite({
+        rawToken: 'token',
+        sourceChannel: 'telegram',
+      });
+      expect(result.url).toBe('https://t.me/my_custom_bot?start=iv_token');
+    });
+
+    test('throws when bot username is not configured', () => {
+      mockBotUsername = undefined;
+      // Also clear the env var to ensure no fallback
+      const prev = process.env.TELEGRAM_BOT_USERNAME;
+      delete process.env.TELEGRAM_BOT_USERNAME;
+      try {
+        expect(() =>
+          telegramInviteTransport.buildShareableInvite({
+            rawToken: 'token',
+            sourceChannel: 'telegram',
+          }),
+        ).toThrow('bot username is not configured');
+      } finally {
+        if (prev !== undefined) process.env.TELEGRAM_BOT_USERNAME = prev;
+      }
+    });
+
+    test('falls back to TELEGRAM_BOT_USERNAME env var', () => {
+      mockBotUsername = undefined;
+      const prev = process.env.TELEGRAM_BOT_USERNAME;
+      process.env.TELEGRAM_BOT_USERNAME = 'env_bot';
+      try {
+        const result = telegramInviteTransport.buildShareableInvite({
+          rawToken: 'token',
+          sourceChannel: 'telegram',
+        });
+        expect(result.url).toBe('https://t.me/env_bot?start=iv_token');
+      } finally {
+        if (prev !== undefined) {
+          process.env.TELEGRAM_BOT_USERNAME = prev;
+        } else {
+          delete process.env.TELEGRAM_BOT_USERNAME;
+        }
+      }
+    });
+  });
+
+  // =========================================================================
+  // Telegram adapter — extractInboundToken
+  // =========================================================================
+
+  describe('telegram extractInboundToken', () => {
+    test('extracts token from structured commandIntent', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'start', payload: 'iv_abc123' },
+        content: '/start iv_abc123',
+      });
+      expect(token).toBe('abc123');
+    });
+
+    test('extracts base64url token from commandIntent', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'start', payload: 'iv_YWJjMTIz-_test' },
+        content: '/start iv_YWJjMTIz-_test',
+      });
+      expect(token).toBe('YWJjMTIz-_test');
+    });
+
+    test('returns undefined when commandIntent has no payload', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'start' },
+        content: '/start',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('returns undefined when commandIntent payload has wrong prefix (gv_)', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'start', payload: 'gv_abc123' },
+        content: '/start gv_abc123',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('returns undefined when commandIntent payload has no prefix', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'start', payload: 'abc123' },
+        content: '/start abc123',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('returns undefined when commandIntent type is not start', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'help', payload: 'iv_abc123' },
+        content: '/help iv_abc123',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('returns undefined when commandIntent payload is iv_ with empty token', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'start', payload: 'iv_' },
+        content: '/start iv_',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('returns undefined when commandIntent payload is iv_ with whitespace-only token', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'start', payload: 'iv_   ' },
+        content: '/start iv_   ',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('extracts token from raw content fallback', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        content: '/start iv_abc123',
+      });
+      expect(token).toBe('abc123');
+    });
+
+    test('extracts token from raw content with extra whitespace', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        content: '/start   iv_token123',
+      });
+      expect(token).toBe('token123');
+    });
+
+    test('returns undefined for empty content', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        content: '',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('returns undefined for content without /start', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        content: 'hello world',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('returns undefined for /start without iv_ prefix in content', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        content: '/start gv_abc123',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('returns undefined for malformed /start with only iv_ in content', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        content: '/start iv_',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('prefers commandIntent over raw content', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'start', payload: 'iv_from_intent' },
+        content: '/start iv_from_content',
+      });
+      expect(token).toBe('from_intent');
+    });
+
+    test('returns undefined when commandIntent rejects, even if content has token', () => {
+      // commandIntent present but payload has wrong prefix
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'start', payload: 'gv_abc123' },
+        content: '/start iv_valid_token',
+      });
+      expect(token).toBeUndefined();
+    });
+  });
+});

--- a/assistant/src/runtime/channel-invite-transport.ts
+++ b/assistant/src/runtime/channel-invite-transport.ts
@@ -1,0 +1,85 @@
+/**
+ * Channel invite transport abstraction.
+ *
+ * Defines a transport interface for building shareable invite links and
+ * extracting inbound invite tokens from channel-specific payloads. Each
+ * channel (Telegram, SMS, Slack, etc.) registers an adapter that knows
+ * how to construct deep links and parse incoming tokens for that channel.
+ *
+ * The transport layer is intentionally thin: it handles URL construction
+ * and token extraction only. Redemption logic lives in
+ * `invite-redemption-service.ts`.
+ */
+
+import type { ChannelId } from '../channels/types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface InviteSharePayload {
+  /** The full URL the recipient can open to redeem the invite. */
+  url: string;
+  /** Human-readable text suitable for display alongside the link. */
+  displayText: string;
+}
+
+export interface ChannelInviteTransport {
+  /** The channel this transport handles. */
+  channel: ChannelId;
+
+  /**
+   * Build a shareable invite payload (URL + display text) from a raw token.
+   *
+   * The raw token is the base64url-encoded secret returned by
+   * `ingress-invite-store.createInvite`. The transport wraps it in a
+   * channel-specific deep link so the recipient can redeem the invite
+   * by clicking/tapping the link.
+   */
+  buildShareableInvite(params: {
+    rawToken: string;
+    sourceChannel: ChannelId;
+  }): InviteSharePayload;
+
+  /**
+   * Extract an invite token from an inbound channel message.
+   *
+   * Returns the raw token string (without the `iv_` prefix) if the
+   * message contains a valid invite token, or `undefined` otherwise.
+   */
+  extractInboundToken(params: {
+    commandIntent?: Record<string, unknown>;
+    content: string;
+    sourceMetadata?: Record<string, unknown>;
+  }): string | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+const registry = new Map<ChannelId, ChannelInviteTransport>();
+
+/**
+ * Register a channel invite transport. Overwrites any previously registered
+ * transport for the same channel.
+ */
+export function registerTransport(transport: ChannelInviteTransport): void {
+  registry.set(transport.channel, transport);
+}
+
+/**
+ * Look up the registered transport for a channel. Returns `undefined` when
+ * no transport has been registered for the given channel.
+ */
+export function getTransport(channel: ChannelId): ChannelInviteTransport | undefined {
+  return registry.get(channel);
+}
+
+/**
+ * Reset the registry. Intended for tests only.
+ * @internal
+ */
+export function _resetRegistry(): void {
+  registry.clear();
+}

--- a/assistant/src/runtime/channel-invite-transports/telegram.ts
+++ b/assistant/src/runtime/channel-invite-transports/telegram.ts
@@ -1,0 +1,105 @@
+/**
+ * Telegram channel invite transport adapter.
+ *
+ * Builds `https://t.me/<botUsername>?start=iv_<token>` deep links and
+ * extracts invite tokens from `/start iv_<token>` command payloads.
+ *
+ * The `iv_` prefix distinguishes invite tokens from `gv_` (guardian
+ * verification) tokens that use the same `/start` deep-link mechanism.
+ */
+
+import type { ChannelId } from '../../channels/types.js';
+import { getCredentialMetadata } from '../../tools/credentials/metadata-store.js';
+import {
+  registerTransport,
+  type ChannelInviteTransport,
+  type InviteSharePayload,
+} from '../channel-invite-transport.js';
+
+// ---------------------------------------------------------------------------
+// Bot username resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the Telegram bot username from credential metadata, falling back
+ * to the TELEGRAM_BOT_USERNAME environment variable. Mirrors the resolution
+ * strategy used in `guardian-outbound-actions.ts`.
+ */
+function getTelegramBotUsername(): string | undefined {
+  const meta = getCredentialMetadata('telegram', 'bot_token');
+  if (meta?.accountInfo && typeof meta.accountInfo === 'string' && meta.accountInfo.trim().length > 0) {
+    return meta.accountInfo.trim();
+  }
+  return process.env.TELEGRAM_BOT_USERNAME || undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Token prefix
+// ---------------------------------------------------------------------------
+
+const INVITE_TOKEN_PREFIX = 'iv_';
+
+// ---------------------------------------------------------------------------
+// Transport implementation
+// ---------------------------------------------------------------------------
+
+export const telegramInviteTransport: ChannelInviteTransport = {
+  channel: 'telegram' as ChannelId,
+
+  buildShareableInvite(params: {
+    rawToken: string;
+    sourceChannel: ChannelId;
+  }): InviteSharePayload {
+    const botUsername = getTelegramBotUsername();
+    if (!botUsername) {
+      throw new Error('Telegram bot username is not configured. Set up the Telegram integration first.');
+    }
+
+    const url = `https://t.me/${botUsername}?start=${INVITE_TOKEN_PREFIX}${params.rawToken}`;
+    return {
+      url,
+      displayText: `Open in Telegram: ${url}`,
+    };
+  },
+
+  extractInboundToken(params: {
+    commandIntent?: Record<string, unknown>;
+    content: string;
+    sourceMetadata?: Record<string, unknown>;
+  }): string | undefined {
+    // Primary path: structured command intent from the gateway.
+    // The gateway normalizes `/start <payload>` into
+    // `{ type: 'start', payload: '<payload>' }`.
+    if (
+      params.commandIntent &&
+      params.commandIntent.type === 'start' &&
+      typeof params.commandIntent.payload === 'string'
+    ) {
+      const payload = params.commandIntent.payload;
+      if (payload.startsWith(INVITE_TOKEN_PREFIX)) {
+        const token = payload.slice(INVITE_TOKEN_PREFIX.length);
+        // Reject empty or whitespace-only tokens
+        if (token.length > 0 && token.trim().length > 0) {
+          return token;
+        }
+      }
+      return undefined;
+    }
+
+    // Fallback: raw content parsing for `/start iv_<token>` messages.
+    // This handles cases where the gateway forwards the raw command text
+    // without a structured commandIntent.
+    const match = params.content.match(/^\/start\s+iv_(\S+)/);
+    if (match && match[1] && match[1].length > 0) {
+      return match[1];
+    }
+
+    return undefined;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Auto-register on import
+// ---------------------------------------------------------------------------
+
+registerTransport(telegramInviteTransport);


### PR DESCRIPTION
Introduce ChannelInviteTransport interface, registry, and Telegram adapter for deep link build/extraction. Part of #10357.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
