### PR TITLE
fix: add missing host id to QR pairing payload

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -1,6 +1,6 @@
-import { randomBytes, randomUUID } from "crypto";
+import { createHash, randomBytes, randomUUID } from "crypto";
 import { appendFileSync, existsSync, lstatSync, mkdirSync, readFileSync, readlinkSync, symlinkSync, unlinkSync } from "fs";
-import { homedir, userInfo } from "os";
+import { homedir, hostname, userInfo } from "os";
 import { join } from "path";
 
 import qrcode from "qrcode-terminal";
@@ -499,9 +499,11 @@ async function displayPairingQRCode(runtimeUrl: string, bearerToken: string | un
       return;
     }
 
+    const hostId = createHash("sha256").update(hostname() + userInfo().username).digest("hex");
     const payload = JSON.stringify({
       type: "vellum-daemon",
       v: 4,
+      id: hostId,
       g: runtimeUrl,
       pairingRequestId,
       pairingSecret,

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -1,5 +1,6 @@
 import { spawn } from "child_process";
-import { randomBytes, randomUUID } from "crypto";
+import { createHash, randomBytes, randomUUID } from "crypto";
+import { hostname, userInfo } from "os";
 import { basename } from "path";
 import qrcode from "qrcode-terminal";
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from "react";
@@ -1322,9 +1323,11 @@ function ChatApp({
             throw new Error(`HTTP ${registerRes.status}: ${body || registerRes.statusText}`);
           }
 
+          const hostId = createHash("sha256").update(hostname() + userInfo().username).digest("hex");
           const payload = JSON.stringify({
             type: "vellum-daemon",
             v: 4,
+            id: hostId,
             g: gatewayUrl,
             pairingRequestId,
             pairingSecret,


### PR DESCRIPTION
## Summary
- The iOS app requires an `id` field in the v4 QR payload (`QRPairingSheet.swift` has a `guard let` on `json["id"]`). Without it, scanning always fails with "QR code is missing required fields"
- Added `id: SHA-256(hostname + username)` to the QR payload in both:
  - `cli/src/commands/hatch.ts` — the `displayPairingQRCode` function (added in #10518)
  - `cli/src/components/DefaultMainScreen.tsx` — the `/pair` slash command (pre-existing bug)
- Matches the same pattern used in `cli/src/commands/pair.ts:37-39` (`getDeviceId()`)

## Test plan
- [ ] Run `vellum hatch` and scan the QR code with the iOS app — should pair successfully
- [ ] Run `/pair` in `vellum client` and scan — should also work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
