### PR TITLE
feat: add vellum mcp add CLI command

### DIFF
--- a/assistant/src/cli/mcp.ts
+++ b/assistant/src/cli/mcp.ts
@@ -1,6 +1,6 @@
 import type { Command } from 'commander';
 
-import { loadRawConfig } from '../config/loader.js';
+import { loadRawConfig, saveRawConfig } from '../config/loader.js';
 import type { McpConfig, McpServerConfig } from '../config/mcp-schema.js';
 import { getCliLogger } from '../util/logger.js';
 
@@ -60,5 +60,71 @@ export function registerMcpCommand(program: Command): void {
         if (cfg.blockedTools) log.info(`    Blocked:   ${cfg.blockedTools.join(', ')}`);
         log.info('');
       }
+    });
+
+  mcp
+    .command('add <name>')
+    .description('Add an MCP server configuration')
+    .requiredOption('-t, --transport-type <type>', 'Transport type: stdio, sse, or streamable-http')
+    .option('-u, --url <url>', 'Server URL (for sse/streamable-http)')
+    .option('-c, --command <cmd>', 'Command to run (for stdio)')
+    .option('-a, --args <args...>', 'Command arguments (for stdio)')
+    .option('-r, --risk <level>', 'Default risk level: low, medium, or high', 'high')
+    .option('--disabled', 'Add as disabled')
+    .action((name: string, opts: {
+      transportType: string;
+      url?: string;
+      command?: string;
+      args?: string[];
+      risk: string;
+      disabled?: boolean;
+    }) => {
+      const raw = loadRawConfig();
+      if (!raw.mcp) raw.mcp = { servers: {} };
+      const mcpConfig = raw.mcp as Record<string, unknown>;
+      if (!mcpConfig.servers) mcpConfig.servers = {};
+      const servers = mcpConfig.servers as Record<string, unknown>;
+
+      if (servers[name]) {
+        log.error(`MCP server "${name}" already exists. Remove it first with: vellum mcp remove ${name}`);
+        return;
+      }
+
+      let transport: Record<string, unknown>;
+      switch (opts.transportType) {
+        case 'stdio':
+          if (!opts.command) {
+            log.error('--command is required for stdio transport');
+            return;
+          }
+          transport = { type: 'stdio', command: opts.command, args: opts.args ?? [] };
+          break;
+        case 'sse':
+        case 'streamable-http':
+          if (!opts.url) {
+            log.error(`--url is required for ${opts.transportType} transport`);
+            return;
+          }
+          transport = { type: opts.transportType, url: opts.url };
+          break;
+        default:
+          log.error(`Unknown transport type: ${opts.transportType}. Must be stdio, sse, or streamable-http`);
+          return;
+      }
+
+      if (!['low', 'medium', 'high'].includes(opts.risk)) {
+        log.error(`Invalid risk level: ${opts.risk}. Must be low, medium, or high`);
+        return;
+      }
+
+      servers[name] = {
+        transport,
+        enabled: !opts.disabled,
+        defaultRiskLevel: opts.risk,
+      };
+
+      saveRawConfig(raw);
+      log.info(`Added MCP server "${name}" (${opts.transportType})`);
+      log.info('Restart the daemon for changes to take effect: vellum daemon restart');
     });
 }


### PR DESCRIPTION
## Summary
- Adds `vellum mcp add <name>` command to configure MCP servers from the CLI
- Supports all three transport types: stdio, sse, and streamable-http
- Validates required fields, prevents duplicates, and checks risk levels

## Usage
```bash
# Add a streamable-http server
vellum mcp add context7 -t streamable-http -u https://mcp.context7.com/mcp -r medium

# Add a stdio server
vellum mcp add my-server -t stdio -c npx -a "-y" "@modelcontextprotocol/server-everything" -r low

# Add as disabled
vellum mcp add staging -t sse -u https://staging.example.com/mcp --disabled
```

## Test plan
- [x] Add streamable-http server — writes to config correctly
- [x] Add stdio server with args — writes command and args
- [x] Duplicate name — shows error, does not overwrite
- [x] Missing required fields (--url for http, --command for stdio) — shows error
- [x] Invalid transport type — shows error
- [x] `vellum mcp list` shows added servers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
