### PR TITLE
fix: report near-real-time CPU utilization in /healthz

### DIFF
--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -75,17 +75,35 @@ interface CpuInfo {
   maxCores: number;
 }
 
+// Track CPU usage over a rolling window so /healthz reports near-real-time
+// utilization instead of a lifetime average (total CPU time / total uptime).
+const CPU_SAMPLE_INTERVAL_MS = 5_000;
+let _lastCpuUsage: NodeJS.CpuUsage = process.cpuUsage();
+let _lastCpuTime: number = Date.now();
+let _cachedCpuPercent = 0;
+
+// Kick off the background sampler. unref() so it never prevents process exit.
+setInterval(() => {
+  const now = Date.now();
+  const newUsage = process.cpuUsage();
+  const elapsedMs = now - _lastCpuTime;
+  if (elapsedMs > 0) {
+    const deltaCpuUs =
+      (newUsage.user - _lastCpuUsage.user) +
+      (newUsage.system - _lastCpuUsage.system);
+    const deltaCpuMs = deltaCpuUs / 1000;
+    const numCores = cpus().length;
+    _cachedCpuPercent =
+      Math.round((deltaCpuMs / (elapsedMs * numCores)) * 10000) / 100;
+  }
+  _lastCpuUsage = newUsage;
+  _lastCpuTime = now;
+}, CPU_SAMPLE_INTERVAL_MS).unref();
+
 function getCpuInfo(): CpuInfo {
-  const usage = process.cpuUsage();
-  const uptimeMs = process.uptime() * 1000;
-  const cpuMs = (usage.user + usage.system) / 1000;
-  const numCores = cpus().length;
-  const currentPercent = uptimeMs > 0
-    ? Math.round((cpuMs / (uptimeMs * numCores)) * 10000) / 100
-    : 0;
   return {
-    currentPercent,
-    maxCores: numCores,
+    currentPercent: _cachedCpuPercent,
+    maxCores: cpus().length,
   };
 }
 


### PR DESCRIPTION
## Summary
- Replace lifetime-average CPU calculation (total CPU time / total uptime) with a background 5-second rolling sampler
- `getCpuInfo()` now returns the delta between two consecutive `process.cpuUsage()` snapshots, accurately reflecting recent load
- The interval is `.unref()`'d so it never prevents process exit

## Original prompt
address this feedback and use a worktree, currentPercent is computed from total process CPU time divided by total uptime, which yields a lifetime average rather than the current CPU load. In long-running processes this becomes heavily smoothed (e.g., after a short CPU spike followed by idle time), so /healthz will report stale values and can mislead autoscaling/alerting that expects near-real-time utilization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
