### PR TITLE
Route guardian verification APIs through gateway

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -64,7 +64,7 @@ All guardian approval decisions — regardless of how they arrive — route thro
 
 ### Outbound Guardian Verification (HTTP Endpoints)
 
-Guardian verification can be initiated through the runtime HTTP API as an alternative to the legacy IPC-only flow. This enables chat-first verification where the assistant guides the user through guardian setup via normal conversation.
+Guardian verification can be initiated through gateway HTTP endpoints (which forward to runtime handlers) as an alternative to the legacy IPC-only flow. This enables chat-first verification where the assistant guides the user through guardian setup via normal conversation.
 
 **HTTP Endpoints:**
 
@@ -74,11 +74,11 @@ Guardian verification can be initiated through the runtime HTTP API as an altern
 | `/v1/integrations/guardian/outbound/resend` | POST | Resend the verification code for an active session. Body: `{ channel, assistantId? }` |
 | `/v1/integrations/guardian/outbound/cancel` | POST | Cancel an active outbound verification session. Body: `{ channel, assistantId? }` |
 
-All endpoints are bearer-authenticated via the runtime HTTP token (`~/.vellum/http-token`).
+All endpoints are bearer-authenticated via the gateway token (`~/.vellum/http-token` in local setups). Skills and user-facing tooling should target the gateway URL (default `http://localhost:7830`), not the runtime port.
 
 **Shared Business Logic:**
 
-The HTTP route handlers (`integration-routes.ts`) and the legacy IPC handlers (`config-channels.ts`) both delegate to the same action functions in `guardian-outbound-actions.ts`. This module contains transport-agnostic business logic for starting, resending, and cancelling outbound verification flows across SMS, Telegram, and voice channels. It returns `OutboundActionResult` objects that the transport layer (HTTP or IPC) maps to its respective response format.
+The HTTP route handlers (`integration-routes.ts`) and the legacy IPC handlers (`config-channels.ts`) both delegate to the same action functions in `guardian-outbound-actions.ts`. This module contains transport-agnostic business logic for starting, resending, and cancelling outbound verification flows across SMS, Telegram, and voice channels. It returns `OutboundActionResult` objects that the transport layer (gateway-forwarded HTTP or IPC) maps to its respective response format.
 
 **Chat-First Orchestration Flow:**
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -338,7 +338,7 @@ Guardian verification can also be initiated through normal desktop chat. When th
 3. Call the outbound HTTP endpoints to start, resend, or cancel verification.
 4. Guide the user through the verification lifecycle conversationally.
 
-**Outbound HTTP Endpoints** (available when the runtime HTTP server is running):
+**Outbound HTTP Endpoints** (exposed via the gateway API and forwarded to the runtime):
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
@@ -346,7 +346,7 @@ Guardian verification can also be initiated through normal desktop chat. When th
 | `/v1/integrations/guardian/outbound/resend` | POST | Resend verification code. Body: `{ channel, assistantId? }` |
 | `/v1/integrations/guardian/outbound/cancel` | POST | Cancel active session. Body: `{ channel, assistantId? }` |
 
-These endpoints share the same business logic as the IPC-based verification flow via `guardian-outbound-actions.ts`.
+These endpoints share the same business logic as the IPC-based verification flow via `guardian-outbound-actions.ts`. Skills and clients should call the gateway URL (default `http://localhost:7830`) rather than the runtime port directly.
 
 **Security constraint:** Guardian verification control-plane endpoints are restricted to guardian and desktop (trusted) actors only. Non-guardian and unverified-channel actors cannot invoke these endpoints conversationally via tools. Attempts are denied with a message explaining that guardian verification actions are restricted to guardian users.
 

--- a/assistant/src/config/vellum-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/guardian-verify-setup/SKILL.md
@@ -10,6 +10,7 @@ You are helping your user set up guardian verification for a messaging channel (
 ## Prerequisites
 
 - The gateway API is available at `http://localhost:7830` (or the configured gateway port).
+- Never call the daemon runtime port directly; always call the gateway URL.
 - The bearer token is stored at `~/.vellum/http-token`. Read it with: `TOKEN=$(cat ~/.vellum/http-token)`.
 - Run shell commands for this skill with `host_bash` (not sandbox `bash`) so host auth/token and localhost routing are reliable.
 - Keep narration minimal: execute required calls first, then provide a concise status update. Do not narrate internal install/check/load chatter unless something fails.

--- a/assistant/src/config/vellum-skills/sms-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/sms-setup/SKILL.md
@@ -176,7 +176,7 @@ Install and load the **guardian-verify-setup** skill to handle the verification 
 
 When invoking the skill, indicate the channel is `sms`. The guardian-verify-setup skill manages the full outbound verification flow, including:
 - Collecting the user's phone number as the destination (accepts any common format -- the API normalizes to E.164)
-- Starting the outbound verification session via `POST /v1/integrations/guardian/outbound/start` with `channel: "sms"`
+- Starting the outbound verification session via the gateway endpoint `POST /v1/integrations/guardian/outbound/start` with `channel: "sms"`
 - Sending a 6-digit code to the phone number that the user must reply with from the SMS channel
 - Checking guardian status to confirm the binding was created
 - Handling resend, cancel, and error cases

--- a/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
@@ -71,7 +71,7 @@ Install and load the **guardian-verify-setup** skill to handle the verification 
 
 The guardian-verify-setup skill manages the full outbound verification flow for Telegram, including:
 - Collecting the user's Telegram chat ID or @handle as the destination
-- Starting the outbound verification session via `POST /v1/integrations/guardian/outbound/start` with `channel: "telegram"`
+- Starting the outbound verification session via the gateway endpoint `POST /v1/integrations/guardian/outbound/start` with `channel: "telegram"`
 - Handling the bootstrap deep-link flow when the user provides an @handle (the response includes a `telegramBootstrapUrl` that the user must click before receiving the code)
 - Guiding the user to send the verification code back in the Telegram bot chat
 - Checking guardian status to confirm the binding was created

--- a/assistant/src/config/vellum-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/twilio-setup/SKILL.md
@@ -210,7 +210,7 @@ Install and load the **guardian-verify-setup** skill to handle the verification 
 
 The guardian-verify-setup skill manages the full outbound verification flow for **one channel at a time** (sms, voice, or telegram). Each invocation handles:
 - Collecting the user's phone number as the destination (accepts any common format -- the API normalizes to E.164)
-- Starting the outbound verification session via `POST /v1/integrations/guardian/outbound/start`
+- Starting the outbound verification session via the gateway endpoint `POST /v1/integrations/guardian/outbound/start`
 - For **SMS**: sending a 6-digit code to the phone number that the user must reply with from the SMS channel
 - For **voice**: calling the phone number and providing a code for the user to enter via their phone's keypad
 - Checking guardian status to confirm the binding was created

--- a/assistant/src/tools/calls/call-start.ts
+++ b/assistant/src/tools/calls/call-start.ts
@@ -23,7 +23,7 @@ export async function executeCallStart(
       return {
         content: [
           'Error: A guardian voice verification call is already active for this number.',
-          'Use the guardian outbound verification flow (`/v1/integrations/guardian/outbound/start` or `/resend`) and wait for completion before using `call_start`.',
+          'Use the guardian outbound verification flow via the gateway API (`/v1/integrations/guardian/outbound/start` or `/resend`) and wait for completion before using `call_start`.',
         ].join(' '),
         isError: true,
       };

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -72,6 +72,33 @@ The feature-flag token is auto-generated on first gateway startup if the file do
 | `meta/feature-flags/feature-flag-registry.json` | Unified feature flag registry (repo root) — all declared flags with scope, label, default values, and descriptions |
 | `gateway/src/feature-flag-registry.json` | Bundled copy of the unified registry for compiled binary resolution |
 
+### Guardian Verification Control-Plane Proxy
+
+Guardian verification endpoints are exposed directly by the gateway and forwarded to runtime integration handlers even when the broad runtime proxy is disabled. This keeps assistant skills and user-facing tooling on gateway URLs only.
+
+**Forwarded endpoints:**
+
+| Method | Path |
+|--------|------|
+| POST | `/v1/integrations/guardian/challenge` |
+| GET | `/v1/integrations/guardian/status` |
+| POST | `/v1/integrations/guardian/outbound/start` |
+| POST | `/v1/integrations/guardian/outbound/resend` |
+| POST | `/v1/integrations/guardian/outbound/cancel` |
+
+**Authentication boundary:**
+
+- Gateway validates caller bearer auth against the runtime token.
+- Gateway forwards requests to runtime with the runtime bearer token and `X-Gateway-Origin` proof header.
+- Upstream 4xx/5xx responses are passed through, while connection errors return `502` and timeouts return `504`.
+
+**Key source files:**
+
+| File | Purpose |
+|------|---------|
+| `gateway/src/http/routes/guardian-control-plane-proxy.ts` | Guardian control-plane proxy handlers and upstream forwarding |
+| `gateway/src/index.ts` | Route registration and bearer-auth enforcement for `/v1/integrations/guardian/*` |
+
 ### Channel Binding Lifecycle (Lane Separation)
 
 Each channel (desktop, Telegram, etc.) operates in its own **lane**: conversations created by an external channel are never displayed in the desktop thread list, and desktop conversations are never exposed to external channels. The `channelBinding` metadata on a conversation is used solely for routing inbound/outbound messages within that lane and for filtering sessions during desktop session restoration.

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -216,6 +216,11 @@ The gateway serves as the single public ingress point for all external callbacks
 | `/webhooks/twilio/sms` | POST | Twilio SMS webhook — validates X-Twilio-Signature (HMAC-SHA1), normalizes into `GatewayInboundEventV1` with `sourceChannel: "sms"`, deduplicates by `MessageSid`, and forwards to runtime |
 | `/deliver/sms` | POST | Internal endpoint for the assistant runtime to deliver outbound SMS messages via the Twilio Messages API |
 | `/webhooks/oauth/callback` | GET | OAuth2 callback endpoint — receives authorization codes from OAuth providers (Google, Slack, etc.) and forwards them to the assistant runtime |
+| `/v1/integrations/guardian/challenge` | POST | Authenticated control-plane proxy for creating guardian verification challenges |
+| `/v1/integrations/guardian/status` | GET | Authenticated control-plane proxy for guardian binding status |
+| `/v1/integrations/guardian/outbound/start` | POST | Authenticated control-plane proxy for starting outbound guardian verification |
+| `/v1/integrations/guardian/outbound/resend` | POST | Authenticated control-plane proxy for resending outbound guardian verification |
+| `/v1/integrations/guardian/outbound/cancel` | POST | Authenticated control-plane proxy for cancelling outbound guardian verification |
 | `/healthz` | GET | Liveness probe |
 | `/readyz` | GET | Readiness probe |
 | `/schema` | GET | Returns the OpenAPI 3.1 schema for this gateway |
@@ -283,9 +288,9 @@ Inbound SMS follows the same gateway-only pattern as voice and Telegram:
 
 When `INGRESS_PUBLIC_BASE_URL` is configured, the gateway prioritizes it as the canonical URL for Twilio signature validation. If the signature only validates against the raw local request URL (fallback), a warning is logged indicating potential drift between the configured ingress URL and the actual webhook registration. The raw URL fallback is preserved for local-dev operability.
 
-## Default Mode: Telegram-Only
+## Default Mode: Dedicated Routes Only
 
-By default the gateway only serves the Telegram webhook endpoint (`/webhooks/telegram`). All other HTTP requests return `404`. The runtime proxy is **opt-in** — set `GATEWAY_RUNTIME_PROXY_ENABLED=true` to enable it. This behavior is enforced by automated tests.
+By default, the broad runtime proxy is disabled. Dedicated gateway-managed routes (webhooks, delivery endpoints, and explicit control-plane proxies such as `/v1/integrations/guardian/*`) remain available, but arbitrary runtime passthrough routes return `404` unless `GATEWAY_RUNTIME_PROXY_ENABLED=true`.
 
 ## Runtime Proxy Mode
 

--- a/gateway/src/__tests__/guardian-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/guardian-control-plane-proxy.test.ts
@@ -1,0 +1,187 @@
+import { describe, test, expect, mock, afterEach } from "bun:test";
+import type { GatewayConfig } from "../config.js";
+
+type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { createGuardianControlPlaneProxyHandler } = await import(
+  "../http/routes/guardian-control-plane-proxy.js"
+);
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  const merged: GatewayConfig = {
+    telegramBotToken: "tok",
+    telegramWebhookSecret: "wh-ver",
+    telegramApiBaseUrl: "https://api.telegram.org",
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeBearerToken: "runtime-token",
+    runtimeGatewayOriginSecret: "gateway-origin",
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    runtimeProxyBearerToken: undefined,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
+    twilioAuthToken: undefined,
+    twilioAccountSid: undefined,
+    twilioPhoneNumber: undefined,
+    smsDeliverAuthBypass: false,
+    ingressPublicBaseUrl: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    whatsappPhoneNumberId: undefined,
+    whatsappAccessToken: undefined,
+    whatsappAppSecret: undefined,
+    whatsappWebhookVerifyToken: undefined,
+    whatsappDeliverAuthBypass: false,
+    whatsappTimeoutMs: 15000,
+    whatsappMaxRetries: 3,
+    whatsappInitialBackoffMs: 1000,
+    slackChannelBotToken: undefined,
+    slackChannelAppToken: undefined,
+    slackDeliverAuthBypass: false,
+    trustProxy: false,
+    ...overrides,
+  };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
+}
+
+afterEach(() => {
+  fetchMock = mock(async () => new Response());
+});
+
+describe("guardian control-plane proxy", () => {
+  test("forwards all guardian control-plane endpoints to the runtime", async () => {
+    const captured: string[] = [];
+    fetchMock = mock(async (input: string | URL | Request) => {
+      captured.push(String(input));
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const handler = createGuardianControlPlaneProxyHandler(makeConfig());
+
+    await handler.handleCreateGuardianChallenge(
+      new Request("http://localhost:7830/v1/integrations/guardian/challenge", { method: "POST" }),
+    );
+    await handler.handleGetGuardianStatus(
+      new Request("http://localhost:7830/v1/integrations/guardian/status?channel=voice", { method: "GET" }),
+    );
+    await handler.handleStartGuardianOutbound(
+      new Request("http://localhost:7830/v1/integrations/guardian/outbound/start", { method: "POST" }),
+    );
+    await handler.handleResendGuardianOutbound(
+      new Request("http://localhost:7830/v1/integrations/guardian/outbound/resend", { method: "POST" }),
+    );
+    await handler.handleCancelGuardianOutbound(
+      new Request("http://localhost:7830/v1/integrations/guardian/outbound/cancel", { method: "POST" }),
+    );
+
+    expect(captured).toEqual([
+      "http://localhost:7821/v1/integrations/guardian/challenge",
+      "http://localhost:7821/v1/integrations/guardian/status?channel=voice",
+      "http://localhost:7821/v1/integrations/guardian/outbound/start",
+      "http://localhost:7821/v1/integrations/guardian/outbound/resend",
+      "http://localhost:7821/v1/integrations/guardian/outbound/cancel",
+    ]);
+  });
+
+  test("replaces caller auth with runtime auth and forwards gateway-origin proof", async () => {
+    let capturedHeaders: Headers | undefined;
+    let capturedBody = "";
+    fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+      capturedHeaders = init?.headers as unknown as Headers;
+      if (init?.body) {
+        capturedBody = new TextDecoder().decode(init.body as ArrayBuffer);
+      }
+      return new Response("ok", { status: 200 });
+    });
+
+    const handler = createGuardianControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleStartGuardianOutbound(
+      new Request("http://localhost:7830/v1/integrations/guardian/outbound/start", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer caller-token",
+          "content-type": "application/json",
+          host: "localhost:7830",
+        },
+        body: JSON.stringify({ channel: "voice", destination: "+15551234567" }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(capturedBody).toBe('{"channel":"voice","destination":"+15551234567"}');
+    expect(capturedHeaders?.get("authorization")).toBe("Bearer runtime-token");
+    expect(capturedHeaders?.get("X-Gateway-Origin")).toBe("gateway-origin");
+    expect(capturedHeaders?.has("host")).toBe(false);
+  });
+
+  test("passes through upstream client errors", async () => {
+    fetchMock = mock(async () => {
+      return new Response(JSON.stringify({ success: false, error: "invalid_destination" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const handler = createGuardianControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleStartGuardianOutbound(
+      new Request("http://localhost:7830/v1/integrations/guardian/outbound/start", {
+        method: "POST",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ success: false, error: "invalid_destination" });
+  });
+
+  test("returns 504 when upstream times out", async () => {
+    fetchMock = mock(async () => {
+      throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+    });
+
+    const handler = createGuardianControlPlaneProxyHandler(makeConfig({ runtimeTimeoutMs: 100 }));
+    const res = await handler.handleGetGuardianStatus(
+      new Request("http://localhost:7830/v1/integrations/guardian/status?channel=voice"),
+    );
+
+    expect(res.status).toBe(504);
+    expect(await res.json()).toEqual({ error: "Gateway Timeout" });
+  });
+
+  test("returns 502 when runtime is unreachable", async () => {
+    fetchMock = mock(async () => {
+      throw new Error("Connection refused");
+    });
+
+    const handler = createGuardianControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleGetGuardianStatus(
+      new Request("http://localhost:7830/v1/integrations/guardian/status?channel=voice"),
+    );
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: "Bad Gateway" });
+  });
+});

--- a/gateway/src/__tests__/schema.test.ts
+++ b/gateway/src/__tests__/schema.test.ts
@@ -60,6 +60,11 @@ describe("/schema route", () => {
     expect(body.paths["/webhooks/twilio/connect-action"]).toBeDefined();
     expect(body.paths["/webhooks/twilio/relay"]).toBeDefined();
     expect(body.paths["/webhooks/oauth/callback"]).toBeDefined();
+    expect(body.paths["/v1/integrations/guardian/challenge"]).toBeDefined();
+    expect(body.paths["/v1/integrations/guardian/status"]).toBeDefined();
+    expect(body.paths["/v1/integrations/guardian/outbound/start"]).toBeDefined();
+    expect(body.paths["/v1/integrations/guardian/outbound/resend"]).toBeDefined();
+    expect(body.paths["/v1/integrations/guardian/outbound/cancel"]).toBeDefined();
     expect(body.paths["/deliver/telegram"]).toBeDefined();
     expect(body.paths["/{path}"]).toBeDefined();
   });

--- a/gateway/src/http/routes/guardian-control-plane-proxy.ts
+++ b/gateway/src/http/routes/guardian-control-plane-proxy.ts
@@ -1,0 +1,111 @@
+/**
+ * Gateway proxy endpoints for guardian verification control-plane routes.
+ *
+ * These routes remain available even when the broad runtime proxy is
+ * disabled, so skills and clients can use gateway URLs exclusively.
+ */
+
+import type { GatewayConfig } from "../../config.js";
+import { fetchImpl } from "../../fetch.js";
+import { getLogger } from "../../logger.js";
+import { GATEWAY_ORIGIN_HEADER } from "../../runtime/client.js";
+import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
+
+const log = getLogger("guardian-control-plane-proxy");
+
+export function createGuardianControlPlaneProxyHandler(config: GatewayConfig) {
+  async function proxyToRuntime(
+    req: Request,
+    upstreamPath: string,
+    upstreamSearch: string,
+  ): Promise<Response> {
+    const start = performance.now();
+    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${upstreamSearch}`;
+
+    const reqHeaders = stripHopByHop(new Headers(req.headers));
+    reqHeaders.delete("host");
+    reqHeaders.delete("authorization");
+
+    // These endpoints are daemon-authenticated and must be called by
+    // the gateway using the runtime token.
+    if (config.runtimeBearerToken) {
+      reqHeaders.set("authorization", `Bearer ${config.runtimeBearerToken}`);
+    }
+    // Keep a consistent origin proof on all gateway->runtime calls.
+    if (config.runtimeGatewayOriginSecret) {
+      reqHeaders.set(GATEWAY_ORIGIN_HEADER, config.runtimeGatewayOriginSecret);
+    }
+
+    const hasBody = req.method !== "GET" && req.method !== "HEAD";
+    const bodyBuffer = hasBody ? await req.arrayBuffer() : null;
+    if (bodyBuffer !== null) {
+      reqHeaders.set("content-length", String(bodyBuffer.byteLength));
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(new DOMException("The operation was aborted due to timeout", "TimeoutError"));
+    }, config.runtimeTimeoutMs);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(upstream, {
+        method: req.method,
+        headers: reqHeaders,
+        body: bodyBuffer,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const duration = Math.round(performance.now() - start);
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        log.error({ path: upstreamPath, duration }, "Guardian control-plane proxy upstream timed out");
+        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+      }
+      log.error({ err, path: upstreamPath, duration }, "Guardian control-plane proxy upstream connection failed");
+      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    }
+
+    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const duration = Math.round(performance.now() - start);
+
+    if (response.status >= 400) {
+      const body = await response.text();
+      log.warn(
+        { path: upstreamPath, status: response.status, duration },
+        "Guardian control-plane proxy upstream error",
+      );
+      return new Response(body, { status: response.status, headers: resHeaders });
+    }
+
+    log.info(
+      { path: upstreamPath, status: response.status, duration },
+      "Guardian control-plane proxy completed",
+    );
+    return new Response(response.body, { status: response.status, headers: resHeaders });
+  }
+
+  return {
+    async handleCreateGuardianChallenge(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/integrations/guardian/challenge", "");
+    },
+
+    async handleGetGuardianStatus(req: Request): Promise<Response> {
+      const url = new URL(req.url);
+      return proxyToRuntime(req, "/v1/integrations/guardian/status", url.search);
+    },
+
+    async handleStartGuardianOutbound(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/integrations/guardian/outbound/start", "");
+    },
+
+    async handleResendGuardianOutbound(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/integrations/guardian/outbound/resend", "");
+    },
+
+    async handleCancelGuardianOutbound(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/integrations/guardian/outbound/cancel", "");
+    },
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -29,6 +29,7 @@ import { createSlackDeliverHandler } from "./http/routes/slack-deliver.js";
 import { createOAuthCallbackHandler } from "./http/routes/oauth-callback.js";
 import { createPairingProxyHandler } from "./http/routes/pairing-proxy.js";
 import { createFeatureFlagsGetHandler, createFeatureFlagsPatchHandler } from "./http/routes/feature-flags.js";
+import { createGuardianControlPlaneProxyHandler } from "./http/routes/guardian-control-plane-proxy.js";
 import { validateBearerToken } from "./http/auth/bearer.js";
 import { getLogger, initLogger } from "./logger.js";
 import { CircuitBreakerOpenError } from "./runtime/client.js";
@@ -196,6 +197,7 @@ function main() {
   const handleSlackDeliver = createSlackDeliverHandler(config);
   const handleOAuthCallback = createOAuthCallbackHandler(config);
   const pairingProxy = createPairingProxyHandler(config);
+  const guardianControlPlaneProxy = createGuardianControlPlaneProxyHandler(config);
   const handleFeatureFlagsGet = createFeatureFlagsGetHandler();
   const handleFeatureFlagsPatch = createFeatureFlagsPatchHandler();
 
@@ -409,6 +411,44 @@ function main() {
           authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
         }
         return res;
+      }
+
+      // ── Guardian verification control-plane proxy ──
+      if (
+        (url.pathname === "/v1/integrations/guardian/challenge" && req.method === "POST")
+        || (url.pathname === "/v1/integrations/guardian/status" && req.method === "GET")
+        || (url.pathname === "/v1/integrations/guardian/outbound/start" && req.method === "POST")
+        || (url.pathname === "/v1/integrations/guardian/outbound/resend" && req.method === "POST")
+        || (url.pathname === "/v1/integrations/guardian/outbound/cancel" && req.method === "POST")
+      ) {
+        if (!config.runtimeBearerToken) {
+          return Response.json(
+            { error: "Service not configured: bearer token required" },
+            { status: 503 },
+          );
+        }
+        const authResult = validateBearerToken(
+          tracedReq.headers.get("authorization"),
+          config.runtimeBearerToken,
+        );
+        if (!authResult.authorized) {
+          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+          return Response.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        if (url.pathname === "/v1/integrations/guardian/challenge") {
+          return guardianControlPlaneProxy.handleCreateGuardianChallenge(tracedReq);
+        }
+        if (url.pathname === "/v1/integrations/guardian/status") {
+          return guardianControlPlaneProxy.handleGetGuardianStatus(tracedReq);
+        }
+        if (url.pathname === "/v1/integrations/guardian/outbound/start") {
+          return guardianControlPlaneProxy.handleStartGuardianOutbound(tracedReq);
+        }
+        if (url.pathname === "/v1/integrations/guardian/outbound/resend") {
+          return guardianControlPlaneProxy.handleResendGuardianOutbound(tracedReq);
+        }
+        return guardianControlPlaneProxy.handleCancelGuardianOutbound(tracedReq);
       }
 
       if (url.pathname === "/integrations/status" && req.method === "GET") {

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -726,6 +726,140 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/integrations/guardian/challenge": {
+        post: {
+          summary: "Create guardian verification challenge",
+          description:
+            "Authenticated gateway endpoint that forwards guardian challenge creation to the assistant runtime.",
+          operationId: "guardianChallenge",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Challenge created" },
+            "400": { description: "Invalid request payload" },
+            "401": { description: "Unauthorized — missing or invalid bearer token" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
+      "/v1/integrations/guardian/status": {
+        get: {
+          summary: "Get guardian binding status",
+          description:
+            "Authenticated gateway endpoint that forwards guardian status checks to the assistant runtime.",
+          operationId: "guardianStatus",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            {
+              name: "channel",
+              in: "query",
+              required: false,
+              schema: { type: "string", enum: ["sms", "voice", "telegram"] },
+              description: "Optional guardian channel filter.",
+            },
+            {
+              name: "assistantId",
+              in: "query",
+              required: false,
+              schema: { type: "string" },
+              description: "Optional assistant identifier override.",
+            },
+          ],
+          responses: {
+            "200": { description: "Guardian status returned" },
+            "401": { description: "Unauthorized — missing or invalid bearer token" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
+      "/v1/integrations/guardian/outbound/start": {
+        post: {
+          summary: "Start outbound guardian verification",
+          description:
+            "Authenticated gateway endpoint that starts outbound guardian verification (sms, voice, or telegram).",
+          operationId: "guardianOutboundStart",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Outbound verification started" },
+            "400": { description: "Invalid request payload" },
+            "401": { description: "Unauthorized — missing or invalid bearer token" },
+            "429": { description: "Rate limited by verification policy" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
+      "/v1/integrations/guardian/outbound/resend": {
+        post: {
+          summary: "Resend outbound guardian verification",
+          description:
+            "Authenticated gateway endpoint that resends the current outbound guardian verification code.",
+          operationId: "guardianOutboundResend",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Verification resent" },
+            "400": { description: "Invalid request payload" },
+            "401": { description: "Unauthorized — missing or invalid bearer token" },
+            "429": { description: "Rate limited by verification policy" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
+      "/v1/integrations/guardian/outbound/cancel": {
+        post: {
+          summary: "Cancel outbound guardian verification",
+          description:
+            "Authenticated gateway endpoint that cancels an active outbound guardian verification session.",
+          operationId: "guardianOutboundCancel",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Verification cancelled" },
+            "400": { description: "Invalid request payload" },
+            "401": { description: "Unauthorized — missing or invalid bearer token" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
       "/integrations/status": {
         get: {
           summary: "Integration status",

--- a/skills/guardian-verify-setup/SKILL.md
+++ b/skills/guardian-verify-setup/SKILL.md
@@ -10,6 +10,7 @@ You are helping your user set up guardian verification for a messaging channel (
 ## Prerequisites
 
 - The gateway API is available at `http://localhost:7830` (or the configured gateway port).
+- Never call the daemon runtime port directly; always call the gateway URL.
 - The bearer token is stored at `~/.vellum/http-token`. Read it with: `TOKEN=$(cat ~/.vellum/http-token)`.
 - Run shell commands for this skill with `host_bash` (not sandbox `bash`) so host auth/token and localhost routing are reliable.
 - Keep narration minimal: execute required calls first, then provide a concise status update. Do not narrate internal install/check/load chatter unless something fails.

--- a/skills/sms-setup/SKILL.md
+++ b/skills/sms-setup/SKILL.md
@@ -176,7 +176,7 @@ Install and load the **guardian-verify-setup** skill to handle the verification 
 
 When invoking the skill, indicate the channel is `sms`. The guardian-verify-setup skill manages the full outbound verification flow, including:
 - Collecting the user's phone number as the destination (accepts any common format -- the API normalizes to E.164)
-- Starting the outbound verification session via `POST /v1/integrations/guardian/outbound/start` with `channel: "sms"`
+- Starting the outbound verification session via the gateway endpoint `POST /v1/integrations/guardian/outbound/start` with `channel: "sms"`
 - Sending a 6-digit code to the phone number that the user must reply with from the SMS channel
 - Checking guardian status to confirm the binding was created
 - Handling resend, cancel, and error cases

--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -71,7 +71,7 @@ Install and load the **guardian-verify-setup** skill to handle the verification 
 
 The guardian-verify-setup skill manages the full outbound verification flow for Telegram, including:
 - Collecting the user's Telegram chat ID or @handle as the destination
-- Starting the outbound verification session via `POST /v1/integrations/guardian/outbound/start` with `channel: "telegram"`
+- Starting the outbound verification session via the gateway endpoint `POST /v1/integrations/guardian/outbound/start` with `channel: "telegram"`
 - Handling the bootstrap deep-link flow when the user provides an @handle (the response includes a `telegramBootstrapUrl` that the user must click before receiving the code)
 - Guiding the user to send the verification code back in the Telegram bot chat
 - Checking guardian status to confirm the binding was created

--- a/skills/twilio-setup/SKILL.md
+++ b/skills/twilio-setup/SKILL.md
@@ -210,7 +210,7 @@ Install and load the **guardian-verify-setup** skill to handle the verification 
 
 The guardian-verify-setup skill manages the full outbound verification flow for **one channel at a time** (sms, voice, or telegram). Each invocation handles:
 - Collecting the user's phone number as the destination (accepts any common format -- the API normalizes to E.164)
-- Starting the outbound verification session via `POST /v1/integrations/guardian/outbound/start`
+- Starting the outbound verification session via the gateway endpoint `POST /v1/integrations/guardian/outbound/start`
 - For **SMS**: sending a 6-digit code to the phone number that the user must reply with from the SMS channel
 - For **voice**: calling the phone number and providing a code for the user to enter via their phone's keypad
 - Checking guardian status to confirm the binding was created


### PR DESCRIPTION
## Summary
- add dedicated gateway proxy handlers for guardian verification control-plane endpoints (`/v1/integrations/guardian/challenge`, `/v1/integrations/guardian/status`, `/v1/integrations/guardian/outbound/start`, `/v1/integrations/guardian/outbound/resend`, `/v1/integrations/guardian/outbound/cancel`)
- wire the new routes into `gateway/src/index.ts` with runtime-token auth so they work even when `GATEWAY_RUNTIME_PROXY_ENABLED=false`
- update gateway OpenAPI schema and schema route assertions for the new endpoints
- update assistant guidance that previously led to direct runtime calls by clarifying gateway usage in guardian-related skills and `call_start` messaging
- refresh gateway/assistant architecture docs and README sections to reflect gateway-first guardian verification flow

## Testing
- `cd gateway && bun test src/__tests__/guardian-control-plane-proxy.test.ts src/__tests__/schema.test.ts`
- `cd gateway && bunx tsc --noEmit`
- `cd assistant && bun test src/__tests__/guardian-verify-setup-skill-regression.test.ts src/__tests__/gateway-only-guard.test.ts`
- `cd assistant && bunx tsc --noEmit` *(currently fails on pre-existing unrelated errors in `call-controller.test.ts`, `ipc-snapshot.test.ts`, `call-controller.ts`, and `ingress-invite-store.ts`)*