### PR TITLE
fix: update schema test + add daemon package resolution CI check

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -107,25 +107,6 @@ jobs:
           SIGN_IDENTITY="-" \
           ./build.sh build
 
-      - name: Verify daemon external package resolution
-        run: |
-          MACOS_DIR="clients/macos/dist/Vellum.app/Contents/MacOS"
-
-          # Verify onnxruntime-node is bundled next to the daemon binary
-          if [ ! -d "$MACOS_DIR/node_modules/onnxruntime-node" ]; then
-            echo "::error::onnxruntime-node not bundled in app — daemon will fail to resolve external packages"
-            exit 1
-          fi
-
-          # Verify daemon can resolve external packages from its own directory
-          cd "$MACOS_DIR"
-          output=$(timeout 5 ./vellum-daemon 2>&1) || true
-          if echo "$output" | grep -q "Cannot find package"; then
-            echo "::error::Daemon binary cannot resolve external packages from its own directory"
-            echo "$output"
-            exit 1
-          fi
-
       - name: Install Playwright dependencies
         working-directory: playwright
         run: bun install

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -107,6 +107,25 @@ jobs:
           SIGN_IDENTITY="-" \
           ./build.sh build
 
+      - name: Verify daemon external package resolution
+        run: |
+          MACOS_DIR="clients/macos/dist/Vellum.app/Contents/MacOS"
+
+          # Verify onnxruntime-node is bundled next to the daemon binary
+          if [ ! -d "$MACOS_DIR/node_modules/onnxruntime-node" ]; then
+            echo "::error::onnxruntime-node not bundled in app — daemon will fail to resolve external packages"
+            exit 1
+          fi
+
+          # Verify daemon can resolve external packages from its own directory
+          cd "$MACOS_DIR"
+          output=$(timeout 5 ./vellum-daemon 2>&1) || true
+          if echo "$output" | grep -q "Cannot find package"; then
+            echo "::error::Daemon binary cannot resolve external packages from its own directory"
+            echo "$output"
+            exit 1
+          fi
+
       - name: Install Playwright dependencies
         working-directory: playwright
         run: bun install

--- a/gateway/src/__tests__/schema.test.ts
+++ b/gateway/src/__tests__/schema.test.ts
@@ -158,7 +158,7 @@ describe("buildSchema()", () => {
     expect(telegramDeliver.anyOf).toContainEqual({ required: ["chatAction"] });
   });
 
-  test("ingress member block request body is required", () => {
+  test("ingress member block request body is optional", () => {
     const schema = buildSchema() as {
       paths: Record<string, {
         post?: {
@@ -171,6 +171,6 @@ describe("buildSchema()", () => {
 
     const ingressMemberBlockPost = schema.paths["/v1/ingress/members/{memberId}/block"]?.post;
     expect(ingressMemberBlockPost).toBeDefined();
-    expect(ingressMemberBlockPost?.requestBody?.required).toBe(true);
+    expect(ingressMemberBlockPost?.requestBody?.required).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Updates the gateway schema test for the ingress member block endpoint to expect `requestBody.required: false` (was changed in #10531 but the test wasn't updated)
- Adds a CI step in the Playwright workflow to verify the daemon binary can resolve `onnxruntime-node` from its bundled location, catching regressions in the build script or the CWD fix from #10539

## Test plan
- [x] Gateway schema tests pass locally (7/7)
- [ ] CI playwright workflow validates the new verification step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
