### PR TITLE
fix: double notarization timeout from 30m to 60m

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,7 +340,7 @@ jobs:
   build-macos:
     needs: bump-and-tag
     runs-on: macos-14
-    timeout-minutes: 15
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: clients/macos
@@ -481,7 +481,7 @@ jobs:
             --password "${{ secrets.APPLE_APP_PASSWORD }}" \
             --team-id "${{ secrets.APPLE_TEAM_ID }}" \
             --wait \
-            --timeout 60m \
+            --timeout 30m \
             2>&1) || NOTARIZE_FAILED=true
 
           echo "$NOTARIZE_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -481,7 +481,7 @@ jobs:
             --password "${{ secrets.APPLE_APP_PASSWORD }}" \
             --team-id "${{ secrets.APPLE_TEAM_ID }}" \
             --wait \
-            --timeout 30m \
+            --timeout 60m \
             2>&1) || NOTARIZE_FAILED=true
 
           echo "$NOTARIZE_OUTPUT"


### PR DESCRIPTION
## Summary
- Doubles the `xcrun notarytool submit --timeout` from 30 minutes to 60 minutes to unblock releases that were timing out during Apple notarization

## Test plan
- [ ] Trigger a release and verify notarization completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
