### PR TITLE
fix: sync settings text fields on blur to prevent stale data

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -32,6 +32,11 @@ struct GatewaySettingsCard: View {
                 gatewayUrlText = newValue
             }
         }
+        .onChange(of: isGatewayUrlFocused) { _, focused in
+            if !focused {
+                gatewayUrlText = store.ingressPublicBaseUrl
+            }
+        }
         .onChange(of: store.ingressConfigLoaded) { _, loaded in
             guard loaded else { return }
             Task { await store.testGatewayOnly() }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -63,6 +63,11 @@ struct SettingsAccountTab: View {
                 platformUrlText = newValue
             }
         }
+        .onChange(of: isPlatformUrlFocused) { _, focused in
+            if !focused {
+                platformUrlText = store.platformBaseUrl
+            }
+        }
         .alert("Retire Assistant", isPresented: $showingRetireConfirmation) {
             Button("Cancel", role: .cancel) {}
             Button("Retire", role: .destructive) {


### PR DESCRIPTION
Adds onChange(of: focus) handlers to GatewaySettingsCard and SettingsAccountTab that sync text field values from the store when focus is lost. Prevents stale data when async store updates were blocked by the focus guard during editing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
