### PR TITLE
M4: Guardian Conversational UX for Invite Links (#10363)

### DIFF
--- a/assistant/src/config/vellum-skills/catalog.json
+++ b/assistant/src/config/vellum-skills/catalog.json
@@ -56,7 +56,7 @@
     {
       "id": "trusted-contacts",
       "name": "Trusted Contacts",
-      "description": "Manage trusted contacts \u2014 list, allow, revoke, and block users who can message the assistant through external channels",
+      "description": "Manage trusted contacts and Telegram invite links \u2014 list, allow, revoke, block users, and create/list/revoke shareable invite links",
       "emoji": "\ud83d\udc65"
     }
   ]

--- a/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
+++ b/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "Trusted Contacts"
-description: "Manage trusted contacts — list, allow, revoke, and block users who can message the assistant through external channels"
+description: "Manage trusted contacts and Telegram invite links — list, allow, revoke, block users, and create/list/revoke invite links for external channels"
 user-invocable: true
 metadata: {"vellum": {"emoji": "\ud83d\udc65"}}
 ---
 
-You are helping your user manage trusted contacts for the Vellum Assistant. Trusted contacts control who is allowed to send messages to the assistant through external channels like Telegram and SMS. All operations go through the gateway HTTP API using `curl` with bearer auth.
+You are helping your user manage trusted contacts and invite links for the Vellum Assistant. Trusted contacts control who is allowed to send messages to the assistant through external channels like Telegram and SMS. Invite links let the guardian share a Telegram deep link that automatically grants access when opened. All operations go through the gateway HTTP API using `curl` with bearer auth.
 
 ## Prerequisites
 
@@ -18,6 +18,7 @@ You are helping your user manage trusted contacts for the Vellum Assistant. Trus
 - **Policy**: Controls what the member can do — `allow` (can message freely) or `deny` (blocked from messaging).
 - **Status**: The member's lifecycle state — `active` (currently effective), `revoked` (access removed), or `blocked` (explicitly denied).
 - **Source channel**: The messaging platform the contact uses (e.g., `telegram`, `sms`).
+- **Invite link**: A shareable Telegram deep link that, when opened by someone, automatically grants them trusted-contact access. Each invite has a token, usage limits, and optional expiration.
 
 ## Available Actions
 
@@ -117,9 +118,101 @@ curl -s -X POST "http://localhost:7830/v1/ingress/members/<member_id>/block" \
   -d '{"reason": "<optional reason>"}'
 ```
 
+### 5. Create a Telegram invite link
+
+Use this when the guardian wants to invite someone to message the assistant on Telegram without needing their user ID upfront. The invite link is a shareable Telegram deep link — when someone opens it, they automatically get trusted-contact access.
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+curl -s -X POST http://localhost:7830/v1/ingress/invites \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "sourceChannel": "telegram",
+    "maxUses": 1,
+    "note": "<optional note, e.g. the person it is for>"
+  }'
+```
+
+Optional fields:
+- `maxUses` — how many times the link can be used (default: 1). Use a higher number for group invites.
+- `expiresInMs` — expiration time in milliseconds from now (e.g., `86400000` for 24 hours). Omit for no expiration.
+- `note` — a human-readable label for the invite (e.g., "For Mom", "Family group").
+
+The response contains `{ ok: true, invite: { id, token, ... } }`. The `token` field is the raw invite token — it is only returned at creation time and cannot be retrieved later.
+
+**Building the shareable link**: After creating the invite, look up the Telegram bot username so you can build the deep link. Query the Telegram integration config:
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+curl -s http://localhost:7830/v1/integrations/telegram/config \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+The response includes `botUsername`. Use it to construct the deep link:
+
+```
+https://t.me/<botUsername>?start=iv_<token>
+```
+
+**Presenting to the guardian**: Give the guardian the link with clear copy-paste instructions:
+
+> Here's your Telegram invite link:
+>
+> `https://t.me/<botUsername>?start=iv_<token>`
+>
+> Share this link with the person you want to invite. When they open it in Telegram and press "Start", they'll automatically be added as a trusted contact and can message the assistant directly.
+>
+> This link can be used <maxUses> time(s)<and expires in X hours/days if applicable>.
+
+If the Telegram bot username is not available (integration not set up), tell the guardian they need to set up the Telegram integration first using the Telegram Setup skill.
+
+### 6. List invite links
+
+Use this to show the guardian their active (and optionally all) invite links.
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+curl -s "http://localhost:7830/v1/ingress/invites?sourceChannel=telegram" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Optional query parameters:
+- `sourceChannel` — filter by channel (e.g., `telegram`)
+- `status` — filter by status (`active`, `revoked`, `redeemed`, `expired`)
+
+The response contains `{ ok: true, invites: [...] }` where each invite has:
+- `id` — unique invite ID (needed for revoke)
+- `sourceChannel` — the channel
+- `tokenHash` — hashed token (the raw token is only available at creation time)
+- `maxUses` — total allowed uses
+- `useCount` — how many times it has been redeemed
+- `expiresAt` — expiration timestamp (null if no expiration)
+- `status` — current status (`active`, `revoked`, `redeemed`, `expired`)
+- `note` — the label set at creation
+- `createdAt` — when the invite was created
+
+**Presenting results**: Format as a readable list. Show the note (or "unnamed" as fallback), status, uses remaining (`maxUses - useCount`), and expiration. Highlight active invites and note which ones have been fully used or expired.
+
+### 7. Revoke an invite link
+
+Use this when the guardian wants to cancel an active invite link. **Always confirm before revoking.**
+
+Ask the user: *"I'll revoke the invite link [note or ID]. It will no longer be usable. Should I proceed?"*
+
+First, list invites to find the invite's `id`, then revoke:
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+curl -s -X DELETE "http://localhost:7830/v1/ingress/invites/<invite_id>" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Replace `<invite_id>` with the invite's `id` from the list response.
+
 ## Confirmation Requirements
 
-**All mutating actions (allow, revoke, block) require explicit user confirmation before execution.** This is a safety measure — modifying who can access the assistant should always be a deliberate choice.
+**All mutating actions (allow, revoke, block, revoke invite) require explicit user confirmation before execution.** This is a safety measure — modifying who can access the assistant should always be a deliberate choice. Creating an invite link does not require confirmation since it does not grant access until someone opens it.
 
 - Clearly state what action you are about to take and who it affects.
 - Wait for the user to confirm before running the curl command.
@@ -133,6 +226,8 @@ curl -s -X POST "http://localhost:7830/v1/ingress/members/<member_id>/block" \
   - `At least one of externalUserId or externalChatId is required` — ask the user for the contact's channel-specific identifier.
   - `Member not found or cannot be revoked` — the member ID may be invalid or the member is already revoked.
   - `Member not found or already blocked` — the member ID may be invalid or the member is already blocked.
+  - `sourceChannel is required for create` — when creating an invite, always pass `"sourceChannel": "telegram"`.
+  - `Invite not found or already revoked` — the invite ID may be invalid or the invite is already revoked.
 
 ## Typical Workflows
 
@@ -145,3 +240,9 @@ curl -s -X POST "http://localhost:7830/v1/ingress/members/<member_id>/block" \
 **"Block [name]"** — List members to find them, confirm the block, then execute.
 
 **"Show me blocked contacts"** — List with `status=blocked` filter.
+
+**"Create a Telegram invite link"** / **"Invite someone on Telegram"** — Create an invite with `sourceChannel: "telegram"`, look up the bot username, build the deep link, and present it with sharing instructions.
+
+**"Show my invites"** / **"List active invite links"** — List invites filtered by `sourceChannel=telegram`, present active invites with uses remaining and expiration info.
+
+**"Revoke invite"** / **"Cancel invite link"** — List invites to identify the target, confirm, then revoke by ID.

--- a/assistant/src/daemon/guardian-invite-intent.ts
+++ b/assistant/src/daemon/guardian-invite-intent.ts
@@ -30,8 +30,8 @@ const LIST_INVITE_PATTERNS: RegExp[] = [
 ];
 
 const REVOKE_INVITE_PATTERNS: RegExp[] = [
-  /\b(?:revoke|cancel|disable|invalidate|delete|remove)\s+(?:the\s+|an?\s+)?invite\s*(?:link)?\b/i,
-  /\b(?:revoke|cancel|disable|invalidate|delete|remove)\s+(?:the\s+|an?\s+)?(?:telegram\s+)?invite\s*(?:link)?\b/i,
+  /\b(?:revoke|cancel|disable|invalidate|delete|remove)\s+(?:the\s+|my\s+|an?\s+)?invite\s*(?:link)?\b/i,
+  /\b(?:revoke|cancel|disable|invalidate|delete|remove)\s+(?:the\s+|my\s+|an?\s+)?(?:telegram\s+)?invite\s*(?:link)?\b/i,
   /\binvite\s*(?:link)?\s+(?:revoke|cancel|disable|invalidate|delete|remove)\b/i,
 ];
 

--- a/assistant/src/daemon/guardian-invite-intent.ts
+++ b/assistant/src/daemon/guardian-invite-intent.ts
@@ -1,0 +1,120 @@
+// Guardian invite intent resolution for deterministic first-turn routing.
+// Exports `resolveGuardianInviteIntent` as the single public entry point.
+// When a guardian invite management request is detected, the session pipeline
+// rewrites the message to force immediate entry into the trusted-contacts
+// skill flow, bypassing the normal agent loop's tendency to produce conceptual
+// preambles before loading the skill.
+
+export type GuardianInviteIntentResult =
+  | { kind: 'none' }
+  | { kind: 'invite_management'; rewrittenContent: string; action?: 'create' | 'list' | 'revoke' };
+
+// ── Direct invite patterns ────────────────────────────────────────────────
+// These capture imperative requests to manage Telegram invite links.
+
+const CREATE_INVITE_PATTERNS: RegExp[] = [
+  /\bcreate\s+(?:a\s+)?(?:telegram\s+)?invite\s*(?:link)?\b/i,
+  /\binvite\s+(?:someone|somebody|a\s+friend|a\s+person)\s+(?:on|to|via|through)\s+telegram\b/i,
+  /\b(?:make|generate|get)\s+(?:a\s+|an\s+)?(?:telegram\s+)?invite\s*(?:link)?\b/i,
+  /\btelegram\s+invite\s*(?:link)?\b/i,
+  /\bsend\s+(?:a\s+|an\s+)?invite\s+(?:link\s+)?(?:on|for|via|through)\s+telegram\b/i,
+  /\bshare\s+(?:a\s+|an\s+)?(?:telegram\s+)?invite\s*(?:link)?\b/i,
+  /\binvite\s+(?:link\s+)?for\s+telegram\b/i,
+];
+
+const LIST_INVITE_PATTERNS: RegExp[] = [
+  /\b(?:show|list|view|see|display)\s+(?:my\s+)?(?:active\s+)?invite(?:s|\s*links?)\b/i,
+  /\b(?:show|list|view|see|display)\s+(?:my\s+)?(?:telegram\s+)?invite(?:s|\s*links?)\b/i,
+  /\bwhat\s+invite(?:s|\s*links?)\s+(?:do\s+I\s+have|are\s+active|exist)\b/i,
+  /\bhow\s+many\s+invite(?:s|\s*links?)\b/i,
+];
+
+const REVOKE_INVITE_PATTERNS: RegExp[] = [
+  /\b(?:revoke|cancel|disable|invalidate|delete|remove)\s+(?:the\s+|an?\s+)?invite\s*(?:link)?\b/i,
+  /\b(?:revoke|cancel|disable|invalidate|delete|remove)\s+(?:the\s+|an?\s+)?(?:telegram\s+)?invite\s*(?:link)?\b/i,
+  /\binvite\s*(?:link)?\s+(?:revoke|cancel|disable|invalidate|delete|remove)\b/i,
+];
+
+// ── Conceptual / question patterns ──────────────────────────────────────
+// These indicate the user is asking *about* invites rather than requesting
+// to manage them. Return passthrough for these.
+
+const CONCEPTUAL_PATTERNS: RegExp[] = [
+  /^\s*(?:how|what|why|when|where|who|which)\b.*\binvite/i,
+  /\bwhat\s+(?:is|are)\s+(?:an?\s+)?invite\s*(?:link)?\b/i,
+  /\bhow\s+(?:do|does|can)\s+(?:invite|invitation)s?\s+work\b/i,
+  /\bexplain\s+(?:the\s+)?invite\b/i,
+  /\btell\s+me\s+about\s+invite\b/i,
+];
+
+/** Common polite/filler words stripped before checking intent-only status. */
+const FILLER_PATTERN =
+  /\b(please|pls|plz|can\s+you|could\s+you|would\s+you|now|right\s+now|thanks|thank\s+you|thx|ty|for\s+me|ok(ay)?|hey|hi|hello|just|i\s+want\s+to|i'd\s+like\s+to|i\s+need\s+to|let's|let\s+me)\b/gi;
+
+// ── Internal helpers ─────────────────────────────────────────────────────
+
+function isConceptualQuestion(text: string): boolean {
+  const cleaned = text.replace(/^\s*(hey|hi|hello|please|pls|plz)[,\s]+/i, '');
+  // Allow "list" / "show" questions through even though they start with
+  // question-like words — these are actionable list requests.
+  if (LIST_INVITE_PATTERNS.some((p) => p.test(cleaned))) return false;
+  return CONCEPTUAL_PATTERNS.some((p) => p.test(cleaned));
+}
+
+function detectAction(text: string): 'create' | 'list' | 'revoke' | undefined {
+  if (CREATE_INVITE_PATTERNS.some((p) => p.test(text))) return 'create';
+  if (REVOKE_INVITE_PATTERNS.some((p) => p.test(text))) return 'revoke';
+  if (LIST_INVITE_PATTERNS.some((p) => p.test(text))) return 'list';
+  return undefined;
+}
+
+// ── Structured intent resolver ───────────────────────────────────────────
+
+/**
+ * Resolves guardian invite management intent from user text.
+ *
+ * Pipeline:
+ * 1. Skip slash commands entirely
+ * 2. Conceptual question gate -- questions return `none`
+ * 3. Detect create/list/revoke invite patterns
+ * 4. On match, build a deterministic model instruction to load trusted-contacts
+ */
+export function resolveGuardianInviteIntent(text: string): GuardianInviteIntentResult {
+  const trimmed = text.trim();
+
+  // Never intercept slash commands
+  if (trimmed.startsWith('/')) {
+    return { kind: 'none' };
+  }
+
+  // Conceptual questions pass through to normal agent processing
+  if (isConceptualQuestion(trimmed)) {
+    return { kind: 'none' };
+  }
+
+  // Strip fillers for pattern matching but keep original for context
+  const withoutFillers = trimmed.replace(FILLER_PATTERN, '').replace(/\s{2,}/g, ' ').trim();
+
+  const action = detectAction(withoutFillers);
+  if (!action) {
+    return { kind: 'none' };
+  }
+
+  // Build the rewritten content that deterministically loads the skill
+  const actionDescriptions: Record<string, string> = {
+    create: 'The user wants to create a Telegram invite link. Create the invite, look up the bot username, and present the shareable deep link with copy-paste instructions.',
+    list: 'The user wants to see their invite links. List all invites (especially active ones for Telegram) and present them in a readable format.',
+    revoke: 'The user wants to revoke an invite link. List invites to identify the target, confirm with the user, then revoke it.',
+  };
+
+  const rewrittenContent = [
+    actionDescriptions[action],
+    'Please invoke the "Trusted Contacts" skill (ID: trusted-contacts) immediately using skill_load.',
+  ].join('\n');
+
+  return {
+    kind: 'invite_management',
+    rewrittenContent,
+    action,
+  };
+}

--- a/assistant/src/daemon/guardian-invite-intent.ts
+++ b/assistant/src/daemon/guardian-invite-intent.ts
@@ -13,7 +13,7 @@ export type GuardianInviteIntentResult =
 // These capture imperative requests to manage Telegram invite links.
 
 const CREATE_INVITE_PATTERNS: RegExp[] = [
-  /\bcreate\s+(?:a\s+)?(?:telegram\s+)?invite\s*(?:link)?\b/i,
+  /\bcreate\s+(?:an?\s+)?(?:telegram\s+)?invite\s*(?:link)?\b/i,
   /\binvite\s+(?:someone|somebody|a\s+friend|a\s+person)\s+(?:on|to|via|through)\s+telegram\b/i,
   /\b(?:make|generate|get)\s+(?:a\s+|an\s+)?(?:telegram\s+)?invite\s*(?:link)?\b/i,
   /\btelegram\s+invite\s*(?:link)?\b/i,
@@ -62,9 +62,11 @@ function isConceptualQuestion(text: string): boolean {
 }
 
 function detectAction(text: string): 'create' | 'list' | 'revoke' | undefined {
-  if (CREATE_INVITE_PATTERNS.some((p) => p.test(text))) return 'create';
+  // Check revoke and list before create — create patterns include the broad
+  // `telegram invite link` matcher that would otherwise swallow revoke/list inputs.
   if (REVOKE_INVITE_PATTERNS.some((p) => p.test(text))) return 'revoke';
   if (LIST_INVITE_PATTERNS.some((p) => p.test(text))) return 'list';
+  if (CREATE_INVITE_PATTERNS.some((p) => p.test(text))) return 'create';
   return undefined;
 }
 

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -36,6 +36,7 @@ import { tryMintGuardianActionGrant } from '../runtime/guardian-action-grant-min
 import { composeGuardianActionMessageGenerative } from '../runtime/guardian-action-message-composer.js';
 import type { GuardianActionCopyGenerator, GuardianFollowUpConversationGenerator } from '../runtime/http-types.js';
 import { getLogger } from '../util/logger.js';
+import { resolveGuardianInviteIntent } from './guardian-invite-intent.js';
 import { resolveGuardianVerificationIntent } from './guardian-verification-intent.js';
 import type { UsageStats } from './ipc-contract.js';
 import type { ServerMessage, UserMessageAttachment } from './ipc-protocol.js';
@@ -299,6 +300,15 @@ export async function drainQueue(session: ProcessSessionContext, reason: QueueDr
       log.info({ conversationId: session.conversationId, channelHint: guardianIntent.channelHint }, 'Guardian verification intent intercepted in queue — forcing skill flow');
       agentLoopContent = guardianIntent.rewrittenContent;
       session.preactivatedSkillIds = ['guardian-verify-setup'];
+    } else {
+      // Guardian invite intent interception — force invite management
+      // requests into the trusted-contacts skill flow.
+      const inviteIntent = resolveGuardianInviteIntent(resolvedContent);
+      if (inviteIntent.kind === 'invite_management') {
+        log.info({ conversationId: session.conversationId, action: inviteIntent.action }, 'Guardian invite intent intercepted in queue — forcing skill flow');
+        agentLoopContent = inviteIntent.rewrittenContent;
+        session.preactivatedSkillIds = ['trusted-contacts'];
+      }
     }
   }
 
@@ -743,6 +753,15 @@ export async function processMessage(
       log.info({ conversationId: session.conversationId, channelHint: guardianIntent.channelHint }, 'Guardian verification intent intercepted — forcing skill flow');
       agentLoopContent = guardianIntent.rewrittenContent;
       session.preactivatedSkillIds = ['guardian-verify-setup'];
+    } else {
+      // Guardian invite intent interception — force invite management
+      // requests into the trusted-contacts skill flow.
+      const inviteIntent = resolveGuardianInviteIntent(resolvedContent);
+      if (inviteIntent.kind === 'invite_management') {
+        log.info({ conversationId: session.conversationId, action: inviteIntent.action }, 'Guardian invite intent intercepted — forcing skill flow');
+        agentLoopContent = inviteIntent.rewrittenContent;
+        session.preactivatedSkillIds = ['trusted-contacts'];
+      }
     }
   }
 


### PR DESCRIPTION
Extend trusted-contacts skill with Telegram invite link workflows: create, list, and revoke invites. Add guardian invite intent resolver for natural language activation. Part of #10357.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
