### PR TITLE
M1: Add pulsing animation to stop button in ComposerView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -61,6 +61,7 @@ struct ComposerView: View {
 
     @Environment(\.conversationZoomScale) private var zoomScale
     @State private var composerFocusRequestID: Int = 0
+    @State private var isStopPulsing = false
     @State private var isStopHovered = false
     @State private var isSendHovered = false
     @State private var isMicrophoneHovered = false
@@ -264,6 +265,12 @@ struct ComposerView: View {
             if isSending && !hasPendingConfirmation {
                 Button(action: onStop) {
                     ZStack {
+                        Circle()
+                            .fill(VColor.textPrimary.opacity(0.15))
+                            .frame(width: 30, height: 30)
+                            .scaleEffect(isStopPulsing ? 1.35 : 1.0)
+                            .opacity(isStopPulsing ? 0.0 : 0.6)
+                            .animation(.easeInOut(duration: 1.2).repeatForever(autoreverses: false), value: isStopPulsing)
                         RoundedRectangle(cornerRadius: 10)
                             .fill(VColor.textPrimary)
                             .frame(width: 30, height: 30)
@@ -284,6 +291,12 @@ struct ComposerView: View {
                         hovering,
                         state: $isStopHovered
                     )
+                }
+                .onChange(of: isSending) {
+                    isStopPulsing = isSending && !hasPendingConfirmation
+                }
+                .onAppear {
+                    isStopPulsing = isSending && !hasPendingConfirmation
                 }
                 .accessibilityLabel("Stop generation")
             } else {

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -292,9 +292,6 @@ struct ComposerView: View {
                         state: $isStopHovered
                     )
                 }
-                .onChange(of: isSending) {
-                    isStopPulsing = isSending && !hasPendingConfirmation
-                }
                 .onAppear {
                     isStopPulsing = isSending && !hasPendingConfirmation
                 }
@@ -378,6 +375,9 @@ struct ComposerView: View {
         }
         .padding(.trailing, -(VSpacing.lg - VSpacing.sm))
         .animation(VAnimation.spring, value: canSend)
+        .onChange(of: isSending) {
+            isStopPulsing = isSending && !hasPendingConfirmation
+        }
     }
 
     private func handleComposerButtonHover(

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -378,6 +378,9 @@ struct ComposerView: View {
         .onChange(of: isSending) {
             isStopPulsing = isSending && !hasPendingConfirmation
         }
+        .onChange(of: hasPendingConfirmation) {
+            isStopPulsing = isSending && !hasPendingConfirmation
+        }
     }
 
     private func handleComposerButtonHover(


### PR DESCRIPTION
Adds a subtle pulsing circle animation behind the stop/pause generation button when the assistant is actively processing. The pulse gently expands and fades out, providing a smooth visual cue that work is happening. Follows the existing MicrophoneButton pulse pattern in the same file.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
