### PR TITLE
feat: tool call trace logs for playwright agent tests

### DIFF
--- a/playwright/agent/agent.ts
+++ b/playwright/agent/agent.ts
@@ -5,6 +5,9 @@
  * and runs the agent in a loop until a test result is reported.
  */
 
+import { appendFileSync, mkdirSync, writeFileSync } from "fs";
+import path from "path";
+
 import Anthropic from "@anthropic-ai/sdk";
 import type { Page } from "playwright";
 
@@ -53,6 +56,7 @@ export interface AgentOptions {
   testContent: string;
   page: Page;
   screenshotDir: string;
+  traceLogPath?: string;
   verbose?: boolean;
 }
 
@@ -69,8 +73,21 @@ export async function runAgent(options: AgentOptions): Promise<TestResult> {
   }
 }
 
+function traceLog(logPath: string | undefined, entry: string): void {
+  if (!logPath) return;
+  const ts = new Date().toISOString();
+  appendFileSync(logPath, `[${ts}] ${entry}\n`);
+}
+
 async function runAgentLoop(options: AgentOptions, signal: AbortSignal): Promise<TestResult> {
-  const { testContent, page, screenshotDir, verbose = false } = options;
+  const { testContent, page, screenshotDir, traceLogPath, verbose = false } = options;
+
+  // Initialize trace log
+  if (traceLogPath) {
+    mkdirSync(path.dirname(traceLogPath), { recursive: true });
+    writeFileSync(traceLogPath, "");
+    traceLog(traceLogPath, "Agent started");
+  }
 
   const client = new Anthropic();
   const messages: Anthropic.MessageParam[] = [
@@ -135,13 +152,12 @@ async function runAgentLoop(options: AgentOptions, signal: AbortSignal): Promise
     // Collect assistant content blocks
     const assistantContent = response.content;
 
-    if (verbose) {
-      for (const block of assistantContent) {
-        if (block.type === "text") {
-          console.log(`  [agent] text: ${block.text}`);
-        } else if (block.type === "tool_use") {
-          console.log(`  [agent] tool_use: ${block.name}(${JSON.stringify(block.input)})`);
-        }
+    for (const block of assistantContent) {
+      if (block.type === "text") {
+        traceLog(traceLogPath, `TEXT ${block.text}`);
+        if (verbose) console.log(`  [agent] text: ${block.text}`);
+      } else if (block.type === "tool_use") {
+        if (verbose) console.log(`  [agent] tool_use: ${block.name}(${JSON.stringify(block.input)})`);
       }
     }
 
@@ -170,12 +186,16 @@ async function runAgentLoop(options: AgentOptions, signal: AbortSignal): Promise
         };
       }
 
+      traceLog(traceLogPath, `CALL ${block.name}(${JSON.stringify(block.input)})`);
+
       const { result, testResult } = await executeTool(
         page,
         block.name,
         block.input as Record<string, unknown>,
         screenshotDir,
       );
+
+      traceLog(traceLogPath, `RESULT ${block.name}: ${result.success ? "ok" : "FAIL"} — ${result.data}`);
 
       if (verbose) {
         console.log(`  [agent] result: ${result.success ? "ok" : "FAIL"} - ${result.data}`);

--- a/playwright/agent/runner.ts
+++ b/playwright/agent/runner.ts
@@ -118,7 +118,7 @@ function generateHtmlReport(report: TestReport): string {
         <td>${t.passed ? "passed" : "failed"}</td>
         <td>${t.duration}</td>
         <td>${t.passed ? "" : escapeHtml(t.message)}</td>
-        <td><a href="${screenshotLink}">screenshots</a> · <a href="${videoLink}">video</a></td>
+        <td><a href="${screenshotLink}">screenshots</a> · <a href="${videoLink}">video</a> · <a href="agent-logs/${encodedName}.log">trace</a></td>
       </tr>`;
     })
     .join("\n");
@@ -213,6 +213,7 @@ async function runTestCase(
     page = await context.newPage();
 
     const screenshotDir = path.resolve(__dirname, "../test-results/agent-screenshots", testCase.name);
+    const traceLogPath = path.resolve(__dirname, "../test-results/agent-logs", `${testCase.name}.log`);
 
     // Start macOS screen recording (captures the actual desktop, not the browser tab)
     const videoDir = path.resolve(__dirname, "../test-results/agent-videos", testCase.name);
@@ -224,6 +225,7 @@ async function runTestCase(
       testContent,
       page,
       screenshotDir,
+      traceLogPath,
       verbose,
     });
 


### PR DESCRIPTION
## Summary
- Each agent test now writes a timestamped trace log to `test-results/agent-logs/<test-name>.log`
- Logs every tool call (name + input), tool result (ok/fail + output), and agent text blocks with ISO timestamps
- HTML report includes a "trace" link alongside screenshots and video for each test

Example log output:
```
[2026-02-27T20:00:01.123Z] Agent started
[2026-02-27T20:00:05.456Z] TEXT I'll start by launching the app...
[2026-02-27T20:00:05.789Z] CALL launch_app({})
[2026-02-27T20:00:08.012Z] RESULT launch_app: ok — App launched
[2026-02-27T20:00:08.345Z] CALL applescript({"script":"tell application..."})
[2026-02-27T20:00:09.678Z] RESULT applescript: FAIL — execution error: Invalid index
```

## Test plan
- [ ] Run playwright agent tests and verify `.log` files appear in `test-results/agent-logs/`
- [ ] Verify HTML report trace links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
