### PR TITLE
M2: Collapsed sidebar thread section

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1317,6 +1317,47 @@ struct MainWindowView: View {
                 threadManager.createThread()
             }
 
+            // MARK: Thread Section (collapsed)
+            if let activeThread = threadManager.activeThread {
+                VStack(spacing: VSpacing.xs) {
+                    let interactionState = threadManager.interactionState(for: activeThread.id)
+                    let interactionDotColor: Color? = {
+                        switch interactionState {
+                        case .processing: return VColor.accent
+                        case .waitingForInput: return VColor.warning
+                        case .error: return VColor.error
+                        case .idle: return nil
+                        }
+                    }()
+
+                    VThreadIcon(
+                        title: activeThread.title,
+                        size: .medium,
+                        isActive: true,
+                        dotColor: interactionDotColor
+                    )
+
+                    // Thread count badge
+                    if regularThreads.count > 0 {
+                        Text("\(regularThreads.count)")
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundColor(VColor.textSecondary)
+                            .padding(.horizontal, VSpacing.xs)
+                            .padding(.vertical, 2)
+                            .background(
+                                Capsule()
+                                    .fill(Forest._700)
+                            )
+                    }
+
+                    // Threads indicator icon
+                    Image(systemName: "bubble.left.and.bubble.right")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(VColor.textMuted)
+                }
+                .padding(.vertical, VSpacing.xs)
+            }
+
             Spacer()
 
             SidebarNavRow(icon: "gearshape", label: "Control Center", isActive: false, isExpanded: false) {


### PR DESCRIPTION
Adds active thread VThreadIcon, non-scheduled thread count badge, and threads indicator icon to the collapsed sidebar. The thread section appears between New Chat and the bottom spacer, showing the current thread's identity and a count of available threads. Part of #10408.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
