### PR TITLE
fix: playwright CI agent script and video recording

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -127,14 +127,12 @@ jobs:
             bun run test
           fi
 
-      - name: Upload screenshots on failure
-        if: steps.tests.outcome == 'failure'
+      - name: Upload test artifacts
+        if: always() && steps.tests.outcome != 'skipped'
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-screenshots
-          path: |
-            playwright/test-results/screenshots/
-            playwright/test-results/agent-screenshots/
+          name: playwright-results
+          path: playwright/test-results/
           retention-days: 7
           if-no-files-found: ignore
 

--- a/playwright/.gitignore
+++ b/playwright/.gitignore
@@ -1,0 +1,1 @@
+test-results/

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -7,4 +7,7 @@ export default defineConfig({
   timeout: 120_000,
   retries: 0,
   reporter: "list",
+  use: {
+    video: "on",
+  },
 });

--- a/playwright/scripts/agent-ci.ts
+++ b/playwright/scripts/agent-ci.ts
@@ -23,6 +23,16 @@ function ghPassthrough(args: string[]): number {
   return result.status ?? 1;
 }
 
+// Capture the current user and most recent run ID before triggering,
+// so we can detect the *new* run by comparing against the previous one.
+const { stdout: ghUser } = gh(["api", "user", "--jq", ".login"]);
+const runListArgs = [
+  "run", "list", "-R", REPO, "-w", WORKFLOW,
+  "-u", ghUser, "-e", "workflow_dispatch",
+  "--limit", "1", "--json", "databaseId", "--jq", ".[0].databaseId",
+];
+const { stdout: previousRunId } = gh(runListArgs);
+
 // Trigger the workflow
 console.log(`Triggering ${WORKFLOW} with agent=true...`);
 const trigger = ghPassthrough(["workflow", "run", WORKFLOW, "-R", REPO, "-f", "agent=true"]);
@@ -30,19 +40,12 @@ if (trigger !== 0) {
   process.exit(trigger);
 }
 
-// Find the run we just created — scope to workflow_dispatch by the current user
-// to avoid picking up an unrelated PR-triggered or other dispatch run.
-const { stdout: ghUser } = gh(["api", "user", "--jq", ".login"]);
-
+// Poll until a new run appears (different ID from the previous one)
 let runId = "";
-for (let attempt = 0; attempt < 10; attempt++) {
+for (let attempt = 0; attempt < 15; attempt++) {
   await new Promise((resolve) => setTimeout(resolve, 2000));
-  const { stdout: id } = gh([
-    "run", "list", "-R", REPO, "-w", WORKFLOW,
-    "-u", ghUser, "-e", "workflow_dispatch",
-    "--limit", "1", "--json", "databaseId", "--jq", ".[0].databaseId",
-  ]);
-  if (id) {
+  const { stdout: id } = gh(runListArgs);
+  if (id && id !== previousRunId) {
     runId = id;
     break;
   }
@@ -80,8 +83,8 @@ console.log("──────────────────────�
 
 // Download artifacts if any
 const { stdout: artifactCount } = gh([
-  "run", "view", runId, "-R", REPO,
-  "--json", "artifacts", "--jq", ".artifacts | length",
+  "api", `repos/${REPO}/actions/runs/${runId}/artifacts`,
+  "--jq", ".total_count",
 ]);
 
 if (parseInt(artifactCount, 10) > 0) {


### PR DESCRIPTION
## Summary
- **Fix stale run detection**: capture the previous run ID before triggering, then poll until a *different* ID appears — avoids latching onto an old completed run
- **Fix artifact download**: `gh run view --json artifacts` is not a valid field — switched to `gh api repos/.../actions/runs/.../artifacts`
- **Video recording**: enable `video: "on"` in playwright config so all test runs produce videos
- **Upload all artifacts**: upload the full `test-results/` directory (videos, screenshots, agent screenshots) on every run, not just on failure
- **Add `.gitignore`**: ignore `test-results/` in the playwright directory

## Test plan
- [ ] `bun run test:agent:ci` correctly identifies the new run (not a stale one)
- [ ] Artifacts are downloaded after run completes
- [ ] Videos appear in `test-results/` when running tests locally
- [ ] CI uploads the full `test-results/` artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
