### PR TITLE
perf(audio): scoped wake word observers + cancellable restart task

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/AlwaysOnAudioMonitor.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/AlwaysOnAudioMonitor.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import Combine
 import Foundation
 import os
 
@@ -6,6 +7,18 @@ private let log = Logger(
     subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant",
     category: "AlwaysOnAudioMonitor"
 )
+
+// KVO-observable UserDefaults properties for scoped wake word settings observation.
+// Using @objc dynamic enables Combine's publisher(for:) key-path KVO without
+// listening to every UserDefaults write app-wide.
+extension UserDefaults {
+    @objc dynamic var wakeWordKeyword: String {
+        return string(forKey: "wakeWordKeyword") ?? "computer"
+    }
+    @objc dynamic var wakeWordEnabled: Bool {
+        return bool(forKey: "wakeWordEnabled")
+    }
+}
 
 /// Always-on audio monitor that manages a `WakeWordEngine` for keyword
 /// detection. The engine owns its own audio pipeline internally.
@@ -26,7 +39,7 @@ final class AlwaysOnAudioMonitor: ObservableObject {
 
     private let engine: WakeWordEngine
     private var configurationChangeObserver: NSObjectProtocol?
-    private var keywordObserver: NSObjectProtocol?
+    private var cancellables = Set<AnyCancellable>()
     /// Tracks the last-observed wakeWordEnabled value so we only react to actual changes,
     /// not unrelated UserDefaults writes (which would restart the engine mid-session).
     private var lastKnownWakeWordEnabled: Bool?
@@ -42,9 +55,6 @@ final class AlwaysOnAudioMonitor: ObservableObject {
 
     deinit {
         if let observer = configurationChangeObserver {
-            NotificationCenter.default.removeObserver(observer)
-        }
-        if let observer = keywordObserver {
             NotificationCenter.default.removeObserver(observer)
         }
         engine.stop()
@@ -102,20 +112,22 @@ final class AlwaysOnAudioMonitor: ObservableObject {
     }
 
     private func observeKeywordChanges() {
-        keywordObserver = NotificationCenter.default.addObserver(
-            forName: UserDefaults.didChangeNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
+        // Scoped KVO observation on the specific key avoids the broad
+        // UserDefaults.didChangeNotification which fires on every write app-wide,
+        // causing high-frequency Task spawning during settings interaction.
+        UserDefaults.standard.publisher(for: \.wakeWordKeyword)
+            .dropFirst()
+            .debounce(for: .milliseconds(100), scheduler: RunLoop.main)
+            .sink { [weak self] newKeyword in
+                self?.engine.updateKeyword(newKeyword)
+            }
+            .store(in: &cancellables)
+
+        UserDefaults.standard.publisher(for: \.wakeWordEnabled)
+            .dropFirst()
+            .debounce(for: .milliseconds(100), scheduler: RunLoop.main)
+            .sink { [weak self] enabled in
                 guard let self else { return }
-
-                // Handle keyword changes
-                let newKeyword = UserDefaults.standard.string(forKey: "wakeWordKeyword") ?? "computer"
-                self.engine.updateKeyword(newKeyword)
-
-                // Handle enabled/disabled toggle — only react when the value actually changes
-                let enabled = UserDefaults.standard.bool(forKey: "wakeWordEnabled")
                 guard enabled != self.lastKnownWakeWordEnabled else { return }
                 self.lastKnownWakeWordEnabled = enabled
 
@@ -127,7 +139,7 @@ final class AlwaysOnAudioMonitor: ObservableObject {
                     self.stopMonitoring()
                 }
             }
-        }
+            .store(in: &cancellables)
     }
 
     private func handleConfigurationChange() {

--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/SpeechWakeWordEngine.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/SpeechWakeWordEngine.swift
@@ -242,10 +242,16 @@ final class SpeechWakeWordEngine: WakeWordEngine {
     }
 
     private func tearDownSession() {
+        // Tap must be removed before stopping the engine — AVAudioEngine retains
+        // input taps internally, so removing after stop can leave a dangling
+        // callback reference and cause a retain cycle in AVAudio's render thread.
+        audioEngine.inputNode.removeTap(onBus: 0)
         if audioEngine.isRunning {
             audioEngine.stop()
         }
-        audioEngine.inputNode.removeTap(onBus: 0)
+        // reset() releases all internal AVAudioEngine resources (nodes, formats,
+        // render graph) that stop() alone does not free.
+        audioEngine.reset()
 
         recognitionRequest?.endAudio()
         recognitionRequest = nil

--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
@@ -27,6 +27,9 @@ final class WakeWordCoordinator: ObservableObject {
 
     private let activationWindow = WakeWordActivationWindow()
     private var stateCancellable: AnyCancellable?
+    /// Stored so it can be cancelled on rapid voice mode toggles, preventing
+    /// stacked restart callbacks from queuing up via the old asyncAfter pattern.
+    private var restartMonitorTask: Task<Void, Never>?
 
     /// Cooldown after activation to prevent re-triggering from leftover audio.
     private var lastActivationTime: Date?
@@ -185,18 +188,24 @@ final class WakeWordCoordinator: ObservableObject {
                             WakeWordFeedback.playDeactivationChime()
                             self.activationWindow.show(state: .listening)
                         }
-                        // Delay to let voice mode's audio engine fully release the mic
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-                            guard let self else { return }
-                            guard self.voiceModeManager.state == .off else { return }
+                        // Cancel any pending restart before scheduling a new one — rapid
+                        // voice mode toggles would otherwise stack up multiple callbacks.
+                        self.restartMonitorTask?.cancel()
+                        self.restartMonitorTask = Task { @MainActor [weak self] in
+                            // Delay to let voice mode's audio engine fully release the mic
+                            try? await Task.sleep(for: .seconds(1))
+                            guard !Task.isCancelled else { return }
+                            guard let self, self.voiceModeManager.state == .off else { return }
                             self.audioMonitor.startMonitoring()
                         }
                     }
                     self.activatedViaWakeWord = false  // always reset, regardless of setting
                 } else if self.audioMonitor.isListening {
                     // Voice mode activated (via button or other path) — stop wake word
-                    // engine so it doesn't compete for the microphone.
+                    // engine so it doesn't compete for the microphone. Also cancel any
+                    // pending restart that hasn't fired yet.
                     log.info("Voice mode activated externally — pausing wake word engine")
+                    self.restartMonitorTask?.cancel()
                     self.audioMonitor.stopMonitoring()
                 }
             }


### PR DESCRIPTION
## Summary
- AlwaysOnAudioMonitor: replace broad `UserDefaults.didChangeNotification` with scoped `publisher(for:)` + 100ms debounce — eliminates high-frequency Task spawning during settings interaction
- WakeWordCoordinator: replace `DispatchQueue.asyncAfter` with stored cancellable `Task` — prevents stacked restart callbacks on rapid voice mode toggles
- WakeWordEngine: verify `removeTap → stop → reset` teardown order to prevent AVAudio internal retain cycles

Part of #10553.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
