### PR TITLE
Fix collapsed sidebar thread switcher UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1426,6 +1426,15 @@ struct MainWindowView: View {
                             .frame(width: 200)
                             .padding(.bottom, VSpacing.sm)
                         }
+                        .onDisappear {
+                            // Reset popover state when badge is removed from hierarchy
+                            // (e.g. thread count drops to ≤1) to prevent stale
+                            // showThreadSwitcher causing the popover to immediately
+                            // reappear when threads are added back.
+                            threadSwitcherHoverTimer?.cancel()
+                            threadSwitcherHoverTimer = nil
+                            showThreadSwitcher = false
+                        }
                 }
             }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1332,107 +1332,100 @@ struct MainWindowView: View {
 
             // MARK: Thread Section (collapsed)
             if let activeThread = threadManager.activeThread {
-                VStack(spacing: VSpacing.xs) {
-                    VThreadIcon(
-                        title: activeThread.title,
-                        size: .medium,
-                        isActive: true,
-                        dotColor: interactionDotColor(for: activeThread)
-                    )
+                // Active thread icon (purely visual, no interaction)
+                VThreadIcon(
+                    title: activeThread.title,
+                    size: .medium,
+                    isActive: true,
+                    dotColor: interactionDotColor(for: activeThread)
+                )
 
-                    // Thread count badge
-                    if regularThreads.count > 0 {
-                        Text("\(regularThreads.count)")
-                            .font(.system(size: 10, weight: .medium))
-                            .foregroundColor(VColor.textSecondary)
-                            .padding(.horizontal, VSpacing.xs)
-                            .padding(.vertical, 2)
-                            .background(
-                                Capsule()
-                                    .fill(Forest._700)
-                            )
-                    }
-
-                    // Threads indicator icon
-                    Image(systemName: "bubble.left.and.bubble.right")
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundColor(VColor.textMuted)
-                }
-                .padding(.vertical, VSpacing.xs)
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    threadSwitcherHoverTimer?.cancel()
-                    threadSwitcherHoverTimer = nil
-                    showThreadSwitcher.toggle()
-                }
-                .onHover { hovering in
-                    if hovering {
-                        threadSwitcherHoverTimer?.cancel()
-                        let work = DispatchWorkItem {
-                            showThreadSwitcher = true
+                // Count badge + popover only when multiple threads exist
+                if regularThreads.count > 1 {
+                    Text("\(regularThreads.count)")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(VColor.textSecondary)
+                        .padding(.horizontal, VSpacing.xs)
+                        .padding(.vertical, 2)
+                        .background(
+                            Capsule()
+                                .fill(Forest._700)
+                        )
+                        .contentShape(Capsule())
+                        .onTapGesture {
+                            threadSwitcherHoverTimer?.cancel()
+                            threadSwitcherHoverTimer = nil
+                            showThreadSwitcher.toggle()
                         }
-                        threadSwitcherHoverTimer = work
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: work)
-                    } else {
-                        threadSwitcherHoverTimer?.cancel()
-                        threadSwitcherHoverTimer = nil
-                    }
-                }
-                .popover(isPresented: $showThreadSwitcher, arrowEdge: .trailing) {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        // Header
-                        Text("\(regularThreads.count) THREADS")
-                            .font(VFont.caption)
-                            .fontWeight(.medium)
-                            .foregroundColor(VColor.textMuted)
-                            .padding(.horizontal, VSpacing.sm)
-                            .padding(.top, VSpacing.sm)
+                        .onHover { hovering in
+                            if hovering {
+                                threadSwitcherHoverTimer?.cancel()
+                                let work = DispatchWorkItem {
+                                    showThreadSwitcher = true
+                                }
+                                threadSwitcherHoverTimer = work
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: work)
+                            } else {
+                                threadSwitcherHoverTimer?.cancel()
+                                threadSwitcherHoverTimer = nil
+                            }
+                        }
+                        .popover(isPresented: $showThreadSwitcher, arrowEdge: .trailing) {
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                // Header
+                                Text("\(regularThreads.count) THREADS")
+                                    .font(VFont.caption)
+                                    .fontWeight(.medium)
+                                    .foregroundColor(VColor.textMuted)
+                                    .padding(.horizontal, VSpacing.sm)
+                                    .padding(.top, VSpacing.sm)
 
-                        // Thread list
-                        ScrollView {
-                            VStack(spacing: 0) {
-                                ForEach(regularThreads) { thread in
-                                    let isActive = thread.id == threadManager.activeThreadId
-                                    HStack(spacing: VSpacing.xs) {
-                                        VThreadIcon(
-                                            title: thread.title,
-                                            size: .small,
-                                            isActive: isActive,
-                                            dotColor: interactionDotColor(for: thread)
-                                        )
+                                // Thread list
+                                ScrollView {
+                                    VStack(spacing: 0) {
+                                        ForEach(regularThreads) { thread in
+                                            let isActive = thread.id == threadManager.activeThreadId
+                                            HStack(spacing: VSpacing.xs) {
+                                                VThreadIcon(
+                                                    title: thread.title,
+                                                    size: .small,
+                                                    isActive: isActive,
+                                                    dotColor: interactionDotColor(for: thread)
+                                                )
 
-                                        Text(thread.title)
-                                            .font(VFont.body)
-                                            .foregroundColor(VColor.textPrimary)
-                                            .lineLimit(1)
-                                            .truncationMode(.tail)
+                                                Text(thread.title)
+                                                    .font(VFont.body)
+                                                    .foregroundColor(VColor.textPrimary)
+                                                    .lineLimit(1)
+                                                    .truncationMode(.tail)
 
-                                        Spacer()
+                                                Spacer()
 
-                                        // Unseen indicator
-                                        if thread.hasUnseenLatestAssistantMessage {
-                                            Circle()
-                                                .fill(Color(hex: 0xE86B40))
-                                                .frame(width: 6, height: 6)
+                                                // Unseen indicator
+                                                if thread.hasUnseenLatestAssistantMessage {
+                                                    Circle()
+                                                        .fill(Color(hex: 0xE86B40))
+                                                        .frame(width: 6, height: 6)
+                                                }
+                                            }
+                                            .padding(.horizontal, VSpacing.sm)
+                                            .padding(.vertical, VSpacing.xs)
+                                            .background(isActive ? VColor.accent.opacity(0.12) : Color.clear)
+                                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                                            .contentShape(Rectangle())
+                                            .onTapGesture {
+                                                selectThread(thread)
+                                                showThreadSwitcher = false
+                                            }
                                         }
                                     }
-                                    .padding(.horizontal, VSpacing.sm)
-                                    .padding(.vertical, VSpacing.xs)
-                                    .background(isActive ? VColor.accent.opacity(0.12) : Color.clear)
-                                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                                    .contentShape(Rectangle())
-                                    .onTapGesture {
-                                        selectThread(thread)
-                                        showThreadSwitcher = false
-                                    }
+                                    .padding(.horizontal, VSpacing.xs)
                                 }
+                                .frame(maxHeight: 300)
                             }
-                            .padding(.horizontal, VSpacing.xs)
+                            .frame(width: 200)
+                            .padding(.bottom, VSpacing.sm)
                         }
-                        .frame(maxHeight: 300)
-                    }
-                    .frame(width: 200)
-                    .padding(.bottom, VSpacing.sm)
                 }
             }
 


### PR DESCRIPTION
Improve the collapsed sidebar thread section: show only thread icon when 1 thread (no hover/popover), show count badge with hover/popover only when >1 threads, remove redundant threads indicator icon, restrict interaction to badge only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
