### PR TITLE
fix: default reminder routing to all_channels with routing heuristics

### DIFF
--- a/assistant/src/config/bundled-skills/reminder/SKILL.md
+++ b/assistant/src/config/bundled-skills/reminder/SKILL.md
@@ -15,11 +15,33 @@ Create, list, and cancel one-time reminders. Reminders fire at a specific future
 
 Control how the reminder is delivered at trigger time with `routing_intent`:
 
-- **single_channel** (default) — deliver to one best channel
+- **single_channel** — deliver to one best channel
 - **multi_channel** — deliver to a subset of channels
-- **all_channels** — deliver to every available channel
+- **all_channels** (default) — deliver to every available channel
 
 Optionally pass `routing_hints` (a JSON object) to influence routing decisions (e.g. preferred channels, exclusions). When omitted, defaults to `{}`.
+
+### Routing Defaults
+
+Use the following heuristics to pick `routing_intent`:
+
+- **Default to `all_channels`** for most reminders. Users setting reminders usually want to be notified wherever they are, and redundant notifications are less harmful than missed ones.
+- **Use `single_channel`** only when the user explicitly specifies a single channel (e.g. "remind me on Telegram") or the reminder is low-stakes and noise reduction matters.
+- **Check `user_message_channel`** from the turn context. If the user is currently active on a specific channel (e.g. `vellum`), always include that channel. Pass it as a routing hint:
+  ```
+  routing_hints: { preferred_channels: ["vellum"] }
+  routing_intent: "all_channels"
+  ```
+- **Never use `single_channel` as a passive default.** If you haven't thought about which channel to use, use `all_channels`.
+
+### Examples
+
+| Scenario | routing_intent | routing_hints |
+|---|---|---|
+| User sets reminder from desktop app | `all_channels` | `{ preferred_channels: ["vellum"] }` |
+| User says "remind me on Telegram" | `single_channel` | `{ preferred_channels: ["telegram"] }` |
+| User sets reminder from Telegram | `all_channels` | `{ preferred_channels: ["telegram"] }` |
+| No channel preference expressed | `all_channels` | `{}` |
 
 ## Usage Notes
 

--- a/assistant/src/config/bundled-skills/time-based-actions/SKILL.md
+++ b/assistant/src/config/bundled-skills/time-based-actions/SKILL.md
@@ -102,11 +102,33 @@ Use `notify` for simple alerts. Use `execute` when the reminder should trigger t
 ## Reminder Routing
 
 `reminder_create` supports a `routing_intent` parameter that controls how the reminder is delivered at trigger time:
-- **`single_channel`** (default) — deliver to one best channel
+- **`single_channel`** — deliver to one best channel
 - **`multi_channel`** — deliver to a subset of channels
-- **`all_channels`** — deliver to every available channel
+- **`all_channels`** (default) — deliver to every available channel
 
 You can also pass `routing_hints` (a JSON object) to influence routing decisions (e.g. preferred channels, exclusions).
+
+### Routing Defaults
+
+Use the following heuristics to pick `routing_intent`:
+
+- **Default to `all_channels`** for most reminders. Users setting reminders usually want to be notified wherever they are, and redundant notifications are less harmful than missed ones.
+- **Use `single_channel`** only when the user explicitly specifies a single channel (e.g. "remind me on Telegram") or the reminder is low-stakes and noise reduction matters.
+- **Check `user_message_channel`** from the turn context. If the user is currently active on a specific channel (e.g. `vellum`), always include that channel. Pass it as a routing hint:
+  ```
+  routing_hints: { preferred_channels: ["vellum"] }
+  routing_intent: "all_channels"
+  ```
+- **Never use `single_channel` as a passive default.** If you haven't thought about which channel to use, use `all_channels`.
+
+### Examples
+
+| Scenario | routing_intent | routing_hints |
+|---|---|---|
+| User sets reminder from desktop app | `all_channels` | `{ preferred_channels: ["vellum"] }` |
+| User says "remind me on Telegram" | `single_channel` | `{ preferred_channels: ["telegram"] }` |
+| User sets reminder from Telegram | `all_channels` | `{ preferred_channels: ["telegram"] }` |
+| No channel preference expressed | `all_channels` | `{}` |
 
 ## Tool Summary
 


### PR DESCRIPTION
## Summary
- Changed default `routing_intent` from `single_channel` to `all_channels` in both reminder and time-based-actions skill docs
- Added routing heuristics section guiding when to use `single_channel` vs `all_channels`
- Added guidance to check `user_message_channel` from turn context and pass it as a routing hint

## Original prompt
Bug: Reminders default to `single_channel` routing, missing desktop notification when user is active on desktop. The reminder skill defaults to `single_channel` without guidance on when to use `all_channels`, causing reminders to be delivered to only one channel (e.g. Telegram) even when the user is active on desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
