### PR TITLE
Collapsed sidebar thread switcher

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1317,6 +1317,47 @@ struct MainWindowView: View {
                 threadManager.createThread()
             }
 
+            // MARK: Thread Section (collapsed)
+            if let activeThread = threadManager.activeThread {
+                VStack(spacing: VSpacing.xs) {
+                    let interactionState = threadManager.interactionState(for: activeThread.id)
+                    let interactionDotColor: Color? = {
+                        switch interactionState {
+                        case .processing: return VColor.accent
+                        case .waitingForInput: return VColor.warning
+                        case .error: return VColor.error
+                        case .idle: return nil
+                        }
+                    }()
+
+                    VThreadIcon(
+                        title: activeThread.title,
+                        size: .medium,
+                        isActive: true,
+                        dotColor: interactionDotColor
+                    )
+
+                    // Thread count badge
+                    if regularThreads.count > 0 {
+                        Text("\(regularThreads.count)")
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundColor(VColor.textSecondary)
+                            .padding(.horizontal, VSpacing.xs)
+                            .padding(.vertical, 2)
+                            .background(
+                                Capsule()
+                                    .fill(Forest._700)
+                            )
+                    }
+
+                    // Threads indicator icon
+                    Image(systemName: "bubble.left.and.bubble.right")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(VColor.textMuted)
+                }
+                .padding(.vertical, VSpacing.xs)
+            }
+
             Spacer()
 
             SidebarNavRow(icon: "gearshape", label: "Control Center", isActive: false, isExpanded: false) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -96,6 +96,9 @@ struct MainWindowView: View {
     /// Nil for returning users (no transition).
     let onSendWakeUp: (() -> Void)?
 
+    @State private var showThreadSwitcher = false
+    /// Work item for the delayed hover trigger on the collapsed thread section.
+    @State private var threadSwitcherHoverTimer: DispatchWorkItem?
     /// Whether the "coming alive" overlay is currently showing.
     @State private var showComingAlive: Bool
 
@@ -902,6 +905,16 @@ struct MainWindowView: View {
         }
     }
 
+    /// Maps a thread's interaction state to a dot color for VThreadIcon.
+    private func interactionDotColor(for thread: ThreadModel) -> Color? {
+        switch threadManager.interactionState(for: thread.id) {
+        case .processing: return VColor.accent
+        case .waitingForInput: return VColor.warning
+        case .error: return VColor.error
+        case .idle: return nil
+        }
+    }
+
     private var regularThreads: [ThreadModel] {
         threadManager.visibleThreads.filter { !$0.isScheduleThread }
     }
@@ -1320,21 +1333,11 @@ struct MainWindowView: View {
             // MARK: Thread Section (collapsed)
             if let activeThread = threadManager.activeThread {
                 VStack(spacing: VSpacing.xs) {
-                    let interactionState = threadManager.interactionState(for: activeThread.id)
-                    let interactionDotColor: Color? = {
-                        switch interactionState {
-                        case .processing: return VColor.accent
-                        case .waitingForInput: return VColor.warning
-                        case .error: return VColor.error
-                        case .idle: return nil
-                        }
-                    }()
-
                     VThreadIcon(
                         title: activeThread.title,
                         size: .medium,
                         isActive: true,
-                        dotColor: interactionDotColor
+                        dotColor: interactionDotColor(for: activeThread)
                     )
 
                     // Thread count badge
@@ -1356,6 +1359,81 @@ struct MainWindowView: View {
                         .foregroundColor(VColor.textMuted)
                 }
                 .padding(.vertical, VSpacing.xs)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    threadSwitcherHoverTimer?.cancel()
+                    threadSwitcherHoverTimer = nil
+                    showThreadSwitcher.toggle()
+                }
+                .onHover { hovering in
+                    if hovering {
+                        threadSwitcherHoverTimer?.cancel()
+                        let work = DispatchWorkItem {
+                            showThreadSwitcher = true
+                        }
+                        threadSwitcherHoverTimer = work
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: work)
+                    } else {
+                        threadSwitcherHoverTimer?.cancel()
+                        threadSwitcherHoverTimer = nil
+                    }
+                }
+                .popover(isPresented: $showThreadSwitcher, arrowEdge: .trailing) {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        // Header
+                        Text("\(regularThreads.count) THREADS")
+                            .font(VFont.caption)
+                            .fontWeight(.medium)
+                            .foregroundColor(VColor.textMuted)
+                            .padding(.horizontal, VSpacing.sm)
+                            .padding(.top, VSpacing.sm)
+
+                        // Thread list
+                        ScrollView {
+                            VStack(spacing: 0) {
+                                ForEach(regularThreads) { thread in
+                                    let isActive = thread.id == threadManager.activeThreadId
+                                    HStack(spacing: VSpacing.xs) {
+                                        VThreadIcon(
+                                            title: thread.title,
+                                            size: .small,
+                                            isActive: isActive,
+                                            dotColor: interactionDotColor(for: thread)
+                                        )
+
+                                        Text(thread.title)
+                                            .font(VFont.body)
+                                            .foregroundColor(VColor.textPrimary)
+                                            .lineLimit(1)
+                                            .truncationMode(.tail)
+
+                                        Spacer()
+
+                                        // Unseen indicator
+                                        if thread.hasUnseenLatestAssistantMessage {
+                                            Circle()
+                                                .fill(Color(hex: 0xE86B40))
+                                                .frame(width: 6, height: 6)
+                                        }
+                                    }
+                                    .padding(.horizontal, VSpacing.sm)
+                                    .padding(.vertical, VSpacing.xs)
+                                    .background(isActive ? VColor.accent.opacity(0.12) : Color.clear)
+                                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                                    .contentShape(Rectangle())
+                                    .onTapGesture {
+                                        selectThread(thread)
+                                        showThreadSwitcher = false
+                                    }
+                                }
+                            }
+                            .padding(.horizontal, VSpacing.xs)
+                        }
+                        .frame(maxHeight: 300)
+                    }
+                    .frame(width: 200)
+                    .padding(.bottom, VSpacing.sm)
+                }
             }
 
             Spacer()

--- a/clients/shared/DesignSystem/Components/Display/VThreadIcon.swift
+++ b/clients/shared/DesignSystem/Components/Display/VThreadIcon.swift
@@ -1,0 +1,183 @@
+import SwiftUI
+
+/// A deterministic initial-letter icon for threads.
+///
+/// Renders the first letter of a thread title (uppercased) inside a rounded square
+/// whose background color is derived from an FNV-1a hash of the title. The same title
+/// always produces the same color, giving threads a stable visual identity.
+public struct VThreadIcon: View {
+    let title: String
+    let size: Size
+    var isActive: Bool = false
+    /// Optional dot color for interaction-state overlay (bottom-right corner).
+    /// Callers map ThreadInteractionState → Color externally to keep the
+    /// design system decoupled from feature types.
+    var dotColor: Color?
+
+    public init(title: String, size: Size, isActive: Bool = false, dotColor: Color? = nil) {
+        self.title = title
+        self.size = size
+        self.isActive = isActive
+        self.dotColor = dotColor
+    }
+
+    public enum Size {
+        /// 20pt — for popover list items
+        case small
+        /// 28pt — for collapsed sidebar
+        case medium
+
+        var dimension: CGFloat {
+            switch self {
+            case .small: return 20
+            case .medium: return 28
+            }
+        }
+
+        var fontSize: CGFloat {
+            switch self {
+            case .small: return 11
+            case .medium: return 14
+            }
+        }
+
+        var cornerRadius: CGFloat {
+            switch self {
+            case .small: return VRadius.sm
+            case .medium: return VRadius.md
+            }
+        }
+
+        /// Size of the interaction-state overlay dot.
+        var dotSize: CGFloat {
+            switch self {
+            case .small: return 6
+            case .medium: return 8
+            }
+        }
+
+        var borderWidth: CGFloat {
+            switch self {
+            case .small: return 1.5
+            case .medium: return 2
+            }
+        }
+    }
+
+    // MARK: - Color Palette
+
+    /// Muted, dark-theme-friendly hex values that complement the Moss/Forest palette.
+    private static let backgroundHexValues: [UInt] = [
+        0x4B6845, // forest green
+        0x4A5568, // slate blue-gray
+        0x5B4E3A, // warm brown
+        0x3D5A5B, // teal
+        0x6B4C5A, // muted mauve
+        0x4E5D3E, // olive
+        0x5A4A6B, // dusty purple
+        0x5C6B4A, // sage
+    ]
+
+    // MARK: - Hash
+
+    /// FNV-1a 64-bit hash for deterministic color assignment.
+    private static func stableHash(_ string: String) -> UInt64 {
+        var hash: UInt64 = 14695981039346656037 // FNV offset basis
+        for byte in string.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1099511628211 // FNV prime
+        }
+        return hash
+    }
+
+    // MARK: - Derived Properties
+
+    private var letter: String {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let first = trimmed.first else { return "?" }
+        return String(first).uppercased()
+    }
+
+    private var backgroundColor: Color {
+        let hash = Self.stableHash(title)
+        let index = Int(hash % UInt64(Self.backgroundHexValues.count))
+        return Color(hex: Self.backgroundHexValues[index])
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        ZStack(alignment: .bottomTrailing) {
+            // Main icon
+            ZStack {
+                RoundedRectangle(cornerRadius: size.cornerRadius, style: .continuous)
+                    .fill(backgroundColor)
+
+                Text(letter)
+                    .font(.system(size: size.fontSize, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white)
+            }
+            .frame(width: size.dimension, height: size.dimension)
+            .overlay(
+                RoundedRectangle(cornerRadius: size.cornerRadius, style: .continuous)
+                    .stroke(isActive ? VColor.accent : Color.clear, lineWidth: size.borderWidth)
+            )
+
+            // Interaction-state overlay dot
+            if let dot = dotColor {
+                Circle()
+                    .fill(dot)
+                    .frame(width: size.dotSize, height: size.dotSize)
+                    .offset(x: size.dotSize * 0.2, y: size.dotSize * 0.2)
+            }
+        }
+        .accessibilityLabel("Thread: \(title)")
+    }
+}
+
+// MARK: - Preview
+
+#Preview("VThreadIcon") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VStack(spacing: VSpacing.xl) {
+            Text("Small (20pt)")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+            HStack(spacing: VSpacing.sm) {
+                VThreadIcon(title: "Customer support", size: .small)
+                VThreadIcon(title: "Design review", size: .small, isActive: true)
+                VThreadIcon(title: "Bug triage", size: .small, dotColor: VColor.accent)
+                VThreadIcon(title: "Sprint planning", size: .small, dotColor: VColor.warning)
+                VThreadIcon(title: "Release notes", size: .small, dotColor: VColor.error)
+            }
+
+            Text("Medium (28pt)")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+            HStack(spacing: VSpacing.md) {
+                VThreadIcon(title: "Customer support", size: .medium)
+                VThreadIcon(title: "Design review", size: .medium, isActive: true)
+                VThreadIcon(title: "Bug triage", size: .medium, dotColor: VColor.accent)
+                VThreadIcon(title: "Sprint planning", size: .medium, dotColor: VColor.warning)
+                VThreadIcon(title: "Release notes", size: .medium, dotColor: VColor.error)
+            }
+
+            Text("Deterministic colors")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+            HStack(spacing: VSpacing.md) {
+                ForEach(["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta"], id: \.self) { name in
+                    VStack(spacing: VSpacing.xs) {
+                        VThreadIcon(title: name, size: .medium)
+                        Text(name)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                }
+            }
+        }
+        .padding()
+    }
+    .frame(width: 600, height: 300)
+}


### PR DESCRIPTION
## Summary
Adds a thread switcher to the collapsed sidebar so users can see the current thread and quickly switch between non-scheduled threads without expanding the sidebar. Shows the active thread's initial-letter icon, a thread count badge, and a popover flyout on hover/click with the full thread list.

## Changes
- **M1: VThreadIcon component** — New `VThreadIcon.swift` design system component that renders a deterministic initial-letter icon for threads using FNV-1a hash-based color derivation. Supports small (20pt) and medium (28pt) sizes, active state border, and generic dot color overlay.
- **M2: Collapsed sidebar thread section** — Added active thread icon, non-scheduled thread count badge, and threads indicator icon to the collapsed sidebar between the New Chat button and bottom spacer.
- **M3: Thread switcher popover** — Hover/click-triggered popover showing all non-scheduled threads with VThreadIcon initials, truncated titles, interaction state dots, and unseen message indicators. Clicking a thread switches to it and dismisses the popover.

## Milestone PRs (merged into feature branch)
- #10412: M1: Add VThreadIcon component
- #10422: M2: Collapsed sidebar thread section
- #10425: M3: Thread switcher popover

## Project issue
Closes #10408

## Test plan
- [ ] Build the macOS app and verify the collapsed sidebar shows the active thread icon
- [ ] Verify the thread count badge shows the correct number of non-scheduled threads
- [ ] Hover over the thread section and verify the popover appears after ~300ms
- [ ] Click the thread section and verify the popover toggles
- [ ] Verify the popover lists all non-scheduled threads (scheduled threads excluded)
- [ ] Click a thread in the popover and verify it switches to that thread and dismisses the popover
- [ ] Verify the active thread is highlighted in the popover list
- [ ] Verify interaction state dots show correctly (processing, waiting, error states)
- [ ] Verify unseen message indicators appear for threads with unread messages

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
