### PR TITLE
Guardian-Initiated Telegram Invite Links

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -280,6 +280,68 @@ External users who are not the guardian can gain access to the assistant through
 | `src/memory/channel-guardian-store.ts` | Approval request and verification challenge persistence |
 | `src/config/vellum-skills/trusted-contacts/SKILL.md` | Skill teaching the assistant to manage contacts via HTTP API |
 
+### Guardian-Initiated Invite Links
+
+A complementary access-granting flow where the guardian proactively creates a shareable invite link rather than waiting for an unknown user to request access. Currently implemented for Telegram; the architecture supports future channel adapters.
+
+**Three-layer architecture:**
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Conversational Orchestration (guardian-invite-intent.ts)    │
+│  Pattern-based intent detection → forces trusted-contacts    │
+│  skill load for create / list / revoke actions               │
+├─────────────────────────────────────────────────────────────┤
+│  Channel Transport Adapters (channel-invite-transport.ts)    │
+│  Registry of per-channel adapters:                           │
+│    • buildShareableInvite(token) → { url, displayText }     │
+│    • extractInboundToken(payload) → token | undefined        │
+│  Registered: Telegram  │  Deferred: SMS, Slack, Voice       │
+├─────────────────────────────────────────────────────────────┤
+│  Core Redemption Engine (invite-redemption-service.ts)       │
+│  Channel-agnostic token validation, expiry, use-count,       │
+│  channel-match enforcement, member creation/reactivation     │
+│  Returns: InviteRedemptionOutcome (discriminated union)      │
+│  Reply templates: invite-redemption-templates.ts             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Invite link flow (Telegram):**
+
+1. Guardian asks the assistant to create an invite via desktop chat.
+2. `guardian-invite-intent.ts` detects the intent and rewrites the message to force-load the `trusted-contacts` skill.
+3. The skill calls the ingress HTTP API to create an invite token, then calls the Telegram transport adapter to build a deep link: `https://t.me/<bot>?start=iv_<token>`.
+4. Guardian shares the link with the invitee out-of-band.
+5. Invitee clicks the link, opening Telegram which sends `/start iv_<token>` to the bot.
+6. The gateway forwards the message to `/channels/inbound`. The inbound handler calls `getTransport('telegram').extractInboundToken()` to parse the `iv_` token.
+7. The token is redeemed via `invite-redemption-service.ts`, which validates, creates an active member record, and returns a `redeemed` outcome.
+8. A deterministic welcome message is delivered to the invitee (bypasses the LLM pipeline).
+
+**Token prefix convention:** The `iv_` prefix distinguishes invite tokens from `gv_` (guardian verification) tokens. Both use the same Telegram `/start` deep-link mechanism but are routed to different handlers.
+
+**Inbound intercept points:** Invite token extraction runs early in the inbound handler, before ACL denial, so valid invites short-circuit the membership check. Two intercept branches handle: (a) non-members — the invite creates their first member record; (b) inactive members (revoked/pending) — the invite reactivates them.
+
+**Deferred channel adapters:**
+
+| Channel | Status | Prerequisites |
+|---------|--------|--------------|
+| Telegram | Shipped | Bot username resolved from credential metadata or `TELEGRAM_BOT_USERNAME` env |
+| SMS | Deferred | Needs a deep-link strategy compatible with SMS (short URL or web redemption page) |
+| Slack | Deferred | Needs DM-safe ingress — Socket Mode handles channel messages but DM-initiated invite flows need routing |
+| Voice | Deferred | Needs DTMF or speech-based token capture integrated with the voice relay state machine |
+
+**Key source files:**
+
+| File | Purpose |
+|------|---------|
+| `src/runtime/invite-redemption-service.ts` | Core redemption engine — token validation, member creation, discriminated-union outcomes |
+| `src/runtime/invite-redemption-templates.ts` | Deterministic reply templates for each redemption outcome |
+| `src/runtime/channel-invite-transport.ts` | Transport adapter registry with `buildShareableInvite` / `extractInboundToken` interface |
+| `src/runtime/channel-invite-transports/telegram.ts` | Telegram adapter — `t.me/<bot>?start=iv_<token>` deep links, `/start iv_<token>` extraction |
+| `src/daemon/guardian-invite-intent.ts` | Intent detection — routes create/list/revoke requests into the trusted-contacts skill |
+| `src/runtime/ingress-service.ts` | Shared business logic for invite/member operations (used by both HTTP routes and IPC) |
+| `src/runtime/routes/inbound-message-handler.ts` | Invite token intercept in the inbound flow (non-member and inactive-member branches) |
+
 ### Update Bulletin System
 
 Release-driven update notification system that surfaces release notes to the assistant via the system prompt.

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -384,7 +384,38 @@ Secure cross-user messaging allows external users (non-guardians) to interact wi
 
 ### Ingress Membership
 
-External users join through **invite tokens** — the owner creates an invite via IPC, and the external user redeems the token by sending it as a channel message. Redemption auto-creates a **member** record with an access policy:
+External users join through **invite tokens**. There are two invite flows:
+
+1. **IPC-based (legacy)** — The owner creates an invite via IPC, obtains the raw token, and shares it manually. The external user redeems the token by sending it as a channel message.
+2. **Guardian-initiated invite links (Telegram)** — The guardian asks the assistant to create an invite link via desktop chat. The assistant creates an invite, builds a channel-specific deep link, and presents it for sharing. The invitee clicks the link and is automatically granted access.
+
+#### Guardian-Initiated Invite Link Flow (Telegram)
+
+1. **Guardian requests invite** — The guardian asks the assistant (via desktop chat) to create a Telegram invite link. The `guardian-invite-intent.ts` module detects the intent and routes the request into the `trusted-contacts` skill.
+2. **Invite creation** — The skill creates an invite token via the ingress HTTP API, looks up the Telegram bot username from the integration config endpoint, and constructs a shareable deep link: `https://t.me/<bot>?start=iv_<token>`.
+3. **Guardian shares link** — The guardian copies the deep link and shares it with the invitee through any messaging channel.
+4. **Invitee redeems** — The invitee clicks the link, which opens Telegram and sends `/start iv_<token>` to the bot. The inbound message handler extracts the token via the transport adapter, redeems it through the invite redemption service, and auto-creates an active member record.
+5. **Access granted** — The invitee receives a welcome message and all subsequent messages pass the ingress ACL.
+
+The `iv_` prefix distinguishes invite tokens from `gv_` (guardian verification) tokens, which use the same Telegram `/start` deep-link mechanism.
+
+#### Invite Redemption Architecture
+
+The invite redemption system uses a three-layer architecture:
+
+- **Core redemption engine** (`invite-redemption-service.ts`) — Channel-agnostic business logic that validates tokens, enforces expiry/use-count/channel-match constraints, handles member reactivation, and returns a discriminated-union `InviteRedemptionOutcome`. Deterministic reply templates (`invite-redemption-templates.ts`) map each outcome to a user-facing message without passing through the LLM.
+- **Channel transport adapters** (`channel-invite-transport.ts` + `channel-invite-transports/`) — A registry of per-channel adapters that know how to build shareable deep links (`buildShareableInvite`) and extract inbound tokens (`extractInboundToken`). Currently only the Telegram adapter is implemented.
+- **Conversational orchestration** (`guardian-invite-intent.ts`) — Pattern-based intent detection that intercepts guardian invite management requests (create, list, revoke) in the session pipeline and forces immediate entry into the `trusted-contacts` skill, bypassing the normal agent loop.
+
+#### Deferred Channel Support
+
+The transport adapter registry is architecturally extensible to additional channels. The following are not yet implemented:
+
+- **SMS** — Requires a deep-link strategy compatible with SMS (e.g., a short URL that redirects to an SMS reply flow or web-based redemption page). The core redemption engine is channel-agnostic and ready.
+- **Slack** — Requires DM-safe ingress (Socket Mode currently handles channel messages but DM-initiated invite flows need additional routing). The adapter would build Slack deep links or slash-command payloads.
+- **Voice** — Requires DTMF or speech-based token capture during an inbound call. The adapter would need to integrate with the voice relay state machine for token entry.
+
+Redemption auto-creates a **member** record with an access policy:
 
 - **`allow`** — Messages are processed normally through the agent pipeline.
 - **`deny`** — Messages are rejected with a refusal notice.
@@ -416,6 +447,12 @@ If no guardian binding exists, escalation fails closed — the message is denied
 | `src/daemon/handlers/config-inbox.ts` | IPC handlers for ingress invite and member contracts |
 | `src/daemon/ipc-contract/inbox.ts` | TypeScript type definitions for ingress IPC messages |
 | `src/runtime/routes/channel-routes.ts` | ACL enforcement point — member lookup, policy check, escalation creation |
+| `src/runtime/invite-redemption-service.ts` | Core redemption engine — token validation, member creation, discriminated-union outcomes |
+| `src/runtime/invite-redemption-templates.ts` | Deterministic reply templates for each redemption outcome |
+| `src/runtime/channel-invite-transport.ts` | Transport adapter registry — `buildShareableInvite` / `extractInboundToken` per channel |
+| `src/runtime/channel-invite-transports/telegram.ts` | Telegram adapter — builds `t.me/<bot>?start=iv_<token>` deep links, extracts `iv_` tokens from `/start` commands |
+| `src/daemon/guardian-invite-intent.ts` | Intent detection — routes guardian invite management requests into the `trusted-contacts` skill |
+| `src/runtime/ingress-service.ts` | Shared business logic for invite/member operations (HTTP + IPC) |
 
 ## Database
 

--- a/assistant/src/__tests__/channel-invite-transport.test.ts
+++ b/assistant/src/__tests__/channel-invite-transport.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// Mock the credential metadata store so the Telegram adapter can resolve
+// the bot username without touching the filesystem.
+let mockBotUsername: string | undefined = 'test_invite_bot';
+mock.module('../tools/credentials/metadata-store.js', () => ({
+  getCredentialMetadata: (service: string, field: string) => {
+    if (service === 'telegram' && field === 'bot_token' && mockBotUsername) {
+      return { accountInfo: mockBotUsername };
+    }
+    return undefined;
+  },
+  upsertCredentialMetadata: () => {},
+  deleteCredentialMetadata: () => {},
+  listCredentialMetadata: () => [],
+}));
+
+import {
+  _resetRegistry,
+  getTransport,
+  registerTransport,
+  type ChannelInviteTransport,
+  type InviteSharePayload,
+} from '../runtime/channel-invite-transport.js';
+
+// Importing the Telegram module auto-registers the transport
+import { telegramInviteTransport } from '../runtime/channel-invite-transports/telegram.js';
+
+describe('channel-invite-transport', () => {
+  beforeEach(() => {
+    _resetRegistry();
+    mockBotUsername = 'test_invite_bot';
+    // Re-register after reset so Telegram tests work
+    registerTransport(telegramInviteTransport);
+  });
+
+  // =========================================================================
+  // Registry
+  // =========================================================================
+
+  describe('registry', () => {
+    test('returns the Telegram transport for telegram channel', () => {
+      const transport = getTransport('telegram');
+      expect(transport).toBeDefined();
+      expect(transport!.channel).toBe('telegram');
+    });
+
+    test('returns undefined for an unregistered channel', () => {
+      const transport = getTransport('sms');
+      expect(transport).toBeUndefined();
+    });
+
+    test('overwrites a previously registered transport for the same channel', () => {
+      const custom: ChannelInviteTransport = {
+        channel: 'telegram',
+        buildShareableInvite: () => ({ url: 'custom', displayText: 'custom' }),
+        extractInboundToken: () => undefined,
+      };
+      registerTransport(custom);
+      const transport = getTransport('telegram');
+      expect(transport!.buildShareableInvite({ rawToken: 'x', sourceChannel: 'telegram' }).url).toBe('custom');
+    });
+
+    test('_resetRegistry clears all transports', () => {
+      _resetRegistry();
+      expect(getTransport('telegram')).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // Telegram adapter — buildShareableInvite
+  // =========================================================================
+
+  describe('telegram buildShareableInvite', () => {
+    test('produces a valid Telegram deep link', () => {
+      const result = telegramInviteTransport.buildShareableInvite({
+        rawToken: 'abc123_test-token',
+        sourceChannel: 'telegram',
+      });
+
+      expect(result.url).toBe('https://t.me/test_invite_bot?start=iv_abc123_test-token');
+      expect(result.displayText).toContain('https://t.me/test_invite_bot?start=iv_abc123_test-token');
+    });
+
+    test('deep link is deterministic for the same token', () => {
+      const a = telegramInviteTransport.buildShareableInvite({ rawToken: 'tok1', sourceChannel: 'telegram' });
+      const b = telegramInviteTransport.buildShareableInvite({ rawToken: 'tok1', sourceChannel: 'telegram' });
+      expect(a.url).toBe(b.url);
+      expect(a.displayText).toBe(b.displayText);
+    });
+
+    test('uses the configured bot username', () => {
+      mockBotUsername = 'my_custom_bot';
+      const result = telegramInviteTransport.buildShareableInvite({
+        rawToken: 'token',
+        sourceChannel: 'telegram',
+      });
+      expect(result.url).toBe('https://t.me/my_custom_bot?start=iv_token');
+    });
+
+    test('throws when bot username is not configured', () => {
+      mockBotUsername = undefined;
+      // Also clear the env var to ensure no fallback
+      const prev = process.env.TELEGRAM_BOT_USERNAME;
+      delete process.env.TELEGRAM_BOT_USERNAME;
+      try {
+        expect(() =>
+          telegramInviteTransport.buildShareableInvite({
+            rawToken: 'token',
+            sourceChannel: 'telegram',
+          }),
+        ).toThrow('bot username is not configured');
+      } finally {
+        if (prev !== undefined) process.env.TELEGRAM_BOT_USERNAME = prev;
+      }
+    });
+
+    test('falls back to TELEGRAM_BOT_USERNAME env var', () => {
+      mockBotUsername = undefined;
+      const prev = process.env.TELEGRAM_BOT_USERNAME;
+      process.env.TELEGRAM_BOT_USERNAME = 'env_bot';
+      try {
+        const result = telegramInviteTransport.buildShareableInvite({
+          rawToken: 'token',
+          sourceChannel: 'telegram',
+        });
+        expect(result.url).toBe('https://t.me/env_bot?start=iv_token');
+      } finally {
+        if (prev !== undefined) {
+          process.env.TELEGRAM_BOT_USERNAME = prev;
+        } else {
+          delete process.env.TELEGRAM_BOT_USERNAME;
+        }
+      }
+    });
+  });
+
+  // =========================================================================
+  // Telegram adapter — extractInboundToken
+  // =========================================================================
+
+  describe('telegram extractInboundToken', () => {
+    test('extracts token from structured commandIntent', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'start', payload: 'iv_abc123' },
+        content: '/start iv_abc123',
+      });
+      expect(token).toBe('abc123');
+    });
+
+    test('extracts base64url token from commandIntent', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'start', payload: 'iv_YWJjMTIz-_test' },
+        content: '/start iv_YWJjMTIz-_test',
+      });
+      expect(token).toBe('YWJjMTIz-_test');
+    });
+
+    test('returns undefined when commandIntent has no payload', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'start' },
+        content: '/start',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('returns undefined when commandIntent payload has wrong prefix (gv_)', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'start', payload: 'gv_abc123' },
+        content: '/start gv_abc123',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('returns undefined when commandIntent payload has no prefix', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'start', payload: 'abc123' },
+        content: '/start abc123',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('returns undefined when commandIntent type is not start', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'help', payload: 'iv_abc123' },
+        content: '/help iv_abc123',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('returns undefined when commandIntent payload is iv_ with empty token', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'start', payload: 'iv_' },
+        content: '/start iv_',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('returns undefined when commandIntent payload is iv_ with whitespace-only token', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'start', payload: 'iv_   ' },
+        content: '/start iv_   ',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('extracts token from raw content fallback', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        content: '/start iv_abc123',
+      });
+      expect(token).toBe('abc123');
+    });
+
+    test('extracts token from raw content with extra whitespace', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        content: '/start   iv_token123',
+      });
+      expect(token).toBe('token123');
+    });
+
+    test('returns undefined for empty content', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        content: '',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('returns undefined for content without /start', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        content: 'hello world',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('returns undefined for /start without iv_ prefix in content', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        content: '/start gv_abc123',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('returns undefined for malformed /start with only iv_ in content', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        content: '/start iv_',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('prefers commandIntent over raw content', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'start', payload: 'iv_from_intent' },
+        content: '/start iv_from_content',
+      });
+      expect(token).toBe('from_intent');
+    });
+
+    test('returns undefined when commandIntent rejects, even if content has token', () => {
+      // commandIntent present but payload has wrong prefix
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'start', payload: 'gv_abc123' },
+        content: '/start iv_valid_token',
+      });
+      expect(token).toBeUndefined();
+    });
+  });
+});

--- a/assistant/src/__tests__/inbound-invite-redemption.test.ts
+++ b/assistant/src/__tests__/inbound-invite-redemption.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Integration tests for the inbound invite redemption intercept.
+ *
+ * Validates that non-members with valid `/start iv_<token>` payloads are
+ * granted access without guardian approval, and that invalid/expired/revoked
+ * tokens produce the correct deterministic refusal messages.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Test isolation: in-memory SQLite via temp directory
+// ---------------------------------------------------------------------------
+
+const testDir = mkdtempSync(join(tmpdir(), 'inbound-invite-redemption-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  normalizeAssistantId: (id: string) => id === 'self' ? 'self' : id,
+  readHttpToken: () => 'test-bearer-token',
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../security/secret-ingress.js', () => ({
+  checkIngressForSecrets: () => ({ blocked: false }),
+}));
+
+mock.module('../config/env.js', () => ({
+  getGatewayInternalBaseUrl: () => 'http://127.0.0.1:7830',
+}));
+
+// Mock the credential metadata store so the Telegram transport adapter
+// resolves without touching the filesystem.
+mock.module('../tools/credentials/metadata-store.js', () => ({
+  getCredentialMetadata: () => undefined,
+  upsertCredentialMetadata: () => {},
+  deleteCredentialMetadata: () => {},
+  listCredentialMetadata: () => [],
+}));
+
+const emitSignalCalls: Array<Record<string, unknown>> = [];
+mock.module('../notifications/emit-signal.js', () => ({
+  emitNotificationSignal: async (params: Record<string, unknown>) => {
+    emitSignalCalls.push(params);
+    return {
+      signalId: 'mock-signal-id',
+      deduplicated: false,
+      dispatched: true,
+      reason: 'mock',
+      deliveryResults: [],
+    };
+  },
+}));
+
+const deliverReplyCalls: Array<{ url: string; payload: Record<string, unknown> }> = [];
+mock.module('../runtime/gateway-client.js', () => ({
+  deliverChannelReply: async (url: string, payload: Record<string, unknown>) => {
+    deliverReplyCalls.push({ url, payload });
+  },
+}));
+
+mock.module('../runtime/approval-message-composer.js', () => ({
+  composeApprovalMessage: () => 'mock approval message',
+  composeApprovalMessageGenerative: async () => 'mock generative message',
+}));
+
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { createInvite, revokeInvite } from '../memory/ingress-invite-store.js';
+import { findMember, upsertMember } from '../memory/ingress-member-store.js';
+import { handleChannelInbound } from '../runtime/routes/channel-routes.js';
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_BEARER_TOKEN = 'test-token';
+let msgCounter = 0;
+
+function resetState(): void {
+  const db = getDb();
+  db.run('DELETE FROM assistant_ingress_members');
+  db.run('DELETE FROM assistant_ingress_invites');
+  db.run('DELETE FROM channel_inbound_events');
+  db.run('DELETE FROM conversations');
+  db.run('DELETE FROM channel_guardian_approval_requests');
+  db.run('DELETE FROM channel_guardian_bindings');
+  db.run('DELETE FROM notification_events');
+  emitSignalCalls.length = 0;
+  deliverReplyCalls.length = 0;
+  msgCounter = 0;
+}
+
+function buildInboundRequest(overrides: Record<string, unknown> = {}): Request {
+  msgCounter++;
+  const body: Record<string, unknown> = {
+    sourceChannel: 'telegram',
+    interface: 'telegram',
+    externalChatId: 'chat-invite-test',
+    externalMessageId: `msg-invite-${Date.now()}-${msgCounter}`,
+    content: '/start iv_sometoken',
+    senderExternalUserId: 'user-invite-123',
+    senderName: 'Invite User',
+    senderUsername: 'invite_user',
+    replyCallbackUrl: 'http://localhost:7830/deliver/telegram',
+    sourceMetadata: {
+      commandIntent: { type: 'start', payload: 'iv_sometoken' },
+    },
+    ...overrides,
+  };
+
+  return new Request('http://localhost:8080/channels/inbound', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Gateway-Origin': TEST_BEARER_TOKEN,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Build a request with a specific invite token, using the structured
+ * commandIntent that the gateway produces for `/start <payload>`.
+ */
+function buildInviteRequest(rawToken: string, overrides: Record<string, unknown> = {}): Request {
+  return buildInboundRequest({
+    content: `/start iv_${rawToken}`,
+    sourceMetadata: {
+      commandIntent: { type: 'start', payload: `iv_${rawToken}` },
+    },
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('inbound invite redemption intercept', () => {
+  beforeEach(resetState);
+
+  test('non-member with valid invite token becomes active member without guardian approval', async () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 5 });
+
+    const req = buildInviteRequest(rawToken);
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = await resp.json() as Record<string, unknown>;
+
+    expect(json.accepted).toBe(true);
+    expect(json.inviteRedemption).toBe('redeemed');
+    expect(json.memberId).toEqual(expect.any(String));
+    expect(json.denied).toBeUndefined();
+
+    // Verify the user is now an active member
+    const member = findMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-invite-123',
+    });
+    expect(member).not.toBeNull();
+    expect(member!.status).toBe('active');
+
+    // Verify a welcome reply was delivered
+    expect(deliverReplyCalls.length).toBe(1);
+    const replyText = (deliverReplyCalls[0].payload as Record<string, unknown>).text;
+    expect(replyText).toContain("Welcome! You've been granted access via invite link.");
+  });
+
+  test('non-member with invalid token gets refusal text', async () => {
+    const req = buildInviteRequest('completely-bogus-token-xyz');
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = await resp.json() as Record<string, unknown>;
+
+    expect(json.accepted).toBe(true);
+    expect(json.denied).toBe(true);
+    expect(json.inviteRedemption).toBe('invalid_token');
+
+    // Verify refusal reply was delivered
+    expect(deliverReplyCalls.length).toBe(1);
+    const replyText = (deliverReplyCalls[0].payload as Record<string, unknown>).text;
+    expect(replyText).toContain('no longer valid');
+
+    // Verify the user was NOT made a member
+    const member = findMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-invite-123',
+    });
+    expect(member).toBeNull();
+  });
+
+  test('non-member with expired token gets appropriate message', async () => {
+    const { rawToken } = createInvite({
+      sourceChannel: 'telegram',
+      maxUses: 1,
+      expiresInMs: -1, // already expired
+    });
+
+    const req = buildInviteRequest(rawToken);
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = await resp.json() as Record<string, unknown>;
+
+    expect(json.accepted).toBe(true);
+    expect(json.denied).toBe(true);
+    expect(json.inviteRedemption).toBe('expired');
+
+    expect(deliverReplyCalls.length).toBe(1);
+    const replyText = (deliverReplyCalls[0].payload as Record<string, unknown>).text;
+    expect(replyText).toContain('no longer valid');
+  });
+
+  test('non-member with revoked token gets refusal text', async () => {
+    const { rawToken, invite } = createInvite({
+      sourceChannel: 'telegram',
+      maxUses: 5,
+    });
+    revokeInvite(invite.id);
+
+    const req = buildInviteRequest(rawToken);
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = await resp.json() as Record<string, unknown>;
+
+    expect(json.accepted).toBe(true);
+    expect(json.denied).toBe(true);
+    expect(json.inviteRedemption).toBe('revoked');
+
+    expect(deliverReplyCalls.length).toBe(1);
+    const replyText = (deliverReplyCalls[0].payload as Record<string, unknown>).text;
+    expect(replyText).toContain('no longer valid');
+  });
+
+  test('existing /start gv_<token> guardian bootstrap flow is unaffected', async () => {
+    // Send a /start gv_ command — should not be intercepted by the invite flow.
+    // Without a valid bootstrap session, it should be denied at the ACL gate.
+    const req = buildInboundRequest({
+      content: '/start gv_some_bootstrap_token',
+      sourceMetadata: {
+        commandIntent: { type: 'start', payload: 'gv_some_bootstrap_token' },
+      },
+    });
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = await resp.json() as Record<string, unknown>;
+
+    // Should be denied as a non-member (bootstrap token is invalid/no session)
+    expect(json.denied).toBe(true);
+    expect(json.reason).toBe('not_a_member');
+    // Should NOT have invite redemption fields
+    expect(json.inviteRedemption).toBeUndefined();
+  });
+
+  test('duplicate Telegram webhook deliveries do not double-redeem', async () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 5 });
+
+    const sharedMessageId = `msg-dedup-${Date.now()}`;
+    const makeReq = () => buildInviteRequest(rawToken, {
+      externalMessageId: sharedMessageId,
+    });
+
+    // First delivery
+    const resp1 = await handleChannelInbound(makeReq(), undefined, TEST_BEARER_TOKEN);
+    const json1 = await resp1.json() as Record<string, unknown>;
+    expect(json1.inviteRedemption).toBe('redeemed');
+
+    // Second delivery (duplicate webhook)
+    const resp2 = await handleChannelInbound(makeReq(), undefined, TEST_BEARER_TOKEN);
+    const json2 = await resp2.json() as Record<string, unknown>;
+    // Dedup kicks in — the message is treated as a duplicate and no second
+    // redemption attempt occurs.
+    expect(json2.duplicate).toBe(true);
+
+    // Only one welcome reply was delivered
+    expect(deliverReplyCalls.length).toBe(1);
+  });
+
+  test('existing active member sending normal message is unaffected', async () => {
+    // Pre-create an active member
+    upsertMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-active-member',
+      externalChatId: 'chat-active',
+      status: 'active',
+      policy: 'allow',
+    });
+
+    // Active member sends a normal message (no invite token)
+    const req = buildInboundRequest({
+      content: 'Hello, just a normal message!',
+      senderExternalUserId: 'user-active-member',
+      externalChatId: 'chat-active',
+      sourceMetadata: {},
+    });
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = await resp.json() as Record<string, unknown>;
+
+    // Should be accepted normally, not denied, not invite-redeemed
+    expect(json.accepted).toBe(true);
+    expect(json.denied).toBeUndefined();
+    expect(json.inviteRedemption).toBeUndefined();
+  });
+
+  test('channel mismatch returns appropriate message', async () => {
+    // Create an invite for SMS, but try to redeem via Telegram
+    const { rawToken } = createInvite({ sourceChannel: 'sms', maxUses: 5 });
+
+    const req = buildInviteRequest(rawToken);
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = await resp.json() as Record<string, unknown>;
+
+    expect(json.accepted).toBe(true);
+    expect(json.denied).toBe(true);
+    expect(json.inviteRedemption).toBe('channel_mismatch');
+
+    expect(deliverReplyCalls.length).toBe(1);
+    const replyText = (deliverReplyCalls[0].payload as Record<string, unknown>).text;
+    expect(replyText).toContain('not valid for this channel');
+  });
+
+  test('already-active member with invite token gets acknowledgement', async () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 5 });
+
+    // Pre-create an active member that will click the invite link
+    upsertMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-already-active',
+      externalChatId: 'chat-invite-test',
+      status: 'active',
+      policy: 'allow',
+    });
+
+    const req = buildInviteRequest(rawToken, {
+      senderExternalUserId: 'user-already-active',
+    });
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = await resp.json() as Record<string, unknown>;
+
+    // Active members pass through the ACL gate, so the invite intercept
+    // does not fire. The message proceeds to normal processing.
+    expect(json.accepted).toBe(true);
+    expect(json.denied).toBeUndefined();
+  });
+});

--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -172,7 +172,7 @@ describe('invite-redemption-service', () => {
     expect((outcome as Extract<InviteRedemptionOutcome, { type: 'already_member' }>).memberId).toEqual(expect.any(String));
   });
 
-  test('returns blocked for a blocked member attempting to redeem an invite', () => {
+  test('returns invalid_token for a blocked member to avoid leaking membership status', () => {
     const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 5 });
 
     // Pre-create a blocked member — simulates a guardian-initiated block
@@ -188,7 +188,7 @@ describe('invite-redemption-service', () => {
       externalUserId: 'blocked-user',
     });
 
-    expect(outcome).toEqual({ ok: false, reason: 'blocked' });
+    expect(outcome).toEqual({ ok: false, reason: 'invalid_token' });
   });
 
   test('does not return already_member for a revoked member', () => {

--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -1,0 +1,289 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'invite-redemption-service-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { getSqlite, initializeDb, resetDb } from '../memory/db.js';
+import { createInvite } from '../memory/ingress-invite-store.js';
+import { upsertMember } from '../memory/ingress-member-store.js';
+import { redeemInvite, type InviteRedemptionOutcome } from '../runtime/invite-redemption-service.js';
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+function resetTables() {
+  getSqlite().run('DELETE FROM assistant_ingress_members');
+  getSqlite().run('DELETE FROM assistant_ingress_invites');
+}
+
+describe('invite-redemption-service', () => {
+  beforeEach(resetTables);
+
+  test('redeems a valid invite and returns typed outcome', () => {
+    const { rawToken, invite } = createInvite({ sourceChannel: 'telegram', maxUses: 1 });
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+    });
+
+    expect(outcome.ok).toBe(true);
+    expect(outcome).toEqual({
+      ok: true,
+      type: 'redeemed',
+      memberId: expect.any(String),
+      inviteId: invite.id,
+    });
+  });
+
+  test('returns invalid_token for a bogus token', () => {
+    const outcome = redeemInvite({
+      rawToken: 'totally-bogus-token',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: 'invalid_token' });
+  });
+
+  test('returns expired for an expired invite', () => {
+    // Create an invite that expired 1 ms ago
+    const { rawToken } = createInvite({
+      sourceChannel: 'telegram',
+      maxUses: 1,
+      expiresInMs: -1,
+    });
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: 'expired' });
+  });
+
+  test('returns revoked for a revoked invite', () => {
+    const { revokeInvite: revokeStoreFn } = require('../memory/ingress-invite-store.js') as typeof import('../memory/ingress-invite-store.js');
+
+    const { rawToken, invite } = createInvite({
+      sourceChannel: 'telegram',
+      maxUses: 1,
+    });
+    revokeStoreFn(invite.id);
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: 'revoked' });
+  });
+
+  test('returns max_uses_reached when invite is fully consumed', () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 1 });
+
+    // First redemption should succeed
+    const first = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+    });
+    expect(first.ok).toBe(true);
+
+    // Second attempt should fail — the invite is now fully redeemed
+    const second = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'user-2',
+    });
+
+    expect(second).toEqual({ ok: false, reason: 'max_uses_reached' });
+  });
+
+  test('returns channel_mismatch when redeeming on wrong channel', () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 1 });
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'sms',
+      externalUserId: 'user-1',
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: 'channel_mismatch' });
+  });
+
+  test('returns missing_identity when no externalUserId or externalChatId', () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 1 });
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: 'missing_identity' });
+  });
+
+  test('returns already_member when user is already an active member', () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 5 });
+
+    // Pre-create an active member
+    upsertMember({
+      sourceChannel: 'telegram',
+      externalUserId: 'existing-user',
+      status: 'active',
+    });
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'existing-user',
+    });
+
+    expect(outcome.ok).toBe(true);
+    expect((outcome as Extract<InviteRedemptionOutcome, { type: 'already_member' }>).type).toBe('already_member');
+    expect((outcome as Extract<InviteRedemptionOutcome, { type: 'already_member' }>).memberId).toEqual(expect.any(String));
+  });
+
+  test('does not return already_member for a revoked member', () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 5 });
+
+    // Pre-create a revoked member
+    const member = upsertMember({
+      sourceChannel: 'telegram',
+      externalUserId: 'revoked-user',
+      status: 'revoked',
+    });
+    expect(member.status).toBe('revoked');
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'revoked-user',
+    });
+
+    // Should redeem, not return already_member
+    expect(outcome.ok).toBe(true);
+    expect((outcome as Extract<InviteRedemptionOutcome, { type: 'redeemed' }>).type).toBe('redeemed');
+  });
+
+  test('raw token is not present in the outcome object', () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 1 });
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+    });
+
+    // Verify the raw token does not appear anywhere in the serialized outcome
+    const serialized = JSON.stringify(outcome);
+    expect(serialized).not.toContain(rawToken);
+  });
+
+  test('channel enforcement blocks cross-channel redemption (voice invite via slack)', () => {
+    const { rawToken } = createInvite({ sourceChannel: 'voice', maxUses: 1 });
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'slack',
+      externalUserId: 'user-1',
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: 'channel_mismatch' });
+  });
+
+  test('returns invalid_token for an active member with a bogus token (no membership probing)', () => {
+    // Pre-create an active member
+    upsertMember({
+      sourceChannel: 'telegram',
+      externalUserId: 'probed-user',
+      status: 'active',
+    });
+
+    // Attempt to redeem with a bogus token — must NOT leak membership status
+    const outcome = redeemInvite({
+      rawToken: 'completely-bogus-token',
+      sourceChannel: 'telegram',
+      externalUserId: 'probed-user',
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: 'invalid_token' });
+  });
+
+  test('returns expired for an active member with an expired invite token', () => {
+    // Create an expired invite
+    const { rawToken } = createInvite({
+      sourceChannel: 'telegram',
+      maxUses: 5,
+      expiresInMs: -1,
+    });
+
+    // Pre-create an active member
+    upsertMember({
+      sourceChannel: 'telegram',
+      externalUserId: 'expired-token-user',
+      status: 'active',
+    });
+
+    // Expired token must return expired, not already_member
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'expired-token-user',
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: 'expired' });
+  });
+
+  test('returns channel_mismatch for an active member with a valid token for a different channel', () => {
+    // Create an invite for SMS
+    const { rawToken } = createInvite({
+      sourceChannel: 'sms',
+      maxUses: 5,
+    });
+
+    // Pre-create an active member on telegram
+    upsertMember({
+      sourceChannel: 'telegram',
+      externalUserId: 'cross-channel-user',
+      status: 'active',
+    });
+
+    // Valid token for wrong channel must return channel_mismatch, not already_member
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'cross-channel-user',
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: 'channel_mismatch' });
+  });
+});

--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -172,6 +172,25 @@ describe('invite-redemption-service', () => {
     expect((outcome as Extract<InviteRedemptionOutcome, { type: 'already_member' }>).memberId).toEqual(expect.any(String));
   });
 
+  test('returns blocked for a blocked member attempting to redeem an invite', () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 5 });
+
+    // Pre-create a blocked member — simulates a guardian-initiated block
+    upsertMember({
+      sourceChannel: 'telegram',
+      externalUserId: 'blocked-user',
+      status: 'blocked',
+    });
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: 'telegram',
+      externalUserId: 'blocked-user',
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: 'blocked' });
+  });
+
   test('does not return already_member for a revoked member', () => {
     const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 5 });
 

--- a/assistant/src/config/vellum-skills/catalog.json
+++ b/assistant/src/config/vellum-skills/catalog.json
@@ -56,7 +56,7 @@
     {
       "id": "trusted-contacts",
       "name": "Trusted Contacts",
-      "description": "Manage trusted contacts \u2014 list, allow, revoke, and block users who can message the assistant through external channels",
+      "description": "Manage trusted contacts and Telegram invite links \u2014 list, allow, revoke, block users, and create/list/revoke shareable invite links",
       "emoji": "\ud83d\udc65"
     }
   ]

--- a/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
+++ b/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "Trusted Contacts"
-description: "Manage trusted contacts — list, allow, revoke, and block users who can message the assistant through external channels"
+description: "Manage trusted contacts and Telegram invite links — list, allow, revoke, block users, and create/list/revoke invite links for external channels"
 user-invocable: true
 metadata: {"vellum": {"emoji": "\ud83d\udc65"}}
 ---
 
-You are helping your user manage trusted contacts for the Vellum Assistant. Trusted contacts control who is allowed to send messages to the assistant through external channels like Telegram and SMS. All operations go through the gateway HTTP API using `curl` with bearer auth.
+You are helping your user manage trusted contacts and invite links for the Vellum Assistant. Trusted contacts control who is allowed to send messages to the assistant through external channels like Telegram and SMS. Invite links let the guardian share a Telegram deep link that automatically grants access when opened. All operations go through the gateway HTTP API using `curl` with bearer auth.
 
 ## Prerequisites
 
@@ -18,6 +18,7 @@ You are helping your user manage trusted contacts for the Vellum Assistant. Trus
 - **Policy**: Controls what the member can do — `allow` (can message freely) or `deny` (blocked from messaging).
 - **Status**: The member's lifecycle state — `active` (currently effective), `revoked` (access removed), or `blocked` (explicitly denied).
 - **Source channel**: The messaging platform the contact uses (e.g., `telegram`, `sms`).
+- **Invite link**: A shareable Telegram deep link that, when opened by someone, automatically grants them trusted-contact access. Each invite has a token, usage limits, and optional expiration.
 
 ## Available Actions
 
@@ -117,9 +118,101 @@ curl -s -X POST "http://localhost:7830/v1/ingress/members/<member_id>/block" \
   -d '{"reason": "<optional reason>"}'
 ```
 
+### 5. Create a Telegram invite link
+
+Use this when the guardian wants to invite someone to message the assistant on Telegram without needing their user ID upfront. The invite link is a shareable Telegram deep link — when someone opens it, they automatically get trusted-contact access.
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+curl -s -X POST http://localhost:7830/v1/ingress/invites \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "sourceChannel": "telegram",
+    "maxUses": 1,
+    "note": "<optional note, e.g. the person it is for>"
+  }'
+```
+
+Optional fields:
+- `maxUses` — how many times the link can be used (default: 1). Use a higher number for group invites.
+- `expiresInMs` — expiration time in milliseconds from now (e.g., `86400000` for 24 hours). Omit for no expiration.
+- `note` — a human-readable label for the invite (e.g., "For Mom", "Family group").
+
+The response contains `{ ok: true, invite: { id, token, ... } }`. The `token` field is the raw invite token — it is only returned at creation time and cannot be retrieved later.
+
+**Building the shareable link**: After creating the invite, look up the Telegram bot username so you can build the deep link. Query the Telegram integration config:
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+curl -s http://localhost:7830/v1/integrations/telegram/config \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+The response includes `botUsername`. Use it to construct the deep link:
+
+```
+https://t.me/<botUsername>?start=iv_<token>
+```
+
+**Presenting to the guardian**: Give the guardian the link with clear copy-paste instructions:
+
+> Here's your Telegram invite link:
+>
+> `https://t.me/<botUsername>?start=iv_<token>`
+>
+> Share this link with the person you want to invite. When they open it in Telegram and press "Start", they'll automatically be added as a trusted contact and can message the assistant directly.
+>
+> This link can be used <maxUses> time(s)<and expires in X hours/days if applicable>.
+
+If the Telegram bot username is not available (integration not set up), tell the guardian they need to set up the Telegram integration first using the Telegram Setup skill.
+
+### 6. List invite links
+
+Use this to show the guardian their active (and optionally all) invite links.
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+curl -s "http://localhost:7830/v1/ingress/invites?sourceChannel=telegram" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Optional query parameters:
+- `sourceChannel` — filter by channel (e.g., `telegram`)
+- `status` — filter by status (`active`, `revoked`, `redeemed`, `expired`)
+
+The response contains `{ ok: true, invites: [...] }` where each invite has:
+- `id` — unique invite ID (needed for revoke)
+- `sourceChannel` — the channel
+- `tokenHash` — hashed token (the raw token is only available at creation time)
+- `maxUses` — total allowed uses
+- `useCount` — how many times it has been redeemed
+- `expiresAt` — expiration timestamp (null if no expiration)
+- `status` — current status (`active`, `revoked`, `redeemed`, `expired`)
+- `note` — the label set at creation
+- `createdAt` — when the invite was created
+
+**Presenting results**: Format as a readable list. Show the note (or "unnamed" as fallback), status, uses remaining (`maxUses - useCount`), and expiration. Highlight active invites and note which ones have been fully used or expired.
+
+### 7. Revoke an invite link
+
+Use this when the guardian wants to cancel an active invite link. **Always confirm before revoking.**
+
+Ask the user: *"I'll revoke the invite link [note or ID]. It will no longer be usable. Should I proceed?"*
+
+First, list invites to find the invite's `id`, then revoke:
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+curl -s -X DELETE "http://localhost:7830/v1/ingress/invites/<invite_id>" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Replace `<invite_id>` with the invite's `id` from the list response.
+
 ## Confirmation Requirements
 
-**All mutating actions (allow, revoke, block) require explicit user confirmation before execution.** This is a safety measure — modifying who can access the assistant should always be a deliberate choice.
+**All mutating actions (allow, revoke, block, revoke invite) require explicit user confirmation before execution.** This is a safety measure — modifying who can access the assistant should always be a deliberate choice. Creating an invite link does not require confirmation since it does not grant access until someone opens it.
 
 - Clearly state what action you are about to take and who it affects.
 - Wait for the user to confirm before running the curl command.
@@ -133,6 +226,8 @@ curl -s -X POST "http://localhost:7830/v1/ingress/members/<member_id>/block" \
   - `At least one of externalUserId or externalChatId is required` — ask the user for the contact's channel-specific identifier.
   - `Member not found or cannot be revoked` — the member ID may be invalid or the member is already revoked.
   - `Member not found or already blocked` — the member ID may be invalid or the member is already blocked.
+  - `sourceChannel is required for create` — when creating an invite, always pass `"sourceChannel": "telegram"`.
+  - `Invite not found or already revoked` — the invite ID may be invalid or the invite is already revoked.
 
 ## Typical Workflows
 
@@ -145,3 +240,9 @@ curl -s -X POST "http://localhost:7830/v1/ingress/members/<member_id>/block" \
 **"Block [name]"** — List members to find them, confirm the block, then execute.
 
 **"Show me blocked contacts"** — List with `status=blocked` filter.
+
+**"Create a Telegram invite link"** / **"Invite someone on Telegram"** — Create an invite with `sourceChannel: "telegram"`, look up the bot username, build the deep link, and present it with sharing instructions.
+
+**"Show my invites"** / **"List active invite links"** — List invites filtered by `sourceChannel=telegram`, present active invites with uses remaining and expiration info.
+
+**"Revoke invite"** / **"Cancel invite link"** — List invites to identify the target, confirm, then revoke by ID.

--- a/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
+++ b/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
@@ -136,7 +136,7 @@ curl -s -X POST http://localhost:7830/v1/ingress/invites \
 
 Optional fields:
 - `maxUses` — how many times the link can be used (default: 1). Use a higher number for group invites.
-- `expiresInMs` — expiration time in milliseconds from now (e.g., `86400000` for 24 hours). Omit for no expiration.
+- `expiresInMs` — expiration time in milliseconds from now (e.g., `86400000` for 24 hours). Defaults to 7 days (`604800000`) if omitted.
 - `note` — a human-readable label for the invite (e.g., "For Mom", "Family group").
 
 The response contains `{ ok: true, invite: { id, token, ... } }`. The `token` field is the raw invite token — it is only returned at creation time and cannot be retrieved later.

--- a/assistant/src/daemon/guardian-invite-intent.ts
+++ b/assistant/src/daemon/guardian-invite-intent.ts
@@ -55,9 +55,11 @@ const FILLER_PATTERN =
 
 function isConceptualQuestion(text: string): boolean {
   const cleaned = text.replace(/^\s*(hey|hi|hello|please|pls|plz)[,\s]+/i, '');
-  // Allow "list" / "show" questions through even though they start with
-  // question-like words — these are actionable list requests.
+  // Allow actionable requests through even though they start with
+  // question-like words — these are imperative invite management requests.
   if (LIST_INVITE_PATTERNS.some((p) => p.test(cleaned))) return false;
+  if (CREATE_INVITE_PATTERNS.some((p) => p.test(cleaned))) return false;
+  if (REVOKE_INVITE_PATTERNS.some((p) => p.test(cleaned))) return false;
   return CONCEPTUAL_PATTERNS.some((p) => p.test(cleaned));
 }
 

--- a/assistant/src/daemon/guardian-invite-intent.ts
+++ b/assistant/src/daemon/guardian-invite-intent.ts
@@ -1,0 +1,122 @@
+// Guardian invite intent resolution for deterministic first-turn routing.
+// Exports `resolveGuardianInviteIntent` as the single public entry point.
+// When a guardian invite management request is detected, the session pipeline
+// rewrites the message to force immediate entry into the trusted-contacts
+// skill flow, bypassing the normal agent loop's tendency to produce conceptual
+// preambles before loading the skill.
+
+export type GuardianInviteIntentResult =
+  | { kind: 'none' }
+  | { kind: 'invite_management'; rewrittenContent: string; action?: 'create' | 'list' | 'revoke' };
+
+// ── Direct invite patterns ────────────────────────────────────────────────
+// These capture imperative requests to manage Telegram invite links.
+
+const CREATE_INVITE_PATTERNS: RegExp[] = [
+  /\bcreate\s+(?:an?\s+)?(?:telegram\s+)?invite\s*(?:link)?\b/i,
+  /\binvite\s+(?:someone|somebody|a\s+friend|a\s+person)\s+(?:on|to|via|through)\s+telegram\b/i,
+  /\b(?:make|generate|get)\s+(?:a\s+|an\s+)?(?:telegram\s+)?invite\s*(?:link)?\b/i,
+  /\btelegram\s+invite\s*(?:link)?\b/i,
+  /\bsend\s+(?:a\s+|an\s+)?invite\s+(?:link\s+)?(?:on|for|via|through)\s+telegram\b/i,
+  /\bshare\s+(?:a\s+|an\s+)?(?:telegram\s+)?invite\s*(?:link)?\b/i,
+  /\binvite\s+(?:link\s+)?for\s+telegram\b/i,
+];
+
+const LIST_INVITE_PATTERNS: RegExp[] = [
+  /\b(?:show|list|view|see|display)\s+(?:my\s+)?(?:active\s+)?invite(?:s|\s*links?)\b/i,
+  /\b(?:show|list|view|see|display)\s+(?:my\s+)?(?:telegram\s+)?invite(?:s|\s*links?)\b/i,
+  /\bwhat\s+invite(?:s|\s*links?)\s+(?:do\s+I\s+have|are\s+active|exist)\b/i,
+  /\bhow\s+many\s+invite(?:s|\s*links?)\b/i,
+];
+
+const REVOKE_INVITE_PATTERNS: RegExp[] = [
+  /\b(?:revoke|cancel|disable|invalidate|delete|remove)\s+(?:the\s+|my\s+|an?\s+)?invite\s*(?:link)?\b/i,
+  /\b(?:revoke|cancel|disable|invalidate|delete|remove)\s+(?:the\s+|my\s+|an?\s+)?(?:telegram\s+)?invite\s*(?:link)?\b/i,
+  /\binvite\s*(?:link)?\s+(?:revoke|cancel|disable|invalidate|delete|remove)\b/i,
+];
+
+// ── Conceptual / question patterns ──────────────────────────────────────
+// These indicate the user is asking *about* invites rather than requesting
+// to manage them. Return passthrough for these.
+
+const CONCEPTUAL_PATTERNS: RegExp[] = [
+  /^\s*(?:how|what|why|when|where|who|which)\b.*\binvite/i,
+  /\bwhat\s+(?:is|are)\s+(?:an?\s+)?invite\s*(?:link)?\b/i,
+  /\bhow\s+(?:do|does|can)\s+(?:invite|invitation)s?\s+work\b/i,
+  /\bexplain\s+(?:the\s+)?invite\b/i,
+  /\btell\s+me\s+about\s+invite\b/i,
+];
+
+/** Common polite/filler words stripped before checking intent-only status. */
+const FILLER_PATTERN =
+  /\b(please|pls|plz|can\s+you|could\s+you|would\s+you|now|right\s+now|thanks|thank\s+you|thx|ty|for\s+me|ok(ay)?|hey|hi|hello|just|i\s+want\s+to|i'd\s+like\s+to|i\s+need\s+to|let's|let\s+me)\b/gi;
+
+// ── Internal helpers ─────────────────────────────────────────────────────
+
+function isConceptualQuestion(text: string): boolean {
+  const cleaned = text.replace(/^\s*(hey|hi|hello|please|pls|plz)[,\s]+/i, '');
+  // Allow "list" / "show" questions through even though they start with
+  // question-like words — these are actionable list requests.
+  if (LIST_INVITE_PATTERNS.some((p) => p.test(cleaned))) return false;
+  return CONCEPTUAL_PATTERNS.some((p) => p.test(cleaned));
+}
+
+function detectAction(text: string): 'create' | 'list' | 'revoke' | undefined {
+  // Check revoke and list before create — create patterns include the broad
+  // `telegram invite link` matcher that would otherwise swallow revoke/list inputs.
+  if (REVOKE_INVITE_PATTERNS.some((p) => p.test(text))) return 'revoke';
+  if (LIST_INVITE_PATTERNS.some((p) => p.test(text))) return 'list';
+  if (CREATE_INVITE_PATTERNS.some((p) => p.test(text))) return 'create';
+  return undefined;
+}
+
+// ── Structured intent resolver ───────────────────────────────────────────
+
+/**
+ * Resolves guardian invite management intent from user text.
+ *
+ * Pipeline:
+ * 1. Skip slash commands entirely
+ * 2. Conceptual question gate -- questions return `none`
+ * 3. Detect create/list/revoke invite patterns
+ * 4. On match, build a deterministic model instruction to load trusted-contacts
+ */
+export function resolveGuardianInviteIntent(text: string): GuardianInviteIntentResult {
+  const trimmed = text.trim();
+
+  // Never intercept slash commands
+  if (trimmed.startsWith('/')) {
+    return { kind: 'none' };
+  }
+
+  // Conceptual questions pass through to normal agent processing
+  if (isConceptualQuestion(trimmed)) {
+    return { kind: 'none' };
+  }
+
+  // Strip fillers for pattern matching but keep original for context
+  const withoutFillers = trimmed.replace(FILLER_PATTERN, '').replace(/\s{2,}/g, ' ').trim();
+
+  const action = detectAction(withoutFillers);
+  if (!action) {
+    return { kind: 'none' };
+  }
+
+  // Build the rewritten content that deterministically loads the skill
+  const actionDescriptions: Record<string, string> = {
+    create: 'The user wants to create a Telegram invite link. Create the invite, look up the bot username, and present the shareable deep link with copy-paste instructions.',
+    list: 'The user wants to see their invite links. List all invites (especially active ones for Telegram) and present them in a readable format.',
+    revoke: 'The user wants to revoke an invite link. List invites to identify the target, confirm with the user, then revoke it.',
+  };
+
+  const rewrittenContent = [
+    actionDescriptions[action],
+    'Please invoke the "Trusted Contacts" skill (ID: trusted-contacts) immediately using skill_load.',
+  ].join('\n');
+
+  return {
+    kind: 'invite_management',
+    rewrittenContent,
+    action,
+  };
+}

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -36,6 +36,7 @@ import { tryMintGuardianActionGrant } from '../runtime/guardian-action-grant-min
 import { composeGuardianActionMessageGenerative } from '../runtime/guardian-action-message-composer.js';
 import type { GuardianActionCopyGenerator, GuardianFollowUpConversationGenerator } from '../runtime/http-types.js';
 import { getLogger } from '../util/logger.js';
+import { resolveGuardianInviteIntent } from './guardian-invite-intent.js';
 import { resolveGuardianVerificationIntent } from './guardian-verification-intent.js';
 import type { UsageStats } from './ipc-contract.js';
 import type { ServerMessage, UserMessageAttachment } from './ipc-protocol.js';
@@ -299,6 +300,15 @@ export async function drainQueue(session: ProcessSessionContext, reason: QueueDr
       log.info({ conversationId: session.conversationId, channelHint: guardianIntent.channelHint }, 'Guardian verification intent intercepted in queue — forcing skill flow');
       agentLoopContent = guardianIntent.rewrittenContent;
       session.preactivatedSkillIds = ['guardian-verify-setup'];
+    } else {
+      // Guardian invite intent interception — force invite management
+      // requests into the trusted-contacts skill flow.
+      const inviteIntent = resolveGuardianInviteIntent(resolvedContent);
+      if (inviteIntent.kind === 'invite_management') {
+        log.info({ conversationId: session.conversationId, action: inviteIntent.action }, 'Guardian invite intent intercepted in queue — forcing skill flow');
+        agentLoopContent = inviteIntent.rewrittenContent;
+        session.preactivatedSkillIds = ['trusted-contacts'];
+      }
     }
   }
 
@@ -743,6 +753,15 @@ export async function processMessage(
       log.info({ conversationId: session.conversationId, channelHint: guardianIntent.channelHint }, 'Guardian verification intent intercepted — forcing skill flow');
       agentLoopContent = guardianIntent.rewrittenContent;
       session.preactivatedSkillIds = ['guardian-verify-setup'];
+    } else {
+      // Guardian invite intent interception — force invite management
+      // requests into the trusted-contacts skill flow.
+      const inviteIntent = resolveGuardianInviteIntent(resolvedContent);
+      if (inviteIntent.kind === 'invite_management') {
+        log.info({ conversationId: session.conversationId, action: inviteIntent.action }, 'Guardian invite intent intercepted — forcing skill flow');
+        agentLoopContent = inviteIntent.rewrittenContent;
+        session.preactivatedSkillIds = ['trusted-contacts'];
+      }
     }
   }
 

--- a/assistant/src/memory/ingress-invite-store.ts
+++ b/assistant/src/memory/ingress-invite-store.ts
@@ -339,12 +339,16 @@ export function redeemInvite(params: {
  * member via invite — the member row already exists and just needs an
  * update, so the transactional INSERT in `redeemInvite` would hit a
  * unique-key constraint.
+ *
+ * Returns `true` if the use was recorded, or `false` if the invite was
+ * concurrently revoked/expired (the WHERE clause constrains to
+ * `status = 'active'` so a stale write is impossible).
  */
 export function recordInviteUse(params: {
   inviteId: string;
   externalUserId?: string;
   externalChatId?: string;
-}): IngressInvite | null {
+}): boolean {
   const db = getDb();
   const now = Date.now();
 
@@ -354,12 +358,14 @@ export function recordInviteUse(params: {
     .where(eq(assistantIngressInvites.id, params.inviteId))
     .get();
 
-  if (!invite) return null;
+  if (!invite) return false;
 
   const newUseCount = invite.useCount + 1;
   const newStatus = newUseCount >= invite.maxUses ? 'redeemed' : 'active';
 
-  db.update(assistantIngressInvites)
+  // Constrain the update to active invites so a concurrent revoke/expire
+  // prevents this write rather than silently overwriting the new status.
+  const result = db.update(assistantIngressInvites)
     .set({
       useCount: newUseCount,
       status: newStatus,
@@ -368,18 +374,15 @@ export function recordInviteUse(params: {
       redeemedAt: now,
       updatedAt: now,
     })
-    .where(eq(assistantIngressInvites.id, invite.id))
+    .where(
+      and(
+        eq(assistantIngressInvites.id, invite.id),
+        eq(assistantIngressInvites.status, 'active'),
+      ),
+    )
     .run();
 
-  return rowToInvite({
-    ...invite,
-    useCount: newUseCount,
-    status: newStatus,
-    redeemedByExternalUserId: params.externalUserId ?? null,
-    redeemedByExternalChatId: params.externalChatId ?? null,
-    redeemedAt: now,
-    updatedAt: now,
-  });
+  return result.changes > 0;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/memory/ingress-invite-store.ts
+++ b/assistant/src/memory/ingress-invite-store.ts
@@ -330,6 +330,59 @@ export function redeemInvite(params: {
 }
 
 // ---------------------------------------------------------------------------
+// recordInviteUse — consume one use without creating a member row
+// ---------------------------------------------------------------------------
+
+/**
+ * Increment an invite's use count and record redemption metadata without
+ * inserting a new member row. Used when reactivating an existing inactive
+ * member via invite — the member row already exists and just needs an
+ * update, so the transactional INSERT in `redeemInvite` would hit a
+ * unique-key constraint.
+ */
+export function recordInviteUse(params: {
+  inviteId: string;
+  externalUserId?: string;
+  externalChatId?: string;
+}): IngressInvite | null {
+  const db = getDb();
+  const now = Date.now();
+
+  const invite = db
+    .select()
+    .from(assistantIngressInvites)
+    .where(eq(assistantIngressInvites.id, params.inviteId))
+    .get();
+
+  if (!invite) return null;
+
+  const newUseCount = invite.useCount + 1;
+  const newStatus = newUseCount >= invite.maxUses ? 'redeemed' : 'active';
+
+  db.update(assistantIngressInvites)
+    .set({
+      useCount: newUseCount,
+      status: newStatus,
+      redeemedByExternalUserId: params.externalUserId ?? null,
+      redeemedByExternalChatId: params.externalChatId ?? null,
+      redeemedAt: now,
+      updatedAt: now,
+    })
+    .where(eq(assistantIngressInvites.id, invite.id))
+    .run();
+
+  return rowToInvite({
+    ...invite,
+    useCount: newUseCount,
+    status: newStatus,
+    redeemedByExternalUserId: params.externalUserId ?? null,
+    redeemedByExternalChatId: params.externalChatId ?? null,
+    redeemedAt: now,
+    updatedAt: now,
+  });
+}
+
+// ---------------------------------------------------------------------------
 // markInviteExpired
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/memory/ingress-invite-store.ts
+++ b/assistant/src/memory/ingress-invite-store.ts
@@ -66,7 +66,7 @@ const DEFAULT_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 // Helpers
 // ---------------------------------------------------------------------------
 
-function hashToken(rawToken: string): string {
+export function hashToken(rawToken: string): string {
   return createHash('sha256').update(rawToken).digest('hex');
 }
 
@@ -268,6 +268,12 @@ export function redeemInvite(params: {
     return { error: 'invite_max_uses_reached' };
   }
 
+  // Enforce channel-scoped redemption: when the caller specifies a channel, it
+  // must match the channel the invite was created for.
+  if (params.sourceChannel && params.sourceChannel !== invite.sourceChannel) {
+    return { error: 'invite_channel_mismatch' };
+  }
+
   const newUseCount = invite.useCount + 1;
   const newStatus = newUseCount >= invite.maxUses ? 'redeemed' : 'active';
 
@@ -321,6 +327,30 @@ export function redeemInvite(params: {
   };
 
   return { invite: updatedInvite, member: rowToMember(memberRow) };
+}
+
+// ---------------------------------------------------------------------------
+// markInviteExpired
+// ---------------------------------------------------------------------------
+
+/**
+ * Transition an invite's status to 'expired' in storage. This is safe to call
+ * even if the invite is already expired — the WHERE clause scopes the update
+ * to 'active' rows so it becomes a no-op in that case.
+ */
+export function markInviteExpired(inviteId: string): void {
+  const db = getDb();
+  const now = Date.now();
+
+  db.update(assistantIngressInvites)
+    .set({ status: 'expired', updatedAt: now })
+    .where(
+      and(
+        eq(assistantIngressInvites.id, inviteId),
+        eq(assistantIngressInvites.status, 'active'),
+      ),
+    )
+    .run();
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/channel-invite-transport.ts
+++ b/assistant/src/runtime/channel-invite-transport.ts
@@ -1,0 +1,85 @@
+/**
+ * Channel invite transport abstraction.
+ *
+ * Defines a transport interface for building shareable invite links and
+ * extracting inbound invite tokens from channel-specific payloads. Each
+ * channel (Telegram, SMS, Slack, etc.) registers an adapter that knows
+ * how to construct deep links and parse incoming tokens for that channel.
+ *
+ * The transport layer is intentionally thin: it handles URL construction
+ * and token extraction only. Redemption logic lives in
+ * `invite-redemption-service.ts`.
+ */
+
+import type { ChannelId } from '../channels/types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface InviteSharePayload {
+  /** The full URL the recipient can open to redeem the invite. */
+  url: string;
+  /** Human-readable text suitable for display alongside the link. */
+  displayText: string;
+}
+
+export interface ChannelInviteTransport {
+  /** The channel this transport handles. */
+  channel: ChannelId;
+
+  /**
+   * Build a shareable invite payload (URL + display text) from a raw token.
+   *
+   * The raw token is the base64url-encoded secret returned by
+   * `ingress-invite-store.createInvite`. The transport wraps it in a
+   * channel-specific deep link so the recipient can redeem the invite
+   * by clicking/tapping the link.
+   */
+  buildShareableInvite(params: {
+    rawToken: string;
+    sourceChannel: ChannelId;
+  }): InviteSharePayload;
+
+  /**
+   * Extract an invite token from an inbound channel message.
+   *
+   * Returns the raw token string (without the `iv_` prefix) if the
+   * message contains a valid invite token, or `undefined` otherwise.
+   */
+  extractInboundToken(params: {
+    commandIntent?: Record<string, unknown>;
+    content: string;
+    sourceMetadata?: Record<string, unknown>;
+  }): string | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+const registry = new Map<ChannelId, ChannelInviteTransport>();
+
+/**
+ * Register a channel invite transport. Overwrites any previously registered
+ * transport for the same channel.
+ */
+export function registerTransport(transport: ChannelInviteTransport): void {
+  registry.set(transport.channel, transport);
+}
+
+/**
+ * Look up the registered transport for a channel. Returns `undefined` when
+ * no transport has been registered for the given channel.
+ */
+export function getTransport(channel: ChannelId): ChannelInviteTransport | undefined {
+  return registry.get(channel);
+}
+
+/**
+ * Reset the registry. Intended for tests only.
+ * @internal
+ */
+export function _resetRegistry(): void {
+  registry.clear();
+}

--- a/assistant/src/runtime/channel-invite-transports/telegram.ts
+++ b/assistant/src/runtime/channel-invite-transports/telegram.ts
@@ -1,0 +1,105 @@
+/**
+ * Telegram channel invite transport adapter.
+ *
+ * Builds `https://t.me/<botUsername>?start=iv_<token>` deep links and
+ * extracts invite tokens from `/start iv_<token>` command payloads.
+ *
+ * The `iv_` prefix distinguishes invite tokens from `gv_` (guardian
+ * verification) tokens that use the same `/start` deep-link mechanism.
+ */
+
+import type { ChannelId } from '../../channels/types.js';
+import { getCredentialMetadata } from '../../tools/credentials/metadata-store.js';
+import {
+  registerTransport,
+  type ChannelInviteTransport,
+  type InviteSharePayload,
+} from '../channel-invite-transport.js';
+
+// ---------------------------------------------------------------------------
+// Bot username resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the Telegram bot username from credential metadata, falling back
+ * to the TELEGRAM_BOT_USERNAME environment variable. Mirrors the resolution
+ * strategy used in `guardian-outbound-actions.ts`.
+ */
+function getTelegramBotUsername(): string | undefined {
+  const meta = getCredentialMetadata('telegram', 'bot_token');
+  if (meta?.accountInfo && typeof meta.accountInfo === 'string' && meta.accountInfo.trim().length > 0) {
+    return meta.accountInfo.trim();
+  }
+  return process.env.TELEGRAM_BOT_USERNAME || undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Token prefix
+// ---------------------------------------------------------------------------
+
+const INVITE_TOKEN_PREFIX = 'iv_';
+
+// ---------------------------------------------------------------------------
+// Transport implementation
+// ---------------------------------------------------------------------------
+
+export const telegramInviteTransport: ChannelInviteTransport = {
+  channel: 'telegram' as ChannelId,
+
+  buildShareableInvite(params: {
+    rawToken: string;
+    sourceChannel: ChannelId;
+  }): InviteSharePayload {
+    const botUsername = getTelegramBotUsername();
+    if (!botUsername) {
+      throw new Error('Telegram bot username is not configured. Set up the Telegram integration first.');
+    }
+
+    const url = `https://t.me/${botUsername}?start=${INVITE_TOKEN_PREFIX}${params.rawToken}`;
+    return {
+      url,
+      displayText: `Open in Telegram: ${url}`,
+    };
+  },
+
+  extractInboundToken(params: {
+    commandIntent?: Record<string, unknown>;
+    content: string;
+    sourceMetadata?: Record<string, unknown>;
+  }): string | undefined {
+    // Primary path: structured command intent from the gateway.
+    // The gateway normalizes `/start <payload>` into
+    // `{ type: 'start', payload: '<payload>' }`.
+    if (
+      params.commandIntent &&
+      params.commandIntent.type === 'start' &&
+      typeof params.commandIntent.payload === 'string'
+    ) {
+      const payload = params.commandIntent.payload;
+      if (payload.startsWith(INVITE_TOKEN_PREFIX)) {
+        const token = payload.slice(INVITE_TOKEN_PREFIX.length);
+        // Reject empty or whitespace-only tokens
+        if (token.length > 0 && token.trim().length > 0) {
+          return token;
+        }
+      }
+      return undefined;
+    }
+
+    // Fallback: raw content parsing for `/start iv_<token>` messages.
+    // This handles cases where the gateway forwards the raw command text
+    // without a structured commandIntent.
+    const match = params.content.match(/^\/start\s+iv_(\S+)/);
+    if (match && match[1] && match[1].length > 0) {
+      return match[1];
+    }
+
+    return undefined;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Auto-register on import
+// ---------------------------------------------------------------------------
+
+registerTransport(telegramInviteTransport);

--- a/assistant/src/runtime/ingress-service.ts
+++ b/assistant/src/runtime/ingress-service.ts
@@ -22,6 +22,10 @@ import {
   revokeMember,
   upsertMember,
 } from '../memory/ingress-member-store.js';
+import {
+  redeemInvite as redeemInviteTyped,
+  type InviteRedemptionOutcome,
+} from './invite-redemption-service.js';
 
 // ---------------------------------------------------------------------------
 // Response shapes — used by both HTTP routes and IPC handlers
@@ -161,6 +165,24 @@ export function redeemIngressInvite(params: {
     return { ok: false, error: result.error };
   }
   return { ok: true, data: inviteToResponse(result.invite) };
+}
+
+// ---------------------------------------------------------------------------
+// Typed invite redemption — preferred entry point for new callers
+// ---------------------------------------------------------------------------
+
+export { type InviteRedemptionOutcome } from './invite-redemption-service.js';
+
+export function redeemIngressInviteTyped(params: {
+  rawToken: string;
+  sourceChannel: string;
+  externalUserId?: string;
+  externalChatId?: string;
+  displayName?: string;
+  username?: string;
+  assistantId?: string;
+}): InviteRedemptionOutcome {
+  return redeemInviteTyped(params);
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -7,6 +7,7 @@
  * persisted, or returned in the outcome.
  */
 
+import { getSqlite } from '../memory/db.js';
 import { findMember, upsertMember } from '../memory/ingress-member-store.js';
 import { findByTokenHash, hashToken, markInviteExpired, redeemInvite as storeRedeemInvite, recordInviteUse } from '../memory/ingress-invite-store.js';
 
@@ -17,7 +18,7 @@ import { findByTokenHash, hashToken, markInviteExpired, redeemInvite as storeRed
 export type InviteRedemptionOutcome =
   | { ok: true; type: 'redeemed'; memberId: string; inviteId: string }
   | { ok: true; type: 'already_member'; memberId: string }
-  | { ok: false; reason: 'invalid_token' | 'expired' | 'revoked' | 'max_uses_reached' | 'channel_mismatch' | 'missing_identity' };
+  | { ok: false; reason: 'invalid_token' | 'expired' | 'revoked' | 'max_uses_reached' | 'channel_mismatch' | 'missing_identity' | 'blocked' };
 
 // ---------------------------------------------------------------------------
 // Error-string to typed-reason mapping
@@ -94,29 +95,39 @@ export function redeemInvite(params: {
     return { ok: true, type: 'already_member', memberId: existingMember.id };
   }
 
-  // Inactive member reactivation: when the user already has a member record
-  // in a non-active state (revoked/pending/blocked), reactivate it via
-  // upsertMember and consume an invite use separately. Falling through to
-  // storeRedeemInvite would try to INSERT a new member row, hitting the
-  // unique-key constraint on the members table.
-  if (existingMember) {
-    const reactivated = upsertMember({
-      assistantId: assistantId ?? invite.assistantId,
-      sourceChannel,
-      externalUserId,
-      externalChatId,
-      displayName,
-      username,
-      status: 'active',
-      policy: 'allow',
-      inviteId: invite.id,
-    });
+  // Blocked members cannot bypass the guardian's explicit block via invite
+  // links. Return a generic failure to avoid leaking membership status.
+  if (existingMember && existingMember.status === 'blocked') {
+    return { ok: false, reason: 'blocked' };
+  }
 
-    recordInviteUse({
-      inviteId: invite.id,
-      externalUserId,
-      externalChatId,
-    });
+  // Inactive member reactivation: when the user already has a member record
+  // in a non-active state (revoked/pending), reactivate it via upsertMember
+  // and consume an invite use atomically. Falling through to storeRedeemInvite
+  // would try to INSERT a new member row, hitting the unique-key constraint
+  // on the members table.
+  if (existingMember) {
+    const reactivated = getSqlite().transaction(() => {
+      const member = upsertMember({
+        assistantId: assistantId ?? invite.assistantId,
+        sourceChannel,
+        externalUserId,
+        externalChatId,
+        displayName,
+        username,
+        status: 'active',
+        policy: 'allow',
+        inviteId: invite.id,
+      });
+
+      recordInviteUse({
+        inviteId: invite.id,
+        externalUserId,
+        externalChatId,
+      });
+
+      return member;
+    }).immediate();
 
     return {
       ok: true,

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -18,7 +18,7 @@ import { findByTokenHash, hashToken, markInviteExpired, redeemInvite as storeRed
 export type InviteRedemptionOutcome =
   | { ok: true; type: 'redeemed'; memberId: string; inviteId: string }
   | { ok: true; type: 'already_member'; memberId: string }
-  | { ok: false; reason: 'invalid_token' | 'expired' | 'revoked' | 'max_uses_reached' | 'channel_mismatch' | 'missing_identity' | 'blocked' };
+  | { ok: false; reason: 'invalid_token' | 'expired' | 'revoked' | 'max_uses_reached' | 'channel_mismatch' | 'missing_identity' };
 
 // ---------------------------------------------------------------------------
 // Error-string to typed-reason mapping
@@ -96,9 +96,10 @@ export function redeemInvite(params: {
   }
 
   // Blocked members cannot bypass the guardian's explicit block via invite
-  // links. Return a generic failure to avoid leaking membership status.
+  // links. Return the same generic failure as an invalid token to avoid
+  // leaking membership status to the caller.
   if (existingMember && existingMember.status === 'blocked') {
-    return { ok: false, reason: 'blocked' };
+    return { ok: false, reason: 'invalid_token' };
   }
 
   // Inactive member reactivation: when the user already has a member record
@@ -107,32 +108,47 @@ export function redeemInvite(params: {
   // would try to INSERT a new member row, hitting the unique-key constraint
   // on the members table.
   if (existingMember) {
-    const reactivated = getSqlite().transaction(() => {
-      const member = upsertMember({
-        assistantId: assistantId ?? invite.assistantId,
-        sourceChannel,
-        externalUserId,
-        externalChatId,
-        displayName,
-        username,
-        status: 'active',
-        policy: 'allow',
-        inviteId: invite.id,
-      });
+    // Sentinel error used to trigger a transaction rollback when the invite
+    // was concurrently revoked/expired between pre-validation and write time.
+    const STALE_INVITE = Symbol('stale_invite');
 
-      recordInviteUse({
-        inviteId: invite.id,
-        externalUserId,
-        externalChatId,
-      });
+    let reactivated: ReturnType<typeof upsertMember> | undefined;
+    try {
+      getSqlite().transaction(() => {
+        reactivated = upsertMember({
+          assistantId: assistantId ?? invite.assistantId,
+          sourceChannel,
+          externalUserId,
+          externalChatId,
+          displayName,
+          username,
+          status: 'active',
+          policy: 'allow',
+          inviteId: invite.id,
+        });
 
-      return member;
-    }).immediate();
+        const recorded = recordInviteUse({
+          inviteId: invite.id,
+          externalUserId,
+          externalChatId,
+        });
+
+        // If the invite was revoked/expired between pre-validation and this
+        // write, recordInviteUse returns false — throw to roll back the
+        // member reactivation so the DB stays consistent.
+        if (!recorded) throw STALE_INVITE;
+      }).immediate();
+    } catch (err) {
+      if (err === STALE_INVITE) {
+        return { ok: false, reason: 'invalid_token' };
+      }
+      throw err;
+    }
 
     return {
       ok: true,
       type: 'redeemed',
-      memberId: reactivated.id,
+      memberId: reactivated!.id,
       inviteId: invite.id,
     };
   }

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -1,0 +1,122 @@
+/**
+ * Typed invite redemption engine.
+ *
+ * Wraps the low-level invite store primitives with channel-scoped enforcement
+ * and a discriminated-union outcome type so callers can handle every case
+ * deterministically. The raw token is accepted as input but is never logged,
+ * persisted, or returned in the outcome.
+ */
+
+import { findMember } from '../memory/ingress-member-store.js';
+import { findByTokenHash, hashToken, markInviteExpired, redeemInvite as storeRedeemInvite } from '../memory/ingress-invite-store.js';
+
+// ---------------------------------------------------------------------------
+// Outcome type
+// ---------------------------------------------------------------------------
+
+export type InviteRedemptionOutcome =
+  | { ok: true; type: 'redeemed'; memberId: string; inviteId: string }
+  | { ok: true; type: 'already_member'; memberId: string }
+  | { ok: false; reason: 'invalid_token' | 'expired' | 'revoked' | 'max_uses_reached' | 'channel_mismatch' | 'missing_identity' };
+
+// ---------------------------------------------------------------------------
+// Error-string to typed-reason mapping
+// ---------------------------------------------------------------------------
+
+const STORE_ERROR_TO_REASON: Record<string, InviteRedemptionOutcome & { ok: false } | undefined> = {
+  invite_not_found: { ok: false, reason: 'invalid_token' },
+  invite_expired: { ok: false, reason: 'expired' },
+  invite_revoked: { ok: false, reason: 'revoked' },
+  invite_redeemed: { ok: false, reason: 'max_uses_reached' },
+  invite_max_uses_reached: { ok: false, reason: 'max_uses_reached' },
+  invite_channel_mismatch: { ok: false, reason: 'channel_mismatch' },
+};
+
+// ---------------------------------------------------------------------------
+// redeemInvite
+// ---------------------------------------------------------------------------
+
+export function redeemInvite(params: {
+  rawToken: string;
+  sourceChannel: string;
+  externalUserId?: string;
+  externalChatId?: string;
+  displayName?: string;
+  username?: string;
+  assistantId?: string;
+}): InviteRedemptionOutcome {
+  const { rawToken, sourceChannel, externalUserId, externalChatId, displayName, username, assistantId } = params;
+
+  if (!externalUserId && !externalChatId) {
+    return { ok: false, reason: 'missing_identity' };
+  }
+
+  // Validate the invite token before any membership checks to prevent
+  // membership-status probing with arbitrary tokens.
+  const tokenHash = hashToken(rawToken);
+  const invite = findByTokenHash(tokenHash);
+
+  if (!invite) {
+    return { ok: false, reason: 'invalid_token' };
+  }
+
+  if (invite.status !== 'active') {
+    const mapped = STORE_ERROR_TO_REASON[`invite_${invite.status}`];
+    if (mapped) return mapped;
+    return { ok: false, reason: 'invalid_token' };
+  }
+
+  if (invite.expiresAt <= Date.now()) {
+    markInviteExpired(invite.id);
+    return { ok: false, reason: 'expired' };
+  }
+
+  if (invite.useCount >= invite.maxUses) {
+    return { ok: false, reason: 'max_uses_reached' };
+  }
+
+  // Enforce channel match: the token must belong to the channel the caller
+  // is redeeming from.
+  if (sourceChannel !== invite.sourceChannel) {
+    return { ok: false, reason: 'channel_mismatch' };
+  }
+
+  // Token is valid — now safe to check existing membership without leaking
+  // membership status to callers with bogus tokens.
+  const existingMember = findMember({
+    assistantId: assistantId ?? invite.assistantId,
+    sourceChannel,
+    externalUserId,
+    externalChatId,
+  });
+
+  if (existingMember && existingMember.status === 'active') {
+    return { ok: true, type: 'already_member', memberId: existingMember.id };
+  }
+
+  // Delegate to the store-level redeem which handles token lookup, expiry,
+  // use-count, and transactional member creation. Channel enforcement is
+  // applied by passing sourceChannel so the store checks it.
+  const result = storeRedeemInvite({
+    rawToken,
+    sourceChannel,
+    externalUserId,
+    externalChatId,
+    displayName,
+    username,
+  });
+
+  if ('error' in result) {
+    const mapped = STORE_ERROR_TO_REASON[result.error];
+    if (mapped) return mapped;
+    // Fallback for any unrecognized store error
+    return { ok: false, reason: 'invalid_token' };
+  }
+
+  return {
+    ok: true,
+    type: 'redeemed',
+    memberId: result.member.id,
+    inviteId: result.invite.id,
+  };
+}

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -7,8 +7,8 @@
  * persisted, or returned in the outcome.
  */
 
-import { findMember } from '../memory/ingress-member-store.js';
-import { findByTokenHash, hashToken, markInviteExpired, redeemInvite as storeRedeemInvite } from '../memory/ingress-invite-store.js';
+import { findMember, upsertMember } from '../memory/ingress-member-store.js';
+import { findByTokenHash, hashToken, markInviteExpired, redeemInvite as storeRedeemInvite, recordInviteUse } from '../memory/ingress-invite-store.js';
 
 // ---------------------------------------------------------------------------
 // Outcome type
@@ -92,6 +92,38 @@ export function redeemInvite(params: {
 
   if (existingMember && existingMember.status === 'active') {
     return { ok: true, type: 'already_member', memberId: existingMember.id };
+  }
+
+  // Inactive member reactivation: when the user already has a member record
+  // in a non-active state (revoked/pending/blocked), reactivate it via
+  // upsertMember and consume an invite use separately. Falling through to
+  // storeRedeemInvite would try to INSERT a new member row, hitting the
+  // unique-key constraint on the members table.
+  if (existingMember) {
+    const reactivated = upsertMember({
+      assistantId: assistantId ?? invite.assistantId,
+      sourceChannel,
+      externalUserId,
+      externalChatId,
+      displayName,
+      username,
+      status: 'active',
+      policy: 'allow',
+      inviteId: invite.id,
+    });
+
+    recordInviteUse({
+      inviteId: invite.id,
+      externalUserId,
+      externalChatId,
+    });
+
+    return {
+      ok: true,
+      type: 'redeemed',
+      memberId: reactivated.id,
+      inviteId: invite.id,
+    };
   }
 
   // Delegate to the store-level redeem which handles token lookup, expiry,

--- a/assistant/src/runtime/invite-redemption-templates.ts
+++ b/assistant/src/runtime/invite-redemption-templates.ts
@@ -19,6 +19,7 @@ export const INVITE_REPLY_TEMPLATES = {
   expired: 'This invite link is no longer valid.',
   revoked: 'This invite link is no longer valid.',
   max_uses_reached: 'This invite link is no longer valid.',
+  blocked: 'This invite link is not valid for you.',
   channel_mismatch: 'This invite link is not valid for this channel.',
   missing_identity: 'Unable to process this invite. Please contact the person who shared it.',
   generic_failure: 'Unable to process this invite. Please contact the person who shared it.',

--- a/assistant/src/runtime/invite-redemption-templates.ts
+++ b/assistant/src/runtime/invite-redemption-templates.ts
@@ -1,0 +1,39 @@
+/**
+ * Deterministic reply templates for invite token redemption outcomes.
+ *
+ * These messages are returned directly to the user without passing through
+ * the LLM pipeline, ensuring consistent and predictable responses for
+ * every invite redemption outcome.
+ */
+
+import type { InviteRedemptionOutcome } from './invite-redemption-service.js';
+
+// ---------------------------------------------------------------------------
+// Template strings
+// ---------------------------------------------------------------------------
+
+export const INVITE_REPLY_TEMPLATES = {
+  redeemed: "Welcome! You've been granted access via invite link.",
+  already_member: 'You already have access.',
+  invalid_token: 'This invite link is no longer valid.',
+  expired: 'This invite link is no longer valid.',
+  revoked: 'This invite link is no longer valid.',
+  max_uses_reached: 'This invite link is no longer valid.',
+  channel_mismatch: 'This invite link is not valid for this channel.',
+  missing_identity: 'Unable to process this invite. Please contact the person who shared it.',
+  generic_failure: 'Unable to process this invite. Please contact the person who shared it.',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Outcome-to-reply resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Map an `InviteRedemptionOutcome` to a deterministic reply string.
+ */
+export function getInviteRedemptionReply(outcome: InviteRedemptionOutcome): string {
+  if (outcome.ok) {
+    return INVITE_REPLY_TEMPLATES[outcome.type];
+  }
+  return INVITE_REPLY_TEMPLATES[outcome.reason] ?? INVITE_REPLY_TEMPLATES.generic_failure;
+}

--- a/assistant/src/runtime/invite-redemption-templates.ts
+++ b/assistant/src/runtime/invite-redemption-templates.ts
@@ -19,7 +19,6 @@ export const INVITE_REPLY_TEMPLATES = {
   expired: 'This invite link is no longer valid.',
   revoked: 'This invite link is no longer valid.',
   max_uses_reached: 'This invite link is no longer valid.',
-  blocked: 'This invite link is not valid for you.',
   channel_mismatch: 'This invite link is not valid for this channel.',
   missing_identity: 'Unable to process this invite. Please contact the person who shared it.',
   generic_failure: 'Unable to process this invite. Please contact the person who shared it.',

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1,8 +1,13 @@
 /**
  * Channel inbound message handler: validates, records, and routes inbound
  * messages from all channels. Handles ingress ACL, edits, guardian
- * verification, guardian action answers, and approval interception.
+ * verification, guardian action answers, approval interception, and
+ * invite token redemption.
  */
+// Side-effect import: registers the Telegram invite transport adapter so
+// getTransport('telegram') resolves at runtime.
+import '../channel-invite-transports/telegram.js';
+
 import { answerCall } from '../../calls/call-domain.js';
 import { isTerminalState } from '../../calls/call-state-machine.js';
 import { getCallSession } from '../../calls/call-store.js';
@@ -72,6 +77,9 @@ import type {
   GuardianFollowUpConversationGenerator,
   MessageProcessor,
 } from '../http-types.js';
+import { getTransport } from '../channel-invite-transport.js';
+import { redeemInvite } from '../invite-redemption-service.js';
+import { getInviteRedemptionReply } from '../invite-redemption-templates.js';
 import { deliverReplyViaCallback } from './channel-delivery-routes.js';
 import {
   canonicalChannelAssistantId,
@@ -214,6 +222,19 @@ export async function handleChannelInbound(
     typeof (rawCommandIntentForAcl as Record<string, unknown>).payload === 'string' &&
     ((rawCommandIntentForAcl as Record<string, unknown>).payload as string).startsWith('gv_');
 
+  // Parse invite token from /start iv_<token> commands using the transport
+  // adapter. The token is extracted once here so both the ACL bypass and
+  // the intercept handler can reference it without re-parsing.
+  const commandIntentForAcl = rawCommandIntentForAcl && typeof rawCommandIntentForAcl === 'object' && !Array.isArray(rawCommandIntentForAcl)
+    ? rawCommandIntentForAcl as Record<string, unknown>
+    : undefined;
+  const inviteTransport = getTransport(sourceChannel);
+  const inviteToken = inviteTransport?.extractInboundToken({
+    commandIntent: commandIntentForAcl,
+    content: trimmedContent,
+    sourceMetadata: body.sourceMetadata,
+  });
+
   if (body.senderExternalUserId) {
     resolvedMember = findMember({
       assistantId: canonicalAssistantId,
@@ -255,6 +276,27 @@ export async function handleChannelInbound(
         } else {
           log.info({ sourceChannel, hasValidBootstrapSession: false }, 'Ingress ACL: bootstrap command bypass denied — no valid pending_bootstrap session');
         }
+      }
+
+      // ── Invite token intercept (non-member) ──
+      // /start iv_<token> deep links grant access without guardian approval.
+      // Intercept here — before the deny gate — so valid invites short-circuit
+      // the ACL rejection and never reach the agent pipeline.
+      if (inviteToken && denyNonMember) {
+        const inviteResult = await handleInviteTokenIntercept({
+          rawToken: inviteToken,
+          sourceChannel,
+          externalChatId,
+          externalMessageId,
+          senderExternalUserId: body.senderExternalUserId,
+          senderName: body.senderName,
+          senderUsername: body.senderUsername,
+          replyCallbackUrl: body.replyCallbackUrl,
+          bearerToken,
+          assistantId,
+          canonicalAssistantId,
+        });
+        if (inviteResult) return inviteResult;
       }
 
       if (denyNonMember) {
@@ -320,6 +362,26 @@ export async function handleChannelInbound(
           } else {
             log.info({ sourceChannel, memberId: resolvedMember.id, hasValidBootstrapSession: false }, 'Ingress ACL: inactive member bootstrap bypass denied');
           }
+        }
+
+        // ── Invite token intercept (inactive member) ──
+        // Same as the non-member branch: invite tokens can reactivate
+        // revoked/pending members without requiring guardian approval.
+        if (inviteToken && denyInactiveMember) {
+          const inviteResult = await handleInviteTokenIntercept({
+            rawToken: inviteToken,
+            sourceChannel,
+            externalChatId,
+            externalMessageId,
+            senderExternalUserId: body.senderExternalUserId,
+            senderName: body.senderName,
+            senderUsername: body.senderUsername,
+            replyCallbackUrl: body.replyCallbackUrl,
+            bearerToken,
+            assistantId,
+            canonicalAssistantId,
+          });
+          if (inviteResult) return inviteResult;
         }
 
         if (denyInactiveMember) {
@@ -1363,6 +1425,121 @@ export async function handleChannelInbound(
     duplicate: result.duplicate,
     eventId: result.eventId,
   });
+}
+
+// ---------------------------------------------------------------------------
+// Invite token intercept
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle an inbound invite token for a non-member or inactive member.
+ *
+ * Redeems the invite, delivers a deterministic reply, and returns a Response
+ * to short-circuit the handler. Returns `null` when the intercept should not
+ * fire (e.g. already_member outcome — let normal flow handle it).
+ */
+async function handleInviteTokenIntercept(params: {
+  rawToken: string;
+  sourceChannel: ChannelId;
+  externalChatId: string;
+  externalMessageId: string;
+  senderExternalUserId?: string;
+  senderName?: string;
+  senderUsername?: string;
+  replyCallbackUrl?: string;
+  bearerToken?: string;
+  assistantId?: string;
+  canonicalAssistantId: string;
+}): Promise<Response | null> {
+  const {
+    rawToken,
+    sourceChannel,
+    externalChatId,
+    externalMessageId,
+    senderExternalUserId,
+    senderName,
+    senderUsername,
+    replyCallbackUrl,
+    bearerToken,
+    assistantId,
+    canonicalAssistantId,
+  } = params;
+
+  // Record the inbound event for dedup tracking BEFORE performing redemption.
+  // Without this, duplicate webhook deliveries (common with Telegram) would
+  // not be tracked: the first delivery redeems the invite and returns early,
+  // then the retry finds an active member, passes ACL, and the raw
+  // /start iv_<token> message leaks into the agent pipeline.
+  const dedupResult = channelDeliveryStore.recordInbound(
+    sourceChannel,
+    externalChatId,
+    externalMessageId,
+    { assistantId: canonicalAssistantId },
+  );
+
+  if (dedupResult.duplicate) {
+    return Response.json({
+      accepted: true,
+      duplicate: true,
+      eventId: dedupResult.eventId,
+    });
+  }
+
+  const outcome = redeemInvite({
+    rawToken,
+    sourceChannel,
+    externalUserId: senderExternalUserId,
+    externalChatId,
+    displayName: senderName,
+    username: senderUsername,
+    assistantId: canonicalAssistantId,
+  });
+
+  log.info(
+    { sourceChannel, externalChatId, ok: outcome.ok, type: outcome.ok ? outcome.type : undefined, reason: !outcome.ok ? outcome.reason : undefined },
+    'Invite token intercept: redemption result',
+  );
+
+  // already_member means the user has an active record — let the normal
+  // flow handle them (they passed ACL or the member is active).
+  if (outcome.ok && outcome.type === 'already_member') {
+    // Deliver a quick acknowledgement and short-circuit so the user
+    // does not trigger the deny gate or a duplicate agent loop.
+    const replyText = getInviteRedemptionReply(outcome);
+    if (replyCallbackUrl) {
+      try {
+        await deliverChannelReply(replyCallbackUrl, {
+          chatId: externalChatId,
+          text: replyText,
+          assistantId,
+        }, bearerToken);
+      } catch (err) {
+        log.error({ err, externalChatId }, 'Failed to deliver invite already-member reply');
+      }
+    }
+    return Response.json({ accepted: true, eventId: dedupResult.eventId, inviteRedemption: 'already_member' });
+  }
+
+  const replyText = getInviteRedemptionReply(outcome);
+
+  if (replyCallbackUrl) {
+    try {
+      await deliverChannelReply(replyCallbackUrl, {
+        chatId: externalChatId,
+        text: replyText,
+        assistantId,
+      }, bearerToken);
+    } catch (err) {
+      log.error({ err, externalChatId }, 'Failed to deliver invite redemption reply');
+    }
+  }
+
+  if (outcome.ok && outcome.type === 'redeemed') {
+    return Response.json({ accepted: true, eventId: dedupResult.eventId, inviteRedemption: 'redeemed', memberId: outcome.memberId });
+  }
+
+  // Failed redemption — inform the user and deny
+  return Response.json({ accepted: true, eventId: dedupResult.eventId, denied: true, inviteRedemption: outcome.reason });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Enable guardians to proactively invite external users via Telegram deep links. The guardian asks the assistant to create an invite link, receives a shareable `https://t.me/<bot>?start=iv_<token>` deep link, and the invitee clicks it to become an active member without manual guardian approval.

## Changes
- **M1: Shared Invite Core Hardening** — Added `invite-redemption-service.ts` with typed `InviteRedemptionOutcome`, channel-match enforcement, expired status persistence, and pre-validation before membership checks
- **M2: Channel Invite Transport Abstraction** — Introduced `ChannelInviteTransport` interface, registry, and Telegram adapter for deep link build/extraction with `iv_` prefix convention
- **M3: Telegram Inbound Invite Redemption Intercept** — Early intercept in inbound handler for `iv_` tokens before non-member deny, with dedup recording, inactive member reactivation, and deterministic reply templates
- **M4: Guardian Conversational UX** — Extended trusted-contacts skill with invite create/list/revoke workflows, added guardian invite intent resolver for natural language routing
- **M5: Documentation** — Updated README and ARCHITECTURE.md with invite flow docs, module references, and deferred channel support

## Milestone PRs (merged into feature branch)
- #10366: M1: Shared Invite Core Hardening (#10358)
- #10372: M2: Channel Invite Transport Abstraction + Telegram Adapter (#10360)
- #10377: M3: Telegram Inbound Invite Redemption Intercept (#10362)
- #10382: M4: Guardian Conversational UX for Invite Links (#10363)
- #10389: M5: Documentation and Architecture Alignment (#10364)

## Project issue
Closes #10357

## Test plan
- [ ] Guardian asks to create a Telegram invite link — receives shareable deep link
- [ ] Non-member clicks invite link → becomes active member without guardian approval
- [ ] Invalid/expired/revoked tokens get deterministic refusal messages
- [ ] Existing `/start gv_<token>` guardian verification flow unaffected
- [ ] Duplicate webhook deliveries are deduplicated
- [ ] Guardian can list and revoke active invites
- [ ] Existing member sending normal messages is unaffected

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
