### PR TITLE
chore: add CODEOWNERS domain coverage for ingress/guardian/escalation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,5 +15,18 @@ assistant/src/config/bundled-skills/ @siddseethepalli
 # Memory system
 assistant/src/memory/ @siddseethepalli
 
+# Ingress / guardian / escalation domains
+assistant/src/runtime/routes/ @NgoHarrison
+assistant/src/runtime/ingress-service.ts @NgoHarrison
+assistant/src/runtime/channel-guardian-service.ts @NgoHarrison
+assistant/src/runtime/guardian-verification-templates.ts @NgoHarrison
+assistant/src/daemon/handlers/config-inbox.ts @NgoHarrison
+assistant/src/daemon/ipc-contract/inbox.ts @NgoHarrison
+assistant/src/notifications/ @NgoHarrison
+assistant/src/memory/ingress-* @NgoHarrison
+assistant/src/memory/inbox-* @NgoHarrison
+assistant/src/memory/guardian-* @NgoHarrison
+assistant/src/memory/channel-guardian-store.ts @NgoHarrison
+
 # CI/CD workflows
 .github/workflows/ @dvargas92495


### PR DESCRIPTION
## Summary\n- add high-level CODEOWNERS entries for ingress/guardian/escalation domains\n- assign these domain paths to @NgoHarrison\n\n## Why\n- request review notifications on changes in these domains\n\n## Testing\n- not applicable (ownership metadata only)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
