### PR TITLE
Pulsing pause button animation during assistant processing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -293,7 +293,10 @@ struct ComposerView: View {
                     )
                 }
                 .onAppear {
-                    isStopPulsing = isSending && !hasPendingConfirmation
+                    isStopPulsing = false
+                    DispatchQueue.main.async {
+                        isStopPulsing = isSending && !hasPendingConfirmation
+                    }
                 }
                 .accessibilityLabel("Stop generation")
             } else {

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -265,12 +265,6 @@ struct ComposerView: View {
             if isSending && !hasPendingConfirmation {
                 Button(action: onStop) {
                     ZStack {
-                        Circle()
-                            .fill(VColor.textPrimary.opacity(0.15))
-                            .frame(width: 30, height: 30)
-                            .scaleEffect(isStopPulsing ? 1.35 : 1.0)
-                            .opacity(isStopPulsing ? 0.0 : 0.6)
-                            .animation(.easeInOut(duration: 1.2).repeatForever(autoreverses: false), value: isStopPulsing)
                         RoundedRectangle(cornerRadius: 10)
                             .fill(VColor.textPrimary)
                             .frame(width: 30, height: 30)
@@ -278,6 +272,8 @@ struct ComposerView: View {
                             .fill(VColor.surface)
                             .frame(width: 10, height: 10)
                     }
+                    .opacity(isStopPulsing ? 0.5 : 1.0)
+                    .animation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true), value: isStopPulsing)
                 }
                 .buttonStyle(ComposerActionButtonStyle(
                     isHovered: isStopHovered,

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -61,6 +61,7 @@ struct ComposerView: View {
 
     @Environment(\.conversationZoomScale) private var zoomScale
     @State private var composerFocusRequestID: Int = 0
+    @State private var isStopPulsing = false
     @State private var isStopHovered = false
     @State private var isSendHovered = false
     @State private var isMicrophoneHovered = false
@@ -264,6 +265,12 @@ struct ComposerView: View {
             if isSending && !hasPendingConfirmation {
                 Button(action: onStop) {
                     ZStack {
+                        Circle()
+                            .fill(VColor.textPrimary.opacity(0.15))
+                            .frame(width: 30, height: 30)
+                            .scaleEffect(isStopPulsing ? 1.35 : 1.0)
+                            .opacity(isStopPulsing ? 0.0 : 0.6)
+                            .animation(.easeInOut(duration: 1.2).repeatForever(autoreverses: false), value: isStopPulsing)
                         RoundedRectangle(cornerRadius: 10)
                             .fill(VColor.textPrimary)
                             .frame(width: 30, height: 30)
@@ -284,6 +291,9 @@ struct ComposerView: View {
                         hovering,
                         state: $isStopHovered
                     )
+                }
+                .onAppear {
+                    isStopPulsing = isSending && !hasPendingConfirmation
                 }
                 .accessibilityLabel("Stop generation")
             } else {
@@ -365,6 +375,12 @@ struct ComposerView: View {
         }
         .padding(.trailing, -(VSpacing.lg - VSpacing.sm))
         .animation(VAnimation.spring, value: canSend)
+        .onChange(of: isSending) {
+            isStopPulsing = isSending && !hasPendingConfirmation
+        }
+        .onChange(of: hasPendingConfirmation) {
+            isStopPulsing = isSending && !hasPendingConfirmation
+        }
     }
 
     private func handleComposerButtonHover(


### PR DESCRIPTION
## Summary
Adds a subtle pulsing animation to the stop/pause generation button in the composer when the assistant is actively processing. The pulse provides a smooth visual cue that the assistant is working, using a gently expanding and fading circle behind the stop icon.

## Changes
- Added pulsing circle animation behind the stop button (scales 1.0→1.35x, fades 0.6→0.0 opacity over 1.2s, repeating)
- Pulse syncs with both `isSending` and `hasPendingConfirmation` state via `.onChange` modifiers
- `.onChange` placed outside the conditional branch to ensure proper state reset across button lifecycle
- Follows the existing MicrophoneButton pulse pattern in the same file

## Milestone PRs (merged into feature branch)
- #10415: M1: Add pulsing animation to stop button in ComposerView

## Project issue
Closes #10413

## Test plan
- [ ] Start a conversation and verify the stop button pulses while the assistant is processing
- [ ] Verify the pulse stops when generation completes
- [ ] Trigger a tool confirmation during generation, verify pulse stops, then dismiss confirmation and verify pulse restarts
- [ ] Send multiple messages in sequence and verify the pulse works each time (not just the first)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
