### PR TITLE
fix: HTML report for agent tests and screen recording duration

### DIFF
--- a/playwright/agent/runner.ts
+++ b/playwright/agent/runner.ts
@@ -97,17 +97,27 @@ interface TestReport {
   tests: { name: string; passed: boolean; message: string; durationMs: number; duration: string }[];
 }
 
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
 function generateHtmlReport(report: TestReport): string {
   const testRows = report.tests
     .map((t) => {
       const icon = t.passed ? "✅" : "❌";
-      const screenshotLink = `agent-screenshots/${t.name}/`;
-      const videoLink = `agent-videos/${t.name}/screen-recording.mov`;
+      const encodedName = encodeURIComponent(t.name);
+      const screenshotLink = `agent-screenshots/${encodedName}/`;
+      const videoLink = `agent-videos/${encodedName}/screen-recording.mov`;
       return `<tr>
-        <td>${icon} ${t.name}</td>
+        <td>${icon} ${escapeHtml(t.name)}</td>
         <td>${t.passed ? "passed" : "failed"}</td>
         <td>${t.duration}</td>
-        <td>${t.passed ? "" : t.message}</td>
+        <td>${t.passed ? "" : escapeHtml(t.message)}</td>
         <td><a href="${screenshotLink}">screenshots</a> · <a href="${videoLink}">video</a></td>
       </tr>`;
     })

--- a/playwright/agent/runner.ts
+++ b/playwright/agent/runner.ts
@@ -89,6 +89,56 @@ function formatDuration(ms: number): string {
   return `${mins}m ${remSecs}s`;
 }
 
+// ── HTML Report ─────────────────────────────────────────────────────
+
+interface TestReport {
+  timestamp: string;
+  summary: { passed: number; failed: number; totalDurationMs: number };
+  tests: { name: string; passed: boolean; message: string; durationMs: number; duration: string }[];
+}
+
+function generateHtmlReport(report: TestReport): string {
+  const testRows = report.tests
+    .map((t) => {
+      const icon = t.passed ? "✅" : "❌";
+      const screenshotLink = `agent-screenshots/${t.name}/`;
+      const videoLink = `agent-videos/${t.name}/screen-recording.mov`;
+      return `<tr>
+        <td>${icon} ${t.name}</td>
+        <td>${t.passed ? "passed" : "failed"}</td>
+        <td>${t.duration}</td>
+        <td>${t.passed ? "" : t.message}</td>
+        <td><a href="${screenshotLink}">screenshots</a> · <a href="${videoLink}">video</a></td>
+      </tr>`;
+    })
+    .join("\n");
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Agent Test Report</title>
+  <style>
+    body { font-family: -apple-system, sans-serif; max-width: 900px; margin: 40px auto; padding: 0 20px; }
+    h1 { margin-bottom: 4px; }
+    .summary { color: #666; margin-bottom: 24px; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { text-align: left; padding: 8px 12px; border-bottom: 1px solid #eee; }
+    th { background: #f5f5f5; }
+    a { color: #0366d6; }
+  </style>
+</head>
+<body>
+  <h1>Agent Test Report</h1>
+  <p class="summary">${report.summary.passed} passed, ${report.summary.failed} failed — ${formatDuration(report.summary.totalDurationMs)} total — ${report.timestamp}</p>
+  <table>
+    <tr><th>Test</th><th>Status</th><th>Duration</th><th>Details</th><th>Artifacts</th></tr>
+    ${testRows}
+  </table>
+</body>
+</html>`;
+}
+
 // ── Runner ──────────────────────────────────────────────────────────
 
 /**
@@ -98,7 +148,9 @@ function formatDuration(ms: number): string {
 function startScreenRecording(videoPath: string): ChildProcess | undefined {
   try {
     mkdirSync(path.dirname(videoPath), { recursive: true });
-    const proc = spawn("screencapture", ["-v", "-x", videoPath], {
+    // Use -V 600 (10 min max) so screencapture starts recording immediately
+    // instead of opening an interactive session. We stop it early with SIGINT.
+    const proc = spawn("screencapture", ["-V", "600", "-x", videoPath], {
       stdio: "ignore",
       detached: true,
     });
@@ -257,6 +309,7 @@ async function main(): Promise<void> {
     })),
   };
   writeFileSync(path.join(reportDir, "test-report.json"), JSON.stringify(report, null, 2));
+  writeFileSync(path.join(reportDir, "index.html"), generateHtmlReport(report));
 
   if (failed > 0) {
     process.exit(1);


### PR DESCRIPTION
## Summary
- **HTML report**: Agent mode runs `bun run agent/runner.ts` directly, bypassing Playwright Test — so the HTML reporter config in `playwright.config.ts` never executes. Now the runner generates its own `test-results/index.html` with test results, durations, and links to screenshots/videos.
- **Screen recording**: `screencapture -v` opens an interactive recording session which doesn't work as a background spawn (resulting in only ~1s of capture). Switched to `screencapture -V 600` which starts recording immediately for up to 10 minutes. We stop it early with SIGINT when the test finishes.

## Test plan
- [ ] Run agent CI and verify `index.html` appears in downloaded artifact
- [ ] Open `index.html` and verify it shows test results with links to screenshots/videos
- [ ] Verify screen recordings capture the full test duration, not just the last second

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
