### PR TITLE
fix: resolve build errors in OnboardingState

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -41,9 +41,6 @@ final class OnboardingState {
     var cloudProvider: String = "local"
     var onboardingVariant: OnboardingVariant = .default
 
-    // Avatar evolution state for progressive visual changes during onboarding
-    var avatarEvolutionState = AvatarEvolutionState()
-
     /// When false, step changes are not written to UserDefaults (used by auth gate).
     var shouldPersist: Bool = true
 
@@ -75,7 +72,7 @@ final class OnboardingState {
     }
 
     var userHostedEnabled: Bool {
-        FeatureFlagManager.shared.isEnabled(.userHostedEnabled)
+        MacOSClientFeatureFlagManager.shared.isEnabled("user_hosted_enabled")
     }
 
     /// Continuous crack progress (0.0–1.0) derived from step and permission state.
@@ -138,13 +135,12 @@ final class OnboardingState {
         // from reopening legacy permission-request steps.
         // When userHostedEnabled is on and a cloud provider is selected, the flow
         // has 3 steps (0–2); otherwise it stays at 2 steps (0–1).
-        let hasCloudStep = FeatureFlagManager.shared.isEnabled(.userHostedEnabled) && cloudProvider != "local"
+        let hasCloudStep = MacOSClientFeatureFlagManager.shared.isEnabled("user_hosted_enabled") && cloudProvider != "local"
         let maxStep = onboardingVariant == .firstMeeting ? 4 : (hasCloudStep ? 2 : 1)
         if currentStep > maxStep {
             currentStep = maxStep
         }
 
-        avatarEvolutionState.load()
     }
 
     func advance(by steps: Int = 1) {
@@ -171,6 +167,5 @@ final class OnboardingState {
         for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress", "onboarding.flowVersion", "onboarding.cloudProvider"] {
             UserDefaults.standard.removeObject(forKey: key)
         }
-        AvatarEvolutionState.clearPersistedState()
     }
 }


### PR DESCRIPTION
## Summary
- Reverts `FeatureFlagManager` → `MacOSClientFeatureFlagManager` (the typealias/rename never landed)
- Reverts `.userHostedEnabled` enum syntax → `"user_hosted_enabled"` string (`isEnabled` takes a `String`)
- Removes `AvatarEvolutionState` references (type was deleted in Avatar System Overhaul #10144)

These were introduced in #10527 and broke the `build-macos` CI job.

## Test plan
- [ ] `build-macos` CI job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
