### PR TITLE
fix: release workflow - non-blocking playwright, correct Slack icons

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -604,8 +604,8 @@ jobs:
           security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
 
   release:
-    needs: [bump-and-tag, publish-npm, publish-meta, build-macos, push-assistant-image, push-gateway-image, ci-cli, ci-gateway, ci-playwright]
-    if: ${{ !cancelled() && needs.bump-and-tag.result == 'success' && needs.publish-npm.result == 'success' && needs.publish-meta.result == 'success' && needs.build-macos.result == 'success' && needs.ci-cli.result == 'success' && needs.ci-gateway.result == 'success' && needs.ci-playwright.result == 'success' }}
+    needs: [bump-and-tag, publish-npm, publish-meta, build-macos, push-assistant-image, push-gateway-image, ci-cli, ci-gateway]
+    if: ${{ !cancelled() && needs.bump-and-tag.result == 'success' && needs.publish-npm.result == 'success' && needs.publish-meta.result == 'success' && needs.build-macos.result == 'success' && needs.ci-cli.result == 'success' && needs.ci-gateway.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -890,7 +890,7 @@ jobs:
 
       - name: Run Playwright tests
         working-directory: playwright
-        run: bun run test
+        run: bunx playwright test tests/hello-world.spec.ts
 
   notify:
     if: always() && !cancelled()
@@ -925,8 +925,7 @@ jobs:
             "${{ needs.release.result }}" \
             "${{ needs.update-platform.result }}" \
             "${{ needs.ci-cli.result }}" \
-            "${{ needs.ci-gateway.result }}" \
-            "${{ needs.ci-playwright.result }}"; do
+            "${{ needs.ci-gateway.result }}"; do
             if [ "$result" = "failure" ] || [ "$result" = "skipped" ]; then
               RELEASE_FAILED="true"
               break
@@ -945,9 +944,9 @@ jobs:
           ci_icon() { if [ "$1" = "success" ]; then printf '✅'; else printf '❌'; fi; }
 
           A=$(ci_icon "${{ needs.ci-assistant.outcome }}")
-          C=$(ci_icon "${{ needs.ci-cli.outcome }}")
-          G=$(ci_icon "${{ needs.ci-gateway.outcome }}")
-          P=$(ci_icon "${{ needs.ci-playwright.outcome }}")
+          C=$(ci_icon "${{ needs.ci-cli.result }}")
+          G=$(ci_icon "${{ needs.ci-gateway.result }}")
+          P=$(ci_icon "${{ needs.ci-playwright.result }}")
           D=$(ci_icon "${{ needs.build-macos.result }}")
           AI=$(ci_icon "${{ needs.push-assistant-image.result }}")
           GI=$(ci_icon "${{ needs.push-gateway-image.result }}")


### PR DESCRIPTION
## Summary
- **Non-blocking playwright**: Removed `ci-playwright` from the `release` job's `needs` and `if` condition so playwright test failures no longer block the release
- **Hello-world only**: Changed the release CI playwright job to only run `tests/hello-world.spec.ts` instead of all agent tests
- **Fixed Slack icons**: `ci-cli` and `ci-gateway` Slack icons were using `needs.<job>.outcome` which is only defined for jobs with `continue-on-error: true`. Since those jobs don't have that flag, `.outcome` evaluated to empty string → ❌ even when the jobs succeeded. Switched to `.result` for ci-cli, ci-gateway, and ci-playwright (kept `.outcome` for ci-assistant which has `continue-on-error: true`)

## Test plan
- [ ] Trigger a release and verify playwright failure doesn't block the release
- [ ] Verify Slack notification shows correct ✅/❌ icons for cli and gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
