### PR TITLE
test: add tests for vellum mcp list CLI command

### DIFF
--- a/assistant/src/__tests__/mcp-cli.test.ts
+++ b/assistant/src/__tests__/mcp-cli.test.ts
@@ -1,0 +1,171 @@
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+
+import { loadRawConfig, saveRawConfig } from '../config/loader.js';
+
+const CLI = join(import.meta.dir, '..', 'index.ts');
+
+function runMcpList(args: string[] = []): { stdout: string; exitCode: number } {
+  const result = spawnSync('bun', ['run', CLI, 'mcp', 'list', ...args], {
+    encoding: 'utf-8',
+    timeout: 10_000,
+  });
+  return {
+    stdout: (result.stdout ?? '').toString(),
+    exitCode: result.status ?? 1,
+  };
+}
+
+describe('vellum mcp list', () => {
+  let originalConfig: Record<string, unknown>;
+
+  beforeAll(() => {
+    originalConfig = loadRawConfig();
+  });
+
+  afterAll(() => {
+    saveRawConfig(originalConfig);
+  });
+
+  test('shows message when no MCP servers configured', () => {
+    const raw = loadRawConfig();
+    const savedMcp = raw.mcp;
+    delete raw.mcp;
+    saveRawConfig(raw);
+
+    try {
+      const { stdout, exitCode } = runMcpList();
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('No MCP servers configured');
+    } finally {
+      raw.mcp = savedMcp;
+      saveRawConfig(raw);
+    }
+  });
+
+  test('lists configured servers', () => {
+    const raw = loadRawConfig();
+    const savedMcp = raw.mcp;
+    raw.mcp = {
+      servers: {
+        'test-server': {
+          transport: { type: 'streamable-http', url: 'https://example.com/mcp' },
+          enabled: true,
+          defaultRiskLevel: 'medium',
+        },
+      },
+    };
+    saveRawConfig(raw);
+
+    try {
+      const { stdout, exitCode } = runMcpList();
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('1 MCP server(s) configured');
+      expect(stdout).toContain('test-server');
+      expect(stdout).toContain('streamable-http');
+      expect(stdout).toContain('https://example.com/mcp');
+      expect(stdout).toContain('medium');
+    } finally {
+      raw.mcp = savedMcp;
+      saveRawConfig(raw);
+    }
+  });
+
+  test('shows disabled status', () => {
+    const raw = loadRawConfig();
+    const savedMcp = raw.mcp;
+    raw.mcp = {
+      servers: {
+        'disabled-server': {
+          transport: { type: 'sse', url: 'https://example.com/sse' },
+          enabled: false,
+          defaultRiskLevel: 'high',
+        },
+      },
+    };
+    saveRawConfig(raw);
+
+    try {
+      const { stdout, exitCode } = runMcpList();
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('disabled');
+    } finally {
+      raw.mcp = savedMcp;
+      saveRawConfig(raw);
+    }
+  });
+
+  test('shows stdio command info', () => {
+    const raw = loadRawConfig();
+    const savedMcp = raw.mcp;
+    raw.mcp = {
+      servers: {
+        'stdio-server': {
+          transport: { type: 'stdio', command: 'npx', args: ['-y', 'some-mcp-server'] },
+          enabled: true,
+          defaultRiskLevel: 'low',
+        },
+      },
+    };
+    saveRawConfig(raw);
+
+    try {
+      const { stdout, exitCode } = runMcpList();
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('stdio-server');
+      expect(stdout).toContain('stdio');
+      expect(stdout).toContain('npx -y some-mcp-server');
+      expect(stdout).toContain('low');
+    } finally {
+      raw.mcp = savedMcp;
+      saveRawConfig(raw);
+    }
+  });
+
+  test('--json outputs valid JSON', () => {
+    const raw = loadRawConfig();
+    const savedMcp = raw.mcp;
+    raw.mcp = {
+      servers: {
+        'json-server': {
+          transport: { type: 'streamable-http', url: 'https://example.com/mcp' },
+          enabled: true,
+          defaultRiskLevel: 'high',
+        },
+      },
+    };
+    saveRawConfig(raw);
+
+    try {
+      const { stdout, exitCode } = runMcpList(['--json']);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].id).toBe('json-server');
+      expect(parsed[0].transport.url).toBe('https://example.com/mcp');
+    } finally {
+      raw.mcp = savedMcp;
+      saveRawConfig(raw);
+    }
+  });
+
+  test('--json outputs empty array when no servers', () => {
+    const raw = loadRawConfig();
+    const savedMcp = raw.mcp;
+    delete raw.mcp;
+    saveRawConfig(raw);
+
+    try {
+      const { stdout, exitCode } = runMcpList(['--json']);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed).toEqual([]);
+    } finally {
+      raw.mcp = savedMcp;
+      saveRawConfig(raw);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds integration tests for the `vellum mcp list` CLI command
- Tests run the actual CLI as a subprocess against real config

## Test cases
- No MCP servers configured → shows helpful message
- Configured server → shows name, transport type, URL, risk level
- Disabled server → shows disabled status
- Stdio transport → shows command and args
- `--json` flag → outputs valid JSON array with server details
- `--json` with no servers → outputs empty array

## Test plan
- [x] All 6 tests pass locally (`bun test src/__tests__/mcp-cli.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
