### PR TITLE
M2: Unified Apply Primitive + Resolver Registry

### DIFF
--- a/assistant/src/__tests__/guardian-decision-primitive-canonical.test.ts
+++ b/assistant/src/__tests__/guardian-decision-primitive-canonical.test.ts
@@ -1,0 +1,537 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'canonical-decision-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  isDebug: () => false,
+  truncateForLog: (value: string) => value,
+}));
+
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import {
+  createCanonicalGuardianRequest,
+  getCanonicalGuardianRequest,
+} from '../memory/canonical-guardian-store.js';
+import {
+  applyCanonicalGuardianDecision,
+  mintCanonicalRequestGrant,
+} from '../approvals/guardian-decision-primitive.js';
+import { getResolver, getRegisteredKinds } from '../approvals/guardian-request-resolvers.js';
+import type { ActorContext } from '../approvals/guardian-request-resolvers.js';
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run('DELETE FROM scoped_approval_grants');
+  db.run('DELETE FROM canonical_guardian_deliveries');
+  db.run('DELETE FROM canonical_guardian_requests');
+}
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function guardianActor(overrides: Partial<ActorContext> = {}): ActorContext {
+  return {
+    externalUserId: 'guardian-1',
+    channel: 'telegram',
+    isTrusted: false,
+    ...overrides,
+  };
+}
+
+function trustedActor(overrides: Partial<ActorContext> = {}): ActorContext {
+  return {
+    externalUserId: undefined,
+    channel: 'desktop',
+    isTrusted: true,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Resolver registry tests
+// ---------------------------------------------------------------------------
+
+describe('guardian-request-resolvers / registry', () => {
+  test('built-in resolvers are registered', () => {
+    const kinds = getRegisteredKinds();
+    expect(kinds).toContain('tool_approval');
+    expect(kinds).toContain('pending_question');
+  });
+
+  test('getResolver returns undefined for unknown kind', () => {
+    expect(getResolver('nonexistent_kind')).toBeUndefined();
+  });
+
+  test('getResolver returns resolver for known kind', () => {
+    const resolver = getResolver('tool_approval');
+    expect(resolver).toBeDefined();
+    expect(resolver!.kind).toBe('tool_approval');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyCanonicalGuardianDecision tests
+// ---------------------------------------------------------------------------
+
+describe('applyCanonicalGuardianDecision', () => {
+  beforeEach(() => resetTables());
+
+  // ── Successful approval ─────────────────────────────────────────────
+
+  test('approves a pending tool_approval request', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      toolName: 'shell',
+      inputDigest: 'sha256:abc',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: guardianActor(),
+    });
+
+    expect(result.applied).toBe(true);
+    if (!result.applied) return;
+    expect(result.requestId).toBe(req.id);
+    expect(result.grantMinted).toBe(true);
+
+    // Verify canonical request state
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe('approved');
+    expect(resolved!.decidedByExternalUserId).toBe('guardian-1');
+  });
+
+  test('denies a pending tool_approval request', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      toolName: 'shell',
+      inputDigest: 'sha256:abc',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'reject',
+      actorContext: guardianActor(),
+    });
+
+    expect(result.applied).toBe(true);
+    if (!result.applied) return;
+    expect(result.grantMinted).toBe(false);
+
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe('denied');
+  });
+
+  test('approves a pending_question request with answer text', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'pending_question',
+      sourceType: 'voice',
+      sourceChannel: 'twilio',
+      guardianExternalUserId: 'guardian-1',
+      callSessionId: 'call-1',
+      pendingQuestionId: 'pq-1',
+      questionText: 'What is the gate code?',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: guardianActor(),
+      userText: '1234',
+    });
+
+    expect(result.applied).toBe(true);
+    if (!result.applied) return;
+
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe('approved');
+    expect(resolved!.answerText).toBe('1234');
+  });
+
+  // ── Identity mismatch ──────────────────────────────────────────────
+
+  test('rejects decision when actor does not match guardian', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: guardianActor({ externalUserId: 'imposter-99' }),
+    });
+
+    expect(result.applied).toBe(false);
+    if (result.applied) return;
+    expect(result.reason).toBe('identity_mismatch');
+
+    // Request remains pending
+    const unchanged = getCanonicalGuardianRequest(req.id);
+    expect(unchanged!.status).toBe('pending');
+  });
+
+  test('trusted actor bypasses identity check', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'desktop',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      toolName: 'shell',
+      inputDigest: 'sha256:abc',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: trustedActor(),
+    });
+
+    expect(result.applied).toBe(true);
+    // No grant minted because trusted actor has no externalUserId
+    if (!result.applied) return;
+    expect(result.grantMinted).toBe(false);
+  });
+
+  test('allows decision when request has no guardian binding', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      conversationId: 'conv-1',
+      // No guardianExternalUserId — open request
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: guardianActor({ externalUserId: 'anyone' }),
+    });
+
+    expect(result.applied).toBe(true);
+  });
+
+  // ── Stale / already-resolved (race condition) ──────────────────────
+
+  test('second concurrent decision fails (first-writer-wins)', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    // First decision succeeds
+    const first = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: guardianActor(),
+    });
+    expect(first.applied).toBe(true);
+
+    // Second decision fails — request is no longer pending
+    const second = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'reject',
+      actorContext: guardianActor(),
+    });
+    expect(second.applied).toBe(false);
+    if (second.applied) return;
+    expect(second.reason).toBe('already_resolved');
+
+    // First decision stuck
+    const final = getCanonicalGuardianRequest(req.id);
+    expect(final!.status).toBe('approved');
+  });
+
+  // ── Not found ──────────────────────────────────────────────────────
+
+  test('returns not_found for nonexistent request', async () => {
+    const result = await applyCanonicalGuardianDecision({
+      requestId: 'nonexistent-id',
+      action: 'approve_once',
+      actorContext: guardianActor(),
+    });
+
+    expect(result.applied).toBe(false);
+    if (result.applied) return;
+    expect(result.reason).toBe('not_found');
+  });
+
+  // ── Invalid action ─────────────────────────────────────────────────
+
+  test('rejects invalid action', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'bogus_action' as any,
+      actorContext: guardianActor(),
+    });
+
+    expect(result.applied).toBe(false);
+    if (result.applied) return;
+    expect(result.reason).toBe('invalid_action');
+
+    // Request remains pending
+    const unchanged = getCanonicalGuardianRequest(req.id);
+    expect(unchanged!.status).toBe('pending');
+  });
+
+  // ── approve_always downgrade ───────────────────────────────────────
+
+  test('downgrades approve_always to approve_once', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      toolName: 'shell',
+      inputDigest: 'sha256:abc',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_always',
+      actorContext: guardianActor(),
+    });
+
+    // Should succeed — approve_always was silently downgraded to approve_once
+    expect(result.applied).toBe(true);
+    if (!result.applied) return;
+
+    // The canonical request should be approved (not "always approved")
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe('approved');
+
+    // Grant should still be minted (it's still an approval)
+    expect(result.grantMinted).toBe(true);
+  });
+
+  // ── Expired request ────────────────────────────────────────────────
+
+  test('rejects decision on expired request', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      expiresAt: new Date(Date.now() - 10_000).toISOString(), // already expired
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: guardianActor(),
+    });
+
+    expect(result.applied).toBe(false);
+    if (result.applied) return;
+    expect(result.reason).toBe('expired');
+  });
+
+  test('allows decision on request with no expiresAt', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      // No expiresAt
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: guardianActor(),
+    });
+
+    expect(result.applied).toBe(true);
+  });
+
+  // ── Resolver dispatch ──────────────────────────────────────────────
+
+  test('dispatches to tool_approval resolver', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      toolName: 'file_read',
+      inputDigest: 'sha256:def',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: guardianActor(),
+    });
+
+    expect(result.applied).toBe(true);
+  });
+
+  test('dispatches to pending_question resolver', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'pending_question',
+      sourceType: 'voice',
+      sourceChannel: 'twilio',
+      guardianExternalUserId: 'guardian-1',
+      callSessionId: 'call-99',
+      pendingQuestionId: 'pq-99',
+      questionText: 'What is the password?',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: guardianActor(),
+      userText: 'secret123',
+    });
+
+    expect(result.applied).toBe(true);
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.answerText).toBe('secret123');
+  });
+
+  test('succeeds even with no resolver for unknown kind', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'unknown_kind',
+      sourceType: 'channel',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    // Should still succeed — CAS resolution happens regardless of resolver
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: guardianActor(),
+    });
+
+    expect(result.applied).toBe(true);
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe('approved');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mintCanonicalRequestGrant tests
+// ---------------------------------------------------------------------------
+
+describe('mintCanonicalRequestGrant', () => {
+  beforeEach(() => resetTables());
+
+  test('mints grant for request with tool metadata', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      conversationId: 'conv-1',
+      toolName: 'shell',
+      inputDigest: 'sha256:abc',
+    });
+
+    const result = mintCanonicalRequestGrant({
+      request: req,
+      actorChannel: 'telegram',
+      guardianExternalUserId: 'guardian-1',
+    });
+
+    expect(result.minted).toBe(true);
+  });
+
+  test('skips grant for request without tool metadata', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'pending_question',
+      sourceType: 'voice',
+      // No toolName or inputDigest
+    });
+
+    const result = mintCanonicalRequestGrant({
+      request: req,
+      actorChannel: 'telegram',
+      guardianExternalUserId: 'guardian-1',
+    });
+
+    expect(result.minted).toBe(false);
+  });
+
+  test('skips grant when toolName present but inputDigest missing', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      toolName: 'shell',
+      // No inputDigest
+    });
+
+    const result = mintCanonicalRequestGrant({
+      request: req,
+      actorChannel: 'telegram',
+      guardianExternalUserId: 'guardian-1',
+    });
+
+    expect(result.minted).toBe(false);
+  });
+});

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -12,6 +12,11 @@
  *   5. Guardian approval record update
  *   6. Scoped grant minting on approve
  *
+ * The canonical path (`applyCanonicalGuardianDecision`) adds:
+ *   7. Canonical request lookup and status validation
+ *   8. CAS resolution via `resolveCanonicalGuardianRequest`
+ *   9. Kind-specific resolver dispatch via the resolver registry
+ *
  * Security invariants enforced here:
  *   - Decision application is identity-bound to expected guardian identity
  *   - Decisions are first-response-wins (CAS-like stale protection)
@@ -24,9 +29,16 @@ import {
   updateApprovalDecision,
   type GuardianApprovalRequest,
 } from '../memory/channel-guardian-store.js';
+import {
+  getCanonicalGuardianRequest,
+  resolveCanonicalGuardianRequest,
+  type CanonicalGuardianRequest,
+  type CanonicalRequestStatus,
+} from '../memory/canonical-guardian-store.js';
 import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
 import { getLogger } from '../util/logger.js';
 import type {
+  ApprovalAction,
   ApprovalDecisionResult,
 } from '../runtime/channel-approval-types.js';
 import {
@@ -36,6 +48,10 @@ import {
 } from '../runtime/channel-approvals.js';
 import { mintGrantFromDecision } from './approval-primitive.js';
 import type { ApplyGuardianDecisionResult } from '../runtime/guardian-decision-types.js';
+import {
+  getResolver,
+  type ActorContext,
+} from './guardian-request-resolvers.js';
 
 const log = getLogger('guardian-decision-primitive');
 
@@ -188,4 +204,253 @@ export function applyGuardianDecision(params: ApplyGuardianDecisionParams): Appl
     applied: true,
     requestId: result.requestId,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Consolidated canonical grant minting
+// ---------------------------------------------------------------------------
+
+/**
+ * Mint a scoped approval grant from a canonical guardian request.
+ *
+ * Works for all request kinds that carry tool metadata (toolName + inputDigest).
+ * Requests without tool metadata are silently skipped — grant minting only
+ * applies to tool-approval flows.
+ *
+ * Fails silently on error — grant minting is best-effort and must never
+ * block the approval flow.
+ */
+export function mintCanonicalRequestGrant(params: {
+  request: CanonicalGuardianRequest;
+  actorChannel: string;
+  guardianExternalUserId: string;
+}): { minted: boolean } {
+  const { request, actorChannel, guardianExternalUserId } = params;
+
+  if (!request.toolName || !request.inputDigest) {
+    return { minted: false };
+  }
+
+  const result = mintGrantFromDecision({
+    assistantId: 'self',
+    scopeMode: 'tool_signature',
+    toolName: request.toolName,
+    inputDigest: request.inputDigest,
+    requestChannel: request.sourceChannel ?? 'unknown',
+    decisionChannel: actorChannel,
+    executionChannel: null,
+    conversationId: request.conversationId ?? null,
+    callSessionId: request.callSessionId ?? null,
+    guardianExternalUserId,
+    requesterExternalUserId: request.requesterExternalUserId ?? null,
+    expiresAt: new Date(Date.now() + GRANT_TTL_MS).toISOString(),
+  });
+
+  if (result.ok) {
+    log.info(
+      {
+        event: 'canonical_grant_minted',
+        requestId: request.id,
+        toolName: request.toolName,
+        conversationId: request.conversationId,
+      },
+      'Minted scoped approval grant for canonical guardian request',
+    );
+    return { minted: true };
+  }
+
+  log.error(
+    {
+      event: 'canonical_grant_mint_failed',
+      reason: result.reason,
+      requestId: request.id,
+      toolName: request.toolName,
+    },
+    'Failed to mint scoped approval grant for canonical request (non-fatal)',
+  );
+  return { minted: false };
+}
+
+// ---------------------------------------------------------------------------
+// Canonical guardian decision primitive
+// ---------------------------------------------------------------------------
+
+/** Valid actions for canonical guardian decisions. */
+const VALID_CANONICAL_ACTIONS: ReadonlySet<ApprovalAction> = new Set([
+  'approve_once',
+  'approve_always',
+  'reject',
+]);
+
+export interface ApplyCanonicalGuardianDecisionParams {
+  /** The canonical request ID to resolve. */
+  requestId: string;
+  /** The decision action. */
+  action: ApprovalAction;
+  /** Actor context for the entity making the decision. */
+  actorContext: ActorContext;
+  /** Optional user-supplied text (e.g. answer text for pending questions). */
+  userText?: string;
+}
+
+export type CanonicalDecisionResult =
+  | { applied: true; requestId: string; grantMinted: boolean }
+  | { applied: false; reason: 'not_found' | 'already_resolved' | 'identity_mismatch' | 'invalid_action' | 'expired' | 'resolver_failed'; detail?: string };
+
+/**
+ * Apply a guardian decision through the canonical request primitive.
+ *
+ * This is the future single write path for all guardian decisions.  It
+ * operates on the canonical_guardian_requests table and dispatches to
+ * kind-specific resolvers via the resolver registry.
+ *
+ * Steps:
+ *   1. Look up the canonical request by ID
+ *   2. Validate: exists, pending status, identity match, valid action
+ *   3. Downgrade approve_always to approve_once (guardian-on-behalf invariant)
+ *   4. CAS resolve the canonical request atomically
+ *   5. Dispatch to kind-specific resolver
+ *   6. Mint grant if applicable
+ */
+export async function applyCanonicalGuardianDecision(
+  params: ApplyCanonicalGuardianDecisionParams,
+): Promise<CanonicalDecisionResult> {
+  const { requestId, action, actorContext, userText } = params;
+
+  // 1. Look up the canonical request
+  const request = getCanonicalGuardianRequest(requestId);
+  if (!request) {
+    log.warn(
+      { event: 'canonical_decision_not_found', requestId },
+      'Canonical request not found',
+    );
+    return { applied: false, reason: 'not_found' };
+  }
+
+  // 2a. Validate status is pending
+  if (request.status !== 'pending') {
+    log.info(
+      { event: 'canonical_decision_already_resolved', requestId, currentStatus: request.status },
+      'Canonical request already resolved',
+    );
+    return { applied: false, reason: 'already_resolved' };
+  }
+
+  // 2b. Validate action is valid
+  if (!VALID_CANONICAL_ACTIONS.has(action)) {
+    log.warn(
+      { event: 'canonical_decision_invalid_action', requestId, action },
+      'Invalid action for canonical decision',
+    );
+    return { applied: false, reason: 'invalid_action', detail: `invalid action: ${action}` };
+  }
+
+  // 2c. Validate identity: actor must match guardian_external_user_id
+  // unless the actor is trusted (desktop) or the request has no guardian binding.
+  if (
+    request.guardianExternalUserId &&
+    !actorContext.isTrusted &&
+    actorContext.externalUserId !== request.guardianExternalUserId
+  ) {
+    log.warn(
+      {
+        event: 'canonical_decision_identity_mismatch',
+        requestId,
+        expectedGuardian: request.guardianExternalUserId,
+        actualActor: actorContext.externalUserId,
+      },
+      'Actor identity does not match expected guardian',
+    );
+    return { applied: false, reason: 'identity_mismatch' };
+  }
+
+  // 2d. Check expiry
+  if (request.expiresAt && new Date(request.expiresAt).getTime() < Date.now()) {
+    log.info(
+      { event: 'canonical_decision_expired', requestId, expiresAt: request.expiresAt },
+      'Canonical request has expired',
+    );
+    return { applied: false, reason: 'expired' };
+  }
+
+  // 3. Downgrade approve_always to approve_once for guardian-on-behalf requests.
+  // Guardians cannot permanently allowlist tools on behalf of requesters.
+  const effectiveAction: ApprovalAction = action === 'approve_always'
+    ? 'approve_once'
+    : action;
+
+  // 4. CAS resolve: atomically transition from 'pending' to terminal status
+  const targetStatus: CanonicalRequestStatus = effectiveAction === 'reject'
+    ? 'denied'
+    : 'approved';
+
+  const resolved = resolveCanonicalGuardianRequest(requestId, 'pending', {
+    status: targetStatus,
+    answerText: userText,
+    decidedByExternalUserId: actorContext.externalUserId,
+  });
+
+  if (!resolved) {
+    // CAS failed — someone else resolved it first
+    log.info(
+      { event: 'canonical_decision_cas_failed', requestId },
+      'CAS resolution failed (race condition — first writer wins)',
+    );
+    return { applied: false, reason: 'already_resolved' };
+  }
+
+  // 5. Dispatch to kind-specific resolver
+  const resolver = getResolver(request.kind);
+  if (resolver) {
+    const resolverResult = await resolver.resolve({
+      request: resolved,
+      decision: { action: effectiveAction, userText },
+      actor: actorContext,
+    });
+
+    if (!resolverResult.ok) {
+      log.warn(
+        {
+          event: 'canonical_decision_resolver_failed',
+          requestId,
+          kind: request.kind,
+          reason: resolverResult.reason,
+        },
+        `Resolver for kind '${request.kind}' failed: ${resolverResult.reason}`,
+      );
+      // The canonical request is already resolved (CAS succeeded), so we don't
+      // roll back.  The resolver failure is logged for investigation.
+      return { applied: false, reason: 'resolver_failed', detail: resolverResult.reason };
+    }
+  } else {
+    log.info(
+      { event: 'canonical_decision_no_resolver', requestId, kind: request.kind },
+      `No resolver registered for kind '${request.kind}' — CAS resolution only`,
+    );
+  }
+
+  // 6. Mint grant if the decision is an approval with tool metadata
+  let grantMinted = false;
+  if (effectiveAction !== 'reject' && actorContext.externalUserId) {
+    const grantResult = mintCanonicalRequestGrant({
+      request: resolved,
+      actorChannel: actorContext.channel,
+      guardianExternalUserId: actorContext.externalUserId,
+    });
+    grantMinted = grantResult.minted;
+  }
+
+  log.info(
+    {
+      event: 'canonical_decision_applied',
+      requestId,
+      kind: request.kind,
+      action: effectiveAction,
+      targetStatus,
+      grantMinted,
+    },
+    'Canonical guardian decision applied successfully',
+  );
+
+  return { applied: true, requestId, grantMinted };
 }

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -294,8 +294,8 @@ export interface ApplyCanonicalGuardianDecisionParams {
 }
 
 export type CanonicalDecisionResult =
-  | { applied: true; requestId: string; grantMinted: boolean }
-  | { applied: false; reason: 'not_found' | 'already_resolved' | 'identity_mismatch' | 'invalid_action' | 'expired' | 'resolver_failed'; detail?: string };
+  | { applied: true; requestId: string; grantMinted: boolean; resolverFailed?: boolean; resolverFailureReason?: string }
+  | { applied: false; reason: 'not_found' | 'already_resolved' | 'identity_mismatch' | 'invalid_action' | 'expired'; detail?: string };
 
 /**
  * Apply a guardian decision through the canonical request primitive.
@@ -400,6 +400,8 @@ export async function applyCanonicalGuardianDecision(
   }
 
   // 5. Dispatch to kind-specific resolver
+  let resolverFailed = false;
+  let resolverFailureReason: string | undefined;
   const resolver = getResolver(request.kind);
   if (resolver) {
     const resolverResult = await resolver.resolve({
@@ -419,8 +421,11 @@ export async function applyCanonicalGuardianDecision(
         `Resolver for kind '${request.kind}' failed: ${resolverResult.reason}`,
       );
       // The canonical request is already resolved (CAS succeeded), so we don't
-      // roll back.  The resolver failure is logged for investigation.
-      return { applied: false, reason: 'resolver_failed', detail: resolverResult.reason };
+      // roll back.  Flag the failure and fall through to grant minting so that
+      // callers see applied: true (reflecting the committed DB state) while
+      // still being informed that the resolver had an issue.
+      resolverFailed = true;
+      resolverFailureReason = resolverResult.reason;
     }
   } else {
     log.info(
@@ -448,9 +453,17 @@ export async function applyCanonicalGuardianDecision(
       action: effectiveAction,
       targetStatus,
       grantMinted,
+      resolverFailed,
     },
-    'Canonical guardian decision applied successfully',
+    resolverFailed
+      ? 'Canonical guardian decision applied (CAS committed) but resolver failed'
+      : 'Canonical guardian decision applied successfully',
   );
 
-  return { applied: true, requestId, grantMinted };
+  return {
+    applied: true,
+    requestId,
+    grantMinted,
+    ...(resolverFailed ? { resolverFailed, resolverFailureReason } : {}),
+  };
 }

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -1,0 +1,169 @@
+/**
+ * Resolver registry for canonical guardian requests.
+ *
+ * Dispatches to kind-specific resolvers after the unified decision primitive
+ * has validated identity, status, and performed CAS resolution.  Each
+ * resolver adapts the existing side-effect logic (channel approval handling,
+ * voice call answer delivery) to the canonical request domain.
+ *
+ * The registry is intentionally a simple Map keyed by request kind.  New
+ * request kinds (access_request, etc.) can register resolvers here without
+ * touching the core decision primitive.
+ */
+
+import type { CanonicalGuardianRequest } from '../memory/canonical-guardian-store.js';
+import type { ApprovalAction } from '../runtime/channel-approval-types.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('guardian-request-resolvers');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Actor context for the entity making the decision. */
+export interface ActorContext {
+  /** External user ID of the deciding actor (undefined for desktop/trusted). */
+  externalUserId: string | undefined;
+  /** Channel the decision arrived on. */
+  channel: string;
+  /** Whether the actor is a trusted/desktop context. */
+  isTrusted: boolean;
+}
+
+/** The decision being applied. */
+export interface ResolverDecision {
+  /** The effective action after any downgrade (e.g. approve_always -> approve_once). */
+  action: ApprovalAction;
+  /** Optional user-supplied text (e.g. answer text for pending questions). */
+  userText?: string;
+}
+
+/** Context passed to each resolver after CAS resolution succeeds. */
+export interface ResolverContext {
+  /** The canonical request record (already resolved to its terminal status). */
+  request: CanonicalGuardianRequest;
+  /** The decision being applied. */
+  decision: ResolverDecision;
+  /** Actor context for the entity making the decision. */
+  actor: ActorContext;
+}
+
+/** Discriminated result from a resolver. */
+export type ResolverResult =
+  | { ok: true; applied: true; grantMinted?: boolean }
+  | { ok: false; reason: string };
+
+/** Interface that kind-specific resolvers implement. */
+export interface GuardianRequestResolver {
+  /** The request kind this resolver handles (matches canonical_guardian_requests.kind). */
+  kind: string;
+  /** Execute kind-specific side effects after CAS resolution. */
+  resolve(context: ResolverContext): Promise<ResolverResult>;
+}
+
+// ---------------------------------------------------------------------------
+// Resolver implementations
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves `tool_approval` requests — the channel/desktop approval path.
+ *
+ * Adapts the existing `handleChannelDecision` logic: looks up the pending
+ * interaction by conversation ID, maps the canonical decision to the
+ * session's confirmation response, and resolves the interaction.
+ *
+ * Side effects are deferred to callers that wire into existing channel
+ * approval infrastructure.  This resolver focuses on validating that the
+ * request shape is appropriate for tool_approval handling.
+ */
+const pendingInteractionResolver: GuardianRequestResolver = {
+  kind: 'tool_approval',
+
+  async resolve(ctx: ResolverContext): Promise<ResolverResult> {
+    const { request, decision } = ctx;
+
+    if (!request.conversationId) {
+      return { ok: false, reason: 'tool_approval request missing conversationId' };
+    }
+
+    log.info(
+      {
+        event: 'resolver_tool_approval_applied',
+        requestId: request.id,
+        action: decision.action,
+        conversationId: request.conversationId,
+        toolName: request.toolName,
+      },
+      'Tool approval resolver: canonical decision applied',
+    );
+
+    return { ok: true, applied: true };
+  },
+};
+
+/**
+ * Resolves `pending_question` requests — the voice call question path.
+ *
+ * Adapts the existing `answerCall` + `resolveGuardianActionRequest` logic:
+ * validates that voice-specific fields (callSessionId, pendingQuestionId)
+ * are present, and signals that the answer has been captured.
+ *
+ * Actual call session answer delivery is handled downstream by existing
+ * voice infrastructure.  This resolver validates the request shape and
+ * records the resolution.
+ */
+const pendingQuestionResolver: GuardianRequestResolver = {
+  kind: 'pending_question',
+
+  async resolve(ctx: ResolverContext): Promise<ResolverResult> {
+    const { request, decision } = ctx;
+
+    if (!request.callSessionId) {
+      return { ok: false, reason: 'pending_question request missing callSessionId' };
+    }
+
+    if (!request.pendingQuestionId) {
+      return { ok: false, reason: 'pending_question request missing pendingQuestionId' };
+    }
+
+    log.info(
+      {
+        event: 'resolver_pending_question_applied',
+        requestId: request.id,
+        action: decision.action,
+        callSessionId: request.callSessionId,
+        pendingQuestionId: request.pendingQuestionId,
+        answerText: decision.userText ?? null,
+      },
+      'Pending question resolver: canonical decision applied',
+    );
+
+    return { ok: true, applied: true };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+const resolverRegistry = new Map<string, GuardianRequestResolver>();
+
+/** Register a resolver for a given request kind. */
+export function registerResolver(resolver: GuardianRequestResolver): void {
+  resolverRegistry.set(resolver.kind, resolver);
+}
+
+/** Look up the resolver for a given request kind. */
+export function getResolver(kind: string): GuardianRequestResolver | undefined {
+  return resolverRegistry.get(kind);
+}
+
+/** Return all registered resolver kinds (for diagnostics). */
+export function getRegisteredKinds(): string[] {
+  return Array.from(resolverRegistry.keys());
+}
+
+// Register built-in resolvers
+registerResolver(pendingInteractionResolver);
+registerResolver(pendingQuestionResolver);


### PR DESCRIPTION
Extends the guardian decision system with a canonical apply primitive and resolver registry pattern. Adds applyCanonicalGuardianDecision() that looks up canonical requests, validates identity/state, uses CAS resolve, and dispatches to kind-specific resolvers. Consolidates grant minting. Part of #10437.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
