### PR TITLE
Fix test process hanging 10+ minutes after completion

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -3112,3 +3112,74 @@ exports[`IPC message snapshots ServerMessage types generate_avatar_response seri
   "type": "generate_avatar_response",
 }
 `;
+
+exports[`IPC message snapshots ClientMessage types guardian_actions_pending_request serializes to expected JSON 1`] = `
+{
+  "conversationId": "conv-guardian-001",
+  "type": "guardian_actions_pending_request",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types guardian_action_decision serializes to expected JSON 1`] = `
+{
+  "action": "approve_once",
+  "conversationId": "conv-guardian-001",
+  "requestId": "req-guardian-001",
+  "type": "guardian_action_decision",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types reorder_threads serializes to expected JSON 1`] = `
+{
+  "type": "reorder_threads",
+  "updates": [
+    {
+      "displayOrder": 0,
+      "isPinned": false,
+      "sessionId": "sess-001",
+    },
+    {
+      "displayOrder": 1,
+      "isPinned": true,
+      "sessionId": "sess-002",
+    },
+  ],
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types guardian_actions_pending_response serializes to expected JSON 1`] = `
+{
+  "conversationId": "conv-guardian-001",
+  "prompts": [
+    {
+      "actions": [
+        {
+          "action": "approve_once",
+          "label": "Approve once",
+        },
+        {
+          "action": "reject",
+          "label": "Reject",
+        },
+      ],
+      "callSessionId": null,
+      "conversationId": "conv-guardian-001",
+      "expiresAt": 1700100000000,
+      "questionText": "Approve tool: bash",
+      "requestCode": "REQ-GU",
+      "requestId": "req-guardian-001",
+      "state": "pending",
+      "toolName": "bash",
+    },
+  ],
+  "type": "guardian_actions_pending_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types guardian_action_decision_response serializes to expected JSON 1`] = `
+{
+  "applied": true,
+  "requestId": "req-guardian-001",
+  "type": "guardian_action_decision_response",
+}
+`;

--- a/assistant/src/__tests__/commit-message-enrichment-service.test.ts
+++ b/assistant/src/__tests__/commit-message-enrichment-service.test.ts
@@ -3,11 +3,12 @@ import { existsSync,mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach,beforeEach, describe, expect, test } from 'bun:test';
+import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
 
 import {
   _resetEnrichmentService,
   CommitEnrichmentService,
+  getEnrichmentService,
 } from '../workspace/commit-message-enrichment-service.js';
 import type { CommitContext } from '../workspace/commit-message-provider.js';
 import { _resetGitServiceRegistry,WorkspaceGitService } from '../workspace/git-service.js';
@@ -27,9 +28,16 @@ describe('CommitEnrichmentService', () => {
   });
 
   afterEach(async () => {
+    try { await getEnrichmentService().shutdown(); } catch { /* ignore */ }
+    _resetEnrichmentService();
     if (existsSync(testDir)) {
       rmSync(testDir, { recursive: true, force: true });
     }
+  });
+
+  afterAll(async () => {
+    try { await getEnrichmentService().shutdown(); } catch { /* ignore */ }
+    _resetEnrichmentService();
   });
 
   function makeContext(overrides?: Partial<CommitContext>): CommitContext {

--- a/assistant/src/__tests__/provider-error-scenarios.test.ts
+++ b/assistant/src/__tests__/provider-error-scenarios.test.ts
@@ -1,8 +1,4 @@
-import { resolve } from 'node:path';
-
 import { describe, expect, mock,test } from 'bun:test';
-
-const retryModulePath = resolve(import.meta.dir, '../util/retry.ts');
 
 mock.module('../util/logger.js', () => ({
   getLogger: () =>
@@ -10,12 +6,67 @@ mock.module('../util/logger.js', () => ({
   isDebug: () => false,
 }));
 
-// Only mock sleep so retries complete instantly; keep real retry logic
-mock.module('../util/retry.js', async () => {
-  const real = await import(retryModulePath);
+// Only mock sleep so retries complete instantly; keep real retry logic.
+// NOTE: We must NOT use `await import()` inside mock.module — it deadlocks
+// bun's module resolver. Instead, inline the real exports and only replace sleep.
+mock.module('../util/retry.js', () => {
+  const DEFAULT_MAX_RETRIES = 3;
+  const DEFAULT_BASE_DELAY_MS = 1000;
+
+  function computeRetryDelay(attempt: number, baseDelayMs = DEFAULT_BASE_DELAY_MS): number {
+    const cap = baseDelayMs * Math.pow(2, attempt);
+    const half = cap / 2;
+    return half + Math.random() * half;
+  }
+
+  function parseRetryAfterMs(value: string): number | undefined {
+    const seconds = Number(value);
+    if (!isNaN(seconds)) return seconds * 1000;
+    const dateMs = Date.parse(value);
+    if (!isNaN(dateMs)) return Math.max(0, dateMs - Date.now());
+    return undefined;
+  }
+
+  function getHttpRetryDelay(
+    response: Response,
+    attempt: number,
+    baseDelayMs = DEFAULT_BASE_DELAY_MS,
+  ): number {
+    const retryAfter = response.headers.get('retry-after');
+    if (retryAfter) {
+      const parsed = parseRetryAfterMs(retryAfter);
+      if (parsed !== undefined) return parsed;
+    }
+    const effectiveBase = attempt === 0 ? baseDelayMs * 2 : baseDelayMs;
+    return Math.max(baseDelayMs, computeRetryDelay(attempt, effectiveBase));
+  }
+
+  function isRetryableStatus(status: number): boolean {
+    return status === 429 || status >= 500;
+  }
+
+  function isRetryableNetworkError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const retryableCodes = new Set(['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'EPIPE']);
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code && retryableCodes.has(code)) return true;
+    if (error.cause instanceof Error) {
+      const causeCode = (error.cause as NodeJS.ErrnoException).code;
+      if (causeCode && retryableCodes.has(causeCode)) return true;
+    }
+    return false;
+  }
+
   return {
-    ...real,
+    DEFAULT_MAX_RETRIES,
+    DEFAULT_BASE_DELAY_MS,
+    computeRetryDelay,
+    parseRetryAfterMs,
+    getHttpRetryDelay,
+    isRetryableStatus,
+    isRetryableNetworkError,
     sleep: () => Promise.resolve(),
+    abortableSleep: () => Promise.resolve(),
   };
 });
 

--- a/assistant/src/__tests__/workspace-lifecycle.test.ts
+++ b/assistant/src/__tests__/workspace-lifecycle.test.ts
@@ -10,8 +10,12 @@ import { existsSync,mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach,beforeEach, describe, expect, test } from 'bun:test';
+import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
 
+import {
+  _resetEnrichmentService,
+  getEnrichmentService,
+} from '../workspace/commit-message-enrichment-service.js';
 import {
   _resetGitServiceRegistry,
   getWorkspaceGitService,
@@ -36,10 +40,17 @@ describe('Workspace git lifecycle (integration)', () => {
     _resetHeartbeatState();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    try { await getEnrichmentService().shutdown(); } catch { /* ignore */ }
+    _resetEnrichmentService();
     if (existsSync(testDir)) {
       rmSync(testDir, { recursive: true, force: true });
     }
+  });
+
+  afterAll(async () => {
+    try { await getEnrichmentService().shutdown(); } catch { /* ignore */ }
+    _resetEnrichmentService();
   });
 
   // Build a clean git env: strip all GIT_* env vars that CI runners


### PR DESCRIPTION
Fixes two root causes of CI test hangs: (1) `workspace-lifecycle.test.ts` and `commit-message-enrichment-service.test.ts` never shut down the global enrichment service, keeping bun's event loop alive; (2) `provider-error-scenarios.test.ts` used `await import()` inside `mock.module()` which deadlocks bun's module resolver.

---

- Requested by: @dvargas92495
- Session: https://app.devin.ai/sessions/b79b14a724414d9a901c8e33c130a992