### PR TITLE
Regenerate IPC Swift code and fix failure counter pagination

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -58,8 +58,8 @@ jobs:
           WORKFLOW_NAME="${WORKFLOW_REF%%@*}"
           WORKFLOW_NAME="${WORKFLOW_NAME##*/}"
 
-          # Get the last 10 completed runs of this workflow on main (excluding current)
-          RUNS=$(gh api "/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_NAME}/runs?branch=main&status=completed&per_page=10" \
+          # Get the last 100 completed runs of this workflow on main (excluding current)
+          RUNS=$(gh api "/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_NAME}/runs?branch=main&status=completed&per_page=100" \
             --jq '[.workflow_runs[] | select(.id != '${{ github.run_id }}') | .conclusion]')
 
           # Count consecutive failures from most recent

--- a/.github/workflows/ci-main-cli.yaml
+++ b/.github/workflows/ci-main-cli.yaml
@@ -48,8 +48,8 @@ jobs:
           WORKFLOW_NAME="${WORKFLOW_REF%%@*}"
           WORKFLOW_NAME="${WORKFLOW_NAME##*/}"
 
-          # Get the last 10 completed runs of this workflow on main (excluding current)
-          RUNS=$(gh api "/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_NAME}/runs?branch=main&status=completed&per_page=10" \
+          # Get the last 100 completed runs of this workflow on main (excluding current)
+          RUNS=$(gh api "/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_NAME}/runs?branch=main&status=completed&per_page=100" \
             --jq '[.workflow_runs[] | select(.id != '${{ github.run_id }}') | .conclusion]')
 
           # Count consecutive failures from most recent

--- a/.github/workflows/ci-main-gateway.yaml
+++ b/.github/workflows/ci-main-gateway.yaml
@@ -49,8 +49,8 @@ jobs:
           WORKFLOW_NAME="${WORKFLOW_REF%%@*}"
           WORKFLOW_NAME="${WORKFLOW_NAME##*/}"
 
-          # Get the last 10 completed runs of this workflow on main (excluding current)
-          RUNS=$(gh api "/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_NAME}/runs?branch=main&status=completed&per_page=10" \
+          # Get the last 100 completed runs of this workflow on main (excluding current)
+          RUNS=$(gh api "/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_NAME}/runs?branch=main&status=completed&per_page=100" \
             --jq '[.workflow_runs[] | select(.id != '${{ github.run_id }}') | .conclusion]')
 
           # Count consecutive failures from most recent

--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -104,8 +104,8 @@ jobs:
           WORKFLOW_NAME="${WORKFLOW_REF%%@*}"
           WORKFLOW_NAME="${WORKFLOW_NAME##*/}"
 
-          # Get the last 10 completed runs of this workflow on main (excluding current)
-          RUNS=$(gh api "/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_NAME}/runs?branch=main&status=completed&per_page=10" \
+          # Get the last 100 completed runs of this workflow on main (excluding current)
+          RUNS=$(gh api "/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_NAME}/runs?branch=main&status=completed&per_page=100" \
             --jq '[.workflow_runs[] | select(.id != '${{ github.run_id }}') | .conclusion]')
 
           # Count consecutive failures from most recent

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1818,7 +1818,7 @@ public struct IPCGalleryManifest: Codable, Sendable {
     }
 }
 
-/// Request from the client to generate a custom avatar via DALL-E.
+/// Request from the client to generate a custom avatar via Gemini.
 public struct IPCGenerateAvatarRequest: Codable, Sendable {
     public let type: String
     /// Text description of the desired avatar appearance.
@@ -1894,6 +1894,92 @@ public struct IPCGetSigningIdentityResponse: Codable, Sendable {
         self.keyId = keyId
         self.publicKey = publicKey
         self.error = error
+    }
+}
+
+public struct IPCGuardianActionDecision: Codable, Sendable {
+    public let type: String
+    public let requestId: String
+    public let action: String
+    public let conversationId: String?
+
+    public init(type: String, requestId: String, action: String, conversationId: String? = nil) {
+        self.type = type
+        self.requestId = requestId
+        self.action = action
+        self.conversationId = conversationId
+    }
+}
+
+public struct IPCGuardianActionDecisionResponse: Codable, Sendable {
+    public let type: String
+    public let applied: Bool
+    public let reason: String?
+    public let requestId: String?
+    public let userText: String?
+
+    public init(type: String, applied: Bool, reason: String? = nil, requestId: String? = nil, userText: String? = nil) {
+        self.type = type
+        self.applied = applied
+        self.reason = reason
+        self.requestId = requestId
+        self.userText = userText
+    }
+}
+
+public struct IPCGuardianActionsPendingRequest: Codable, Sendable {
+    public let type: String
+    public let conversationId: String
+
+    public init(type: String, conversationId: String) {
+        self.type = type
+        self.conversationId = conversationId
+    }
+}
+
+public struct IPCGuardianActionsPendingResponse: Codable, Sendable {
+    public let type: String
+    public let conversationId: String
+    public let prompts: [IPCGuardianActionsPendingResponsePrompt]
+
+    public init(type: String, conversationId: String, prompts: [IPCGuardianActionsPendingResponsePrompt]) {
+        self.type = type
+        self.conversationId = conversationId
+        self.prompts = prompts
+    }
+}
+
+public struct IPCGuardianActionsPendingResponsePrompt: Codable, Sendable {
+    public let requestId: String
+    public let requestCode: String
+    public let state: String
+    public let questionText: String
+    public let toolName: String?
+    public let actions: [IPCGuardianActionsPendingResponsePromptAction]
+    public let expiresAt: Int
+    public let conversationId: String
+    public let callSessionId: String?
+
+    public init(requestId: String, requestCode: String, state: String, questionText: String, toolName: String?, actions: [IPCGuardianActionsPendingResponsePromptAction], expiresAt: Int, conversationId: String, callSessionId: String?) {
+        self.requestId = requestId
+        self.requestCode = requestCode
+        self.state = state
+        self.questionText = questionText
+        self.toolName = toolName
+        self.actions = actions
+        self.expiresAt = expiresAt
+        self.conversationId = conversationId
+        self.callSessionId = callSessionId
+    }
+}
+
+public struct IPCGuardianActionsPendingResponsePromptAction: Codable, Sendable {
+    public let action: String
+    public let label: String
+
+    public init(action: String, label: String) {
+        self.action = action
+        self.label = label
     }
 }
 


### PR DESCRIPTION
## Summary
- Regenerate `IPCContractGenerated.swift` to match current IPC contract (fixes `check:ipc-generated` failure)
- Bump `per_page` from 10 to 100 in all `ci-main-*` workflows so the consecutive failure counter accurately reflects reality instead of capping at ~10

## Test plan
- [ ] CI passes (IPC check no longer fails)
- [ ] Consecutive failure counter reports accurate count on next failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
