### PR TITLE
M1: Add VThreadIcon component

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/VThreadIcon.swift
+++ b/clients/shared/DesignSystem/Components/Display/VThreadIcon.swift
@@ -9,7 +9,10 @@ public struct VThreadIcon: View {
     let title: String
     let size: Size
     var isActive: Bool = false
-    var interactionState: ThreadInteractionState = .idle
+    /// Optional dot color for interaction-state overlay (bottom-right corner).
+    /// Callers map ThreadInteractionState → Color externally to keep the
+    /// design system decoupled from feature types.
+    var dotColor: Color?
 
     public enum Size {
         /// 20pt — for popover list items
@@ -56,16 +59,16 @@ public struct VThreadIcon: View {
 
     // MARK: - Color Palette
 
-    /// Muted, dark-theme-friendly background colors that complement the Moss/Forest palette.
-    private static let backgroundColors: [Color] = [
-        Color(hex: 0x4B6845),  // forest green
-        Color(hex: 0x4A5568),  // slate blue-gray
-        Color(hex: 0x5B4E3A),  // warm brown
-        Color(hex: 0x3D5A5B),  // teal
-        Color(hex: 0x6B4C5A),  // muted mauve
-        Color(hex: 0x4E5D3E),  // olive
-        Color(hex: 0x5A4A6B),  // dusty purple
-        Color(hex: 0x5C6B4A),  // sage
+    /// Muted, dark-theme-friendly hex values that complement the Moss/Forest palette.
+    private static let backgroundHexValues: [UInt] = [
+        0x4B6845, // forest green
+        0x4A5568, // slate blue-gray
+        0x5B4E3A, // warm brown
+        0x3D5A5B, // teal
+        0x6B4C5A, // muted mauve
+        0x4E5D3E, // olive
+        0x5A4A6B, // dusty purple
+        0x5C6B4A, // sage
     ]
 
     // MARK: - Hash
@@ -90,21 +93,8 @@ public struct VThreadIcon: View {
 
     private var backgroundColor: Color {
         let hash = Self.stableHash(title)
-        let index = Int(hash % UInt64(Self.backgroundColors.count))
-        return Self.backgroundColors[index]
-    }
-
-    private var interactionDotColor: Color? {
-        switch interactionState {
-        case .idle:
-            return nil
-        case .processing:
-            return VColor.accent
-        case .waitingForInput:
-            return VColor.warning
-        case .error:
-            return VColor.error
-        }
+        let index = Int(hash % UInt64(Self.backgroundHexValues.count))
+        return Color(hex: Self.backgroundHexValues[index])
     }
 
     // MARK: - Body
@@ -127,9 +117,9 @@ public struct VThreadIcon: View {
             )
 
             // Interaction-state overlay dot
-            if let dotColor = interactionDotColor {
+            if let dot = dotColor {
                 Circle()
-                    .fill(dotColor)
+                    .fill(dot)
                     .frame(width: size.dotSize, height: size.dotSize)
                     .offset(x: size.dotSize * 0.2, y: size.dotSize * 0.2)
             }
@@ -150,9 +140,9 @@ public struct VThreadIcon: View {
             HStack(spacing: VSpacing.sm) {
                 VThreadIcon(title: "Customer support", size: .small)
                 VThreadIcon(title: "Design review", size: .small, isActive: true)
-                VThreadIcon(title: "Bug triage", size: .small, interactionState: .processing)
-                VThreadIcon(title: "Sprint planning", size: .small, interactionState: .waitingForInput)
-                VThreadIcon(title: "Release notes", size: .small, interactionState: .error)
+                VThreadIcon(title: "Bug triage", size: .small, dotColor: VColor.accent)
+                VThreadIcon(title: "Sprint planning", size: .small, dotColor: VColor.warning)
+                VThreadIcon(title: "Release notes", size: .small, dotColor: VColor.error)
             }
 
             Text("Medium (28pt)")
@@ -161,9 +151,9 @@ public struct VThreadIcon: View {
             HStack(spacing: VSpacing.md) {
                 VThreadIcon(title: "Customer support", size: .medium)
                 VThreadIcon(title: "Design review", size: .medium, isActive: true)
-                VThreadIcon(title: "Bug triage", size: .medium, interactionState: .processing)
-                VThreadIcon(title: "Sprint planning", size: .medium, interactionState: .waitingForInput)
-                VThreadIcon(title: "Release notes", size: .medium, interactionState: .error)
+                VThreadIcon(title: "Bug triage", size: .medium, dotColor: VColor.accent)
+                VThreadIcon(title: "Sprint planning", size: .medium, dotColor: VColor.warning)
+                VThreadIcon(title: "Release notes", size: .medium, dotColor: VColor.error)
             }
 
             Text("Deterministic colors")

--- a/clients/shared/DesignSystem/Components/Display/VThreadIcon.swift
+++ b/clients/shared/DesignSystem/Components/Display/VThreadIcon.swift
@@ -14,6 +14,13 @@ public struct VThreadIcon: View {
     /// design system decoupled from feature types.
     var dotColor: Color?
 
+    public init(title: String, size: Size, isActive: Bool = false, dotColor: Color? = nil) {
+        self.title = title
+        self.size = size
+        self.isActive = isActive
+        self.dotColor = dotColor
+    }
+
     public enum Size {
         /// 20pt — for popover list items
         case small

--- a/clients/shared/DesignSystem/Components/Display/VThreadIcon.swift
+++ b/clients/shared/DesignSystem/Components/Display/VThreadIcon.swift
@@ -1,0 +1,186 @@
+import SwiftUI
+
+/// A deterministic initial-letter icon for threads.
+///
+/// Renders the first letter of a thread title (uppercased) inside a rounded square
+/// whose background color is derived from an FNV-1a hash of the title. The same title
+/// always produces the same color, giving threads a stable visual identity.
+public struct VThreadIcon: View {
+    let title: String
+    let size: Size
+    var isActive: Bool = false
+    var interactionState: ThreadInteractionState = .idle
+
+    public enum Size {
+        /// 20pt — for popover list items
+        case small
+        /// 28pt — for collapsed sidebar
+        case medium
+
+        var dimension: CGFloat {
+            switch self {
+            case .small: return 20
+            case .medium: return 28
+            }
+        }
+
+        var fontSize: CGFloat {
+            switch self {
+            case .small: return 11
+            case .medium: return 14
+            }
+        }
+
+        var cornerRadius: CGFloat {
+            switch self {
+            case .small: return VRadius.sm
+            case .medium: return VRadius.md
+            }
+        }
+
+        /// Size of the interaction-state overlay dot.
+        var dotSize: CGFloat {
+            switch self {
+            case .small: return 6
+            case .medium: return 8
+            }
+        }
+
+        var borderWidth: CGFloat {
+            switch self {
+            case .small: return 1.5
+            case .medium: return 2
+            }
+        }
+    }
+
+    // MARK: - Color Palette
+
+    /// Muted, dark-theme-friendly background colors that complement the Moss/Forest palette.
+    private static let backgroundColors: [Color] = [
+        Color(hex: 0x4B6845),  // forest green
+        Color(hex: 0x4A5568),  // slate blue-gray
+        Color(hex: 0x5B4E3A),  // warm brown
+        Color(hex: 0x3D5A5B),  // teal
+        Color(hex: 0x6B4C5A),  // muted mauve
+        Color(hex: 0x4E5D3E),  // olive
+        Color(hex: 0x5A4A6B),  // dusty purple
+        Color(hex: 0x5C6B4A),  // sage
+    ]
+
+    // MARK: - Hash
+
+    /// FNV-1a 64-bit hash for deterministic color assignment.
+    private static func stableHash(_ string: String) -> UInt64 {
+        var hash: UInt64 = 14695981039346656037 // FNV offset basis
+        for byte in string.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1099511628211 // FNV prime
+        }
+        return hash
+    }
+
+    // MARK: - Derived Properties
+
+    private var letter: String {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let first = trimmed.first else { return "?" }
+        return String(first).uppercased()
+    }
+
+    private var backgroundColor: Color {
+        let hash = Self.stableHash(title)
+        let index = Int(hash % UInt64(Self.backgroundColors.count))
+        return Self.backgroundColors[index]
+    }
+
+    private var interactionDotColor: Color? {
+        switch interactionState {
+        case .idle:
+            return nil
+        case .processing:
+            return VColor.accent
+        case .waitingForInput:
+            return VColor.warning
+        case .error:
+            return VColor.error
+        }
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        ZStack(alignment: .bottomTrailing) {
+            // Main icon
+            ZStack {
+                RoundedRectangle(cornerRadius: size.cornerRadius, style: .continuous)
+                    .fill(backgroundColor)
+
+                Text(letter)
+                    .font(.system(size: size.fontSize, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white)
+            }
+            .frame(width: size.dimension, height: size.dimension)
+            .overlay(
+                RoundedRectangle(cornerRadius: size.cornerRadius, style: .continuous)
+                    .stroke(isActive ? VColor.accent : Color.clear, lineWidth: size.borderWidth)
+            )
+
+            // Interaction-state overlay dot
+            if let dotColor = interactionDotColor {
+                Circle()
+                    .fill(dotColor)
+                    .frame(width: size.dotSize, height: size.dotSize)
+                    .offset(x: size.dotSize * 0.2, y: size.dotSize * 0.2)
+            }
+        }
+        .accessibilityLabel("Thread: \(title)")
+    }
+}
+
+// MARK: - Preview
+
+#Preview("VThreadIcon") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VStack(spacing: VSpacing.xl) {
+            Text("Small (20pt)")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+            HStack(spacing: VSpacing.sm) {
+                VThreadIcon(title: "Customer support", size: .small)
+                VThreadIcon(title: "Design review", size: .small, isActive: true)
+                VThreadIcon(title: "Bug triage", size: .small, interactionState: .processing)
+                VThreadIcon(title: "Sprint planning", size: .small, interactionState: .waitingForInput)
+                VThreadIcon(title: "Release notes", size: .small, interactionState: .error)
+            }
+
+            Text("Medium (28pt)")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+            HStack(spacing: VSpacing.md) {
+                VThreadIcon(title: "Customer support", size: .medium)
+                VThreadIcon(title: "Design review", size: .medium, isActive: true)
+                VThreadIcon(title: "Bug triage", size: .medium, interactionState: .processing)
+                VThreadIcon(title: "Sprint planning", size: .medium, interactionState: .waitingForInput)
+                VThreadIcon(title: "Release notes", size: .medium, interactionState: .error)
+            }
+
+            Text("Deterministic colors")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+            HStack(spacing: VSpacing.md) {
+                ForEach(["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta"], id: \.self) { name in
+                    VStack(spacing: VSpacing.xs) {
+                        VThreadIcon(title: name, size: .medium)
+                        Text(name)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                }
+            }
+        }
+        .padding()
+    }
+    .frame(width: 600, height: 300)
+}


### PR DESCRIPTION
Adds a VThreadIcon component that renders a deterministic initial-letter icon for threads. Uses FNV-1a hash to derive consistent colors from thread titles. Supports small (20pt) and medium (28pt) sizes with optional active state border. Part of #10408.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
