### PR TITLE
fix: clean up MCP resources on connect timeout and failed tool discovery

### DIFF
--- a/assistant/src/mcp/client.ts
+++ b/assistant/src/mcp/client.ts
@@ -40,12 +40,19 @@ export class McpClient {
 
     console.log(`[MCP] Connecting to server "${this.serverId}"...`);
     this.transport = this.createTransport(transportConfig);
-    await Promise.race([
-      this.client.connect(this.transport),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error(`MCP server "${this.serverId}" connection timed out after ${CONNECT_TIMEOUT_MS}ms`)), CONNECT_TIMEOUT_MS),
-      ),
-    ]);
+    try {
+      await Promise.race([
+        this.client.connect(this.transport),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error(`MCP server "${this.serverId}" connection timed out after ${CONNECT_TIMEOUT_MS}ms`)), CONNECT_TIMEOUT_MS),
+        ),
+      ]);
+    } catch (err) {
+      // Clean up the transport on failure (e.g., kill spawned stdio process)
+      try { await this.client.close(); } catch { /* ignore cleanup errors */ }
+      this.transport = undefined;
+      throw err;
+    }
     this.connected = true;
     console.log(`[MCP] Server "${this.serverId}" connected successfully`);
     log.info({ serverId: this.serverId }, 'MCP client connected');

--- a/assistant/src/mcp/manager.ts
+++ b/assistant/src/mcp/manager.ts
@@ -51,6 +51,13 @@ export class McpServerManager {
       } catch (err) {
         console.error(`[MCP] Failed to connect to server "${serverId}":`, err);
         log.error({ err, serverId }, 'Failed to connect to MCP server');
+        // Clean up any partially-connected client
+        const staleClient = this.clients.get(serverId);
+        if (staleClient) {
+          try { await staleClient.disconnect(); } catch { /* ignore */ }
+          this.clients.delete(serverId);
+          this.serverConfigs.delete(serverId);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Close MCP transport on connect timeout to prevent leaked stdio processes
- Disconnect and remove client from manager when tool discovery fails, instead of retaining a useless connection

## Original prompt
Addresses review feedback from #10467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
