### PR TITLE
Unify icon button hover states with shared VIconButtonStyle

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -272,7 +272,7 @@ struct ComposerView: View {
                             .frame(width: 10, height: 10)
                     }
                 }
-                .buttonStyle(ComposerActionButtonStyle(
+                .buttonStyle(VIconButtonStyle(
                     isHovered: isStopHovered,
                     isFocused: focusedComposerAction == .stop,
                     size: composerActionButtonSize
@@ -292,7 +292,7 @@ struct ComposerView: View {
                         .font(.system(size: composerActionIconSize, weight: .regular))
                         .foregroundColor(adaptiveColor(light: Forest._500, dark: Moss._400))
                 }
-                .buttonStyle(ComposerActionButtonStyle(
+                .buttonStyle(VIconButtonStyle(
                     isHovered: isAttachmentHovered,
                     isFocused: focusedComposerAction == .attachment,
                     size: composerActionButtonSize
@@ -323,7 +323,7 @@ struct ComposerView: View {
                                 .foregroundColor(.white)
                         }
                     }
-                    .buttonStyle(ComposerActionButtonStyle(
+                    .buttonStyle(VIconButtonStyle(
                         isHovered: isSendHovered,
                         isFocused: focusedComposerAction == .send,
                         size: composerActionButtonSize
@@ -344,7 +344,7 @@ struct ComposerView: View {
                         iconSize: composerActionIconSize,
                         action: { onMicrophoneToggle(); focusedComposerAction = nil }
                     )
-                        .buttonStyle(ComposerActionButtonStyle(
+                        .buttonStyle(VIconButtonStyle(
                             isHovered: isMicrophoneHovered,
                             isFocused: focusedComposerAction == .microphone,
                             size: composerActionButtonSize
@@ -1054,44 +1054,6 @@ private struct MicrophoneButton: View {
         .onAppear {
             isPulsing = isRecording
         }
-    }
-}
-
-private struct ComposerActionButtonStyle: ButtonStyle {
-    let isHovered: Bool
-    let isFocused: Bool
-    let size: CGFloat
-
-    @Environment(\.isEnabled) private var isEnabled
-
-    func makeBody(configuration: Configuration) -> some View {
-        let isInteractive = isEnabled && (isHovered || configuration.isPressed || isFocused)
-        let backgroundOpacity: Double = {
-            if !isInteractive { return 0 }
-            return configuration.isPressed ? 0.5 : 0.28
-        }()
-
-        return configuration.label
-            .frame(width: size, height: size)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .fill(VColor.surfaceBorder.opacity(backgroundOpacity))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .stroke(
-                        isEnabled && isFocused
-                            ? VColor.accent.opacity(0.72)
-                            : VColor.surfaceBorder.opacity(isEnabled && isHovered ? 0.5 : 0),
-                        lineWidth: isEnabled && isFocused ? 1.25 : 1
-                    )
-            )
-            .contentShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .focusEffectDisabled()
-            .scaleEffect(configuration.isPressed ? 0.97 : 1)
-            .animation(VAnimation.fast, value: configuration.isPressed)
-            .animation(VAnimation.fast, value: isHovered)
-            .animation(VAnimation.fast, value: isFocused)
     }
 }
 

--- a/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
@@ -39,8 +39,9 @@ public struct VIconButton: View {
                         .font(VFont.caption)
                 }
             }
+            .foregroundColor(iconForegroundColor)
         }
-        .buttonStyle(VIconButtonStyle(isActive: isActive, isHovered: isHovered, iconOnly: iconOnly))
+        .buttonStyle(VIconButtonStyle(isActive: isActive, isHovered: isHovered))
         #if os(macOS)
         .onHover { hovering in
             isHovered = hovering
@@ -52,6 +53,13 @@ public struct VIconButton: View {
         #endif
         .accessibilityLabel(label)
         .modifier(OptionalHelpModifier(tooltip: tooltip))
+    }
+
+    private var iconForegroundColor: Color {
+        if isActive {
+            return adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._300)
+        }
+        return adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._400)
     }
 }
 
@@ -70,30 +78,47 @@ private struct OptionalHelpModifier: ViewModifier {
     }
 }
 
-private struct VIconButtonStyle: ButtonStyle {
-    let isActive: Bool
-    let isHovered: Bool
-    let iconOnly: Bool
+public struct VIconButtonStyle: ButtonStyle {
+    public var isActive: Bool
+    public var isHovered: Bool
+    public var isFocused: Bool
+    public var size: CGFloat?
 
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .foregroundColor(foregroundColor(isPressed: configuration.isPressed))
-            .padding(VSpacing.sm)
-            .background(backgroundColor(isPressed: configuration.isPressed))
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .contentShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .animation(VAnimation.fast, value: configuration.isPressed)
-            .animation(VAnimation.fast, value: isHovered)
+    @Environment(\.isEnabled) private var isEnabled
+
+    public init(isActive: Bool = false, isHovered: Bool, isFocused: Bool = false, size: CGFloat? = nil) {
+        self.isActive = isActive
+        self.isHovered = isHovered
+        self.isFocused = isFocused
+        self.size = size
     }
 
-    private func foregroundColor(isPressed: Bool) -> Color {
-        if isActive || isPressed {
-            return adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._300)
-        }
-        return adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._400)
+    public func makeBody(configuration: Configuration) -> some View {
+        let shape = RoundedRectangle(cornerRadius: VRadius.md)
+
+        configuration.label
+            .frame(width: size, height: size)
+            .padding(size == nil ? VSpacing.sm : 0)
+            .background(shape.fill(backgroundColor(isPressed: configuration.isPressed)))
+            .overlay(
+                shape.stroke(
+                    borderColor,
+                    lineWidth: isEnabled && isFocused ? 1.25 : 1
+                )
+            )
+            .clipShape(shape)
+            .contentShape(shape)
+            .focusEffectDisabled()
+            .scaleEffect(configuration.isPressed ? 0.97 : 1)
+            .animation(VAnimation.fast, value: configuration.isPressed)
+            .animation(VAnimation.fast, value: isHovered)
+            .animation(VAnimation.fast, value: isFocused)
     }
 
     private func backgroundColor(isPressed: Bool) -> Color {
+        guard isEnabled else {
+            return isActive ? adaptiveColor(light: Moss._100, dark: Moss._700).opacity(0.5) : .clear
+        }
         if isActive {
             if isPressed { return adaptiveColor(light: Moss._200, dark: Moss._600) }
             if isHovered { return adaptiveColor(light: Moss._200, dark: Moss._600) }
@@ -103,6 +128,11 @@ private struct VIconButtonStyle: ButtonStyle {
             if isHovered { return adaptiveColor(light: Moss._100, dark: Moss._700) }
             return .clear
         }
+    }
+
+    private var borderColor: Color {
+        guard isEnabled, isFocused else { return .clear }
+        return VColor.accent.opacity(0.72)
     }
 }
 


### PR DESCRIPTION
## Summary
- Promoted `VIconButtonStyle` to a public design system component with new `isFocused` and `size` parameters
- Replaced the composer-specific `ComposerActionButtonStyle` with `VIconButtonStyle` so all icon buttons (toolbar, composer attach, mic, send, stop) share the same hover/press/focus appearance
- Moved foreground color handling out of the button style into `VIconButton` body, so the style purely handles container appearance (background, border, shape)

## Original prompt
the hover state of these two icon buttons are different. Lets unify them and ideally use a shared design system component for icon buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
