### PR TITLE
fix: add pagination, commit status, and failure handling to wait-ci

### DIFF
--- a/.claude/wait-ci
+++ b/.claude/wait-ci
@@ -46,9 +46,10 @@ if [[ -z "$REPO" ]]; then
   exit 1
 fi
 
-# Temp file for capturing stderr separately from JSON stdout
+# Temp files for capturing stderr and paginated API output
 STDERR_FILE=$(mktemp)
-trap 'rm -f "$STDERR_FILE"' EXIT
+CHECKS_RAW_FILE=""
+trap 'rm -f "$STDERR_FILE" "$CHECKS_RAW_FILE"' EXIT
 
 echo "==> Waiting for CI checks on PR #$PR_NUMBER (timeout: ${MAX_WAIT}s)..."
 
@@ -69,13 +70,17 @@ while true; do
     continue
   fi
 
-  # Fetch check runs via GitHub API (works with all gh versions)
-  CHECKS_OUTPUT=""
+  # Fetch check runs via GitHub API with pagination (works with gh 2.32.x+).
+  # --paginate with --jq outputs each page's result separately; we merge them
+  # with jq -s to handle repos with >30 check runs. We use a temp file to
+  # capture the raw paginated output so stderr can be captured independently.
+  CHECKS_RAW_FILE=$(mktemp)  # trap cleans up on exit if interrupted mid-iteration
   CHECKS_RC=0
-  CHECKS_OUTPUT=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --jq '.check_runs | map({name: .name, status: .status, conclusion: .conclusion})' 2>"$STDERR_FILE") || CHECKS_RC=$?
+  gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --paginate --jq '.check_runs | map({name: .name, status: .status, conclusion: .conclusion})' >"$CHECKS_RAW_FILE" 2>"$STDERR_FILE" || CHECKS_RC=$?
 
   if [[ "$CHECKS_RC" -ne 0 ]]; then
     STDERR_CONTENT=$(cat "$STDERR_FILE" 2>/dev/null || true)
+    rm -f "$CHECKS_RAW_FILE"
     echo "Warning: gh api check-runs failed (exit $CHECKS_RC): $STDERR_CONTENT" >&2
     if [[ "$ELAPSED" -ge "$MAX_WAIT" ]]; then
       echo "Timeout: could not retrieve CI checks after ${MAX_WAIT}s on PR #$PR_NUMBER." >&2
@@ -87,7 +92,24 @@ while true; do
     continue
   fi
 
-  CHECKS="$CHECKS_OUTPUT"
+  # Merge paginated results: each page emits a separate JSON array, combine them
+  CHECKS_OUTPUT=$(jq -s 'add // []' "$CHECKS_RAW_FILE")
+  rm -f "$CHECKS_RAW_FILE"
+
+  # Fetch legacy commit status contexts (some CI integrations report via statuses, not check runs)
+  STATUSES_OUTPUT=""
+  STATUSES_RC=0
+  STATUSES_OUTPUT=$(gh api "repos/$REPO/commits/$HEAD_SHA/status" --jq '.statuses | map({name: .context, status: (if .state == "pending" then "pending" else "completed" end), conclusion: (if .state == "success" then "success" elif .state == "pending" then null elif .state == "error" then "failure" else .state end)})' 2>"$STDERR_FILE") || STATUSES_RC=$?
+
+  if [[ "$STATUSES_RC" -ne 0 ]]; then
+    STDERR_CONTENT=$(cat "$STDERR_FILE" 2>/dev/null || true)
+    echo "Warning: gh api commit status failed (exit $STATUSES_RC): $STDERR_CONTENT" >&2
+    # Non-fatal: proceed with check runs only
+    STATUSES_OUTPUT="[]"
+  fi
+
+  # Merge check runs and commit statuses into a single list
+  CHECKS=$(jq -s '.[0] + .[1]' <(echo "$CHECKS_OUTPUT") <(echo "$STATUSES_OUTPUT"))
   TOTAL=$(echo "$CHECKS" | jq 'length')
 
   if [[ "$TOTAL" -eq 0 ]]; then
@@ -111,13 +133,16 @@ while true; do
   # Reset the empty-check tracker once we see real checks.
   SEEN_EMPTY=false
 
-  # Count by status: completed checks have a conclusion, others are pending
+  # Count by status: completed checks have a conclusion, others are pending.
+  # Treat any completed conclusion that is NOT explicitly passing as a failure.
+  # Passing conclusions: success, neutral, skipped.
+  # This catches failure, cancelled, timed_out, action_required, startup_failure, stale, and any future non-passing states.
   PENDING=$(echo "$CHECKS" | jq '[.[] | select(.status != "completed")] | length')
-  FAILED=$(echo "$CHECKS" | jq '[.[] | select(.status == "completed" and (.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out"))] | length')
+  FAILED=$(echo "$CHECKS" | jq '[.[] | select(.status == "completed" and .conclusion != null and (.conclusion != "success" and .conclusion != "neutral" and .conclusion != "skipped"))] | length')
 
   if [[ "$FAILED" -gt 0 ]]; then
     echo "CI checks failed on PR #$PR_NUMBER:" >&2
-    echo "$CHECKS" | jq -r '.[] | select(.status == "completed" and (.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out")) | "  \(.name): \(.conclusion)"' >&2
+    echo "$CHECKS" | jq -r '.[] | select(.status == "completed" and .conclusion != null and (.conclusion != "success" and .conclusion != "neutral" and .conclusion != "skipped")) | "  \(.name): \(.conclusion)"' >&2
     exit 1
   fi
 


### PR DESCRIPTION
Addresses review feedback from PR #10538: adds --paginate for repos with >30 checks, includes commit status contexts in evaluation, and treats all non-passing conclusions as failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
