### PR TITLE
fix: exclude feature-flags from vellum npm package

### DIFF
--- a/meta/package.json
+++ b/meta/package.json
@@ -5,6 +5,9 @@
   "bin": {
     "vellum": "./bin/vellum.js"
   },
+  "files": [
+    "bin"
+  ],
   "dependencies": {
     "@vellumai/assistant": "0.3.19",
     "@vellumai/cli": "0.3.19",


### PR DESCRIPTION
## Summary
- Added `"files": ["bin"]` to `meta/package.json` so only `bin/vellum.js` is published to npm.
- Previously there was no `files` field, so `feature-flags/` was included in the tarball.
- Verified with `npm pack --dry-run` — package now contains only `bin/vellum.js` + `package.json` (358B total).

## Test plan
- [x] `npm pack --dry-run` shows only `bin/vellum.js` and `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
