### PR TITLE
test: add tests for grant retry review feedback from #10373

### DIFF
--- a/assistant/src/__tests__/approval-primitive.test.ts
+++ b/assistant/src/__tests__/approval-primitive.test.ts
@@ -537,4 +537,76 @@ describe('approval-primitive / consumeGrantForInvocation retry', () => {
     expect(elapsed).toBeGreaterThanOrEqual(450);
     expect(elapsed).toBeLessThan(1_500);
   });
+
+  test('returns aborted when signal fires during retry polling', async () => {
+    const digest = computeToolApprovalDigest('shell', { command: 'aborted' });
+    const controller = new AbortController();
+
+    // Abort after 200ms — well before the 2s max wait
+    setTimeout(() => controller.abort(), 200);
+
+    const start = Date.now();
+    const result = await consumeGrantForInvocation(
+      {
+        toolName: 'shell',
+        inputDigest: digest,
+        consumingRequestId: 'consumer-aborted',
+        assistantId: 'self',
+      },
+      { maxWaitMs: 2_000, intervalMs: 50, signal: controller.signal },
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('aborted');
+    // Should have exited shortly after the abort (200ms), not waited the full 2s
+    expect(elapsed).toBeLessThan(1_000);
+  });
+
+  test('returns aborted immediately when signal is already aborted', async () => {
+    const digest = computeToolApprovalDigest('shell', { command: 'pre-aborted' });
+    const controller = new AbortController();
+    controller.abort();
+
+    const start = Date.now();
+    const result = await consumeGrantForInvocation(
+      {
+        toolName: 'shell',
+        inputDigest: digest,
+        consumingRequestId: 'consumer-pre-aborted',
+        assistantId: 'self',
+      },
+      { maxWaitMs: 2_000, intervalMs: 50, signal: controller.signal },
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('aborted');
+    // Should return nearly instantly since signal was already aborted
+    expect(elapsed).toBeLessThan(200);
+  });
+
+  test('skips retry entirely when maxWaitMs is 0', async () => {
+    const digest = computeToolApprovalDigest('shell', { command: 'no-retry' });
+
+    const start = Date.now();
+    const result = await consumeGrantForInvocation(
+      {
+        toolName: 'shell',
+        inputDigest: digest,
+        consumingRequestId: 'consumer-no-retry',
+        assistantId: 'self',
+      },
+      { maxWaitMs: 0 },
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('no_match');
+    // Should return nearly instantly — no retry loop
+    expect(elapsed).toBeLessThan(100);
+  });
 });

--- a/assistant/src/__tests__/tool-approval-handler.test.ts
+++ b/assistant/src/__tests__/tool-approval-handler.test.ts
@@ -347,4 +347,98 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
 
     expect(result.allowed).toBe(false);
   });
+
+  test('non-voice channel denial is instant (no retry polling)', async () => {
+    const toolName = 'bash';
+    const input = { command: 'rm -rf /' };
+
+    // executionChannel defaults to undefined (non-voice)
+    const context = makeContext({
+      guardianActorRole: 'non-guardian',
+      executionChannel: 'telegram',
+    });
+
+    const start = Date.now();
+    const result = await handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.allowed).toBe(false);
+    if (result.allowed) return;
+    expect(result.result.content).toContain('guardian approval');
+    // Non-voice denials should be nearly instant — no 10s retry polling
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  test('voice channel with delayed grant succeeds via retry polling', async () => {
+    const toolName = 'bash';
+    const input = { command: 'echo hello' };
+    const digest = computeToolApprovalDigest(toolName, input);
+
+    // Mint the grant after 300ms — the voice retry polling should find it
+    setTimeout(() => {
+      mintGrantFromDecision(
+        mintParams({
+          scopeMode: 'tool_signature',
+          toolName,
+          inputDigest: digest,
+        }),
+      );
+    }, 300);
+
+    const context = makeContext({
+      guardianActorRole: 'non-guardian',
+      executionChannel: 'voice',
+    });
+
+    const start = Date.now();
+    const result = await handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.allowed).toBe(true);
+    // Should have taken at least ~300ms (the minting delay) but not the full 10s
+    expect(elapsed).toBeGreaterThanOrEqual(250);
+    expect(elapsed).toBeLessThan(5_000);
+  });
+
+  test('voice channel abort returns Cancelled instead of guardian_approval_required', async () => {
+    const toolName = 'bash';
+    const input = { command: 'deploy --force' };
+
+    const controller = new AbortController();
+    // Abort after 200ms to simulate voice barge-in
+    setTimeout(() => controller.abort(), 200);
+
+    const context = makeContext({
+      guardianActorRole: 'non-guardian',
+      executionChannel: 'voice',
+      signal: controller.signal,
+    });
+
+    const start = Date.now();
+    const result = await handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.allowed).toBe(false);
+    if (result.allowed) return;
+    // Should return 'Cancelled', not a guardian_approval_required message
+    expect(result.result.content).toBe('Cancelled');
+    expect(result.result.isError).toBe(true);
+    // Should exit promptly after the abort signal, not wait full 10s
+    expect(elapsed).toBeLessThan(2_000);
+
+    // The lifecycle event should be an error with 'Cancelled', not permission_denied
+    const errorEvents = events.filter((e) => e.type === 'error');
+    expect(errorEvents.length).toBeGreaterThanOrEqual(1);
+    const lastError = errorEvents[errorEvents.length - 1];
+    if (lastError.type === 'error') {
+      expect(lastError.errorMessage).toBe('Cancelled');
+      expect(lastError.isExpected).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Add AbortSignal tests for `consumeGrantForInvocation` (signal during polling, pre-aborted signal, maxWaitMs: 0 skip)
- Add voice vs non-voice channel scoping tests for `checkPreExecutionGates` (instant non-voice denial, delayed voice grant via retry)
- Add abort cancellation test verifying voice barge-in produces 'Cancelled' not 'guardian_approval_required'

Addresses feedback from #10373
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
