### PR TITLE
M5: Session/Desktop Router Migration (Vellum/mac path)

### DIFF
--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -35,6 +35,7 @@ import { executeFollowupAction } from '../runtime/guardian-action-followup-execu
 import { tryMintGuardianActionGrant } from '../runtime/guardian-action-grant-minter.js';
 import { composeGuardianActionMessageGenerative } from '../runtime/guardian-action-message-composer.js';
 import type { ApprovalConversationGenerator, GuardianActionCopyGenerator, GuardianFollowUpConversationGenerator } from '../runtime/http-types.js';
+import { routeGuardianReply } from '../runtime/guardian-reply-router.js';
 import { getLogger } from '../util/logger.js';
 import { resolveGuardianInviteIntent } from './guardian-invite-intent.js';
 import { resolveGuardianVerificationIntent } from './guardian-verification-intent.js';
@@ -404,6 +405,66 @@ export async function processMessage(
   await session.ensureActorScopedHistory();
   session.currentActiveSurfaceId = activeSurfaceId;
   session.currentPage = currentPage;
+
+  // ── Canonical guardian reply router (desktop/session path) ──
+  // Attempts to route inbound messages through the canonical decision pipeline
+  // before falling through to the legacy guardian action interception. Handles
+  // deterministic request code prefixes and NL classification, with all
+  // decisions flowing through applyCanonicalGuardianDecision.
+  if (content.trim().length > 0) {
+    const routerResult = await routeGuardianReply({
+      messageText: content.trim(),
+      channel: 'vellum',
+      actor: {
+        externalUserId: undefined,
+        channel: 'vellum',
+        isTrusted: true,
+      },
+      conversationId: session.conversationId,
+      approvalConversationGenerator: _approvalConversationGenerator,
+    });
+
+    if (routerResult.consumed) {
+      const guardianIfCtx = session.getTurnInterfaceContext();
+      const routerChannelMeta = {
+        userMessageChannel: 'vellum' as const,
+        assistantMessageChannel: 'vellum' as const,
+        userMessageInterface: guardianIfCtx?.userMessageInterface ?? 'vellum',
+        assistantMessageInterface: guardianIfCtx?.assistantMessageInterface ?? 'vellum',
+        provenanceActorRole: 'guardian' as const,
+      };
+
+      const userMsg = createUserMessage(content, attachments);
+      const persisted = await conversationStore.addMessage(
+        session.conversationId,
+        'user',
+        JSON.stringify(userMsg.content),
+        routerChannelMeta,
+      );
+      session.messages.push(userMsg);
+
+      const replyText = routerResult.replyText
+        ?? (routerResult.decisionApplied ? 'Decision applied.' : 'Request already resolved.');
+      const assistantMsg = createAssistantMessage(replyText);
+      await conversationStore.addMessage(
+        session.conversationId,
+        'assistant',
+        JSON.stringify(assistantMsg.content),
+        routerChannelMeta,
+      );
+      session.messages.push(assistantMsg);
+
+      onEvent({ type: 'assistant_text_delta', text: replyText });
+      onEvent({ type: 'message_complete', sessionId: session.conversationId });
+
+      log.info(
+        { conversationId: session.conversationId, routerType: routerResult.type, requestId: routerResult.requestId },
+        'Session guardian reply routed through canonical pipeline',
+      );
+
+      return persisted.id;
+    }
+  }
 
   // ── Unified guardian action answer interception (mac channel) ──
   // Deterministic priority matching: pending → follow-up → expired.

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -115,13 +115,17 @@ function parseCallbackAction(data: string): ParsedCallback | null {
  * 6-char alphanumeric request code at the start of a message.
  * Returns the matching canonical request and the remaining text after
  * the code prefix.
+ *
+ * When `scopeConversationId` is provided, the matched request must belong
+ * to that conversation — otherwise the code is treated as unmatched so
+ * that requests from other sessions are never accidentally consumed.
  */
 interface CodeParseResult {
   request: CanonicalGuardianRequest;
   remainingText: string;
 }
 
-function parseRequestCode(text: string): CodeParseResult | null {
+function parseRequestCode(text: string, scopeConversationId?: string): CodeParseResult | null {
   // Request codes are 6 hex chars (A-F, 0-9), uppercase
   const upper = text.toUpperCase();
   const match = upper.match(/^([A-F0-9]{6})(?:\s|$)/);
@@ -130,6 +134,16 @@ function parseRequestCode(text: string): CodeParseResult | null {
   const code = match[1];
   const request = getCanonicalGuardianRequestByCode(code);
   if (!request) return null;
+
+  // Scope to the current conversation when requested, so a code belonging
+  // to a different session/conversation is not consumed here.
+  if (scopeConversationId && request.conversationId && request.conversationId !== scopeConversationId) {
+    log.info(
+      { event: 'router_code_conversation_mismatch', code, requestId: request.id, expected: scopeConversationId, actual: request.conversationId },
+      'Request code matched a canonical request from a different conversation — ignoring',
+    );
+    return null;
+  }
 
   const remainingText = text.slice(code.length).trim();
   return { request, remainingText };
@@ -191,19 +205,32 @@ function notConsumed(): GuardianReplyResult {
 export async function routeGuardianReply(
   ctx: GuardianReplyContext,
 ): Promise<GuardianReplyResult> {
-  const { messageText, channel, actor, callbackData, approvalConversationGenerator } = ctx;
+  const { messageText, channel, actor, conversationId, callbackData, approvalConversationGenerator } = ctx;
 
   // ── 1. Deterministic callback parsing (button presses) ──
   if (callbackData) {
     const parsed = parseCallbackAction(callbackData);
     if (parsed) {
+      // When scoped to a conversation, verify the target request belongs to it
+      // before applying the decision. This prevents button presses in one
+      // session from resolving requests that belong to a different session.
+      if (conversationId) {
+        const targetRequest = getCanonicalGuardianRequest(parsed.requestId);
+        if (targetRequest && targetRequest.conversationId && targetRequest.conversationId !== conversationId) {
+          log.info(
+            { event: 'router_callback_conversation_mismatch', requestId: parsed.requestId, expected: conversationId, actual: targetRequest.conversationId },
+            'Callback target request belongs to a different conversation — ignoring',
+          );
+          return notConsumed();
+        }
+      }
       return applyDecision(parsed.requestId, parsed.action, actor);
     }
   }
 
   // ── 2. Request code parsing (6-char alphanumeric prefix) ──
   if (messageText.length > 0) {
-    const codeResult = parseRequestCode(messageText);
+    const codeResult = parseRequestCode(messageText, conversationId);
     if (codeResult) {
       const { request } = codeResult;
 


### PR DESCRIPTION
## Summary
- Replaced duplicated guardian reply interception in session path with shared M3 router
- Desktop/session path now routes guardian decisions through canonical primitive
- Aligned session behavior with inbound channel router semantics

Part of #10437
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
