### PR TITLE
fix: align reminder routing_intent code defaults with documentation

### DIFF
--- a/assistant/src/config/bundled-skills/reminder/TOOLS.json
+++ b/assistant/src/config/bundled-skills/reminder/TOOLS.json
@@ -29,7 +29,7 @@
           "routing_intent": {
             "type": "string",
             "enum": ["single_channel", "multi_channel", "all_channels"],
-            "description": "How the reminder is routed at trigger time. single_channel (default) delivers to one best channel, multi_channel delivers to a subset, all_channels delivers everywhere."
+            "description": "How the reminder is routed at trigger time. single_channel delivers to one best channel, multi_channel delivers to a subset, all_channels (default) delivers everywhere."
           },
           "routing_hints": {
             "type": "object",

--- a/assistant/src/tools/reminder/reminder-store.ts
+++ b/assistant/src/tools/reminder/reminder-store.ts
@@ -52,7 +52,7 @@ export function insertReminder(params: {
   const db = getDb();
   const id = uuid();
   const now = Date.now();
-  const routingIntent = params.routingIntent ?? 'single_channel';
+  const routingIntent = params.routingIntent ?? 'all_channels';
   const routingHints = params.routingHints ?? {};
   const row = {
     id,

--- a/assistant/src/tools/reminder/reminder.ts
+++ b/assistant/src/tools/reminder/reminder.ts
@@ -38,7 +38,7 @@ export function executeReminderCreate(input: Record<string, unknown>): ToolExecu
   }
 
   // Validate routing_intent if provided
-  const routingIntent: RoutingIntent = (routingIntentRaw as RoutingIntent) ?? 'single_channel';
+  const routingIntent: RoutingIntent = (routingIntentRaw as RoutingIntent) ?? 'all_channels';
   if (routingIntentRaw !== undefined && !VALID_ROUTING_INTENTS.has(routingIntentRaw)) {
     return {
       content: `Error: routing_intent must be one of: single_channel, multi_channel, all_channels`,


### PR DESCRIPTION
## Summary
- Changed the default `routing_intent` fallback from `single_channel` to `all_channels` in `reminder.ts` and `reminder-store.ts`
- Updated the `TOOLS.json` tool schema description to document `all_channels` as the default

Addresses review feedback on #10379: the SKILL.md was updated to say `all_channels` is the default, but the actual code and tool schema still defaulted to `single_channel`. This mismatch meant reminders continued routing to a single channel when the LLM omitted the parameter.

## Test plan
- [ ] Create a reminder without specifying `routing_intent` and verify it defaults to `all_channels`
- [ ] Create a reminder with explicit `routing_intent: "single_channel"` and verify it uses `single_channel`
- [ ] Verify the tool schema shown to the LLM reflects `all_channels (default)` in the description

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
