### PR TITLE
Make gateway, cli, and macOS CI checks blocking in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -923,8 +923,11 @@ jobs:
             "${{ needs.push-assistant-image.result }}" \
             "${{ needs.push-gateway-image.result }}" \
             "${{ needs.release.result }}" \
-            "${{ needs.update-platform.result }}"; do
-            if [ "$result" = "failure" ]; then
+            "${{ needs.update-platform.result }}" \
+            "${{ needs.ci-cli.result }}" \
+            "${{ needs.ci-gateway.result }}" \
+            "${{ needs.ci-playwright.result }}"; do
+            if [ "$result" = "failure" ] || [ "$result" = "skipped" ]; then
               RELEASE_FAILED="true"
               break
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -604,8 +604,8 @@ jobs:
           security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
 
   release:
-    needs: [bump-and-tag, publish-npm, publish-meta, build-macos, push-assistant-image, push-gateway-image]
-    if: ${{ !cancelled() && needs.bump-and-tag.result == 'success' && needs.publish-npm.result == 'success' && needs.publish-meta.result == 'success' && needs.build-macos.result == 'success' }}
+    needs: [bump-and-tag, publish-npm, publish-meta, build-macos, push-assistant-image, push-gateway-image, ci-cli, ci-gateway, ci-playwright]
+    if: ${{ !cancelled() && needs.bump-and-tag.result == 'success' && needs.publish-npm.result == 'success' && needs.publish-meta.result == 'success' && needs.build-macos.result == 'success' && needs.ci-cli.result == 'success' && needs.ci-gateway.result == 'success' && needs.ci-playwright.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -781,7 +781,6 @@ jobs:
   ci-cli:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -804,7 +803,6 @@ jobs:
   ci-gateway:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -830,7 +828,6 @@ jobs:
 
   ci-playwright:
     runs-on: macos-14
-    continue-on-error: true
     timeout-minutes: 60
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from `ci-cli`, `ci-gateway`, and `ci-playwright` jobs in the release workflow
- Add all three as required dependencies of the `release` job so failures prevent the release from proceeding
- `ci-assistant` left as non-blocking for now (will be addressed separately)

## Test plan
- [ ] Trigger a release and verify the CI checks run and gate the release job
- [ ] Verify the notify job still reports status for all CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
