### PR TITLE
M4: Channel adapter alignment for guardian prompts

### DIFF
--- a/assistant/src/runtime/channel-approval-types.ts
+++ b/assistant/src/runtime/channel-approval-types.ts
@@ -7,6 +7,8 @@
  * same approval flow can be reused across transports.
  */
 
+import type { GuardianDecisionAction } from './guardian-decision-types.js';
+
 // ---------------------------------------------------------------------------
 // Approval actions
 // ---------------------------------------------------------------------------
@@ -26,6 +28,21 @@ export const DEFAULT_APPROVAL_ACTIONS: readonly ApprovalActionOption[] = [
   { id: 'approve_always', label: 'Approve always' },
   { id: 'reject', label: 'Reject' },
 ] as const;
+
+/**
+ * Map `GuardianDecisionAction[]` to `ApprovalActionOption[]` so channel
+ * prompt payloads can be derived from the unified decision action set.
+ * The `action` field from GuardianDecisionAction maps to the `id` field
+ * on ApprovalActionOption (both are canonical action identifiers).
+ */
+export function toApprovalActionOptions(
+  actions: GuardianDecisionAction[],
+): ApprovalActionOption[] {
+  return actions.map(a => ({
+    id: a.action as ApprovalAction,
+    label: a.label,
+  }));
+}
 
 // ---------------------------------------------------------------------------
 // Approval prompt

--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -17,7 +17,8 @@ import type {
   ApprovalUIMetadata,
   ChannelApprovalPrompt,
 } from './channel-approval-types.js';
-import { DEFAULT_APPROVAL_ACTIONS } from './channel-approval-types.js';
+import { toApprovalActionOptions } from './channel-approval-types.js';
+import { buildDecisionActions, buildPlainTextFallback } from './guardian-decision-types.js';
 import * as pendingInteractions from './pending-interactions.js';
 
 /** Summary of a pending interaction, used by channel approval flows. */
@@ -69,6 +70,11 @@ export function getApprovalInfoByConversation(conversationId: string): PendingAp
 
 /**
  * Internal helper: turn a PendingApprovalInfo into a ChannelApprovalPrompt.
+ *
+ * Derives actions from the shared `buildDecisionActions` builder defined in
+ * guardian-decision-types.ts, then maps them to the channel-facing
+ * `ApprovalActionOption` shape. This ensures channel button sets are always
+ * consistent with the unified `GuardianDecisionPrompt` type.
  */
 function buildPromptFromApprovalInfo(info: PendingApprovalInfo): ChannelApprovalPrompt {
   const promptText = composeApprovalMessage({
@@ -76,15 +82,11 @@ function buildPromptFromApprovalInfo(info: PendingApprovalInfo): ChannelApproval
     toolName: info.toolName,
   });
 
-  // Hide "approve always" when persistent trust rules are disallowed for this invocation.
-  const actions = info.persistentDecisionsAllowed === false
-    ? DEFAULT_APPROVAL_ACTIONS.filter((a) => a.id !== 'approve_always')
-    : [...DEFAULT_APPROVAL_ACTIONS];
-
-  // Plain-text fallback must remain parser-compatible (contains "yes"/"always"/"no" keywords).
-  const plainTextFallback = info.persistentDecisionsAllowed === false
-    ? `${promptText}\n\nReply "yes" to approve or "no" to reject.`
-    : `${promptText}\n\nReply "yes" to approve once, "always" to approve always, or "no" to reject.`;
+  const decisionActions = buildDecisionActions({
+    persistentDecisionsAllowed: info.persistentDecisionsAllowed,
+  });
+  const actions = toApprovalActionOptions(decisionActions);
+  const plainTextFallback = buildPlainTextFallback(promptText, decisionActions);
 
   return { promptText, actions, plainTextFallback };
 }
@@ -199,6 +201,10 @@ export function handleChannelDecision(
  * Build an approval prompt that includes context about which non-guardian
  * user is requesting the action. Sent to the guardian's chat so they
  * can approve or deny on behalf of the requester.
+ *
+ * Uses the shared `buildDecisionActions` builder with `forGuardianOnBehalf`
+ * set to true, which excludes `approve_always` since guardians cannot
+ * permanently allowlist tools on behalf of requesters.
  */
 export function buildGuardianApprovalPrompt(
   info: PendingApprovalInfo,
@@ -210,11 +216,9 @@ export function buildGuardianApprovalPrompt(
     requesterIdentifier,
   });
 
-  // Guardian approvals are always one-time decisions — "approve always"
-  // doesn't make sense when the guardian is approving on behalf of someone else.
-  const actions = DEFAULT_APPROVAL_ACTIONS.filter((a) => a.id !== 'approve_always');
-
-  const plainTextFallback = `${promptText}\n\nReply "yes" to approve or "no" to reject.`;
+  const decisionActions = buildDecisionActions({ forGuardianOnBehalf: true });
+  const actions = toApprovalActionOptions(decisionActions);
+  const plainTextFallback = buildPlainTextFallback(promptText, decisionActions);
 
   return { promptText, actions, plainTextFallback };
 }

--- a/assistant/src/runtime/guardian-decision-types.ts
+++ b/assistant/src/runtime/guardian-decision-types.ts
@@ -34,6 +34,53 @@ export interface GuardianDecisionAction {
 }
 
 // ---------------------------------------------------------------------------
+// Shared decision action constants
+// ---------------------------------------------------------------------------
+
+/** Canonical set of all guardian decision actions with their labels. */
+export const GUARDIAN_DECISION_ACTIONS = {
+  approve_once:   { action: 'approve_once',   label: 'Approve once' },
+  approve_always: { action: 'approve_always', label: 'Approve always' },
+  reject:         { action: 'reject',         label: 'Reject' },
+} as const satisfies Record<string, GuardianDecisionAction>;
+
+/**
+ * Build the set of `GuardianDecisionAction` items appropriate for a prompt,
+ * respecting whether persistent decisions (approve_always) are allowed.
+ *
+ * When `persistentDecisionsAllowed` is `false`, the `approve_always` action
+ * is excluded. When `forGuardianOnBehalf` is `true` (guardian acting on behalf
+ * of a requester), `approve_always` is also excluded since guardians cannot
+ * permanently allowlist tools on behalf of others.
+ */
+export function buildDecisionActions(opts?: {
+  persistentDecisionsAllowed?: boolean;
+  forGuardianOnBehalf?: boolean;
+}): GuardianDecisionAction[] {
+  const showAlways = opts?.persistentDecisionsAllowed !== false && !opts?.forGuardianOnBehalf;
+  return [
+    GUARDIAN_DECISION_ACTIONS.approve_once,
+    ...(showAlways ? [GUARDIAN_DECISION_ACTIONS.approve_always] : []),
+    GUARDIAN_DECISION_ACTIONS.reject,
+  ];
+}
+
+/**
+ * Build the plain-text fallback instruction string that matches the given
+ * set of decision actions. Ensures the text always includes parser-compatible
+ * keywords (yes/always/no) so text-based fallback remains actionable.
+ */
+export function buildPlainTextFallback(
+  promptText: string,
+  actions: GuardianDecisionAction[],
+): string {
+  const hasAlways = actions.some(a => a.action === 'approve_always');
+  return hasAlways
+    ? `${promptText}\n\nReply "yes" to approve once, "always" to approve always, or "no" to reject.`
+    : `${promptText}\n\nReply "yes" to approve or "no" to reject.`;
+}
+
+// ---------------------------------------------------------------------------
 // Apply decision
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -12,6 +12,7 @@ import { applyGuardianDecision } from '../../approvals/guardian-decision-primiti
 import { handleChannelDecision } from '../channel-approvals.js';
 import type { ApprovalAction } from '../channel-approval-types.js';
 import type { GuardianDecisionPrompt } from '../guardian-decision-types.js';
+import { buildDecisionActions } from '../guardian-decision-types.js';
 import { httpError } from '../http-errors.js';
 import * as pendingInteractions from '../pending-interactions.js';
 
@@ -128,10 +129,7 @@ export function listGuardianDecisionPrompts(params: {
       state: 'pending',
       questionText: approval.reason ?? `Approve tool: ${approval.toolName ?? 'unknown'}`,
       toolName: approval.toolName ?? null,
-      actions: [
-        { action: 'approve_once', label: 'Approve once' },
-        { action: 'reject', label: 'Reject' },
-      ],
+      actions: buildDecisionActions({ forGuardianOnBehalf: true }),
       expiresAt: approval.expiresAt,
       conversationId: approval.conversationId,
       callSessionId: null,
@@ -151,20 +149,15 @@ export function listGuardianDecisionPrompts(params: {
     if (prompts.some(p => p.requestId === interaction.requestId)) continue;
 
     const details = interaction.confirmationDetails;
-    // Hide "approve always" when persistent trust rules are disallowed for this
-    // invocation, matching the gating in getChannelApprovalPrompt.
-    const showAlways = details.persistentDecisionsAllowed !== false;
     prompts.push({
       requestId: interaction.requestId,
       requestCode: interaction.requestId.slice(0, 6).toUpperCase(),
       state: 'pending',
       questionText: `Approve tool: ${details.toolName}`,
       toolName: details.toolName,
-      actions: [
-        { action: 'approve_once', label: 'Approve once' },
-        ...(showAlways ? [{ action: 'approve_always', label: 'Approve always' }] : []),
-        { action: 'reject', label: 'Reject' },
-      ],
+      actions: buildDecisionActions({
+        persistentDecisionsAllowed: details.persistentDecisionsAllowed,
+      }),
       expiresAt: Date.now() + 300_000,
       conversationId,
       callSessionId: null,


### PR DESCRIPTION
Aligns Telegram and WhatsApp channel adapters to use the unified GuardianDecisionPrompt type from the shared primitive, ensuring structured prompt objects drive rich buttons consistently. Respects persistentDecisionsAllowed when building channel-specific button sets.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
