### PR TITLE
fix: balance NSCursor push/pop stack in VInlineActionField

### DIFF
--- a/clients/shared/DesignSystem/Core/Inputs/VInlineActionField.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VInlineActionField.swift
@@ -20,6 +20,9 @@ public struct VInlineActionField: View {
     public let action: () -> Void
 
     @State private var isHovered = false
+    #if os(macOS)
+    @State private var cursorPushed = false
+    #endif
 
     public init(
         text: Binding<String>,
@@ -69,9 +72,27 @@ public struct VInlineActionField: View {
             .onHover { hovering in
                 isHovered = isEmpty ? false : hovering
                 #if os(macOS)
-                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                if hovering && !isEmpty {
+                    if !cursorPushed {
+                        NSCursor.pointingHand.push()
+                        cursorPushed = true
+                    }
+                } else {
+                    if cursorPushed {
+                        NSCursor.pop()
+                        cursorPushed = false
+                    }
+                }
                 #endif
             }
+            #if os(macOS)
+            .onDisappear {
+                if cursorPushed {
+                    NSCursor.pop()
+                    cursorPushed = false
+                }
+            }
+            #endif
             .padding(.trailing, VSpacing.sm)
         }
         .background(VColor.inputBackground)


### PR DESCRIPTION
## Summary
- Fixes cursor stack imbalance in VInlineActionField when the button disappears while hovered (e.g., clicking Save swaps the field out)
- Adds `cursorPushed` state flag to track whether a cursor has been pushed onto the NSCursor stack
- Guards push/pop with the flag to prevent double-push or double-pop
- Adds `onDisappear` handler to pop the cursor if the view is removed while still hovered
- Also fixes cursor being pushed when the button is in its disabled (empty) state

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/10356

## Test plan
- [ ] Verify the pointing-hand cursor appears when hovering the action button with non-empty text
- [ ] Verify the cursor resets to arrow after clicking Save (which removes the field)
- [ ] Verify no stuck pointing-hand cursor when the component is removed while hovered
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
