### PR TITLE
fix(parental): center Switch Mode modal content

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1681,41 +1681,46 @@ private struct ProfileSwitchModal: View {
     private var isChildToParental: Bool { activeProfile == "child" }
 
     var body: some View {
-        VStack(spacing: VSpacing.md) {
-            // Title
-            Text(isChildToParental ? "Switch to Parental Mode" : "Switch to Restricted Mode")
-                .font(VFont.headline)
-                .foregroundColor(VColor.textPrimary)
+        ZStack {
+            VColor.background.ignoresSafeArea()
+
+            VStack(spacing: VSpacing.md) {
+                // Title
+                Text(isChildToParental ? "Switch to Parental Mode" : "Switch to Restricted Mode")
+                    .font(VFont.headline)
+                    .foregroundColor(VColor.textPrimary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity, alignment: .center)
+
+                // From/to avatar icons
+                HStack(spacing: VSpacing.md) {
+                    profileAvatarColumn(isParental: !isChildToParental)
+                    Image(systemName: "arrow.right")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(VColor.textMuted)
+                    profileAvatarColumn(isParental: isChildToParental)
+                }
                 .frame(maxWidth: .infinity, alignment: .center)
 
-            // From/to avatar icons
-            HStack(spacing: VSpacing.md) {
-                profileAvatarColumn(isParental: !isChildToParental)
-                Image(systemName: "arrow.right")
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(VColor.textMuted)
-                profileAvatarColumn(isParental: isChildToParental)
-            }
-            .frame(maxWidth: .infinity, alignment: .center)
+                ZStack {
+                    enterPINContent
+                        .opacity(step == .enterPIN ? 1 : 0)
+                        .allowsHitTesting(step == .enterPIN)
 
-            ZStack {
-                enterPINContent
-                    .opacity(step == .enterPIN ? 1 : 0)
-                    .allowsHitTesting(step == .enterPIN)
-
-                switchingContent
-                    .opacity(step == .switching ? 1 : 0)
-                    .allowsHitTesting(step == .switching)
-                    .transition(.opacity)
+                    switchingContent
+                        .opacity(step == .switching ? 1 : 0)
+                        .allowsHitTesting(step == .switching)
+                        .transition(.opacity)
+                }
+                .frame(maxWidth: .infinity)
             }
-            .frame(maxWidth: .infinity)
+            .padding(VSpacing.xl)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
         }
-        .padding(VSpacing.xl)
-        .frame(width: 340)
-        .fixedSize(horizontal: true, vertical: true)
-        .background(VColor.background)
+        .frame(width: 360, height: 280)
         .animation(VAnimation.standard, value: step)
     }
+
 
     private var enterPINContent: some View {
         VStack(alignment: .center, spacing: VSpacing.md) {
@@ -1737,16 +1742,18 @@ private struct ProfileSwitchModal: View {
                 Text(" ").font(VFont.caption)
             }
 
-            HStack {
-                VButton(label: "Cancel", style: .secondary) { dismiss() }
+            HStack(spacing: VSpacing.sm) {
                 Spacer()
+                VButton(label: "Cancel", style: .secondary) { dismiss() }
                 VButton(label: "Switch Mode", style: .primary) {
                     performSwitch()
                 }
                 .disabled(isChildToParental && pin.count != 6)
                 .keyboardShortcut(.return, modifiers: [])
+                Spacer()
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
     }
 
     private var switchingContent: some View {


### PR DESCRIPTION
## Summary
- Modal content is now centered both vertically and horizontally inside the sheet window
- Replaced the outer `VStack` with a `ZStack` containing `VColor.background.ignoresSafeArea()` and a content `VStack` with `.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)`
- Set a fixed `frame(width: 360, height: 280)` on the outer `ZStack` so the sheet has a defined size for the OS to center content within
- Added `.multilineTextAlignment(.center)` to the title text
- Fixed the buttons row to use `Spacer()` on both sides for symmetric horizontal centering
- Added `.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)` to `enterPINContent`'s `VStack`

## Test plan
- [ ] Open the Switch Mode modal as a child user — content (title, avatar icons, PIN field, buttons) is centered both horizontally and vertically
- [ ] Open the Switch Mode modal as a parental user — content (title, avatars, buttons, no PIN field) is centered
- [ ] Confirm the Cancel and Switch Mode buttons are horizontally centered (equal spacing on left and right)
- [ ] Confirm the "Switching profile..." spinner is centered while the switch is in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
