### PR TITLE
M2: Ensure apps open in view-only mode (not edit state)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -316,25 +316,6 @@ struct MainWindowView: View {
                     }
                 }
 
-                // Sticky behavior: if isAppChatOpen is true and we just navigated to .app,
-                // auto-transition to .appEditing so the chat dock stays open.
-                // Guard: only auto-transition from .app (not .appEditing) to avoid infinite loops.
-                if case .app(let appId) = newSelection, isAppChatOpen {
-                    let threadId = threadManager.activeThreadId
-                        ?? threadManager.visibleThreads.first?.id
-                    if let threadId {
-                        threadManager.selectThread(id: threadId)
-                        windowState.setAppEditing(appId: appId, threadId: threadId)
-                    } else {
-                        // No threads exist — create one, then transition
-                        threadManager.createThread()
-                        if let newThreadId = threadManager.activeThreadId {
-                            windowState.setAppEditing(appId: appId, threadId: newThreadId)
-                        }
-                    }
-                    return
-                }
-
                 // Sync surface and chat dock state when selection changes
                 let expanded = windowState.isDynamicExpanded
                 let docked = windowState.isChatDockOpen


### PR DESCRIPTION
Remove the sticky behavior that auto-enters appEditing mode based on isAppChatOpen. Apps now always open in .app() view-only mode. The Edit button in PanelCoordinator remains the sole entry point to edit mode. Part of #10385.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
