### PR TITLE
fix: mark invite-intercepted inbound events as processed

### DIFF
--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1521,6 +1521,7 @@ async function handleInviteTokenIntercept(params: {
         log.error({ err, externalChatId }, 'Failed to deliver invite already-member reply');
       }
     }
+    channelDeliveryStore.markProcessed(dedupResult.eventId);
     return Response.json({ accepted: true, eventId: dedupResult.eventId, inviteRedemption: 'already_member' });
   }
 
@@ -1539,10 +1540,12 @@ async function handleInviteTokenIntercept(params: {
   }
 
   if (outcome.ok && outcome.type === 'redeemed') {
+    channelDeliveryStore.markProcessed(dedupResult.eventId);
     return Response.json({ accepted: true, eventId: dedupResult.eventId, inviteRedemption: 'redeemed', memberId: outcome.memberId });
   }
 
   // Failed redemption — inform the user and deny
+  channelDeliveryStore.markProcessed(dedupResult.eventId);
   return Response.json({ accepted: true, eventId: dedupResult.eventId, denied: true, inviteRedemption: outcome.reason });
 }
 


### PR DESCRIPTION
## Summary
- `handleInviteTokenIntercept` records inbound events for dedup via `recordInbound()` but never called `markProcessed()`, leaving events permanently stuck with `processing_status='pending'`
- Added `channelDeliveryStore.markProcessed()` to all three terminal return paths: already_member, redeemed, and failed redemption
- Aligns invite intercept behavior with the normal inbound pipeline in `processChannelMessageInBackground`

## Original prompt
fix the last remaining issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
