### PR TITLE
fix(parental): settings bugs — toggles, smart button, PIN flow, toast, clear icon, centering

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1681,41 +1681,46 @@ private struct ProfileSwitchModal: View {
     private var isChildToParental: Bool { activeProfile == "child" }
 
     var body: some View {
-        VStack(spacing: VSpacing.md) {
-            // Title
-            Text(isChildToParental ? "Switch to Parental Mode" : "Switch to Restricted Mode")
-                .font(VFont.headline)
-                .foregroundColor(VColor.textPrimary)
+        ZStack {
+            VColor.background.ignoresSafeArea()
+
+            VStack(spacing: VSpacing.md) {
+                // Title
+                Text(isChildToParental ? "Switch to Parental Mode" : "Switch to Restricted Mode")
+                    .font(VFont.headline)
+                    .foregroundColor(VColor.textPrimary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity, alignment: .center)
+
+                // From/to avatar icons
+                HStack(spacing: VSpacing.md) {
+                    profileAvatarColumn(isParental: !isChildToParental)
+                    Image(systemName: "arrow.right")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(VColor.textMuted)
+                    profileAvatarColumn(isParental: isChildToParental)
+                }
                 .frame(maxWidth: .infinity, alignment: .center)
 
-            // From/to avatar icons
-            HStack(spacing: VSpacing.md) {
-                profileAvatarColumn(isParental: !isChildToParental)
-                Image(systemName: "arrow.right")
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(VColor.textMuted)
-                profileAvatarColumn(isParental: isChildToParental)
-            }
-            .frame(maxWidth: .infinity, alignment: .center)
+                ZStack {
+                    enterPINContent
+                        .opacity(step == .enterPIN ? 1 : 0)
+                        .allowsHitTesting(step == .enterPIN)
 
-            ZStack {
-                enterPINContent
-                    .opacity(step == .enterPIN ? 1 : 0)
-                    .allowsHitTesting(step == .enterPIN)
-
-                switchingContent
-                    .opacity(step == .switching ? 1 : 0)
-                    .allowsHitTesting(step == .switching)
-                    .transition(.opacity)
+                    switchingContent
+                        .opacity(step == .switching ? 1 : 0)
+                        .allowsHitTesting(step == .switching)
+                        .transition(.opacity)
+                }
+                .frame(maxWidth: .infinity)
             }
-            .frame(maxWidth: .infinity)
+            .padding(VSpacing.xl)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
         }
-        .padding(VSpacing.xl)
-        .frame(width: 340)
-        .fixedSize(horizontal: true, vertical: true)
-        .background(VColor.background)
+        .frame(width: 360, height: 280)
         .animation(VAnimation.standard, value: step)
     }
+
 
     private var enterPINContent: some View {
         VStack(alignment: .center, spacing: VSpacing.md) {
@@ -1737,16 +1742,18 @@ private struct ProfileSwitchModal: View {
                 Text(" ").font(VFont.caption)
             }
 
-            HStack {
-                VButton(label: "Cancel", style: .secondary) { dismiss() }
+            HStack(spacing: VSpacing.sm) {
                 Spacer()
+                VButton(label: "Cancel", style: .secondary) { dismiss() }
                 VButton(label: "Switch Mode", style: .primary) {
                     performSwitch()
                 }
                 .disabled(isChildToParental && pin.count != 6)
                 .keyboardShortcut(.return, modifiers: [])
+                Spacer()
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
     }
 
     private var switchingContent: some View {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
@@ -23,6 +23,7 @@ struct SettingsParentalTab: View {
     @State private var isLoading: Bool = false
     @State private var errorMessage: String?
     @State private var successMessage: String?
+    @State private var showSuccessToast: Bool = false
 
     // -- PIN sheet --
     @State private var showingPINSheet: Bool = false
@@ -71,21 +72,23 @@ struct SettingsParentalTab: View {
             }
         }
         .overlay(alignment: .bottom) {
-            if let success = successMessage {
-                VToast(message: success, style: .success)
+            if showSuccessToast, let msg = successMessage {
+                VToast(message: msg, style: .success)
                     .padding(.horizontal, VSpacing.lg)
                     .padding(.bottom, VSpacing.md)
                     .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .onAppear {
+                        Task {
+                            try? await Task.sleep(for: .seconds(3))
+                            withAnimation(VAnimation.standard) {
+                                showSuccessToast = false
+                                successMessage = nil
+                            }
+                        }
+                    }
             }
         }
-        .animation(VAnimation.standard, value: successMessage)
-        .onChange(of: successMessage) { _, newMsg in
-            guard newMsg != nil else { return }
-            Task {
-                try? await Task.sleep(for: .seconds(3))
-                withAnimation(VAnimation.standard) { successMessage = nil }
-            }
-        }
+        .animation(VAnimation.standard, value: showSuccessToast)
         .onAppear {
             loadSettings()
             settingsStore.loadActivityLog()
@@ -119,15 +122,18 @@ struct SettingsParentalTab: View {
                             case .set:
                                 hasPIN = true
                                 successMessage = "PIN set."
+                                showSuccessToast = true
                             case .change:
                                 // The old PIN is now invalid; clear the cache so subsequent
                                 // updates don't silently send a stale credential.
                                 settingsStore.cachedPIN = nil
                                 successMessage = "PIN changed."
+                                showSuccessToast = true
                             case .clear:
                                 hasPIN = false
                                 settingsStore.cachedPIN = nil
                                 successMessage = "PIN cleared."
+                                showSuccessToast = true
                             }
                         }
                     case .failure(let msg):
@@ -598,7 +604,7 @@ struct SettingsParentalTab: View {
                     exportActivityLog()
                 }
                 .disabled(settingsStore.activityLog.isEmpty)
-                VButton(label: "Clear Log", style: .danger) {
+                VButton(label: "Clear Log", leftIcon: "trash", style: .danger, size: .small) {
                     settingsStore.clearActivityLogEntries(pin: settingsStore.cachedPIN)
                 }
                 .accessibilityLabel("Clear activity log")
@@ -838,9 +844,10 @@ struct SettingsParentalTab: View {
     // MARK: - Daemon interactions
 
     private func loadSettings() {
-        isLoading = true
         errorMessage = nil
 
+        guard daemonClient != nil else { return }
+        isLoading = true
         let stream = daemonClient?.subscribe()
         Task {
             do {
@@ -935,10 +942,14 @@ struct SettingsParentalTab: View {
     }
 
     private func updateAllowlist(apps: [String]?, widgets: [String]?) {
-        isLoading = true
+        // Optimistic update so toggles respond immediately even if daemon is unavailable.
+        if let apps = apps { allowedApps = apps; settingsStore.allowedApps = apps }
+        if let widgets = widgets { allowedWidgets = widgets; settingsStore.allowedWidgets = widgets }
         errorMessage = nil
         successMessage = nil
 
+        guard daemonClient != nil else { return }
+        isLoading = true
         let stream = daemonClient?.subscribe()
         let pin = settingsStore.cachedPIN
         Task {
@@ -1059,10 +1070,13 @@ struct SettingsParentalTab: View {
     }
 
     private func updateContentRestrictions(_ restrictions: [String]) {
-        isLoading = true
+        // Optimistic update so toggles respond immediately even if daemon is unavailable.
+        contentRestrictions = Set(restrictions)
         errorMessage = nil
         successMessage = nil
 
+        guard daemonClient != nil else { return }
+        isLoading = true
         let stream = daemonClient?.subscribe()
         let pin = settingsStore.cachedPIN
         Task {
@@ -1104,10 +1118,13 @@ struct SettingsParentalTab: View {
     }
 
     private func updateToolCategories(_ categories: [String]) {
-        isLoading = true
+        // Optimistic update so toggles respond immediately even if daemon is unavailable.
+        blockedToolCategories = Set(categories)
         errorMessage = nil
         successMessage = nil
 
+        guard daemonClient != nil else { return }
+        isLoading = true
         let stream = daemonClient?.subscribe()
         let pin = settingsStore.cachedPIN
         Task {
@@ -1243,6 +1260,7 @@ private struct PINSheet: View {
 
     var body: some View {
         VStack(spacing: VSpacing.xl) {
+            Spacer(minLength: 0)
             // Header
             VStack(spacing: VSpacing.xs) {
                 Text(title)
@@ -1261,6 +1279,7 @@ private struct PINSheet: View {
             // always reset to "" before the step is changed, so a stale
             // onChange callback from the previous step can never fire advance().
             PINCircleField(text: $pinInput, focusTrigger: pinFocusTrigger)
+                .frame(maxWidth: .infinity, alignment: .center)
                 .id(step)
                 .onChange(of: pinInput) { _, v in
                     if v.count == 6 { advance() }
@@ -1276,6 +1295,7 @@ private struct PINSheet: View {
                 Text(" ").font(VFont.caption)
             }
 
+            Spacer(minLength: 0)
             // Footer
             if isLoading {
                 ProgressView().scaleEffect(0.8)
@@ -1284,11 +1304,22 @@ private struct PINSheet: View {
             }
         }
         .padding(VSpacing.xl)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .frame(width: 320)
         .background(VColor.background)
         .onAppear {
-            step = (mode == .set) ? .enterNew : .enterCurrent
+            // Always reset to the correct starting step for the given mode.
+            // This handles re-presentation of the sheet after a previous session.
+            if mode == .set {
+                step = .enterNew
+            } else {
+                step = .enterCurrent
+            }
             pinInput = ""
+            storedCurrent = ""
+            storedNew = ""
+            errorMessage = nil
+            isLoading = false
         }
     }
 


### PR DESCRIPTION
## Summary

- **Issues 1 & 2 (toggles / Enable All do nothing):** All three update functions (`updateContentRestrictions`, `updateToolCategories`, `updateAllowlist`) now apply an optimistic local-state update _before_ making the IPC call, so the UI responds immediately regardless of daemon availability. Each function also guards `guard daemonClient != nil else { return }` so `isLoading` is never set when the daemon is absent — eliminating the 8-second lock that disabled every control. `loadSettings` got the same guard so the initial load no longer freezes the UI.
- **Issue 3 (toast doesn't appear after PIN change):** Replaced the `onChange(of: successMessage)` auto-dismiss pattern with a dedicated `showSuccessToast: Bool` state. The overlay is conditioned on that bool, and the 3-second auto-dismiss runs inside an `.onAppear` Task on the toast itself — immune to sheet-teardown races that previously swallowed the message.
- **Issue 4 (Change PIN skips current-PIN step):** `PINSheet.onAppear` now fully resets `step`, `pinInput`, `storedCurrent`, `storedNew`, `errorMessage`, and `isLoading` on every presentation, preventing stale state from a previous sheet session from skipping the `.enterCurrent` step.
- **Issue 5 (Clear Log icon):** Clear Log button updated to `VButton(label: "Clear Log", leftIcon: "trash", style: .danger, size: .small)`.
- **Issue 6 (PIN input centering):** `PINCircleField` gets `.frame(maxWidth: .infinity, alignment: .center)`; outer `VStack` gains `Spacer(minLength: 0)` top/bottom and `.frame(maxWidth: .infinity, maxHeight: .infinity)` for proper vertical centering inside the sheet.

## Test plan

- [ ] Open Parental Controls settings with daemon running — enable/disable individual toggles in Content Restrictions, Tool Restrictions, Apps, Integrations; verify they respond immediately
- [ ] Click "Enable All" / "Disable All" in each section — verify state changes instantly
- [ ] Open settings with daemon NOT running — same toggle and button tests; verify they still flip locally without blocking UI
- [ ] Change PIN via Settings — verify the sheet opens at "Enter your current passcode" (not "Enter new passcode")
- [ ] Complete a PIN change — verify the success toast appears at the bottom after the sheet dismisses
- [ ] Open the Clear Log section — verify the "Clear Log" button has a trash icon
- [ ] Open the Change Passcode / Set Passcode sheet — verify the PIN circle field is horizontally and vertically centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
