### PR TITLE
feat: add `vellum mcp remove` CLI command

### DIFF
--- a/assistant/src/cli/mcp.ts
+++ b/assistant/src/cli/mcp.ts
@@ -132,4 +132,24 @@ export function registerMcpCommand(program: Command): void {
       log.info(`Added MCP server "${name}" (${opts.transportType})`);
       log.info('Restart the daemon for changes to take effect: vellum daemon restart');
     });
+
+  mcp
+    .command('remove <name>')
+    .description('Remove an MCP server configuration')
+    .action((name: string) => {
+      const raw = loadRawConfig();
+      const mcpConfig = raw.mcp as Record<string, unknown> | undefined;
+      const servers = mcpConfig?.servers as Record<string, unknown> | undefined;
+
+      if (!servers || !servers[name]) {
+        log.error(`MCP server "${name}" not found.`);
+        process.exitCode = 1;
+        return;
+      }
+
+      delete servers[name];
+      saveRawConfig(raw);
+      log.info(`Removed MCP server "${name}".`);
+      log.info('Restart the daemon for changes to take effect: vellum daemon restart');
+    });
 }


### PR DESCRIPTION
## Summary
- Add `vellum mcp remove <name>` command to delete an MCP server from config
- Errors with exit code 1 if the server doesn't exist
- Reminds user to restart the daemon after removal

## Test plan
- [x] Tested manually: remove nonexistent server shows error
- [x] Tested manually: add → list → remove → list flow works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
