### PR TITLE
fix: resolve remaining macOS build errors in onboarding views

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -39,7 +39,7 @@ struct APIKeyStepView: View {
     @FocusState private var keyFieldFocused: Bool
 
     private var userHostedEnabled: Bool {
-        FeatureFlagManager.shared.isEnabled(.userHostedEnabled)
+        MacOSClientFeatureFlagManager.shared.isEnabled("user_hosted_enabled")
     }
 
     var body: some View {
@@ -122,9 +122,9 @@ struct APIKeyStepView: View {
                 }
                 Spacer()
                 Circle()
-                    .fill(isSelected ? Sage._600 : Color.clear)
+                    .fill(isSelected ? Forest._600 : Color.clear)
                     .overlay(
-                        Circle().stroke(isSelected ? Sage._600 : VColor.surfaceBorder, lineWidth: 1.5)
+                        Circle().stroke(isSelected ? Forest._600 : VColor.surfaceBorder, lineWidth: 1.5)
                     )
                     .overlay(
                         isSelected
@@ -138,10 +138,10 @@ struct APIKeyStepView: View {
             .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)
-                    .fill(isSelected ? Sage._600.opacity(0.1) : Color.clear)
+                    .fill(isSelected ? Forest._600.opacity(0.1) : Color.clear)
                     .overlay(
                         RoundedRectangle(cornerRadius: VRadius.lg)
-                            .stroke(isSelected ? Sage._600.opacity(0.5) : VColor.surfaceBorder, lineWidth: 1)
+                            .stroke(isSelected ? Forest._600.opacity(0.5) : VColor.surfaceBorder, lineWidth: 1)
                     )
             )
         }
@@ -206,11 +206,11 @@ struct APIKeyStepView: View {
                         .fill(primaryButtonDisabled
                             ? adaptiveColor(
                                 light: Stone._900.opacity(0.3),
-                                dark: Sage._600.opacity(0.3)
+                                dark: Forest._600.opacity(0.3)
                             )
                             : adaptiveColor(
                                 light: Stone._900,
-                                dark: Sage._600
+                                dark: Forest._600
                             )
                         )
                 )
@@ -359,6 +359,6 @@ struct APIKeyStepView: View {
     }
     .frame(width: 460, height: 620)
     .onAppear {
-        FeatureFlagManager.shared.setOverride(.userHostedEnabled, enabled: true)
+        MacOSClientFeatureFlagManager.shared.setOverride("user_hosted_enabled", enabled: true)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct HatchingStepView: View {
     @Bindable var state: OnboardingState
 
-    @State private var cliLauncher = CLILauncher()
+    @State private var cliLauncher = AssistantCli()
     @State private var showContent = false
     @State private var eggWobble = false
     @State private var eggCracked = false
@@ -181,7 +181,7 @@ struct HatchingStepView: View {
     private func startHatching() {
         let apiKey = APIKeyManager.getKey() ?? ""
 
-        let config = CLILauncher.RemoteHatchConfig(
+        let config = AssistantCli.RemoteHatchConfig(
             remote: state.cloudProvider,
             gcpProjectId: state.gcpProjectId,
             gcpZone: state.gcpZone,

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -26,8 +26,8 @@ struct OnboardingFlowView: View {
                     .background(
                         RadialGradient(
                             colors: [
-                                adaptiveColor(light: Slate._100, dark: Slate._900),
-                                adaptiveColor(light: Slate._200, dark: Slate._950)
+                                adaptiveColor(light: Moss._100, dark: Moss._900),
+                                adaptiveColor(light: Moss._200, dark: Moss._950)
                             ],
                             center: .center,
                             startRadius: 0,
@@ -42,9 +42,10 @@ struct OnboardingFlowView: View {
                 VStack(spacing: 0) {
                     Spacer()
 
-                    // Persistent evolving avatar — stays in place across step transitions
-                    EvolvingAvatarView(evolutionState: state.avatarEvolutionState, animated: true)
-                        .scaleEffect(0.3)
+                    Image("VellyLogo")
+                        .resizable()
+                        .interpolation(.none)
+                        .aspectRatio(contentMode: .fit)
                         .frame(width: 128, height: 128)
                         .padding(.bottom, VSpacing.xxl)
 
@@ -61,8 +62,6 @@ struct OnboardingFlowView: View {
                                     guard !isAdvancingFromWakeUp else { return }
                                     isAdvancingFromWakeUp = true
                                     state.hasHatched = true
-                                    DeterministicEvolutionEngine.applyMilestone(.hatched, to: state.avatarEvolutionState)
-                                    state.avatarEvolutionState.save()
                                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                                         state.advance()
                                     }
@@ -93,8 +92,8 @@ struct OnboardingFlowView: View {
                 .background(
                     RadialGradient(
                         colors: [
-                            adaptiveColor(light: Stone._100, dark: Slate._900),
-                            adaptiveColor(light: Stone._200, dark: Slate._950)
+                            adaptiveColor(light: Stone._100, dark: Moss._900),
+                            adaptiveColor(light: Stone._200, dark: Moss._950)
                         ],
                         center: .center,
                         startRadius: 0,

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -52,6 +52,7 @@ final class OnboardingState {
     var sshHost: String = ""
     var sshUser: String = ""
     var sshPrivateKey: String = ""
+    var customQRCodeImageData: Data = Data()
     var selectedModel: String = "claude-opus-4-6"
     var isHatching: Bool = false
     var hatchLogLines: [String] = []


### PR DESCRIPTION
## Summary
Fixes all remaining build errors introduced by the onboarding refactor PRs that referenced nonexistent types:

- **APIKeyStepView**: `FeatureFlagManager` → `MacOSClientFeatureFlagManager`, `Sage` → `Forest` color scale
- **HatchingStepView**: `CLILauncher` → `AssistantCli`
- **OnboardingFlowView**: `Slate` → `Moss` color scale, removed `EvolvingAvatarView`/`DeterministicEvolutionEngine` (deleted types)
- **OnboardingState**: Restored `customQRCodeImageData` property (still used by `CloudCredentialsStepView`)

## Test plan
- [ ] `build-macos` CI job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
