### PR TITLE
M1: Add subtle pulse animation to assistant avatar during streaming

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -24,6 +24,7 @@ struct ChatBubble: View {
 
     @State private var appearance = AvatarAppearanceManager.shared
     @State private var isHovered = false
+    @State private var isPulsing = false
 
     @State private var showCopyConfirmation = false
     @State private var copyConfirmationTimer: DispatchWorkItem?
@@ -212,7 +213,26 @@ struct ChatBubble: View {
                                 Circle()
                                     .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
                             )
+                            .opacity(isPulsing ? 0.4 : 1.0)
                             .offset(x: -(28 + VSpacing.sm), y: 2)
+                            .onChange(of: isLatestAssistantMessage && message.isStreaming) { _, shouldPulse in
+                                if shouldPulse {
+                                    withAnimation(VAnimation.pulse) {
+                                        isPulsing = true
+                                    }
+                                } else {
+                                    withAnimation(VAnimation.fast) {
+                                        isPulsing = false
+                                    }
+                                }
+                            }
+                            .onAppear {
+                                if isLatestAssistantMessage && message.isStreaming {
+                                    withAnimation(VAnimation.pulse) {
+                                        isPulsing = true
+                                    }
+                                }
+                            }
                     }
                 }
                 .padding(.leading, isUser ? 0 : 28 + VSpacing.sm)

--- a/clients/shared/DesignSystem/Tokens/AnimationTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/AnimationTokens.swift
@@ -13,6 +13,9 @@ public enum VAnimation {
     /// Bouncy spring for celebratory/attention-grabbing motion
     public static let bouncy   = Animation.spring(response: 0.3, dampingFraction: 0.5)
 
+    /// Gentle repeating pulse for indicating activity (e.g. streaming avatar)
+    public static let pulse    = Animation.easeInOut(duration: 1.5).repeatForever(autoreverses: true)
+
     // MARK: - Durations (for use with withAnimation or explicit timing)
 
     public static let durationFast: TimeInterval     = 0.15


### PR DESCRIPTION
Add a gentle repeating opacity pulse to the assistant profile icon while the latest assistant message is actively streaming. Uses a new VAnimation.pulse preset (1.5s easeInOut, repeating) and applies it to the avatar in ChatBubble. Part of #10416.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
