### PR TITLE
fix: resolve type error in MCP client transport cleanup

### DIFF
--- a/assistant/src/mcp/client.ts
+++ b/assistant/src/mcp/client.ts
@@ -50,7 +50,7 @@ export class McpClient {
     } catch (err) {
       // Clean up the transport on failure (e.g., kill spawned stdio process)
       try { await this.client.close(); } catch { /* ignore cleanup errors */ }
-      this.transport = undefined;
+      this.transport = null;
       throw err;
     }
     this.connected = true;


### PR DESCRIPTION
## Summary
- Fix `TS2322` type error in `assistant/src/mcp/client.ts:53` that's breaking CI on main
- `this.transport` is typed as `... | null` but was being assigned `undefined` in the catch block of `connect()`
- Changed to `null` to match the declared type

## Test plan
- [x] `bunx tsc --noEmit` passes locally
- [ ] CI type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
