### PR TITLE
fix: disambiguate clock-position temporal expressions in reminder skills

### DIFF
--- a/assistant/src/config/bundled-skills/reminder/SKILL.md
+++ b/assistant/src/config/bundled-skills/reminder/SKILL.md
@@ -28,3 +28,28 @@ Optionally pass `routing_hints` (a JSON object) to influence routing decisions (
 - For task tracking ("add to my tasks", "add to my queue"), use task_list_add instead.
 - `fire_at` must be a strict ISO 8601 timestamp with timezone offset or Z (e.g. `2025-03-15T09:00:00-05:00` or `2025-03-15T09:00:00Z`). Ambiguous timestamps without timezone info will be rejected.
 - `label` is a short human-readable summary shown in the notification.
+
+### Anchored & Ambiguous Relative Time
+
+Phrases like "at the 45 minute mark", "at the top of the hour", "on the half-hour", "at noon", "20 minutes in", or "when I hit an hour" are **clock-position or anchored relative time** expressions. Do NOT treat them as offsets from now.
+
+**Resolution rules (in priority order):**
+
+1. **Clock-position expressions** — map directly to a wall-clock time:
+   - "top of the hour" / "on the hour" → next :00 (e.g. 10:00 AM)
+   - "the X minute mark" / "at :XX" → current hour's :XX; if already past, advance one hour
+   - "the half-hour mark" / "half past" → nearest upcoming :30
+   - "noon" / "midnight" → 12:00 PM or 12:00 AM today; if past, tomorrow
+   - "quarter past" / "quarter to" → :15 or :45 of current or next hour
+
+2. **Session-anchored expressions** — if the user mentioned a start time earlier in conversation ("I got here at 9", "meeting started at 2pm"), compute `start_time + offset`.
+
+3. **Ask only if truly ambiguous** — if neither rule 1 nor rule 2 resolves, ask: "Do you mean [clock time] or [X minutes from now]?" Never silently default to "from now."
+
+**Examples:**
+- "at the 45 min mark" (now: 9:39) → 9:45 AM
+- "at the 45 min mark" (now: 9:50) → 10:45 AM
+- "top of the hour" (now: 9:39) → 10:00 AM
+- "at noon" → 12:00 PM today
+- "20 minutes in, I started at 2pm" → 2:20 PM
+- "at the hour mark" with no start time → ask for clarification

--- a/assistant/src/config/bundled-skills/time-based-actions/SKILL.md
+++ b/assistant/src/config/bundled-skills/time-based-actions/SKILL.md
@@ -55,6 +55,31 @@ When the user says "in X minutes/hours", compute the ISO 8601 timestamp yourself
 - Format as ISO 8601 with timezone: `2025-03-15T09:05:00-05:00`
 - Pass to `reminder_create` as `fire_at`
 
+### Anchored & Ambiguous Relative Time
+
+Phrases like "at the 45 minute mark", "at the top of the hour", "on the half-hour", "at noon", "20 minutes in", or "when I hit an hour" are **clock-position or anchored relative time** expressions. Do NOT treat them as offsets from now.
+
+**Resolution rules (in priority order):**
+
+1. **Clock-position expressions** — map directly to a wall-clock time:
+   - "top of the hour" / "on the hour" → next :00 (e.g. 10:00 AM)
+   - "the X minute mark" / "at :XX" → current hour's :XX; if already past, advance one hour
+   - "the half-hour mark" / "half past" → nearest upcoming :30
+   - "noon" / "midnight" → 12:00 PM or 12:00 AM today; if past, tomorrow
+   - "quarter past" / "quarter to" → :15 or :45 of current or next hour
+
+2. **Session-anchored expressions** — if the user mentioned a start time earlier in conversation ("I got here at 9", "meeting started at 2pm"), compute `start_time + offset`.
+
+3. **Ask only if truly ambiguous** — if neither rule 1 nor rule 2 resolves, ask: "Do you mean [clock time] or [X minutes from now]?" Never silently default to "from now."
+
+**Examples:**
+- "at the 45 min mark" (now: 9:39) → 9:45 AM
+- "at the 45 min mark" (now: 9:50) → 10:45 AM
+- "top of the hour" (now: 9:39) → 10:00 AM
+- "at noon" → 12:00 PM today
+- "20 minutes in, I started at 2pm" → 2:20 PM
+- "at the hour mark" with no start time → ask for clarification
+
 ## "Remind me to X" Disambiguation
 
 The word "remind" is ambiguous. Route based on whether a time is specified:


### PR DESCRIPTION
## Summary
- Adds "Anchored & Ambiguous Relative Time" section to both `time-based-actions/SKILL.md` and `reminder/SKILL.md`
- Defines priority-ordered resolution rules: clock-position expressions → session-anchored expressions → ask for clarification
- Includes concrete examples covering "at the X min mark", "top of the hour", "at noon", session-anchored offsets, and the ambiguous fallback case

## Original prompt
Bug: Ambiguous temporal expressions misinterpreted as "X minutes/hours from now"

When a user says "remind me at the 45 min mark," the assistant computes `now + 45 minutes` instead of recognizing this as a clock-position reference. The time-based actions and reminder skills had no guidance for disambiguating clock-position or anchored relative time expressions. This adds resolution rules to both skill files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
