### PR TITLE
feat: add vellum mcp list CLI command

### DIFF
--- a/assistant/src/cli/mcp.ts
+++ b/assistant/src/cli/mcp.ts
@@ -1,0 +1,58 @@
+import type { Command } from 'commander';
+
+import { loadRawConfig } from '../config/loader.js';
+import type { McpConfig, McpServerConfig } from '../config/mcp-schema.js';
+import { getCliLogger } from '../util/logger.js';
+
+const log = getCliLogger('cli');
+
+export function registerMcpCommand(program: Command): void {
+  const mcp = program.command('mcp').description('Manage MCP (Model Context Protocol) servers');
+
+  mcp
+    .command('list')
+    .description('List configured MCP servers and their status')
+    .option('--json', 'Output as JSON')
+    .action((opts: { json?: boolean }) => {
+      const raw = loadRawConfig();
+      const mcpConfig = raw.mcp as Partial<McpConfig> | undefined;
+      const servers = mcpConfig?.servers ?? {};
+      const entries = Object.entries(servers) as [string, McpServerConfig][];
+
+      if (entries.length === 0) {
+        if (opts.json) {
+          process.stdout.write(JSON.stringify([], null, 2) + '\n');
+        } else {
+          log.info('No MCP servers configured.');
+        }
+        return;
+      }
+
+      if (opts.json) {
+        const result = entries.map(([id, config]) => ({ id, ...config }));
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+        return;
+      }
+
+      log.info(`${entries.length} MCP server(s) configured:\n`);
+      for (const [id, cfg] of entries) {
+        const enabled = cfg.enabled !== false;
+        const transport = cfg.transport;
+        const risk = cfg.defaultRiskLevel ?? 'high';
+        const status = enabled ? '✓ enabled' : '✗ disabled';
+
+        log.info(`  ${id}`);
+        log.info(`    Status:    ${status}`);
+        log.info(`    Transport: ${transport?.type ?? 'unknown'}`);
+        if (transport?.type === 'stdio') {
+          log.info(`    Command:   ${transport.command} ${(transport.args ?? []).join(' ')}`);
+        } else if (transport && 'url' in transport) {
+          log.info(`    URL:       ${transport.url}`);
+        }
+        log.info(`    Risk:      ${risk}`);
+        if (cfg.allowedTools) log.info(`    Allowed:   ${cfg.allowedTools.join(', ')}`);
+        if (cfg.blockedTools) log.info(`    Blocked:   ${cfg.blockedTools.join(', ')}`);
+        log.info('');
+      }
+    });
+}

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -26,6 +26,7 @@ import {
 import { registerEmailCommand } from './cli/email.js';
 import { registerInfluencerCommand } from './cli/influencer.js';
 import { registerMapCommand } from './cli/map.js';
+import { registerMcpCommand } from './cli/mcp.js';
 import { registerSequenceCommand } from './cli/sequence.js';
 import { registerTwitterCommand } from './cli/twitter.js';
 import { registerHooksCommand } from './hooks/cli.js';
@@ -48,6 +49,7 @@ registerMemoryCommand(program);
 registerAuditCommand(program);
 registerDoctorCommand(program);
 registerHooksCommand(program);
+registerMcpCommand(program);
 registerEmailCommand(program);
 registerAmazonCommand(program);
 registerCompletionsCommand(program);


### PR DESCRIPTION
## Summary
- Adds `vellum mcp list` command to view configured MCP servers
- Shows server ID, enabled status, transport type, URL/command, and risk level
- Supports `--json` flag for machine-readable output

## Usage
```bash
$ vellum mcp list
1 MCP server(s) configured:

  context7
    Status:    ✓ enabled
    Transport: streamable-http
    URL:       https://mcp.context7.com/mcp
    Risk:      medium

$ vellum mcp list --json
[{"id":"context7","defaultRiskLevel":"medium","enabled":true,...}]
```

## Test plan
- [x] `vellum mcp list` with configured servers shows formatted output
- [x] `vellum mcp list --json` outputs valid JSON
- [x] `vellum mcp list` with no servers shows helpful message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
