### PR TITLE
fix: guard against malformed MCP server entries in mcp list

### DIFF
--- a/assistant/src/cli/mcp.ts
+++ b/assistant/src/cli/mcp.ts
@@ -29,13 +29,19 @@ export function registerMcpCommand(program: Command): void {
       }
 
       if (opts.json) {
-        const result = entries.map(([id, config]) => ({ id, ...config }));
+        const result = entries
+          .filter(([, config]) => config && typeof config === 'object')
+          .map(([id, config]) => ({ id, ...config }));
         process.stdout.write(JSON.stringify(result, null, 2) + '\n');
         return;
       }
 
       log.info(`${entries.length} MCP server(s) configured:\n`);
       for (const [id, cfg] of entries) {
+        if (!cfg || typeof cfg !== 'object') {
+          log.info(`  ${id} (invalid config — skipped)\n`);
+          continue;
+        }
         const enabled = cfg.enabled !== false;
         const transport = cfg.transport;
         const risk = cfg.defaultRiskLevel ?? 'high';


### PR DESCRIPTION
## Summary
- Skip null/non-object entries in `vellum mcp list` to prevent crashes on malformed config
- Filter invalid entries from JSON output path as well
- Log a helpful "(invalid config — skipped)" message for malformed entries

## Original prompt
Addresses feedback from PR #10478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
