### PR TITLE
fix: align reminder tests and DB schema default to all_channels

### DIFF
--- a/assistant/src/__tests__/reminder-store.test.ts
+++ b/assistant/src/__tests__/reminder-store.test.ts
@@ -45,7 +45,7 @@ describe('reminder-store', () => {
     expect(r.status).toBe('pending');
     expect(r.firedAt).toBeNull();
     expect(r.conversationId).toBeNull();
-    expect(r.routingIntent).toBe('single_channel');
+    expect(r.routingIntent).toBe('all_channels');
     expect(r.routingHints).toEqual({});
     expect(r.createdAt).toBeGreaterThan(0);
     expect(r.updatedAt).toBeGreaterThan(0);
@@ -69,7 +69,7 @@ describe('reminder-store', () => {
     expect(fetched!.routingHints).toEqual({ preferred: ['telegram', 'sms'] });
   });
 
-  test('insertReminder defaults routingIntent to single_channel when omitted', () => {
+  test('insertReminder defaults routingIntent to all_channels when omitted', () => {
     const r = insertReminder({
       label: 'No routing',
       message: 'Should default',
@@ -77,11 +77,11 @@ describe('reminder-store', () => {
       mode: 'notify',
     });
 
-    expect(r.routingIntent).toBe('single_channel');
+    expect(r.routingIntent).toBe('all_channels');
     expect(r.routingHints).toEqual({});
 
     const fetched = getReminder(r.id);
-    expect(fetched!.routingIntent).toBe('single_channel');
+    expect(fetched!.routingIntent).toBe('all_channels');
     expect(fetched!.routingHints).toEqual({});
   });
 
@@ -113,7 +113,7 @@ describe('reminder-store', () => {
 
     const all = listReminders();
     expect(all).toHaveLength(2);
-    expect(all[0].routingIntent).toBe('single_channel');
+    expect(all[0].routingIntent).toBe('all_channels');
     expect(all[1].routingIntent).toBe('multi_channel');
   });
 

--- a/assistant/src/__tests__/reminder.test.ts
+++ b/assistant/src/__tests__/reminder.test.ts
@@ -154,16 +154,16 @@ describe('reminder tool', () => {
 
   // ── routing ────────────────────────────────────────────────────────
 
-  test('create defaults routing_intent to single_channel', async () => {
+  test('create defaults routing_intent to all_channels', async () => {
     const future = new Date(Date.now() + 60_000).toISOString();
     const result = executeReminderCreate({
       fire_at: future,
       label: 'Default routing',
-      message: 'Should default to single_channel',
+      message: 'Should default to all_channels',
     });
 
     expect(result.isError).toBe(false);
-    expect(result.content).toContain('Routing: single_channel');
+    expect(result.content).toContain('Routing: all_channels');
   });
 
   test('create with routing_intent all_channels succeeds', async () => {
@@ -242,7 +242,7 @@ describe('reminder tool', () => {
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Reminder created');
-    expect(result.content).toContain('Routing: single_channel');
+    expect(result.content).toContain('Routing: all_channels');
   });
 
   // ── list ────────────────────────────────────────────────────────────

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -246,7 +246,7 @@ export const reminders = sqliteTable('reminders', {
   status: text('status').notNull(),               // 'pending' | 'firing' | 'fired' | 'cancelled'
   firedAt: integer('fired_at'),
   conversationId: text('conversation_id'),
-  routingIntent: text('routing_intent').notNull().default('single_channel'),   // 'single_channel' | 'multi_channel' | 'all_channels'
+  routingIntent: text('routing_intent').notNull().default('all_channels'),   // 'single_channel' | 'multi_channel' | 'all_channels'
   routingHintsJson: text('routing_hints_json').notNull().default('{}'),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),


### PR DESCRIPTION
Updates reminder test assertions and the Drizzle ORM schema default from single_channel to all_channels, matching the code change from PR #10544.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
