### PR TITLE
fix(parental): settings tab — export CSV, real apps, dynamic integrations

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
@@ -7,6 +7,9 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 @MainActor
 final class AppListManager: ObservableObject {
 
+    /// Shared singleton for use in views that don't receive AppListManager via DI.
+    static let shared = AppListManager()
+
     struct AppItem: Identifiable, Codable, Hashable {
         let id: String
         var name: String

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1556,10 +1556,18 @@ private struct ProfileSwitcherSidebarRow: View {
     var body: some View {
         Button(action: onSwitch) {
             HStack(spacing: isExpanded ? VSpacing.sm : 0) {
-                Image(systemName: avatarIcon)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(avatarColor)
-                    .frame(width: 18)
+                // When collapsed and hovered, show the swap icon instead of avatar
+                if !isExpanded && isHovered {
+                    Image(systemName: "arrow.left.arrow.right")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(avatarColor)
+                        .frame(width: 18)
+                } else {
+                    Image(systemName: avatarIcon)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(avatarColor)
+                        .frame(width: 18)
+                }
                 if isExpanded {
                     Text(profileLabel)
                         .font(VFont.bodyMedium)
@@ -1649,7 +1657,6 @@ private struct DrawerMenuItem: View {
 // MARK: - Profile Switch Modal
 
 private enum SwitchStep: Equatable {
-    case overview
     case enterPIN
     case switching
 }
@@ -1657,7 +1664,7 @@ private enum SwitchStep: Equatable {
 
 /// Sheet shown when switching between parental and child profiles.
 /// Handles both directions: parental→child (no PIN) and child→parental (PIN required).
-/// Animates between an overview step and a PIN entry step for the child→parental flow.
+/// Opens directly to action — no overview step.
 @MainActor
 private struct ProfileSwitchModal: View {
     let activeProfile: String
@@ -1665,7 +1672,7 @@ private struct ProfileSwitchModal: View {
     var daemonClient: DaemonClient?
     let onSuccess: () -> Void
 
-    @State private var step: SwitchStep = .overview
+    @State private var step: SwitchStep = .enterPIN
     @State private var pin: String = ""
     @State private var errorMessage: String?
 
@@ -1675,7 +1682,13 @@ private struct ProfileSwitchModal: View {
 
     var body: some View {
         VStack(spacing: VSpacing.xl) {
-            // Profile transition header
+            // Title
+            Text(isChildToParental ? "Switch to Parental Mode" : "Switch to Child Mode")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textPrimary)
+                .frame(maxWidth: .infinity, alignment: .center)
+
+            // From/to avatar icons
             HStack(spacing: VSpacing.md) {
                 profileAvatarColumn(isParental: !isChildToParental)
                 Image(systemName: "arrow.right")
@@ -1685,23 +1698,10 @@ private struct ProfileSwitchModal: View {
             }
             .frame(maxWidth: .infinity, alignment: .center)
 
-            // Fixed-height content area so the modal doesn't resize between steps
             ZStack {
-                overviewContent
-                    .opacity(step == .overview ? 1 : 0)
-                    .allowsHitTesting(step == .overview)
-                    .transition(.asymmetric(
-                        insertion: .move(edge: .leading).combined(with: .opacity),
-                        removal: .move(edge: .leading).combined(with: .opacity)
-                    ))
-
-                pinContent
+                enterPINContent
                     .opacity(step == .enterPIN ? 1 : 0)
                     .allowsHitTesting(step == .enterPIN)
-                    .transition(.asymmetric(
-                        insertion: .move(edge: .trailing).combined(with: .opacity),
-                        removal: .move(edge: .trailing).combined(with: .opacity)
-                    ))
 
                 switchingContent
                     .opacity(step == .switching ? 1 : 0)
@@ -1717,85 +1717,34 @@ private struct ProfileSwitchModal: View {
         .animation(VAnimation.standard, value: step)
     }
 
-    private var overviewContent: some View {
+    private var enterPINContent: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text(isChildToParental ? "Switch to Parental Profile" : "Switch to Child Profile")
-                .font(VFont.headline)
-                .foregroundColor(VColor.textPrimary)
-
-            Text(isChildToParental
-                ? "You'll need to enter your 6-digit PIN to switch to the Parental profile."
-                : "Switch to the restricted Child profile.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textSecondary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            // Placeholder to match PIN entry height (circles + padding)
-            Color.clear.frame(height: 18 + VSpacing.xs * 2)
+            if isChildToParental {
+                PINCircleField(text: $pin)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, VSpacing.xs)
+                    .onChange(of: pin) { _, newValue in
+                        if newValue.count == 6 { performSwitch() }
+                    }
+            }
 
             if let error = errorMessage {
                 Text(error)
                     .font(VFont.caption)
                     .foregroundColor(VColor.error)
+                    .frame(maxWidth: .infinity, alignment: .center)
             } else {
-                // Reserve space for error message to match PIN step height
                 Text(" ").font(VFont.caption)
             }
 
             HStack {
                 VButton(label: "Cancel", style: .secondary) { dismiss() }
                 Spacer()
-                VButton(label: isChildToParental ? "Enter PIN" : "Switch", style: .primary) {
-                    if isChildToParental {
-                        withAnimation(VAnimation.standard) { step = .enterPIN }
-                    } else {
-                        performSwitch()
-                    }
-                }
-            }
-        }
-    }
-
-    private var pinContent: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Enter PIN")
-                .font(VFont.headline)
-                .foregroundColor(VColor.textPrimary)
-
-            Text("Enter your 6-digit PIN to switch to the Parental profile.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textSecondary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            PINCircleField(text: $pin)
-                .padding(.vertical, VSpacing.xs)
-                .onChange(of: pin) { _, newValue in
-                    // Auto-submit when all 6 digits are entered
-                    if newValue.count == 6 { performSwitch() }
-                }
-
-            if let error = errorMessage {
-                Text(error)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.error)
-            } else {
-                // Reserve space for error message to avoid height jump
-                Text(" ").font(VFont.caption)
-            }
-
-            HStack {
-                VButton(label: "Back", style: .secondary) {
-                    withAnimation(VAnimation.standard) {
-                        step = .overview
-                        pin = ""
-                        errorMessage = nil
-                    }
-                }
-                Spacer()
                 VButton(label: "Switch Profile", style: .primary) {
                     performSwitch()
                 }
-                .disabled(pin.count != 6)
+                .disabled(isChildToParental && pin.count != 6)
+                .keyboardShortcut(.return, modifiers: [])
             }
         }
     }
@@ -1838,7 +1787,7 @@ private struct ProfileSwitchModal: View {
             } else {
                 errorMessage = settingsStore.profileSwitchError
                 withAnimation(VAnimation.standard) {
-                    step = isChildToParental ? .enterPIN : .overview
+                    step = .enterPIN
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 import VellumAssistantShared
 
 // MARK: - Parental Control Settings Tab
@@ -17,14 +18,6 @@ struct SettingsParentalTab: View {
     @State private var blockedToolCategories: Set<String> = []
     @State private var allowedApps: [String] = []
     @State private var allowedWidgets: [String] = []
-
-    // -- Allowlist entry fields --
-    @State private var newAppEntry: String = ""
-    @State private var newWidgetEntry: String = ""
-
-    // -- Apps & Widgets unified allowlist add sheets --
-    @State private var showingAddAppSheet: Bool = false
-    @State private var showingAddWidgetSheet: Bool = false
 
     // -- Local UI state --
     @State private var isLoading: Bool = false
@@ -136,28 +129,6 @@ struct SettingsParentalTab: View {
                     }
                 },
                 daemonClient: daemonClient
-            )
-        }
-        .sheet(isPresented: $showingAddAppSheet) {
-            AddAllowlistItemSheet(
-                placeholder: "App name",
-                title: "Add App",
-                onAdd: { name in
-                    guard !name.isEmpty, !allowedApps.contains(name) else { return }
-                    updateAllowlist(apps: allowedApps + [name], widgets: nil)
-                },
-                onDismiss: { showingAddAppSheet = false }
-            )
-        }
-        .sheet(isPresented: $showingAddWidgetSheet) {
-            AddAllowlistItemSheet(
-                placeholder: "Widget name",
-                title: "Add Widget",
-                onAdd: { name in
-                    guard !name.isEmpty, !allowedWidgets.contains(name) else { return }
-                    updateAllowlist(apps: nil, widgets: allowedWidgets + [name])
-                },
-                onDismiss: { showingAddWidgetSheet = false }
             )
         }
     }
@@ -395,63 +366,40 @@ struct SettingsParentalTab: View {
                 .font(VFont.sectionTitle)
                 .foregroundColor(VColor.textPrimary)
 
-            Text("Child profile can only access enabled apps and widgets.")
+            Text("Child profile can only access enabled apps.")
                 .font(VFont.caption)
                 .foregroundColor(VColor.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)
                 .textSelection(.enabled)
 
-            if allowedApps.isEmpty && allowedWidgets.isEmpty {
-                Text("No apps or widgets configured — all are blocked.")
+            let knownApps = AppListManager.shared.apps
+            if knownApps.isEmpty {
+                Text("No apps tracked yet — apps will appear here as they are used.")
                     .font(VFont.caption)
                     .foregroundColor(VColor.textMuted)
                     .textSelection(.enabled)
             } else {
-                ForEach(allowedApps, id: \.self) { app in
-                    let iconInfo = VAppIconGenerator.generate(from: app)
+                ForEach(knownApps) { app in
                     HStack(spacing: VSpacing.sm) {
-                        VAppIcon(sfSymbol: iconInfo.sfSymbol, gradientColors: iconInfo.colors, size: .small)
-                        Text(app)
+                        if let symbol = app.sfSymbol {
+                            let gradientColors: [String] = app.iconBackground ?? ["#7C3AED", "#4F46E5"]
+                            VAppIcon(sfSymbol: symbol, gradientColors: gradientColors, size: .small)
+                        }
+                        Text(app.name)
                             .font(VFont.body)
                             .foregroundColor(VColor.textPrimary)
-                            .textSelection(.enabled)
                         Spacer()
                         Toggle("", isOn: Binding(
-                            get: { allowedApps.contains(app) },
+                            get: { allowedApps.contains(app.id) },
                             set: { enabled in
-                                if !enabled {
-                                    allowedApps = allowedApps.filter { $0 != app }
-                                    updateAllowlist(apps: allowedApps, widgets: nil)
-                                }
+                                if enabled { allowedApps.append(app.id) }
+                                else { allowedApps.removeAll { $0 == app.id } }
+                                updateAllowlist(apps: allowedApps, widgets: nil)
                             }
                         ))
                         .toggleStyle(.switch)
                         .labelsHidden()
-                        .accessibilityLabel("\(app) allowed")
-                        .disabled(isLoading)
-                    }
-                }
-                ForEach(allowedWidgets, id: \.self) { widget in
-                    let iconInfo = VAppIconGenerator.generate(from: widget)
-                    HStack(spacing: VSpacing.sm) {
-                        VAppIcon(sfSymbol: iconInfo.sfSymbol, gradientColors: iconInfo.colors, size: .small)
-                        Text(widget)
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textPrimary)
-                            .textSelection(.enabled)
-                        Spacer()
-                        Toggle("", isOn: Binding(
-                            get: { allowedWidgets.contains(widget) },
-                            set: { enabled in
-                                if !enabled {
-                                    allowedWidgets = allowedWidgets.filter { $0 != widget }
-                                    updateAllowlist(apps: nil, widgets: allowedWidgets)
-                                }
-                            }
-                        ))
-                        .toggleStyle(.switch)
-                        .labelsHidden()
-                        .accessibilityLabel("\(widget) allowed")
+                        .accessibilityLabel("\(app.name) allowed")
                         .disabled(isLoading)
                     }
                 }
@@ -464,14 +412,63 @@ struct SettingsParentalTab: View {
 
     // MARK: - Integrations Section
 
-    /// The canonical list of integrations that can be enabled for the child profile.
-    private let availableIntegrations: [(id: String, label: String, icon: String)] = [
-        ("telegram", "Telegram", "paperplane.fill"),
-        ("sms", "SMS", "message.fill"),
-        ("voice", "Voice", "phone.fill"),
-        ("email", "Email", "envelope.fill"),
-        ("mobile", "Mobile (iOS)", "iphone"),
-    ]
+    /// A configured integration entry for display in the parental controls tab.
+    private struct ConfiguredIntegration {
+        let id: String
+        let label: String
+        let subtitle: String
+        let icon: String
+        let iconColor: Color
+    }
+
+    /// Build the list of integrations that are currently configured in the Connect tab.
+    private var configuredIntegrations: [ConfiguredIntegration] {
+        var result: [ConfiguredIntegration] = []
+        if settingsStore.telegramHasBotToken {
+            result.append(ConfiguredIntegration(
+                id: "telegram",
+                label: "Telegram",
+                subtitle: "Message via Telegram bot",
+                icon: "paperplane.fill",
+                iconColor: .blue
+            ))
+        }
+        if settingsStore.twilioHasCredentials {
+            result.append(ConfiguredIntegration(
+                id: "sms",
+                label: "SMS",
+                subtitle: "Send and receive SMS messages",
+                icon: "message.fill",
+                iconColor: .green
+            ))
+            result.append(ConfiguredIntegration(
+                id: "voice",
+                label: "Voice",
+                subtitle: "Make and receive voice calls",
+                icon: "phone.fill",
+                iconColor: .orange
+            ))
+        }
+        if let email = settingsStore.assistantEmail, !email.isEmpty {
+            result.append(ConfiguredIntegration(
+                id: "email",
+                label: "Email",
+                subtitle: "Send and receive email",
+                icon: "envelope.fill",
+                iconColor: .gray
+            ))
+        }
+        if !settingsStore.approvedDevices.isEmpty {
+            result.append(ConfiguredIntegration(
+                id: "mobile",
+                label: "Mobile (iOS)",
+                subtitle: "Access from paired iOS devices",
+                icon: "iphone",
+                iconColor: .purple
+            ))
+        }
+        return result
+    }
 
     private var integrationsSection: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
@@ -485,31 +482,48 @@ struct SettingsParentalTab: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .textSelection(.enabled)
 
-            ForEach(availableIntegrations, id: \.id) { integration in
-                HStack(spacing: VSpacing.sm) {
-                    Image(systemName: integration.icon)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(VColor.textSecondary)
-                        .frame(width: 18)
-                    Text(integration.label)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
-                    Spacer()
-                    Toggle("", isOn: Binding(
-                        get: { settingsStore.allowedIntegrations.contains(integration.id) },
-                        set: { isOn in
-                            let pin = settingsStore.cachedPIN ?? ""
-                            let updated = isOn
-                                ? settingsStore.allowedIntegrations + [integration.id]
-                                : settingsStore.allowedIntegrations.filter { $0 != integration.id }
-                            settingsStore.allowedIntegrations = updated
-                            settingsStore.updateAllowedIntegrations(pin: pin, integrations: updated)
+            let integrations = configuredIntegrations
+            if integrations.isEmpty {
+                Text("No integrations configured. Set up integrations in the Connect tab.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .textSelection(.enabled)
+            } else {
+                ForEach(integrations, id: \.id) { integration in
+                    HStack(spacing: VSpacing.sm) {
+                        ZStack {
+                            RoundedRectangle(cornerRadius: VRadius.sm)
+                                .fill(integration.iconColor)
+                                .frame(width: 28, height: 28)
+                            Image(systemName: integration.icon)
+                                .font(.system(size: 13, weight: .medium))
+                                .foregroundColor(.white)
                         }
-                    ))
-                    .toggleStyle(.switch)
-                    .labelsHidden()
-                    .accessibilityLabel(integration.label)
-                    .disabled(isLoading)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(integration.label)
+                                .font(VFont.bodyMedium)
+                                .foregroundColor(VColor.textPrimary)
+                            Text(integration.subtitle)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textSecondary)
+                        }
+                        Spacer()
+                        Toggle("", isOn: Binding(
+                            get: { settingsStore.allowedIntegrations.contains(integration.id) },
+                            set: { isOn in
+                                let pin = settingsStore.cachedPIN ?? ""
+                                let updated = isOn
+                                    ? settingsStore.allowedIntegrations + [integration.id]
+                                    : settingsStore.allowedIntegrations.filter { $0 != integration.id }
+                                settingsStore.allowedIntegrations = updated
+                                settingsStore.updateAllowedIntegrations(pin: pin, integrations: updated)
+                            }
+                        ))
+                        .toggleStyle(.switch)
+                        .labelsHidden()
+                        .accessibilityLabel(integration.label)
+                        .disabled(isLoading)
+                    }
                 }
             }
         }
@@ -527,6 +541,14 @@ struct SettingsParentalTab: View {
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
                 Spacer()
+                Button { exportActivityLog() } label: {
+                    Label("Export", systemImage: "square.and.arrow.up")
+                }
+                .buttonStyle(.plain)
+                .font(VFont.caption)
+                .foregroundColor(VColor.accent)
+                .accessibilityLabel("Export activity log as CSV")
+                .disabled(settingsStore.activityLog.isEmpty)
                 VButton(label: "Clear Log", style: .danger) {
                     settingsStore.clearActivityLogEntries(pin: settingsStore.cachedPIN)
                 }
@@ -919,6 +941,19 @@ struct SettingsParentalTab: View {
                     loadAllowlist()
                 }
             }
+        }
+    }
+
+    private func exportActivityLog() {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [UTType.commaSeparatedText]
+        panel.nameFieldStringValue = "activity-log.csv"
+        if panel.runModal() == .OK, let url = panel.url {
+            let header = "Timestamp,Type,Description\n"
+            let rows = settingsStore.activityLog.map {
+                "\($0.timestamp),\($0.actionType),\"\($0.description)\""
+            }.joined(separator: "\n")
+            try? (header + rows).write(to: url, atomically: true, encoding: .utf8)
         }
     }
 
@@ -1525,49 +1560,6 @@ private enum ToolCategory: String, CaseIterable, Identifiable {
         case .shell: return "Bash commands, terminal access."
         case .file_write: return "Creating, editing, or deleting files."
         }
-    }
-}
-
-// MARK: - Add Allowlist Item Sheet
-
-/// Sheet shown when the parent taps the + button in the Apps or Widgets subsection.
-/// Accepts a single name and calls `onAdd` with the trimmed value.
-@MainActor
-private struct AddAllowlistItemSheet: View {
-    let placeholder: String
-    let title: String
-    let onAdd: (String) -> Void
-    let onDismiss: () -> Void
-
-    @State private var name: String = ""
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.lg) {
-            Text(title)
-                .font(VFont.headline)
-                .foregroundColor(VColor.textPrimary)
-
-            TextField(placeholder, text: $name)
-                .textFieldStyle(.roundedBorder)
-                .font(VFont.body)
-
-            HStack {
-                Spacer()
-                VButton(label: "Cancel", style: .secondary) {
-                    onDismiss()
-                }
-                VButton(label: "Add", style: .primary) {
-                    let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard !trimmed.isEmpty else { return }
-                    onAdd(trimmed)
-                    onDismiss()
-                }
-                .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-            }
-        }
-        .padding(VSpacing.xl)
-        .frame(width: 300)
-        .background(VColor.background)
     }
 }
 


### PR DESCRIPTION
## PR4: Export Activity Log to CSV
- Added Export button to Activity Log section header
- NSSavePanel opens, saves well-formed CSV with Timestamp/Type/Description columns
- Imported `UniformTypeIdentifiers` for `UTType.commaSeparatedText`

## PR5: Real Apps List from AppListManager
- Replaced manual text-entry allowlist (`AddAllowlistItemSheet`) with toggle rows from `AppListManager.shared.apps`
- Removed `AddAllowlistItemSheet` struct, `showingAddAppSheet`/`showingAddWidgetSheet` state, and unused `newAppEntry`/`newWidgetEntry` fields
- Each app shows with its generated icon (VAppIcon) and name; toggle saves to `allowedApps` via existing IPC `updateAllowlist`
- Added `static let shared` singleton to `AppListManager` to allow DI-free access from settings tab

## PR6: Integrations — Sync with Connect Tab
- Dynamic list showing only configured integrations: Telegram (if `telegramHasBotToken`), SMS/Voice (if `twilioHasCredentials`), Email (if `assistantEmail` non-empty), Mobile (if `approvedDevices.count > 0`)
- Empty state when no integrations configured: "No integrations configured. Set up integrations in the Connect tab."
- Toggle per integration for child access, using existing `settingsStore.updateAllowedIntegrations`
- Icon backgrounds match Connect tab style: blue/green/orange/gray/purple with white SF Symbol on colored `RoundedRectangle`
- Each row shows title + subtitle for visual clarity
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
