### PR TITLE
fix: VInlineActionField empty-save and async-overwrite regressions from #10365

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -10,6 +10,7 @@ struct GatewaySettingsCard: View {
     var daemonClient: DaemonClient?
 
     @State private var gatewayUrlText: String = ""
+    @State private var isGatewayUrlFocused: Bool = false
     @State private var gatewayTargetCopied: Bool = false
 
     var body: some View {
@@ -27,7 +28,9 @@ struct GatewaySettingsCard: View {
             gatewayUrlText = store.ingressPublicBaseUrl
         }
         .onChange(of: store.ingressPublicBaseUrl) { _, newValue in
-            gatewayUrlText = newValue
+            if !isGatewayUrlFocused {
+                gatewayUrlText = newValue
+            }
         }
         .onChange(of: store.ingressConfigLoaded) { _, loaded in
             guard loaded else { return }
@@ -105,7 +108,7 @@ struct GatewaySettingsCard: View {
                     .foregroundColor(VColor.textSecondary)
             }
 
-            VInlineActionField(text: $gatewayUrlText, placeholder: "https://your-tunnel.example.com") {
+            VInlineActionField(text: $gatewayUrlText, placeholder: "https://your-tunnel.example.com", allowEmpty: true, isFocused: $isGatewayUrlFocused) {
                 store.saveIngressPublicBaseUrl(gatewayUrlText)
             }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -12,6 +12,7 @@ struct SettingsAccountTab: View {
 
     // -- Account / Vellum section state --
     @State private var platformUrlText: String = ""
+    @State private var isPlatformUrlFocused: Bool = false
 
     // -- Assistant Info state (from SettingsAdvancedTab) --
     @State private var showingRetireConfirmation: Bool = false
@@ -58,7 +59,9 @@ struct SettingsAccountTab: View {
             Task { await loadHatchFlag() }
         }
         .onChange(of: store.platformBaseUrl) { _, newValue in
-            platformUrlText = newValue
+            if !isPlatformUrlFocused {
+                platformUrlText = newValue
+            }
         }
         .alert("Retire Assistant", isPresented: $showingRetireConfirmation) {
             Button("Cancel", role: .cancel) {}
@@ -109,7 +112,7 @@ struct SettingsAccountTab: View {
                     .font(VFont.caption)
                     .foregroundColor(VColor.textSecondary)
 
-                VInlineActionField(text: $platformUrlText, placeholder: "https://platform.vellum.ai") {
+                VInlineActionField(text: $platformUrlText, placeholder: "https://platform.vellum.ai", isFocused: $isPlatformUrlFocused) {
                     store.savePlatformBaseUrl(platformUrlText)
                     Task { await store.checkVellumPlatform() }
                 }

--- a/clients/shared/DesignSystem/Core/Inputs/VInlineActionField.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VInlineActionField.swift
@@ -12,13 +12,21 @@ import AppKit
 ///     store.saveKey(apiKey)
 /// }
 /// ```
+///
+/// Pass `allowEmpty: true` when saving an empty value is a valid action (e.g., clearing a URL).
+/// Pass `isFocused:` to observe focus state and guard against async overwrites of in-progress edits.
 public struct VInlineActionField: View {
     @Binding public var text: String
     public let placeholder: String
     public var actionLabel: String
     public var isSecure: Bool
+    public var allowEmpty: Bool
     public let action: () -> Void
 
+    /// Optional binding so parents can observe whether the field is focused.
+    private var externalFocused: Binding<Bool>?
+
+    @FocusState private var fieldFocused: Bool
     @State private var isHovered = false
     #if os(macOS)
     @State private var cursorPushed = false
@@ -29,38 +37,43 @@ public struct VInlineActionField: View {
         placeholder: String,
         actionLabel: String = "Save",
         isSecure: Bool = false,
+        allowEmpty: Bool = false,
+        isFocused: Binding<Bool>? = nil,
         action: @escaping () -> Void
     ) {
         self._text = text
         self.placeholder = placeholder
         self.actionLabel = actionLabel
         self.isSecure = isSecure
+        self.allowEmpty = allowEmpty
+        self.externalFocused = isFocused
         self.action = action
     }
 
-    private var isEmpty: Bool {
-        text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    private var isActionDisabled: Bool {
+        !allowEmpty && text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     public var body: some View {
         HStack(spacing: 0) {
             inputField
+                .focused($fieldFocused)
                 .padding(.leading, VSpacing.md)
                 .padding(.vertical, VSpacing.md)
                 .onSubmit {
-                    if !isEmpty { action() }
+                    if !isActionDisabled { action() }
                 }
 
             Button {
-                if !isEmpty { action() }
+                if !isActionDisabled { action() }
             } label: {
                 Text(actionLabel)
                     .font(VFont.captionMedium)
-                    .foregroundColor(isEmpty ? VColor.textMuted : .white)
+                    .foregroundColor(isActionDisabled ? VColor.textMuted : .white)
                     .padding(.horizontal, VSpacing.md)
                     .padding(.vertical, VSpacing.buttonV)
                     .background(
-                        isEmpty
+                        isActionDisabled
                             ? VColor.surfaceBorder.opacity(0.5)
                             : (isHovered ? VColor.buttonPrimaryHover : VColor.buttonPrimary)
                     )
@@ -68,11 +81,11 @@ public struct VInlineActionField: View {
                     .animation(VAnimation.fast, value: isHovered)
             }
             .buttonStyle(.plain)
-            .disabled(isEmpty)
+            .disabled(isActionDisabled)
             .onHover { hovering in
-                isHovered = isEmpty ? false : hovering
+                isHovered = isActionDisabled ? false : hovering
                 #if os(macOS)
-                if hovering && !isEmpty {
+                if hovering && !isActionDisabled {
                     if !cursorPushed {
                         NSCursor.pointingHand.push()
                         cursorPushed = true
@@ -101,6 +114,9 @@ public struct VInlineActionField: View {
             RoundedRectangle(cornerRadius: VRadius.md)
                 .stroke(VColor.surfaceBorder, lineWidth: 1)
         )
+        .onChange(of: fieldFocused) { _, focused in
+            externalFocused?.wrappedValue = focused
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
Addresses review feedback from #10365:

- **Empty value regression**: `VInlineActionField` blocked saving empty values because of its `isEmpty` guard, which prevented users from clearing the Gateway URL to disable ingress. Added `allowEmpty: Bool = false` parameter that skips the empty-check when true. Used in `GatewaySettingsCard` where clearing the URL is the only UI path to disable ingress.
- **Async overwrite regression**: Removing `@FocusState` tracking from parent views meant async IPC config responses could overwrite in-progress text edits. Added built-in `@FocusState` tracking inside `VInlineActionField` with an optional `isFocused: Binding<Bool>?` parameter so parents can observe focus state. Restored focus guards in `GatewaySettingsCard` and `SettingsAccountTab` onChange handlers.

## Test plan
- [ ] Open Gateway settings, set a URL, then clear it and click Save — ingress should disable
- [ ] Open Gateway settings and start typing immediately — async config refresh should not overwrite partial input
- [ ] Open Account settings (dev mode), start typing in Platform URL — same focus protection applies
- [ ] Existing VInlineActionField usages (API keys, channels) are unaffected (default `allowEmpty: false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
