### PR TITLE
fix: set cwd when spawning daemon so onnxruntime-node resolves

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -377,6 +377,7 @@ export async function startLocalDaemon(): Promise<void> {
       }
 
       const child = spawn(daemonBinary, [], {
+        cwd: dirname(daemonBinary),
         detached: true,
         stdio: "ignore",
         env: daemonEnv,


### PR DESCRIPTION
## Summary
- The daemon binary is compiled with `--external onnxruntime-node`, meaning it resolves the package from `node_modules/` at runtime
- The `node_modules/` directory is bundled alongside the daemon at `Contents/MacOS/node_modules/`
- But `spawn()` was called without `cwd`, so Bun looked for `node_modules/` relative to the inherited working directory (e.g. `$HOME`) and failed with: `Cannot find package 'onnxruntime-node' from '/$bunfs/root/vellum-daemon-arm64'`
- Fix: set `cwd: dirname(daemonBinary)` so the daemon runs from its own directory and `node_modules/` resolves correctly

## Test plan
- [ ] Install the desktop app on a fresh machine and verify `vellum hatch` succeeds
- [ ] Verify daemon starts and creates `~/.vellum/` with socket and token files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
