### PR TITLE
Pulse assistant profile icon during streaming

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -24,6 +24,7 @@ struct ChatBubble: View {
 
     @State private var appearance = AvatarAppearanceManager.shared
     @State private var isHovered = false
+    @State private var isPulsing = false
 
     @State private var showCopyConfirmation = false
     @State private var copyConfirmationTimer: DispatchWorkItem?
@@ -212,7 +213,26 @@ struct ChatBubble: View {
                                 Circle()
                                     .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
                             )
+                            .opacity(isPulsing ? 0.4 : 1.0)
                             .offset(x: -(28 + VSpacing.sm), y: 2)
+                            .onChange(of: isLatestAssistantMessage && message.isStreaming) { _, shouldPulse in
+                                if shouldPulse {
+                                    withAnimation(VAnimation.pulse) {
+                                        isPulsing = true
+                                    }
+                                } else {
+                                    withAnimation(VAnimation.fast) {
+                                        isPulsing = false
+                                    }
+                                }
+                            }
+                            .onAppear {
+                                if isLatestAssistantMessage && message.isStreaming {
+                                    withAnimation(VAnimation.pulse) {
+                                        isPulsing = true
+                                    }
+                                }
+                            }
                     }
                 }
                 .padding(.leading, isUser ? 0 : 28 + VSpacing.sm)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -35,6 +35,7 @@ struct ChatBubble: View {
     /// manager publishes any change (the "thundering herd" problem).
     var activeSurfaceId: String?
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.conversationZoomScale) var conversationZoomScale
 
     var isUser: Bool { message.role == .user }
@@ -216,7 +217,7 @@ struct ChatBubble: View {
                             .opacity(isPulsing ? 0.4 : 1.0)
                             .offset(x: -(28 + VSpacing.sm), y: 2)
                             .onChange(of: isLatestAssistantMessage && message.isStreaming) { _, shouldPulse in
-                                if shouldPulse {
+                                if shouldPulse && !reduceMotion {
                                     withAnimation(VAnimation.pulse) {
                                         isPulsing = true
                                     }
@@ -226,8 +227,15 @@ struct ChatBubble: View {
                                     }
                                 }
                             }
+                            .onChange(of: reduceMotion) { _, isReduced in
+                                if isReduced && isPulsing {
+                                    withAnimation(VAnimation.fast) {
+                                        isPulsing = false
+                                    }
+                                }
+                            }
                             .onAppear {
-                                if isLatestAssistantMessage && message.isStreaming {
+                                if isLatestAssistantMessage && message.isStreaming && !reduceMotion {
                                     withAnimation(VAnimation.pulse) {
                                         isPulsing = true
                                     }

--- a/clients/shared/DesignSystem/Tokens/AnimationTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/AnimationTokens.swift
@@ -13,6 +13,9 @@ public enum VAnimation {
     /// Bouncy spring for celebratory/attention-grabbing motion
     public static let bouncy   = Animation.spring(response: 0.3, dampingFraction: 0.5)
 
+    /// Gentle repeating pulse for indicating activity (e.g. streaming avatar)
+    public static let pulse    = Animation.easeInOut(duration: 1.5).repeatForever(autoreverses: true)
+
     // MARK: - Durations (for use with withAnimation or explicit timing)
 
     public static let durationFast: TimeInterval     = 0.15


### PR DESCRIPTION
## Summary
Add a subtle pulsing opacity animation to the assistant's profile icon (avatar) in the chat message list while the assistant is actively generating/streaming a response. The pulse is gentle and non-distracting — it animates opacity between 1.0 and 0.4 using a 1.5s easeInOut repeating animation, providing a visual cue that the assistant is working without drawing attention away from the message content.

## Changes
- Added `VAnimation.pulse` animation preset to `AnimationTokens.swift` — a 1.5s easeInOut repeating animation for activity indicators
- Added `@State private var isPulsing` to `ChatBubble.swift` to drive the animation
- Applied opacity modifier to the avatar image that animates when `isLatestAssistantMessage && message.isStreaming`
- Used `.onChange(of:)` and `.onAppear` to start/stop the pulse cleanly when streaming begins/ends

## Milestone PRs (merged into feature branch)
- #10419: M1: Add subtle pulse animation to assistant avatar during streaming

## Project issue
Closes #10416

## Test plan
- [ ] Start a conversation and send a message to the assistant
- [ ] While the assistant is streaming, verify the profile icon gently pulses (opacity fades in/out)
- [ ] When streaming completes, verify the icon returns to full opacity smoothly
- [ ] Scroll up to a previous assistant message while a new one is streaming — only the latest should pulse
- [ ] Verify non-assistant (user) messages never show the pulse

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
