### PR TITLE
feat: wait for CI checks to pass before merging PRs

### DIFF
--- a/.claude/commands/blitz.md
+++ b/.claude/commands/blitz.md
@@ -117,7 +117,7 @@ Read AGENTS.md in the repo root for project conventions and structure.
 ## Repo-specific gotchas
 - `gh pr view` does NOT support a `merged` --json field. Use `state` and `mergedAt`: `gh pr view <N> --json state,mergedAt,title,url`
 - This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
-- Do NOT wait for CI checks to pass before merging. Merge immediately.
+- Wait for CI checks to pass before merging. Use `.claude/wait-ci <PR_NUMBER>` before `gh pr merge`. The `.claude/ship --merge` flag does this automatically.
 - `tail` and `head` may not be available in the shell. Don't pipe to them.
 
 ## Your worktree
@@ -235,9 +235,12 @@ Wait for fresh reviews: Poll for **new** reviews posted after `last_fix_push_tim
   - If aggregate status is `pending`, continue polling.
 - If **5 minutes** pass with no new reviews, ensure the PR is tracked in `.private/UNREVIEWED_PRS.md` (add it if not already present), then proceed to Step 6. Log: `"No new reviews within 5 minutes after fixes pushed. Proceeding to merge (PR tracked in UNREVIEWED_PRS.md)."`
 
-#### Step 6: Merge to main
+#### Step 6: Wait for CI and merge to main
+
+Wait for CI checks to pass before merging:
 
 ```bash
+.claude/wait-ci <pr-number>
 gh pr merge <pr-number> --squash
 ```
 

--- a/.claude/commands/do.md
+++ b/.claude/commands/do.md
@@ -7,7 +7,7 @@ If `$ARGUMENTS` is empty, stop and tell the user to provide a description of wha
 ## Repo-specific gotchas
 
 - **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
-- **CI**: Do NOT wait for CI checks to pass before merging. Merge immediately.
+- **CI**: Wait for CI checks to pass before merging. `.claude/ship --merge` does this automatically via `.claude/wait-ci`.
 
 ## Steps
 

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -106,7 +106,7 @@ Read AGENTS.md in the repo root for project conventions and structure.
 ## Repo-specific gotchas
 - `gh pr view` does NOT support a `merged` --json field. Use `state` and `mergedAt`: `gh pr view <N> --json state,mergedAt,title,url`
 - This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
-- Do NOT wait for CI checks to pass before merging. Merge immediately.
+- Wait for CI checks to pass before merging. Use `.claude/wait-ci <PR_NUMBER>` before `gh pr merge`. The `.claude/ship --merge` flag does this automatically.
 - `tail` and `head` may not be available in the shell. Don't pipe to them.
 
 ## Your worktree
@@ -152,7 +152,7 @@ Read AGENTS.md in the repo root for project conventions and structure.
 ## Repo-specific gotchas
 - `gh pr view` does NOT support a `merged` --json field. Use `state` and `mergedAt`: `gh pr view <N> --json state,mergedAt,title,url`
 - This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
-- Do NOT wait for CI checks to pass before merging. Merge immediately.
+- Wait for CI checks to pass before merging. Use `.claude/wait-ci <PR_NUMBER>` before `gh pr merge`. The `.claude/ship --merge` flag does this automatically.
 - `tail` and `head` may not be available in the shell. Don't pipe to them.
 
 ## Your worktree
@@ -453,10 +453,11 @@ After the feature branch has been updated with main, the milestone branch may no
    git fetch origin <milestone-pr-branch>
    ```
 
-**Step 4: Merge the milestone PR into the feature branch.**
+**Step 4: Wait for CI and merge the milestone PR into the feature branch.**
 
-1. Merge the milestone PR:
+1. Wait for CI checks to pass, then merge the milestone PR:
    ```bash
+   .claude/wait-ci <milestone-pr-number>
    gh pr merge <milestone-pr-number> --squash
    ```
 2. Fetch the updated feature branch:
@@ -645,7 +646,7 @@ Read AGENTS.md in the repo root for project conventions and structure.
 ## Repo-specific gotchas
 - `gh pr view` does NOT support a `merged` --json field. Use `state` and `mergedAt`: `gh pr view <N> --json state,mergedAt,title,url`
 - This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
-- Do NOT wait for CI checks to pass before merging. Merge immediately.
+- Wait for CI checks to pass before merging. Use `.claude/wait-ci <PR_NUMBER>` before `gh pr merge`. The `.claude/ship --merge` flag does this automatically.
 - `tail` and `head` may not be available in the shell. Don't pipe to them.
 
 ## Your worktree
@@ -742,8 +743,9 @@ gh project view "$GH_PROJECT_NUMBER" --owner "$GH_PROJECT_OWNER" --format json |
 
    Pause and ask: **"All milestones complete, Codex review approved, and CI is stable. Ready to merge the final PR into main?"**
 
-   - If the user confirms, merge the final PR:
+   - If the user confirms, wait for CI and merge the final PR:
      ```bash
+     .claude/wait-ci <final-pr-number>
      gh pr merge <final-pr-number> --squash
      ```
      Then update the project issue status to "Done" and close it:

--- a/.claude/commands/safe-do.md
+++ b/.claude/commands/safe-do.md
@@ -7,7 +7,7 @@ If `$ARGUMENTS` is empty, stop and tell the user to provide a description of wha
 ## Repo-specific gotchas
 
 - **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
-- **CI**: Do NOT wait for CI checks to pass before merging. Merge immediately.
+- **CI**: Wait for CI checks to pass before merging. Use `.claude/wait-ci <PR_NUMBER>` before `gh pr merge`.
 
 ## Steps
 
@@ -290,7 +290,7 @@ Read AGENTS.md in the repo root for project conventions and structure.
 ## Repo-specific gotchas
 - `gh pr view` does NOT support a `merged` --json field. Use `state` and `mergedAt`: `gh pr view <N> --json state,mergedAt,title,url`
 - This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
-- Do NOT wait for CI checks to pass before merging. Merge immediately.
+- Wait for CI checks to pass before merging. Use `.claude/wait-ci <PR_NUMBER>` before `gh pr merge`.
 - `tail` and `head` may not be available in the shell. Don't pipe to them.
 
 ## Your worktree

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -14,7 +14,7 @@ If no arguments are provided, default to 12 workers with no task limit (run unti
 
 - **gh pr view fields**: `merged` is NOT a valid --json field. Use `state` and `mergedAt` instead: `gh pr view <N> --json state,mergedAt,title,url`
 - **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
-- **CI**: Do NOT wait for CI checks to pass before merging. Merge immediately.
+- **CI**: Wait for CI checks to pass before merging. Use `.claude/wait-ci <PR_NUMBER>` before `gh pr merge`. The `.claude/ship --merge` flag does this automatically.
 - **No piping to tail/head**: `tail` and `head` may not be available in the shell. Avoid `cmd | tail -N`. Instead, run the command directly and let output truncate naturally, or use the Read tool on output files.
 
 ## Phase 1: Setup
@@ -55,7 +55,7 @@ Read AGENTS.md in the repo root for project conventions and structure.
 ## Repo-specific gotchas
 - `gh pr view` does NOT support a `merged` --json field. Use `state` and `mergedAt`: `gh pr view <N> --json state,mergedAt,title,url`
 - This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
-- Do NOT wait for CI checks to pass before merging. Merge immediately.
+- Wait for CI checks to pass before merging. Use `.claude/wait-ci <PR_NUMBER>` before `gh pr merge`. The `.claude/ship --merge` flag does this automatically.
 - `tail` and `head` may not be available in the shell. Don't pipe to them.
 
 ## Your worktree

--- a/.claude/phases/repo-gotchas.md
+++ b/.claude/phases/repo-gotchas.md
@@ -2,5 +2,5 @@
 
 - **gh pr view fields**: `merged` is NOT a valid --json field. Use `state` and `mergedAt` instead: `gh pr view <N> --json state,mergedAt,title,url`
 - **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
-- **CI**: Do NOT wait for CI checks to pass before merging. Merge immediately.
+- **CI**: Wait for CI checks to pass before merging. Use `.claude/wait-ci <PR_NUMBER>` before `gh pr merge`. The `.claude/ship --merge` flag does this automatically.
 - **No piping to tail/head**: `tail` and `head` may not be available in the shell. Don't pipe to them.

--- a/.claude/ship
+++ b/.claude/ship
@@ -121,6 +121,10 @@ fi
 
 # Merge
 if $MERGE; then
+  # Wait for CI checks to pass before merging
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  "$SCRIPT_DIR/wait-ci" "$PR_NUMBER"
+
   echo "==> Merging PR #$PR_NUMBER (squash)..."
   gh pr merge "$PR_NUMBER" --squash
   echo "Merged."

--- a/.claude/wait-ci
+++ b/.claude/wait-ci
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# .claude/wait-ci — Wait for CI checks on a PR to complete
+# Polls every 30 seconds. Exits 0 if all pass, 1 if any fail, 2 on timeout.
+#
+# Usage: .claude/wait-ci <PR_NUMBER> [MAX_WAIT_SECONDS]
+#   PR_NUMBER          The PR number to check
+#   MAX_WAIT_SECONDS   Timeout in seconds (default: 600 = 10 minutes)
+
+usage() {
+  cat <<'EOF'
+Usage: .claude/wait-ci <PR_NUMBER> [MAX_WAIT_SECONDS]
+
+Waits for all CI checks on a PR to complete.
+  - Exits 0 if all checks pass (or no checks are configured).
+  - Exits 1 if any check fails.
+  - Exits 2 if timeout is reached with checks still pending.
+
+Arguments:
+  PR_NUMBER          The PR number to check (required)
+  MAX_WAIT_SECONDS   Timeout in seconds (default: 600)
+EOF
+}
+
+if [[ $# -lt 1 ]] || [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+PR_NUMBER="$1"
+MAX_WAIT="${2:-600}"
+POLL_INTERVAL=30
+ELAPSED=0
+
+echo "==> Waiting for CI checks on PR #$PR_NUMBER (timeout: ${MAX_WAIT}s)..."
+
+while true; do
+  CHECKS=$(gh pr checks "$PR_NUMBER" --json name,state,conclusion 2>/dev/null || echo "[]")
+  TOTAL=$(echo "$CHECKS" | jq 'length')
+
+  if [[ "$TOTAL" -eq 0 ]]; then
+    echo "No CI checks configured on PR #$PR_NUMBER. Proceeding."
+    exit 0
+  fi
+
+  PENDING=$(echo "$CHECKS" | jq '[.[] | select(.state != "COMPLETED")] | length')
+  FAILED=$(echo "$CHECKS" | jq '[.[] | select(.state == "COMPLETED" and .conclusion == "FAILURE")] | length')
+
+  if [[ "$FAILED" -gt 0 ]]; then
+    echo "CI checks failed on PR #$PR_NUMBER:" >&2
+    echo "$CHECKS" | jq -r '.[] | select(.conclusion == "FAILURE") | "  \(.name): FAILURE"' >&2
+    exit 1
+  fi
+
+  if [[ "$PENDING" -eq 0 ]]; then
+    echo "All $TOTAL CI checks passed on PR #$PR_NUMBER."
+    exit 0
+  fi
+
+  if [[ "$ELAPSED" -ge "$MAX_WAIT" ]]; then
+    echo "Timeout: CI checks still pending after ${MAX_WAIT}s on PR #$PR_NUMBER." >&2
+    echo "$CHECKS" | jq -r '.[] | select(.state != "COMPLETED") | "  \(.name): \(.state)"' >&2
+    exit 2
+  fi
+
+  echo "CI: $((TOTAL - PENDING))/$TOTAL complete (${ELAPSED}s/${MAX_WAIT}s)..."
+  sleep "$POLL_INTERVAL"
+  ELAPSED=$((ELAPSED + POLL_INTERVAL))
+done

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ dist
 !.claude/gh-project
 !.claude/gh-review
 !.claude/check-pr-reviews
+!.claude/wait-ci
 .private/
 temp.sh
 context.md


### PR DESCRIPTION
## Summary
- Add `.claude/wait-ci` helper script that polls CI checks every 30s (10min timeout), exits 0 on all pass, 1 on any failure
- Integrate into `.claude/ship --merge` so all ship-based merges automatically wait for CI
- Update `/do`, `/safe-do`, `/blitz`, `/safe-blitz`, `/swarm` commands and `repo-gotchas.md` — replace all 'Do NOT wait for CI' instructions with 'Wait for CI' and add `.claude/wait-ci` calls before direct `gh pr merge` invocations

## Original prompt
Help me update these slash commands to wait for CI to either pass or fail with no failures relating to the branch/PR before merging the PR:
/do
/safe-do
/blitz
/safe-blitz

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
