### PR TITLE
fix(parental): PIN change requires current PIN + fix success toast

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
@@ -79,8 +79,8 @@ struct SettingsParentalTab: View {
             }
         }
         .animation(VAnimation.standard, value: successMessage)
-        .onChange(of: successMessage) { msg in
-            guard msg != nil else { return }
+        .onChange(of: successMessage) { _, newMsg in
+            guard newMsg != nil else { return }
             Task {
                 try? await Task.sleep(for: .seconds(3))
                 withAnimation(VAnimation.standard) { successMessage = nil }
@@ -109,19 +109,26 @@ struct SettingsParentalTab: View {
                     showingPINSheet = false
                     switch result {
                     case .success(let mode):
-                        switch mode {
-                        case .set:
-                            hasPIN = true
-                            successMessage = "PIN set."
-                        case .change:
-                            // The old PIN is now invalid; clear the cache so subsequent
-                            // updates don't silently send a stale credential.
-                            settingsStore.cachedPIN = nil
-                            successMessage = "PIN changed."
-                        case .clear:
-                            hasPIN = false
-                            settingsStore.cachedPIN = nil
-                            successMessage = "PIN cleared."
+                        // Delay the toast slightly so the sheet-dismiss animation
+                        // finishes before successMessage is set. Without this delay,
+                        // the sheet teardown can race with the onChange observer and
+                        // the toast never appears.
+                        Task {
+                            try? await Task.sleep(for: .milliseconds(350))
+                            switch mode {
+                            case .set:
+                                hasPIN = true
+                                successMessage = "PIN set."
+                            case .change:
+                                // The old PIN is now invalid; clear the cache so subsequent
+                                // updates don't silently send a stale credential.
+                                settingsStore.cachedPIN = nil
+                                successMessage = "PIN changed."
+                            case .clear:
+                                hasPIN = false
+                                settingsStore.cachedPIN = nil
+                                successMessage = "PIN cleared."
+                            }
                         }
                     case .failure(let msg):
                         errorMessage = msg
@@ -1299,9 +1306,10 @@ private struct PINSheet: View {
             }
         case .change:
             if step == .enterCurrent {
-                storedCurrent = pinInput
-                pinInput = ""
-                withAnimation(VAnimation.standard) { step = .enterNew }
+                // Verify the current PIN against the daemon before allowing
+                // the user to enter a new PIN. This prevents anyone who does
+                // not know the current PIN from changing it.
+                verifyCurrentPIN()
             } else if step == .enterNew {
                 storedNew = pinInput
                 pinInput = ""
@@ -1321,6 +1329,65 @@ private struct PINSheet: View {
         storedNew = ""
         pinInput = ""
         withAnimation(VAnimation.standard) { step = .enterNew }
+    }
+
+    /// Verifies the current PIN against the daemon before allowing the user to
+    /// proceed to the new-PIN entry step in the `.change` flow. On failure the
+    /// field is cleared and an error message is shown so the user can retry.
+    private func verifyCurrentPIN() {
+        guard !isLoading else { return }
+        let pinToVerify = pinInput
+        isLoading = true
+        errorMessage = nil
+        let stream = daemonClient?.subscribe()
+        Task {
+            do {
+                try daemonClient?.sendParentalControlVerifyPin(pin: pinToVerify)
+            } catch {
+                await MainActor.run {
+                    isLoading = false
+                    errorMessage = error.localizedDescription
+                    pinInput = ""
+                }
+                return
+            }
+
+            let response: ParentalControlVerifyPinResponseMessage? = await withTaskGroup(
+                of: ParentalControlVerifyPinResponseMessage?.self
+            ) { group in
+                group.addTask {
+                    guard let stream else { return nil }
+                    for await message in stream {
+                        if case .parentalControlVerifyPinResponse(let msg) = message { return msg }
+                    }
+                    return nil
+                }
+                group.addTask {
+                    try? await Task.sleep(nanoseconds: 8_000_000_000)
+                    return nil
+                }
+                let first = await group.next() ?? nil
+                group.cancelAll()
+                return first
+            }
+
+            await MainActor.run {
+                isLoading = false
+                if let r = response {
+                    if r.verified {
+                        storedCurrent = pinToVerify
+                        pinInput = ""
+                        withAnimation(VAnimation.standard) { step = .enterNew }
+                    } else {
+                        errorMessage = "Incorrect passcode. Try again."
+                        pinInput = ""
+                    }
+                } else {
+                    errorMessage = "No response from daemon."
+                    pinInput = ""
+                }
+            }
+        }
     }
 
     private func submit() {


### PR DESCRIPTION
## Changes

### PIN change flow
- When changing PIN, the first step now asks for the current PIN and **verifies it against the daemon** via `sendParentalControlVerifyPin` before advancing to the new-PIN entry step
- If the daemon returns `verified=false`, the field clears and shows "Incorrect passcode. Try again." — the user cannot proceed without the correct current PIN
- Only after successful verification is the current PIN stored and forwarded to the final `changePin` IPC call

### Success toast
- Fixed `onChange(of: successMessage)` using the old single-argument closure form, which does not fire reliably on all SwiftUI versions — switched to the two-argument `{ _, newMsg in }` form
- Fixed a race between sheet dismissal and the `onChange` observer: `successMessage` is now set inside a `Task` with a 350 ms delay after `showingPINSheet = false`, so the sheet animation completes before the observer fires and the toast is guaranteed to appear

## Test plan
- [ ] Open Settings > Parental Controls with a PIN set
- [ ] Tap "Change Passcode" — confirm the sheet opens at "Enter your current passcode"
- [ ] Enter a wrong PIN — confirm "Incorrect passcode. Try again." is shown and the field clears
- [ ] Enter the correct PIN — confirm it advances to "Enter your new passcode"
- [ ] Complete the new PIN + confirm steps — confirm the PIN changes and the "PIN changed." toast appears
- [ ] Repeat for "Set Passcode" and "Remove Passcode" — confirm toasts appear for those too

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
