### PR TITLE
fix: restore canonical access_request delivery side effects and fix guardian decision bugs

### DIFF
--- a/assistant/src/__tests__/notification-guardian-path.test.ts
+++ b/assistant/src/__tests__/notification-guardian-path.test.ts
@@ -110,8 +110,8 @@ function resetTables(): void {
   const db = getDb();
   db.run('DELETE FROM canonical_guardian_deliveries');
   db.run('DELETE FROM canonical_guardian_requests');
-  db.run('DELETE FROM canonical_guardian_deliveries');
-  db.run('DELETE FROM canonical_guardian_requests');
+  db.run('DELETE FROM guardian_action_deliveries');
+  db.run('DELETE FROM guardian_action_requests');
   db.run('DELETE FROM call_pending_questions');
   db.run('DELETE FROM call_events');
   db.run('DELETE FROM call_sessions');

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -51,6 +51,7 @@ import { mintGrantFromDecision } from './approval-primitive.js';
 import {
   getResolver,
   type ActorContext,
+  type ChannelDeliveryContext,
 } from './guardian-request-resolvers.js';
 
 const log = getLogger('guardian-decision-primitive');
@@ -291,6 +292,8 @@ export interface ApplyCanonicalGuardianDecisionParams {
   actorContext: ActorContext;
   /** Optional user-supplied text (e.g. answer text for pending questions). */
   userText?: string;
+  /** Optional channel delivery context — present when the decision arrived via a channel message. */
+  channelDeliveryContext?: ChannelDeliveryContext;
 }
 
 export type CanonicalDecisionResult =
@@ -315,7 +318,7 @@ export type CanonicalDecisionResult =
 export async function applyCanonicalGuardianDecision(
   params: ApplyCanonicalGuardianDecisionParams,
 ): Promise<CanonicalDecisionResult> {
-  const { requestId, action, actorContext, userText } = params;
+  const { requestId, action, actorContext, userText, channelDeliveryContext } = params;
 
   // 1. Look up the canonical request
   const request = getCanonicalGuardianRequest(requestId);
@@ -406,8 +409,9 @@ export async function applyCanonicalGuardianDecision(
   if (resolver) {
     const resolverResult = await resolver.resolve({
       request: resolved,
-      decision: { action, userText },
+      decision: { action: effectiveAction, userText },
       actor: actorContext,
+      channelDeliveryContext,
     });
 
     if (!resolverResult.ok) {

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -13,8 +13,10 @@
 
 import { answerCall } from '../calls/call-domain.js';
 import type { CanonicalGuardianRequest } from '../memory/canonical-guardian-store.js';
+import { emitNotificationSignal } from '../notifications/emit-signal.js';
 import type { ApprovalAction } from '../runtime/channel-approval-types.js';
 import { createOutboundSession } from '../runtime/channel-guardian-service.js';
+import { deliverChannelReply } from '../runtime/gateway-client.js';
 import * as pendingInteractions from '../runtime/pending-interactions.js';
 import { addRule } from '../permissions/trust-store.js';
 import { getTool } from '../tools/registry.js';
@@ -44,6 +46,18 @@ export interface ResolverDecision {
   userText?: string;
 }
 
+/** Channel delivery context for resolvers that need to send messages. */
+export interface ChannelDeliveryContext {
+  /** URL to POST channel replies to. */
+  replyCallbackUrl: string;
+  /** Chat ID of the guardian receiving the reply. */
+  guardianChatId: string;
+  /** Assistant ID for attribution. */
+  assistantId: string;
+  /** Optional bearer token for authenticated delivery. */
+  bearerToken?: string;
+}
+
 /** Context passed to each resolver after CAS resolution succeeds. */
 export interface ResolverContext {
   /** The canonical request record (already resolved to its terminal status). */
@@ -52,6 +66,8 @@ export interface ResolverContext {
   decision: ResolverDecision;
   /** Actor context for the entity making the decision. */
   actor: ActorContext;
+  /** Optional channel delivery context — present when the decision arrived via a channel message. */
+  channelDeliveryContext?: ChannelDeliveryContext;
 }
 
 /** Discriminated result from a resolver. */
@@ -245,39 +261,89 @@ const pendingQuestionResolver: GuardianRequestResolver = {
  * because canonical requests have no legacy channel_guardian_approval_requests
  * row, making the resolveApprovalRequest step a no-op that returns 'stale'.
  *
- * For deny: the canonical CAS already moved the request to 'denied' status,
- * so no additional side effect is needed.
+ * When a `channelDeliveryContext` is provided (channel path), the resolver
+ * also delivers the verification code to the guardian, notifies the requester,
+ * and emits lifecycle notification signals — mirroring the legacy
+ * handleAccessRequestApproval side effects.
+ *
+ * For deny: notifies the requester and emits denial lifecycle signals when
+ * channelDeliveryContext is available.
  */
 const accessRequestResolver: GuardianRequestResolver = {
   kind: 'access_request',
 
   async resolve(ctx: ResolverContext): Promise<ResolverResult> {
-    const { request, decision } = ctx;
+    const { request, decision, channelDeliveryContext } = ctx;
+    const channel = request.sourceChannel ?? 'unknown';
+    const requesterExternalUserId = request.requesterExternalUserId ?? '';
+    const requesterChatId = request.requesterExternalUserId ?? '';
+    const decidedByExternalUserId = ctx.actor.externalUserId ?? '';
+    const assistantId = channelDeliveryContext?.assistantId ?? 'self';
 
     if (decision.action === 'reject') {
-      // Canonical CAS already set the request to 'denied'. No additional
-      // side effect needed for deny.
       log.info(
-        {
-          event: 'resolver_access_request_denied',
-          requestId: request.id,
-        },
-        'Access request resolver: deny — no additional side effect needed',
+        { event: 'resolver_access_request_denied', requestId: request.id },
+        'Access request resolver: deny',
       );
+
+      // Deliver denial notification and lifecycle signals when channel context is available
+      if (channelDeliveryContext) {
+        try {
+          await deliverChannelReply(channelDeliveryContext.replyCallbackUrl, {
+            chatId: requesterChatId,
+            text: 'Your access request has been denied by the guardian.',
+            assistantId,
+          }, channelDeliveryContext.bearerToken);
+        } catch (err) {
+          log.error({ err, requesterChatId }, 'Failed to notify requester of access request denial');
+        }
+
+        const deniedPayload = {
+          sourceChannel: channel,
+          requesterExternalUserId,
+          requesterChatId,
+          decidedByExternalUserId,
+          decision: 'denied' as const,
+        };
+
+        void emitNotificationSignal({
+          sourceEventName: 'ingress.trusted_contact.guardian_decision',
+          sourceChannel: channel,
+          sourceSessionId: request.conversationId ?? '',
+          assistantId,
+          attentionHints: {
+            requiresAction: false,
+            urgency: 'medium',
+            isAsyncBackground: false,
+            visibleInSourceNow: false,
+          },
+          contextPayload: deniedPayload,
+          dedupeKey: `trusted-contact:guardian-decision:${request.id}`,
+        });
+
+        void emitNotificationSignal({
+          sourceEventName: 'ingress.trusted_contact.denied',
+          sourceChannel: channel,
+          sourceSessionId: request.conversationId ?? '',
+          assistantId,
+          attentionHints: {
+            requiresAction: false,
+            urgency: 'low',
+            isAsyncBackground: false,
+            visibleInSourceNow: false,
+          },
+          contextPayload: deniedPayload,
+          dedupeKey: `trusted-contact:denied:${request.id}`,
+        });
+      }
+
       return { ok: true, applied: true };
     }
 
     // On approve: mint an identity-bound verification session so the
-    // requester can verify their identity. This is the key side effect
-    // that handleAccessRequestDecision used to provide.
-    const channel = request.sourceChannel ?? 'unknown';
-    const requesterExternalUserId = request.requesterExternalUserId ?? '';
-    // For access requests the requesterChatId is typically the same as
-    // requesterExternalUserId (Telegram user ID, phone E.164, etc.).
-    const requesterChatId = request.requesterExternalUserId ?? '';
-
+    // requester can verify their identity.
     const session = createOutboundSession({
-      assistantId: 'self',
+      assistantId,
       channel,
       expectedExternalUserId: requesterExternalUserId,
       expectedChatId: requesterChatId,
@@ -296,6 +362,79 @@ const accessRequestResolver: GuardianRequestResolver = {
       },
       'Access request resolver: minted verification session',
     );
+
+    // Deliver the verification code to the guardian and notify the requester
+    // when channel delivery context is available (channel message path).
+    if (channelDeliveryContext) {
+      let codeDelivered = true;
+
+      // Deliver verification code to guardian
+      try {
+        const codeText = `You approved access for ${requesterExternalUserId}. `
+          + `Give them this verification code: ${session.secret}. `
+          + `The code expires in 10 minutes.`;
+        await deliverChannelReply(channelDeliveryContext.replyCallbackUrl, {
+          chatId: channelDeliveryContext.guardianChatId,
+          text: codeText,
+          assistantId,
+        }, channelDeliveryContext.bearerToken);
+      } catch (err) {
+        log.error(
+          { err, guardianChatId: channelDeliveryContext.guardianChatId },
+          'Failed to deliver verification code to guardian',
+        );
+        codeDelivered = false;
+      }
+
+      // Notify the requester
+      if (codeDelivered) {
+        try {
+          await deliverChannelReply(channelDeliveryContext.replyCallbackUrl, {
+            chatId: requesterChatId,
+            text: 'Your access request has been approved! '
+              + 'Please enter the 6-digit verification code you receive from the guardian.',
+            assistantId,
+          }, channelDeliveryContext.bearerToken);
+        } catch (err) {
+          log.error({ err, requesterChatId }, 'Failed to notify requester of access request approval');
+        }
+      } else {
+        try {
+          await deliverChannelReply(channelDeliveryContext.replyCallbackUrl, {
+            chatId: requesterChatId,
+            text: 'Your access request was approved, but we were unable to '
+              + 'deliver the verification code. Please try again later.',
+            assistantId,
+          }, channelDeliveryContext.bearerToken);
+        } catch (err) {
+          log.error({ err, requesterChatId }, 'Failed to notify requester of delivery failure');
+        }
+      }
+
+      // Emit verification_sent with visibleInSourceNow=true so the notification
+      // pipeline suppresses delivery — the guardian already received the code.
+      if (codeDelivered) {
+        void emitNotificationSignal({
+          sourceEventName: 'ingress.trusted_contact.verification_sent',
+          sourceChannel: channel,
+          sourceSessionId: request.conversationId ?? '',
+          assistantId,
+          attentionHints: {
+            requiresAction: false,
+            urgency: 'low',
+            isAsyncBackground: true,
+            visibleInSourceNow: true,
+          },
+          contextPayload: {
+            sourceChannel: channel,
+            requesterExternalUserId,
+            requesterChatId,
+            verificationSessionId: session.sessionId,
+          },
+          dedupeKey: `trusted-contact:verification-sent:${session.sessionId}`,
+        });
+      }
+    }
 
     return { ok: true, applied: true };
   },

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -27,7 +27,7 @@ import {
   applyCanonicalGuardianDecision,
   type CanonicalDecisionResult,
 } from '../approvals/guardian-decision-primitive.js';
-import type { ActorContext } from '../approvals/guardian-request-resolvers.js';
+import type { ActorContext, ChannelDeliveryContext } from '../approvals/guardian-request-resolvers.js';
 import {
   getCanonicalGuardianRequest,
   getCanonicalGuardianRequestByCode,
@@ -58,6 +58,8 @@ export interface GuardianReplyContext {
   pendingRequestIds?: string[];
   /** Conversation generator for NL classification (injected by daemon). */
   approvalConversationGenerator?: ApprovalConversationGenerator;
+  /** Optional channel delivery context for resolver-driven side effects. */
+  channelDeliveryContext?: ChannelDeliveryContext;
 }
 
 export type GuardianReplyResultType =
@@ -224,7 +226,7 @@ function notConsumed(): GuardianReplyResult {
 export async function routeGuardianReply(
   ctx: GuardianReplyContext,
 ): Promise<GuardianReplyResult> {
-  const { messageText, channel, actor, conversationId, callbackData, approvalConversationGenerator } = ctx;
+  const { messageText, channel, actor, conversationId, callbackData, approvalConversationGenerator, channelDeliveryContext } = ctx;
 
   // ── 1. Deterministic callback parsing (button presses) ──
   // No conversationId scoping here — the guardian's reply comes from a
@@ -234,7 +236,7 @@ export async function routeGuardianReply(
   if (callbackData) {
     const parsed = parseCallbackAction(callbackData);
     if (parsed) {
-      return applyDecision(parsed.requestId, parsed.action, actor);
+      return applyDecision(parsed.requestId, parsed.action, actor, undefined, channelDeliveryContext);
     }
   }
 
@@ -309,7 +311,7 @@ export async function routeGuardianReply(
       // If the text indicates rejection, use reject; otherwise approve_once.
       const action = inferActionFromText(codeResult.remainingText);
 
-      return applyDecision(request.id, action, actor, codeResult.remainingText);
+      return applyDecision(request.id, action, actor, codeResult.remainingText, channelDeliveryContext);
     }
   }
 
@@ -321,25 +323,13 @@ export async function routeGuardianReply(
       return notConsumed();
     }
 
-    // Scope pending requests to the current conversation so disambiguation
-    // only shows requests that can actually be resolved from this thread.
-    // Requests without a conversationId are included as they may be global.
-    const pendingRequests = conversationId
-      ? allPendingRequests.filter(r => !r.conversationId || r.conversationId === conversationId)
-      : allPendingRequests;
-
-    if (pendingRequests.length === 0) {
-      log.info(
-        { event: 'router_nl_no_conversation_requests', conversationId, totalPending: allPendingRequests.length },
-        'No pending requests match the current conversation',
-      );
-      return {
-        decisionApplied: false,
-        consumed: false,
-        type: 'not_consumed',
-        replyText: 'No pending requests in this conversation.',
-      };
-    }
+    // Use all pending requests for the guardian without conversation scoping.
+    // Guardian requests for channel/voice flows are created on the requester's
+    // conversation, not the guardian's reply thread, so filtering by
+    // conversationId would incorrectly drop valid pending requests. Identity-
+    // based filtering in findPendingCanonicalRequests already constrains
+    // results to the correct guardian.
+    const pendingRequests = allPendingRequests;
 
     // Build the conversation context for the NL engine
     const engineContext: ApprovalConversationContext = {
@@ -413,7 +403,7 @@ export async function routeGuardianReply(
       };
     }
 
-    const result = await applyDecision(targetId, decisionAction, actor, messageText);
+    const result = await applyDecision(targetId, decisionAction, actor, messageText, channelDeliveryContext);
 
     // Attach the engine's reply text for stale/expired/identity-mismatch cases,
     // but preserve the explicit failure text when the resolver failed — the engine
@@ -441,12 +431,14 @@ async function applyDecision(
   action: ApprovalAction,
   actor: ActorContext,
   userText?: string,
+  channelDeliveryContext?: ChannelDeliveryContext,
 ): Promise<GuardianReplyResult> {
   const canonicalResult = await applyCanonicalGuardianDecision({
     requestId,
     action,
     actorContext: actor,
     userText,
+    channelDeliveryContext,
   });
 
   if (canonicalResult.applied) {

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -891,6 +891,12 @@ export async function handleChannelInbound(
       conversationId: result.conversationId,
       callbackData: body.callbackData,
       approvalConversationGenerator,
+      channelDeliveryContext: {
+        replyCallbackUrl,
+        guardianChatId: externalChatId,
+        assistantId: canonicalAssistantId,
+        bearerToken,
+      },
     });
 
     if (routerResult.consumed) {

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -504,6 +504,7 @@ final class HTTPTransport {
                     onMessage?(.guardianActionDecisionResponse(GuardianActionDecisionResponseMessage(
                         applied: false,
                         reason: "authentication_failed",
+                        resolverFailureReason: nil,
                         requestId: requestId,
                         userText: nil
                     )))
@@ -515,6 +516,7 @@ final class HTTPTransport {
                     onMessage?(.guardianActionDecisionResponse(GuardianActionDecisionResponseMessage(
                         applied: false,
                         reason: "HTTP \(http.statusCode)",
+                        resolverFailureReason: nil,
                         requestId: requestId,
                         userText: nil
                     )))
@@ -534,6 +536,7 @@ final class HTTPTransport {
             onMessage?(.guardianActionDecisionResponse(GuardianActionDecisionResponseMessage(
                 applied: false,
                 reason: error.localizedDescription,
+                resolverFailureReason: nil,
                 requestId: requestId,
                 userText: nil
             )))

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2979,6 +2979,7 @@ public struct GuardianActionsPendingResponseMessage: Decodable, Sendable {
 public struct GuardianActionDecisionResponseMessage: Decodable, Sendable {
     public let applied: Bool
     public let reason: String?
+    public let resolverFailureReason: String?
     public let requestId: String?
     public let userText: String?
 }


### PR DESCRIPTION
## Summary
- **P1: approve_always downgrade bypass** — The `applyCanonicalGuardianDecision` function correctly downgraded `approve_always` to `approve_once` but then passed the original `action` to the resolver instead of `effectiveAction`, allowing guardians to permanently allowlist tools via `addRule()`.
- **P1: Missing access_request delivery side effects** — The canonical access_request resolver only minted a verification session but never delivered the code to the guardian, notified the requester, or emitted lifecycle signals. Added `ChannelDeliveryContext` threading from `inbound-message-handler` → `routeGuardianReply` → `applyCanonicalGuardianDecision` → resolver, enabling the access_request resolver to mirror legacy `handleAccessRequestApproval` side effects.
- **P1: NL conversation filter bug** — The NL routing path filtered pending canonical requests to the current conversation, but guardian requests for channel/voice flows are created on the requester's conversation (not the guardian's reply thread), causing all NL replies to return `not_consumed`. Removed conversation scoping since identity-based filtering already constrains results.
- **P3: Test duplicate DELETE** — Fixed copy-paste error in `resetTables()` that deleted from `canonical_guardian_*` tables twice instead of also cleaning `guardian_action_*` tables.
- **P3: IPC contract drift** — Added missing `resolverFailureReason` field to Swift `GuardianActionDecisionResponseMessage` struct to match the daemon IPC contract.

## Original prompt
Help address this feedback:
https://github.com/vellum-ai/vellum-assistant/pull/10523#discussion_r2866638681
https://github.com/vellum-ai/vellum-assistant/pull/10523#discussion_r2866640628
https://github.com/vellum-ai/vellum-assistant/pull/10523#discussion_r2866640678

And also:

P1: Canonical access_request approvals appear to have lost user-facing delivery side effects (code/denial notifications).
The canonical resolver now only mints a verification session and returns success, with no direct delivery or notification emission for either approve or deny: guardian-request-resolvers.ts:254.
Inbound guardian replies now short-circuit on canonical router consumption and skip legacy interception/orchestration: inbound-message-handler.ts:871.
The legacy path still contains the full access-request side effects (deliver code to guardian, notify requester, emit lifecycle signals): guardian-approval-interception.ts:913.
I also reproduced: approving a canonical access_request creates a verification challenge but returns no reply text and emits no notification_events in that flow.

P3: IPC contract drift for resolver failure diagnostics.
Daemon IPC contract includes resolverFailureReason: guardian-actions.ts:43, but Swift decode model omits it: IPCMessages.swift:2979.
This is non-blocking, but the client drops detailed failure context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
