### PR TITLE
M1: Replace Guardian Request Schema with Canonical Domain

### DIFF
--- a/assistant/src/__tests__/canonical-guardian-store.test.ts
+++ b/assistant/src/__tests__/canonical-guardian-store.test.ts
@@ -1,0 +1,464 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'canonical-guardian-store-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  createCanonicalGuardianDelivery,
+  createCanonicalGuardianRequest,
+  getCanonicalGuardianRequest,
+  listCanonicalGuardianDeliveries,
+  listCanonicalGuardianRequests,
+  resolveCanonicalGuardianRequest,
+  updateCanonicalGuardianDelivery,
+  updateCanonicalGuardianRequest,
+} from '../memory/canonical-guardian-store.js';
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run('DELETE FROM canonical_guardian_deliveries');
+  db.run('DELETE FROM canonical_guardian_requests');
+}
+
+describe('canonical-guardian-store', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  afterAll(() => {
+    resetDb();
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  // ── createCanonicalGuardianRequest ────────────────────────────────
+
+  test('creates a request with all fields populated', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'voice',
+      sourceChannel: 'twilio',
+      conversationId: 'conv-1',
+      requesterExternalUserId: 'user-1',
+      guardianExternalUserId: 'guardian-1',
+      callSessionId: 'session-1',
+      pendingQuestionId: 'pq-1',
+      questionText: 'Can I run this tool?',
+      requestCode: 'ABC123',
+      toolName: 'file_edit',
+      inputDigest: 'sha256:deadbeef',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    expect(req.id).toBeTruthy();
+    expect(req.kind).toBe('tool_approval');
+    expect(req.sourceType).toBe('voice');
+    expect(req.sourceChannel).toBe('twilio');
+    expect(req.status).toBe('pending');
+    expect(req.toolName).toBe('file_edit');
+    expect(req.createdAt).toBeTruthy();
+    expect(req.updatedAt).toBeTruthy();
+  });
+
+  test('creates a request with minimal fields', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'access_request',
+      sourceType: 'channel',
+    });
+
+    expect(req.id).toBeTruthy();
+    expect(req.kind).toBe('access_request');
+    expect(req.sourceType).toBe('channel');
+    expect(req.sourceChannel).toBeNull();
+    expect(req.conversationId).toBeNull();
+    expect(req.toolName).toBeNull();
+    expect(req.status).toBe('pending');
+  });
+
+  // ── getCanonicalGuardianRequest ───────────────────────────────────
+
+  test('gets a request by ID', () => {
+    const created = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'voice',
+    });
+
+    const fetched = getCanonicalGuardianRequest(created.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.id).toBe(created.id);
+    expect(fetched!.kind).toBe('tool_approval');
+  });
+
+  test('returns null for nonexistent ID', () => {
+    const fetched = getCanonicalGuardianRequest('nonexistent');
+    expect(fetched).toBeNull();
+  });
+
+  // ── listCanonicalGuardianRequests ─────────────────────────────────
+
+  test('lists all requests with no filters', () => {
+    createCanonicalGuardianRequest({ kind: 'tool_approval', sourceType: 'voice' });
+    createCanonicalGuardianRequest({ kind: 'access_request', sourceType: 'channel' });
+
+    const all = listCanonicalGuardianRequests();
+    expect(all).toHaveLength(2);
+  });
+
+  test('filters by status', () => {
+    createCanonicalGuardianRequest({ kind: 'tool_approval', sourceType: 'voice' });
+    const req2 = createCanonicalGuardianRequest({ kind: 'access_request', sourceType: 'channel' });
+    updateCanonicalGuardianRequest(req2.id, { status: 'approved' });
+
+    const pending = listCanonicalGuardianRequests({ status: 'pending' });
+    expect(pending).toHaveLength(1);
+    expect(pending[0].kind).toBe('tool_approval');
+
+    const approved = listCanonicalGuardianRequests({ status: 'approved' });
+    expect(approved).toHaveLength(1);
+    expect(approved[0].kind).toBe('access_request');
+  });
+
+  test('filters by guardianExternalUserId', () => {
+    createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'voice',
+      guardianExternalUserId: 'guardian-A',
+    });
+    createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'voice',
+      guardianExternalUserId: 'guardian-B',
+    });
+
+    const filtered = listCanonicalGuardianRequests({ guardianExternalUserId: 'guardian-A' });
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].guardianExternalUserId).toBe('guardian-A');
+  });
+
+  test('filters by conversationId', () => {
+    createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'voice',
+      conversationId: 'conv-X',
+    });
+    createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'voice',
+      conversationId: 'conv-Y',
+    });
+
+    const filtered = listCanonicalGuardianRequests({ conversationId: 'conv-X' });
+    expect(filtered).toHaveLength(1);
+  });
+
+  test('filters by sourceType', () => {
+    createCanonicalGuardianRequest({ kind: 'tool_approval', sourceType: 'voice' });
+    createCanonicalGuardianRequest({ kind: 'tool_approval', sourceType: 'channel' });
+    createCanonicalGuardianRequest({ kind: 'tool_approval', sourceType: 'desktop' });
+
+    const voiceOnly = listCanonicalGuardianRequests({ sourceType: 'voice' });
+    expect(voiceOnly).toHaveLength(1);
+  });
+
+  test('filters by kind', () => {
+    createCanonicalGuardianRequest({ kind: 'tool_approval', sourceType: 'voice' });
+    createCanonicalGuardianRequest({ kind: 'pending_question', sourceType: 'voice' });
+    createCanonicalGuardianRequest({ kind: 'access_request', sourceType: 'channel' });
+
+    const toolOnly = listCanonicalGuardianRequests({ kind: 'tool_approval' });
+    expect(toolOnly).toHaveLength(1);
+  });
+
+  test('combines multiple filters', () => {
+    createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'voice',
+      guardianExternalUserId: 'guardian-A',
+    });
+    createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      guardianExternalUserId: 'guardian-A',
+    });
+    createCanonicalGuardianRequest({
+      kind: 'access_request',
+      sourceType: 'voice',
+      guardianExternalUserId: 'guardian-A',
+    });
+
+    const filtered = listCanonicalGuardianRequests({
+      kind: 'tool_approval',
+      sourceType: 'voice',
+      guardianExternalUserId: 'guardian-A',
+    });
+    expect(filtered).toHaveLength(1);
+  });
+
+  // ── updateCanonicalGuardianRequest ────────────────────────────────
+
+  test('updates request fields', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'voice',
+    });
+
+    const updated = updateCanonicalGuardianRequest(req.id, {
+      status: 'approved',
+      answerText: 'Looks good',
+      decidedByExternalUserId: 'guardian-1',
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('approved');
+    expect(updated!.answerText).toBe('Looks good');
+    expect(updated!.decidedByExternalUserId).toBe('guardian-1');
+    // updatedAt should have changed
+    expect(updated!.updatedAt).not.toBe(req.updatedAt);
+  });
+
+  test('returns null when updating nonexistent request', () => {
+    const updated = updateCanonicalGuardianRequest('nonexistent', { status: 'approved' });
+    expect(updated).toBeNull();
+  });
+
+  // ── resolveCanonicalGuardianRequest (CAS) ─────────────────────────
+
+  test('resolves a pending request to approved', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'voice',
+    });
+
+    const resolved = resolveCanonicalGuardianRequest(req.id, 'pending', {
+      status: 'approved',
+      answerText: 'Approved by guardian',
+      decidedByExternalUserId: 'guardian-1',
+    });
+
+    expect(resolved).not.toBeNull();
+    expect(resolved!.status).toBe('approved');
+    expect(resolved!.answerText).toBe('Approved by guardian');
+    expect(resolved!.decidedByExternalUserId).toBe('guardian-1');
+  });
+
+  test('resolves a pending request to denied', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+    });
+
+    const resolved = resolveCanonicalGuardianRequest(req.id, 'pending', {
+      status: 'denied',
+      answerText: 'Not allowed',
+    });
+
+    expect(resolved).not.toBeNull();
+    expect(resolved!.status).toBe('denied');
+  });
+
+  test('CAS fails when expectedStatus does not match', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'voice',
+    });
+
+    // Try to resolve with wrong expected status
+    const result = resolveCanonicalGuardianRequest(req.id, 'approved', {
+      status: 'denied',
+    });
+
+    expect(result).toBeNull();
+
+    // Verify the request is unchanged
+    const unchanged = getCanonicalGuardianRequest(req.id);
+    expect(unchanged!.status).toBe('pending');
+  });
+
+  test('CAS race condition: two concurrent resolves, only one succeeds', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'voice',
+    });
+
+    // First resolve succeeds
+    const first = resolveCanonicalGuardianRequest(req.id, 'pending', {
+      status: 'approved',
+      answerText: 'First approver',
+      decidedByExternalUserId: 'guardian-1',
+    });
+    expect(first).not.toBeNull();
+    expect(first!.status).toBe('approved');
+
+    // Second resolve fails because status is no longer 'pending'
+    const second = resolveCanonicalGuardianRequest(req.id, 'pending', {
+      status: 'denied',
+      answerText: 'Second denier',
+      decidedByExternalUserId: 'guardian-2',
+    });
+    expect(second).toBeNull();
+
+    // Verify the first decision stuck
+    const final = getCanonicalGuardianRequest(req.id);
+    expect(final!.status).toBe('approved');
+    expect(final!.answerText).toBe('First approver');
+    expect(final!.decidedByExternalUserId).toBe('guardian-1');
+  });
+
+  test('CAS returns null for nonexistent request', () => {
+    const result = resolveCanonicalGuardianRequest('nonexistent', 'pending', {
+      status: 'approved',
+    });
+    expect(result).toBeNull();
+  });
+
+  // ── Voice-originated and channel-originated request shapes ────────
+
+  test('voice-originated request shape is representable', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'pending_question',
+      sourceType: 'voice',
+      sourceChannel: 'twilio',
+      conversationId: 'conv-voice-1',
+      guardianExternalUserId: 'guardian-phone',
+      callSessionId: 'call-123',
+      pendingQuestionId: 'pq-456',
+      questionText: 'What is the gate code?',
+      requestCode: 'A1B2C3',
+      expiresAt: new Date(Date.now() + 30_000).toISOString(),
+    });
+
+    expect(req.sourceType).toBe('voice');
+    expect(req.callSessionId).toBe('call-123');
+    expect(req.pendingQuestionId).toBe('pq-456');
+    expect(req.requestCode).toBe('A1B2C3');
+  });
+
+  test('channel-originated request shape is representable', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      conversationId: 'conv-tg-1',
+      requesterExternalUserId: 'requester-tg-user',
+      guardianExternalUserId: 'guardian-tg-user',
+      toolName: 'execute_code',
+      inputDigest: 'sha256:abcdef',
+      expiresAt: new Date(Date.now() + 120_000).toISOString(),
+    });
+
+    expect(req.sourceType).toBe('channel');
+    expect(req.sourceChannel).toBe('telegram');
+    expect(req.requesterExternalUserId).toBe('requester-tg-user');
+    expect(req.toolName).toBe('execute_code');
+    // Voice-specific fields are null for channel requests
+    expect(req.callSessionId).toBeNull();
+    expect(req.pendingQuestionId).toBeNull();
+  });
+
+  test('desktop-originated request shape is representable', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'access_request',
+      sourceType: 'desktop',
+      conversationId: 'conv-desktop-1',
+      guardianExternalUserId: 'guardian-desktop',
+      questionText: 'User wants to access settings',
+    });
+
+    expect(req.sourceType).toBe('desktop');
+    expect(req.sourceChannel).toBeNull();
+    expect(req.callSessionId).toBeNull();
+  });
+
+  // ── Canonical Guardian Deliveries ─────────────────────────────────
+
+  test('creates and lists deliveries for a request', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'voice',
+    });
+
+    const d1 = createCanonicalGuardianDelivery({
+      requestId: req.id,
+      destinationChannel: 'telegram',
+      destinationChatId: 'chat-123',
+    });
+    const d2 = createCanonicalGuardianDelivery({
+      requestId: req.id,
+      destinationChannel: 'sms',
+      destinationChatId: 'chat-456',
+    });
+
+    expect(d1.id).toBeTruthy();
+    expect(d1.requestId).toBe(req.id);
+    expect(d1.destinationChannel).toBe('telegram');
+    expect(d1.status).toBe('pending');
+
+    const deliveries = listCanonicalGuardianDeliveries(req.id);
+    expect(deliveries).toHaveLength(2);
+    const channels = deliveries.map((d) => d.destinationChannel).sort();
+    expect(channels).toEqual(['sms', 'telegram']);
+  });
+
+  test('lists empty deliveries for a request with none', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'voice',
+    });
+
+    const deliveries = listCanonicalGuardianDeliveries(req.id);
+    expect(deliveries).toHaveLength(0);
+  });
+
+  test('updates delivery status', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'voice',
+    });
+    const delivery = createCanonicalGuardianDelivery({
+      requestId: req.id,
+      destinationChannel: 'telegram',
+    });
+
+    const updated = updateCanonicalGuardianDelivery(delivery.id, {
+      status: 'sent',
+      destinationMessageId: 'msg-789',
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('sent');
+    expect(updated!.destinationMessageId).toBe('msg-789');
+  });
+
+  test('returns null when updating nonexistent delivery', () => {
+    const updated = updateCanonicalGuardianDelivery('nonexistent', { status: 'sent' });
+    expect(updated).toBeNull();
+  });
+});

--- a/assistant/src/memory/canonical-guardian-store.ts
+++ b/assistant/src/memory/canonical-guardian-store.ts
@@ -1,0 +1,354 @@
+/**
+ * Store for canonical guardian requests and deliveries.
+ *
+ * Unifies voice guardian action requests/deliveries and channel guardian
+ * approval requests into a single persistence model.  Resolution uses
+ * compare-and-swap (CAS) semantics: the first writer to transition a
+ * request from the expected status wins.
+ */
+
+import { and, eq } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+
+import { getDb, rawChanges } from './db.js';
+import {
+  canonicalGuardianDeliveries,
+  canonicalGuardianRequests,
+} from './schema.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type CanonicalRequestStatus = 'pending' | 'approved' | 'denied' | 'expired' | 'cancelled';
+
+export interface CanonicalGuardianRequest {
+  id: string;
+  kind: string;
+  sourceType: string;
+  sourceChannel: string | null;
+  conversationId: string | null;
+  requesterExternalUserId: string | null;
+  guardianExternalUserId: string | null;
+  callSessionId: string | null;
+  pendingQuestionId: string | null;
+  questionText: string | null;
+  requestCode: string | null;
+  toolName: string | null;
+  inputDigest: string | null;
+  status: CanonicalRequestStatus;
+  answerText: string | null;
+  decidedByExternalUserId: string | null;
+  followupState: string | null;
+  expiresAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CanonicalGuardianDelivery {
+  id: string;
+  requestId: string;
+  destinationChannel: string;
+  destinationConversationId: string | null;
+  destinationChatId: string | null;
+  destinationMessageId: string | null;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function rowToRequest(row: typeof canonicalGuardianRequests.$inferSelect): CanonicalGuardianRequest {
+  return {
+    id: row.id,
+    kind: row.kind,
+    sourceType: row.sourceType,
+    sourceChannel: row.sourceChannel,
+    conversationId: row.conversationId,
+    requesterExternalUserId: row.requesterExternalUserId,
+    guardianExternalUserId: row.guardianExternalUserId,
+    callSessionId: row.callSessionId,
+    pendingQuestionId: row.pendingQuestionId,
+    questionText: row.questionText,
+    requestCode: row.requestCode,
+    toolName: row.toolName,
+    inputDigest: row.inputDigest,
+    status: row.status as CanonicalRequestStatus,
+    answerText: row.answerText,
+    decidedByExternalUserId: row.decidedByExternalUserId,
+    followupState: row.followupState,
+    expiresAt: row.expiresAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function rowToDelivery(row: typeof canonicalGuardianDeliveries.$inferSelect): CanonicalGuardianDelivery {
+  return {
+    id: row.id,
+    requestId: row.requestId,
+    destinationChannel: row.destinationChannel,
+    destinationConversationId: row.destinationConversationId,
+    destinationChatId: row.destinationChatId,
+    destinationMessageId: row.destinationMessageId,
+    status: row.status,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Canonical Guardian Requests
+// ---------------------------------------------------------------------------
+
+export interface CreateCanonicalGuardianRequestParams {
+  id?: string;
+  kind: string;
+  sourceType: string;
+  sourceChannel?: string;
+  conversationId?: string;
+  requesterExternalUserId?: string;
+  guardianExternalUserId?: string;
+  callSessionId?: string;
+  pendingQuestionId?: string;
+  questionText?: string;
+  requestCode?: string;
+  toolName?: string;
+  inputDigest?: string;
+  status?: CanonicalRequestStatus;
+  answerText?: string;
+  decidedByExternalUserId?: string;
+  followupState?: string;
+  expiresAt?: string;
+}
+
+export function createCanonicalGuardianRequest(params: CreateCanonicalGuardianRequestParams): CanonicalGuardianRequest {
+  const db = getDb();
+  const now = new Date().toISOString();
+  const id = params.id ?? uuid();
+
+  const row = {
+    id,
+    kind: params.kind,
+    sourceType: params.sourceType,
+    sourceChannel: params.sourceChannel ?? null,
+    conversationId: params.conversationId ?? null,
+    requesterExternalUserId: params.requesterExternalUserId ?? null,
+    guardianExternalUserId: params.guardianExternalUserId ?? null,
+    callSessionId: params.callSessionId ?? null,
+    pendingQuestionId: params.pendingQuestionId ?? null,
+    questionText: params.questionText ?? null,
+    requestCode: params.requestCode ?? null,
+    toolName: params.toolName ?? null,
+    inputDigest: params.inputDigest ?? null,
+    status: params.status ?? ('pending' as const),
+    answerText: params.answerText ?? null,
+    decidedByExternalUserId: params.decidedByExternalUserId ?? null,
+    followupState: params.followupState ?? null,
+    expiresAt: params.expiresAt ?? null,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  db.insert(canonicalGuardianRequests).values(row).run();
+  return rowToRequest(row);
+}
+
+export function getCanonicalGuardianRequest(id: string): CanonicalGuardianRequest | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(canonicalGuardianRequests)
+    .where(eq(canonicalGuardianRequests.id, id))
+    .get();
+  return row ? rowToRequest(row) : null;
+}
+
+export interface ListCanonicalGuardianRequestsFilters {
+  status?: CanonicalRequestStatus;
+  guardianExternalUserId?: string;
+  conversationId?: string;
+  sourceType?: string;
+  kind?: string;
+}
+
+export function listCanonicalGuardianRequests(filters?: ListCanonicalGuardianRequestsFilters): CanonicalGuardianRequest[] {
+  const db = getDb();
+
+  const conditions = [];
+  if (filters?.status) {
+    conditions.push(eq(canonicalGuardianRequests.status, filters.status));
+  }
+  if (filters?.guardianExternalUserId) {
+    conditions.push(eq(canonicalGuardianRequests.guardianExternalUserId, filters.guardianExternalUserId));
+  }
+  if (filters?.conversationId) {
+    conditions.push(eq(canonicalGuardianRequests.conversationId, filters.conversationId));
+  }
+  if (filters?.sourceType) {
+    conditions.push(eq(canonicalGuardianRequests.sourceType, filters.sourceType));
+  }
+  if (filters?.kind) {
+    conditions.push(eq(canonicalGuardianRequests.kind, filters.kind));
+  }
+
+  if (conditions.length === 0) {
+    return db.select().from(canonicalGuardianRequests).all().map(rowToRequest);
+  }
+
+  return db
+    .select()
+    .from(canonicalGuardianRequests)
+    .where(and(...conditions))
+    .all()
+    .map(rowToRequest);
+}
+
+export interface UpdateCanonicalGuardianRequestParams {
+  status?: CanonicalRequestStatus;
+  answerText?: string;
+  decidedByExternalUserId?: string;
+  followupState?: string;
+  expiresAt?: string;
+}
+
+export function updateCanonicalGuardianRequest(
+  id: string,
+  updates: UpdateCanonicalGuardianRequestParams,
+): CanonicalGuardianRequest | null {
+  const db = getDb();
+  const now = new Date().toISOString();
+
+  const setValues: Record<string, unknown> = { updatedAt: now };
+  if (updates.status !== undefined) setValues.status = updates.status;
+  if (updates.answerText !== undefined) setValues.answerText = updates.answerText;
+  if (updates.decidedByExternalUserId !== undefined) setValues.decidedByExternalUserId = updates.decidedByExternalUserId;
+  if (updates.followupState !== undefined) setValues.followupState = updates.followupState;
+  if (updates.expiresAt !== undefined) setValues.expiresAt = updates.expiresAt;
+
+  db.update(canonicalGuardianRequests)
+    .set(setValues)
+    .where(eq(canonicalGuardianRequests.id, id))
+    .run();
+
+  return getCanonicalGuardianRequest(id);
+}
+
+export interface ResolveDecision {
+  status: CanonicalRequestStatus;
+  answerText?: string;
+  decidedByExternalUserId?: string;
+}
+
+/**
+ * Compare-and-swap resolve: only transitions the request from `expectedStatus`
+ * to the new status atomically. Returns the updated request on success, or
+ * null if the current status did not match `expectedStatus` (first-writer-wins).
+ */
+export function resolveCanonicalGuardianRequest(
+  id: string,
+  expectedStatus: CanonicalRequestStatus,
+  decision: ResolveDecision,
+): CanonicalGuardianRequest | null {
+  const db = getDb();
+  const now = new Date().toISOString();
+
+  const setValues: Record<string, unknown> = {
+    status: decision.status,
+    updatedAt: now,
+  };
+  if (decision.answerText !== undefined) setValues.answerText = decision.answerText;
+  if (decision.decidedByExternalUserId !== undefined) setValues.decidedByExternalUserId = decision.decidedByExternalUserId;
+
+  db.update(canonicalGuardianRequests)
+    .set(setValues)
+    .where(
+      and(
+        eq(canonicalGuardianRequests.id, id),
+        eq(canonicalGuardianRequests.status, expectedStatus),
+      ),
+    )
+    .run();
+
+  if (rawChanges() === 0) return null;
+
+  return getCanonicalGuardianRequest(id);
+}
+
+// ---------------------------------------------------------------------------
+// Canonical Guardian Deliveries
+// ---------------------------------------------------------------------------
+
+export interface CreateCanonicalGuardianDeliveryParams {
+  id?: string;
+  requestId: string;
+  destinationChannel: string;
+  destinationConversationId?: string;
+  destinationChatId?: string;
+  destinationMessageId?: string;
+  status?: string;
+}
+
+export function createCanonicalGuardianDelivery(params: CreateCanonicalGuardianDeliveryParams): CanonicalGuardianDelivery {
+  const db = getDb();
+  const now = new Date().toISOString();
+  const id = params.id ?? uuid();
+
+  const row = {
+    id,
+    requestId: params.requestId,
+    destinationChannel: params.destinationChannel,
+    destinationConversationId: params.destinationConversationId ?? null,
+    destinationChatId: params.destinationChatId ?? null,
+    destinationMessageId: params.destinationMessageId ?? null,
+    status: params.status ?? ('pending' as const),
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  db.insert(canonicalGuardianDeliveries).values(row).run();
+  return rowToDelivery(row);
+}
+
+export function listCanonicalGuardianDeliveries(requestId: string): CanonicalGuardianDelivery[] {
+  const db = getDb();
+  return db
+    .select()
+    .from(canonicalGuardianDeliveries)
+    .where(eq(canonicalGuardianDeliveries.requestId, requestId))
+    .all()
+    .map(rowToDelivery);
+}
+
+export interface UpdateCanonicalGuardianDeliveryParams {
+  status?: string;
+  destinationMessageId?: string;
+}
+
+export function updateCanonicalGuardianDelivery(
+  id: string,
+  updates: UpdateCanonicalGuardianDeliveryParams,
+): CanonicalGuardianDelivery | null {
+  const db = getDb();
+  const now = new Date().toISOString();
+
+  const setValues: Record<string, unknown> = { updatedAt: now };
+  if (updates.status !== undefined) setValues.status = updates.status;
+  if (updates.destinationMessageId !== undefined) setValues.destinationMessageId = updates.destinationMessageId;
+
+  db.update(canonicalGuardianDeliveries)
+    .set(setValues)
+    .where(eq(canonicalGuardianDeliveries.id, id))
+    .run();
+
+  const row = db
+    .select()
+    .from(canonicalGuardianDeliveries)
+    .where(eq(canonicalGuardianDeliveries.id, id))
+    .get();
+
+  return row ? rowToDelivery(row) : null;
+}

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -3,6 +3,7 @@ import {
   addCoreColumns,
   createAssistantInboxTables,
   createCallSessionsTables,
+  createCanonicalGuardianTables,
   createChannelGuardianTables,
   createContactsAndTriageTables,
   createConversationAttentionTables,
@@ -144,6 +145,9 @@ export function initializeDb(): void {
 
   // 23. Thread decision audit columns on notification_deliveries
   migrateNotificationDeliveryThreadDecision(database);
+
+  // 24. Canonical guardian requests and deliveries (unified cross-source guardian domain)
+  createCanonicalGuardianTables(database);
 
   validateMigrationState(database);
 }

--- a/assistant/src/memory/migrations/121-canonical-guardian-requests.ts
+++ b/assistant/src/memory/migrations/121-canonical-guardian-requests.ts
@@ -1,0 +1,59 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Create canonical_guardian_requests and canonical_guardian_deliveries tables.
+ *
+ * These tables unify the split voice (guardian_action_requests / guardian_action_deliveries)
+ * and channel (channel_guardian_approval_requests) persistence models into a single
+ * canonical domain. Uses CREATE TABLE IF NOT EXISTS for idempotency.
+ */
+export function createCanonicalGuardianTables(database: DrizzleDb): void {
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS canonical_guardian_requests (
+      id TEXT PRIMARY KEY,
+      kind TEXT NOT NULL,
+      source_type TEXT NOT NULL,
+      source_channel TEXT,
+      conversation_id TEXT,
+      requester_external_user_id TEXT,
+      guardian_external_user_id TEXT,
+      call_session_id TEXT,
+      pending_question_id TEXT,
+      question_text TEXT,
+      request_code TEXT,
+      tool_name TEXT,
+      input_digest TEXT,
+      status TEXT NOT NULL DEFAULT 'pending',
+      answer_text TEXT,
+      decided_by_external_user_id TEXT,
+      followup_state TEXT,
+      expires_at TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_status ON canonical_guardian_requests(status)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_guardian ON canonical_guardian_requests(guardian_external_user_id, status)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_conversation ON canonical_guardian_requests(conversation_id, status)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_source ON canonical_guardian_requests(source_type, status)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_kind ON canonical_guardian_requests(kind, status)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_request_code ON canonical_guardian_requests(request_code)`);
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS canonical_guardian_deliveries (
+      id TEXT PRIMARY KEY,
+      request_id TEXT NOT NULL REFERENCES canonical_guardian_requests(id) ON DELETE CASCADE,
+      destination_channel TEXT NOT NULL,
+      destination_conversation_id TEXT,
+      destination_chat_id TEXT,
+      destination_message_id TEXT,
+      status TEXT NOT NULL DEFAULT 'pending',
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_deliveries_request_id ON canonical_guardian_deliveries(request_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_deliveries_status ON canonical_guardian_deliveries(status)`);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -58,6 +58,7 @@ export { createConversationAttentionTables } from './117-conversation-attention.
 export { migrateReminderRoutingIntent } from './118-reminder-routing-intent.js';
 export { migrateSchemaIndexesAndColumns } from './119-schema-indexes-and-columns.js';
 export { migrateFkCascadeRebuilds } from './120-fk-cascade-rebuilds.js';
+export { createCanonicalGuardianTables } from './121-canonical-guardian-requests.js';
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -874,6 +874,57 @@ export const guardianActionDeliveries = sqliteTable('guardian_action_deliveries'
   index('idx_guardian_action_deliveries_dest_conversation').on(table.destinationConversationId),
 ]);
 
+// ── Canonical Guardian Requests (unified cross-source guardian domain) ─
+
+export const canonicalGuardianRequests = sqliteTable('canonical_guardian_requests', {
+  id: text('id').primaryKey(),
+  kind: text('kind').notNull(),
+  sourceType: text('source_type').notNull(),
+  sourceChannel: text('source_channel'),
+  conversationId: text('conversation_id'),
+  requesterExternalUserId: text('requester_external_user_id'),
+  guardianExternalUserId: text('guardian_external_user_id'),
+  callSessionId: text('call_session_id'),
+  pendingQuestionId: text('pending_question_id'),
+  questionText: text('question_text'),
+  requestCode: text('request_code'),
+  toolName: text('tool_name'),
+  inputDigest: text('input_digest'),
+  status: text('status').notNull().default('pending'),
+  answerText: text('answer_text'),
+  decidedByExternalUserId: text('decided_by_external_user_id'),
+  followupState: text('followup_state'),
+  expiresAt: text('expires_at'),
+  createdAt: text('created_at').notNull(),
+  updatedAt: text('updated_at').notNull(),
+}, (table) => [
+  index('idx_canonical_guardian_requests_status').on(table.status),
+  index('idx_canonical_guardian_requests_guardian').on(table.guardianExternalUserId, table.status),
+  index('idx_canonical_guardian_requests_conversation').on(table.conversationId, table.status),
+  index('idx_canonical_guardian_requests_source').on(table.sourceType, table.status),
+  index('idx_canonical_guardian_requests_kind').on(table.kind, table.status),
+  index('idx_canonical_guardian_requests_request_code').on(table.requestCode),
+]);
+
+// ── Canonical Guardian Deliveries (per-channel delivery tracking) ─────
+
+export const canonicalGuardianDeliveries = sqliteTable('canonical_guardian_deliveries', {
+  id: text('id').primaryKey(),
+  requestId: text('request_id')
+    .notNull()
+    .references(() => canonicalGuardianRequests.id, { onDelete: 'cascade' }),
+  destinationChannel: text('destination_channel').notNull(),
+  destinationConversationId: text('destination_conversation_id'),
+  destinationChatId: text('destination_chat_id'),
+  destinationMessageId: text('destination_message_id'),
+  status: text('status').notNull().default('pending'),
+  createdAt: text('created_at').notNull(),
+  updatedAt: text('updated_at').notNull(),
+}, (table) => [
+  index('idx_canonical_guardian_deliveries_request_id').on(table.requestId),
+  index('idx_canonical_guardian_deliveries_status').on(table.status),
+]);
+
 // ── Assistant Inbox ──────────────────────────────────────────────────
 
 export const assistantIngressInvites = sqliteTable('assistant_ingress_invites', {


### PR DESCRIPTION
Introduces canonical_guardian_requests and canonical_guardian_deliveries tables with unified store APIs supporting create/list/get/update/CAS-resolve operations. Part of #10437.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
