### PR TITLE
fix: isolate MCP CLI tests from real workspace config

### DIFF
--- a/assistant/src/__tests__/mcp-cli.test.ts
+++ b/assistant/src/__tests__/mcp-cli.test.ts
@@ -1,16 +1,20 @@
 import { spawnSync } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-
-import { loadRawConfig, saveRawConfig } from '../config/loader.js';
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
 
 const CLI = join(import.meta.dir, '..', 'index.ts');
+
+let testDataDir: string;
+let configPath: string;
 
 function runMcpList(args: string[] = []): { stdout: string; exitCode: number } {
   const result = spawnSync('bun', ['run', CLI, 'mcp', 'list', ...args], {
     encoding: 'utf-8',
     timeout: 10_000,
+    env: { ...process.env, BASE_DATA_DIR: testDataDir },
   });
   return {
     stdout: (result.stdout ?? '').toString(),
@@ -18,154 +22,120 @@ function runMcpList(args: string[] = []): { stdout: string; exitCode: number } {
   };
 }
 
-describe('vellum mcp list', () => {
-  let originalConfig: Record<string, unknown>;
+function writeConfig(config: Record<string, unknown>): void {
+  writeFileSync(configPath, JSON.stringify(config), 'utf-8');
+}
 
+describe('vellum mcp list', () => {
   beforeAll(() => {
-    originalConfig = loadRawConfig();
+    testDataDir = join(tmpdir(), `vellum-mcp-cli-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const workspaceDir = join(testDataDir, '.vellum', 'workspace');
+    mkdirSync(workspaceDir, { recursive: true });
+    configPath = join(workspaceDir, 'config.json');
+    writeConfig({});
   });
 
   afterAll(() => {
-    saveRawConfig(originalConfig);
+    rmSync(testDataDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    writeConfig({});
   });
 
   test('shows message when no MCP servers configured', () => {
-    const raw = loadRawConfig();
-    const savedMcp = raw.mcp;
-    delete raw.mcp;
-    saveRawConfig(raw);
-
-    try {
-      const { stdout, exitCode } = runMcpList();
-      expect(exitCode).toBe(0);
-      expect(stdout).toContain('No MCP servers configured');
-    } finally {
-      raw.mcp = savedMcp;
-      saveRawConfig(raw);
-    }
+    const { stdout, exitCode } = runMcpList();
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('No MCP servers configured');
   });
 
   test('lists configured servers', () => {
-    const raw = loadRawConfig();
-    const savedMcp = raw.mcp;
-    raw.mcp = {
-      servers: {
-        'test-server': {
-          transport: { type: 'streamable-http', url: 'https://example.com/mcp' },
-          enabled: true,
-          defaultRiskLevel: 'medium',
+    writeConfig({
+      mcp: {
+        servers: {
+          'test-server': {
+            transport: { type: 'streamable-http', url: 'https://example.com/mcp' },
+            enabled: true,
+            defaultRiskLevel: 'medium',
+          },
         },
       },
-    };
-    saveRawConfig(raw);
+    });
 
-    try {
-      const { stdout, exitCode } = runMcpList();
-      expect(exitCode).toBe(0);
-      expect(stdout).toContain('1 MCP server(s) configured');
-      expect(stdout).toContain('test-server');
-      expect(stdout).toContain('streamable-http');
-      expect(stdout).toContain('https://example.com/mcp');
-      expect(stdout).toContain('medium');
-    } finally {
-      raw.mcp = savedMcp;
-      saveRawConfig(raw);
-    }
+    const { stdout, exitCode } = runMcpList();
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('1 MCP server(s) configured');
+    expect(stdout).toContain('test-server');
+    expect(stdout).toContain('streamable-http');
+    expect(stdout).toContain('https://example.com/mcp');
+    expect(stdout).toContain('medium');
   });
 
   test('shows disabled status', () => {
-    const raw = loadRawConfig();
-    const savedMcp = raw.mcp;
-    raw.mcp = {
-      servers: {
-        'disabled-server': {
-          transport: { type: 'sse', url: 'https://example.com/sse' },
-          enabled: false,
-          defaultRiskLevel: 'high',
+    writeConfig({
+      mcp: {
+        servers: {
+          'disabled-server': {
+            transport: { type: 'sse', url: 'https://example.com/sse' },
+            enabled: false,
+            defaultRiskLevel: 'high',
+          },
         },
       },
-    };
-    saveRawConfig(raw);
+    });
 
-    try {
-      const { stdout, exitCode } = runMcpList();
-      expect(exitCode).toBe(0);
-      expect(stdout).toContain('disabled');
-    } finally {
-      raw.mcp = savedMcp;
-      saveRawConfig(raw);
-    }
+    const { stdout, exitCode } = runMcpList();
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('disabled');
   });
 
   test('shows stdio command info', () => {
-    const raw = loadRawConfig();
-    const savedMcp = raw.mcp;
-    raw.mcp = {
-      servers: {
-        'stdio-server': {
-          transport: { type: 'stdio', command: 'npx', args: ['-y', 'some-mcp-server'] },
-          enabled: true,
-          defaultRiskLevel: 'low',
+    writeConfig({
+      mcp: {
+        servers: {
+          'stdio-server': {
+            transport: { type: 'stdio', command: 'npx', args: ['-y', 'some-mcp-server'] },
+            enabled: true,
+            defaultRiskLevel: 'low',
+          },
         },
       },
-    };
-    saveRawConfig(raw);
+    });
 
-    try {
-      const { stdout, exitCode } = runMcpList();
-      expect(exitCode).toBe(0);
-      expect(stdout).toContain('stdio-server');
-      expect(stdout).toContain('stdio');
-      expect(stdout).toContain('npx -y some-mcp-server');
-      expect(stdout).toContain('low');
-    } finally {
-      raw.mcp = savedMcp;
-      saveRawConfig(raw);
-    }
+    const { stdout, exitCode } = runMcpList();
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('stdio-server');
+    expect(stdout).toContain('stdio');
+    expect(stdout).toContain('npx -y some-mcp-server');
+    expect(stdout).toContain('low');
   });
 
   test('--json outputs valid JSON', () => {
-    const raw = loadRawConfig();
-    const savedMcp = raw.mcp;
-    raw.mcp = {
-      servers: {
-        'json-server': {
-          transport: { type: 'streamable-http', url: 'https://example.com/mcp' },
-          enabled: true,
-          defaultRiskLevel: 'high',
+    writeConfig({
+      mcp: {
+        servers: {
+          'json-server': {
+            transport: { type: 'streamable-http', url: 'https://example.com/mcp' },
+            enabled: true,
+            defaultRiskLevel: 'high',
+          },
         },
       },
-    };
-    saveRawConfig(raw);
+    });
 
-    try {
-      const { stdout, exitCode } = runMcpList(['--json']);
-      expect(exitCode).toBe(0);
-      const parsed = JSON.parse(stdout);
-      expect(Array.isArray(parsed)).toBe(true);
-      expect(parsed).toHaveLength(1);
-      expect(parsed[0].id).toBe('json-server');
-      expect(parsed[0].transport.url).toBe('https://example.com/mcp');
-    } finally {
-      raw.mcp = savedMcp;
-      saveRawConfig(raw);
-    }
+    const { stdout, exitCode } = runMcpList(['--json']);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].id).toBe('json-server');
+    expect(parsed[0].transport.url).toBe('https://example.com/mcp');
   });
 
   test('--json outputs empty array when no servers', () => {
-    const raw = loadRawConfig();
-    const savedMcp = raw.mcp;
-    delete raw.mcp;
-    saveRawConfig(raw);
-
-    try {
-      const { stdout, exitCode } = runMcpList(['--json']);
-      expect(exitCode).toBe(0);
-      const parsed = JSON.parse(stdout);
-      expect(parsed).toEqual([]);
-    } finally {
-      raw.mcp = savedMcp;
-      saveRawConfig(raw);
-    }
+    const { stdout, exitCode } = runMcpList(['--json']);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Use a per-test temp directory via `BASE_DATA_DIR` env var instead of the real `~/.vellum/workspace/config.json`
- Write config directly with `writeFileSync` instead of `loadRawConfig`/`saveRawConfig` — simpler and no backup/restore needed
- Clean up temp dir in `afterAll`

## Original prompt
Addresses review feedback from #10483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
