### PR TITLE
fix: handle empty body in handleBlockMember ingress route

### DIFF
--- a/assistant/src/runtime/routes/ingress-routes.ts
+++ b/assistant/src/runtime/routes/ingress-routes.ts
@@ -93,8 +93,13 @@ export async function handleRevokeMember(req: Request, memberId: string): Promis
  * POST /v1/ingress/members/:id/block
  */
 export async function handleBlockMember(req: Request, memberId: string): Promise<Response> {
-  const body = (await req.json()) as Record<string, unknown>;
-  const reason = body.reason as string | undefined;
+  let reason: string | undefined;
+  try {
+    const body = (await req.json()) as Record<string, unknown>;
+    reason = body.reason as string | undefined;
+  } catch {
+    // Body is optional — callers may omit it entirely
+  }
 
   const result = blockIngressMember(memberId, reason);
 

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -955,7 +955,7 @@ export function buildSchema(): Record<string, unknown> {
             },
           ],
           requestBody: {
-            required: true,
+            required: false,
             content: {
               "application/json": {
                 schema: { type: "object", additionalProperties: true },


### PR DESCRIPTION
## Summary
- Address Codex P2 feedback from PR #10455
- Make handleBlockMember gracefully handle missing/empty request body with try/catch (matching the existing pattern in handleRevokeMember)
- Mark the request body as optional (required: false) in the OpenAPI schema to match the runtime behavior

Addresses feedback from #10455
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
