### PR TITLE
fix: add retry logic to createConversation for SQLite disk I/O errors

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -166,7 +166,7 @@ export function createConversation(titleOrOpts?: string | { title?: string; thre
       break;
     } catch (err) {
       const code = (err as { code?: string }).code ?? '';
-      if (attempt < MAX_RETRIES && (code === 'SQLITE_BUSY' || code.startsWith('SQLITE_IOERR'))) {
+      if (attempt < MAX_RETRIES && (code.startsWith('SQLITE_BUSY') || code.startsWith('SQLITE_IOERR'))) {
         log.warn({ attempt, conversationId: id, code }, 'createConversation: transient SQLite error, retrying');
         // Synchronous sleep — createConversation is synchronous and the
         // retry window is short (50-150ms), so Bun.sleepSync is appropriate.
@@ -233,7 +233,8 @@ export async function addMessage(conversationId: string, role: string, content: 
       ? metadata.userMessageChannel
       : null;
   // Wrap insert + updatedAt bump in a transaction so they're atomic.
-  // Retry on SQLITE_BUSY in case busy_timeout is exhausted under heavy contention.
+  // Retry on SQLITE_BUSY* and SQLITE_IOERR* — covers WAL contention variants
+  // (SQLITE_BUSY_SNAPSHOT, SQLITE_BUSY_RECOVERY) and transient disk I/O errors.
   // Timestamp is recomputed each attempt so a late retry doesn't persist a stale updatedAt.
   const MAX_RETRIES = 3;
   let now!: number;
@@ -263,8 +264,9 @@ export async function addMessage(conversationId: string, role: string, content: 
       });
       break;
     } catch (err) {
-      if (attempt < MAX_RETRIES && (err as { code?: string }).code === 'SQLITE_BUSY') {
-        log.warn({ attempt, conversationId }, 'addMessage: SQLITE_BUSY, retrying');
+      const errCode = (err as { code?: string }).code ?? '';
+      if (attempt < MAX_RETRIES && (errCode.startsWith('SQLITE_BUSY') || errCode.startsWith('SQLITE_IOERR'))) {
+        log.warn({ attempt, conversationId, code: errCode }, 'addMessage: transient SQLite error, retrying');
         await Bun.sleep(50 * (attempt + 1));
         continue;
       }

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -156,7 +156,27 @@ export function createConversation(titleOrOpts?: string | { title?: string; thre
     source,
     memoryScopeId,
   };
-  db.insert(conversations).values(conversation).run();
+
+  // Retry on SQLITE_BUSY and SQLITE_IOERR — transient disk I/O errors or WAL
+  // contention can cause the first attempt to fail even under normal load.
+  const MAX_RETRIES = 3;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      db.insert(conversations).values(conversation).run();
+      break;
+    } catch (err) {
+      const code = (err as { code?: string }).code ?? '';
+      if (attempt < MAX_RETRIES && (code === 'SQLITE_BUSY' || code.startsWith('SQLITE_IOERR'))) {
+        log.warn({ attempt, conversationId: id, code }, 'createConversation: transient SQLite error, retrying');
+        // Synchronous sleep — createConversation is synchronous and the
+        // retry window is short (50-150ms), so Bun.sleepSync is appropriate.
+        Bun.sleepSync(50 * (attempt + 1));
+        continue;
+      }
+      throw err;
+    }
+  }
+
   return conversation;
 }
 


### PR DESCRIPTION
## Summary

Fixes SQLiteError disk I/O error crashes in the conversation store (Sentry issue BRAIN-J).

Root cause: `createConversation` had no retry logic, so transient `SQLITE_BUSY` or `SQLITE_IOERR` errors (disk I/O spikes, WAL contention) would immediately throw and crash the calling code.

Fix:
- Add retry loop (max 3 attempts, 50ms * attempt backoff) to `createConversation`, matching the existing pattern in `addMessage`
- Retry on `SQLITE_BUSY` and any `SQLITE_IOERR*` error codes
- Use synchronous sleep (`Bun.sleepSync`) since `createConversation` is a synchronous function
- WAL mode was already enabled in `db-connection.ts` (`PRAGMA journal_mode=WAL`) — no change needed there

Closes #10494

Original prompt: M5: Fix SQLiteError disk I/O error resilience in conversation store (BRAIN-J) (#10494)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
