### PR TITLE
feat: add memory and cpu metrics to /healthz with container-aware memory limit

### DIFF
--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -42,11 +42,31 @@ interface MemoryInfo {
   maxMb: number;
 }
 
+// Read the container memory limit from cgroups if available, falling back to host total.
+// cgroups v2: /sys/fs/cgroup/memory.max (returns "max" when unlimited)
+// cgroups v1: /sys/fs/cgroup/memory/memory.limit_in_bytes (large sentinel when unlimited)
+function getContainerMemoryLimitBytes(): number | null {
+  try {
+    const v2 = readFileSync('/sys/fs/cgroup/memory.max', 'utf-8').trim();
+    if (v2 !== 'max') {
+      const bytes = parseInt(v2, 10);
+      if (!isNaN(bytes) && bytes > 0) return bytes;
+    }
+  } catch { /* not available */ }
+  try {
+    const v1 = readFileSync('/sys/fs/cgroup/memory/memory.limit_in_bytes', 'utf-8').trim();
+    const bytes = parseInt(v1, 10);
+    // cgroups v1 uses a near-INT64_MAX sentinel when no limit is set
+    if (!isNaN(bytes) && bytes > 0 && bytes < totalmem() * 1.5) return bytes;
+  } catch { /* not available */ }
+  return null;
+}
+
 function getMemoryInfo(): MemoryInfo {
   const bytesToMb = (b: number) => Math.round((b / (1024 * 1024)) * 100) / 100;
   return {
     currentMb: bytesToMb(process.memoryUsage().rss),
-    maxMb: bytesToMb(totalmem()),
+    maxMb: bytesToMb(getContainerMemoryLimitBytes() ?? totalmem()),
   };
 }
 


### PR DESCRIPTION
## Summary
- `/healthz` now returns `memory` (`currentMb` = process RSS, `maxMb` = container cgroup limit or host total) and `cpu` (`currentPercent` = avg since startup, `maxCores` = logical CPU count)
- `maxMb` reads from cgroups v2 (`/sys/fs/cgroup/memory.max`) or v1 (`memory.limit_in_bytes`) when available, falling back to `os.totalmem()` — so containerized deployments report the actual memory ceiling rather than host RAM

## Original prompt
address this feedback maxMb is populated with os.totalmem(), which reports host RAM, not the process/container memory ceiling. In containerized deployments with memory limits, this overstates the maximum available memory and makes the health payload's memory headroom calculation inaccurate for production monitoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
