### PR TITLE
feat: add agent mode to Playwright CI

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -26,6 +26,7 @@ permissions:
 
 jobs:
   headless:
+    if: github.event_name != 'workflow_dispatch'
     name: Headless Browser Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -2,6 +2,12 @@ name: Playwright Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      agent:
+        description: 'Run agent-based tests instead of standard Playwright tests'
+        required: false
+        type: boolean
+        default: false
   pull_request:
     types: [labeled, synchronize, opened, reopened]
     paths:
@@ -104,18 +110,30 @@ jobs:
         working-directory: playwright
         run: bun install
 
+      - name: Install Chromium
+        if: inputs.agent
+        working-directory: playwright
+        run: bunx playwright install --with-deps chromium
+
       - name: Run Playwright tests
         id: tests
         working-directory: playwright
         continue-on-error: true
-        run: bun run test
+        run: |
+          if [ "${{ inputs.agent }}" = "true" ]; then
+            bun run test:agent
+          else
+            bun run test
+          fi
 
       - name: Upload screenshots on failure
         if: steps.tests.outcome == 'failure'
         uses: actions/upload-artifact@v4
         with:
           name: playwright-screenshots
-          path: playwright/test-results/screenshots/
+          path: |
+            playwright/test-results/screenshots/
+            playwright/test-results/agent-screenshots/
           retention-days: 7
           if-no-files-found: ignore
 

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -9,7 +9,8 @@
     "test:debug": "playwright test --debug",
     "test:agent": "bun run agent/runner.ts",
     "test:agent:headed": "bun run agent/runner.ts --headed",
-    "test:agent:verbose": "bun run agent/runner.ts --verbose"
+    "test:agent:verbose": "bun run agent/runner.ts --verbose",
+    "test:agent:ci": "gh workflow run playwright.yaml -f agent=true"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.0"


### PR DESCRIPTION
## Summary
- Adds an `agent` boolean input to the Playwright workflow's `workflow_dispatch` trigger
- When enabled, installs Chromium and runs `bun run test:agent` (agent-based tests) instead of `bun run test` (standard Playwright tests)
- Uploads agent screenshots alongside standard screenshots on failure

## Usage
Trigger manually from Actions tab with "agent" checkbox enabled, or via CLI:
```bash
gh workflow run playwright.yaml -f agent=true
```

## Test plan
- [ ] Default workflow_dispatch (agent unchecked) runs standard `bun run test`
- [ ] workflow_dispatch with agent=true runs `bun run test:agent`
- [ ] PR-triggered runs are unaffected (always run standard tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
