### PR TITLE
fix: add pagination, commit status, and failure handling to wait-ci

### DIFF
--- a/.claude/wait-ci
+++ b/.claude/wait-ci
@@ -69,10 +69,10 @@ while true; do
     continue
   fi
 
-  # Fetch check runs via GitHub API (works with all gh versions)
+  # Fetch check runs via GitHub API with pagination (works with all gh versions)
   CHECKS_OUTPUT=""
   CHECKS_RC=0
-  CHECKS_OUTPUT=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --jq '.check_runs | map({name: .name, status: .status, conclusion: .conclusion})' 2>"$STDERR_FILE") || CHECKS_RC=$?
+  CHECKS_OUTPUT=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --paginate --slurp --jq '[.[].check_runs[]] | map({name: .name, status: .status, conclusion: .conclusion})' 2>"$STDERR_FILE") || CHECKS_RC=$?
 
   if [[ "$CHECKS_RC" -ne 0 ]]; then
     STDERR_CONTENT=$(cat "$STDERR_FILE" 2>/dev/null || true)
@@ -87,7 +87,20 @@ while true; do
     continue
   fi
 
-  CHECKS="$CHECKS_OUTPUT"
+  # Fetch legacy commit status contexts (some CI integrations report via statuses, not check runs)
+  STATUSES_OUTPUT=""
+  STATUSES_RC=0
+  STATUSES_OUTPUT=$(gh api "repos/$REPO/commits/$HEAD_SHA/status" --jq '.statuses | map({name: .context, status: (if .state == "pending" then "pending" else "completed" end), conclusion: (if .state == "success" then "success" elif .state == "pending" then null elif .state == "error" then "failure" else .state end)})' 2>"$STDERR_FILE") || STATUSES_RC=$?
+
+  if [[ "$STATUSES_RC" -ne 0 ]]; then
+    STDERR_CONTENT=$(cat "$STDERR_FILE" 2>/dev/null || true)
+    echo "Warning: gh api commit status failed (exit $STATUSES_RC): $STDERR_CONTENT" >&2
+    # Non-fatal: proceed with check runs only
+    STATUSES_OUTPUT="[]"
+  fi
+
+  # Merge check runs and commit statuses into a single list
+  CHECKS=$(jq -s '.[0] + .[1]' <(echo "$CHECKS_OUTPUT") <(echo "$STATUSES_OUTPUT"))
   TOTAL=$(echo "$CHECKS" | jq 'length')
 
   if [[ "$TOTAL" -eq 0 ]]; then
@@ -111,13 +124,16 @@ while true; do
   # Reset the empty-check tracker once we see real checks.
   SEEN_EMPTY=false
 
-  # Count by status: completed checks have a conclusion, others are pending
+  # Count by status: completed checks have a conclusion, others are pending.
+  # Treat any completed conclusion that is NOT explicitly passing as a failure.
+  # Passing conclusions: success, neutral, skipped.
+  # This catches failure, cancelled, timed_out, action_required, startup_failure, stale, and any future non-passing states.
   PENDING=$(echo "$CHECKS" | jq '[.[] | select(.status != "completed")] | length')
-  FAILED=$(echo "$CHECKS" | jq '[.[] | select(.status == "completed" and (.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out"))] | length')
+  FAILED=$(echo "$CHECKS" | jq '[.[] | select(.status == "completed" and .conclusion != null and (.conclusion != "success" and .conclusion != "neutral" and .conclusion != "skipped"))] | length')
 
   if [[ "$FAILED" -gt 0 ]]; then
     echo "CI checks failed on PR #$PR_NUMBER:" >&2
-    echo "$CHECKS" | jq -r '.[] | select(.status == "completed" and (.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out")) | "  \(.name): \(.conclusion)"' >&2
+    echo "$CHECKS" | jq -r '.[] | select(.status == "completed" and .conclusion != null and (.conclusion != "success" and .conclusion != "neutral" and .conclusion != "skipped")) | "  \(.name): \(.conclusion)"' >&2
     exit 1
   fi
 


### PR DESCRIPTION
Addresses review feedback from PR #10538: adds --paginate for repos with >30 checks, includes commit status contexts in evaluation, and treats all non-passing conclusions as failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
