### PR TITLE
fix: playwright agent screenshots and artifact output

### DIFF
--- a/playwright/agent/runner.ts
+++ b/playwright/agent/runner.ts
@@ -100,8 +100,11 @@ async function runTestCase(
     const { body } = parseFrontmatter(testCase.rawContent);
     const testContent = body;
 
-    // Create browser context and page
-    context = await browser.newContext();
+    // Create browser context with video recording
+    const videoDir = path.resolve(__dirname, "../test-results/agent-videos", testCase.name);
+    context = await browser.newContext({
+      recordVideo: { dir: videoDir },
+    });
     page = await context.newPage();
 
     const screenshotDir = path.resolve(__dirname, "../test-results/agent-screenshots", testCase.name);

--- a/playwright/agent/tools/screenshot.ts
+++ b/playwright/agent/tools/screenshot.ts
@@ -1,7 +1,13 @@
 /**
- * Take a screenshot of the current page.
+ * Take a screenshot of the macOS screen via screencapture.
+ *
+ * We use the system screencapture command rather than page.screenshot()
+ * because the agent tests interact with native macOS desktop apps via
+ * AppleScript/System Events — the Playwright browser page is just a
+ * blank tab used for web-based tool calls.
  */
 
+import { execSync } from "child_process";
 import { mkdirSync } from "fs";
 
 import type Anthropic from "@anthropic-ai/sdk";
@@ -12,7 +18,7 @@ import type { ToolContext, ToolHandlerResult } from "./types";
 export const definition: Anthropic.Tool = {
   name: "screenshot",
   description:
-    "Take a screenshot of the current page. Returns the file path of the saved screenshot.",
+    "Take a screenshot of the current macOS screen. Returns the file path of the saved screenshot.",
   input_schema: {
     type: "object" as const,
     properties: {
@@ -26,14 +32,21 @@ export const definition: Anthropic.Tool = {
 };
 
 export async function execute(
-  page: Page,
+  _page: Page,
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolHandlerResult> {
   mkdirSync(context.screenshotDir, { recursive: true });
   const filePath = `${context.screenshotDir}/${input.name as string}.png`;
-  await page.screenshot({ path: filePath });
-  return {
-    result: { success: true, data: `Screenshot saved to ${filePath}` },
-  };
+  try {
+    execSync(`screencapture -x ${filePath}`, { timeout: 10_000 });
+    return {
+      result: { success: true, data: `Screenshot saved to ${filePath}` },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      result: { success: false, data: `screencapture failed: ${message}` },
+    };
+  }
 }

--- a/playwright/agent/tools/screenshot.ts
+++ b/playwright/agent/tools/screenshot.ts
@@ -7,7 +7,7 @@
  * blank tab used for web-based tool calls.
  */
 
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { mkdirSync } from "fs";
 
 import type Anthropic from "@anthropic-ai/sdk";
@@ -39,7 +39,7 @@ export async function execute(
   mkdirSync(context.screenshotDir, { recursive: true });
   const filePath = `${context.screenshotDir}/${input.name as string}.png`;
   try {
-    execSync(`screencapture -x ${filePath}`, { timeout: 10_000 });
+    execFileSync("screencapture", ["-x", filePath], { timeout: 10_000 });
     return {
       result: { success: true, data: `Screenshot saved to ${filePath}` },
     };

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   testDir: "./tests",
   timeout: 120_000,
   retries: 0,
-  reporter: "list",
+  reporter: [["list"], ["html", { open: "never", outputFolder: "test-results/html-report" }]],
   use: {
     video: "on",
   },


### PR DESCRIPTION
## Summary
- **Screenshot tool**: Switched from `page.screenshot()` to macOS `screencapture -x` — the agent tests interact with native desktop apps via AppleScript/System Events, so the Playwright browser page is just a blank Chromium tab (producing 4KB empty PNGs). `screencapture` captures the actual macOS screen showing the app under test.
- **Video recording**: Added `recordVideo: { dir }` option to the agent runner's `browser.newContext()` call so browser activity is captured.
- **HTML reporter**: Added `["html", { open: "never" }]` reporter alongside `"list"` in `playwright.config.ts` so standard test runs produce an `index.html` report in the artifacts.

## Test plan
- [ ] Trigger an agent CI run and verify the downloaded artifact.zip contains:
  - Non-empty screenshots (actual macOS screen captures)
  - Video files in `agent-videos/`
  - HTML report in `html-report/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
