### PR TITLE
fix: balance NSCursor push/pop in VInlineActionField hover handler

### DIFF
--- a/clients/shared/DesignSystem/Core/Inputs/VInlineActionField.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VInlineActionField.swift
@@ -69,9 +69,7 @@ public struct VInlineActionField: View {
             .onHover { hovering in
                 isHovered = isEmpty ? false : hovering
                 #if os(macOS)
-                if !isEmpty {
-                    if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                }
+                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
                 #endif
             }
             .padding(.trailing, VSpacing.sm)


### PR DESCRIPTION
## Summary
- Remove conditional `!isEmpty` guard around NSCursor push/pop in VInlineActionField's onHover handler
- The guard could leave the cursor stack unbalanced when the text field contents changed while hovering (e.g., user clears field while hovering the Send button)
- Now matches the unconditional push/pop pattern used by all other onHover handlers in the codebase

Addresses feedback from #10354
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
