### PR TITLE
fix: restrict isRmOfKnownSafeFile risk downgrade to bash tool only

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -398,10 +398,10 @@ async function classifyRiskUncached(toolName: string, input: Record<string, unkn
       if (HIGH_RISK_PROGRAMS.has(prog)) return RiskLevel.High;
 
       if (prog === 'rm') {
-        // `rm` of known safe workspace files (no flags, bare filename) is
-        // Medium rather than High so scope-limited allow rules can approve
-        // it without needing allowHighRisk, which would bypass path checks.
-        if (isRmOfKnownSafeFile(seg.args)) {
+        // Only downgrade rm of known safe workspace files for sandboxed bash.
+        // host_bash has a global allow rule that would auto-approve Medium-risk
+        // commands, so rm on the host must always require explicit approval.
+        if (toolName === 'bash' && isRmOfKnownSafeFile(seg.args)) {
           maxRisk = RiskLevel.Medium;
           continue;
         }


### PR DESCRIPTION
The isRmOfKnownSafeFile Medium risk downgrade was applied to both bash and host_bash tools. host_bash has a global allow rule (scope: everywhere) that auto-approves Medium-risk commands, so rm BOOTSTRAP.md and rm UPDATES.md on the host were silently approved without user confirmation — a security regression. Now the downgrade only applies when toolName === 'bash'.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
