### PR TITLE
fix: set non-zero exit code on mcp add validation errors

### DIFF
--- a/assistant/src/cli/mcp.ts
+++ b/assistant/src/cli/mcp.ts
@@ -87,6 +87,7 @@ export function registerMcpCommand(program: Command): void {
 
       if (servers[name]) {
         log.error(`MCP server "${name}" already exists. Remove it first with: vellum mcp remove ${name}`);
+        process.exitCode = 1;
         return;
       }
 
@@ -95,6 +96,7 @@ export function registerMcpCommand(program: Command): void {
         case 'stdio':
           if (!opts.command) {
             log.error('--command is required for stdio transport');
+            process.exitCode = 1;
             return;
           }
           transport = { type: 'stdio', command: opts.command, args: opts.args ?? [] };
@@ -103,17 +105,20 @@ export function registerMcpCommand(program: Command): void {
         case 'streamable-http':
           if (!opts.url) {
             log.error(`--url is required for ${opts.transportType} transport`);
+            process.exitCode = 1;
             return;
           }
           transport = { type: opts.transportType, url: opts.url };
           break;
         default:
           log.error(`Unknown transport type: ${opts.transportType}. Must be stdio, sse, or streamable-http`);
+          process.exitCode = 1;
           return;
       }
 
       if (!['low', 'medium', 'high'].includes(opts.risk)) {
         log.error(`Invalid risk level: ${opts.risk}. Must be low, medium, or high`);
+        process.exitCode = 1;
         return;
       }
 


### PR DESCRIPTION
## Summary
- Add `process.exitCode = 1` before each `return` in the 5 error paths of the `mcp add` command handler
- Aligns with the convention used by other CLI commands (twitter.ts, amazon.ts, config-commands.ts)
- Without this, scripts couldn't distinguish failed `vellum mcp add` from successful ones

## Original prompt
Addresses review feedback from #10501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
