### PR TITLE
fix: update schema test for optional block member request body

### DIFF
--- a/gateway/src/__tests__/schema.test.ts
+++ b/gateway/src/__tests__/schema.test.ts
@@ -158,7 +158,7 @@ describe("buildSchema()", () => {
     expect(telegramDeliver.anyOf).toContainEqual({ required: ["chatAction"] });
   });
 
-  test("ingress member block request body is required", () => {
+  test("ingress member block request body is optional", () => {
     const schema = buildSchema() as {
       paths: Record<string, {
         post?: {
@@ -171,6 +171,6 @@ describe("buildSchema()", () => {
 
     const ingressMemberBlockPost = schema.paths["/v1/ingress/members/{memberId}/block"]?.post;
     expect(ingressMemberBlockPost).toBeDefined();
-    expect(ingressMemberBlockPost?.requestBody?.required).toBe(true);
+    expect(ingressMemberBlockPost?.requestBody?.required).toBe(false);
   });
 });


### PR DESCRIPTION
Updates the schema test to match the change from PR #10531 where the block member endpoint request body was changed from required to optional. Renames the test and fixes the assertion.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
