### PR TITLE
fix: 5-minute timeout per agent test and AppleScript error guidance

### DIFF
--- a/playwright/agent/agent.ts
+++ b/playwright/agent/agent.ts
@@ -57,10 +57,25 @@ export interface AgentOptions {
 }
 
 export async function runAgent(options: AgentOptions): Promise<TestResult> {
+  const timeoutResult: TestResult = {
+    passed: false,
+    message: `Test timed out after ${MAX_TEST_DURATION_MS / 1000}s.`,
+  };
+
+  // Race the agent loop against a hard deadline so the timeout fires
+  // even if an await (API call, tool execution) is in flight.
+  return Promise.race([
+    runAgentLoop(options),
+    new Promise<TestResult>((resolve) =>
+      setTimeout(() => resolve(timeoutResult), MAX_TEST_DURATION_MS),
+    ),
+  ]);
+}
+
+async function runAgentLoop(options: AgentOptions): Promise<TestResult> {
   const { testContent, page, screenshotDir, verbose = false } = options;
 
   const client = new Anthropic();
-  const testStartTime = Date.now();
   const messages: Anthropic.MessageParam[] = [
     {
       role: "user",
@@ -69,16 +84,6 @@ export async function runAgent(options: AgentOptions): Promise<TestResult> {
   ];
 
   for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
-    // Check time limit
-    const elapsed = Date.now() - testStartTime;
-    if (elapsed > MAX_TEST_DURATION_MS) {
-      const elapsedSec = Math.floor(elapsed / 1000);
-      return {
-        passed: false,
-        message: `Test timed out after ${elapsedSec}s (limit: ${MAX_TEST_DURATION_MS / 1000}s).`,
-      };
-    }
-
     if (verbose) {
       console.log(`  [agent] iteration ${iteration + 1}`);
     }

--- a/playwright/agent/agent.ts
+++ b/playwright/agent/agent.ts
@@ -57,22 +57,19 @@ export interface AgentOptions {
 }
 
 export async function runAgent(options: AgentOptions): Promise<TestResult> {
-  const timeoutResult: TestResult = {
-    passed: false,
-    message: `Test timed out after ${MAX_TEST_DURATION_MS / 1000}s.`,
-  };
+  const controller = new AbortController();
+  const { signal } = controller;
 
-  // Race the agent loop against a hard deadline so the timeout fires
-  // even if an await (API call, tool execution) is in flight.
-  return Promise.race([
-    runAgentLoop(options),
-    new Promise<TestResult>((resolve) =>
-      setTimeout(() => resolve(timeoutResult), MAX_TEST_DURATION_MS),
-    ),
-  ]);
+  const timeoutId = setTimeout(() => controller.abort(), MAX_TEST_DURATION_MS);
+
+  try {
+    return await runAgentLoop(options, signal);
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
-async function runAgentLoop(options: AgentOptions): Promise<TestResult> {
+async function runAgentLoop(options: AgentOptions, signal: AbortSignal): Promise<TestResult> {
   const { testContent, page, screenshotDir, verbose = false } = options;
 
   const client = new Anthropic();
@@ -84,12 +81,26 @@ async function runAgentLoop(options: AgentOptions): Promise<TestResult> {
   ];
 
   for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
+    if (signal.aborted) {
+      return {
+        passed: false,
+        message: `Test timed out after ${MAX_TEST_DURATION_MS / 1000}s.`,
+      };
+    }
+
     if (verbose) {
       console.log(`  [agent] iteration ${iteration + 1}`);
     }
 
     let response: Anthropic.Message;
     for (let retry = 0; ; retry++) {
+      if (signal.aborted) {
+        return {
+          passed: false,
+          message: `Test timed out after ${MAX_TEST_DURATION_MS / 1000}s.`,
+        };
+      }
+
       try {
         const stream = client.messages.stream({
           model: MODEL,
@@ -101,6 +112,12 @@ async function runAgentLoop(options: AgentOptions): Promise<TestResult> {
         response = await stream.finalMessage();
         break;
       } catch (err: unknown) {
+        if (signal.aborted) {
+          return {
+            passed: false,
+            message: `Test timed out after ${MAX_TEST_DURATION_MS / 1000}s.`,
+          };
+        }
         const isRetryable =
           err instanceof Anthropic.APIError &&
           (err.status === 429 || err.status === 529 || err.status === 503);
@@ -145,6 +162,13 @@ async function runAgentLoop(options: AgentOptions): Promise<TestResult> {
 
     for (const block of assistantContent) {
       if (block.type !== "tool_use") continue;
+
+      if (signal.aborted) {
+        return {
+          passed: false,
+          message: `Test timed out after ${MAX_TEST_DURATION_MS / 1000}s.`,
+        };
+      }
 
       const { result, testResult } = await executeTool(
         page,

--- a/playwright/agent/agent.ts
+++ b/playwright/agent/agent.ts
@@ -13,6 +13,7 @@ import { TOOL_DEFINITIONS, executeTool, type TestResult } from "./tools";
 // ── Constants ───────────────────────────────────────────────────────
 
 const MAX_ITERATIONS = 1000;
+const MAX_TEST_DURATION_MS = 5 * 60 * 1000; // 5 minutes per test
 const MAX_RETRIES = 5;
 const INITIAL_RETRY_DELAY_MS = 5000;
 const MODEL = "claude-opus-4-6";
@@ -36,7 +37,15 @@ Rules:
 - Never embed secrets directly in test content. Use type_env_var to type secret values (e.g., API keys) from environment variables without exposing them.
 - After completing all steps, verify each expected outcome.
 - You MUST call report_result exactly once when done, indicating whether the test passed or failed.
-- If a step fails (tool returns an error), try to recover once. If it still fails, report the test as failed with details.`;
+- If a step fails (tool returns an error), try to recover once. If it still fails, report the test as failed with details.
+- You have a strict 5-minute time limit. Work efficiently and avoid unnecessary retries.
+
+AppleScript tips (avoid common errors):
+- ALWAYS dump the accessibility tree (entire contents of window 1) BEFORE trying to interact with elements. Never guess element indices.
+- Static text elements are read-only — do not try to set their value.
+- Use "click" and "keystroke" for input, not "set value" on non-editable elements.
+- Ensure proper AppleScript syntax: use "of" for hierarchy, quote strings, and avoid bare ordinal words like "1st", "2nd", "3rd" outside of proper AppleScript context.
+- If an element reference fails with "Invalid index", re-inspect the accessibility tree to find the correct path.`;
 
 // ── Agent Loop ──────────────────────────────────────────────────────
 
@@ -51,6 +60,7 @@ export async function runAgent(options: AgentOptions): Promise<TestResult> {
   const { testContent, page, screenshotDir, verbose = false } = options;
 
   const client = new Anthropic();
+  const testStartTime = Date.now();
   const messages: Anthropic.MessageParam[] = [
     {
       role: "user",
@@ -59,6 +69,16 @@ export async function runAgent(options: AgentOptions): Promise<TestResult> {
   ];
 
   for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
+    // Check time limit
+    const elapsed = Date.now() - testStartTime;
+    if (elapsed > MAX_TEST_DURATION_MS) {
+      const elapsedSec = Math.floor(elapsed / 1000);
+      return {
+        passed: false,
+        message: `Test timed out after ${elapsedSec}s (limit: ${MAX_TEST_DURATION_MS / 1000}s).`,
+      };
+    }
+
     if (verbose) {
       console.log(`  [agent] iteration ${iteration + 1}`);
     }


### PR DESCRIPTION
## Summary
Addresses issues from [run 22499490680](https://github.com/vellum-ai/vellum-assistant/actions/runs/22499490680):

- **5-minute timeout**: `permission-denial-handling` took 627s (10+ min) and `tool-permission-prompts` took 278s due to the agent generating broken AppleScript and retrying repeatedly. Added `MAX_TEST_DURATION_MS = 5 * 60 * 1000` check at the start of each agent iteration — tests exceeding the limit fail with a clear timeout message.

- **AppleScript guidance in system prompt**: The errors were all from the LLM agent generating imperfect AppleScript:
  - `-1719 Invalid index`: Agent guessed element indices without inspecting the accessibility tree first
  - `-10006 Can't set`: Agent tried to modify read-only static text elements
  - `-2741 script error "rd"`: Agent generated syntactically broken AppleScript
  
  Added explicit tips: always dump the accessibility tree before interacting, don't modify static text, use proper AppleScript syntax.

- **Time awareness**: Told the agent about the 5-minute limit so it works efficiently and avoids excessive retries.

## Test plan
- [ ] Run agent tests — tests should fail rather than run for 10+ minutes
- [ ] Verify the AppleScript guidance reduces error rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
