### PR TITLE
Route Telegram and ingress control-plane APIs through gateway

### DIFF
--- a/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
@@ -12,7 +12,7 @@ You are helping your user connect a Telegram bot to the Vellum Assistant gateway
 
 Before beginning setup, verify these conditions are met:
 
-1. **Gateway API is reachable:** Run `TOKEN=$(cat ~/.vellum/http-token) && curl -sf http://localhost:7830/v1/health -H "Authorization: Bearer $TOKEN"` — it should return health JSON (for example `{"status":"healthy",...}`). If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
+1. **Gateway API is reachable:** Run `curl -sf http://localhost:7830/healthz` — it should return gateway health JSON (for example `{"status":"ok"}`). If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
 2. **Public ingress URL is configured.** The gateway webhook URL is derived from `${ingress.publicBaseUrl}/webhooks/telegram`. If the ingress URL is not configured, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the URL before continuing.
 3. **Use gateway control-plane routes only.** Telegram setup/config actions in this skill must call gateway endpoints under `/v1/integrations/telegram/*` — never call the daemon runtime port directly.
 

--- a/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
@@ -12,7 +12,7 @@ You are helping your user connect a Telegram bot to the Vellum Assistant gateway
 
 Before beginning setup, verify these conditions are met:
 
-1. **Gateway + runtime are reachable through the gateway:** Run `TOKEN=$(cat ~/.vellum/http-token) && curl -sf http://localhost:7830/v1/health -H "Authorization: Bearer $TOKEN"` — it should return runtime health JSON (for example `{"status":"healthy",...}`). If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
+1. **Gateway API is reachable:** Run `TOKEN=$(cat ~/.vellum/http-token) && curl -sf http://localhost:7830/v1/health -H "Authorization: Bearer $TOKEN"` — it should return health JSON (for example `{"status":"healthy",...}`). If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
 2. **Public ingress URL is configured.** The gateway webhook URL is derived from `${ingress.publicBaseUrl}/webhooks/telegram`. If the ingress URL is not configured, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the URL before continuing.
 3. **Use gateway control-plane routes only.** Telegram setup/config actions in this skill must call gateway endpoints under `/v1/integrations/telegram/*` — never call the daemon runtime port directly.
 

--- a/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
@@ -12,7 +12,7 @@ You are helping your user connect a Telegram bot to the Vellum Assistant gateway
 
 Before beginning setup, verify these conditions are met:
 
-1. **Gateway API is reachable:** Run `curl -sf http://localhost:7830/healthz` — it should return gateway health JSON (for example `{"status":"ok"}`). If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
+1. **Gateway API base URL is set and reachable:** Use the configured gateway URL in `GATEWAY_BASE_URL` (from Settings "Local Gateway Target"), then run `curl -sf "$GATEWAY_BASE_URL/healthz"` — it should return gateway health JSON (for example `{"status":"ok"}`). If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
 2. **Public ingress URL is configured.** The gateway webhook URL is derived from `${ingress.publicBaseUrl}/webhooks/telegram`. If the ingress URL is not configured, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the URL before continuing.
 3. **Use gateway control-plane routes only.** Telegram setup/config actions in this skill must call gateway endpoints under `/v1/integrations/telegram/*` — never call the daemon runtime port directly.
 
@@ -37,7 +37,7 @@ The token is collected securely via a system-level prompt and is never exposed i
 After the token is collected, call the composite setup endpoint which validates the token, stores credentials, and registers bot commands in a single request:
 
 ```bash
-curl -sf -X POST http://localhost:7830/v1/integrations/telegram/setup \
+curl -sf -X POST "$GATEWAY_BASE_URL/v1/integrations/telegram/setup" \
   -H "Authorization: Bearer $(cat ~/.vellum/http-token)" \
   -H "Content-Type: application/json" \
   -d '{}'
@@ -98,7 +98,7 @@ If routing is misconfigured, inbound Telegram messages will be rejected and the 
 Before reporting success, confirm the guardian binding was actually created. Check the guardian binding status:
 
 ```bash
-curl -sf http://localhost:7830/v1/integrations/guardian/status?channel=telegram \
+curl -sf "$GATEWAY_BASE_URL/v1/integrations/guardian/status?channel=telegram" \
   -H "Authorization: Bearer $(cat ~/.vellum/http-token)"
 ```
 
@@ -117,7 +117,7 @@ Summarize what was done:
 - Guardian identity: {verified | not configured}
 - Guardian verification status: {verified via outbound flow | skipped}
 - Routing configuration validated
-- To re-check guardian status later, use: `curl -sf http://localhost:7830/v1/integrations/guardian/status?channel=telegram -H "Authorization: Bearer $(cat ~/.vellum/http-token)"`
+- To re-check guardian status later, use: `curl -sf "$GATEWAY_BASE_URL/v1/integrations/guardian/status?channel=telegram" -H "Authorization: Bearer $(cat ~/.vellum/http-token)"`
 
 The gateway automatically detects credentials from the vault, reconciles the Telegram webhook registration, and begins accepting Telegram webhooks shortly. In single-assistant mode, routing is automatically configured — no manual environment variable configuration or webhook registration is needed. If the webhook secret changes later, the gateway's credential watcher will automatically re-register the webhook. If the ingress URL changes (e.g., tunnel restart), the assistant daemon triggers an immediate internal reconcile so the webhook re-registers automatically without a gateway restart.
 

--- a/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
@@ -14,6 +14,7 @@ Before beginning setup, verify these conditions are met:
 
 1. **Gateway is running:** Run `curl -sf http://localhost:7830/healthz` — it should return OK. If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
 2. **Public ingress URL is configured.** The gateway webhook URL is derived from `${ingress.publicBaseUrl}/webhooks/telegram`. If the ingress URL is not configured, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the URL before continuing.
+3. **Use gateway control-plane routes only.** Telegram setup/config actions in this skill must call gateway endpoints under `/v1/integrations/telegram/*` — never call the daemon runtime port directly.
 
 ## What You Need
 

--- a/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
@@ -12,7 +12,7 @@ You are helping your user connect a Telegram bot to the Vellum Assistant gateway
 
 Before beginning setup, verify these conditions are met:
 
-1. **Gateway is running:** Run `curl -sf http://localhost:7830/healthz` — it should return OK. If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
+1. **Gateway + runtime are reachable through the gateway:** Run `TOKEN=$(cat ~/.vellum/http-token) && curl -sf http://localhost:7830/v1/health -H "Authorization: Bearer $TOKEN"` — it should return runtime health JSON (for example `{"status":"healthy",...}`). If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
 2. **Public ingress URL is configured.** The gateway webhook URL is derived from `${ingress.publicBaseUrl}/webhooks/telegram`. If the ingress URL is not configured, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the URL before continuing.
 3. **Use gateway control-plane routes only.** Telegram setup/config actions in this skill must call gateway endpoints under `/v1/integrations/telegram/*` — never call the daemon runtime port directly.
 

--- a/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
+++ b/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
@@ -10,6 +10,7 @@ You are helping your user manage trusted contacts and invite links for the Vellu
 ## Prerequisites
 
 - The gateway API is available at `http://localhost:7830` (or the configured gateway port).
+- Use gateway control-plane routes only: this skill calls `/v1/ingress/*` and `/v1/integrations/telegram/config` on the gateway, never the daemon runtime port directly.
 - The bearer token is stored at `~/.vellum/http-token`. Read it with: `TOKEN=$(cat ~/.vellum/http-token)`.
 
 ## Concepts

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -99,6 +99,43 @@ Guardian verification endpoints are exposed directly by the gateway and forwarde
 | `gateway/src/http/routes/guardian-control-plane-proxy.ts` | Guardian control-plane proxy handlers and upstream forwarding |
 | `gateway/src/index.ts` | Route registration and bearer-auth enforcement for `/v1/integrations/guardian/*` |
 
+### Telegram + Ingress Control-Plane Proxies
+
+Telegram integration setup/config endpoints and ingress members/invites endpoints are also exposed directly by the gateway and forwarded to runtime handlers even when the broad runtime proxy is disabled.
+
+**Forwarded Telegram endpoints:**
+
+| Method | Path |
+|--------|------|
+| GET/POST/DELETE | `/v1/integrations/telegram/config` |
+| POST | `/v1/integrations/telegram/commands` |
+| POST | `/v1/integrations/telegram/setup` |
+
+**Forwarded ingress endpoints:**
+
+| Method | Path |
+|--------|------|
+| GET/POST | `/v1/ingress/members` |
+| DELETE | `/v1/ingress/members/:memberId` |
+| POST | `/v1/ingress/members/:memberId/block` |
+| GET/POST | `/v1/ingress/invites` |
+| DELETE | `/v1/ingress/invites/:inviteId` |
+| POST | `/v1/ingress/invites/redeem` |
+
+**Authentication boundary:**
+
+- Gateway validates caller bearer auth against the runtime token.
+- Gateway forwards requests to runtime with the runtime bearer token and `X-Gateway-Origin` proof header.
+- Upstream 4xx/5xx responses are passed through, while connection errors return `502` and timeouts return `504`.
+
+**Key source files:**
+
+| File | Purpose |
+|------|---------|
+| `gateway/src/http/routes/telegram-control-plane-proxy.ts` | Telegram control-plane proxy handlers and upstream forwarding |
+| `gateway/src/http/routes/ingress-control-plane-proxy.ts` | Ingress control-plane proxy handlers and upstream forwarding |
+| `gateway/src/index.ts` | Route registration and bearer-auth enforcement for `/v1/integrations/telegram/*` and `/v1/ingress/*` |
+
 ### Channel Binding Lifecycle (Lane Separation)
 
 Each channel (desktop, Telegram, etc.) operates in its own **lane**: conversations created by an external channel are never displayed in the desktop thread list, and desktop conversations are never exposed to external channels. The `channelBinding` metadata on a conversation is used solely for routing inbound/outbound messages within that lane and for filtering sessions during desktop session restoration.

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -25,6 +25,7 @@ Internet
        v
      Gateway (http://127.0.0.1:7830)
        |
+       +-- Dedicated /v1/health --> Runtime /v1/health
        +-- Runtime proxy /v1/* --> Runtime (http://127.0.0.1:7821)
        +-- /webhooks/* --> BLOCKED (404, never forwarded to runtime)
 ```
@@ -98,6 +99,23 @@ Guardian verification endpoints are exposed directly by the gateway and forwarde
 |------|---------|
 | `gateway/src/http/routes/guardian-control-plane-proxy.ts` | Guardian control-plane proxy handlers and upstream forwarding |
 | `gateway/src/index.ts` | Route registration and bearer-auth enforcement for `/v1/integrations/guardian/*` |
+
+### Runtime Health Proxy
+
+Runtime health is exposed directly by the gateway at `GET /v1/health` and forwarded to the runtime's `GET /v1/health` endpoint even when the broad runtime proxy is disabled.
+
+**Authentication boundary:**
+
+- Gateway validates caller bearer auth against the runtime token.
+- Gateway forwards the request to runtime with the runtime bearer token and `X-Gateway-Origin` proof header.
+- Upstream 4xx/5xx responses are passed through, while connection errors return `502` and timeouts return `504`.
+
+**Key source files:**
+
+| File | Purpose |
+|------|---------|
+| `gateway/src/http/routes/runtime-health-proxy.ts` | Runtime health proxy handler and upstream forwarding |
+| `gateway/src/index.ts` | Route registration and bearer-auth enforcement for `/v1/health` |
 
 ### Telegram + Ingress Control-Plane Proxies
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -230,6 +230,7 @@ The gateway serves as the single public ingress point for all external callbacks
 | `/v1/ingress/invites` | GET/POST | Authenticated control-plane proxy for listing/creating ingress invites |
 | `/v1/ingress/invites/:id` | DELETE | Authenticated control-plane proxy for revoking an ingress invite |
 | `/v1/ingress/invites/redeem` | POST | Authenticated control-plane proxy for redeeming an ingress invite |
+| `/v1/health` | GET | Authenticated runtime health proxy (`/v1/health` on runtime) |
 | `/healthz` | GET | Liveness probe |
 | `/readyz` | GET | Readiness probe |
 | `/schema` | GET | Returns the OpenAPI 3.1 schema for this gateway |
@@ -299,7 +300,7 @@ When `INGRESS_PUBLIC_BASE_URL` is configured, the gateway prioritizes it as the 
 
 ## Default Mode: Dedicated Routes Only
 
-By default, the broad runtime proxy is disabled. Dedicated gateway-managed routes (webhooks, delivery endpoints, and explicit control-plane proxies such as `/v1/integrations/guardian/*`, `/v1/integrations/telegram/*`, and `/v1/ingress/*`) remain available, but arbitrary runtime passthrough routes return `404` unless `GATEWAY_RUNTIME_PROXY_ENABLED=true`.
+By default, the broad runtime proxy is disabled. Dedicated gateway-managed routes (webhooks, delivery endpoints, explicit control-plane proxies such as `/v1/integrations/guardian/*`, `/v1/integrations/telegram/*`, and `/v1/ingress/*`, plus the authenticated runtime health route `/v1/health`) remain available, but arbitrary runtime passthrough routes return `404` unless `GATEWAY_RUNTIME_PROXY_ENABLED=true`.
 
 ## Runtime Proxy Mode
 
@@ -349,6 +350,7 @@ Text and attachments are sent separately — the text reply goes first via `send
 
 | Endpoint | Method | Behavior |
 |----------|--------|----------|
+| `/v1/health` | GET | Authenticated proxy to runtime health (`/v1/health`) |
 | `/healthz` | GET | Always returns `200` while the process is alive |
 | `/readyz` | GET | Returns `200` while accepting traffic; `503` during graceful shutdown drain |
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -221,6 +221,15 @@ The gateway serves as the single public ingress point for all external callbacks
 | `/v1/integrations/guardian/outbound/start` | POST | Authenticated control-plane proxy for starting outbound guardian verification |
 | `/v1/integrations/guardian/outbound/resend` | POST | Authenticated control-plane proxy for resending outbound guardian verification |
 | `/v1/integrations/guardian/outbound/cancel` | POST | Authenticated control-plane proxy for cancelling outbound guardian verification |
+| `/v1/integrations/telegram/config` | GET/POST/DELETE | Authenticated control-plane proxy for Telegram integration config |
+| `/v1/integrations/telegram/commands` | POST | Authenticated control-plane proxy for Telegram command registration |
+| `/v1/integrations/telegram/setup` | POST | Authenticated control-plane proxy for Telegram setup orchestration |
+| `/v1/ingress/members` | GET/POST | Authenticated control-plane proxy for listing/upserting ingress members |
+| `/v1/ingress/members/:id` | DELETE | Authenticated control-plane proxy for revoking an ingress member |
+| `/v1/ingress/members/:id/block` | POST | Authenticated control-plane proxy for blocking an ingress member |
+| `/v1/ingress/invites` | GET/POST | Authenticated control-plane proxy for listing/creating ingress invites |
+| `/v1/ingress/invites/:id` | DELETE | Authenticated control-plane proxy for revoking an ingress invite |
+| `/v1/ingress/invites/redeem` | POST | Authenticated control-plane proxy for redeeming an ingress invite |
 | `/healthz` | GET | Liveness probe |
 | `/readyz` | GET | Readiness probe |
 | `/schema` | GET | Returns the OpenAPI 3.1 schema for this gateway |
@@ -290,7 +299,7 @@ When `INGRESS_PUBLIC_BASE_URL` is configured, the gateway prioritizes it as the 
 
 ## Default Mode: Dedicated Routes Only
 
-By default, the broad runtime proxy is disabled. Dedicated gateway-managed routes (webhooks, delivery endpoints, and explicit control-plane proxies such as `/v1/integrations/guardian/*`) remain available, but arbitrary runtime passthrough routes return `404` unless `GATEWAY_RUNTIME_PROXY_ENABLED=true`.
+By default, the broad runtime proxy is disabled. Dedicated gateway-managed routes (webhooks, delivery endpoints, and explicit control-plane proxies such as `/v1/integrations/guardian/*`, `/v1/integrations/telegram/*`, and `/v1/ingress/*`) remain available, but arbitrary runtime passthrough routes return `404` unless `GATEWAY_RUNTIME_PROXY_ENABLED=true`.
 
 ## Runtime Proxy Mode
 

--- a/gateway/src/__tests__/ingress-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/ingress-control-plane-proxy.test.ts
@@ -1,0 +1,180 @@
+import { describe, test, expect, mock, afterEach } from "bun:test";
+import type { GatewayConfig } from "../config.js";
+
+type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { createIngressControlPlaneProxyHandler } = await import(
+  "../http/routes/ingress-control-plane-proxy.js"
+);
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  const merged: GatewayConfig = {
+    telegramBotToken: "tok",
+    telegramWebhookSecret: "wh-ver",
+    telegramApiBaseUrl: "https://api.telegram.org",
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeBearerToken: "runtime-token",
+    runtimeGatewayOriginSecret: "gateway-origin",
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    runtimeProxyBearerToken: undefined,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
+    twilioAuthToken: undefined,
+    twilioAccountSid: undefined,
+    twilioPhoneNumber: undefined,
+    smsDeliverAuthBypass: false,
+    ingressPublicBaseUrl: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    whatsappPhoneNumberId: undefined,
+    whatsappAccessToken: undefined,
+    whatsappAppSecret: undefined,
+    whatsappWebhookVerifyToken: undefined,
+    whatsappDeliverAuthBypass: false,
+    whatsappTimeoutMs: 15000,
+    whatsappMaxRetries: 3,
+    whatsappInitialBackoffMs: 1000,
+    slackChannelBotToken: undefined,
+    slackChannelAppToken: undefined,
+    slackDeliverAuthBypass: false,
+    trustProxy: false,
+    ...overrides,
+  };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
+}
+
+afterEach(() => {
+  fetchMock = mock(async () => new Response());
+});
+
+describe("ingress control-plane proxy", () => {
+  test("forwards ingress endpoints to the runtime", async () => {
+    const captured: string[] = [];
+    fetchMock = mock(async (input: string | URL | Request) => {
+      captured.push(String(input));
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const handler = createIngressControlPlaneProxyHandler(makeConfig());
+
+    await handler.handleListMembers(
+      new Request("http://localhost:7830/v1/ingress/members?sourceChannel=telegram"),
+    );
+    await handler.handleUpsertMember(
+      new Request("http://localhost:7830/v1/ingress/members", { method: "POST" }),
+    );
+    await handler.handleRevokeMember(
+      new Request("http://localhost:7830/v1/ingress/members/mbr_123", { method: "DELETE" }),
+      "mbr_123",
+    );
+    await handler.handleBlockMember(
+      new Request("http://localhost:7830/v1/ingress/members/mbr_123/block", { method: "POST" }),
+      "mbr_123",
+    );
+    await handler.handleListInvites(
+      new Request("http://localhost:7830/v1/ingress/invites?status=active"),
+    );
+    await handler.handleCreateInvite(
+      new Request("http://localhost:7830/v1/ingress/invites", { method: "POST" }),
+    );
+    await handler.handleRedeemInvite(
+      new Request("http://localhost:7830/v1/ingress/invites/redeem", { method: "POST" }),
+    );
+    await handler.handleRevokeInvite(
+      new Request("http://localhost:7830/v1/ingress/invites/inv_123", { method: "DELETE" }),
+      "inv_123",
+    );
+
+    expect(captured).toEqual([
+      "http://localhost:7821/v1/ingress/members?sourceChannel=telegram",
+      "http://localhost:7821/v1/ingress/members",
+      "http://localhost:7821/v1/ingress/members/mbr_123",
+      "http://localhost:7821/v1/ingress/members/mbr_123/block",
+      "http://localhost:7821/v1/ingress/invites?status=active",
+      "http://localhost:7821/v1/ingress/invites",
+      "http://localhost:7821/v1/ingress/invites/redeem",
+      "http://localhost:7821/v1/ingress/invites/inv_123",
+    ]);
+  });
+
+  test("replaces caller auth with runtime auth and forwards gateway-origin proof", async () => {
+    let capturedHeaders: Headers | undefined;
+    fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+      capturedHeaders = init?.headers as unknown as Headers;
+      return new Response("ok", { status: 200 });
+    });
+
+    const handler = createIngressControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleUpsertMember(
+      new Request("http://localhost:7830/v1/ingress/members", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer caller-token",
+          host: "localhost:7830",
+        },
+        body: JSON.stringify({ sourceChannel: "telegram", externalUserId: "u_1" }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(capturedHeaders?.get("authorization")).toBe("Bearer runtime-token");
+    expect(capturedHeaders?.get("X-Gateway-Origin")).toBe("gateway-origin");
+    expect(capturedHeaders?.has("host")).toBe(false);
+  });
+
+  test("passes through upstream client errors", async () => {
+    fetchMock = mock(async () => {
+      return new Response(JSON.stringify({ ok: false, error: "sourceChannel is required" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const handler = createIngressControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleCreateInvite(
+      new Request("http://localhost:7830/v1/ingress/invites", { method: "POST" }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ ok: false, error: "sourceChannel is required" });
+  });
+
+  test("returns 504 when upstream times out", async () => {
+    fetchMock = mock(async () => {
+      throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+    });
+
+    const handler = createIngressControlPlaneProxyHandler(makeConfig({ runtimeTimeoutMs: 100 }));
+    const res = await handler.handleListMembers(
+      new Request("http://localhost:7830/v1/ingress/members"),
+    );
+
+    expect(res.status).toBe(504);
+    expect(await res.json()).toEqual({ error: "Gateway Timeout" });
+  });
+});

--- a/gateway/src/__tests__/ingress-control-plane-route-match.test.ts
+++ b/gateway/src/__tests__/ingress-control-plane-route-match.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { matchIngressControlPlaneRoute } from "../http/routes/ingress-control-plane-route-match.js";
+
+describe("matchIngressControlPlaneRoute", () => {
+  test("matches redeem invite only for POST", () => {
+    expect(matchIngressControlPlaneRoute("/v1/ingress/invites/redeem", "POST")).toEqual({
+      kind: "redeemInvite",
+    });
+
+    // DELETE should treat `redeem` as an invite ID so revoke routing still works.
+    expect(matchIngressControlPlaneRoute("/v1/ingress/invites/redeem", "DELETE")).toEqual({
+      kind: "revokeInvite",
+      inviteId: "redeem",
+    });
+  });
+
+  test("matches ingress member routes", () => {
+    expect(matchIngressControlPlaneRoute("/v1/ingress/members", "GET")).toEqual({
+      kind: "listMembers",
+    });
+    expect(matchIngressControlPlaneRoute("/v1/ingress/members", "POST")).toEqual({
+      kind: "upsertMember",
+    });
+    expect(matchIngressControlPlaneRoute("/v1/ingress/members/mbr_1/block", "POST")).toEqual({
+      kind: "blockMember",
+      memberId: "mbr_1",
+    });
+    expect(matchIngressControlPlaneRoute("/v1/ingress/members/mbr_1", "DELETE")).toEqual({
+      kind: "revokeMember",
+      memberId: "mbr_1",
+    });
+  });
+
+  test("matches ingress invite routes", () => {
+    expect(matchIngressControlPlaneRoute("/v1/ingress/invites", "GET")).toEqual({
+      kind: "listInvites",
+    });
+    expect(matchIngressControlPlaneRoute("/v1/ingress/invites", "POST")).toEqual({
+      kind: "createInvite",
+    });
+    expect(matchIngressControlPlaneRoute("/v1/ingress/invites/inv_1", "DELETE")).toEqual({
+      kind: "revokeInvite",
+      inviteId: "inv_1",
+    });
+  });
+
+  test("returns null for unsupported method/path combinations", () => {
+    expect(matchIngressControlPlaneRoute("/v1/ingress/invites/redeem", "GET")).toBeNull();
+    expect(matchIngressControlPlaneRoute("/v1/ingress/invites/inv_1", "POST")).toBeNull();
+    expect(matchIngressControlPlaneRoute("/v1/ingress/members/mbr_1", "POST")).toBeNull();
+    expect(matchIngressControlPlaneRoute("/v1/ingress/unknown", "GET")).toBeNull();
+  });
+});

--- a/gateway/src/__tests__/runtime-health-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-health-proxy.test.ts
@@ -1,0 +1,129 @@
+import { describe, test, expect, mock, afterEach } from "bun:test";
+import type { GatewayConfig } from "../config.js";
+
+type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { createRuntimeHealthProxyHandler } = await import(
+  "../http/routes/runtime-health-proxy.js"
+);
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  const merged: GatewayConfig = {
+    telegramBotToken: "tok",
+    telegramWebhookSecret: "wh-ver",
+    telegramApiBaseUrl: "https://api.telegram.org",
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeBearerToken: "runtime-token",
+    runtimeGatewayOriginSecret: "gateway-origin",
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    runtimeProxyBearerToken: undefined,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
+    twilioAuthToken: undefined,
+    twilioAccountSid: undefined,
+    twilioPhoneNumber: undefined,
+    smsDeliverAuthBypass: false,
+    ingressPublicBaseUrl: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    whatsappPhoneNumberId: undefined,
+    whatsappAccessToken: undefined,
+    whatsappAppSecret: undefined,
+    whatsappWebhookVerifyToken: undefined,
+    whatsappDeliverAuthBypass: false,
+    whatsappTimeoutMs: 15000,
+    whatsappMaxRetries: 3,
+    whatsappInitialBackoffMs: 1000,
+    slackChannelBotToken: undefined,
+    slackChannelAppToken: undefined,
+    slackDeliverAuthBypass: false,
+    trustProxy: false,
+    ...overrides,
+  };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
+}
+
+afterEach(() => {
+  fetchMock = mock(async () => new Response());
+});
+
+describe("runtime health proxy", () => {
+  test("forwards to runtime /v1/health", async () => {
+    const captured: string[] = [];
+    fetchMock = mock(async (input: string | URL | Request) => {
+      captured.push(String(input));
+      return new Response(JSON.stringify({ status: "healthy" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const handler = createRuntimeHealthProxyHandler(makeConfig());
+    const res = await handler.handleRuntimeHealth(
+      new Request("http://localhost:7830/v1/health"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(captured).toEqual(["http://localhost:7821/v1/health"]);
+    expect(await res.json()).toEqual({ status: "healthy" });
+  });
+
+  test("replaces caller auth with runtime auth and forwards gateway-origin proof", async () => {
+    let capturedHeaders: Headers | undefined;
+    fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+      capturedHeaders = init?.headers as unknown as Headers;
+      return new Response("ok", { status: 200 });
+    });
+
+    const handler = createRuntimeHealthProxyHandler(makeConfig());
+    const res = await handler.handleRuntimeHealth(
+      new Request("http://localhost:7830/v1/health", {
+        headers: {
+          authorization: "Bearer caller-token",
+          host: "localhost:7830",
+        },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(capturedHeaders?.get("authorization")).toBe("Bearer runtime-token");
+    expect(capturedHeaders?.get("X-Gateway-Origin")).toBe("gateway-origin");
+    expect(capturedHeaders?.has("host")).toBe(false);
+  });
+
+  test("returns 504 on timeout", async () => {
+    fetchMock = mock(async () => {
+      throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+    });
+
+    const handler = createRuntimeHealthProxyHandler(makeConfig({ runtimeTimeoutMs: 100 }));
+    const res = await handler.handleRuntimeHealth(
+      new Request("http://localhost:7830/v1/health"),
+    );
+
+    expect(res.status).toBe(504);
+    expect(await res.json()).toEqual({ error: "Gateway Timeout" });
+  });
+});

--- a/gateway/src/__tests__/schema.test.ts
+++ b/gateway/src/__tests__/schema.test.ts
@@ -60,6 +60,15 @@ describe("/schema route", () => {
     expect(body.paths["/webhooks/twilio/connect-action"]).toBeDefined();
     expect(body.paths["/webhooks/twilio/relay"]).toBeDefined();
     expect(body.paths["/webhooks/oauth/callback"]).toBeDefined();
+    expect(body.paths["/v1/integrations/telegram/config"]).toBeDefined();
+    expect(body.paths["/v1/integrations/telegram/commands"]).toBeDefined();
+    expect(body.paths["/v1/integrations/telegram/setup"]).toBeDefined();
+    expect(body.paths["/v1/ingress/members"]).toBeDefined();
+    expect(body.paths["/v1/ingress/members/{memberId}"]).toBeDefined();
+    expect(body.paths["/v1/ingress/members/{memberId}/block"]).toBeDefined();
+    expect(body.paths["/v1/ingress/invites"]).toBeDefined();
+    expect(body.paths["/v1/ingress/invites/redeem"]).toBeDefined();
+    expect(body.paths["/v1/ingress/invites/{inviteId}"]).toBeDefined();
     expect(body.paths["/v1/integrations/guardian/challenge"]).toBeDefined();
     expect(body.paths["/v1/integrations/guardian/status"]).toBeDefined();
     expect(body.paths["/v1/integrations/guardian/outbound/start"]).toBeDefined();

--- a/gateway/src/__tests__/schema.test.ts
+++ b/gateway/src/__tests__/schema.test.ts
@@ -157,4 +157,20 @@ describe("buildSchema()", () => {
     });
     expect(telegramDeliver.anyOf).toContainEqual({ required: ["chatAction"] });
   });
+
+  test("ingress member block request body is required", () => {
+    const schema = buildSchema() as {
+      paths: Record<string, {
+        post?: {
+          requestBody?: {
+            required?: boolean;
+          };
+        };
+      }>;
+    };
+
+    const ingressMemberBlockPost = schema.paths["/v1/ingress/members/{memberId}/block"]?.post;
+    expect(ingressMemberBlockPost).toBeDefined();
+    expect(ingressMemberBlockPost?.requestBody?.required).toBe(true);
+  });
 });

--- a/gateway/src/__tests__/schema.test.ts
+++ b/gateway/src/__tests__/schema.test.ts
@@ -54,6 +54,7 @@ describe("/schema route", () => {
     expect(body.paths["/healthz"]).toBeDefined();
     expect(body.paths["/readyz"]).toBeDefined();
     expect(body.paths["/schema"]).toBeDefined();
+    expect(body.paths["/v1/health"]).toBeDefined();
     expect(body.paths["/webhooks/telegram"]).toBeDefined();
     expect(body.paths["/webhooks/twilio/voice"]).toBeDefined();
     expect(body.paths["/webhooks/twilio/status"]).toBeDefined();

--- a/gateway/src/__tests__/telegram-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/telegram-control-plane-proxy.test.ts
@@ -1,0 +1,166 @@
+import { describe, test, expect, mock, afterEach } from "bun:test";
+import type { GatewayConfig } from "../config.js";
+
+type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { createTelegramControlPlaneProxyHandler } = await import(
+  "../http/routes/telegram-control-plane-proxy.js"
+);
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  const merged: GatewayConfig = {
+    telegramBotToken: "tok",
+    telegramWebhookSecret: "wh-ver",
+    telegramApiBaseUrl: "https://api.telegram.org",
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeBearerToken: "runtime-token",
+    runtimeGatewayOriginSecret: "gateway-origin",
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    runtimeProxyBearerToken: undefined,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
+    twilioAuthToken: undefined,
+    twilioAccountSid: undefined,
+    twilioPhoneNumber: undefined,
+    smsDeliverAuthBypass: false,
+    ingressPublicBaseUrl: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    whatsappPhoneNumberId: undefined,
+    whatsappAccessToken: undefined,
+    whatsappAppSecret: undefined,
+    whatsappWebhookVerifyToken: undefined,
+    whatsappDeliverAuthBypass: false,
+    whatsappTimeoutMs: 15000,
+    whatsappMaxRetries: 3,
+    whatsappInitialBackoffMs: 1000,
+    slackChannelBotToken: undefined,
+    slackChannelAppToken: undefined,
+    slackDeliverAuthBypass: false,
+    trustProxy: false,
+    ...overrides,
+  };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
+}
+
+afterEach(() => {
+  fetchMock = mock(async () => new Response());
+});
+
+describe("telegram control-plane proxy", () => {
+  test("forwards telegram control-plane endpoints to the runtime", async () => {
+    const captured: string[] = [];
+    fetchMock = mock(async (input: string | URL | Request) => {
+      captured.push(String(input));
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const handler = createTelegramControlPlaneProxyHandler(makeConfig());
+
+    await handler.handleGetTelegramConfig(
+      new Request("http://localhost:7830/v1/integrations/telegram/config"),
+    );
+    await handler.handleSetTelegramConfig(
+      new Request("http://localhost:7830/v1/integrations/telegram/config", { method: "POST" }),
+    );
+    await handler.handleClearTelegramConfig(
+      new Request("http://localhost:7830/v1/integrations/telegram/config", { method: "DELETE" }),
+    );
+    await handler.handleSetTelegramCommands(
+      new Request("http://localhost:7830/v1/integrations/telegram/commands", { method: "POST" }),
+    );
+    await handler.handleSetupTelegram(
+      new Request("http://localhost:7830/v1/integrations/telegram/setup", { method: "POST" }),
+    );
+
+    expect(captured).toEqual([
+      "http://localhost:7821/v1/integrations/telegram/config",
+      "http://localhost:7821/v1/integrations/telegram/config",
+      "http://localhost:7821/v1/integrations/telegram/config",
+      "http://localhost:7821/v1/integrations/telegram/commands",
+      "http://localhost:7821/v1/integrations/telegram/setup",
+    ]);
+  });
+
+  test("replaces caller auth with runtime auth and forwards gateway-origin proof", async () => {
+    let capturedHeaders: Headers | undefined;
+    fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+      capturedHeaders = init?.headers as unknown as Headers;
+      return new Response("ok", { status: 200 });
+    });
+
+    const handler = createTelegramControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleSetupTelegram(
+      new Request("http://localhost:7830/v1/integrations/telegram/setup", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer caller-token",
+          "content-type": "application/json",
+          host: "localhost:7830",
+        },
+        body: JSON.stringify({}),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(capturedHeaders?.get("authorization")).toBe("Bearer runtime-token");
+    expect(capturedHeaders?.get("X-Gateway-Origin")).toBe("gateway-origin");
+    expect(capturedHeaders?.has("host")).toBe(false);
+  });
+
+  test("passes through upstream client errors", async () => {
+    fetchMock = mock(async () => {
+      return new Response(JSON.stringify({ success: false, error: "invalid_bot_token" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const handler = createTelegramControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleSetupTelegram(
+      new Request("http://localhost:7830/v1/integrations/telegram/setup", { method: "POST" }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ success: false, error: "invalid_bot_token" });
+  });
+
+  test("returns 502 when runtime is unreachable", async () => {
+    fetchMock = mock(async () => {
+      throw new Error("Connection refused");
+    });
+
+    const handler = createTelegramControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleGetTelegramConfig(
+      new Request("http://localhost:7830/v1/integrations/telegram/config"),
+    );
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: "Bad Gateway" });
+  });
+});

--- a/gateway/src/__tests__/telegram-only-default.test.ts
+++ b/gateway/src/__tests__/telegram-only-default.test.ts
@@ -1,10 +1,9 @@
 import { describe, test, expect, afterAll } from "bun:test";
 
 /**
- * Proves that non-Telegram requests return 404 when the gateway runs in its
- * default configuration (proxy disabled). Uses the same routing logic as
- * src/index.ts so that changes to the production routing (e.g. accidentally
- * enabling the proxy by default) will be caught by this test.
+ * Proves that runtime proxy passthrough routes stay disabled by default while
+ * dedicated gateway routes still work. Uses the same routing logic as
+ * src/index.ts so that changes to production defaults are caught here.
  */
 
 // Minimal env for loadConfig
@@ -12,6 +11,7 @@ const env: Record<string, string> = {
   TELEGRAM_BOT_TOKEN: "test-tok",
   TELEGRAM_WEBHOOK_SECRET: "wh-sec",
   ASSISTANT_RUNTIME_BASE_URL: "http://localhost:7821",
+  RUNTIME_BEARER_TOKEN: "test-runtime-token",
   GATEWAY_PORT: "7830",
   // GATEWAY_RUNTIME_PROXY_ENABLED intentionally unset → defaults to false
 };
@@ -35,10 +35,15 @@ const { createTelegramWebhookHandler } = await import(
 const { createRuntimeProxyHandler } = await import(
   "../http/routes/runtime-proxy.js"
 );
+const { createRuntimeHealthProxyHandler } = await import(
+  "../http/routes/runtime-health-proxy.js"
+);
+const { validateBearerToken } = await import("../http/auth/bearer.js");
 
 const config = loadConfig();
 
 const { handler: handleTelegramWebhook } = createTelegramWebhookHandler(config);
+const runtimeHealthProxy = createRuntimeHealthProxyHandler(config);
 
 // Mirror production routing from src/index.ts: only create proxy when enabled
 const handleRuntimeProxy = config.runtimeProxyEnabled
@@ -60,6 +65,17 @@ async function handleRequest(req: Request): Promise<Response> {
     return handleTelegramWebhook(req);
   }
 
+  if (url.pathname === "/v1/health" && req.method === "GET") {
+    const authResult = validateBearerToken(
+      req.headers.get("authorization"),
+      config.runtimeBearerToken ?? "",
+    );
+    if (!authResult.authorized) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    return runtimeHealthProxy.handleRuntimeHealth(req);
+  }
+
   if (handleRuntimeProxy) {
     return handleRuntimeProxy(req);
   }
@@ -74,7 +90,7 @@ afterAll(() => {
   }
 });
 
-describe("Telegram-only default: non-Telegram requests return 404", () => {
+describe("Telegram-only default: runtime proxy is disabled by default", () => {
   test("GET / returns 404", async () => {
     const res = await handleRequest(new Request("http://gateway.test/"));
     expect(res.status).toBe(404);
@@ -82,9 +98,9 @@ describe("Telegram-only default: non-Telegram requests return 404", () => {
     expect(body.error).toBe("Not found");
   });
 
-  test("GET /v1/health returns 404", async () => {
+  test("GET /v1/health returns 401 without bearer auth", async () => {
     const res = await handleRequest(new Request("http://gateway.test/v1/health"));
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(401);
   });
 
   test("POST /v1/assistants/foo/chat returns 404", async () => {

--- a/gateway/src/http/routes/ingress-control-plane-proxy.ts
+++ b/gateway/src/http/routes/ingress-control-plane-proxy.ts
@@ -1,0 +1,124 @@
+/**
+ * Gateway proxy endpoints for ingress members/invites control-plane routes.
+ *
+ * These routes remain available even when the broad runtime proxy is
+ * disabled, so skills and clients can use gateway URLs exclusively.
+ */
+
+import type { GatewayConfig } from "../../config.js";
+import { fetchImpl } from "../../fetch.js";
+import { getLogger } from "../../logger.js";
+import { GATEWAY_ORIGIN_HEADER } from "../../runtime/client.js";
+import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
+
+const log = getLogger("ingress-control-plane-proxy");
+
+export function createIngressControlPlaneProxyHandler(config: GatewayConfig) {
+  async function proxyToRuntime(
+    req: Request,
+    upstreamPath: string,
+    upstreamSearch: string,
+  ): Promise<Response> {
+    const start = performance.now();
+    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${upstreamSearch}`;
+
+    const reqHeaders = stripHopByHop(new Headers(req.headers));
+    reqHeaders.delete("host");
+    reqHeaders.delete("authorization");
+
+    if (config.runtimeBearerToken) {
+      reqHeaders.set("authorization", `Bearer ${config.runtimeBearerToken}`);
+    }
+    if (config.runtimeGatewayOriginSecret) {
+      reqHeaders.set(GATEWAY_ORIGIN_HEADER, config.runtimeGatewayOriginSecret);
+    }
+
+    const hasBody = req.method !== "GET" && req.method !== "HEAD";
+    const bodyBuffer = hasBody ? await req.arrayBuffer() : null;
+    if (bodyBuffer !== null) {
+      reqHeaders.set("content-length", String(bodyBuffer.byteLength));
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(new DOMException("The operation was aborted due to timeout", "TimeoutError"));
+    }, config.runtimeTimeoutMs);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(upstream, {
+        method: req.method,
+        headers: reqHeaders,
+        body: bodyBuffer,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const duration = Math.round(performance.now() - start);
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        log.error({ path: upstreamPath, duration }, "Ingress control-plane proxy upstream timed out");
+        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+      }
+      log.error({ err, path: upstreamPath, duration }, "Ingress control-plane proxy upstream connection failed");
+      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    }
+
+    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const duration = Math.round(performance.now() - start);
+
+    if (response.status >= 400) {
+      const body = await response.text();
+      log.warn(
+        { path: upstreamPath, status: response.status, duration },
+        "Ingress control-plane proxy upstream error",
+      );
+      return new Response(body, { status: response.status, headers: resHeaders });
+    }
+
+    log.info(
+      { path: upstreamPath, status: response.status, duration },
+      "Ingress control-plane proxy completed",
+    );
+    return new Response(response.body, { status: response.status, headers: resHeaders });
+  }
+
+  return {
+    async handleListMembers(req: Request): Promise<Response> {
+      const url = new URL(req.url);
+      return proxyToRuntime(req, "/v1/ingress/members", url.search);
+    },
+
+    async handleUpsertMember(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/ingress/members", "");
+    },
+
+    async handleBlockMember(req: Request, memberId: string): Promise<Response> {
+      const encoded = encodeURIComponent(memberId);
+      return proxyToRuntime(req, `/v1/ingress/members/${encoded}/block`, "");
+    },
+
+    async handleRevokeMember(req: Request, memberId: string): Promise<Response> {
+      const encoded = encodeURIComponent(memberId);
+      return proxyToRuntime(req, `/v1/ingress/members/${encoded}`, "");
+    },
+
+    async handleListInvites(req: Request): Promise<Response> {
+      const url = new URL(req.url);
+      return proxyToRuntime(req, "/v1/ingress/invites", url.search);
+    },
+
+    async handleCreateInvite(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/ingress/invites", "");
+    },
+
+    async handleRedeemInvite(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/ingress/invites/redeem", "");
+    },
+
+    async handleRevokeInvite(req: Request, inviteId: string): Promise<Response> {
+      const encoded = encodeURIComponent(inviteId);
+      return proxyToRuntime(req, `/v1/ingress/invites/${encoded}`, "");
+    },
+  };
+}

--- a/gateway/src/http/routes/ingress-control-plane-route-match.ts
+++ b/gateway/src/http/routes/ingress-control-plane-route-match.ts
@@ -1,0 +1,47 @@
+export type IngressControlPlaneRoute =
+  | { kind: "listMembers" }
+  | { kind: "upsertMember" }
+  | { kind: "blockMember"; memberId: string }
+  | { kind: "revokeMember"; memberId: string }
+  | { kind: "listInvites" }
+  | { kind: "createInvite" }
+  | { kind: "redeemInvite" }
+  | { kind: "revokeInvite"; inviteId: string };
+
+export function matchIngressControlPlaneRoute(
+  pathname: string,
+  method: string,
+): IngressControlPlaneRoute | null {
+  if (pathname === "/v1/ingress/members") {
+    if (method === "GET") return { kind: "listMembers" };
+    if (method === "POST") return { kind: "upsertMember" };
+    return null;
+  }
+
+  if (pathname === "/v1/ingress/invites") {
+    if (method === "GET") return { kind: "listInvites" };
+    if (method === "POST") return { kind: "createInvite" };
+    return null;
+  }
+
+  const memberBlockMatch = pathname.match(/^\/v1\/ingress\/members\/([^/]+)\/block$/);
+  if (memberBlockMatch && method === "POST") {
+    return { kind: "blockMember", memberId: memberBlockMatch[1] };
+  }
+
+  const memberMatch = pathname.match(/^\/v1\/ingress\/members\/([^/]+)$/);
+  if (memberMatch && method === "DELETE") {
+    return { kind: "revokeMember", memberId: memberMatch[1] };
+  }
+
+  if (pathname === "/v1/ingress/invites/redeem" && method === "POST") {
+    return { kind: "redeemInvite" };
+  }
+
+  const inviteMatch = pathname.match(/^\/v1\/ingress\/invites\/([^/]+)$/);
+  if (inviteMatch && method === "DELETE") {
+    return { kind: "revokeInvite", inviteId: inviteMatch[1] };
+  }
+
+  return null;
+}

--- a/gateway/src/http/routes/runtime-health-proxy.ts
+++ b/gateway/src/http/routes/runtime-health-proxy.ts
@@ -1,0 +1,73 @@
+/**
+ * Gateway proxy endpoint for runtime health checks.
+ *
+ * Exposes GET /v1/health through the gateway even when the broad runtime
+ * proxy is disabled.
+ */
+
+import type { GatewayConfig } from "../../config.js";
+import { fetchImpl } from "../../fetch.js";
+import { getLogger } from "../../logger.js";
+import { GATEWAY_ORIGIN_HEADER } from "../../runtime/client.js";
+import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
+
+const log = getLogger("runtime-health-proxy");
+
+export function createRuntimeHealthProxyHandler(config: GatewayConfig) {
+  async function handleRuntimeHealth(req: Request): Promise<Response> {
+    const start = performance.now();
+    const upstream = `${config.assistantRuntimeBaseUrl}/v1/health`;
+
+    const reqHeaders = stripHopByHop(new Headers(req.headers));
+    reqHeaders.delete("host");
+    reqHeaders.delete("authorization");
+
+    if (config.runtimeBearerToken) {
+      reqHeaders.set("authorization", `Bearer ${config.runtimeBearerToken}`);
+    }
+    if (config.runtimeGatewayOriginSecret) {
+      reqHeaders.set(GATEWAY_ORIGIN_HEADER, config.runtimeGatewayOriginSecret);
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(new DOMException("The operation was aborted due to timeout", "TimeoutError"));
+    }, config.runtimeTimeoutMs);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(upstream, {
+        method: "GET",
+        headers: reqHeaders,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const duration = Math.round(performance.now() - start);
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        log.error({ duration }, "Runtime health proxy upstream timed out");
+        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+      }
+      log.error({ err, duration }, "Runtime health proxy upstream connection failed");
+      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    }
+
+    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const duration = Math.round(performance.now() - start);
+
+    if (response.status >= 400) {
+      const body = await response.text();
+      log.warn(
+        { status: response.status, duration },
+        "Runtime health proxy upstream error",
+      );
+      return new Response(body, { status: response.status, headers: resHeaders });
+    }
+
+    log.info({ status: response.status, duration }, "Runtime health proxy completed");
+    return new Response(response.body, { status: response.status, headers: resHeaders });
+  }
+
+  return { handleRuntimeHealth };
+}

--- a/gateway/src/http/routes/telegram-control-plane-proxy.ts
+++ b/gateway/src/http/routes/telegram-control-plane-proxy.ts
@@ -1,0 +1,107 @@
+/**
+ * Gateway proxy endpoints for Telegram integration control-plane routes.
+ *
+ * These routes remain available even when the broad runtime proxy is
+ * disabled, so skills and clients can use gateway URLs exclusively.
+ */
+
+import type { GatewayConfig } from "../../config.js";
+import { fetchImpl } from "../../fetch.js";
+import { getLogger } from "../../logger.js";
+import { GATEWAY_ORIGIN_HEADER } from "../../runtime/client.js";
+import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
+
+const log = getLogger("telegram-control-plane-proxy");
+
+export function createTelegramControlPlaneProxyHandler(config: GatewayConfig) {
+  async function proxyToRuntime(
+    req: Request,
+    upstreamPath: string,
+    upstreamSearch: string,
+  ): Promise<Response> {
+    const start = performance.now();
+    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${upstreamSearch}`;
+
+    const reqHeaders = stripHopByHop(new Headers(req.headers));
+    reqHeaders.delete("host");
+    reqHeaders.delete("authorization");
+
+    if (config.runtimeBearerToken) {
+      reqHeaders.set("authorization", `Bearer ${config.runtimeBearerToken}`);
+    }
+    if (config.runtimeGatewayOriginSecret) {
+      reqHeaders.set(GATEWAY_ORIGIN_HEADER, config.runtimeGatewayOriginSecret);
+    }
+
+    const hasBody = req.method !== "GET" && req.method !== "HEAD";
+    const bodyBuffer = hasBody ? await req.arrayBuffer() : null;
+    if (bodyBuffer !== null) {
+      reqHeaders.set("content-length", String(bodyBuffer.byteLength));
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(new DOMException("The operation was aborted due to timeout", "TimeoutError"));
+    }, config.runtimeTimeoutMs);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(upstream, {
+        method: req.method,
+        headers: reqHeaders,
+        body: bodyBuffer,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const duration = Math.round(performance.now() - start);
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        log.error({ path: upstreamPath, duration }, "Telegram control-plane proxy upstream timed out");
+        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+      }
+      log.error({ err, path: upstreamPath, duration }, "Telegram control-plane proxy upstream connection failed");
+      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    }
+
+    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const duration = Math.round(performance.now() - start);
+
+    if (response.status >= 400) {
+      const body = await response.text();
+      log.warn(
+        { path: upstreamPath, status: response.status, duration },
+        "Telegram control-plane proxy upstream error",
+      );
+      return new Response(body, { status: response.status, headers: resHeaders });
+    }
+
+    log.info(
+      { path: upstreamPath, status: response.status, duration },
+      "Telegram control-plane proxy completed",
+    );
+    return new Response(response.body, { status: response.status, headers: resHeaders });
+  }
+
+  return {
+    async handleGetTelegramConfig(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/integrations/telegram/config", "");
+    },
+
+    async handleSetTelegramConfig(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/integrations/telegram/config", "");
+    },
+
+    async handleClearTelegramConfig(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/integrations/telegram/config", "");
+    },
+
+    async handleSetTelegramCommands(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/integrations/telegram/commands", "");
+    },
+
+    async handleSetupTelegram(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/integrations/telegram/setup", "");
+    },
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -32,6 +32,7 @@ import { createFeatureFlagsGetHandler, createFeatureFlagsPatchHandler } from "./
 import { createGuardianControlPlaneProxyHandler } from "./http/routes/guardian-control-plane-proxy.js";
 import { createTelegramControlPlaneProxyHandler } from "./http/routes/telegram-control-plane-proxy.js";
 import { createIngressControlPlaneProxyHandler } from "./http/routes/ingress-control-plane-proxy.js";
+import { createRuntimeHealthProxyHandler } from "./http/routes/runtime-health-proxy.js";
 import { validateBearerToken } from "./http/auth/bearer.js";
 import { getLogger, initLogger } from "./logger.js";
 import { CircuitBreakerOpenError } from "./runtime/client.js";
@@ -202,6 +203,7 @@ function main() {
   const guardianControlPlaneProxy = createGuardianControlPlaneProxyHandler(config);
   const telegramControlPlaneProxy = createTelegramControlPlaneProxyHandler(config);
   const ingressControlPlaneProxy = createIngressControlPlaneProxyHandler(config);
+  const runtimeHealthProxy = createRuntimeHealthProxyHandler(config);
   const handleFeatureFlagsGet = createFeatureFlagsGetHandler();
   const handleFeatureFlagsPatch = createFeatureFlagsPatchHandler();
 
@@ -433,6 +435,13 @@ function main() {
           return Response.json({ error: "Unauthorized" }, { status: 401 });
         }
         return null;
+      }
+
+      // ── Runtime health proxy ──
+      if (url.pathname === "/v1/health" && req.method === "GET") {
+        const authError = requireRuntimeBearerAuth();
+        if (authError) return authError;
+        return runtimeHealthProxy.handleRuntimeHealth(tracedReq);
       }
 
       // ── Telegram integration control-plane proxy ──

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -30,6 +30,8 @@ import { createOAuthCallbackHandler } from "./http/routes/oauth-callback.js";
 import { createPairingProxyHandler } from "./http/routes/pairing-proxy.js";
 import { createFeatureFlagsGetHandler, createFeatureFlagsPatchHandler } from "./http/routes/feature-flags.js";
 import { createGuardianControlPlaneProxyHandler } from "./http/routes/guardian-control-plane-proxy.js";
+import { createTelegramControlPlaneProxyHandler } from "./http/routes/telegram-control-plane-proxy.js";
+import { createIngressControlPlaneProxyHandler } from "./http/routes/ingress-control-plane-proxy.js";
 import { validateBearerToken } from "./http/auth/bearer.js";
 import { getLogger, initLogger } from "./logger.js";
 import { CircuitBreakerOpenError } from "./runtime/client.js";
@@ -198,6 +200,8 @@ function main() {
   const handleOAuthCallback = createOAuthCallbackHandler(config);
   const pairingProxy = createPairingProxyHandler(config);
   const guardianControlPlaneProxy = createGuardianControlPlaneProxyHandler(config);
+  const telegramControlPlaneProxy = createTelegramControlPlaneProxyHandler(config);
+  const ingressControlPlaneProxy = createIngressControlPlaneProxyHandler(config);
   const handleFeatureFlagsGet = createFeatureFlagsGetHandler();
   const handleFeatureFlagsPatch = createFeatureFlagsPatchHandler();
 
@@ -413,14 +417,7 @@ function main() {
         return res;
       }
 
-      // ── Guardian verification control-plane proxy ──
-      if (
-        (url.pathname === "/v1/integrations/guardian/challenge" && req.method === "POST")
-        || (url.pathname === "/v1/integrations/guardian/status" && req.method === "GET")
-        || (url.pathname === "/v1/integrations/guardian/outbound/start" && req.method === "POST")
-        || (url.pathname === "/v1/integrations/guardian/outbound/resend" && req.method === "POST")
-        || (url.pathname === "/v1/integrations/guardian/outbound/cancel" && req.method === "POST")
-      ) {
+      function requireRuntimeBearerAuth(): Response | null {
         if (!config.runtimeBearerToken) {
           return Response.json(
             { error: "Service not configured: bearer token required" },
@@ -435,6 +432,86 @@ function main() {
           authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
           return Response.json({ error: "Unauthorized" }, { status: 401 });
         }
+        return null;
+      }
+
+      // ── Telegram integration control-plane proxy ──
+      if (
+        (url.pathname === "/v1/integrations/telegram/config" && req.method === "GET")
+        || (url.pathname === "/v1/integrations/telegram/config" && req.method === "POST")
+        || (url.pathname === "/v1/integrations/telegram/config" && req.method === "DELETE")
+        || (url.pathname === "/v1/integrations/telegram/commands" && req.method === "POST")
+        || (url.pathname === "/v1/integrations/telegram/setup" && req.method === "POST")
+      ) {
+        const authError = requireRuntimeBearerAuth();
+        if (authError) return authError;
+
+        if (url.pathname === "/v1/integrations/telegram/config" && req.method === "GET") {
+          return telegramControlPlaneProxy.handleGetTelegramConfig(tracedReq);
+        }
+        if (url.pathname === "/v1/integrations/telegram/config" && req.method === "POST") {
+          return telegramControlPlaneProxy.handleSetTelegramConfig(tracedReq);
+        }
+        if (url.pathname === "/v1/integrations/telegram/config" && req.method === "DELETE") {
+          return telegramControlPlaneProxy.handleClearTelegramConfig(tracedReq);
+        }
+        if (url.pathname === "/v1/integrations/telegram/commands") {
+          return telegramControlPlaneProxy.handleSetTelegramCommands(tracedReq);
+        }
+        return telegramControlPlaneProxy.handleSetupTelegram(tracedReq);
+      }
+
+      // ── Ingress members/invites control-plane proxy ──
+      const ingressMemberBlockMatch = url.pathname.match(/^\/v1\/ingress\/members\/([^/]+)\/block$/);
+      const ingressMemberMatch = url.pathname.match(/^\/v1\/ingress\/members\/([^/]+)$/);
+      const ingressInviteMatch = url.pathname.match(/^\/v1\/ingress\/invites\/([^/]+)$/);
+      if (
+        (url.pathname === "/v1/ingress/members" && req.method === "GET")
+        || (url.pathname === "/v1/ingress/members" && req.method === "POST")
+        || (!!ingressMemberBlockMatch && req.method === "POST")
+        || (!!ingressMemberMatch && req.method === "DELETE")
+        || (url.pathname === "/v1/ingress/invites" && req.method === "GET")
+        || (url.pathname === "/v1/ingress/invites" && req.method === "POST")
+        || (url.pathname === "/v1/ingress/invites/redeem" && req.method === "POST")
+        || (!!ingressInviteMatch && req.method === "DELETE")
+      ) {
+        const authError = requireRuntimeBearerAuth();
+        if (authError) return authError;
+
+        if (url.pathname === "/v1/ingress/members" && req.method === "GET") {
+          return ingressControlPlaneProxy.handleListMembers(tracedReq);
+        }
+        if (url.pathname === "/v1/ingress/members" && req.method === "POST") {
+          return ingressControlPlaneProxy.handleUpsertMember(tracedReq);
+        }
+        if (ingressMemberBlockMatch && req.method === "POST") {
+          return ingressControlPlaneProxy.handleBlockMember(tracedReq, ingressMemberBlockMatch[1]);
+        }
+        if (ingressMemberMatch && req.method === "DELETE") {
+          return ingressControlPlaneProxy.handleRevokeMember(tracedReq, ingressMemberMatch[1]);
+        }
+        if (url.pathname === "/v1/ingress/invites" && req.method === "GET") {
+          return ingressControlPlaneProxy.handleListInvites(tracedReq);
+        }
+        if (url.pathname === "/v1/ingress/invites" && req.method === "POST") {
+          return ingressControlPlaneProxy.handleCreateInvite(tracedReq);
+        }
+        if (url.pathname === "/v1/ingress/invites/redeem") {
+          return ingressControlPlaneProxy.handleRedeemInvite(tracedReq);
+        }
+        return ingressControlPlaneProxy.handleRevokeInvite(tracedReq, ingressInviteMatch![1]);
+      }
+
+      // ── Guardian verification control-plane proxy ──
+      if (
+        (url.pathname === "/v1/integrations/guardian/challenge" && req.method === "POST")
+        || (url.pathname === "/v1/integrations/guardian/status" && req.method === "GET")
+        || (url.pathname === "/v1/integrations/guardian/outbound/start" && req.method === "POST")
+        || (url.pathname === "/v1/integrations/guardian/outbound/resend" && req.method === "POST")
+        || (url.pathname === "/v1/integrations/guardian/outbound/cancel" && req.method === "POST")
+      ) {
+        const authError = requireRuntimeBearerAuth();
+        if (authError) return authError;
 
         if (url.pathname === "/v1/integrations/guardian/challenge") {
           return guardianControlPlaneProxy.handleCreateGuardianChallenge(tracedReq);
@@ -452,20 +529,8 @@ function main() {
       }
 
       if (url.pathname === "/integrations/status" && req.method === "GET") {
-        if (!config.runtimeBearerToken) {
-          return Response.json(
-            { error: "Service not configured: bearer token required" },
-            { status: 503 },
-          );
-        }
-        const authResult = validateBearerToken(
-          tracedReq.headers.get("authorization"),
-          config.runtimeBearerToken,
-        );
-        if (!authResult.authorized) {
-          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
-          return Response.json({ error: "Unauthorized" }, { status: 401 });
-        }
+        const authError = requireRuntimeBearerAuth();
+        if (authError) return authError;
         return Response.json({
           email: {
             address: config.assistantEmail ?? null,

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -32,6 +32,7 @@ import { createFeatureFlagsGetHandler, createFeatureFlagsPatchHandler } from "./
 import { createGuardianControlPlaneProxyHandler } from "./http/routes/guardian-control-plane-proxy.js";
 import { createTelegramControlPlaneProxyHandler } from "./http/routes/telegram-control-plane-proxy.js";
 import { createIngressControlPlaneProxyHandler } from "./http/routes/ingress-control-plane-proxy.js";
+import { matchIngressControlPlaneRoute } from "./http/routes/ingress-control-plane-route-match.js";
 import { createRuntimeHealthProxyHandler } from "./http/routes/runtime-health-proxy.js";
 import { validateBearerToken } from "./http/auth/bearer.js";
 import { getLogger, initLogger } from "./logger.js";
@@ -471,44 +472,29 @@ function main() {
       }
 
       // ── Ingress members/invites control-plane proxy ──
-      const ingressMemberBlockMatch = url.pathname.match(/^\/v1\/ingress\/members\/([^/]+)\/block$/);
-      const ingressMemberMatch = url.pathname.match(/^\/v1\/ingress\/members\/([^/]+)$/);
-      const ingressInviteMatch = url.pathname.match(/^\/v1\/ingress\/invites\/([^/]+)$/);
-      if (
-        (url.pathname === "/v1/ingress/members" && req.method === "GET")
-        || (url.pathname === "/v1/ingress/members" && req.method === "POST")
-        || (!!ingressMemberBlockMatch && req.method === "POST")
-        || (!!ingressMemberMatch && req.method === "DELETE")
-        || (url.pathname === "/v1/ingress/invites" && req.method === "GET")
-        || (url.pathname === "/v1/ingress/invites" && req.method === "POST")
-        || (url.pathname === "/v1/ingress/invites/redeem" && req.method === "POST")
-        || (!!ingressInviteMatch && req.method === "DELETE")
-      ) {
+      const ingressRoute = matchIngressControlPlaneRoute(url.pathname, req.method);
+      if (ingressRoute) {
         const authError = requireRuntimeBearerAuth();
         if (authError) return authError;
 
-        if (url.pathname === "/v1/ingress/members" && req.method === "GET") {
-          return ingressControlPlaneProxy.handleListMembers(tracedReq);
+        switch (ingressRoute.kind) {
+          case "listMembers":
+            return ingressControlPlaneProxy.handleListMembers(tracedReq);
+          case "upsertMember":
+            return ingressControlPlaneProxy.handleUpsertMember(tracedReq);
+          case "blockMember":
+            return ingressControlPlaneProxy.handleBlockMember(tracedReq, ingressRoute.memberId);
+          case "revokeMember":
+            return ingressControlPlaneProxy.handleRevokeMember(tracedReq, ingressRoute.memberId);
+          case "listInvites":
+            return ingressControlPlaneProxy.handleListInvites(tracedReq);
+          case "createInvite":
+            return ingressControlPlaneProxy.handleCreateInvite(tracedReq);
+          case "redeemInvite":
+            return ingressControlPlaneProxy.handleRedeemInvite(tracedReq);
+          case "revokeInvite":
+            return ingressControlPlaneProxy.handleRevokeInvite(tracedReq, ingressRoute.inviteId);
         }
-        if (url.pathname === "/v1/ingress/members" && req.method === "POST") {
-          return ingressControlPlaneProxy.handleUpsertMember(tracedReq);
-        }
-        if (ingressMemberBlockMatch && req.method === "POST") {
-          return ingressControlPlaneProxy.handleBlockMember(tracedReq, ingressMemberBlockMatch[1]);
-        }
-        if (ingressMemberMatch && req.method === "DELETE") {
-          return ingressControlPlaneProxy.handleRevokeMember(tracedReq, ingressMemberMatch[1]);
-        }
-        if (url.pathname === "/v1/ingress/invites" && req.method === "GET") {
-          return ingressControlPlaneProxy.handleListInvites(tracedReq);
-        }
-        if (url.pathname === "/v1/ingress/invites" && req.method === "POST") {
-          return ingressControlPlaneProxy.handleCreateInvite(tracedReq);
-        }
-        if (url.pathname === "/v1/ingress/invites/redeem") {
-          return ingressControlPlaneProxy.handleRedeemInvite(tracedReq);
-        }
-        return ingressControlPlaneProxy.handleRevokeInvite(tracedReq, ingressInviteMatch![1]);
       }
 
       // ── Guardian verification control-plane proxy ──

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -955,7 +955,7 @@ export function buildSchema(): Record<string, unknown> {
             },
           ],
           requestBody: {
-            required: false,
+            required: true,
             content: {
               "application/json": {
                 schema: { type: "object", additionalProperties: true },

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -726,6 +726,296 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/integrations/telegram/config": {
+        get: {
+          summary: "Get Telegram integration config",
+          description:
+            "Authenticated gateway endpoint that forwards Telegram integration config reads to the assistant runtime.",
+          operationId: "telegramConfigGet",
+          security: [{ BearerAuth: [] }],
+          responses: {
+            "200": { description: "Telegram config returned" },
+            "401": { description: "Unauthorized — missing or invalid bearer token" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+        post: {
+          summary: "Set Telegram integration config",
+          description:
+            "Authenticated gateway endpoint that forwards Telegram integration config writes to the assistant runtime.",
+          operationId: "telegramConfigPost",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Telegram config updated" },
+            "400": { description: "Invalid request payload" },
+            "401": { description: "Unauthorized — missing or invalid bearer token" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+        delete: {
+          summary: "Clear Telegram integration config",
+          description:
+            "Authenticated gateway endpoint that clears Telegram integration config via the assistant runtime.",
+          operationId: "telegramConfigDelete",
+          security: [{ BearerAuth: [] }],
+          responses: {
+            "200": { description: "Telegram config cleared" },
+            "401": { description: "Unauthorized — missing or invalid bearer token" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
+      "/v1/integrations/telegram/commands": {
+        post: {
+          summary: "Set Telegram commands",
+          description:
+            "Authenticated gateway endpoint that forwards Telegram command registration to the assistant runtime.",
+          operationId: "telegramCommandsPost",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Telegram commands updated" },
+            "400": { description: "Invalid request payload" },
+            "401": { description: "Unauthorized — missing or invalid bearer token" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
+      "/v1/integrations/telegram/setup": {
+        post: {
+          summary: "Run Telegram setup",
+          description:
+            "Authenticated gateway endpoint that forwards Telegram setup orchestration to the assistant runtime.",
+          operationId: "telegramSetupPost",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Telegram setup completed" },
+            "400": { description: "Invalid request payload" },
+            "401": { description: "Unauthorized — missing or invalid bearer token" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
+      "/v1/ingress/members": {
+        get: {
+          summary: "List ingress members",
+          description:
+            "Authenticated gateway endpoint that lists ingress members via the assistant runtime.",
+          operationId: "ingressMembersGet",
+          security: [{ BearerAuth: [] }],
+          responses: {
+            "200": { description: "Ingress members returned" },
+            "401": { description: "Unauthorized — missing or invalid bearer token" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+        post: {
+          summary: "Upsert ingress member",
+          description:
+            "Authenticated gateway endpoint that creates or updates an ingress member via the assistant runtime.",
+          operationId: "ingressMembersPost",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Ingress member upserted" },
+            "400": { description: "Invalid request payload" },
+            "401": { description: "Unauthorized — missing or invalid bearer token" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
+      "/v1/ingress/members/{memberId}": {
+        delete: {
+          summary: "Revoke ingress member",
+          description:
+            "Authenticated gateway endpoint that revokes an ingress member via the assistant runtime.",
+          operationId: "ingressMemberDelete",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            {
+              name: "memberId",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          responses: {
+            "200": { description: "Ingress member revoked" },
+            "401": { description: "Unauthorized — missing or invalid bearer token" },
+            "404": { description: "Member not found" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
+      "/v1/ingress/members/{memberId}/block": {
+        post: {
+          summary: "Block ingress member",
+          description:
+            "Authenticated gateway endpoint that blocks an ingress member via the assistant runtime.",
+          operationId: "ingressMemberBlockPost",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            {
+              name: "memberId",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          requestBody: {
+            required: false,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Ingress member blocked" },
+            "401": { description: "Unauthorized — missing or invalid bearer token" },
+            "404": { description: "Member not found or already blocked" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
+      "/v1/ingress/invites": {
+        get: {
+          summary: "List ingress invites",
+          description:
+            "Authenticated gateway endpoint that lists ingress invites via the assistant runtime.",
+          operationId: "ingressInvitesGet",
+          security: [{ BearerAuth: [] }],
+          responses: {
+            "200": { description: "Ingress invites returned" },
+            "401": { description: "Unauthorized — missing or invalid bearer token" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+        post: {
+          summary: "Create ingress invite",
+          description:
+            "Authenticated gateway endpoint that creates an ingress invite via the assistant runtime.",
+          operationId: "ingressInvitesPost",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Ingress invite created" },
+            "400": { description: "Invalid request payload" },
+            "401": { description: "Unauthorized — missing or invalid bearer token" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
+      "/v1/ingress/invites/redeem": {
+        post: {
+          summary: "Redeem ingress invite",
+          description:
+            "Authenticated gateway endpoint that redeems an ingress invite via the assistant runtime.",
+          operationId: "ingressInvitesRedeemPost",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Ingress invite redeemed" },
+            "400": { description: "Invalid request payload" },
+            "401": { description: "Unauthorized — missing or invalid bearer token" },
+            "404": { description: "Invite not found" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
+      "/v1/ingress/invites/{inviteId}": {
+        delete: {
+          summary: "Revoke ingress invite",
+          description:
+            "Authenticated gateway endpoint that revokes an ingress invite via the assistant runtime.",
+          operationId: "ingressInvitesDelete",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            {
+              name: "inviteId",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          responses: {
+            "200": { description: "Ingress invite revoked" },
+            "401": { description: "Unauthorized — missing or invalid bearer token" },
+            "404": { description: "Invite not found or already revoked" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
       "/v1/integrations/guardian/challenge": {
         post: {
           summary: "Create guardian verification challenge",

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -70,6 +70,52 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/health": {
+        get: {
+          summary: "Runtime health (via gateway)",
+          description:
+            "Authenticated gateway endpoint that proxies runtime health checks to `/v1/health` on the assistant runtime.",
+          operationId: "runtimeHealth",
+          security: [{ BearerAuth: [] }],
+          responses: {
+            "200": {
+              description: "Runtime health returned",
+            },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "503": {
+              description: "Bearer token not configured",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "502": {
+              description: "Failed to reach assistant runtime",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "504": {
+              description: "Assistant runtime request timed out",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
       "/webhooks/telegram": {
         post: {
           summary: "Telegram webhook",

--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -12,7 +12,7 @@ You are helping your user connect a Telegram bot to the Vellum Assistant gateway
 
 Before beginning setup, verify these conditions are met:
 
-1. **Gateway API is reachable:** Run `TOKEN=$(cat ~/.vellum/http-token) && curl -sf http://localhost:7830/v1/health -H "Authorization: Bearer $TOKEN"` — it should return health JSON (for example `{"status":"healthy",...}`). If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
+1. **Gateway API is reachable:** Run `curl -sf http://localhost:7830/healthz` — it should return gateway health JSON (for example `{"status":"ok"}`). If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
 2. **Public ingress URL is configured.** The gateway webhook URL is derived from `${ingress.publicBaseUrl}/webhooks/telegram`. If the ingress URL is not configured, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the URL before continuing.
 3. **Use gateway control-plane routes only.** Telegram setup/config actions in this skill must call gateway endpoints under `/v1/integrations/telegram/*` — never call the daemon runtime port directly.
 

--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -12,7 +12,7 @@ You are helping your user connect a Telegram bot to the Vellum Assistant gateway
 
 Before beginning setup, verify these conditions are met:
 
-1. **Gateway + runtime are reachable through the gateway:** Run `TOKEN=$(cat ~/.vellum/http-token) && curl -sf http://localhost:7830/v1/health -H "Authorization: Bearer $TOKEN"` — it should return runtime health JSON (for example `{"status":"healthy",...}`). If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
+1. **Gateway API is reachable:** Run `TOKEN=$(cat ~/.vellum/http-token) && curl -sf http://localhost:7830/v1/health -H "Authorization: Bearer $TOKEN"` — it should return health JSON (for example `{"status":"healthy",...}`). If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
 2. **Public ingress URL is configured.** The gateway webhook URL is derived from `${ingress.publicBaseUrl}/webhooks/telegram`. If the ingress URL is not configured, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the URL before continuing.
 3. **Use gateway control-plane routes only.** Telegram setup/config actions in this skill must call gateway endpoints under `/v1/integrations/telegram/*` — never call the daemon runtime port directly.
 

--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -12,7 +12,7 @@ You are helping your user connect a Telegram bot to the Vellum Assistant gateway
 
 Before beginning setup, verify these conditions are met:
 
-1. **Gateway API is reachable:** Run `curl -sf http://localhost:7830/healthz` — it should return gateway health JSON (for example `{"status":"ok"}`). If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
+1. **Gateway API base URL is set and reachable:** Use the configured gateway URL in `GATEWAY_BASE_URL` (from Settings "Local Gateway Target"), then run `curl -sf "$GATEWAY_BASE_URL/healthz"` — it should return gateway health JSON (for example `{"status":"ok"}`). If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
 2. **Public ingress URL is configured.** The gateway webhook URL is derived from `${ingress.publicBaseUrl}/webhooks/telegram`. If the ingress URL is not configured, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the URL before continuing.
 3. **Use gateway control-plane routes only.** Telegram setup/config actions in this skill must call gateway endpoints under `/v1/integrations/telegram/*` — never call the daemon runtime port directly.
 
@@ -37,7 +37,7 @@ The token is collected securely via a system-level prompt and is never exposed i
 After the token is collected, call the composite setup endpoint which validates the token, stores credentials, and registers bot commands in a single request:
 
 ```bash
-curl -sf -X POST http://localhost:7830/v1/integrations/telegram/setup \
+curl -sf -X POST "$GATEWAY_BASE_URL/v1/integrations/telegram/setup" \
   -H "Authorization: Bearer $(cat ~/.vellum/http-token)" \
   -H "Content-Type: application/json" \
   -d '{}'
@@ -98,7 +98,7 @@ If routing is misconfigured, inbound Telegram messages will be rejected and the 
 Before reporting success, confirm the guardian binding was actually created. Check the guardian binding status:
 
 ```bash
-curl -sf http://localhost:7830/v1/integrations/guardian/status?channel=telegram \
+curl -sf "$GATEWAY_BASE_URL/v1/integrations/guardian/status?channel=telegram" \
   -H "Authorization: Bearer $(cat ~/.vellum/http-token)"
 ```
 
@@ -117,7 +117,7 @@ Summarize what was done:
 - Guardian identity: {verified | not configured}
 - Guardian verification status: {verified via outbound flow | skipped}
 - Routing configuration validated
-- To re-check guardian status later, use: `curl -sf http://localhost:7830/v1/integrations/guardian/status?channel=telegram -H "Authorization: Bearer $(cat ~/.vellum/http-token)"`
+- To re-check guardian status later, use: `curl -sf "$GATEWAY_BASE_URL/v1/integrations/guardian/status?channel=telegram" -H "Authorization: Bearer $(cat ~/.vellum/http-token)"`
 
 The gateway automatically detects credentials from the vault, reconciles the Telegram webhook registration, and begins accepting Telegram webhooks shortly. In single-assistant mode, routing is automatically configured — no manual environment variable configuration or webhook registration is needed. If the webhook secret changes later, the gateway's credential watcher will automatically re-register the webhook. If the ingress URL changes (e.g., tunnel restart), the assistant daemon triggers an immediate internal reconcile so the webhook re-registers automatically without a gateway restart.
 

--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -14,6 +14,7 @@ Before beginning setup, verify these conditions are met:
 
 1. **Gateway is running:** Run `curl -sf http://localhost:7830/healthz` — it should return OK. If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
 2. **Public ingress URL is configured.** The gateway webhook URL is derived from `${ingress.publicBaseUrl}/webhooks/telegram`. If the ingress URL is not configured, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the URL before continuing.
+3. **Use gateway control-plane routes only.** Telegram setup/config actions in this skill must call gateway endpoints under `/v1/integrations/telegram/*` — never call the daemon runtime port directly.
 
 ## What You Need
 

--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -12,7 +12,7 @@ You are helping your user connect a Telegram bot to the Vellum Assistant gateway
 
 Before beginning setup, verify these conditions are met:
 
-1. **Gateway is running:** Run `curl -sf http://localhost:7830/healthz` — it should return OK. If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
+1. **Gateway + runtime are reachable through the gateway:** Run `TOKEN=$(cat ~/.vellum/http-token) && curl -sf http://localhost:7830/v1/health -H "Authorization: Bearer $TOKEN"` — it should return runtime health JSON (for example `{"status":"healthy",...}`). If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
 2. **Public ingress URL is configured.** The gateway webhook URL is derived from `${ingress.publicBaseUrl}/webhooks/telegram`. If the ingress URL is not configured, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the URL before continuing.
 3. **Use gateway control-plane routes only.** Telegram setup/config actions in this skill must call gateway endpoints under `/v1/integrations/telegram/*` — never call the daemon runtime port directly.
 

--- a/skills/trusted-contacts/SKILL.md
+++ b/skills/trusted-contacts/SKILL.md
@@ -10,6 +10,7 @@ You are helping your user manage trusted contacts for the Vellum Assistant. Trus
 ## Prerequisites
 
 - The gateway API is available at `http://localhost:7830` (or the configured gateway port).
+- Use gateway control-plane routes only: this skill calls `/v1/ingress/*` on the gateway, never the daemon runtime port directly.
 - The bearer token is stored at `~/.vellum/http-token`. Read it with: `TOKEN=$(cat ~/.vellum/http-token)`.
 
 ## Concepts


### PR DESCRIPTION
## Summary
- add dedicated gateway control-plane proxies for Telegram integration endpoints:
  - `GET/POST/DELETE /v1/integrations/telegram/config`
  - `POST /v1/integrations/telegram/commands`
  - `POST /v1/integrations/telegram/setup`
- add dedicated gateway control-plane proxies for ingress endpoints:
  - `GET/POST /v1/ingress/members`
  - `DELETE /v1/ingress/members/:memberId`
  - `POST /v1/ingress/members/:memberId/block`
  - `GET/POST /v1/ingress/invites`
  - `DELETE /v1/ingress/invites/:inviteId`
  - `POST /v1/ingress/invites/redeem`
- wire these routes into `gateway/src/index.ts` with runtime bearer auth so they work even when `GATEWAY_RUNTIME_PROXY_ENABLED=false`
- document the new dedicated routes in gateway OpenAPI schema, README, and ARCHITECTURE docs
- update `telegram-setup` and `trusted-contacts` skills to explicitly require gateway control-plane routes (no direct daemon port usage)

## Testing
- `cd gateway && bun test src/__tests__/telegram-control-plane-proxy.test.ts src/__tests__/ingress-control-plane-proxy.test.ts src/__tests__/schema.test.ts`
- `cd gateway && bunx tsc --noEmit`
- `cd assistant && bun test src/__tests__/gateway-only-guard.test.ts`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
