### PR TITLE
fix: convert eager tool imports to static to fix production module not found crash

### DIFF
--- a/assistant/src/tools/swarm/delegate.ts
+++ b/assistant/src/tools/swarm/delegate.ts
@@ -8,6 +8,7 @@ import { executeSwarm } from '../../swarm/orchestrator.js';
 import { generatePlan } from '../../swarm/router-planner.js';
 import { getLogger } from '../../util/logger.js';
 import { truncate } from '../../util/truncate.js';
+import { registerTool } from '../registry.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 
 const log = getLogger('swarm-delegate');
@@ -177,6 +178,8 @@ export const swarmDelegateTool: Tool = {
     }
   },
 };
+
+registerTool(swarmDelegateTool);
 
 /** Clear all active sessions — only for testing. */
 export function _resetSwarmActive(): void {

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -16,8 +16,10 @@ import { setAvatarTool } from './system/avatar-generator.js';
 import { navigateSettingsTabTool } from './system/navigate-settings.js';
 import { openSystemSettingsTool } from './system/open-system-settings.js';
 import { voiceConfigUpdateTool } from './system/voice-config.js';
+import { shellTool } from './terminal/shell.js';
 import type { Tool } from './types.js';
 import { screenWatchTool } from './watch/screen-watch.js';
+import { swarmDelegateTool } from './swarm/delegate.js';
 
 // ── Eager side-effect modules ───────────────────────────────────────
 // These static imports trigger top-level `registerTool()` side effects.
@@ -123,10 +125,7 @@ export const lazyTools: LazyToolDescriptor[] = [
         required: ['command'],
       },
     },
-    loader: async () => {
-      const mod = await import('./terminal/shell.js');
-      return mod.shellTool;
-    },
+    loader: async () => shellTool,
   },
   {
     name: 'swarm_delegate',
@@ -155,9 +154,6 @@ export const lazyTools: LazyToolDescriptor[] = [
         required: ['objective'],
       },
     },
-    loader: async () => {
-      const mod = await import('./swarm/delegate.js');
-      return mod.swarmDelegateTool;
-    },
+    loader: async () => swarmDelegateTool,
   },
 ];

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -20,22 +20,32 @@ import type { Tool } from './types.js';
 import { screenWatchTool } from './watch/screen-watch.js';
 
 // ── Eager side-effect modules ───────────────────────────────────────
-// Importing these modules triggers a top-level `registerTool()` call.
+// These static imports trigger top-level `registerTool()` side effects.
+//
+// IMPORTANT: These MUST be static imports (not dynamic `await import()`).
+// When the daemon is compiled with `bun --compile`, dynamic imports with
+// relative string literals resolve against the virtual `/$bunfs/root/`
+// filesystem root rather than the module's own directory, causing
+// "Cannot find module './filesystem/read.js'" crashes in production builds.
+// Static imports are resolved at bundle time and are always safe.
+import './assets/materialize.js';
+import './assets/search.js';
+import './filesystem/edit.js';
+import './filesystem/read.js';
+import './filesystem/view-image.js';
+import './filesystem/write.js';
+import './network/web-fetch.js';
+import './network/web-search.js';
+import './skills/delete-managed.js';
+import './skills/load.js';
+import './skills/scaffold-managed.js';
+import './system/request-permission.js';
+import './system/version.js';
 
-export async function loadEagerModules(): Promise<void> {
-  await import('./filesystem/read.js');
-  await import('./filesystem/write.js');
-  await import('./filesystem/edit.js');
-  await import('./network/web-search.js');
-  await import('./network/web-fetch.js');
-  await import('./skills/load.js');
-  await import('./skills/scaffold-managed.js');
-  await import('./skills/delete-managed.js');
-  await import('./system/request-permission.js');
-  await import('./assets/search.js');
-  await import('./assets/materialize.js');
-  await import('./filesystem/view-image.js');
-  await import('./system/version.js');
+// loadEagerModules is a no-op now that all eager registrations happen via
+// static imports above. Kept for API compatibility with registry.ts callers.
+export function loadEagerModules(): Promise<void> {
+  return Promise.resolve();
 }
 
 // Tool names registered by the eager modules above.  Listed explicitly so

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -6,7 +6,6 @@
  * so adding/removing tools only requires editing this manifest.
  */
 
-import { RiskLevel } from '../permissions/types.js';
 import { accountManageTool } from './credentials/account-registry.js';
 import { credentialStoreTool } from './credentials/vault.js';
 import { memorySaveTool, memorySearchTool, memoryUpdateTool } from './memory/register.js';
@@ -16,10 +15,8 @@ import { setAvatarTool } from './system/avatar-generator.js';
 import { navigateSettingsTabTool } from './system/navigate-settings.js';
 import { openSystemSettingsTool } from './system/open-system-settings.js';
 import { voiceConfigUpdateTool } from './system/voice-config.js';
-import { shellTool } from './terminal/shell.js';
 import type { Tool } from './types.js';
 import { screenWatchTool } from './watch/screen-watch.js';
-import { swarmDelegateTool } from './swarm/delegate.js';
 
 // ── Eager side-effect modules ───────────────────────────────────────
 // These static imports trigger top-level `registerTool()` side effects.
@@ -41,8 +38,10 @@ import './network/web-search.js';
 import './skills/delete-managed.js';
 import './skills/load.js';
 import './skills/scaffold-managed.js';
+import './swarm/delegate.js';
 import './system/request-permission.js';
 import './system/version.js';
+import './terminal/shell.js';
 
 // loadEagerModules is a no-op now that all eager registrations happen via
 // static imports above. Kept for API compatibility with registry.ts callers.
@@ -55,6 +54,7 @@ export function loadEagerModules(): Promise<void> {
 // already in the registry before init ran (e.g. when a test file imports
 // an eager module at the top level).
 export const eagerModuleToolNames: string[] = [
+  'bash',
   'file_read',
   'file_write',
   'file_edit',
@@ -66,6 +66,7 @@ export const eagerModuleToolNames: string[] = [
   'request_system_permission',
   'asset_search',
   'asset_materialize',
+  'swarm_delegate',
   'view_image',
   'version',
 ];
@@ -90,70 +91,8 @@ export const explicitTools: Tool[] = [
 
 // ── Lazy tool descriptors ───────────────────────────────────────────
 // Tools that defer module loading until first invocation.
+// bash and swarm_delegate were previously lazy but are now eagerly registered
+// via side-effect imports above, preserving their full definitions (including
+// the `reason` field on bash) and fixing bun --compile module-not-found crashes.
 
-export const lazyTools: LazyToolDescriptor[] = [
-  {
-    name: 'bash',
-    description: 'Execute a shell command on the local machine',
-    category: 'terminal',
-    defaultRiskLevel: RiskLevel.Medium,
-    definition: {
-      name: 'bash',
-      description: 'Execute a shell command on the local machine',
-      input_schema: {
-        type: 'object',
-        properties: {
-          command: {
-            type: 'string',
-            description: 'The shell command to execute',
-          },
-          timeout_seconds: {
-            type: 'number',
-            description: 'Optional timeout in seconds. Defaults to the configured default (120s). Cannot exceed the configured maximum.',
-          },
-          network_mode: {
-            type: 'string',
-            enum: ['off', 'proxied'],
-            description: 'Network access mode for the command. "off" (default) blocks network access; "proxied" routes traffic through the credential proxy.',
-          },
-          credential_ids: {
-            type: 'array',
-            items: { type: 'string' },
-            description: 'Optional list of credential IDs to inject via the proxy when network_mode is "proxied".',
-          },
-        },
-        required: ['command'],
-      },
-    },
-    loader: async () => shellTool,
-  },
-  {
-    name: 'swarm_delegate',
-    description: 'Decompose a complex task into parallel specialist subtasks and execute them concurrently.',
-    category: 'orchestration',
-    defaultRiskLevel: RiskLevel.Medium,
-    definition: {
-      name: 'swarm_delegate',
-      description: 'Decompose a complex task into parallel specialist subtasks and execute them concurrently. Use this for multi-part tasks that benefit from parallel research, coding, and review.',
-      input_schema: {
-        type: 'object',
-        properties: {
-          objective: {
-            type: 'string',
-            description: 'The complex task to decompose and execute in parallel',
-          },
-          context: {
-            type: 'string',
-            description: 'Optional additional context about the task or codebase',
-          },
-          max_workers: {
-            type: 'number',
-            description: 'Maximum concurrent workers (1-6, default from config)',
-          },
-        },
-        required: ['objective'],
-      },
-    },
-    loader: async () => swarmDelegateTool,
-  },
-];
+export const lazyTools: LazyToolDescriptor[] = [];


### PR DESCRIPTION
## Summary

Fixes production crash: `Cannot find module './filesystem/read.js' from '/$bunfs/root/vellum-daemon'`

Root cause: `loadEagerModules()` in `tool-manifest.ts` used dynamic `await import('./filesystem/read.js')` calls. In `bun --compile` production builds, dynamic imports with relative string literals resolve against the virtual `/$bunfs/root/` filesystem root rather than the importing module's directory, so the relative paths fail at runtime.

Fix: Convert all dynamic `await import()` calls in `loadEagerModules()` to static side-effect imports at the top of the file. Bun resolves static imports at bundle time (safe), whereas dynamic imports need a resolvable runtime path (broken inside bunfs). `loadEagerModules()` is now a no-op that returns `Promise.resolve()` for API compatibility.

Closes #10492

Original prompt: M3: Fix 'Cannot find module ./filesystem/read.js' production crash (BRAIN-E) (#10492)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
