### PR TITLE
feat: polished status display for agent CI script

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -128,6 +128,7 @@ jobs:
           fi
 
       - name: Upload test artifacts
+        id: upload-artifacts
         if: always() && steps.tests.outcome != 'skipped'
         uses: actions/upload-artifact@v4
         with:
@@ -135,6 +136,13 @@ jobs:
           path: playwright/test-results/
           retention-days: 7
           if-no-files-found: ignore
+
+      - name: Output artifact URL
+        if: always() && steps.upload-artifacts.outputs.artifact-id
+        run: |
+          ARTIFACT_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.upload-artifacts.outputs.artifact-id }}"
+          echo "::notice title=Playwright Artifacts::$ARTIFACT_URL"
+          echo "artifact-url=$ARTIFACT_URL" >> "$GITHUB_OUTPUT"
 
       - name: Generate GitHub App token
         if: steps.tests.outcome == 'failure'

--- a/playwright/agent/agent.ts
+++ b/playwright/agent/agent.ts
@@ -13,6 +13,8 @@ import { TOOL_DEFINITIONS, executeTool, type TestResult } from "./tools";
 // ── Constants ───────────────────────────────────────────────────────
 
 const MAX_ITERATIONS = 1000;
+const MAX_RETRIES = 5;
+const INITIAL_RETRY_DELAY_MS = 5000;
 const MODEL = "claude-opus-4-6";
 
 const SYSTEM_PROMPT = `You are a QA test automation agent for a desktop application. Your job is to execute end-to-end test cases described in markdown and verify the expected outcomes.
@@ -61,15 +63,32 @@ export async function runAgent(options: AgentOptions): Promise<TestResult> {
       console.log(`  [agent] iteration ${iteration + 1}`);
     }
 
-    const stream = client.messages.stream({
-      model: MODEL,
-      max_tokens: 32000,
-      system: SYSTEM_PROMPT,
-      tools: TOOL_DEFINITIONS,
-      messages,
-    });
-
-    const response = await stream.finalMessage();
+    let response: Anthropic.Message;
+    for (let retry = 0; ; retry++) {
+      try {
+        const stream = client.messages.stream({
+          model: MODEL,
+          max_tokens: 32000,
+          system: SYSTEM_PROMPT,
+          tools: TOOL_DEFINITIONS,
+          messages,
+        });
+        response = await stream.finalMessage();
+        break;
+      } catch (err: unknown) {
+        const isRetryable =
+          err instanceof Anthropic.APIError &&
+          (err.status === 429 || err.status === 529 || err.status === 503);
+        if (!isRetryable || retry >= MAX_RETRIES) {
+          throw err;
+        }
+        const delay = INITIAL_RETRY_DELAY_MS * 2 ** retry;
+        if (verbose) {
+          console.log(`  [agent] API ${err.status} — retrying in ${delay / 1000}s (attempt ${retry + 1}/${MAX_RETRIES})`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
 
     // Collect assistant content blocks
     const assistantContent = response.content;

--- a/playwright/scripts/agent-ci.ts
+++ b/playwright/scripts/agent-ci.ts
@@ -10,6 +10,7 @@ import { spawnSync } from "child_process";
 
 const REPO = "vellum-ai/vellum-assistant";
 const WORKFLOW = "playwright.yaml";
+const POLL_INTERVAL_MS = 5000;
 
 const detach = process.argv.includes("-d");
 
@@ -21,6 +22,64 @@ function gh(args: string[]): { stdout: string; status: number } {
 function ghPassthrough(args: string[]): number {
   const result = spawnSync("gh", args, { encoding: "utf-8", stdio: "inherit" });
   return result.status ?? 1;
+}
+
+interface StepInfo {
+  name: string;
+  status: string;
+  conclusion: string | null;
+  number: number;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+interface JobInfo {
+  name: string;
+  status: string;
+  conclusion: string | null;
+  steps: StepInfo[];
+  startedAt: string;
+}
+
+function formatElapsed(startTime: Date): string {
+  const elapsed = Math.floor((Date.now() - startTime.getTime()) / 1000);
+  const mins = Math.floor(elapsed / 60);
+  const secs = elapsed % 60;
+  if (mins === 0) return `${secs}s`;
+  return `${mins}m ${secs}s`;
+}
+
+function stepIcon(step: StepInfo): string {
+  if (step.conclusion === "success") return "✓";
+  if (step.conclusion === "failure") return "✗";
+  if (step.conclusion === "skipped") return "⊘";
+  if (step.status === "in_progress") return "●";
+  return "○";
+}
+
+function renderStatus(runUrl: string, startTime: Date, jobs: JobInfo[]): void {
+  const lines: string[] = [];
+
+  lines.push(`\x1b[2J\x1b[H`); // clear screen
+  lines.push(`Playwright Tests · ${runUrl}`);
+  lines.push(`Elapsed: ${formatElapsed(startTime)}`);
+  lines.push("");
+
+  // Find the "Playwright Tests" job (the only one we care about)
+  const job = jobs.find((j) => j.name === "Playwright Tests") ?? jobs[0];
+  if (!job) {
+    lines.push("  Waiting for job to start...");
+    process.stdout.write(lines.join("\n") + "\n");
+    return;
+  }
+
+  for (const step of job.steps) {
+    const icon = stepIcon(step);
+    const color = step.conclusion === "failure" ? "\x1b[31m" : step.conclusion === "success" ? "\x1b[32m" : step.status === "in_progress" ? "\x1b[33m" : "\x1b[90m";
+    lines.push(`  ${color}${icon}\x1b[0m ${step.name}`);
+  }
+
+  process.stdout.write(lines.join("\n") + "\n");
 }
 
 // Capture the current user and most recent run ID before triggering,
@@ -64,22 +123,41 @@ if (detach) {
   process.exit(0);
 }
 
-console.log(`Run: ${runUrl}\n`);
+// Poll until complete with custom status display
+const startTime = new Date();
+let conclusion = "";
 
-// Poll until complete
-const watchStatus = ghPassthrough(["run", "watch", runId, "-R", REPO, "--exit-status"]);
+while (true) {
+  const { stdout: json } = gh([
+    "run", "view", runId, "-R", REPO,
+    "--json", "status,conclusion,jobs",
+  ]);
 
-// Print summary
-const { stdout: summary } = gh([
-  "run", "view", runId, "-R", REPO,
-  "--json", "conclusion,displayTitle,updatedAt",
-  "--jq", `"Result: \\(.conclusion)  (\\(.displayTitle))\\nFinished: \\(.updatedAt)"`,
-]);
+  try {
+    const run = JSON.parse(json) as {
+      status: string;
+      conclusion: string | null;
+      jobs: JobInfo[];
+    };
 
-console.log("\n─────────────────────────────────────────");
-console.log(summary);
-console.log(`URL: ${runUrl}`);
-console.log("─────────────────────────────────────────");
+    renderStatus(runUrl, startTime, run.jobs);
+
+    if (run.status === "completed") {
+      conclusion = run.conclusion ?? "failure";
+      break;
+    }
+  } catch {
+    // API may return empty during initial queueing
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+}
+
+// Final summary
+const icon = conclusion === "success" ? "✓" : "✗";
+const color = conclusion === "success" ? "\x1b[32m" : "\x1b[31m";
+console.log(`\n${color}${icon}\x1b[0m Playwright Tests ${conclusion} in ${formatElapsed(startTime)}`);
+console.log(`  ${runUrl}`);
 
 // Download artifacts if any
 const { stdout: artifactCount } = gh([
@@ -93,4 +171,4 @@ if (parseInt(artifactCount, 10) > 0) {
   console.log("Saved to test-results/ci-artifacts/");
 }
 
-process.exit(watchStatus);
+process.exit(conclusion === "success" ? 0 : 1);

--- a/playwright/scripts/agent-ci.ts
+++ b/playwright/scripts/agent-ci.ts
@@ -158,18 +158,25 @@ const icon = conclusion === "success" ? "✓" : "✗";
 const color = conclusion === "success" ? "\x1b[32m" : "\x1b[31m";
 console.log(`\n${color}${icon}\x1b[0m Playwright Tests ${conclusion} in ${formatElapsed(startTime)}`);
 console.log(`  ${runUrl}`);
-console.log(`  ${runUrl}#artifacts`);
 
-// Download artifacts if any
-const { stdout: artifactCount } = gh([
+// Fetch specific artifact URL
+const { stdout: artifactJson } = gh([
   "api", `repos/${REPO}/actions/runs/${runId}/artifacts`,
-  "--jq", ".total_count",
+  "--jq", ".artifacts[0] // empty | {id, name}",
 ]);
 
-if (parseInt(artifactCount, 10) > 0) {
-  console.log("\nDownloading artifacts...");
-  ghPassthrough(["run", "download", runId, "-R", REPO, "-D", "test-results/ci-artifacts"]);
-  console.log("Saved to test-results/ci-artifacts/");
+if (artifactJson) {
+  try {
+    const artifact = JSON.parse(artifactJson) as { id: number; name: string };
+    const artifactUrl = `https://github.com/${REPO}/actions/runs/${runId}/artifacts/${artifact.id}`;
+    console.log(`  ${artifactUrl}`);
+
+    console.log("\nDownloading artifacts...");
+    ghPassthrough(["run", "download", runId, "-R", REPO, "-D", "test-results/ci-artifacts"]);
+    console.log("Saved to test-results/ci-artifacts/");
+  } catch {
+    // artifact JSON parse failed, skip download
+  }
 }
 
 process.exit(conclusion === "success" ? 0 : 1);

--- a/playwright/scripts/agent-ci.ts
+++ b/playwright/scripts/agent-ci.ts
@@ -158,6 +158,7 @@ const icon = conclusion === "success" ? "✓" : "✗";
 const color = conclusion === "success" ? "\x1b[32m" : "\x1b[31m";
 console.log(`\n${color}${icon}\x1b[0m Playwright Tests ${conclusion} in ${formatElapsed(startTime)}`);
 console.log(`  ${runUrl}`);
+console.log(`  ${runUrl}#artifacts`);
 
 // Download artifacts if any
 const { stdout: artifactCount } = gh([


### PR DESCRIPTION
## Summary
Replaces `gh run watch` with a custom polling loop that addresses 3 pieces of feedback:

1. **Run URL under title** — shows `Playwright Tests · <url>` at the top so you can click through
2. **No Jobs wrapper** — steps are shown directly since we only run the "Playwright Tests" job
3. **Elapsed time with seconds** — shows `2m 34s` instead of `2 minutes ago`, refreshed every 5s

Example output:
```
Playwright Tests · https://github.com/vellum-ai/vellum-assistant/actions/runs/12345
Elapsed: 3m 12s

  ✓ Checkout
  ✓ Select Xcode 16.2
  ✓ Authenticate to GCP
  ✓ Fetch Anthropic API key from Secret Manager
  ● Build macOS app
  ○ Install Playwright dependencies
  ○ Run Playwright tests
```

## Test plan
- [ ] `bun run test:agent:ci` shows the new status display
- [ ] Elapsed time updates every poll cycle
- [ ] Final summary shows pass/fail with total elapsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
