### PR TITLE
fix: use execFileSync to avoid shell injection in findSocketOwnerPid

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -1,4 +1,4 @@
-import { execSync, spawn } from "child_process";
+import { execFileSync, spawn } from "child_process";
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import { createRequire } from "module";
 import { createConnection } from "net";
@@ -206,7 +206,7 @@ function readWorkspaceIngressPublicBaseUrl(): string | undefined {
  *  Returns the PID if found, undefined otherwise. */
 function findSocketOwnerPid(socketPath: string): number | undefined {
   try {
-    const output = execSync(`lsof -U -a -F p -- ${JSON.stringify(socketPath)}`, {
+    const output = execFileSync("lsof", ["-U", "-a", "-F", "p", "--", socketPath], {
       encoding: "utf-8",
       timeout: 3000,
       stdio: ["ignore", "pipe", "ignore"],


### PR DESCRIPTION
Addresses Devin review feedback on PR #10324. Replaces JSON.stringify shell escaping with execFileSync array args to prevent shell metacharacter expansion.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
