### PR TITLE
Remove app edit mode on open and kill chat toggle button

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -238,42 +238,6 @@ struct MainWindowView: View {
         return threadManager.activeThreadId!
     }
 
-    private func toggleChatBubble() {
-        switch windowState.selection {
-        case .app(let appId):
-            // Toggle ON: open chat alongside app
-            let threadId = resolveThreadId()
-            threadManager.selectThread(id: threadId)
-            windowState.setAppEditing(appId: appId, threadId: threadId)
-            isAppChatOpen = true
-
-        case .appEditing(let appId, _):
-            // Toggle OFF: close chat, return to app-only view
-            windowState.selection = .app(appId)
-            isAppChatOpen = false
-
-        case .panel(let panelType) where panelType != .voiceMode && panelType != .documentEditor:
-            // Toggle: flip isAppChatOpen for any panel view
-            // (voiceMode and documentEditor have their own dedicated split layouts)
-            isAppChatOpen.toggle()
-
-        default:
-            break
-        }
-    }
-
-    /// Whether the chat bubble toggle should be visible for the current selection.
-    /// Hidden when already in a full-screen chat thread (.thread / .none),
-    /// or on panels that have their own dedicated chat layouts.
-    private var isChatBubbleVisible: Bool {
-        if windowState.isShowingChat { return false }
-        if case .panel(let panelType) = windowState.selection,
-           panelType == .voiceMode || panelType == .documentEditor {
-            return false
-        }
-        return true
-    }
-
     /// Whether the chat bubble toggle is active (chat is open).
     private var isChatBubbleActive: Bool {
         switch windowState.selection {
@@ -432,13 +396,6 @@ struct MainWindowView: View {
                     sidebarExpanded.toggle()
                 }
             }
-            if isChatBubbleVisible {
-                ChatBubbleToggle(
-                    isActive: isChatBubbleActive,
-                    tooltip: isChatBubbleActive ? "Hide chat" : "Show chat",
-                    onToggle: { toggleChatBubble() }
-                )
-            }
             Spacer()
             PTTKeyIndicator {
                 settingsStore.pendingSettingsTab = .voice
@@ -593,6 +550,11 @@ struct MainWindowView: View {
             JITPermissionView(manager: jitPermissionManager)
         }
         .onAppear {
+            // Reset stale chat-dock state for users upgrading from versions
+            // that had the ChatBubbleToggle (now removed). Without this,
+            // isAppChatOpen could remain persisted as true with no UI to
+            // disable it, leaving panels stuck in split mode.
+            isAppChatOpen = false
             windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected)
             selectedThreadId = threadManager.activeThreadId
             // Initialize persistent thread tracking on launch

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -594,15 +594,9 @@ struct MainWindowView: View {
                 if let surface = windowState.activeDynamicParsedSurface,
                    case .dynamicPage(let dpData) = surface.data,
                    let appId = dpData.appId {
-                    // Auto-dock chat alongside the app so the user can
-                    // keep chatting while viewing the surface.
-                    let threadId = threadManager.activeThreadId ?? threadManager.visibleThreads.first?.id
-                    if let threadId {
-                        threadManager.selectThread(id: threadId)
-                        windowState.setAppEditing(appId: appId, threadId: threadId)
-                    } else {
-                        windowState.selection = .app(appId)
-                    }
+                    // Open in view-only mode; user can enter edit mode
+                    // via the Edit button in the toolbar.
+                    windowState.selection = .app(appId)
                 } else {
                     windowState.selection = .app(msg.surfaceId)
                 }
@@ -939,7 +933,6 @@ struct MainWindowView: View {
     @ViewBuilder
     private func sidebarPinnedAppRow(_ app: AppListManager.AppItem) -> some View {
         Button(action: {
-            windowState.selection = .app(app.id)
             openAppInWorkspace(app: app)
         }) {
             HStack(spacing: VSpacing.sm) {
@@ -1001,7 +994,6 @@ struct MainWindowView: View {
     @ViewBuilder
     private func sidebarPinnedAppIcon(_ app: AppListManager.AppItem) -> some View {
         Button(action: {
-            windowState.selection = .app(app.id)
             openAppInWorkspace(app: app)
         }) {
             Image(systemName: app.sfSymbol ?? "square.grid.2x2")
@@ -1244,8 +1236,6 @@ struct MainWindowView: View {
     @ViewBuilder
     private func sidebarAppItem(_ app: AppListManager.AppItem) -> some View {
         Button(action: {
-            // Clicking a different app exits edit mode; same app stays in .app mode
-            windowState.selection = .app(app.id)
             openAppInWorkspace(app: app)
         }) {
             HStack(spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -316,25 +316,6 @@ struct MainWindowView: View {
                     }
                 }
 
-                // Sticky behavior: if isAppChatOpen is true and we just navigated to .app,
-                // auto-transition to .appEditing so the chat dock stays open.
-                // Guard: only auto-transition from .app (not .appEditing) to avoid infinite loops.
-                if case .app(let appId) = newSelection, isAppChatOpen {
-                    let threadId = threadManager.activeThreadId
-                        ?? threadManager.visibleThreads.first?.id
-                    if let threadId {
-                        threadManager.selectThread(id: threadId)
-                        windowState.setAppEditing(appId: appId, threadId: threadId)
-                    } else {
-                        // No threads exist — create one, then transition
-                        threadManager.createThread()
-                        if let newThreadId = threadManager.activeThreadId {
-                            windowState.setAppEditing(appId: appId, threadId: newThreadId)
-                        }
-                    }
-                    return
-                }
-
                 // Sync surface and chat dock state when selection changes
                 let expanded = windowState.isDynamicExpanded
                 let docked = windowState.isChatDockOpen


### PR DESCRIPTION
## Summary
When opening an app in Vellum, it now always opens in view-only mode instead of potentially re-entering edit state. The chat bubble toggle button has been removed from the top navigation bar entirely.

## Changes
- Removed ChatBubbleToggle rendering, `isChatBubbleVisible` computed property, and `toggleChatBubble()` function from the navigation toolbar
- Added `isAppChatOpen = false` reset on app launch to clear stale persisted state for upgrading users
- Removed the sticky behavior that auto-transitioned from `.app` to `.appEditing` when `isAppChatOpen` was `true`
- The Edit button in PanelCoordinator remains the sole entry point to edit mode

## Milestone PRs (merged into feature branch)
- #10388: M1: Remove ChatBubbleToggle from navigation toolbar
- #10392: M2: Ensure apps open in view-only mode (not edit state)

## Project issue
Closes #10385

## Test plan
- [ ] Launch app — verify no chat toggle button in the top bar
- [ ] Open an app from the sidebar — verify it opens in view-only mode (no "Done Editing" button visible)
- [ ] Click "Edit" in the panel coordinator — verify edit mode still works
- [ ] Click "Done Editing" — verify you return to view-only mode
- [ ] Restart the app — verify it doesn't re-enter edit mode

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
