### PR TITLE
fix: call checkAndApplyPrivacyFlag() in onDaemonRestarted reconnect handler

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1160,6 +1160,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                     self.setupAmbientAgent()
                     self.refreshAppsCache()
                     self.refreshSkillsCache()
+                    self.checkAndApplyPrivacyFlag()
                 }
             }
         }


### PR DESCRIPTION
The privacy opt-out check (which closes Sentry if the user has disabled usage data collection) was only called in the initial connect path. If the initial connection failed but a later reconnect via onDaemonRestarted succeeded, Sentry would remain active for the entire session even when the user opted out. Now also calls checkAndApplyPrivacyFlag() after successful reconnect.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
