### PR TITLE
fix: agent CI artifact download, blank video, screen recording

### DIFF
--- a/playwright/agent/runner.ts
+++ b/playwright/agent/runner.ts
@@ -92,6 +92,7 @@ function startScreenRecording(videoPath: string): ChildProcess | undefined {
       stdio: "ignore",
       detached: true,
     });
+    proc.on("error", () => {}); // ignore spawn failures (e.g., not on macOS)
     proc.unref();
     return proc;
   } catch {

--- a/playwright/agent/runner.ts
+++ b/playwright/agent/runner.ts
@@ -10,7 +10,8 @@
 
 import "dotenv/config";
 
-import { readdirSync, readFileSync } from "fs";
+import { type ChildProcess, spawn } from "child_process";
+import { mkdirSync, readdirSync, readFileSync } from "fs";
 import path from "path";
 
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
@@ -80,6 +81,38 @@ function discoverTestCases(casesDir: string, filter?: string): TestCase[] {
 
 // ── Runner ──────────────────────────────────────────────────────────
 
+/**
+ * Start a macOS screen recording via `screencapture -v`.
+ * Returns the child process so it can be stopped later with SIGINT.
+ */
+function startScreenRecording(videoPath: string): ChildProcess | undefined {
+  try {
+    mkdirSync(path.dirname(videoPath), { recursive: true });
+    const proc = spawn("screencapture", ["-v", "-x", videoPath], {
+      stdio: "ignore",
+      detached: true,
+    });
+    proc.unref();
+    return proc;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Stop a screen recording by sending SIGINT, which tells screencapture
+ * to finalize and save the video file.
+ */
+async function stopScreenRecording(proc: ChildProcess | undefined): Promise<void> {
+  if (!proc || proc.killed) return;
+  proc.kill("SIGINT");
+  // Wait for the process to exit so the video file is fully written
+  await new Promise<void>((resolve) => {
+    proc.on("exit", resolve);
+    setTimeout(resolve, 3000); // fallback timeout
+  });
+}
+
 async function runTestCase(
   testCase: TestCase,
   browser: Browser,
@@ -89,6 +122,7 @@ async function runTestCase(
   let context: BrowserContext | undefined;
   let page: Page | undefined;
   let fixtureCtx: FixtureContext | undefined;
+  let recorder: ChildProcess | undefined;
 
   try {
     // Setup fixture if needed
@@ -100,14 +134,17 @@ async function runTestCase(
     const { body } = parseFrontmatter(testCase.rawContent);
     const testContent = body;
 
-    // Create browser context with video recording
-    const videoDir = path.resolve(__dirname, "../test-results/agent-videos", testCase.name);
-    context = await browser.newContext({
-      recordVideo: { dir: videoDir },
-    });
+    // Create browser context (no recordVideo — it captures the blank browser
+    // tab, not the macOS desktop where the native app is being tested)
+    context = await browser.newContext();
     page = await context.newPage();
 
     const screenshotDir = path.resolve(__dirname, "../test-results/agent-screenshots", testCase.name);
+
+    // Start macOS screen recording (captures the actual desktop, not the browser tab)
+    const videoDir = path.resolve(__dirname, "../test-results/agent-videos", testCase.name);
+    const videoPath = path.join(videoDir, "screen-recording.mov");
+    recorder = startScreenRecording(videoPath);
 
     // Run the agent
     const result = await runAgent({
@@ -132,6 +169,7 @@ async function runTestCase(
       durationMs: Date.now() - startTime,
     };
   } finally {
+    await stopScreenRecording(recorder);
     if (page) await page.close().catch(() => {});
     if (context) await context.close().catch(() => {});
     if (fixtureCtx) await fixtureCtx.teardown().catch(() => {});

--- a/playwright/scripts/agent-ci.ts
+++ b/playwright/scripts/agent-ci.ts
@@ -7,6 +7,7 @@
  */
 
 import { spawnSync } from "child_process";
+import { rmSync } from "fs";
 
 const REPO = "vellum-ai/vellum-assistant";
 const WORKFLOW = "playwright.yaml";
@@ -172,6 +173,7 @@ if (artifactJson) {
     console.log(`  ${artifactUrl}`);
 
     console.log("\nDownloading artifacts...");
+    rmSync("test-results/ci-artifacts", { recursive: true, force: true });
     ghPassthrough(["run", "download", runId, "-R", REPO, "-D", "test-results/ci-artifacts"]);
     console.log("Saved to test-results/ci-artifacts/");
   } catch {


### PR DESCRIPTION
## Summary
- **Download error**: Clear `ci-artifacts/` directory before downloading so stale files from previous runs don't cause "file exists" extraction errors.
- **Blank video**: Replaced Playwright's `recordVideo` (which captured an 80s blank Chromium tab) with macOS `screencapture -v`, which records the actual desktop showing the native app under test. Recording starts before each test case and is stopped with SIGINT afterward.
- **HTML report**: The HTML reporter in `playwright.config.ts` only applies to standard Playwright Test runs (`bun run test`), not agent mode (`bun run test:agent`) which uses a custom runner. This is expected behavior — agent test artifacts are screenshots + screen recordings.

## Test plan
- [ ] Run `bun run test:agent:ci` twice in a row — second download should not error
- [ ] Check artifact for `agent-videos/<test-name>/screen-recording.mov` with actual desktop content
- [ ] Verify screenshots still work (screencapture -x, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
