### PR TITLE
fix(parental): permission request button in chat for blocked tool calls

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -15,6 +15,9 @@ struct ChatBubble: View {
     var onReportMessage: ((String?) -> Void)?
     /// Called when expanding a tool call with truncated content to fetch the full text.
     var onRehydrate: (() -> Void)?
+    /// Called when the user taps "Request Permission" on a blocked tool call.
+    /// Receives `(toolName, reason)` from the request-permission sheet.
+    var onRequestPermission: ((String, String) -> Void)?
     var mediaEmbedSettings: MediaEmbedResolverSettings?
     /// Resolves the daemon HTTP port at call time so lazy-loaded video
     /// attachments always use the latest port after daemon restarts.
@@ -29,6 +32,7 @@ struct ChatBubble: View {
     @State private var copyConfirmationTimer: DispatchWorkItem?
     @State private var mediaEmbedIntents: [MediaEmbedIntent] = []
     @State var stepsExpanded = false
+    @State private var showingRequestPermissionSheet = false
     /// Injected from the parent instead of observing the shared singleton directly.
     /// This avoids every ChatBubble in the list re-rendering whenever the overlay
     /// manager publishes any change (the "thundering herd" problem).
@@ -180,6 +184,11 @@ struct ChatBubble: View {
                         trailingStatus
                     }
 
+                    // "Request Permission" button — shown in child profile when a tool was blocked
+                    if !isUser && message.hasBlockedToolCall && onRequestPermission != nil {
+                        requestPermissionButton
+                    }
+
                     if hasOverflowActions {
                         overflowMenuButton
                             .opacity(showOverflowMenu ? 1 : 0)
@@ -220,6 +229,44 @@ struct ChatBubble: View {
             guard !Task.isCancelled else { return }
             mediaEmbedIntents = resolved
         }
+        .sheet(isPresented: $showingRequestPermissionSheet) {
+            let blockedToolName = message.toolCalls.first(where: { $0.isBlockedByParentalControls })?.toolName ?? ""
+            BlockedToolPermissionSheet(
+                toolName: blockedToolName,
+                onSubmit: { toolName, reason in
+                    showingRequestPermissionSheet = false
+                    onRequestPermission?(toolName, reason)
+                },
+                onCancel: {
+                    showingRequestPermissionSheet = false
+                }
+            )
+        }
+    }
+
+    // MARK: - Request Permission Button
+
+    private var requestPermissionButton: some View {
+        Button {
+            showingRequestPermissionSheet = true
+        } label: {
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: "lock.open.fill")
+                    .font(.system(size: 11))
+                    .foregroundColor(VColor.warning)
+                Text("Request Permission")
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.warning)
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.xs)
+            .background(Capsule().fill(VColor.warning.opacity(0.1)))
+            .overlay(Capsule().stroke(VColor.warning.opacity(0.4), lineWidth: 0.5))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Request parent permission for blocked tool")
+        .padding(.top, VSpacing.xxs)
+        .transition(.opacity)
     }
 
     // MARK: - Overflow Menu

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -55,6 +55,8 @@ struct ChatView: View {
     var onSubagentTap: ((String) -> Void)?
     /// Called to rehydrate truncated message content on demand.
     var onRehydrateMessage: ((UUID) -> Void)?
+    /// Called when the child taps "Request Permission" on a blocked tool call.
+    var onRequestPermission: ((String, String) -> Void)?
     @ObservedObject var subagentDetailStore: SubagentDetailStore
     /// Resolves the daemon HTTP port at call time so lazy-loaded video
     /// attachments always use the latest port after daemon restarts.
@@ -193,6 +195,7 @@ struct ChatView: View {
                             onAbortSubagent: onAbortSubagent,
                             onSubagentTap: onSubagentTap,
                             onRehydrateMessage: onRehydrateMessage,
+                            onRequestPermission: onRequestPermission,
                             subagentDetailStore: subagentDetailStore,
                             displayedMessageCount: displayedMessageCount,
                             hasMoreMessages: hasMoreMessages,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -24,6 +24,9 @@ struct MessageListView: View {
     var onSubagentTap: ((String) -> Void)?
     /// Called to rehydrate truncated message content on demand.
     var onRehydrateMessage: ((UUID) -> Void)?
+    /// Called when the child taps "Request Permission" on a parental-blocked tool call.
+    /// Receives `(toolName, reason)` so the view model can send the approval create IPC message.
+    var onRequestPermission: ((String, String) -> Void)?
     @ObservedObject var subagentDetailStore: SubagentDetailStore
 
     // MARK: - Pagination
@@ -210,6 +213,7 @@ struct MessageListView: View {
                                 dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
                                 onReportMessage: onReportMessage,
                                 onRehydrate: message.wasTruncated ? { onRehydrateMessage?(message.id) } : nil,
+                                onRequestPermission: onRequestPermission,
                                 mediaEmbedSettings: mediaEmbedSettings,
                                 resolveHttpPort: resolveHttpPort,
                                 showAvatar: !previousIsAssistant,

--- a/clients/macos/vellum-assistant/Features/Chat/RequestPermissionSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/RequestPermissionSheet.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+import VellumAssistantShared
+
+// MARK: - Request Permission Sheet
+
+/// Modal sheet that lets a child-profile user describe why they need a blocked
+/// tool and choose "Request Once" or "Request Always" to create a parent-approval
+/// request via the daemon.
+struct BlockedToolPermissionSheet: View {
+    /// Pre-populated tool name inferred from the blocked tool call.
+    let toolName: String
+    /// Called when the user submits the request.  Receives `(toolName, reason, scope)`.
+    let onSubmit: (String, String) -> Void
+    let onCancel: () -> Void
+
+    @State private var reason: String = ""
+    @State private var isSending: Bool = false
+
+    private var canSubmit: Bool {
+        !reason.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isSending
+    }
+
+    private var friendlyToolName: String {
+        switch toolName {
+        case "bash", "host_bash":          return "Terminal (bash)"
+        case "browser":                    return "Web browser"
+        case "file_read", "host_file_read": return "File read"
+        case "file_write", "host_file_write": return "File write"
+        case "computer":                   return "Computer control"
+        default:                           return toolName
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            // Title
+            Text("Request Parent Permission")
+                .font(VFont.title)
+                .foregroundColor(VColor.textPrimary)
+
+            // Blocked tool pill
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 11))
+                    .foregroundColor(VColor.warning)
+                Text(friendlyToolName)
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.textSecondary)
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.xs)
+            .background(Capsule().fill(VColor.surface))
+            .overlay(Capsule().stroke(VColor.warning.opacity(0.4), lineWidth: 0.5))
+
+            // Reason field
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Why do you need this?")
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.textPrimary)
+                Text("Your parent will see this message.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+
+                TextEditor(text: $reason)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .scrollContentBackground(.hidden)
+                    .padding(VSpacing.sm)
+                    .background(VColor.backgroundSubtle)
+                    .cornerRadius(VRadius.md)
+                    .frame(height: 100)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.surfaceBorder, lineWidth: 1)
+                    )
+            }
+
+            // Buttons
+            HStack(spacing: VSpacing.sm) {
+                Button("Cancel") {
+                    onCancel()
+                }
+                .buttonStyle(.plain)
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+
+                Spacer()
+
+                VButton(label: isSending ? "Sending…" : "Send Request", style: .primary) {
+                    guard canSubmit else { return }
+                    isSending = true
+                    let trimmed = reason.trimmingCharacters(in: .whitespacesAndNewlines)
+                    onSubmit(toolName, trimmed)
+                }
+                .disabled(!canSubmit)
+                .accessibilityLabel("Send permission request to parent")
+            }
+        }
+        .padding(VSpacing.xl)
+        .frame(width: 400)
+        .background(VColor.background)
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Blocked Tool Permission Sheet") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        BlockedToolPermissionSheet(
+            toolName: "bash",
+            onSubmit: { _, _ in },
+            onCancel: {}
+        )
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
@@ -7,6 +7,9 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 @MainActor
 final class AppListManager: ObservableObject {
 
+    /// Shared singleton for use in views that don't receive AppListManager via DI.
+    static let shared = AppListManager()
+
     struct AppItem: Identifiable, Codable, Hashable {
         let id: String
         var name: String

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -768,6 +768,9 @@ struct ActiveChatViewWrapper: View {
             onRehydrateMessage: { messageId in
                 viewModel.rehydrateMessage(id: messageId)
             },
+            onRequestPermission: { toolName, reason in
+                viewModel.requestPermission(toolName: toolName, reason: reason)
+            },
             subagentDetailStore: viewModel.subagentDetailStore,
             resolveHttpPort: daemonClient.httpPortResolver,
             isHistoryLoaded: viewModel.isHistoryLoaded,

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
@@ -40,6 +40,9 @@ struct SettingsParentalTab: View {
 
     // -- Parent: pending approvals --
     @State private var pendingRequests: [ApprovalRequestItem] = []
+    /// Timer that auto-refreshes the pending-approvals list every 15 seconds when the
+    /// parental profile is active, so newly submitted child requests appear promptly.
+    private let approvalRefreshTimer = Timer.publish(every: 15, on: .main, in: .common).autoconnect()
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
@@ -72,6 +75,17 @@ struct SettingsParentalTab: View {
             loadSettings()
             settingsStore.loadActivityLog()
             settingsStore.loadAllowedIntegrations(pin: settingsStore.cachedPIN ?? "")
+            // Load pending approvals immediately when the parental profile is active.
+            if settingsStore.activeProfile == "parental" && isEnabled {
+                loadPendingApprovals()
+            }
+        }
+        .onReceive(approvalRefreshTimer) { _ in
+            // Silently refresh the pending-approvals list in the background so the
+            // parent sees new child requests without having to tap Refresh manually.
+            if settingsStore.activeProfile == "parental" && isEnabled {
+                loadPendingApprovals()
+            }
         }
         .sheet(isPresented: $showingPINSheet) {
             PINSheet(

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 import VellumAssistantShared
 
 // MARK: - Parental Control Settings Tab
@@ -17,14 +18,6 @@ struct SettingsParentalTab: View {
     @State private var blockedToolCategories: Set<String> = []
     @State private var allowedApps: [String] = []
     @State private var allowedWidgets: [String] = []
-
-    // -- Allowlist entry fields --
-    @State private var newAppEntry: String = ""
-    @State private var newWidgetEntry: String = ""
-
-    // -- Apps & Widgets unified allowlist add sheets --
-    @State private var showingAddAppSheet: Bool = false
-    @State private var showingAddWidgetSheet: Bool = false
 
     // -- Local UI state --
     @State private var isLoading: Bool = false
@@ -136,28 +129,6 @@ struct SettingsParentalTab: View {
                     }
                 },
                 daemonClient: daemonClient
-            )
-        }
-        .sheet(isPresented: $showingAddAppSheet) {
-            AddAllowlistItemSheet(
-                placeholder: "App name",
-                title: "Add App",
-                onAdd: { name in
-                    guard !name.isEmpty, !allowedApps.contains(name) else { return }
-                    updateAllowlist(apps: allowedApps + [name], widgets: nil)
-                },
-                onDismiss: { showingAddAppSheet = false }
-            )
-        }
-        .sheet(isPresented: $showingAddWidgetSheet) {
-            AddAllowlistItemSheet(
-                placeholder: "Widget name",
-                title: "Add Widget",
-                onAdd: { name in
-                    guard !name.isEmpty, !allowedWidgets.contains(name) else { return }
-                    updateAllowlist(apps: nil, widgets: allowedWidgets + [name])
-                },
-                onDismiss: { showingAddWidgetSheet = false }
             )
         }
     }
@@ -395,63 +366,40 @@ struct SettingsParentalTab: View {
                 .font(VFont.sectionTitle)
                 .foregroundColor(VColor.textPrimary)
 
-            Text("Child profile can only access enabled apps and widgets.")
+            Text("Child profile can only access enabled apps.")
                 .font(VFont.caption)
                 .foregroundColor(VColor.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)
                 .textSelection(.enabled)
 
-            if allowedApps.isEmpty && allowedWidgets.isEmpty {
-                Text("No apps or widgets configured — all are blocked.")
+            let knownApps = AppListManager.shared.apps
+            if knownApps.isEmpty {
+                Text("No apps tracked yet — apps will appear here as they are used.")
                     .font(VFont.caption)
                     .foregroundColor(VColor.textMuted)
                     .textSelection(.enabled)
             } else {
-                ForEach(allowedApps, id: \.self) { app in
-                    let iconInfo = VAppIconGenerator.generate(from: app)
+                ForEach(knownApps) { app in
                     HStack(spacing: VSpacing.sm) {
-                        VAppIcon(sfSymbol: iconInfo.sfSymbol, gradientColors: iconInfo.colors, size: .small)
-                        Text(app)
+                        if let symbol = app.sfSymbol {
+                            let gradientColors: [String] = app.iconBackground ?? ["#7C3AED", "#4F46E5"]
+                            VAppIcon(sfSymbol: symbol, gradientColors: gradientColors, size: .small)
+                        }
+                        Text(app.name)
                             .font(VFont.body)
                             .foregroundColor(VColor.textPrimary)
-                            .textSelection(.enabled)
                         Spacer()
                         Toggle("", isOn: Binding(
-                            get: { allowedApps.contains(app) },
+                            get: { allowedApps.contains(app.id) },
                             set: { enabled in
-                                if !enabled {
-                                    allowedApps = allowedApps.filter { $0 != app }
-                                    updateAllowlist(apps: allowedApps, widgets: nil)
-                                }
+                                if enabled { allowedApps.append(app.id) }
+                                else { allowedApps.removeAll { $0 == app.id } }
+                                updateAllowlist(apps: allowedApps, widgets: nil)
                             }
                         ))
                         .toggleStyle(.switch)
                         .labelsHidden()
-                        .accessibilityLabel("\(app) allowed")
-                        .disabled(isLoading)
-                    }
-                }
-                ForEach(allowedWidgets, id: \.self) { widget in
-                    let iconInfo = VAppIconGenerator.generate(from: widget)
-                    HStack(spacing: VSpacing.sm) {
-                        VAppIcon(sfSymbol: iconInfo.sfSymbol, gradientColors: iconInfo.colors, size: .small)
-                        Text(widget)
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textPrimary)
-                            .textSelection(.enabled)
-                        Spacer()
-                        Toggle("", isOn: Binding(
-                            get: { allowedWidgets.contains(widget) },
-                            set: { enabled in
-                                if !enabled {
-                                    allowedWidgets = allowedWidgets.filter { $0 != widget }
-                                    updateAllowlist(apps: nil, widgets: allowedWidgets)
-                                }
-                            }
-                        ))
-                        .toggleStyle(.switch)
-                        .labelsHidden()
-                        .accessibilityLabel("\(widget) allowed")
+                        .accessibilityLabel("\(app.name) allowed")
                         .disabled(isLoading)
                     }
                 }
@@ -464,14 +412,63 @@ struct SettingsParentalTab: View {
 
     // MARK: - Integrations Section
 
-    /// The canonical list of integrations that can be enabled for the child profile.
-    private let availableIntegrations: [(id: String, label: String, icon: String)] = [
-        ("telegram", "Telegram", "paperplane.fill"),
-        ("sms", "SMS", "message.fill"),
-        ("voice", "Voice", "phone.fill"),
-        ("email", "Email", "envelope.fill"),
-        ("mobile", "Mobile (iOS)", "iphone"),
-    ]
+    /// A configured integration entry for display in the parental controls tab.
+    private struct ConfiguredIntegration {
+        let id: String
+        let label: String
+        let subtitle: String
+        let icon: String
+        let iconColor: Color
+    }
+
+    /// Build the list of integrations that are currently configured in the Connect tab.
+    private var configuredIntegrations: [ConfiguredIntegration] {
+        var result: [ConfiguredIntegration] = []
+        if settingsStore.telegramHasBotToken {
+            result.append(ConfiguredIntegration(
+                id: "telegram",
+                label: "Telegram",
+                subtitle: "Message via Telegram bot",
+                icon: "paperplane.fill",
+                iconColor: .blue
+            ))
+        }
+        if settingsStore.twilioHasCredentials {
+            result.append(ConfiguredIntegration(
+                id: "sms",
+                label: "SMS",
+                subtitle: "Send and receive SMS messages",
+                icon: "message.fill",
+                iconColor: .green
+            ))
+            result.append(ConfiguredIntegration(
+                id: "voice",
+                label: "Voice",
+                subtitle: "Make and receive voice calls",
+                icon: "phone.fill",
+                iconColor: .orange
+            ))
+        }
+        if let email = settingsStore.assistantEmail, !email.isEmpty {
+            result.append(ConfiguredIntegration(
+                id: "email",
+                label: "Email",
+                subtitle: "Send and receive email",
+                icon: "envelope.fill",
+                iconColor: .gray
+            ))
+        }
+        if !settingsStore.approvedDevices.isEmpty {
+            result.append(ConfiguredIntegration(
+                id: "mobile",
+                label: "Mobile (iOS)",
+                subtitle: "Access from paired iOS devices",
+                icon: "iphone",
+                iconColor: .purple
+            ))
+        }
+        return result
+    }
 
     private var integrationsSection: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
@@ -485,31 +482,48 @@ struct SettingsParentalTab: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .textSelection(.enabled)
 
-            ForEach(availableIntegrations, id: \.id) { integration in
-                HStack(spacing: VSpacing.sm) {
-                    Image(systemName: integration.icon)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(VColor.textSecondary)
-                        .frame(width: 18)
-                    Text(integration.label)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
-                    Spacer()
-                    Toggle("", isOn: Binding(
-                        get: { settingsStore.allowedIntegrations.contains(integration.id) },
-                        set: { isOn in
-                            let pin = settingsStore.cachedPIN ?? ""
-                            let updated = isOn
-                                ? settingsStore.allowedIntegrations + [integration.id]
-                                : settingsStore.allowedIntegrations.filter { $0 != integration.id }
-                            settingsStore.allowedIntegrations = updated
-                            settingsStore.updateAllowedIntegrations(pin: pin, integrations: updated)
+            let integrations = configuredIntegrations
+            if integrations.isEmpty {
+                Text("No integrations configured. Set up integrations in the Connect tab.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .textSelection(.enabled)
+            } else {
+                ForEach(integrations, id: \.id) { integration in
+                    HStack(spacing: VSpacing.sm) {
+                        ZStack {
+                            RoundedRectangle(cornerRadius: VRadius.sm)
+                                .fill(integration.iconColor)
+                                .frame(width: 28, height: 28)
+                            Image(systemName: integration.icon)
+                                .font(.system(size: 13, weight: .medium))
+                                .foregroundColor(.white)
                         }
-                    ))
-                    .toggleStyle(.switch)
-                    .labelsHidden()
-                    .accessibilityLabel(integration.label)
-                    .disabled(isLoading)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(integration.label)
+                                .font(VFont.bodyMedium)
+                                .foregroundColor(VColor.textPrimary)
+                            Text(integration.subtitle)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textSecondary)
+                        }
+                        Spacer()
+                        Toggle("", isOn: Binding(
+                            get: { settingsStore.allowedIntegrations.contains(integration.id) },
+                            set: { isOn in
+                                let pin = settingsStore.cachedPIN ?? ""
+                                let updated = isOn
+                                    ? settingsStore.allowedIntegrations + [integration.id]
+                                    : settingsStore.allowedIntegrations.filter { $0 != integration.id }
+                                settingsStore.allowedIntegrations = updated
+                                settingsStore.updateAllowedIntegrations(pin: pin, integrations: updated)
+                            }
+                        ))
+                        .toggleStyle(.switch)
+                        .labelsHidden()
+                        .accessibilityLabel(integration.label)
+                        .disabled(isLoading)
+                    }
                 }
             }
         }
@@ -527,6 +541,14 @@ struct SettingsParentalTab: View {
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
                 Spacer()
+                Button { exportActivityLog() } label: {
+                    Label("Export", systemImage: "square.and.arrow.up")
+                }
+                .buttonStyle(.plain)
+                .font(VFont.caption)
+                .foregroundColor(VColor.accent)
+                .accessibilityLabel("Export activity log as CSV")
+                .disabled(settingsStore.activityLog.isEmpty)
                 VButton(label: "Clear Log", style: .danger) {
                     settingsStore.clearActivityLogEntries(pin: settingsStore.cachedPIN)
                 }
@@ -919,6 +941,19 @@ struct SettingsParentalTab: View {
                     loadAllowlist()
                 }
             }
+        }
+    }
+
+    private func exportActivityLog() {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [UTType.commaSeparatedText]
+        panel.nameFieldStringValue = "activity-log.csv"
+        if panel.runModal() == .OK, let url = panel.url {
+            let header = "Timestamp,Type,Description\n"
+            let rows = settingsStore.activityLog.map {
+                "\($0.timestamp),\($0.actionType),\"\($0.description)\""
+            }.joined(separator: "\n")
+            try? (header + rows).write(to: url, atomically: true, encoding: .utf8)
         }
     }
 
@@ -1525,49 +1560,6 @@ private enum ToolCategory: String, CaseIterable, Identifiable {
         case .shell: return "Bash commands, terminal access."
         case .file_write: return "Creating, editing, or deleting files."
         }
-    }
-}
-
-// MARK: - Add Allowlist Item Sheet
-
-/// Sheet shown when the parent taps the + button in the Apps or Widgets subsection.
-/// Accepts a single name and calls `onAdd` with the trimmed value.
-@MainActor
-private struct AddAllowlistItemSheet: View {
-    let placeholder: String
-    let title: String
-    let onAdd: (String) -> Void
-    let onDismiss: () -> Void
-
-    @State private var name: String = ""
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.lg) {
-            Text(title)
-                .font(VFont.headline)
-                .foregroundColor(VColor.textPrimary)
-
-            TextField(placeholder, text: $name)
-                .textFieldStyle(.roundedBorder)
-                .font(VFont.body)
-
-            HStack {
-                Spacer()
-                VButton(label: "Cancel", style: .secondary) {
-                    onDismiss()
-                }
-                VButton(label: "Add", style: .primary) {
-                    let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard !trimmed.isEmpty else { return }
-                    onAdd(trimmed)
-                    onDismiss()
-                }
-                .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-            }
-        }
-        .padding(VSpacing.xl)
-        .frame(width: 300)
-        .background(VColor.background)
     }
 }
 

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -614,6 +614,11 @@ public struct ToolCallData: Identifiable, Equatable {
     public var buildingStatus: String?
     /// Sub-tool steps for claude_code tool calls (live progress tracking).
     public var claudeCodeSteps: [ClaudeCodeSubStep] = []
+    /// True when this tool call was blocked by parental control settings.
+    /// Detected by matching the well-known error result returned by the daemon.
+    public var isBlockedByParentalControls: Bool {
+        isError && (result ?? "").contains("blocked by parental control settings")
+    }
     /// Pre-decoded NSImage cached to avoid repeated base64 decoding in SwiftUI body.
     #if os(macOS)
     public var cachedImage: NSImage?
@@ -1377,6 +1382,12 @@ public struct ChatMessage: Identifiable, Equatable {
     /// during history loading (via maxTextChars/maxToolResultChars). Full content
     /// can be fetched on demand via message_content_request.
     public var wasTruncated: Bool = false
+
+    /// True when at least one tool call in this message was blocked by parental control settings.
+    /// Used to show the "Request Permission" affordance below the message bubble.
+    public var hasBlockedToolCall: Bool {
+        toolCalls.contains { $0.isBlockedByParentalControls }
+    }
 
     /// Concatenated text from all segments. Backward-compatible computed property.
     public var text: String {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1789,6 +1789,29 @@ public final class ChatViewModel: ObservableObject {
         }
     }
 
+    // MARK: - Parental Control Permission Requests
+
+    /// Create a parental-control approval request from the child profile.
+    /// Sends `parental_control_approval_create` to the daemon so the parent can
+    /// review and respond in Settings → Parental → Pending Approvals.
+    ///
+    /// - Parameters:
+    ///   - toolName: The name of the blocked tool (e.g. ash\, rowser\).
+    ///   - reason:   A short description of why the child needs this tool.
+    public func requestPermission(toolName: String, reason: String) {
+        guard daemonClient.isConnected else {
+            log.warning("Cannot send approval create: daemon not connected")
+            errorText = "Cannot request permission — not connected."
+            return
+        }
+        do {
+            try daemonClient.send(ParentalControlApprovalCreateRequestMessage(toolName: toolName, reason: reason))
+        } catch {
+            log.error("Failed to send parental control approval create: \(error.localizedDescription)")
+            errorText = "Failed to send permission request."
+        }
+    }
+
     /// Send an add_trust_rule message to persist a trust rule.
     /// Returns `true` if the IPC send succeeded, `false` otherwise.
     public func addTrustRule(toolName: String, pattern: String, scope: String, decision: String) -> Bool {


### PR DESCRIPTION
## PR7: Permission Request Button in Chat

When a tool call is blocked by parental controls, a "Request Permission" button appears below the message bubble.

### Changes

- **`ChatMessage.swift`** (`ToolCallData.isBlockedByParentalControls`, `ChatMessage.hasBlockedToolCall`): detects blocked tool calls via the well-known error result string returned by the daemon (`"This tool is blocked by parental control settings."`)
- **`ChatViewModel.swift`** (`requestPermission(toolName:reason:)`): sends `parental_control_approval_create` IPC to the daemon; wired to `daemonClient.sendParentalControlApprovalCreate` which already existed
- **`BlockedToolPermissionSheet.swift`** (new): amber-accented modal sheet showing the blocked tool name, a reason text editor, and a "Send Request" button
- **`ChatBubble.swift`**: amber "Request Permission" pill button below the trailing status for assistant messages that have a blocked tool call; tapping opens `BlockedToolPermissionSheet`
- **`MessageListView.swift` / `ChatView.swift` / `PanelCoordinator.swift`**: thread the `onRequestPermission: ((String, String) -> Void)?` callback from `ChatBubble` up to `ChatViewModel.requestPermission`
- **`SettingsParentalTab.swift`**: 15-second `Timer.publish` auto-refreshes the Pending Approvals list when the parental profile is active, so new child requests appear promptly without manual tap

### UX Flow

1. Child triggers a tool call that parental controls block
2. The assistant message shows a completed-with-error tool chip, followed by an amber "Request Permission" pill button
3. Child taps the button → `BlockedToolPermissionSheet` appears with the tool name pre-filled
4. Child types a reason and taps "Send Request" → `requestPermission(toolName:reason:)` fires the IPC
5. Parent opens Settings → Parental → Pending Approvals (auto-refreshed every 15s) and sees the request
6. Parent approves or rejects from the existing approval row UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
