### PR TITLE
fix(parental): compact centered Switch Mode modal

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1681,7 +1681,7 @@ private struct ProfileSwitchModal: View {
     private var isChildToParental: Bool { activeProfile == "child" }
 
     var body: some View {
-        VStack(spacing: VSpacing.xl) {
+        VStack(spacing: VSpacing.md) {
             // Title
             Text(isChildToParental ? "Switch to Parental Mode" : "Switch to Restricted Mode")
                 .font(VFont.headline)
@@ -1718,7 +1718,7 @@ private struct ProfileSwitchModal: View {
     }
 
     private var enterPINContent: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
+        VStack(alignment: .center, spacing: VSpacing.md) {
             if isChildToParental {
                 PINCircleField(text: $pin)
                     .frame(maxWidth: .infinity, alignment: .center)
@@ -1757,7 +1757,7 @@ private struct ProfileSwitchModal: View {
                 .foregroundColor(VColor.textSecondary)
         }
         .frame(maxWidth: .infinity, alignment: .center)
-        .padding(.vertical, VSpacing.xl)
+        .padding(.vertical, VSpacing.sm)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

- Fixed modal body VStack spacing from `VSpacing.xl` (24pt) to `VSpacing.md` (12pt) — reduces excessive gaps between title, icons row, and content area
- Fixed `enterPINContent` VStack alignment from `.leading` to `.center` — centers the PIN field, error text, and button row horizontally within the modal
- Fixed `switchingContent` vertical padding from `VSpacing.xl` (24pt) to `VSpacing.sm` (8pt) — eliminates the oversized spinner area

## Test plan

- [ ] Open the Switch Modes modal from child profile — confirm title, avatar icons row, PIN field, and Cancel/Switch Mode buttons are all centered, with tight uniform spacing
- [ ] Open the Switch Modes modal from parental profile — same check without PIN field; modal should be visibly more compact
- [ ] Enter wrong PIN — verify error message appears centered under the PIN field
- [ ] Trigger the switching state — confirm the spinner row is compact, not padded with excessive vertical space

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
