### PR TITLE
fix: restore !== null checks for guardian followup CAS in session and inbound handler

### DIFF
--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -576,9 +576,9 @@ export async function processMessage(
 
           let stateApplied = true;
           if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
-            stateApplied = progressFollowupState(request.id, 'dispatching', turnResult.disposition) !== undefined;
+            stateApplied = progressFollowupState(request.id, 'dispatching', turnResult.disposition) !== null;
           } else if (turnResult.disposition === 'decline') {
-            stateApplied = finalizeFollowup(request.id, 'declined') !== undefined;
+            stateApplied = finalizeFollowup(request.id, 'declined') !== null;
           }
 
           if (!stateApplied) {

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1087,9 +1087,9 @@ export async function handleChannelInbound(
 
           let stateApplied = true;
           if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
-            stateApplied = progressFollowupState(request.id, 'dispatching', turnResult.disposition) !== undefined;
+            stateApplied = progressFollowupState(request.id, 'dispatching', turnResult.disposition) !== null;
           } else if (turnResult.disposition === 'decline') {
-            stateApplied = finalizeFollowup(request.id, 'declined') !== undefined;
+            stateApplied = finalizeFollowup(request.id, 'declined') !== null;
           }
 
           if (!stateApplied) {


### PR DESCRIPTION
Both progressFollowupState and finalizeFollowup return null on failed compare-and-set, not undefined. The !== undefined checks always evaluate true (null !== undefined is true in JS), causing stale guardian replies to be incorrectly marked as applied and follow-up actions to fire on already-resolved requests. Restores the correct !== null checks in both handler paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
