### PR TITLE
fix: add retry polling to grant consumption for voice pipeline race condition

### DIFF
--- a/assistant/src/__tests__/approval-primitive.test.ts
+++ b/assistant/src/__tests__/approval-primitive.test.ts
@@ -168,10 +168,10 @@ describe('approval-primitive / mintGrantFromDecision', () => {
 describe('approval-primitive / consumeGrantForInvocation', () => {
   beforeEach(() => clearTables());
 
-  test('consumes a request_id grant when requestId matches', () => {
+  test('consumes a request_id grant when requestId matches', async () => {
     mintGrantFromDecision(mintParams({ scopeMode: 'request_id', requestId: 'req-100' }));
 
-    const result = consumeGrantForInvocation({
+    const result = await consumeGrantForInvocation({
       requestId: 'req-100',
       toolName: 'shell',
       inputDigest: computeToolApprovalDigest('shell', { command: 'ls' }),
@@ -185,7 +185,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
     expect(result.grant.consumedByRequestId).toBe('consumer-1');
   });
 
-  test('consumes a tool_signature grant when tool+input matches', () => {
+  test('consumes a tool_signature grant when tool+input matches', async () => {
     const digest = computeToolApprovalDigest('shell', { command: 'ls' });
     mintGrantFromDecision(
       mintParams({
@@ -195,7 +195,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
       }),
     );
 
-    const result = consumeGrantForInvocation({
+    const result = await consumeGrantForInvocation({
       toolName: 'shell',
       inputDigest: digest,
       consumingRequestId: 'consumer-2',
@@ -207,7 +207,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
     expect(result.grant.status).toBe('consumed');
   });
 
-  test('falls back to tool_signature when request_id does not match', () => {
+  test('falls back to tool_signature when request_id does not match', async () => {
     const digest = computeToolApprovalDigest('shell', { command: 'ls' });
     // Mint a tool_signature grant (not request_id)
     mintGrantFromDecision(
@@ -218,7 +218,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
       }),
     );
 
-    const result = consumeGrantForInvocation({
+    const result = await consumeGrantForInvocation({
       requestId: 'nonexistent-req',
       toolName: 'shell',
       inputDigest: digest,
@@ -235,8 +235,8 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
   // Consume miss scenarios
   // ---------------------------------------------------------------------------
 
-  test('miss: no grants exist at all', () => {
-    const result = consumeGrantForInvocation({
+  test('miss: no grants exist at all', async () => {
+    const result = await consumeGrantForInvocation({
       toolName: 'shell',
       inputDigest: computeToolApprovalDigest('shell', { command: 'ls' }),
       consumingRequestId: 'consumer-miss',
@@ -248,7 +248,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
     expect(result.reason).toBe('no_match');
   });
 
-  test('miss: tool name mismatch', () => {
+  test('miss: tool name mismatch', async () => {
     const digest = computeToolApprovalDigest('shell', { command: 'ls' });
     mintGrantFromDecision(
       mintParams({
@@ -258,7 +258,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
       }),
     );
 
-    const result = consumeGrantForInvocation({
+    const result = await consumeGrantForInvocation({
       toolName: 'file_write',
       inputDigest: digest,
       consumingRequestId: 'consumer-mismatch-tool',
@@ -270,7 +270,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
     expect(result.reason).toBe('no_match');
   });
 
-  test('miss: input digest mismatch', () => {
+  test('miss: input digest mismatch', async () => {
     mintGrantFromDecision(
       mintParams({
         scopeMode: 'tool_signature',
@@ -279,7 +279,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
       }),
     );
 
-    const result = consumeGrantForInvocation({
+    const result = await consumeGrantForInvocation({
       toolName: 'shell',
       inputDigest: computeToolApprovalDigest('shell', { command: 'rm -rf /' }),
       consumingRequestId: 'consumer-mismatch-input',
@@ -291,7 +291,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
     expect(result.reason).toBe('no_match');
   });
 
-  test('miss: assistant ID mismatch', () => {
+  test('miss: assistant ID mismatch', async () => {
     mintGrantFromDecision(
       mintParams({
         scopeMode: 'request_id',
@@ -300,7 +300,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
       }),
     );
 
-    const result = consumeGrantForInvocation({
+    const result = await consumeGrantForInvocation({
       requestId: 'req-assist',
       toolName: 'shell',
       inputDigest: computeToolApprovalDigest('shell', {}),
@@ -313,7 +313,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
     expect(result.reason).toBe('no_match');
   });
 
-  test('miss: grant expired', () => {
+  test('miss: grant expired', async () => {
     const pastExpiry = new Date(Date.now() - 60_000).toISOString();
     mintGrantFromDecision(
       mintParams({
@@ -323,7 +323,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
       }),
     );
 
-    const result = consumeGrantForInvocation({
+    const result = await consumeGrantForInvocation({
       requestId: 'req-expired',
       toolName: 'shell',
       inputDigest: computeToolApprovalDigest('shell', {}),
@@ -340,12 +340,12 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
   // One-time consume semantics
   // ---------------------------------------------------------------------------
 
-  test('one-time consume: second consume of the same grant fails', () => {
+  test('one-time consume: second consume of the same grant fails', async () => {
     mintGrantFromDecision(
       mintParams({ scopeMode: 'request_id', requestId: 'req-once' }),
     );
 
-    const first = consumeGrantForInvocation({
+    const first = await consumeGrantForInvocation({
       requestId: 'req-once',
       toolName: 'shell',
       inputDigest: computeToolApprovalDigest('shell', {}),
@@ -354,7 +354,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
     });
     expect(first.ok).toBe(true);
 
-    const second = consumeGrantForInvocation({
+    const second = await consumeGrantForInvocation({
       requestId: 'req-once',
       toolName: 'shell',
       inputDigest: computeToolApprovalDigest('shell', {}),
@@ -366,7 +366,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
     expect(second.reason).toBe('no_match');
   });
 
-  test('one-time consume: tool_signature grant is consumed only once', () => {
+  test('one-time consume: tool_signature grant is consumed only once', async () => {
     const digest = computeToolApprovalDigest('shell', { command: 'deploy' });
     mintGrantFromDecision(
       mintParams({
@@ -376,7 +376,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
       }),
     );
 
-    const first = consumeGrantForInvocation({
+    const first = await consumeGrantForInvocation({
       toolName: 'shell',
       inputDigest: digest,
       consumingRequestId: 'consumer-sig-first',
@@ -384,7 +384,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
     });
     expect(first.ok).toBe(true);
 
-    const second = consumeGrantForInvocation({
+    const second = await consumeGrantForInvocation({
       toolName: 'shell',
       inputDigest: digest,
       consumingRequestId: 'consumer-sig-second',
@@ -399,7 +399,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
   // Context-scoped consume
   // ---------------------------------------------------------------------------
 
-  test('consumes tool_signature grant with matching conversation context', () => {
+  test('consumes tool_signature grant with matching conversation context', async () => {
     const digest = computeToolApprovalDigest('shell', { command: 'test' });
     mintGrantFromDecision(
       mintParams({
@@ -411,7 +411,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
       }),
     );
 
-    const result = consumeGrantForInvocation({
+    const result = await consumeGrantForInvocation({
       toolName: 'shell',
       inputDigest: digest,
       consumingRequestId: 'consumer-ctx',
@@ -423,7 +423,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
     expect(result.ok).toBe(true);
   });
 
-  test('miss: conversation context mismatch on tool_signature grant', () => {
+  test('miss: conversation context mismatch on tool_signature grant', async () => {
     const digest = computeToolApprovalDigest('shell', { command: 'test' });
     mintGrantFromDecision(
       mintParams({
@@ -434,7 +434,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
       }),
     );
 
-    const result = consumeGrantForInvocation({
+    const result = await consumeGrantForInvocation({
       toolName: 'shell',
       inputDigest: digest,
       consumingRequestId: 'consumer-ctx-mismatch',
@@ -445,5 +445,96 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.reason).toBe('no_match');
+  });
+});
+
+// ===========================================================================
+// RETRY POLLING TESTS
+// ===========================================================================
+
+describe('approval-primitive / consumeGrantForInvocation retry', () => {
+  beforeEach(() => clearTables());
+
+  test('succeeds immediately when grant already exists (no retry needed)', async () => {
+    const digest = computeToolApprovalDigest('shell', { command: 'ls' });
+    mintGrantFromDecision(
+      mintParams({
+        scopeMode: 'tool_signature',
+        toolName: 'shell',
+        inputDigest: digest,
+      }),
+    );
+
+    const start = Date.now();
+    const result = await consumeGrantForInvocation({
+      toolName: 'shell',
+      inputDigest: digest,
+      consumingRequestId: 'consumer-async-immediate',
+      assistantId: 'self',
+    });
+    const elapsed = Date.now() - start;
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.grant.status).toBe('consumed');
+    // Should return nearly instantly — well under the retry interval
+    expect(elapsed).toBeLessThan(200);
+  });
+
+  test('retries and succeeds when grant appears after a delay', async () => {
+    const digest = computeToolApprovalDigest('shell', { command: 'delayed' });
+
+    // Mint the grant after 300ms — the async consumer should retry and find it
+    setTimeout(() => {
+      mintGrantFromDecision(
+        mintParams({
+          scopeMode: 'tool_signature',
+          toolName: 'shell',
+          inputDigest: digest,
+        }),
+      );
+    }, 300);
+
+    const start = Date.now();
+    const result = await consumeGrantForInvocation(
+      {
+        toolName: 'shell',
+        inputDigest: digest,
+        consumingRequestId: 'consumer-async-delayed',
+        assistantId: 'self',
+      },
+      { maxWaitMs: 5_000, intervalMs: 100 },
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.grant.status).toBe('consumed');
+    // Should have taken at least ~300ms (the delay) but less than the max wait
+    expect(elapsed).toBeGreaterThanOrEqual(250);
+    expect(elapsed).toBeLessThan(5_000);
+  });
+
+  test('returns failure after timeout when no grant appears', async () => {
+    const digest = computeToolApprovalDigest('shell', { command: 'never-minted' });
+
+    const start = Date.now();
+    const result = await consumeGrantForInvocation(
+      {
+        toolName: 'shell',
+        inputDigest: digest,
+        consumingRequestId: 'consumer-async-timeout',
+        assistantId: 'self',
+      },
+      { maxWaitMs: 500, intervalMs: 100 },
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('no_match');
+    // Should have waited approximately the max wait time
+    expect(elapsed).toBeGreaterThanOrEqual(450);
+    expect(elapsed).toBeLessThan(1_500);
   });
 });

--- a/assistant/src/__tests__/approval-primitive.test.ts
+++ b/assistant/src/__tests__/approval-primitive.test.ts
@@ -241,7 +241,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
       inputDigest: computeToolApprovalDigest('shell', { command: 'ls' }),
       consumingRequestId: 'consumer-miss',
       assistantId: 'self',
-    });
+    }, { maxWaitMs: 0 });
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
@@ -263,7 +263,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
       inputDigest: digest,
       consumingRequestId: 'consumer-mismatch-tool',
       assistantId: 'self',
-    });
+    }, { maxWaitMs: 0 });
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
@@ -284,7 +284,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
       inputDigest: computeToolApprovalDigest('shell', { command: 'rm -rf /' }),
       consumingRequestId: 'consumer-mismatch-input',
       assistantId: 'self',
-    });
+    }, { maxWaitMs: 0 });
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
@@ -306,7 +306,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
       inputDigest: computeToolApprovalDigest('shell', {}),
       consumingRequestId: 'consumer-assist-mismatch',
       assistantId: 'assistant-B',
-    });
+    }, { maxWaitMs: 0 });
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
@@ -329,7 +329,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
       inputDigest: computeToolApprovalDigest('shell', {}),
       consumingRequestId: 'consumer-expired',
       assistantId: 'self',
-    });
+    }, { maxWaitMs: 0 });
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
@@ -360,7 +360,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
       inputDigest: computeToolApprovalDigest('shell', {}),
       consumingRequestId: 'consumer-second',
       assistantId: 'self',
-    });
+    }, { maxWaitMs: 0 });
     expect(second.ok).toBe(false);
     if (second.ok) return;
     expect(second.reason).toBe('no_match');
@@ -389,7 +389,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
       inputDigest: digest,
       consumingRequestId: 'consumer-sig-second',
       assistantId: 'self',
-    });
+    }, { maxWaitMs: 0 });
     expect(second.ok).toBe(false);
     if (second.ok) return;
     expect(second.reason).toBe('no_match');
@@ -440,7 +440,7 @@ describe('approval-primitive / consumeGrantForInvocation', () => {
       consumingRequestId: 'consumer-ctx-mismatch',
       assistantId: 'self',
       conversationId: 'conv-B',
-    });
+    }, { maxWaitMs: 0 });
 
     expect(result.ok).toBe(false);
     if (result.ok) return;

--- a/assistant/src/__tests__/tool-approval-handler.test.ts
+++ b/assistant/src/__tests__/tool-approval-handler.test.ts
@@ -124,7 +124,7 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
     events.length = 0;
   });
 
-  test('untrusted actor + matching tool_signature grant -> allow', () => {
+  test('untrusted actor + matching tool_signature grant -> allow', async () => {
     const toolName = 'bash';
     const input = { command: 'ls -la' };
     const digest = computeToolApprovalDigest(toolName, input);
@@ -140,7 +140,7 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
     expect(mintResult.ok).toBe(true);
 
     const context = makeContext({ guardianActorRole: 'non-guardian' });
-    const result = handler.checkPreExecutionGates(
+    const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
 
@@ -150,12 +150,12 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
     expect(deniedEvents.length).toBe(0);
   });
 
-  test('untrusted actor + no matching grant -> deny with guardian_approval_required', () => {
+  test('untrusted actor + no matching grant -> deny with guardian_approval_required', async () => {
     const toolName = 'bash';
     const input = { command: 'rm -rf /' };
 
     const context = makeContext({ guardianActorRole: 'non-guardian' });
-    const result = handler.checkPreExecutionGates(
+    const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
 
@@ -169,7 +169,7 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
     expect(deniedEvents.length).toBe(1);
   });
 
-  test('unverified_channel actor + matching grant -> allow', () => {
+  test('unverified_channel actor + matching grant -> allow', async () => {
     const toolName = 'bash';
     const input = { command: 'echo hello' };
     const digest = computeToolApprovalDigest(toolName, input);
@@ -183,19 +183,19 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
     );
 
     const context = makeContext({ guardianActorRole: 'unverified_channel' });
-    const result = handler.checkPreExecutionGates(
+    const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
 
     expect(result.allowed).toBe(true);
   });
 
-  test('unverified_channel actor + no grant -> deny', () => {
+  test('unverified_channel actor + no grant -> deny', async () => {
     const toolName = 'bash';
     const input = { command: 'deploy' };
 
     const context = makeContext({ guardianActorRole: 'unverified_channel' });
-    const result = handler.checkPreExecutionGates(
+    const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
 
@@ -204,7 +204,7 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
     expect(result.result.content).toContain('verified channel identity');
   });
 
-  test('grant is one-time: second invocation with same input denied', () => {
+  test('grant is one-time: second invocation with same input denied', async () => {
     const toolName = 'bash';
     const input = { command: 'ls' };
     const digest = computeToolApprovalDigest(toolName, input);
@@ -220,19 +220,19 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
     const context = makeContext({ guardianActorRole: 'non-guardian' });
 
     // First invocation — should consume the grant and allow
-    const first = handler.checkPreExecutionGates(
+    const first = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
     expect(first.allowed).toBe(true);
 
     // Second invocation — grant already consumed, should deny
-    const second = handler.checkPreExecutionGates(
+    const second = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
     expect(second.allowed).toBe(false);
   });
 
-  test('grant with mismatched input digest -> deny', () => {
+  test('grant with mismatched input digest -> deny', async () => {
     const toolName = 'bash';
     const grantInput = { command: 'ls' };
     const invokeInput = { command: 'rm -rf /' };
@@ -247,14 +247,14 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
     );
 
     const context = makeContext({ guardianActorRole: 'non-guardian' });
-    const result = handler.checkPreExecutionGates(
+    const result = await handler.checkPreExecutionGates(
       toolName, invokeInput, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
 
     expect(result.allowed).toBe(false);
   });
 
-  test('expired grant -> deny', () => {
+  test('expired grant -> deny', async () => {
     const toolName = 'bash';
     const input = { command: 'ls' };
     const digest = computeToolApprovalDigest(toolName, input);
@@ -270,20 +270,20 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
     );
 
     const context = makeContext({ guardianActorRole: 'non-guardian' });
-    const result = handler.checkPreExecutionGates(
+    const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
 
     expect(result.allowed).toBe(false);
   });
 
-  test('guardian actor bypasses grant check entirely (no grant needed)', () => {
+  test('guardian actor bypasses grant check entirely (no grant needed)', async () => {
     const toolName = 'bash';
     const input = { command: 'deploy' };
 
     // No grants minted at all
     const context = makeContext({ guardianActorRole: 'guardian' });
-    const result = handler.checkPreExecutionGates(
+    const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
 
@@ -291,19 +291,19 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
     expect(result.allowed).toBe(true);
   });
 
-  test('undefined actor role (desktop/trusted) bypasses grant check', () => {
+  test('undefined actor role (desktop/trusted) bypasses grant check', async () => {
     const toolName = 'bash';
     const input = { command: 'deploy' };
 
     const context = makeContext({ guardianActorRole: undefined });
-    const result = handler.checkPreExecutionGates(
+    const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
 
     expect(result.allowed).toBe(true);
   });
 
-  test('grant with matching request_id scope -> allow', () => {
+  test('grant with matching request_id scope -> allow', async () => {
     const toolName = 'bash';
     const input = { command: 'ls' };
 
@@ -315,14 +315,14 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
     );
 
     const context = makeContext({ guardianActorRole: 'non-guardian', requestId: 'req-1' });
-    const result = handler.checkPreExecutionGates(
+    const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
 
     expect(result.allowed).toBe(true);
   });
 
-  test('grant with context fields (conversationId) must match', () => {
+  test('grant with context fields (conversationId) must match', async () => {
     const toolName = 'bash';
     const input = { command: 'ls' };
     const digest = computeToolApprovalDigest(toolName, input);
@@ -341,7 +341,7 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
       guardianActorRole: 'non-guardian',
       conversationId: 'conv-1',
     });
-    const result = handler.checkPreExecutionGates(
+    const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
 

--- a/assistant/src/approvals/approval-primitive.ts
+++ b/assistant/src/approvals/approval-primitive.ts
@@ -167,7 +167,7 @@ export interface ConsumeByToolSignatureParams {
 
 export type ConsumeGrantResult =
   | { ok: true; grant: ScopedApprovalGrant }
-  | { ok: false; reason: 'no_match' | 'scope_mismatch' | 'expired' | 'already_consumed' };
+  | { ok: false; reason: 'no_match' | 'scope_mismatch' | 'expired' | 'already_consumed' | 'aborted' };
 
 export interface ConsumeGrantParams {
   requestId?: string;
@@ -339,14 +339,16 @@ export async function consumeGrantForInvocation(
   while (Date.now() < deadline) {
     // Exit promptly on cancellation (e.g. voice barge-in) so the session
     // can tear down the current turn without waiting for the full timeout.
+    // Returns 'aborted' (not 'no_match') so callers can distinguish
+    // cancellation from a genuine grant miss.
     if (signal?.aborted) {
-      return first;
+      return { ok: false, reason: 'aborted' };
     }
 
     await new Promise((resolve) => setTimeout(resolve, interval));
 
     if (signal?.aborted) {
-      return first;
+      return { ok: false, reason: 'aborted' };
     }
 
     const result = consumeGrantSync(params);

--- a/assistant/src/approvals/approval-primitive.ts
+++ b/assistant/src/approvals/approval-primitive.ts
@@ -313,7 +313,13 @@ export async function consumeGrantForInvocation(
     return first;
   }
 
+  // When maxWaitMs is 0, skip retry entirely — used by non-voice channels
+  // where grant-minting race conditions don't apply.
   const maxWait = options?.maxWaitMs ?? GRANT_RETRY_MAX_WAIT_MS;
+  if (maxWait <= 0) {
+    return first;
+  }
+
   const interval = options?.intervalMs ?? GRANT_RETRY_INTERVAL_MS;
   const deadline = Date.now() + maxWait;
 

--- a/assistant/src/approvals/approval-primitive.ts
+++ b/assistant/src/approvals/approval-primitive.ts
@@ -169,18 +169,7 @@ export type ConsumeGrantResult =
   | { ok: true; grant: ScopedApprovalGrant }
   | { ok: false; reason: 'no_match' | 'scope_mismatch' | 'expired' | 'already_consumed' };
 
-/**
- * Consume a scoped approval grant for a tool invocation.
- *
- * Tries `request_id` mode first when a requestId is provided, then falls
- * back to `tool_signature` mode.  This mirrors the priority ordering at
- * the consume site: an exact request-bound grant takes precedence over a
- * tool-signature grant.
- *
- * Returns a discriminated result with structured miss reasons for
- * diagnostics.
- */
-export function consumeGrantForInvocation(params: {
+export interface ConsumeGrantParams {
   requestId?: string;
   toolName: string;
   inputDigest: string;
@@ -191,7 +180,20 @@ export function consumeGrantForInvocation(params: {
   callSessionId?: string;
   requesterExternalUserId?: string;
   now?: string;
-}): ConsumeGrantResult {
+}
+
+/**
+ * Single synchronous attempt to consume a scoped approval grant.
+ *
+ * Tries `request_id` mode first when a requestId is provided, then falls
+ * back to `tool_signature` mode.  This mirrors the priority ordering at
+ * the consume site: an exact request-bound grant takes precedence over a
+ * tool-signature grant.
+ *
+ * This is an internal helper — callers should use {@link consumeGrantForInvocation}
+ * which adds retry polling to handle the voice pipeline race condition.
+ */
+function consumeGrantSync(params: ConsumeGrantParams): ConsumeGrantResult {
   // Try request_id mode first when a requestId is provided
   if (params.requestId) {
     const reqResult: ConsumeByRequestIdResult = consumeScopedApprovalGrantByRequestId(
@@ -274,6 +276,85 @@ export function consumeGrantForInvocation(params: {
       executionChannel: params.executionChannel ?? null,
     },
     'No tool_signature grant match found',
+  );
+
+  return { ok: false, reason: 'no_match' };
+}
+
+// ---------------------------------------------------------------------------
+// Public consume API (with retry for voice pipeline race condition)
+// ---------------------------------------------------------------------------
+
+/** Default polling interval for grant retry (ms). */
+const GRANT_RETRY_INTERVAL_MS = 250;
+/** Default maximum wait time for grant retry (ms). */
+const GRANT_RETRY_MAX_WAIT_MS = 10_000;
+
+/**
+ * Consume a scoped approval grant for a tool invocation.
+ *
+ * Performs a synchronous lookup first and returns immediately when a
+ * matching grant exists.  When the first attempt misses, retries with
+ * polling to handle the voice pipeline race condition where the grant
+ * may still be in-flight: `answerCall()` triggers the voice turn as
+ * fire-and-forget, and the voice LLM can attempt tool execution before
+ * `tryMintGuardianActionGrant`'s LLM fallback finishes minting the
+ * grant.  Polling bridges this timing gap without changing the
+ * fire-and-forget architecture.
+ */
+export async function consumeGrantForInvocation(
+  params: ConsumeGrantParams,
+  options?: { maxWaitMs?: number; intervalMs?: number },
+): Promise<ConsumeGrantResult> {
+  // Fast path: try once synchronously — covers the common case where the
+  // grant already exists (deterministic classifier, or prior turns).
+  const first = consumeGrantSync(params);
+  if (first.ok) {
+    return first;
+  }
+
+  const maxWait = options?.maxWaitMs ?? GRANT_RETRY_MAX_WAIT_MS;
+  const interval = options?.intervalMs ?? GRANT_RETRY_INTERVAL_MS;
+  const deadline = Date.now() + maxWait;
+
+  log.info(
+    {
+      event: 'approval_primitive_consume_retry_start',
+      toolName: params.toolName,
+      consumingRequestId: params.consumingRequestId,
+      maxWaitMs: maxWait,
+      intervalMs: interval,
+    },
+    'Grant not found on first attempt; starting retry polling',
+  );
+
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, interval));
+
+    const result = consumeGrantSync(params);
+    if (result.ok) {
+      log.info(
+        {
+          event: 'approval_primitive_consume_retry_hit',
+          toolName: params.toolName,
+          consumingRequestId: params.consumingRequestId,
+          grantId: result.grant.id,
+          elapsedMs: maxWait - (deadline - Date.now()),
+        },
+        'Grant found after retry polling',
+      );
+      return result;
+    }
+  }
+
+  log.info(
+    {
+      event: 'approval_primitive_consume_retry_timeout',
+      toolName: params.toolName,
+      consumingRequestId: params.consumingRequestId,
+      maxWaitMs: maxWait,
+    },
+    'Grant retry polling timed out — no matching grant found',
   );
 
   return { ok: false, reason: 'no_match' };

--- a/assistant/src/approvals/approval-primitive.ts
+++ b/assistant/src/approvals/approval-primitive.ts
@@ -304,7 +304,7 @@ const GRANT_RETRY_MAX_WAIT_MS = 10_000;
  */
 export async function consumeGrantForInvocation(
   params: ConsumeGrantParams,
-  options?: { maxWaitMs?: number; intervalMs?: number },
+  options?: { maxWaitMs?: number; intervalMs?: number; signal?: AbortSignal },
 ): Promise<ConsumeGrantResult> {
   // Fast path: try once synchronously — covers the common case where the
   // grant already exists (deterministic classifier, or prior turns).
@@ -334,8 +334,20 @@ export async function consumeGrantForInvocation(
     'Grant not found on first attempt; starting retry polling',
   );
 
+  const signal = options?.signal;
+
   while (Date.now() < deadline) {
+    // Exit promptly on cancellation (e.g. voice barge-in) so the session
+    // can tear down the current turn without waiting for the full timeout.
+    if (signal?.aborted) {
+      return first;
+    }
+
     await new Promise((resolve) => setTimeout(resolve, interval));
+
+    if (signal?.aborted) {
+      return first;
+    }
 
     const result = consumeGrantSync(params);
     if (result.ok) {

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -346,7 +346,7 @@ export async function startVoiceTurn(opts: VoiceTurnOptions): Promise<VoiceTurnH
   const autoDeny = !isGuardian;
   const autoAllow = isGuardian;
   let lastError: string | null = null;
-  session.updateClient((msg: ServerMessage) => {
+  session.updateClient(async (msg: ServerMessage) => {
     if (msg.type === 'confirmation_request') {
       if (autoDeny) {
         // Non-guardian voice callers have no interactive approval UI.
@@ -357,7 +357,7 @@ export async function startVoiceTurn(opts: VoiceTurnOptions): Promise<VoiceTurnH
         // that bypass the pre-exec gate. We must check for a matching
         // scoped grant here so those cases are not incorrectly denied.
         const inputDigest = computeToolApprovalDigest(msg.toolName, msg.input);
-        const consumeResult = consumeGrantForInvocation({
+        const consumeResult = await consumeGrantForInvocation({
           requestId: msg.requestId,
           toolName: msg.toolName,
           inputDigest,

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -351,38 +351,46 @@ export async function startVoiceTurn(opts: VoiceTurnOptions): Promise<VoiceTurnH
       if (autoDeny) {
         // Non-guardian voice callers have no interactive approval UI.
         // The pre-exec gate (tool-approval-handler.ts) handles grant
-        // consumption for tool execution confirmations, but some
-        // confirmation_request events originate from proxy/network
+        // consumption with retry for tool execution confirmations, but
+        // some confirmation_request events originate from proxy/network
         // paths (e.g. PermissionPrompter in createProxyApprovalCallback)
-        // that bypass the pre-exec gate. We must check for a matching
-        // scoped grant here so those cases are not incorrectly denied.
-        const inputDigest = computeToolApprovalDigest(msg.toolName, msg.input);
-        const consumeResult = await consumeGrantForInvocation({
-          requestId: msg.requestId,
-          toolName: msg.toolName,
-          inputDigest,
-          consumingRequestId: msg.requestId,
-          assistantId: opts.assistantId ?? 'self',
-          executionChannel: 'voice',
-          conversationId: opts.conversationId,
-          callSessionId: opts.callSessionId,
-          requesterExternalUserId: opts.guardianContext?.requesterExternalUserId,
-        });
+        // that bypass the pre-exec gate. We do a single sync lookup here
+        // (maxWaitMs: 0) since the primary retry path is in the pre-exec
+        // gate; this secondary path just needs a quick check.
+        try {
+          const inputDigest = computeToolApprovalDigest(msg.toolName, msg.input);
+          const consumeResult = await consumeGrantForInvocation({
+            requestId: msg.requestId,
+            toolName: msg.toolName,
+            inputDigest,
+            consumingRequestId: msg.requestId,
+            assistantId: opts.assistantId ?? 'self',
+            executionChannel: 'voice',
+            conversationId: opts.conversationId,
+            callSessionId: opts.callSessionId,
+            requesterExternalUserId: opts.guardianContext?.requesterExternalUserId,
+          }, { maxWaitMs: 0 });
 
-        if (consumeResult.ok) {
-          log.info(
-            { turnId, toolName: msg.toolName, grantId: consumeResult.grant.id },
-            'Consumed scoped grant — allowing non-guardian voice confirmation',
+          if (consumeResult.ok) {
+            log.info(
+              { turnId, toolName: msg.toolName, grantId: consumeResult.grant.id },
+              'Consumed scoped grant — allowing non-guardian voice confirmation',
+            );
+            session.handleConfirmationResponse(
+              msg.requestId,
+              'allow',
+              undefined,
+              undefined,
+              `Permission approved for "${msg.toolName}": guardian pre-approved via scoped grant.`,
+            );
+            publishToHub(msg);
+            return;
+          }
+        } catch (err) {
+          log.error(
+            { err, turnId, toolName: msg.toolName },
+            'Error consuming grant in voice confirmation handler — falling through to deny',
           );
-          session.handleConfirmationResponse(
-            msg.requestId,
-            'allow',
-            undefined,
-            undefined,
-            `Permission approved for "${msg.toolName}": guardian pre-approved via scoped grant.`,
-          );
-          publishToHub(msg);
-          return;
         }
 
         log.info(

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -58,7 +58,7 @@ export class ToolExecutor {
 
     // Run pre-execution approval gates (abort, parental controls, guardian
     // policy, allowed-tool-set, task-run preflight, tool registry lookup).
-    const gateResult = this.approvalHandler.checkPreExecutionGates(
+    const gateResult = await this.approvalHandler.checkPreExecutionGates(
       name, input, context, executionTarget, riskLevel, startTime,
       (event) => emitLifecycleEvent(context, event),
     );

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -50,7 +50,7 @@ export class ToolApprovalHandler {
    * Returns the resolved Tool if all gates pass, or an early-return
    * ToolExecutionResult if any gate blocks execution.
    */
-  checkPreExecutionGates(
+  async checkPreExecutionGates(
     name: string,
     input: Record<string, unknown>,
     context: ToolContext,
@@ -58,7 +58,7 @@ export class ToolApprovalHandler {
     riskLevel: string,
     startTime: number,
     emitLifecycleEvent: (event: ToolLifecycleEvent) => void,
-  ): PreExecutionGateResult {
+  ): Promise<PreExecutionGateResult> {
     // Bail out immediately if the session was aborted before this tool started.
     if (context.signal?.aborted) {
       const durationMs = Date.now() - startTime;
@@ -247,7 +247,7 @@ export class ToolApprovalHandler {
     // rejection (allowedToolNames, task-run preflight, registry lookup)
     // does not waste the one-time-use grant.
     if (needsGrantConsumption && deferredConsumeParams) {
-      const grantResult = consumeGrantForInvocation(deferredConsumeParams);
+      const grantResult = await consumeGrantForInvocation(deferredConsumeParams);
 
       if (grantResult.ok) {
         log.info({

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -246,8 +246,17 @@ export class ToolApprovalHandler {
     // required. Deferring consumption to this point ensures a downstream
     // rejection (allowedToolNames, task-run preflight, registry lookup)
     // does not waste the one-time-use grant.
+    //
+    // Retry polling is scoped to the voice channel where a race condition
+    // exists between fire-and-forget turn execution and LLM fallback grant
+    // minting (2-5s). Non-voice channels get an instant sync lookup so
+    // normal denials are not delayed.
     if (needsGrantConsumption && deferredConsumeParams) {
-      const grantResult = await consumeGrantForInvocation(deferredConsumeParams);
+      const isVoice = context.executionChannel === 'voice';
+      const grantResult = await consumeGrantForInvocation(
+        deferredConsumeParams,
+        isVoice ? undefined : { maxWaitMs: 0 },
+      );
 
       if (grantResult.ok) {
         log.info({

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -271,6 +271,31 @@ export class ToolApprovalHandler {
         return { allowed: true, tool, grantConsumed: true };
       }
 
+      // Treat abort as a cancellation — not a grant denial. This matches
+      // the abort check at the top of checkPreExecutionGates so the caller
+      // sees a consistent "Cancelled" result instead of a spurious
+      // guardian_approval_required denial during voice barge-in.
+      if (grantResult.reason === 'aborted') {
+        const durationMs = Date.now() - startTime;
+        emitLifecycleEvent({
+          type: 'error',
+          toolName: name,
+          executionTarget,
+          input,
+          workingDir: context.workingDir,
+          sessionId: context.sessionId,
+          conversationId: context.conversationId,
+          requestId: context.requestId,
+          riskLevel,
+          decision: 'error',
+          durationMs,
+          errorMessage: 'Cancelled',
+          isExpected: true,
+          errorCategory: 'tool_failure',
+        });
+        return { allowed: false, result: { content: 'Cancelled', isError: true } };
+      }
+
       // No matching grant or race condition — deny.
       const reason = guardianApprovalDeniedMessage(context.guardianActorRole, name);
       log.warn({

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -255,7 +255,7 @@ export class ToolApprovalHandler {
       const isVoice = context.executionChannel === 'voice';
       const grantResult = await consumeGrantForInvocation(
         deferredConsumeParams,
-        isVoice ? undefined : { maxWaitMs: 0 },
+        isVoice ? { signal: context.signal } : { maxWaitMs: 0 },
       );
 
       if (grantResult.ok) {


### PR DESCRIPTION
## Summary
- Adds retry polling to `consumeGrantForInvocation` to bridge the timing gap between fire-and-forget voice turn execution and LLM fallback grant minting
- Unified the consume API: single async `consumeGrantForInvocation` with built-in retry (250ms interval, 10s max wait), fast-path returns immediately when grant exists
- Made voice-session-bridge `updateClient` callback async so both consumption sites use the same retry-enabled API

## Original prompt
Fix the grant-minting race condition in the voice pipeline where the LLM fallback classifier in tryMintGuardianActionGrant can take 2-5 seconds, but the voice turn (kicked off as fire-and-forget by flushPendingInstructions in call-controller.ts:990) races ahead and tries to consume the grant before it's minted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
