### PR TITLE
M3: Migrate macOS Flags to Registry + UI

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -908,7 +908,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
         guard let assistant, assistant.isRemote, let runtimeUrl = assistant.runtimeUrl else {
             // Local assistant or no assistant.
-            if MacOSClientFeatureFlagManager.shared.isEnabled(.localHttpEnabled) {
+            if MacOSClientFeatureFlagManager.shared.isEnabled("local_http_enabled") {
                 // Use HTTP transport for the local daemon instead of IPC.
                 // Bearer token is nil; resolved lazily at connect time.
                 let portString = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "7821"

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -39,7 +39,7 @@ struct APIKeyStepView: View {
     @FocusState private var keyFieldFocused: Bool
 
     private var userHostedEnabled: Bool {
-        MacOSClientFeatureFlagManager.shared.isEnabled(.userHostedEnabled)
+        MacOSClientFeatureFlagManager.shared.isEnabled("user_hosted_enabled")
     }
 
     var body: some View {
@@ -337,6 +337,6 @@ struct APIKeyStepView: View {
     }
     .frame(width: 460, height: 620)
     .onAppear {
-        MacOSClientFeatureFlagManager.shared.setOverride(.userHostedEnabled, enabled: true)
+        MacOSClientFeatureFlagManager.shared.setOverride("user_hosted_enabled", enabled: true)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
@@ -6,7 +6,7 @@ struct ModelSelectionStepView: View {
     @Bindable var state: OnboardingState
 
     private var userHostedEnabled: Bool {
-        MacOSClientFeatureFlagManager.shared.isEnabled(.userHostedEnabled)
+        MacOSClientFeatureFlagManager.shared.isEnabled("user_hosted_enabled")
     }
 
     @State private var showTitle = false

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -75,7 +75,7 @@ final class OnboardingState {
     }
 
     var userHostedEnabled: Bool {
-        MacOSClientFeatureFlagManager.shared.isEnabled(.userHostedEnabled)
+        MacOSClientFeatureFlagManager.shared.isEnabled("user_hosted_enabled")
     }
 
     /// Continuous crack progress (0.0–1.0) derived from step and permission state.
@@ -138,7 +138,7 @@ final class OnboardingState {
         // from reopening legacy permission-request steps.
         // When userHostedEnabled is on and a cloud provider is selected, the flow
         // has 3 steps (0–2); otherwise it stays at 2 steps (0–1).
-        let hasCloudStep = MacOSClientFeatureFlagManager.shared.isEnabled(.userHostedEnabled) && cloudProvider != "local"
+        let hasCloudStep = MacOSClientFeatureFlagManager.shared.isEnabled("user_hosted_enabled") && cloudProvider != "local"
         let maxStep = onboardingVariant == .firstMeeting ? 4 : (hasCloudStep ? 2 : 1)
         if currentStep > maxStep {
             currentStep = maxStep

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
@@ -8,7 +8,7 @@ struct SettingsAdvancedDevTab: View {
     @ObservedObject var store: SettingsStore
     var daemonClient: DaemonClient?
 
-    @State private var macOSFlagStates: [(flag: MacOSClientFeatureFlag, enabled: Bool)] = []
+    @State private var macOSFlagStates: [MacOSFeatureFlagState] = []
     @State private var assistantFlags: [DaemonClient.AssistantFeatureFlag] = []
     @State private var assistantFlagsError: String?
     @State private var isLoadingAssistantFlags = false
@@ -34,9 +34,7 @@ struct SettingsAdvancedDevTab: View {
             developerSection
         }
         .onAppear {
-            macOSFlagStates = MacOSClientFeatureFlag.allCases.map { flag in
-                (flag: flag, enabled: MacOSClientFeatureFlagManager.shared.isEnabled(flag))
-            }
+            macOSFlagStates = MacOSClientFeatureFlagManager.shared.allFlagStates()
             if testerModel == nil, let dc = daemonClient {
                 testerModel = ToolPermissionTesterModel(daemonClient: dc)
             }
@@ -164,17 +162,31 @@ struct SettingsAdvancedDevTab: View {
                 .font(VFont.caption)
                 .foregroundColor(VColor.textMuted)
 
-            ForEach(Array(macOSFlagStates.enumerated()), id: \.element.flag) { index, entry in
-                Toggle(entry.flag.displayName, isOn: Binding(
-                    get: { macOSFlagStates[index].enabled },
-                    set: { newValue in
-                        macOSFlagStates[index].enabled = newValue
-                        MacOSClientFeatureFlagManager.shared.setOverride(entry.flag, enabled: newValue)
+            if macOSFlagStates.isEmpty {
+                Text("No macOS feature flags available.")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textMuted)
+            } else {
+                ForEach(Array(macOSFlagStates.enumerated()), id: \.element.id) { index, entry in
+                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                        Toggle(entry.label, isOn: Binding(
+                            get: { macOSFlagStates[index].enabled },
+                            set: { newValue in
+                                macOSFlagStates[index].enabled = newValue
+                                MacOSClientFeatureFlagManager.shared.setOverride(entry.key, enabled: newValue)
+                            }
+                        ))
+                        .toggleStyle(.switch)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+
+                        if !entry.description.isEmpty {
+                            Text(entry.description)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
                     }
-                ))
-                .toggleStyle(.switch)
-                .font(VFont.body)
-                .foregroundColor(VColor.textSecondary)
+                }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/clients/shared/Utilities/MacOSClientFeatureFlagManager.swift
+++ b/clients/shared/Utilities/MacOSClientFeatureFlagManager.swift
@@ -1,24 +1,27 @@
 import Foundation
+import os
 
 private let flagPrefix = "VELLUM_FLAG_"
+private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "FeatureFlags")
 
-public enum MacOSClientFeatureFlag: String, CaseIterable {
-    case userHostedEnabled = "user_hosted_enabled"
-    case localHttpEnabled = "local_http_enabled"
-
-    public var displayName: String {
-        switch self {
-        case .userHostedEnabled: return "User Hosted Enabled"
-        case .localHttpEnabled: return "Local HTTP Enabled"
-        }
-    }
+/// Represents the resolved state of a single macOS feature flag for UI display.
+public struct MacOSFeatureFlagState: Identifiable {
+    public let id: String
+    public let key: String
+    public let label: String
+    public let description: String
+    public let defaultEnabled: Bool
+    public var enabled: Bool
 }
 
 public final class MacOSClientFeatureFlagManager: @unchecked Sendable {
     public static let shared = MacOSClientFeatureFlagManager()
 
     private let lock = NSLock()
-    private var flags: [String: Bool]
+    /// Overrides from env vars, .env file, and UserDefaults. Keyed by normalized flag name.
+    private var overrides: [String: Bool]
+    /// Flag definitions loaded from the unified registry.
+    private var flagDefinitions: [FeatureFlagDefinition]
 
     init(environment: [String: String]? = nil) {
         let env = environment ?? ProcessInfo.processInfo.environment
@@ -28,43 +31,70 @@ public final class MacOSClientFeatureFlagManager: @unchecked Sendable {
             guard !name.isEmpty else { continue }
             loaded[name] = Self.parseBool(value)
         }
-        self.flags = loaded
+        self.overrides = loaded
+        self.flagDefinitions = []
+        loadRegistry()
     }
 
-    public func isEnabled(_ flag: String) -> Bool {
+    /// Load macOS-scope flag definitions from the bundled registry.
+    private func loadRegistry() {
+        if let registry = loadFeatureFlagRegistry() {
+            flagDefinitions = registry.macosScopeFlags()
+        } else {
+            log.warning("Failed to load feature flag registry from bundle — falling back to empty definitions")
+            flagDefinitions = []
+        }
+    }
+
+    /// Check whether a flag is enabled by its key (e.g. "user_hosted_enabled").
+    /// Resolution order: override (env var / .env file / UserDefaults) -> registry defaultEnabled -> false.
+    public func isEnabled(_ key: String) -> Bool {
         lock.lock()
         defer { lock.unlock() }
-        return flags[Self.normalize(flag)] ?? false
+        if let override = overrides[Self.normalize(key)] {
+            return override
+        }
+        // Fall back to registry default
+        if let def = flagDefinitions.first(where: { Self.normalize($0.key) == Self.normalize(key) }) {
+            return def.defaultEnabled
+        }
+        return false
     }
 
-    public func isEnabled(_ flag: MacOSClientFeatureFlag) -> Bool {
-        isEnabled(flag.rawValue)
-    }
-
+    /// Return all overrides (for backward compatibility with tests).
     public func allFlags() -> [String: Bool] {
         lock.lock()
         defer { lock.unlock() }
-        return flags
+        return overrides
     }
 
-    public func setOverride(_ flag: String, enabled: Bool) {
+    /// Return the resolved state of all macOS-scope flag definitions for UI display.
+    public func allFlagStates() -> [MacOSFeatureFlagState] {
         lock.lock()
         defer { lock.unlock() }
-        flags[Self.normalize(flag)] = enabled
+        return flagDefinitions.map { def in
+            let enabled = overrides[Self.normalize(def.key)] ?? def.defaultEnabled
+            return MacOSFeatureFlagState(
+                id: def.id,
+                key: def.key,
+                label: def.label,
+                description: def.description,
+                defaultEnabled: def.defaultEnabled,
+                enabled: enabled
+            )
+        }
     }
 
-    public func setOverride(_ flag: MacOSClientFeatureFlag, enabled: Bool) {
-        setOverride(flag.rawValue, enabled: enabled)
-    }
-
-    public func removeOverride(_ flag: String) {
+    public func setOverride(_ key: String, enabled: Bool) {
         lock.lock()
         defer { lock.unlock() }
-        flags.removeValue(forKey: Self.normalize(flag))
+        overrides[Self.normalize(key)] = enabled
     }
 
-    public func removeOverride(_ flag: MacOSClientFeatureFlag) {
-        removeOverride(flag.rawValue)
+    public func removeOverride(_ key: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        overrides.removeValue(forKey: Self.normalize(key))
     }
 
     /// Load VELLUM_FLAG_* entries from a `.env` file and apply them as overrides.
@@ -82,7 +112,7 @@ public final class MacOSClientFeatureFlagManager: @unchecked Sendable {
             let name = String(key.dropFirst(flagPrefix.count)).lowercased().replacingOccurrences(of: "_", with: "")
             guard !name.isEmpty else { continue }
             let value = String(parts[1]).trimmingCharacters(in: .whitespaces)
-            flags[name] = Self.parseBool(value)
+            overrides[name] = Self.parseBool(value)
         }
     }
 

--- a/clients/shared/Utilities/MacOSClientFeatureFlagManager.swift
+++ b/clients/shared/Utilities/MacOSClientFeatureFlagManager.swift
@@ -2,6 +2,7 @@ import Foundation
 import os
 
 private let flagPrefix = "VELLUM_FLAG_"
+private let userDefaultsPrefix = "MacOSFeatureFlag."
 private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "FeatureFlags")
 
 /// Represents the resolved state of a single macOS feature flag for UI display.
@@ -26,6 +27,16 @@ public final class MacOSClientFeatureFlagManager: @unchecked Sendable {
     init(environment: [String: String]? = nil) {
         let env = environment ?? ProcessInfo.processInfo.environment
         var loaded: [String: Bool] = [:]
+
+        // Load UserDefaults overrides first (lowest priority among overrides)
+        let defaults = UserDefaults.standard
+        for key in defaults.dictionaryRepresentation().keys where key.hasPrefix(userDefaultsPrefix) {
+            let name = String(key.dropFirst(userDefaultsPrefix.count))
+            guard !name.isEmpty else { continue }
+            loaded[name] = defaults.bool(forKey: key)
+        }
+
+        // Env var overrides take priority over UserDefaults
         for (key, value) in env where key.hasPrefix(flagPrefix) {
             let name = String(key.dropFirst(flagPrefix.count)).lowercased().replacingOccurrences(of: "_", with: "")
             guard !name.isEmpty else { continue }
@@ -88,13 +99,17 @@ public final class MacOSClientFeatureFlagManager: @unchecked Sendable {
     public func setOverride(_ key: String, enabled: Bool) {
         lock.lock()
         defer { lock.unlock() }
-        overrides[Self.normalize(key)] = enabled
+        let normalized = Self.normalize(key)
+        overrides[normalized] = enabled
+        UserDefaults.standard.set(enabled, forKey: userDefaultsPrefix + normalized)
     }
 
     public func removeOverride(_ key: String) {
         lock.lock()
         defer { lock.unlock() }
-        overrides.removeValue(forKey: Self.normalize(key))
+        let normalized = Self.normalize(key)
+        overrides.removeValue(forKey: normalized)
+        UserDefaults.standard.removeObject(forKey: userDefaultsPrefix + normalized)
     }
 
     /// Load VELLUM_FLAG_* entries from a `.env` file and apply them as overrides.


### PR DESCRIPTION
Replaces hardcoded MacOSClientFeatureFlag enum with registry-driven definitions loaded from the unified feature flag registry. Manager now loads macOS-scope flags from the bundled registry, resolves enabled state via override chain (env/UserDefaults/default), and exposes definitions for the settings UI. Settings Advanced Dev tab now displays labels from the registry. All enum-based call sites updated to key-based lookups. Part of #10348.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
