### PR TITLE
feat: add Privacy settings tab with collect-usage-data opt-out toggle

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -9,6 +9,7 @@ enum SettingsTab: String {
     case permissions = "Permissions"
     case automation = "Automation"
     case appearance = "Appearance"
+    case privacy = "Privacy"
     case parental = "Parental"
     case advanced = "Advanced"
 
@@ -16,7 +17,7 @@ enum SettingsTab: String {
     static func visibleTabs(isDevMode: Bool) -> [SettingsTab] {
         var tabs: [SettingsTab] = [
             .account, .channels, .modelsAndServices, .voice,
-            .automation, .appearance, .permissions
+            .automation, .appearance, .permissions, .privacy
         ]
         if isDevMode {
             tabs.append(.advanced)
@@ -254,6 +255,8 @@ struct SettingsPanel: View {
             SettingsAutomationTab(daemonClient: daemonClient, showingReminders: $showingReminders, showingScheduledTasks: $showingScheduledTasks, showingHeartbeatConfig: $showingHeartbeatConfig)
         case .appearance:
             SettingsAppearanceTab(store: store)
+        case .privacy:
+            SettingsPrivacyTab(daemonClient: daemonClient)
         case .parental:
             permissionsContent
         case .advanced:

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -1,0 +1,119 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Privacy settings tab — lets the user opt out of crash reporting and
+/// error diagnostics sent to help improve the app.
+@MainActor
+struct SettingsPrivacyTab: View {
+    var daemonClient: DaemonClient?
+
+    private static let collectUsageDataKey = "feature_flags.collect-usage-data.enabled"
+
+    @State private var collectUsageData: Bool = true
+    @State private var isLoading: Bool = false
+    @State private var isUpdating: Bool = false
+    @State private var loadError: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xl) {
+            diagnosticsSection
+        }
+        .onAppear {
+            Task { await loadPrivacyFlags() }
+        }
+    }
+
+    // MARK: - Diagnostics Section
+
+    private var diagnosticsSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            HStack {
+                Text("Diagnostics")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+                Spacer()
+                if isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                        .progressViewStyle(.circular)
+                }
+            }
+
+            if let error = loadError {
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(VColor.warning)
+                        .font(.system(size: 12))
+                    Text(error)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.error)
+                }
+            }
+
+            HStack {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Collect usage data")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Text("Send crash reports and error diagnostics to help improve the app. No personal data or message content is ever sent.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+                Spacer()
+                Toggle("", isOn: Binding(
+                    get: { collectUsageData },
+                    set: { newValue in
+                        collectUsageData = newValue
+                        Task { await setCollectUsageData(newValue) }
+                    }
+                ))
+                .toggleStyle(.switch)
+                .disabled(isLoading || isUpdating || daemonClient == nil)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(VSpacing.lg)
+        .vCard(background: VColor.surfaceSubtle)
+    }
+
+    // MARK: - Data Loading
+
+    private func loadPrivacyFlags() async {
+        guard let daemonClient else { return }
+        isLoading = true
+        loadError = nil
+        do {
+            let flags = try await daemonClient.getFeatureFlags()
+            if let flag = flags.first(where: { $0.key == Self.collectUsageDataKey }) {
+                collectUsageData = flag.enabled
+            }
+            // If the flag is not present in the registry response, default to true
+            // (matches the registry defaultEnabled: true).
+        } catch {
+            loadError = "Could not load privacy settings: \(error.localizedDescription)"
+        }
+        isLoading = false
+    }
+
+    private func setCollectUsageData(_ enabled: Bool) async {
+        guard let daemonClient else { return }
+        isUpdating = true
+        do {
+            try await daemonClient.setFeatureFlag(key: Self.collectUsageDataKey, enabled: enabled)
+        } catch {
+            // Revert the optimistic toggle on failure
+            collectUsageData = !enabled
+            loadError = "Could not save privacy setting: \(error.localizedDescription)"
+        }
+        isUpdating = false
+    }
+}
+
+#Preview("SettingsPrivacyTab") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        SettingsPrivacyTab(daemonClient: nil)
+            .frame(width: 480)
+            .padding()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -100,6 +100,8 @@ struct SettingsPrivacyTab: View {
         isUpdating = true
         do {
             try await daemonClient.setFeatureFlag(key: Self.collectUsageDataKey, enabled: enabled)
+            // Clear any previous error so stale failure messages don't persist after a successful save.
+            loadError = nil
         } catch {
             // Revert the optimistic toggle on failure
             collectUsageData = !enabled


### PR DESCRIPTION
## Summary

- Adds a new "Privacy" tab to macOS Settings sidebar (visible to all users, not dev-mode-only)
- The tab contains a "Collect usage data" toggle that maps to the `feature_flags.collect-usage-data.enabled` feature flag
- On appear, the tab loads the current flag value via `GET /v1/feature-flags` using `DaemonClient.getFeatureFlags()`
- Toggle changes are persisted via `DaemonClient.setFeatureFlag(key:enabled:)`
- Optimistic UI update with revert-on-failure pattern, matching existing flag toggle UI in SettingsAdvancedDevTab
- Defaults to `true` if the flag is absent from the API response (matches registry `defaultEnabled: true`)
- Follows macOS design system conventions: VColor, VFont, VSpacing, @MainActor, no @Previewable

Closes #10491

Original prompt: M2: Add Privacy settings opt-out toggle in macOS Settings (#10491)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
