### PR TITLE
M5: Documentation and Architecture Alignment (#10364)

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -280,6 +280,68 @@ External users who are not the guardian can gain access to the assistant through
 | `src/memory/channel-guardian-store.ts` | Approval request and verification challenge persistence |
 | `src/config/vellum-skills/trusted-contacts/SKILL.md` | Skill teaching the assistant to manage contacts via HTTP API |
 
+### Guardian-Initiated Invite Links
+
+A complementary access-granting flow where the guardian proactively creates a shareable invite link rather than waiting for an unknown user to request access. Currently implemented for Telegram; the architecture supports future channel adapters.
+
+**Three-layer architecture:**
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Conversational Orchestration (guardian-invite-intent.ts)    │
+│  Pattern-based intent detection → forces trusted-contacts    │
+│  skill load for create / list / revoke actions               │
+├─────────────────────────────────────────────────────────────┤
+│  Channel Transport Adapters (channel-invite-transport.ts)    │
+│  Registry of per-channel adapters:                           │
+│    • buildShareableInvite(token) → { url, displayText }     │
+│    • extractInboundToken(payload) → token | undefined        │
+│  Registered: Telegram  │  Deferred: SMS, Slack, Voice       │
+├─────────────────────────────────────────────────────────────┤
+│  Core Redemption Engine (invite-redemption-service.ts)       │
+│  Channel-agnostic token validation, expiry, use-count,       │
+│  channel-match enforcement, member creation/reactivation     │
+│  Returns: InviteRedemptionOutcome (discriminated union)      │
+│  Reply templates: invite-redemption-templates.ts             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Invite link flow (Telegram):**
+
+1. Guardian asks the assistant to create an invite via desktop chat.
+2. `guardian-invite-intent.ts` detects the intent and rewrites the message to force-load the `trusted-contacts` skill.
+3. The skill calls the ingress HTTP API to create an invite token, then calls the Telegram transport adapter to build a deep link: `https://t.me/<bot>?start=iv_<token>`.
+4. Guardian shares the link with the invitee out-of-band.
+5. Invitee clicks the link, opening Telegram which sends `/start iv_<token>` to the bot.
+6. The gateway forwards the message to `/channels/inbound`. The inbound handler calls `getTransport('telegram').extractInboundToken()` to parse the `iv_` token.
+7. The token is redeemed via `invite-redemption-service.ts`, which validates, creates an active member record, and returns a `redeemed` outcome.
+8. A deterministic welcome message is delivered to the invitee (bypasses the LLM pipeline).
+
+**Token prefix convention:** The `iv_` prefix distinguishes invite tokens from `gv_` (guardian verification) tokens. Both use the same Telegram `/start` deep-link mechanism but are routed to different handlers.
+
+**Inbound intercept points:** Invite token extraction runs early in the inbound handler, before ACL denial, so valid invites short-circuit the membership check. Two intercept branches handle: (a) non-members — the invite creates their first member record; (b) inactive members (revoked/pending) — the invite reactivates them.
+
+**Deferred channel adapters:**
+
+| Channel | Status | Prerequisites |
+|---------|--------|--------------|
+| Telegram | Shipped | Bot username resolved from credential metadata or `TELEGRAM_BOT_USERNAME` env |
+| SMS | Deferred | Needs a deep-link strategy compatible with SMS (short URL or web redemption page) |
+| Slack | Deferred | Needs DM-safe ingress — Socket Mode handles channel messages but DM-initiated invite flows need routing |
+| Voice | Deferred | Needs DTMF or speech-based token capture integrated with the voice relay state machine |
+
+**Key source files:**
+
+| File | Purpose |
+|------|---------|
+| `src/runtime/invite-redemption-service.ts` | Core redemption engine — token validation, member creation, discriminated-union outcomes |
+| `src/runtime/invite-redemption-templates.ts` | Deterministic reply templates for each redemption outcome |
+| `src/runtime/channel-invite-transport.ts` | Transport adapter registry with `buildShareableInvite` / `extractInboundToken` interface |
+| `src/runtime/channel-invite-transports/telegram.ts` | Telegram adapter — `t.me/<bot>?start=iv_<token>` deep links, `/start iv_<token>` extraction |
+| `src/daemon/guardian-invite-intent.ts` | Intent detection — routes create/list/revoke requests into the trusted-contacts skill |
+| `src/runtime/ingress-service.ts` | Shared business logic for invite/member operations (used by both HTTP routes and IPC) |
+| `src/runtime/routes/inbound-message-handler.ts` | Invite token intercept in the inbound flow (non-member and inactive-member branches) |
+
 ### Update Bulletin System
 
 Release-driven update notification system that surfaces release notes to the assistant via the system prompt.

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -384,7 +384,38 @@ Secure cross-user messaging allows external users (non-guardians) to interact wi
 
 ### Ingress Membership
 
-External users join through **invite tokens** — the owner creates an invite via IPC, and the external user redeems the token by sending it as a channel message. Redemption auto-creates a **member** record with an access policy:
+External users join through **invite tokens**. There are two invite flows:
+
+1. **IPC-based (legacy)** — The owner creates an invite via IPC, obtains the raw token, and shares it manually. The external user redeems the token by sending it as a channel message.
+2. **Guardian-initiated invite links (Telegram)** — The guardian asks the assistant to create an invite link via desktop chat. The assistant creates an invite, builds a channel-specific deep link, and presents it for sharing. The invitee clicks the link and is automatically granted access.
+
+#### Guardian-Initiated Invite Link Flow (Telegram)
+
+1. **Guardian requests invite** — The guardian asks the assistant (via desktop chat) to create a Telegram invite link. The `guardian-invite-intent.ts` module detects the intent and routes the request into the `trusted-contacts` skill.
+2. **Invite creation** — The skill creates an invite token via the ingress HTTP API and passes it to the Telegram invite transport adapter, which builds a shareable deep link: `https://t.me/<bot>?start=iv_<token>`.
+3. **Guardian shares link** — The guardian copies the deep link and shares it with the invitee through any messaging channel.
+4. **Invitee redeems** — The invitee clicks the link, which opens Telegram and sends `/start iv_<token>` to the bot. The inbound message handler extracts the token via the transport adapter, redeems it through the invite redemption service, and auto-creates an active member record.
+5. **Access granted** — The invitee receives a welcome message and all subsequent messages pass the ingress ACL.
+
+The `iv_` prefix distinguishes invite tokens from `gv_` (guardian verification) tokens, which use the same Telegram `/start` deep-link mechanism.
+
+#### Invite Redemption Architecture
+
+The invite redemption system uses a three-layer architecture:
+
+- **Core redemption engine** (`invite-redemption-service.ts`) — Channel-agnostic business logic that validates tokens, enforces expiry/use-count/channel-match constraints, handles member reactivation, and returns a discriminated-union `InviteRedemptionOutcome`. Deterministic reply templates (`invite-redemption-templates.ts`) map each outcome to a user-facing message without passing through the LLM.
+- **Channel transport adapters** (`channel-invite-transport.ts` + `channel-invite-transports/`) — A registry of per-channel adapters that know how to build shareable deep links (`buildShareableInvite`) and extract inbound tokens (`extractInboundToken`). Currently only the Telegram adapter is implemented.
+- **Conversational orchestration** (`guardian-invite-intent.ts`) — Pattern-based intent detection that intercepts guardian invite management requests (create, list, revoke) in the session pipeline and forces immediate entry into the `trusted-contacts` skill, bypassing the normal agent loop.
+
+#### Deferred Channel Support
+
+The transport adapter registry is architecturally extensible to additional channels. The following are not yet implemented:
+
+- **SMS** — Requires a deep-link strategy compatible with SMS (e.g., a short URL that redirects to an SMS reply flow or web-based redemption page). The core redemption engine is channel-agnostic and ready.
+- **Slack** — Requires DM-safe ingress (Socket Mode currently handles channel messages but DM-initiated invite flows need additional routing). The adapter would build Slack deep links or slash-command payloads.
+- **Voice** — Requires DTMF or speech-based token capture during an inbound call. The adapter would need to integrate with the voice relay state machine for token entry.
+
+Redemption auto-creates a **member** record with an access policy:
 
 - **`allow`** — Messages are processed normally through the agent pipeline.
 - **`deny`** — Messages are rejected with a refusal notice.
@@ -416,6 +447,12 @@ If no guardian binding exists, escalation fails closed — the message is denied
 | `src/daemon/handlers/config-inbox.ts` | IPC handlers for ingress invite and member contracts |
 | `src/daemon/ipc-contract/inbox.ts` | TypeScript type definitions for ingress IPC messages |
 | `src/runtime/routes/channel-routes.ts` | ACL enforcement point — member lookup, policy check, escalation creation |
+| `src/runtime/invite-redemption-service.ts` | Core redemption engine — token validation, member creation, discriminated-union outcomes |
+| `src/runtime/invite-redemption-templates.ts` | Deterministic reply templates for each redemption outcome |
+| `src/runtime/channel-invite-transport.ts` | Transport adapter registry — `buildShareableInvite` / `extractInboundToken` per channel |
+| `src/runtime/channel-invite-transports/telegram.ts` | Telegram adapter — builds `t.me/<bot>?start=iv_<token>` deep links, extracts `iv_` tokens from `/start` commands |
+| `src/daemon/guardian-invite-intent.ts` | Intent detection — routes guardian invite management requests into the `trusted-contacts` skill |
+| `src/runtime/ingress-service.ts` | Shared business logic for invite/member operations (HTTP + IPC) |
 
 ## Database
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -392,7 +392,7 @@ External users join through **invite tokens**. There are two invite flows:
 #### Guardian-Initiated Invite Link Flow (Telegram)
 
 1. **Guardian requests invite** — The guardian asks the assistant (via desktop chat) to create a Telegram invite link. The `guardian-invite-intent.ts` module detects the intent and routes the request into the `trusted-contacts` skill.
-2. **Invite creation** — The skill creates an invite token via the ingress HTTP API and passes it to the Telegram invite transport adapter, which builds a shareable deep link: `https://t.me/<bot>?start=iv_<token>`.
+2. **Invite creation** — The skill creates an invite token via the ingress HTTP API, looks up the Telegram bot username from the integration config endpoint, and constructs a shareable deep link: `https://t.me/<bot>?start=iv_<token>`.
 3. **Guardian shares link** — The guardian copies the deep link and shares it with the invitee through any messaging channel.
 4. **Invitee redeems** — The invitee clicks the link, which opens Telegram and sends `/start iv_<token>` to the bot. The inbound message handler extracts the token via the transport adapter, redeems it through the invite redemption service, and auto-creates an active member record.
 5. **Access granted** — The invitee receives a welcome message and all subsequent messages pass the ingress ACL.


### PR DESCRIPTION
Update README and architecture docs to reflect guardian-initiated Telegram invite link feature. Document new modules, invite flow, and deferred channel support. Part of #10357.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
