### PR TITLE
fix(parental): Switch Mode modal layout polish

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1726,14 +1726,16 @@ private struct ProfileSwitchModal: View {
                     .multilineTextAlignment(.center)
             }
 
-            HStack(spacing: VSpacing.sm) {
+            HStack {
                 VButton(label: "Cancel", style: .secondary) { dismiss() }
+                Spacer()
                 VButton(label: "Switch Mode", style: .primary) { performSwitch() }
                     .disabled(isChildToParental && pin.count != 6)
                     .keyboardShortcut(.return, modifiers: [])
             }
         }
-        .padding(VSpacing.xl)
+        .padding(.horizontal, VSpacing.xl)
+        .padding(.vertical, VSpacing.xxl)
         .frame(maxWidth: .infinity)
     }
 


### PR DESCRIPTION
## Summary

- Buttons spread horizontally: Cancel pinned left, Switch Mode pinned right via `Spacer()` between them (was clustered center with fixed spacing)
- More vertical padding around content section: `.padding(.vertical, VSpacing.xxl)` replacing the uniform `.padding(VSpacing.xl)`, with `.padding(.horizontal, VSpacing.xl)` kept for sides

## Test plan

- [ ] Open Switch Mode modal from the menu bar (child profile active)
- [ ] Verify Cancel is on the left and Switch Mode is on the right with space between them
- [ ] Verify the modal has noticeably more breathing room at the top and bottom
- [ ] Confirm switching from child -> parental (enter 6-digit PIN) still works
- [ ] Confirm switching from parental -> child (no PIN) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
