### PR TITLE
Align OAuth skill callback guidance to $GATEWAY_BASE_URL

### DIFF
--- a/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
@@ -104,7 +104,7 @@ Tell the user:
 > 2. Application type: Select **"Web application"** (not Desktop app)
 > 3. Name: **Vellum Assistant**
 > 4. Under **Authorized redirect URIs**, click **Add URI** and enter:
->    `$GATEWAY_BASE_URL/oauth/callback`
+>    `$GATEWAY_BASE_URL/webhooks/oauth/callback`
 > 5. Click **Create**
 >
 > A dialog will show your **Client ID** and **Client Secret**. Copy both values — you'll need them in the next step.
@@ -314,7 +314,7 @@ Otherwise, work through the consent screen wizard. The wizard has multiple pages
 
 ## Step 6: Create OAuth Credentials and Capture Both Client ID and Secret
 
-**Goal:** A "Web application" OAuth client exists, and both its Client ID and Client Secret are stored in the vault.
+**Goal:** A "Desktop app" OAuth client exists, and both its Client ID and Client Secret are stored in the vault.
 
 ### CRITICAL — Credential Capture Protocol
 
@@ -340,9 +340,9 @@ Navigate to `https://console.cloud.google.com/apis/credentials?project=PROJECT_I
 Find the option to create new credentials (typically a button labeled "Create Credentials" or similar), then select "OAuth client ID" from the menu.
 
 On the creation form:
-- Application type: **Web application**
+- Application type: **Desktop app**
 - Name: "Vellum Assistant"
-- Under **Authorized redirect URIs**, add `$GATEWAY_BASE_URL/oauth/callback`
+- Do NOT add any redirect URIs for the desktop app flow
 
 Submit the form.
 
@@ -393,7 +393,7 @@ action: "oauth2_connect"
 service: "integration:gmail"
 ```
 
-This auto-reads client_id and client_secret from the secure store and auto-fills auth_url, token_url, scopes, and extra_params from well-known config. The OAuth flow returns through `$GATEWAY_BASE_URL/oauth/callback`.
+This auto-reads client_id and client_secret from the secure store and auto-fills auth_url, token_url, scopes, and extra_params from well-known config.
 
 **If the user sees a "This app isn't verified" warning:** Tell them this is normal for apps in testing mode. Click "Advanced" then "Go to Vellum Assistant (unsafe)" to proceed.
 

--- a/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
@@ -104,14 +104,14 @@ Tell the user:
 > 2. Application type: Select **"Web application"** (not Desktop app)
 > 3. Name: **Vellum Assistant**
 > 4. Under **Authorized redirect URIs**, click **Add URI** and enter:
->    `GATEWAY_OAUTH_CALLBACK_URL`
+>    `$GATEWAY_BASE_URL/oauth/callback`
 > 5. Click **Create**
 >
 > A dialog will show your **Client ID** and **Client Secret**. Copy both values — you'll need them in the next step.
 
-(Substitute the actual gateway OAuth callback URL. This is obtained from `getOAuthCallbackUrl(loadConfig())` — the skill should compute and insert this URL.)
+(Use the injected `GATEWAY_BASE_URL` value to build the callback URL shown above.)
 
-**Important:** Channel users must use **"Web application"** credentials (not Desktop app) because the OAuth callback goes through the gateway's public URL, not localhost.
+**Important:** Channel users must use **"Web application"** credentials (not Desktop app) because the OAuth callback goes through the gateway's public URL.
 
 ### Channel Step 6: Store Credentials
 
@@ -314,7 +314,7 @@ Otherwise, work through the consent screen wizard. The wizard has multiple pages
 
 ## Step 6: Create OAuth Credentials and Capture Both Client ID and Secret
 
-**Goal:** A "Desktop app" OAuth client exists, and both its Client ID and Client Secret are stored in the vault.
+**Goal:** A "Web application" OAuth client exists, and both its Client ID and Client Secret are stored in the vault.
 
 ### CRITICAL — Credential Capture Protocol
 
@@ -340,9 +340,9 @@ Navigate to `https://console.cloud.google.com/apis/credentials?project=PROJECT_I
 Find the option to create new credentials (typically a button labeled "Create Credentials" or similar), then select "OAuth client ID" from the menu.
 
 On the creation form:
-- Application type: **Desktop app** (not Web application — Desktop app uses localhost redirects)
+- Application type: **Web application**
 - Name: "Vellum Assistant"
-- Do NOT add any redirect URIs
+- Under **Authorized redirect URIs**, add `$GATEWAY_BASE_URL/oauth/callback`
 
 Submit the form.
 
@@ -393,7 +393,7 @@ action: "oauth2_connect"
 service: "integration:gmail"
 ```
 
-This auto-reads client_id and client_secret from the secure store and auto-fills auth_url, token_url, scopes, and extra_params from well-known config. The OAuth flow uses a localhost callback — no public URL or tunnel is needed.
+This auto-reads client_id and client_secret from the secure store and auto-fills auth_url, token_url, scopes, and extra_params from well-known config. The OAuth flow returns through `$GATEWAY_BASE_URL/oauth/callback`.
 
 **If the user sees a "This app isn't verified" warning:** Tell them this is normal for apps in testing mode. Click "Advanced" then "Go to Vellum Assistant (unsafe)" to proceed.
 

--- a/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
@@ -94,17 +94,24 @@ Tell the user:
 
 ### Channel Step 5: Create OAuth Credentials (Web Application)
 
+Before sending Step 4 to the user, resolve the concrete callback URL:
+- Read the configured public gateway URL (`ingress.publicBaseUrl`). If it is missing, run the `public-ingress` skill first.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- When you send the instructions below, replace `OAUTH_CALLBACK_URL` with that concrete value. Never send placeholders literally.
+
 Tell the user:
 
 > **Step 4: Create OAuth credentials**
 >
 > Open: `https://console.cloud.google.com/apis/credentials?project=PROJECT_ID`
 >
+> Use this exact redirect URI:
+> `OAUTH_CALLBACK_URL`
+>
 > 1. Click **+ Create Credentials** → **OAuth client ID**
 > 2. Application type: Select **"Web application"** (not Desktop app)
 > 3. Name: **Vellum Assistant**
-> 4. Under **Authorized redirect URIs**, click **Add URI** and enter:
->    `$GATEWAY_BASE_URL/webhooks/oauth/callback`
+> 4. Under **Authorized redirect URIs**, click **Add URI** and paste the redirect URI shown above
 > 5. Click **Create**
 >
 > A dialog will show your **Client ID** and **Client Secret**. Copy both values — you'll need them in the next step.

--- a/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
@@ -109,9 +109,7 @@ Tell the user:
 >
 > A dialog will show your **Client ID** and **Client Secret**. Copy both values — you'll need them in the next step.
 
-(Use the injected `GATEWAY_BASE_URL` value to build the callback URL shown above.)
-
-**Important:** Channel users must use **"Web application"** credentials (not Desktop app) because the OAuth callback goes through the gateway's public URL.
+**Important:** Channel users must use **"Web application"** credentials (not Desktop app) because the OAuth callback goes through the gateway URL.
 
 ### Channel Step 6: Store Credentials
 

--- a/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
@@ -86,16 +86,16 @@ Tell the user: "Permissions configured! Now let's set up the redirect URL and ge
 
 Navigate to the "OAuth & Permissions" page if not already there.
 
-The redirect URL uses a localhost callback — no public URL or tunnel is needed.
+Use the gateway callback URL so OAuth returns through gateway ingress.
 
 In the "Redirect URLs" section:
 1. Click "Add New Redirect URL"
-2. Enter `http://127.0.0.1:17322/oauth/callback`
+2. Enter `$GATEWAY_BASE_URL/oauth/callback`
 3. Click "Add" then "Save URLs"
 
 Take a `browser_snapshot` to confirm.
 
-Tell the user: "Redirect URL configured. This uses a local callback so no tunnel or public URL is needed."
+Tell the user: "Redirect URL configured. This now routes back through your gateway callback URL."
 
 ## Step 5: Extract Client ID and Client Secret
 
@@ -137,7 +137,7 @@ Once connected, tell the user:
 Summarize what was accomplished:
 - Created a Slack App called "Vellum Assistant"
 - Configured User Token Scopes for reading, writing, and searching
-- Set up the OAuth redirect URL (localhost callback — no tunnel needed)
+- Set up the OAuth redirect URL (`$GATEWAY_BASE_URL/oauth/callback`)
 - Connected your Slack workspace
 
 ## Error Handling

--- a/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
@@ -86,16 +86,23 @@ Tell the user: "Permissions configured! Now let's set up the redirect URL and ge
 
 Navigate to the "OAuth & Permissions" page if not already there.
 
-Use the gateway callback URL so OAuth returns through gateway ingress.
+Before entering the redirect URL, resolve the exact value from the well-known OAuth config:
+
+```
+credential_store describe:
+  service: "integration:slack"
+```
+
+Read the `redirectUri` field from that response and use it exactly as shown.
 
 In the "Redirect URLs" section:
 1. Click "Add New Redirect URL"
-2. Enter `$GATEWAY_BASE_URL/oauth/callback`
+2. Enter the `redirectUri` value returned above
 3. Click "Add" then "Save URLs"
 
 Take a `browser_snapshot` to confirm.
 
-Tell the user: "Redirect URL configured. This now routes back through your gateway callback URL."
+Tell the user: "Redirect URL configured using the redirect URI from Vellum's Slack OAuth profile."
 
 ## Step 5: Extract Client ID and Client Secret
 
@@ -137,7 +144,7 @@ Once connected, tell the user:
 Summarize what was accomplished:
 - Created a Slack App called "Vellum Assistant"
 - Configured User Token Scopes for reading, writing, and searching
-- Set up the OAuth redirect URL (`$GATEWAY_BASE_URL/oauth/callback`)
+- Set up the OAuth redirect URL from the Slack OAuth profile
 - Connected your Slack workspace
 
 ## Error Handling

--- a/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
@@ -96,9 +96,10 @@ credential_store describe:
 Read the `redirectUri` field from that response and use it exactly as shown.
 
 In the "Redirect URLs" section:
-1. Click "Add New Redirect URL"
-2. Enter the `redirectUri` value returned above
-3. Click "Add" then "Save URLs"
+1. If `redirectUri` says "automatic", skip adding a redirect URL for this provider.
+2. If `redirectUri` mentions "not currently configured" / `GATEWAY_BASE_URL` / `INGRESS_PUBLIC_BASE_URL`, stop and ask the user to configure public ingress first.
+3. Otherwise, click "Add New Redirect URL" and enter the `redirectUri` value exactly as returned.
+4. Click "Add" then "Save URLs"
 
 Take a `browser_snapshot` to confirm.
 

--- a/skills/google-oauth-setup/SKILL.md
+++ b/skills/google-oauth-setup/SKILL.md
@@ -124,7 +124,7 @@ Tell the user: "Consent screen is configured! Almost there — just need to crea
 
 > **Create OAuth Credentials**
 >
-> I'm about to create OAuth Web Application credentials for Vellum Assistant. This generates a client ID and secret that Vellum uses to initiate the authorization flow. We'll register the gateway callback URL so OAuth always returns through your configured gateway.
+> I'm about to create OAuth Desktop Application credentials for Vellum Assistant. This generates a client ID and secret that Vellum uses to initiate the authorization flow.
 
 Wait for the user to approve. If they decline, explain that credentials are the final step needed and offer to try again or cancel.
 
@@ -133,10 +133,10 @@ Once approved, navigate to `https://console.cloud.google.com/apis/credentials?pr
 Use `browser_click` on "+ Create Credentials" at the top, then select "OAuth client ID" from the dropdown.
 
 Take a `browser_snapshot` and fill in:
-1. **Application type:** Select **"Web application"** from the dropdown
+1. **Application type:** Select **"Desktop app"** from the dropdown
 2. **Name:** "Vellum Assistant"
-3. Under **Authorized redirect URIs**, add:
-   - `$GATEWAY_BASE_URL/oauth/callback`
+
+**Do NOT add any redirect URIs** for the desktop app flow.
 
 Use `browser_click` on the "Create" button.
 
@@ -177,7 +177,7 @@ action: "oauth2_connect"
 service: "integration:gmail"
 ```
 
-This auto-reads client_id/client_secret from the secure store and auto-fills endpoints, scopes, and params from well-known config. The OAuth flow returns through `$GATEWAY_BASE_URL/oauth/callback`.
+This auto-reads client_id/client_secret from the secure store and auto-fills endpoints, scopes, and params from well-known config.
 
 Wait for the flow to complete.
 
@@ -193,7 +193,7 @@ Summarize what was accomplished:
 - Created a Google Cloud project (or used an existing one)
 - Enabled the Gmail API and Google Calendar API
 - Configured the OAuth consent screen with appropriate scopes (including calendar)
-- Created OAuth Web Application credentials with gateway callback URL
+- Created OAuth Desktop Application credentials
 - Connected your Gmail and Google Calendar accounts
 
 ## Error Handling

--- a/skills/google-oauth-setup/SKILL.md
+++ b/skills/google-oauth-setup/SKILL.md
@@ -124,7 +124,7 @@ Tell the user: "Consent screen is configured! Almost there — just need to crea
 
 > **Create OAuth Credentials**
 >
-> I'm about to create OAuth Desktop Application credentials for Vellum Assistant. This generates a client ID that Vellum uses to initiate the authorization flow. No redirect URIs are needed — desktop apps use a secure localhost callback automatically.
+> I'm about to create OAuth Web Application credentials for Vellum Assistant. This generates a client ID and secret that Vellum uses to initiate the authorization flow. We'll register the gateway callback URL so OAuth always returns through your configured gateway.
 
 Wait for the user to approve. If they decline, explain that credentials are the final step needed and offer to try again or cancel.
 
@@ -133,10 +133,10 @@ Once approved, navigate to `https://console.cloud.google.com/apis/credentials?pr
 Use `browser_click` on "+ Create Credentials" at the top, then select "OAuth client ID" from the dropdown.
 
 Take a `browser_snapshot` and fill in:
-1. **Application type:** Select **"Desktop app"** from the dropdown
+1. **Application type:** Select **"Web application"** from the dropdown
 2. **Name:** "Vellum Assistant"
-
-**Do NOT add any redirect URIs** — Desktop app credentials handle localhost redirects automatically.
+3. Under **Authorized redirect URIs**, add:
+   - `$GATEWAY_BASE_URL/oauth/callback`
 
 Use `browser_click` on the "Create" button.
 
@@ -177,7 +177,7 @@ action: "oauth2_connect"
 service: "integration:gmail"
 ```
 
-This auto-reads client_id/client_secret from the secure store and auto-fills endpoints, scopes, and params from well-known config. The OAuth flow uses a localhost callback — no public URL or tunnel is needed.
+This auto-reads client_id/client_secret from the secure store and auto-fills endpoints, scopes, and params from well-known config. The OAuth flow returns through `$GATEWAY_BASE_URL/oauth/callback`.
 
 Wait for the flow to complete.
 
@@ -193,7 +193,7 @@ Summarize what was accomplished:
 - Created a Google Cloud project (or used an existing one)
 - Enabled the Gmail API and Google Calendar API
 - Configured the OAuth consent screen with appropriate scopes (including calendar)
-- Created OAuth Desktop Application credentials
+- Created OAuth Web Application credentials with gateway callback URL
 - Connected your Gmail and Google Calendar accounts
 
 ## Error Handling

--- a/skills/oauth-setup/SKILL.md
+++ b/skills/oauth-setup/SKILL.md
@@ -97,8 +97,8 @@ Take a `browser_screenshot` after adding all scopes.
 ### Step 7: Set redirect URL
 
 Check the `redirectUri` from the config:
-- If it starts with `http://127.0.0.1:` — tell the user "This uses a local callback, no public URL needed" and enter the URL in the redirect URL field.
-- If it mentions "not currently configured" or "INGRESS_PUBLIC_BASE_URL" — the user needs a public URL configured. Check if one is set; if not, load the `public-ingress` skill first.
+- If it mentions "not currently configured", `GATEWAY_BASE_URL`, or `INGRESS_PUBLIC_BASE_URL` — the user needs a public gateway URL configured. Check if one is set; if not, load the `public-ingress` skill first.
+- Otherwise, enter the `redirectUri` exactly as provided.
 - If it says "automatic" — skip this step entirely (no redirect URI needed).
 
 Take a `browser_snapshot` to confirm.

--- a/skills/oauth-setup/SKILL.md
+++ b/skills/oauth-setup/SKILL.md
@@ -98,8 +98,8 @@ Take a `browser_screenshot` after adding all scopes.
 
 Check the `redirectUri` from the config:
 - If it mentions "not currently configured", `GATEWAY_BASE_URL`, or `INGRESS_PUBLIC_BASE_URL` — the user needs a public gateway URL configured. Check if one is set; if not, load the `public-ingress` skill first.
-- Otherwise, enter the `redirectUri` exactly as provided.
 - If it says "automatic" — skip this step entirely (no redirect URI needed).
+- Otherwise, enter the `redirectUri` exactly as provided.
 
 Take a `browser_snapshot` to confirm.
 

--- a/skills/slack-oauth-setup/SKILL.md
+++ b/skills/slack-oauth-setup/SKILL.md
@@ -86,16 +86,16 @@ Tell the user: "Permissions configured! Now let's set up the redirect URL and ge
 
 Navigate to the "OAuth & Permissions" page if not already there.
 
-The redirect URL uses a localhost callback — no public URL or tunnel is needed.
+Use the gateway callback URL so OAuth returns through gateway ingress.
 
 In the "Redirect URLs" section:
 1. Click "Add New Redirect URL"
-2. Enter `http://127.0.0.1:17322/oauth/callback`
+2. Enter `$GATEWAY_BASE_URL/oauth/callback`
 3. Click "Add" then "Save URLs"
 
 Take a `browser_snapshot` to confirm.
 
-Tell the user: "Redirect URL configured. This uses a local callback so no tunnel or public URL is needed."
+Tell the user: "Redirect URL configured. This now routes back through your gateway callback URL."
 
 ## Step 5: Extract Client ID and Client Secret
 
@@ -137,7 +137,7 @@ Once connected, tell the user:
 Summarize what was accomplished:
 - Created a Slack App called "Vellum Assistant"
 - Configured User Token Scopes for reading, writing, and searching
-- Set up the OAuth redirect URL (localhost callback — no tunnel needed)
+- Set up the OAuth redirect URL (`$GATEWAY_BASE_URL/oauth/callback`)
 - Connected your Slack workspace
 
 ## Error Handling

--- a/skills/slack-oauth-setup/SKILL.md
+++ b/skills/slack-oauth-setup/SKILL.md
@@ -86,16 +86,23 @@ Tell the user: "Permissions configured! Now let's set up the redirect URL and ge
 
 Navigate to the "OAuth & Permissions" page if not already there.
 
-Use the gateway callback URL so OAuth returns through gateway ingress.
+Before entering the redirect URL, resolve the exact value from the well-known OAuth config:
+
+```
+credential_store describe:
+  service: "integration:slack"
+```
+
+Read the `redirectUri` field from that response and use it exactly as shown.
 
 In the "Redirect URLs" section:
 1. Click "Add New Redirect URL"
-2. Enter `$GATEWAY_BASE_URL/oauth/callback`
+2. Enter the `redirectUri` value returned above
 3. Click "Add" then "Save URLs"
 
 Take a `browser_snapshot` to confirm.
 
-Tell the user: "Redirect URL configured. This now routes back through your gateway callback URL."
+Tell the user: "Redirect URL configured using the redirect URI from Vellum's Slack OAuth profile."
 
 ## Step 5: Extract Client ID and Client Secret
 
@@ -137,7 +144,7 @@ Once connected, tell the user:
 Summarize what was accomplished:
 - Created a Slack App called "Vellum Assistant"
 - Configured User Token Scopes for reading, writing, and searching
-- Set up the OAuth redirect URL (`$GATEWAY_BASE_URL/oauth/callback`)
+- Set up the OAuth redirect URL from the Slack OAuth profile
 - Connected your Slack workspace
 
 ## Error Handling

--- a/skills/slack-oauth-setup/SKILL.md
+++ b/skills/slack-oauth-setup/SKILL.md
@@ -96,9 +96,10 @@ credential_store describe:
 Read the `redirectUri` field from that response and use it exactly as shown.
 
 In the "Redirect URLs" section:
-1. Click "Add New Redirect URL"
-2. Enter the `redirectUri` value returned above
-3. Click "Add" then "Save URLs"
+1. If `redirectUri` says "automatic", skip adding a redirect URL for this provider.
+2. If `redirectUri` mentions "not currently configured" / `GATEWAY_BASE_URL` / `INGRESS_PUBLIC_BASE_URL`, stop and ask the user to configure public ingress first.
+3. Otherwise, click "Add New Redirect URL" and enter the `redirectUri` value exactly as returned.
+4. Click "Add" then "Save URLs"
 
 Take a `browser_snapshot` to confirm.
 


### PR DESCRIPTION
## Summary
- replace hardcoded localhost OAuth callback guidance in Slack and Google SKILL docs with `$GATEWAY_BASE_URL/oauth/callback`
- update generic OAuth setup guidance to avoid localhost-specific branching and rely on configured `redirectUri` / public gateway checks
- keep public-ingress ngrok dashboard line untouched per request (`assistant/src/config/bundled-skills/public-ingress/SKILL.md:173`)

## Validation
- `rg -n "localhost|127\.0\.0\.1" --glob '**/SKILL.md' | rg -v "http://127.0.0.1:4040/api/tunnels" | rg -v "^assistant/src/config/bundled-skills/public-ingress/SKILL.md:173:"` returns no matches

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
