### PR TITLE
fix: update BrowserPiPManager default frameSize to match 800x600 screencast dimensions

### DIFF
--- a/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPManager.swift
+++ b/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPManager.swift
@@ -16,7 +16,7 @@ final class BrowserPiPManager: ObservableObject {
     @Published var highlights: [BrowserHighlight] = []
     @Published var isInteractive: Bool = false
     var handoffMessage: String?
-    var frameSize: CGSize = CGSize(width: 1280, height: 960)
+    var frameSize: CGSize = CGSize(width: 800, height: 600)
 
     var activePage: BrowserPage? {
         pages.first(where: { $0.active })


### PR DESCRIPTION
Addresses Devin review feedback on PR #10329. Updates the default frameSize in BrowserPiPManager.swift from 1280x960 to 800x600 to match the server-side SCREENCAST_WIDTH/SCREENCAST_HEIGHT constants, preventing coordinate mismatches before the first frame is decoded.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
