### PR TITLE
fix: use correct gh pr checks fields and add error handling in wait-ci

### DIFF
--- a/.claude/wait-ci
+++ b/.claude/wait-ci
@@ -32,24 +32,63 @@ PR_NUMBER="$1"
 MAX_WAIT="${2:-600}"
 POLL_INTERVAL=30
 ELAPSED=0
+# Track whether we've seen at least one poll with no checks, so we can
+# give GitHub a grace period to register CI checks after PR creation.
+SEEN_EMPTY=false
 
 echo "==> Waiting for CI checks on PR #$PR_NUMBER (timeout: ${MAX_WAIT}s)..."
 
 while true; do
-  CHECKS=$(gh pr checks "$PR_NUMBER" --json name,state,conclusion 2>/dev/null || echo "[]")
+  # Fetch checks using the 'bucket' field (valid in gh 2.72+).
+  # Capture the exit code separately so API/auth/network errors are not masked.
+  CHECKS_OUTPUT=""
+  CHECKS_RC=0
+  CHECKS_OUTPUT=$(gh pr checks "$PR_NUMBER" --json name,bucket 2>&1) || CHECKS_RC=$?
+
+  if [[ "$CHECKS_RC" -ne 0 ]]; then
+    echo "Warning: gh pr checks failed (exit $CHECKS_RC): $CHECKS_OUTPUT" >&2
+    # Treat transient errors as "pending" — keep polling rather than
+    # silently passing or failing.
+    if [[ "$ELAPSED" -ge "$MAX_WAIT" ]]; then
+      echo "Timeout: could not retrieve CI checks after ${MAX_WAIT}s on PR #$PR_NUMBER." >&2
+      exit 2
+    fi
+    echo "CI: retrying in ${POLL_INTERVAL}s (${ELAPSED}s/${MAX_WAIT}s)..."
+    sleep "$POLL_INTERVAL"
+    ELAPSED=$((ELAPSED + POLL_INTERVAL))
+    continue
+  fi
+
+  CHECKS="$CHECKS_OUTPUT"
   TOTAL=$(echo "$CHECKS" | jq 'length')
 
   if [[ "$TOTAL" -eq 0 ]]; then
-    echo "No CI checks configured on PR #$PR_NUMBER. Proceeding."
-    exit 0
+    if $SEEN_EMPTY; then
+      # Second consecutive poll with no checks — no CI is configured.
+      echo "No CI checks configured on PR #$PR_NUMBER. Proceeding."
+      exit 0
+    fi
+    # First time seeing zero checks — GitHub may not have registered them yet.
+    SEEN_EMPTY=true
+    if [[ "$ELAPSED" -ge "$MAX_WAIT" ]]; then
+      echo "No CI checks configured on PR #$PR_NUMBER. Proceeding."
+      exit 0
+    fi
+    echo "CI: no checks found yet, waiting for registration (${ELAPSED}s/${MAX_WAIT}s)..."
+    sleep "$POLL_INTERVAL"
+    ELAPSED=$((ELAPSED + POLL_INTERVAL))
+    continue
   fi
 
-  PENDING=$(echo "$CHECKS" | jq '[.[] | select(.state != "COMPLETED")] | length')
-  FAILED=$(echo "$CHECKS" | jq '[.[] | select(.state == "COMPLETED" and .conclusion == "FAILURE")] | length')
+  # Reset the empty-check tracker once we see real checks.
+  SEEN_EMPTY=false
+
+  PENDING=$(echo "$CHECKS" | jq '[.[] | select(.bucket == "pending")] | length')
+  FAILED=$(echo "$CHECKS" | jq '[.[] | select(.bucket == "fail" or .bucket == "cancel")] | length')
 
   if [[ "$FAILED" -gt 0 ]]; then
     echo "CI checks failed on PR #$PR_NUMBER:" >&2
-    echo "$CHECKS" | jq -r '.[] | select(.conclusion == "FAILURE") | "  \(.name): FAILURE"' >&2
+    echo "$CHECKS" | jq -r '.[] | select(.bucket == "fail" or .bucket == "cancel") | "  \(.name): \(.bucket)"' >&2
     exit 1
   fi
 
@@ -60,7 +99,7 @@ while true; do
 
   if [[ "$ELAPSED" -ge "$MAX_WAIT" ]]; then
     echo "Timeout: CI checks still pending after ${MAX_WAIT}s on PR #$PR_NUMBER." >&2
-    echo "$CHECKS" | jq -r '.[] | select(.state != "COMPLETED") | "  \(.name): \(.state)"' >&2
+    echo "$CHECKS" | jq -r '.[] | select(.bucket == "pending") | "  \(.name): pending"' >&2
     exit 2
   fi
 


### PR DESCRIPTION
## Summary
- Fix critical bug: replace invalid `conclusion` field with `bucket` field in `gh pr checks --json`
- Add proper error handling to distinguish API errors from 'no checks configured'
- Add grace period to avoid race condition with CI check registration after PR creation

Addresses feedback from #10526
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
