### PR TITLE
feat: playwright test timing in artifacts and live CI display

### DIFF
--- a/playwright/agent/runner.ts
+++ b/playwright/agent/runner.ts
@@ -11,7 +11,7 @@
 import "dotenv/config";
 
 import { type ChildProcess, spawn } from "child_process";
-import { mkdirSync, readdirSync, readFileSync } from "fs";
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "fs";
 import path from "path";
 
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
@@ -77,6 +77,16 @@ function discoverTestCases(casesDir: string, filter?: string): TestCase[] {
   }
 
   return cases;
+}
+
+// ── Formatting ──────────────────────────────────────────────────────
+
+function formatDuration(ms: number): string {
+  const secs = Math.floor(ms / 1000);
+  const mins = Math.floor(secs / 60);
+  const remSecs = secs % 60;
+  if (mins === 0) return `${remSecs}s`;
+  return `${mins}m ${remSecs}s`;
 }
 
 // ── Runner ──────────────────────────────────────────────────────────
@@ -231,6 +241,22 @@ async function main(): Promise<void> {
     `Results: ${passed} passed, ${failed} failed (${(totalDuration / 1000).toFixed(1)}s total)`,
   );
   console.log("─".repeat(60));
+
+  // Write test report for artifact consumption
+  const reportDir = path.resolve(__dirname, "../test-results");
+  mkdirSync(reportDir, { recursive: true });
+  const report = {
+    timestamp: new Date().toISOString(),
+    summary: { passed, failed, totalDurationMs: totalDuration },
+    tests: results.map((r) => ({
+      name: r.name,
+      passed: r.passed,
+      message: r.message,
+      durationMs: r.durationMs,
+      duration: formatDuration(r.durationMs),
+    })),
+  };
+  writeFileSync(path.join(reportDir, "test-report.json"), JSON.stringify(report, null, 2));
 
   if (failed > 0) {
     process.exit(1);

--- a/playwright/scripts/agent-ci.ts
+++ b/playwright/scripts/agent-ci.ts
@@ -58,6 +58,50 @@ function stepIcon(step: StepInfo): string {
   return "○";
 }
 
+function formatStepDuration(step: StepInfo): string {
+  if (step.startedAt && step.completedAt) {
+    const start = new Date(step.startedAt);
+    const end = new Date(step.completedAt);
+    const secs = Math.floor((end.getTime() - start.getTime()) / 1000);
+    const mins = Math.floor(secs / 60);
+    const remSecs = secs % 60;
+    if (mins === 0) return `${remSecs}s`;
+    return `${mins}m ${remSecs}s`;
+  }
+  if (step.startedAt && step.status === "in_progress") {
+    const secs = Math.floor((Date.now() - new Date(step.startedAt).getTime()) / 1000);
+    const mins = Math.floor(secs / 60);
+    const remSecs = secs % 60;
+    if (mins === 0) return `${remSecs}s`;
+    return `${mins}m ${remSecs}s`;
+  }
+  return "";
+}
+
+interface TestLine {
+  name: string;
+  passed: boolean;
+  duration: string;
+}
+
+/** Parse test result lines from the "Run Playwright tests" step logs. */
+function parseTestLines(logText: string): TestLine[] {
+  const tests: TestLine[] = [];
+  // Match runner output: "  ✓ test-name (12.3s)" or "  ✗ test-name (12.3s)"
+  const regex = /^\s*[✓✗]\s+(.+?)\s+\(([^)]+)\)/gm;
+  let match;
+  while ((match = regex.exec(logText)) !== null) {
+    tests.push({
+      name: match[1],
+      passed: logText[match.index + logText.slice(match.index).search(/[✓✗]/)] === "✓",
+      duration: match[2],
+    });
+  }
+  return tests;
+}
+
+let cachedTestLines: TestLine[] = [];
+
 function renderStatus(runUrl: string, startTime: Date, jobs: JobInfo[]): void {
   const lines: string[] = [];
 
@@ -76,8 +120,19 @@ function renderStatus(runUrl: string, startTime: Date, jobs: JobInfo[]): void {
 
   for (const step of job.steps) {
     const icon = stepIcon(step);
+    const duration = formatStepDuration(step);
+    const durationSuffix = duration ? ` \x1b[90m(${duration})\x1b[0m` : "";
     const color = step.conclusion === "failure" ? "\x1b[31m" : step.conclusion === "success" ? "\x1b[32m" : step.status === "in_progress" ? "\x1b[33m" : "\x1b[90m";
-    lines.push(`  ${color}${icon}\x1b[0m ${step.name}`);
+    lines.push(`  ${color}${icon}\x1b[0m ${step.name}${durationSuffix}`);
+
+    // Show test sub-bullets under "Run Playwright tests"
+    if (step.name === "Run Playwright tests" && cachedTestLines.length > 0) {
+      for (const t of cachedTestLines) {
+        const tIcon = t.passed ? "✓" : "✗";
+        const tColor = t.passed ? "\x1b[32m" : "\x1b[31m";
+        lines.push(`    ${tColor}${tIcon}\x1b[0m ${t.name} \x1b[90m(${t.duration})\x1b[0m`);
+      }
+    }
   }
 
   process.stdout.write(lines.join("\n") + "\n");
@@ -141,6 +196,26 @@ while (true) {
       jobs: JobInfo[];
     };
 
+    // Fetch test sub-bullets from job logs when the test step has finished
+    const playwrightJob = run.jobs.find((j) => j.name === "Playwright Tests");
+    const testStep = playwrightJob?.steps.find((s) => s.name === "Run Playwright tests");
+    if (testStep?.completedAt && cachedTestLines.length === 0 && playwrightJob) {
+      try {
+        const { stdout: jobsJson } = gh([
+          "run", "view", runId, "-R", REPO, "--json", "jobs", "--jq",
+          `.jobs[] | select(.name == "Playwright Tests") | .databaseId`,
+        ]);
+        if (jobsJson) {
+          const { stdout: logText } = gh([
+            "api", `repos/${REPO}/actions/jobs/${jobsJson}/logs`,
+          ]);
+          cachedTestLines = parseTestLines(logText);
+        }
+      } catch {
+        // Log fetching may fail; continue without sub-bullets
+      }
+    }
+
     renderStatus(runUrl, startTime, run.jobs);
 
     if (run.status === "completed") {
@@ -159,6 +234,16 @@ const icon = conclusion === "success" ? "✓" : "✗";
 const color = conclusion === "success" ? "\x1b[32m" : "\x1b[31m";
 console.log(`\n${color}${icon}\x1b[0m Playwright Tests ${conclusion} in ${formatElapsed(startTime)}`);
 console.log(`  ${runUrl}`);
+
+// Show individual test results
+if (cachedTestLines.length > 0) {
+  console.log("\n  Tests:");
+  for (const t of cachedTestLines) {
+    const tIcon = t.passed ? "✓" : "✗";
+    const tColor = t.passed ? "\x1b[32m" : "\x1b[31m";
+    console.log(`    ${tColor}${tIcon}\x1b[0m ${t.name} \x1b[90m(${t.duration})\x1b[0m`);
+  }
+}
 
 // Fetch specific artifact URL
 const { stdout: artifactJson } = gh([


### PR DESCRIPTION
## Summary
- **Test report artifact**: The agent runner now writes `test-results/test-report.json` with per-test timing data (name, passed/failed, duration in ms and formatted string). This gets uploaded as part of the CI artifact.
- **Step durations in live display**: Each CI step now shows elapsed time — computed from `startedAt`/`completedAt` for finished steps, or live-updating for in-progress steps.
- **Test sub-bullets**: After the "Run Playwright tests" step completes, job logs are fetched and parsed to show individual test results as indented sub-bullets under the step, with pass/fail icons and durations. These also appear in the final summary.

Example live display:
```
Playwright Tests · https://github.com/.../runs/123
Elapsed: 3m 45s

  ✓ Checkout (2s)
  ✓ Build macOS app (4m 12s)
  ✓ Run Playwright tests (1m 23s)
    ✓ hello-world (80.5s)
    ✗ onboarding-flow (2.8s)
  ● Upload test artifacts (3s)
```

## Test plan
- [ ] Run `bun run test:agent:ci` and verify step durations appear in the live display
- [ ] Verify test sub-bullets appear after "Run Playwright tests" completes
- [ ] Download artifact and check `test-report.json` has per-test timing data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
