### PR TITLE
fix(parental): toggles always responsive + modal centering

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1684,50 +1684,36 @@ private struct ProfileSwitchModal: View {
         ZStack {
             VColor.background.ignoresSafeArea()
 
-            VStack(spacing: VSpacing.md) {
-                // Title
-                Text(isChildToParental ? "Switch to Parental Mode" : "Switch to Restricted Mode")
-                    .font(VFont.headline)
-                    .foregroundColor(VColor.textPrimary)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: .infinity, alignment: .center)
-
-                // From/to avatar icons
-                HStack(spacing: VSpacing.md) {
-                    profileAvatarColumn(isParental: !isChildToParental)
-                    Image(systemName: "arrow.right")
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundColor(VColor.textMuted)
-                    profileAvatarColumn(isParental: isChildToParental)
-                }
-                .frame(maxWidth: .infinity, alignment: .center)
-
-                ZStack {
-                    enterPINContent
-                        .opacity(step == .enterPIN ? 1 : 0)
-                        .allowsHitTesting(step == .enterPIN)
-
-                    switchingContent
-                        .opacity(step == .switching ? 1 : 0)
-                        .allowsHitTesting(step == .switching)
-                        .transition(.opacity)
-                }
-                .frame(maxWidth: .infinity)
+            if step == .switching {
+                switchingContent
+            } else {
+                enterPINContent
             }
-            .padding(VSpacing.xl)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
         }
-        .frame(width: 360, height: 280)
+        .frame(width: 340)
+        .fixedSize(horizontal: true, vertical: true)
         .animation(VAnimation.standard, value: step)
     }
 
-
     private var enterPINContent: some View {
-        VStack(alignment: .center, spacing: VSpacing.md) {
+        VStack(alignment: .center, spacing: VSpacing.lg) {
+            // Title
+            Text(isChildToParental ? "Switch to Parental Mode" : "Switch to Restricted Mode")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textPrimary)
+                .multilineTextAlignment(.center)
+
+            // From/to avatar icons
+            HStack(spacing: VSpacing.xl) {
+                profileAvatarColumn(isParental: !isChildToParental)
+                Image(systemName: "arrow.right")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(VColor.textMuted)
+                profileAvatarColumn(isParental: isChildToParental)
+            }
+
             if isChildToParental {
                 PINCircleField(text: $pin)
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .padding(.vertical, VSpacing.xs)
                     .onChange(of: pin) { _, newValue in
                         if newValue.count == 6 { performSwitch() }
                     }
@@ -1737,34 +1723,29 @@ private struct ProfileSwitchModal: View {
                 Text(error)
                     .font(VFont.caption)
                     .foregroundColor(VColor.error)
-                    .frame(maxWidth: .infinity, alignment: .center)
-            } else {
-                Text(" ").font(VFont.caption)
+                    .multilineTextAlignment(.center)
             }
 
             HStack(spacing: VSpacing.sm) {
-                Spacer()
                 VButton(label: "Cancel", style: .secondary) { dismiss() }
-                VButton(label: "Switch Mode", style: .primary) {
-                    performSwitch()
-                }
-                .disabled(isChildToParental && pin.count != 6)
-                .keyboardShortcut(.return, modifiers: [])
-                Spacer()
+                VButton(label: "Switch Mode", style: .primary) { performSwitch() }
+                    .disabled(isChildToParental && pin.count != 6)
+                    .keyboardShortcut(.return, modifiers: [])
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .padding(VSpacing.xl)
+        .frame(maxWidth: .infinity)
     }
 
     private var switchingContent: some View {
         HStack(spacing: VSpacing.sm) {
             ProgressView().scaleEffect(0.7)
-            Text("Switching profile…")
+            Text("Switching…")
                 .font(VFont.body)
                 .foregroundColor(VColor.textSecondary)
         }
-        .frame(maxWidth: .infinity, alignment: .center)
-        .padding(.vertical, VSpacing.sm)
+        .padding(VSpacing.xl)
+        .frame(maxWidth: .infinity)
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
@@ -949,7 +949,6 @@ struct SettingsParentalTab: View {
         successMessage = nil
 
         guard daemonClient != nil else { return }
-        isLoading = true
         let stream = daemonClient?.subscribe()
         let pin = settingsStore.cachedPIN
         Task {
@@ -960,9 +959,7 @@ struct SettingsParentalTab: View {
                     allowedWidgets: widgets
                 )
             } catch {
-                // Transport/connection error — no response will arrive, so restore state from daemon.
                 await MainActor.run {
-                    isLoading = false
                     errorMessage = error.localizedDescription
                     loadAllowlist()
                 }
@@ -987,7 +984,6 @@ struct SettingsParentalTab: View {
             }
 
             await MainActor.run {
-                isLoading = false
                 if let r = response, r.success {
                     allowedApps = r.allowedApps
                     allowedWidgets = r.allowedWidgets
@@ -995,7 +991,6 @@ struct SettingsParentalTab: View {
                     settingsStore.allowedWidgets = r.allowedWidgets
                 } else {
                     errorMessage = response?.error ?? "Update failed."
-                    // Reload to restore correct state on failure
                     loadAllowlist()
                 }
             }
@@ -1076,14 +1071,13 @@ struct SettingsParentalTab: View {
         successMessage = nil
 
         guard daemonClient != nil else { return }
-        isLoading = true
         let stream = daemonClient?.subscribe()
         let pin = settingsStore.cachedPIN
         Task {
             do {
                 try daemonClient?.sendParentalControlUpdate(pin: pin, contentRestrictions: restrictions)
             } catch {
-                await MainActor.run { isLoading = false; errorMessage = error.localizedDescription }
+                await MainActor.run { errorMessage = error.localizedDescription }
                 return
             }
 
@@ -1105,12 +1099,10 @@ struct SettingsParentalTab: View {
             }
 
             await MainActor.run {
-                isLoading = false
                 if let r = response, r.success {
                     contentRestrictions = Set(r.content_restrictions)
                 } else {
                     errorMessage = response?.error ?? "Update failed."
-                    // revert local toggle
                     loadSettings()
                 }
             }
@@ -1124,14 +1116,13 @@ struct SettingsParentalTab: View {
         successMessage = nil
 
         guard daemonClient != nil else { return }
-        isLoading = true
         let stream = daemonClient?.subscribe()
         let pin = settingsStore.cachedPIN
         Task {
             do {
                 try daemonClient?.sendParentalControlUpdate(pin: pin, blockedToolCategories: categories)
             } catch {
-                await MainActor.run { isLoading = false; errorMessage = error.localizedDescription }
+                await MainActor.run { errorMessage = error.localizedDescription }
                 return
             }
 
@@ -1153,7 +1144,6 @@ struct SettingsParentalTab: View {
             }
 
             await MainActor.run {
-                isLoading = false
                 if let r = response, r.success {
                     blockedToolCategories = Set(r.blocked_tool_categories)
                 } else {


### PR DESCRIPTION
## Switches/buttons fix
- Removed `isLoading = true` from `updateAllowlist`, `updateContentRestrictions`, `updateToolCategories`
- Root cause: these functions do an optimistic local update first, but then set `isLoading = true` which re-disabled all controls for up to 8 seconds while waiting for the daemon response — making every tap appear to do nothing
- Removed corresponding `isLoading = false` from their response/error paths

## Switch Mode modal centering
- Replaced fixed `height: 280` + `maxHeight: .infinity` (which fought each other) with `fixedSize(horizontal: true, vertical: true)` — sheet now sizes naturally to content
- Simplified step rendering to plain `if/else` instead of opacity-layered `ZStack`
- Content VStack uses `alignment: .center, spacing: .lg` — title, icons, PIN field, buttons all centered
- Removed placeholder `Text(" ")` spacer that was reserving space for the error slot
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
