### PR TITLE
fix: bump default context window to 200k tokens

### DIFF
--- a/assistant/src/config/core-schema.ts
+++ b/assistant/src/config/core-schema.ts
@@ -124,7 +124,7 @@ export const ContextWindowConfigSchema = z.object({
     .number({ error: 'contextWindow.maxInputTokens must be a number' })
     .int('contextWindow.maxInputTokens must be an integer')
     .positive('contextWindow.maxInputTokens must be a positive integer')
-    .default(180000),
+    .default(200000),
   targetInputTokens: z
     .number({ error: 'contextWindow.targetInputTokens must be a number' })
     .int('contextWindow.targetInputTokens must be an integer')


### PR DESCRIPTION
## Summary
- Bump `contextWindow.maxInputTokens` default from 180,000 to 200,000 to match Opus 4.6's full context window

## Test plan
- [ ] Verify session status shows 200,000 tokens after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
