### PR TITLE
M3: Telegram Inbound Invite Redemption Intercept (#10362)

### DIFF
--- a/assistant/src/__tests__/inbound-invite-redemption.test.ts
+++ b/assistant/src/__tests__/inbound-invite-redemption.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Integration tests for the inbound invite redemption intercept.
+ *
+ * Validates that non-members with valid `/start iv_<token>` payloads are
+ * granted access without guardian approval, and that invalid/expired/revoked
+ * tokens produce the correct deterministic refusal messages.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Test isolation: in-memory SQLite via temp directory
+// ---------------------------------------------------------------------------
+
+const testDir = mkdtempSync(join(tmpdir(), 'inbound-invite-redemption-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  normalizeAssistantId: (id: string) => id === 'self' ? 'self' : id,
+  readHttpToken: () => 'test-bearer-token',
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../security/secret-ingress.js', () => ({
+  checkIngressForSecrets: () => ({ blocked: false }),
+}));
+
+mock.module('../config/env.js', () => ({
+  getGatewayInternalBaseUrl: () => 'http://127.0.0.1:7830',
+}));
+
+// Mock the credential metadata store so the Telegram transport adapter
+// resolves without touching the filesystem.
+mock.module('../tools/credentials/metadata-store.js', () => ({
+  getCredentialMetadata: () => undefined,
+  upsertCredentialMetadata: () => {},
+  deleteCredentialMetadata: () => {},
+  listCredentialMetadata: () => [],
+}));
+
+const emitSignalCalls: Array<Record<string, unknown>> = [];
+mock.module('../notifications/emit-signal.js', () => ({
+  emitNotificationSignal: async (params: Record<string, unknown>) => {
+    emitSignalCalls.push(params);
+    return {
+      signalId: 'mock-signal-id',
+      deduplicated: false,
+      dispatched: true,
+      reason: 'mock',
+      deliveryResults: [],
+    };
+  },
+}));
+
+const deliverReplyCalls: Array<{ url: string; payload: Record<string, unknown> }> = [];
+mock.module('../runtime/gateway-client.js', () => ({
+  deliverChannelReply: async (url: string, payload: Record<string, unknown>) => {
+    deliverReplyCalls.push({ url, payload });
+  },
+}));
+
+mock.module('../runtime/approval-message-composer.js', () => ({
+  composeApprovalMessage: () => 'mock approval message',
+  composeApprovalMessageGenerative: async () => 'mock generative message',
+}));
+
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { createInvite, revokeInvite } from '../memory/ingress-invite-store.js';
+import { findMember, upsertMember } from '../memory/ingress-member-store.js';
+import { handleChannelInbound } from '../runtime/routes/channel-routes.js';
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_BEARER_TOKEN = 'test-token';
+let msgCounter = 0;
+
+function resetState(): void {
+  const db = getDb();
+  db.run('DELETE FROM assistant_ingress_members');
+  db.run('DELETE FROM assistant_ingress_invites');
+  db.run('DELETE FROM channel_inbound_events');
+  db.run('DELETE FROM conversations');
+  db.run('DELETE FROM channel_guardian_approval_requests');
+  db.run('DELETE FROM channel_guardian_bindings');
+  db.run('DELETE FROM notification_events');
+  emitSignalCalls.length = 0;
+  deliverReplyCalls.length = 0;
+  msgCounter = 0;
+}
+
+function buildInboundRequest(overrides: Record<string, unknown> = {}): Request {
+  msgCounter++;
+  const body: Record<string, unknown> = {
+    sourceChannel: 'telegram',
+    interface: 'telegram',
+    externalChatId: 'chat-invite-test',
+    externalMessageId: `msg-invite-${Date.now()}-${msgCounter}`,
+    content: '/start iv_sometoken',
+    senderExternalUserId: 'user-invite-123',
+    senderName: 'Invite User',
+    senderUsername: 'invite_user',
+    replyCallbackUrl: 'http://localhost:7830/deliver/telegram',
+    sourceMetadata: {
+      commandIntent: { type: 'start', payload: 'iv_sometoken' },
+    },
+    ...overrides,
+  };
+
+  return new Request('http://localhost:8080/channels/inbound', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Gateway-Origin': TEST_BEARER_TOKEN,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Build a request with a specific invite token, using the structured
+ * commandIntent that the gateway produces for `/start <payload>`.
+ */
+function buildInviteRequest(rawToken: string, overrides: Record<string, unknown> = {}): Request {
+  return buildInboundRequest({
+    content: `/start iv_${rawToken}`,
+    sourceMetadata: {
+      commandIntent: { type: 'start', payload: `iv_${rawToken}` },
+    },
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('inbound invite redemption intercept', () => {
+  beforeEach(resetState);
+
+  test('non-member with valid invite token becomes active member without guardian approval', async () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 5 });
+
+    const req = buildInviteRequest(rawToken);
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = await resp.json() as Record<string, unknown>;
+
+    expect(json.accepted).toBe(true);
+    expect(json.inviteRedemption).toBe('redeemed');
+    expect(json.memberId).toEqual(expect.any(String));
+    expect(json.denied).toBeUndefined();
+
+    // Verify the user is now an active member
+    const member = findMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-invite-123',
+    });
+    expect(member).not.toBeNull();
+    expect(member!.status).toBe('active');
+
+    // Verify a welcome reply was delivered
+    expect(deliverReplyCalls.length).toBe(1);
+    const replyText = (deliverReplyCalls[0].payload as Record<string, unknown>).text;
+    expect(replyText).toContain("Welcome! You've been granted access via invite link.");
+  });
+
+  test('non-member with invalid token gets refusal text', async () => {
+    const req = buildInviteRequest('completely-bogus-token-xyz');
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = await resp.json() as Record<string, unknown>;
+
+    expect(json.accepted).toBe(true);
+    expect(json.denied).toBe(true);
+    expect(json.inviteRedemption).toBe('invalid_token');
+
+    // Verify refusal reply was delivered
+    expect(deliverReplyCalls.length).toBe(1);
+    const replyText = (deliverReplyCalls[0].payload as Record<string, unknown>).text;
+    expect(replyText).toContain('no longer valid');
+
+    // Verify the user was NOT made a member
+    const member = findMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-invite-123',
+    });
+    expect(member).toBeNull();
+  });
+
+  test('non-member with expired token gets appropriate message', async () => {
+    const { rawToken } = createInvite({
+      sourceChannel: 'telegram',
+      maxUses: 1,
+      expiresInMs: -1, // already expired
+    });
+
+    const req = buildInviteRequest(rawToken);
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = await resp.json() as Record<string, unknown>;
+
+    expect(json.accepted).toBe(true);
+    expect(json.denied).toBe(true);
+    expect(json.inviteRedemption).toBe('expired');
+
+    expect(deliverReplyCalls.length).toBe(1);
+    const replyText = (deliverReplyCalls[0].payload as Record<string, unknown>).text;
+    expect(replyText).toContain('no longer valid');
+  });
+
+  test('non-member with revoked token gets refusal text', async () => {
+    const { rawToken, invite } = createInvite({
+      sourceChannel: 'telegram',
+      maxUses: 5,
+    });
+    revokeInvite(invite.id);
+
+    const req = buildInviteRequest(rawToken);
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = await resp.json() as Record<string, unknown>;
+
+    expect(json.accepted).toBe(true);
+    expect(json.denied).toBe(true);
+    expect(json.inviteRedemption).toBe('revoked');
+
+    expect(deliverReplyCalls.length).toBe(1);
+    const replyText = (deliverReplyCalls[0].payload as Record<string, unknown>).text;
+    expect(replyText).toContain('no longer valid');
+  });
+
+  test('existing /start gv_<token> guardian bootstrap flow is unaffected', async () => {
+    // Send a /start gv_ command — should not be intercepted by the invite flow.
+    // Without a valid bootstrap session, it should be denied at the ACL gate.
+    const req = buildInboundRequest({
+      content: '/start gv_some_bootstrap_token',
+      sourceMetadata: {
+        commandIntent: { type: 'start', payload: 'gv_some_bootstrap_token' },
+      },
+    });
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = await resp.json() as Record<string, unknown>;
+
+    // Should be denied as a non-member (bootstrap token is invalid/no session)
+    expect(json.denied).toBe(true);
+    expect(json.reason).toBe('not_a_member');
+    // Should NOT have invite redemption fields
+    expect(json.inviteRedemption).toBeUndefined();
+  });
+
+  test('duplicate Telegram webhook deliveries do not double-redeem', async () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 5 });
+
+    const sharedMessageId = `msg-dedup-${Date.now()}`;
+    const makeReq = () => buildInviteRequest(rawToken, {
+      externalMessageId: sharedMessageId,
+    });
+
+    // First delivery
+    const resp1 = await handleChannelInbound(makeReq(), undefined, TEST_BEARER_TOKEN);
+    const json1 = await resp1.json() as Record<string, unknown>;
+    expect(json1.inviteRedemption).toBe('redeemed');
+
+    // Second delivery (duplicate webhook)
+    const resp2 = await handleChannelInbound(makeReq(), undefined, TEST_BEARER_TOKEN);
+    const json2 = await resp2.json() as Record<string, unknown>;
+    // Dedup kicks in — the message is treated as a duplicate and no second
+    // redemption attempt occurs.
+    expect(json2.duplicate).toBe(true);
+
+    // Only one welcome reply was delivered
+    expect(deliverReplyCalls.length).toBe(1);
+  });
+
+  test('existing active member sending normal message is unaffected', async () => {
+    // Pre-create an active member
+    upsertMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-active-member',
+      externalChatId: 'chat-active',
+      status: 'active',
+      policy: 'allow',
+    });
+
+    // Active member sends a normal message (no invite token)
+    const req = buildInboundRequest({
+      content: 'Hello, just a normal message!',
+      senderExternalUserId: 'user-active-member',
+      externalChatId: 'chat-active',
+      sourceMetadata: {},
+    });
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = await resp.json() as Record<string, unknown>;
+
+    // Should be accepted normally, not denied, not invite-redeemed
+    expect(json.accepted).toBe(true);
+    expect(json.denied).toBeUndefined();
+    expect(json.inviteRedemption).toBeUndefined();
+  });
+
+  test('channel mismatch returns appropriate message', async () => {
+    // Create an invite for SMS, but try to redeem via Telegram
+    const { rawToken } = createInvite({ sourceChannel: 'sms', maxUses: 5 });
+
+    const req = buildInviteRequest(rawToken);
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = await resp.json() as Record<string, unknown>;
+
+    expect(json.accepted).toBe(true);
+    expect(json.denied).toBe(true);
+    expect(json.inviteRedemption).toBe('channel_mismatch');
+
+    expect(deliverReplyCalls.length).toBe(1);
+    const replyText = (deliverReplyCalls[0].payload as Record<string, unknown>).text;
+    expect(replyText).toContain('not valid for this channel');
+  });
+
+  test('already-active member with invite token gets acknowledgement', async () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 5 });
+
+    // Pre-create an active member that will click the invite link
+    upsertMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-already-active',
+      externalChatId: 'chat-invite-test',
+      status: 'active',
+      policy: 'allow',
+    });
+
+    const req = buildInviteRequest(rawToken, {
+      senderExternalUserId: 'user-already-active',
+    });
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = await resp.json() as Record<string, unknown>;
+
+    // Active members pass through the ACL gate, so the invite intercept
+    // does not fire. The message proceeds to normal processing.
+    expect(json.accepted).toBe(true);
+    expect(json.denied).toBeUndefined();
+  });
+});

--- a/assistant/src/memory/ingress-invite-store.ts
+++ b/assistant/src/memory/ingress-invite-store.ts
@@ -330,6 +330,59 @@ export function redeemInvite(params: {
 }
 
 // ---------------------------------------------------------------------------
+// recordInviteUse — consume one use without creating a member row
+// ---------------------------------------------------------------------------
+
+/**
+ * Increment an invite's use count and record redemption metadata without
+ * inserting a new member row. Used when reactivating an existing inactive
+ * member via invite — the member row already exists and just needs an
+ * update, so the transactional INSERT in `redeemInvite` would hit a
+ * unique-key constraint.
+ */
+export function recordInviteUse(params: {
+  inviteId: string;
+  externalUserId?: string;
+  externalChatId?: string;
+}): IngressInvite | null {
+  const db = getDb();
+  const now = Date.now();
+
+  const invite = db
+    .select()
+    .from(assistantIngressInvites)
+    .where(eq(assistantIngressInvites.id, params.inviteId))
+    .get();
+
+  if (!invite) return null;
+
+  const newUseCount = invite.useCount + 1;
+  const newStatus = newUseCount >= invite.maxUses ? 'redeemed' : 'active';
+
+  db.update(assistantIngressInvites)
+    .set({
+      useCount: newUseCount,
+      status: newStatus,
+      redeemedByExternalUserId: params.externalUserId ?? null,
+      redeemedByExternalChatId: params.externalChatId ?? null,
+      redeemedAt: now,
+      updatedAt: now,
+    })
+    .where(eq(assistantIngressInvites.id, invite.id))
+    .run();
+
+  return rowToInvite({
+    ...invite,
+    useCount: newUseCount,
+    status: newStatus,
+    redeemedByExternalUserId: params.externalUserId ?? null,
+    redeemedByExternalChatId: params.externalChatId ?? null,
+    redeemedAt: now,
+    updatedAt: now,
+  });
+}
+
+// ---------------------------------------------------------------------------
 // markInviteExpired
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -7,8 +7,8 @@
  * persisted, or returned in the outcome.
  */
 
-import { findMember } from '../memory/ingress-member-store.js';
-import { findByTokenHash, hashToken, markInviteExpired, redeemInvite as storeRedeemInvite } from '../memory/ingress-invite-store.js';
+import { findMember, upsertMember } from '../memory/ingress-member-store.js';
+import { findByTokenHash, hashToken, markInviteExpired, redeemInvite as storeRedeemInvite, recordInviteUse } from '../memory/ingress-invite-store.js';
 
 // ---------------------------------------------------------------------------
 // Outcome type
@@ -92,6 +92,38 @@ export function redeemInvite(params: {
 
   if (existingMember && existingMember.status === 'active') {
     return { ok: true, type: 'already_member', memberId: existingMember.id };
+  }
+
+  // Inactive member reactivation: when the user already has a member record
+  // in a non-active state (revoked/pending/blocked), reactivate it via
+  // upsertMember and consume an invite use separately. Falling through to
+  // storeRedeemInvite would try to INSERT a new member row, hitting the
+  // unique-key constraint on the members table.
+  if (existingMember) {
+    const reactivated = upsertMember({
+      assistantId: assistantId ?? invite.assistantId,
+      sourceChannel,
+      externalUserId,
+      externalChatId,
+      displayName,
+      username,
+      status: 'active',
+      policy: 'allow',
+      inviteId: invite.id,
+    });
+
+    recordInviteUse({
+      inviteId: invite.id,
+      externalUserId,
+      externalChatId,
+    });
+
+    return {
+      ok: true,
+      type: 'redeemed',
+      memberId: reactivated.id,
+      inviteId: invite.id,
+    };
   }
 
   // Delegate to the store-level redeem which handles token lookup, expiry,

--- a/assistant/src/runtime/invite-redemption-templates.ts
+++ b/assistant/src/runtime/invite-redemption-templates.ts
@@ -1,0 +1,39 @@
+/**
+ * Deterministic reply templates for invite token redemption outcomes.
+ *
+ * These messages are returned directly to the user without passing through
+ * the LLM pipeline, ensuring consistent and predictable responses for
+ * every invite redemption outcome.
+ */
+
+import type { InviteRedemptionOutcome } from './invite-redemption-service.js';
+
+// ---------------------------------------------------------------------------
+// Template strings
+// ---------------------------------------------------------------------------
+
+export const INVITE_REPLY_TEMPLATES = {
+  redeemed: "Welcome! You've been granted access via invite link.",
+  already_member: 'You already have access.',
+  invalid_token: 'This invite link is no longer valid.',
+  expired: 'This invite link is no longer valid.',
+  revoked: 'This invite link is no longer valid.',
+  max_uses_reached: 'This invite link is no longer valid.',
+  channel_mismatch: 'This invite link is not valid for this channel.',
+  missing_identity: 'Unable to process this invite. Please contact the person who shared it.',
+  generic_failure: 'Unable to process this invite. Please contact the person who shared it.',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Outcome-to-reply resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Map an `InviteRedemptionOutcome` to a deterministic reply string.
+ */
+export function getInviteRedemptionReply(outcome: InviteRedemptionOutcome): string {
+  if (outcome.ok) {
+    return INVITE_REPLY_TEMPLATES[outcome.type];
+  }
+  return INVITE_REPLY_TEMPLATES[outcome.reason] ?? INVITE_REPLY_TEMPLATES.generic_failure;
+}

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1,8 +1,13 @@
 /**
  * Channel inbound message handler: validates, records, and routes inbound
  * messages from all channels. Handles ingress ACL, edits, guardian
- * verification, guardian action answers, and approval interception.
+ * verification, guardian action answers, approval interception, and
+ * invite token redemption.
  */
+// Side-effect import: registers the Telegram invite transport adapter so
+// getTransport('telegram') resolves at runtime.
+import '../channel-invite-transports/telegram.js';
+
 import { answerCall } from '../../calls/call-domain.js';
 import { isTerminalState } from '../../calls/call-state-machine.js';
 import { getCallSession } from '../../calls/call-store.js';
@@ -72,6 +77,9 @@ import type {
   GuardianFollowUpConversationGenerator,
   MessageProcessor,
 } from '../http-types.js';
+import { getTransport } from '../channel-invite-transport.js';
+import { redeemInvite } from '../invite-redemption-service.js';
+import { getInviteRedemptionReply } from '../invite-redemption-templates.js';
 import { deliverReplyViaCallback } from './channel-delivery-routes.js';
 import {
   canonicalChannelAssistantId,
@@ -214,6 +222,19 @@ export async function handleChannelInbound(
     typeof (rawCommandIntentForAcl as Record<string, unknown>).payload === 'string' &&
     ((rawCommandIntentForAcl as Record<string, unknown>).payload as string).startsWith('gv_');
 
+  // Parse invite token from /start iv_<token> commands using the transport
+  // adapter. The token is extracted once here so both the ACL bypass and
+  // the intercept handler can reference it without re-parsing.
+  const commandIntentForAcl = rawCommandIntentForAcl && typeof rawCommandIntentForAcl === 'object' && !Array.isArray(rawCommandIntentForAcl)
+    ? rawCommandIntentForAcl as Record<string, unknown>
+    : undefined;
+  const inviteTransport = getTransport(sourceChannel);
+  const inviteToken = inviteTransport?.extractInboundToken({
+    commandIntent: commandIntentForAcl,
+    content: trimmedContent,
+    sourceMetadata: body.sourceMetadata,
+  });
+
   if (body.senderExternalUserId) {
     resolvedMember = findMember({
       assistantId: canonicalAssistantId,
@@ -255,6 +276,27 @@ export async function handleChannelInbound(
         } else {
           log.info({ sourceChannel, hasValidBootstrapSession: false }, 'Ingress ACL: bootstrap command bypass denied — no valid pending_bootstrap session');
         }
+      }
+
+      // ── Invite token intercept (non-member) ──
+      // /start iv_<token> deep links grant access without guardian approval.
+      // Intercept here — before the deny gate — so valid invites short-circuit
+      // the ACL rejection and never reach the agent pipeline.
+      if (inviteToken && denyNonMember) {
+        const inviteResult = await handleInviteTokenIntercept({
+          rawToken: inviteToken,
+          sourceChannel,
+          externalChatId,
+          externalMessageId,
+          senderExternalUserId: body.senderExternalUserId,
+          senderName: body.senderName,
+          senderUsername: body.senderUsername,
+          replyCallbackUrl: body.replyCallbackUrl,
+          bearerToken,
+          assistantId,
+          canonicalAssistantId,
+        });
+        if (inviteResult) return inviteResult;
       }
 
       if (denyNonMember) {
@@ -320,6 +362,26 @@ export async function handleChannelInbound(
           } else {
             log.info({ sourceChannel, memberId: resolvedMember.id, hasValidBootstrapSession: false }, 'Ingress ACL: inactive member bootstrap bypass denied');
           }
+        }
+
+        // ── Invite token intercept (inactive member) ──
+        // Same as the non-member branch: invite tokens can reactivate
+        // revoked/pending members without requiring guardian approval.
+        if (inviteToken && denyInactiveMember) {
+          const inviteResult = await handleInviteTokenIntercept({
+            rawToken: inviteToken,
+            sourceChannel,
+            externalChatId,
+            externalMessageId,
+            senderExternalUserId: body.senderExternalUserId,
+            senderName: body.senderName,
+            senderUsername: body.senderUsername,
+            replyCallbackUrl: body.replyCallbackUrl,
+            bearerToken,
+            assistantId,
+            canonicalAssistantId,
+          });
+          if (inviteResult) return inviteResult;
         }
 
         if (denyInactiveMember) {
@@ -1363,6 +1425,100 @@ export async function handleChannelInbound(
     duplicate: result.duplicate,
     eventId: result.eventId,
   });
+}
+
+// ---------------------------------------------------------------------------
+// Invite token intercept
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle an inbound invite token for a non-member or inactive member.
+ *
+ * Redeems the invite, delivers a deterministic reply, and returns a Response
+ * to short-circuit the handler. Returns `null` when the intercept should not
+ * fire (e.g. already_member outcome — let normal flow handle it).
+ */
+async function handleInviteTokenIntercept(params: {
+  rawToken: string;
+  sourceChannel: ChannelId;
+  externalChatId: string;
+  externalMessageId: string;
+  senderExternalUserId?: string;
+  senderName?: string;
+  senderUsername?: string;
+  replyCallbackUrl?: string;
+  bearerToken?: string;
+  assistantId?: string;
+  canonicalAssistantId: string;
+}): Promise<Response | null> {
+  const {
+    rawToken,
+    sourceChannel,
+    externalChatId,
+    senderExternalUserId,
+    senderName,
+    senderUsername,
+    replyCallbackUrl,
+    bearerToken,
+    assistantId,
+    canonicalAssistantId,
+  } = params;
+
+  const outcome = redeemInvite({
+    rawToken,
+    sourceChannel,
+    externalUserId: senderExternalUserId,
+    externalChatId,
+    displayName: senderName,
+    username: senderUsername,
+    assistantId: canonicalAssistantId,
+  });
+
+  log.info(
+    { sourceChannel, externalChatId, ok: outcome.ok, type: outcome.ok ? outcome.type : undefined, reason: !outcome.ok ? outcome.reason : undefined },
+    'Invite token intercept: redemption result',
+  );
+
+  // already_member means the user has an active record — let the normal
+  // flow handle them (they passed ACL or the member is active).
+  if (outcome.ok && outcome.type === 'already_member') {
+    // Deliver a quick acknowledgement and short-circuit so the user
+    // does not trigger the deny gate or a duplicate agent loop.
+    const replyText = getInviteRedemptionReply(outcome);
+    if (replyCallbackUrl) {
+      try {
+        await deliverChannelReply(replyCallbackUrl, {
+          chatId: externalChatId,
+          text: replyText,
+          assistantId,
+        }, bearerToken);
+      } catch (err) {
+        log.error({ err, externalChatId }, 'Failed to deliver invite already-member reply');
+      }
+    }
+    return Response.json({ accepted: true, inviteRedemption: 'already_member' });
+  }
+
+  const replyText = getInviteRedemptionReply(outcome);
+
+  if (replyCallbackUrl) {
+    try {
+      await deliverChannelReply(replyCallbackUrl, {
+        chatId: externalChatId,
+        text: replyText,
+        assistantId,
+      }, bearerToken);
+    } catch (err) {
+      log.error({ err, externalChatId }, 'Failed to deliver invite redemption reply');
+    }
+  }
+
+  if (outcome.ok && outcome.type === 'redeemed') {
+    return Response.json({ accepted: true, inviteRedemption: 'redeemed', memberId: outcome.memberId });
+  }
+
+  // Failed redemption — inform the user and deny
+  return Response.json({ accepted: true, denied: true, inviteRedemption: outcome.reason });
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1455,6 +1455,7 @@ async function handleInviteTokenIntercept(params: {
     rawToken,
     sourceChannel,
     externalChatId,
+    externalMessageId,
     senderExternalUserId,
     senderName,
     senderUsername,
@@ -1463,6 +1464,26 @@ async function handleInviteTokenIntercept(params: {
     assistantId,
     canonicalAssistantId,
   } = params;
+
+  // Record the inbound event for dedup tracking BEFORE performing redemption.
+  // Without this, duplicate webhook deliveries (common with Telegram) would
+  // not be tracked: the first delivery redeems the invite and returns early,
+  // then the retry finds an active member, passes ACL, and the raw
+  // /start iv_<token> message leaks into the agent pipeline.
+  const dedupResult = channelDeliveryStore.recordInbound(
+    sourceChannel,
+    externalChatId,
+    externalMessageId,
+    { assistantId: canonicalAssistantId },
+  );
+
+  if (dedupResult.duplicate) {
+    return Response.json({
+      accepted: true,
+      duplicate: true,
+      eventId: dedupResult.eventId,
+    });
+  }
 
   const outcome = redeemInvite({
     rawToken,
@@ -1496,7 +1517,7 @@ async function handleInviteTokenIntercept(params: {
         log.error({ err, externalChatId }, 'Failed to deliver invite already-member reply');
       }
     }
-    return Response.json({ accepted: true, inviteRedemption: 'already_member' });
+    return Response.json({ accepted: true, eventId: dedupResult.eventId, inviteRedemption: 'already_member' });
   }
 
   const replyText = getInviteRedemptionReply(outcome);
@@ -1514,11 +1535,11 @@ async function handleInviteTokenIntercept(params: {
   }
 
   if (outcome.ok && outcome.type === 'redeemed') {
-    return Response.json({ accepted: true, inviteRedemption: 'redeemed', memberId: outcome.memberId });
+    return Response.json({ accepted: true, eventId: dedupResult.eventId, inviteRedemption: 'redeemed', memberId: outcome.memberId });
   }
 
   // Failed redemption — inform the user and deny
-  return Response.json({ accepted: true, denied: true, inviteRedemption: outcome.reason });
+  return Response.json({ accepted: true, eventId: dedupResult.eventId, denied: true, inviteRedemption: outcome.reason });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Add early intercept in inbound handler for invite token redemption via Telegram deep links. Non-members with valid iv_ tokens are granted access without guardian approval. Part of #10357.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
