### PR TITLE
test: add tests for vellum mcp add CLI command

### DIFF
--- a/assistant/src/__tests__/mcp-cli.test.ts
+++ b/assistant/src/__tests__/mcp-cli.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -10,20 +10,33 @@ const CLI = join(import.meta.dir, '..', 'index.ts');
 let testDataDir: string;
 let configPath: string;
 
-function runMcpList(args: string[] = []): { stdout: string; exitCode: number } {
-  const result = spawnSync('bun', ['run', CLI, 'mcp', 'list', ...args], {
+function runMcp(subcommand: string, args: string[] = []): { stdout: string; stderr: string; exitCode: number } {
+  const result = spawnSync('bun', ['run', CLI, 'mcp', subcommand, ...args], {
     encoding: 'utf-8',
     timeout: 10_000,
     env: { ...process.env, BASE_DATA_DIR: testDataDir },
   });
   return {
     stdout: (result.stdout ?? '').toString(),
+    stderr: (result.stderr ?? '').toString(),
     exitCode: result.status ?? 1,
   };
 }
 
+function runMcpList(args: string[] = []) {
+  return runMcp('list', args);
+}
+
+function runMcpAdd(name: string, args: string[]) {
+  return runMcp('add', [name, ...args]);
+}
+
 function writeConfig(config: Record<string, unknown>): void {
   writeFileSync(configPath, JSON.stringify(config), 'utf-8');
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(configPath, 'utf-8'));
 }
 
 describe('vellum mcp list', () => {
@@ -137,5 +150,109 @@ describe('vellum mcp list', () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toEqual([]);
+  });
+});
+
+describe('vellum mcp add', () => {
+  beforeAll(() => {
+    testDataDir = join(tmpdir(), `vellum-mcp-add-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const workspaceDir = join(testDataDir, '.vellum', 'workspace');
+    mkdirSync(workspaceDir, { recursive: true });
+    configPath = join(workspaceDir, 'config.json');
+    writeConfig({});
+  });
+
+  afterAll(() => {
+    rmSync(testDataDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    writeConfig({});
+  });
+
+  test('adds a streamable-http server', () => {
+    const { stdout, exitCode } = runMcpAdd('test-http', [
+      '-t', 'streamable-http', '-u', 'https://example.com/mcp', '-r', 'medium',
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('Added MCP server "test-http"');
+
+    const updated = readConfig();
+    const servers = (updated.mcp as Record<string, unknown> | undefined)?.servers as Record<string, unknown> | undefined;
+    const server = servers?.['test-http'] as Record<string, unknown>;
+    expect(server).toBeDefined();
+    expect((server.transport as Record<string, unknown>).type).toBe('streamable-http');
+    expect((server.transport as Record<string, unknown>).url).toBe('https://example.com/mcp');
+    expect(server.defaultRiskLevel).toBe('medium');
+    expect(server.enabled).toBe(true);
+  });
+
+  test('adds a stdio server with args', () => {
+    const { stdout, exitCode } = runMcpAdd('test-stdio', [
+      '-t', 'stdio', '-c', 'npx', '-a', '-y', 'some-server', '-r', 'low',
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('Added MCP server "test-stdio"');
+
+    const updated = readConfig();
+    const servers = (updated.mcp as Record<string, unknown> | undefined)?.servers as Record<string, unknown> | undefined;
+    const server = servers?.['test-stdio'] as Record<string, unknown>;
+    const transport = server.transport as Record<string, unknown>;
+    expect(transport.type).toBe('stdio');
+    expect(transport.command).toBe('npx');
+    expect(transport.args).toEqual(['-y', 'some-server']);
+  });
+
+  test('adds server as disabled with --disabled flag', () => {
+    const { exitCode } = runMcpAdd('test-disabled', [
+      '-t', 'sse', '-u', 'https://example.com/sse', '--disabled',
+    ]);
+    expect(exitCode).toBe(0);
+
+    const updated = readConfig();
+    const servers = (updated.mcp as Record<string, unknown> | undefined)?.servers as Record<string, unknown> | undefined;
+    const server = servers?.['test-disabled'] as Record<string, unknown>;
+    expect(server.enabled).toBe(false);
+  });
+
+  test('rejects duplicate server name', () => {
+    writeConfig({
+      mcp: {
+        servers: {
+          existing: {
+            transport: { type: 'sse', url: 'https://example.com' },
+            enabled: true,
+            defaultRiskLevel: 'high',
+          },
+        },
+      },
+    });
+
+    const { stderr } = runMcpAdd('existing', [
+      '-t', 'sse', '-u', 'https://other.com',
+    ]);
+    expect(stderr).toContain('already exists');
+  });
+
+  test('rejects stdio without --command', () => {
+    const { stderr } = runMcpAdd('bad-stdio', ['-t', 'stdio']);
+    expect(stderr).toContain('--command is required');
+  });
+
+  test('rejects streamable-http without --url', () => {
+    const { stderr } = runMcpAdd('bad-http', ['-t', 'streamable-http']);
+    expect(stderr).toContain('--url is required');
+  });
+
+  test('defaults risk to high', () => {
+    const { exitCode } = runMcpAdd('default-risk', [
+      '-t', 'sse', '-u', 'https://example.com/sse',
+    ]);
+    expect(exitCode).toBe(0);
+
+    const updated = readConfig();
+    const servers = (updated.mcp as Record<string, unknown> | undefined)?.servers as Record<string, unknown> | undefined;
+    const server = servers?.['default-risk'] as Record<string, unknown>;
+    expect(server.defaultRiskLevel).toBe('high');
   });
 });


### PR DESCRIPTION
## Summary
- Add 7 integration tests for `vellum mcp add` CLI command
- Cover success paths: streamable-http, stdio with args, disabled flag, default risk level
- Cover error paths: duplicate server name, missing --command for stdio, missing --url for streamable-http
- Use isolated temp directories (same pattern as existing mcp list tests)

## Test plan
- [x] All 13 tests pass (6 list + 7 add)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
