### PR TITLE
fix: use free function adaptiveColor in IdentityPanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -53,7 +53,7 @@ struct IdentityPanel: View {
                             .padding(.bottom, VSpacing.xl)
 
                         // Divider
-                        Divider().background(VColor.adaptiveColor(light: Moss._50, dark: Moss._500))
+                        Divider().background(adaptiveColor(light: Moss._50, dark: Moss._500))
 
                         // Role + Hatched date
                         VStack(alignment: .leading, spacing: VSpacing.lg) {


### PR DESCRIPTION
## Summary
- `adaptiveColor` is a free function (defined in `ColorTokens.swift`), not a static member of `VColor`. `IdentityPanel.swift:56` was calling `VColor.adaptiveColor(...)` which fails to compile.

Fixes https://github.com/vellum-ai/vellum-assistant/actions/runs/22497971941/job/65177368437

## Test plan
- [x] `swift build` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
