### PR TITLE
M1: Identity Canonicalization Primitive + Actor Trust Resolver

### DIFF
--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -1,0 +1,225 @@
+/**
+ * Unified inbound actor trust resolver.
+ *
+ * Produces a single trust-resolved actor context from raw inbound identity
+ * fields. Normalizes sender identity via channel-agnostic canonicalization,
+ * then resolves trust classification by checking guardian bindings and
+ * ingress member records.
+ *
+ * Trust classifications:
+ * - `guardian`: sender matches the active guardian binding for this channel.
+ * - `trusted_contact`: sender is an active ingress member (not the guardian).
+ * - `unknown`: sender has no member record or no identity could be established.
+ *
+ * The legacy `ActorRole` enum (`guardian` / `non-guardian` / `unverified_channel`)
+ * is still required by existing policy gates. The `toLegacyActorRole()` mapper
+ * converts the new trust classification to the legacy enum.
+ */
+
+import type { ChannelId } from '../channels/types.js';
+import { findMember } from '../memory/ingress-member-store.js';
+import type { IngressMember } from '../memory/ingress-member-store.js';
+import { canonicalizeInboundIdentity } from '../util/canonicalize-identity.js';
+import { normalizeAssistantId } from '../util/platform.js';
+import { getGuardianBinding } from './channel-guardian-service.js';
+import type { ActorRole, DenialReason, GuardianContext } from './guardian-context-resolver.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type TrustClass = 'guardian' | 'trusted_contact' | 'unknown';
+
+export interface ActorTrustContext {
+  /** Canonical (normalized) sender identity. Null when identity could not be established. */
+  canonicalSenderId: string | null;
+  /** Guardian binding match, if any, for this (assistantId, channel). */
+  guardianBindingMatch: {
+    guardianExternalUserId: string;
+    guardianDeliveryChatId: string | null;
+  } | null;
+  /** Ingress member record, if any, for this sender. */
+  memberRecord: IngressMember | null;
+  /** Trust classification. */
+  trustClass: TrustClass;
+  /** Assistant-facing metadata for downstream consumption. */
+  actorMetadata: {
+    identifier: string | undefined;
+    displayName: string | undefined;
+    username: string | undefined;
+    channel: ChannelId;
+    trustStatus: TrustClass;
+  };
+  /** Legacy denial reason for backward-compatible unverified_channel paths. */
+  denialReason?: DenialReason;
+}
+
+export interface ResolveActorTrustInput {
+  assistantId: string;
+  sourceChannel: ChannelId;
+  externalChatId: string;
+  senderExternalUserId?: string;
+  senderUsername?: string;
+  senderDisplayName?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the inbound actor's trust context from raw identity fields.
+ *
+ * 1. Canonicalize the sender identity (E.164 for phone channels, trimmed ID otherwise).
+ * 2. Look up the guardian binding for (assistantId, channel).
+ * 3. Compare canonical sender identity to the guardian binding.
+ * 4. Look up the ingress member record using the canonical identity.
+ * 5. Classify: guardian > trusted_contact (active member) > unknown.
+ */
+export function resolveActorTrust(input: ResolveActorTrustInput): ActorTrustContext {
+  const assistantId = normalizeAssistantId(input.assistantId);
+
+  const rawUserId = typeof input.senderExternalUserId === 'string' && input.senderExternalUserId.trim().length > 0
+    ? input.senderExternalUserId.trim()
+    : undefined;
+
+  const senderUsername = typeof input.senderUsername === 'string' && input.senderUsername.trim().length > 0
+    ? input.senderUsername.trim()
+    : undefined;
+
+  const senderDisplayName = typeof input.senderDisplayName === 'string' && input.senderDisplayName.trim().length > 0
+    ? input.senderDisplayName.trim()
+    : undefined;
+
+  // Canonical identity: normalize phone-like channels to E.164.
+  const canonicalSenderId = rawUserId
+    ? canonicalizeInboundIdentity(input.sourceChannel, rawUserId)
+    : null;
+
+  const identifier = senderUsername ? `@${senderUsername}` : canonicalSenderId ?? undefined;
+
+  // No identity at all => unknown
+  if (!canonicalSenderId) {
+    return {
+      canonicalSenderId: null,
+      guardianBindingMatch: null,
+      memberRecord: null,
+      trustClass: 'unknown',
+      actorMetadata: {
+        identifier,
+        displayName: senderDisplayName,
+        username: senderUsername,
+        channel: input.sourceChannel,
+        trustStatus: 'unknown',
+      },
+      denialReason: 'no_identity',
+    };
+  }
+
+  // Guardian binding lookup
+  const binding = getGuardianBinding(assistantId, input.sourceChannel);
+  const guardianBindingMatch = binding
+    ? { guardianExternalUserId: binding.guardianExternalUserId, guardianDeliveryChatId: binding.guardianDeliveryChatId }
+    : null;
+
+  // Check if sender IS the guardian. Compare canonical sender against the
+  // binding's guardian identity (also canonicalize for phone channels to
+  // handle formatting variance in the stored binding).
+  let isGuardian = false;
+  if (binding) {
+    const canonicalGuardianId = canonicalizeInboundIdentity(input.sourceChannel, binding.guardianExternalUserId);
+    isGuardian = canonicalGuardianId === canonicalSenderId;
+  }
+
+  // Ingress member lookup using canonical identity.
+  const memberRecord = findMember({
+    assistantId,
+    sourceChannel: input.sourceChannel,
+    externalUserId: canonicalSenderId,
+    externalChatId: input.externalChatId,
+  });
+
+  // Trust classification
+  let trustClass: TrustClass;
+  if (isGuardian) {
+    trustClass = 'guardian';
+  } else if (memberRecord && memberRecord.status === 'active') {
+    trustClass = 'trusted_contact';
+  } else {
+    trustClass = 'unknown';
+  }
+
+  // Denial reason for legacy compatibility
+  let denialReason: DenialReason | undefined;
+  if (!isGuardian && !binding) {
+    denialReason = 'no_binding';
+  }
+
+  return {
+    canonicalSenderId,
+    guardianBindingMatch,
+    memberRecord,
+    trustClass,
+    actorMetadata: {
+      identifier,
+      displayName: senderDisplayName,
+      username: senderUsername,
+      channel: input.sourceChannel,
+      trustStatus: trustClass,
+    },
+    denialReason,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Legacy compatibility mapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Map the new trust classification to the legacy ActorRole enum used by
+ * existing policy gates. This preserves backward compatibility while the
+ * codebase migrates to the unified trust model.
+ *
+ * Mapping:
+ * - guardian => 'guardian'
+ * - trusted_contact => 'non-guardian' (existing gates treat active members as non-guardian)
+ * - unknown (no_identity) => 'unverified_channel'
+ * - unknown (no_binding) => 'unverified_channel'
+ * - unknown (with binding, not guardian) => 'non-guardian'
+ */
+export function toLegacyActorRole(ctx: ActorTrustContext): ActorRole {
+  if (ctx.trustClass === 'guardian') return 'guardian';
+  if (ctx.trustClass === 'trusted_contact') return 'non-guardian';
+
+  // unknown: distinguish between unverified_channel and non-guardian
+  if (ctx.denialReason === 'no_identity' || ctx.denialReason === 'no_binding') {
+    return 'unverified_channel';
+  }
+
+  // Has a binding, has identity, but not guardian and not a member => non-guardian
+  if (ctx.guardianBindingMatch && ctx.canonicalSenderId) {
+    return 'non-guardian';
+  }
+
+  return 'unverified_channel';
+}
+
+/**
+ * Convert an ActorTrustContext into the legacy GuardianContext shape that
+ * existing route-level code expects. This is a bridge for incremental
+ * migration — new code should consume ActorTrustContext directly.
+ */
+export function toGuardianContextCompat(ctx: ActorTrustContext, externalChatId: string): GuardianContext {
+  const actorRole = toLegacyActorRole(ctx);
+
+  return {
+    actorRole,
+    guardianChatId: ctx.guardianBindingMatch?.guardianDeliveryChatId ??
+      (actorRole === 'guardian' ? externalChatId : undefined),
+    guardianExternalUserId: ctx.guardianBindingMatch?.guardianExternalUserId,
+    requesterIdentifier: ctx.actorMetadata.identifier,
+    requesterExternalUserId: ctx.canonicalSenderId ?? undefined,
+    requesterChatId: externalChatId,
+    denialReason: ctx.denialReason,
+  };
+}

--- a/assistant/src/runtime/guardian-context-resolver.ts
+++ b/assistant/src/runtime/guardian-context-resolver.ts
@@ -4,9 +4,13 @@
  * This module centralizes how we classify an inbound actor as
  * guardian/non-guardian/unverified so every channel path uses the same
  * source-of-truth logic.
+ *
+ * Guardian binding comparisons now use canonicalized identities (E.164 for
+ * phone-like channels) to eliminate formatting-variance mismatches.
  */
 import type { ChannelId } from '../channels/types.js';
 import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
+import { canonicalizeInboundIdentity } from '../util/canonicalize-identity.js';
 import { normalizeAssistantId } from '../util/platform.js';
 import { getGuardianBinding } from './channel-guardian-service.js';
 
@@ -41,18 +45,29 @@ export interface ResolveGuardianContextInput {
  * - active binding exists but sender differs -> non-guardian
  * - no sender identity -> unverified_channel (no_identity)
  * - no binding -> unverified_channel (no_binding)
+ *
+ * Identity comparison is normalization-safe: both the sender ID and the
+ * guardian binding ID are canonicalized for the source channel before
+ * comparison, so formatting differences (e.g. `+1 (555) 123-4567` vs
+ * `+15551234567`) do not cause false non-guardian classifications.
  */
 export function resolveGuardianContext(input: ResolveGuardianContextInput): GuardianContext {
   const assistantId = normalizeAssistantId(input.assistantId);
-  const senderExternalUserId = typeof input.senderExternalUserId === 'string' && input.senderExternalUserId.trim().length > 0
+  const rawUserId = typeof input.senderExternalUserId === 'string' && input.senderExternalUserId.trim().length > 0
     ? input.senderExternalUserId.trim()
     : undefined;
   const senderUsername = typeof input.senderUsername === 'string' && input.senderUsername.trim().length > 0
     ? input.senderUsername.trim()
     : undefined;
-  const requesterIdentifier = senderUsername ? `@${senderUsername}` : senderExternalUserId;
 
-  if (!senderExternalUserId) {
+  // Canonicalize sender identity for normalization-safe comparisons.
+  const canonicalSenderId = rawUserId
+    ? canonicalizeInboundIdentity(input.sourceChannel, rawUserId)
+    : undefined;
+
+  const requesterIdentifier = senderUsername ? `@${senderUsername}` : canonicalSenderId;
+
+  if (!canonicalSenderId) {
     return {
       actorRole: 'unverified_channel',
       denialReason: 'no_identity',
@@ -68,18 +83,25 @@ export function resolveGuardianContext(input: ResolveGuardianContextInput): Guar
       actorRole: 'unverified_channel',
       denialReason: 'no_binding',
       requesterIdentifier,
-      requesterExternalUserId: senderExternalUserId,
+      requesterExternalUserId: canonicalSenderId,
       requesterChatId: input.externalChatId,
     };
   }
 
-  if (binding.guardianExternalUserId === senderExternalUserId) {
+  // Canonicalize the stored guardian identity for the same channel so
+  // phone-format variance in the binding record doesn't cause mismatches.
+  const canonicalGuardianId = canonicalizeInboundIdentity(
+    input.sourceChannel,
+    binding.guardianExternalUserId,
+  );
+
+  if (canonicalGuardianId === canonicalSenderId) {
     return {
       actorRole: 'guardian',
       guardianChatId: binding.guardianDeliveryChatId || input.externalChatId,
       guardianExternalUserId: binding.guardianExternalUserId,
       requesterIdentifier,
-      requesterExternalUserId: senderExternalUserId,
+      requesterExternalUserId: canonicalSenderId,
       requesterChatId: input.externalChatId,
     };
   }
@@ -89,7 +111,7 @@ export function resolveGuardianContext(input: ResolveGuardianContextInput): Guar
     guardianChatId: binding.guardianDeliveryChatId,
     guardianExternalUserId: binding.guardianExternalUserId,
     requesterIdentifier,
-    requesterExternalUserId: senderExternalUserId,
+    requesterExternalUserId: canonicalSenderId,
     requesterChatId: input.externalChatId,
   };
 }

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -892,7 +892,7 @@ export async function handleChannelInbound(
     assistantId: canonicalAssistantId,
     sourceChannel,
     externalChatId,
-    senderExternalUserId: body.senderExternalUserId,
+    senderExternalUserId: rawSenderId ?? body.senderExternalUserId,
     senderUsername: body.senderUsername,
   });
 

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -22,6 +22,7 @@ import * as externalConversationStore from '../../memory/external-conversation-s
 import { findMember, updateLastSeen, upsertMember } from '../../memory/ingress-member-store.js';
 import { emitNotificationSignal } from '../../notifications/emit-signal.js';
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
+import { canonicalizeInboundIdentity } from '../../util/canonicalize-identity.js';
 import { IngressBlockedError } from '../../util/errors.js';
 import { getLogger } from '../../util/logger.js';
 import { readHttpToken } from '../../util/platform.js';
@@ -184,6 +185,14 @@ export async function handleChannelInbound(
     log.debug({ raw: assistantId, canonical: canonicalAssistantId }, 'Canonicalized channel assistant ID');
   }
 
+  // Canonicalize the sender identity so all trust lookups, member matching,
+  // and guardian binding comparisons use a normalized form. Phone-like
+  // channels (sms, voice, whatsapp) are normalized to E.164; non-phone
+  // channels pass through the platform-stable ID unchanged.
+  const canonicalSenderId = body.senderExternalUserId
+    ? canonicalizeInboundIdentity(sourceChannel, body.senderExternalUserId)
+    : null;
+
   // ── Ingress ACL enforcement ──
   // Track the resolved member so the escalate branch can reference it after
   // recordInbound (where we have a conversationId).
@@ -217,11 +226,11 @@ export async function handleChannelInbound(
     sourceMetadata: body.sourceMetadata,
   });
 
-  if (body.senderExternalUserId) {
+  if (canonicalSenderId) {
     resolvedMember = findMember({
       assistantId: canonicalAssistantId,
       sourceChannel,
-      externalUserId: body.senderExternalUserId,
+      externalUserId: canonicalSenderId,
       externalChatId,
     });
 
@@ -282,7 +291,7 @@ export async function handleChannelInbound(
       }
 
       if (denyNonMember) {
-        log.info({ sourceChannel, externalUserId: body.senderExternalUserId }, 'Ingress ACL: no member record, denying');
+        log.info({ sourceChannel, externalUserId: canonicalSenderId }, 'Ingress ACL: no member record, denying');
 
         // Notify the guardian about the access request so they can approve/deny.
         // Only fires when a guardian binding exists and no duplicate pending
@@ -293,7 +302,7 @@ export async function handleChannelInbound(
             canonicalAssistantId,
             sourceChannel,
             externalChatId,
-            senderExternalUserId: body.senderExternalUserId,
+            senderExternalUserId: canonicalSenderId ?? body.senderExternalUserId,
             senderName: body.senderName,
             senderUsername: body.senderUsername,
           });
@@ -379,7 +388,7 @@ export async function handleChannelInbound(
                 canonicalAssistantId,
                 sourceChannel,
                 externalChatId,
-                senderExternalUserId: body.senderExternalUserId,
+                senderExternalUserId: canonicalSenderId ?? body.senderExternalUserId,
                 senderName: body.senderName,
                 senderUsername: body.senderUsername,
               });
@@ -552,7 +561,7 @@ export async function handleChannelInbound(
       conversationId: result.conversationId,
       sourceChannel,
       externalChatId,
-      externalUserId: body.senderExternalUserId ?? null,
+      externalUserId: canonicalSenderId ?? body.senderExternalUserId ?? null,
       displayName: body.senderName ?? null,
       username: body.senderUsername ?? null,
     });
@@ -587,7 +596,7 @@ export async function handleChannelInbound(
       sourceType: 'channel',
       sourceChannel,
       conversationId: result.conversationId,
-      requesterExternalUserId: body.senderExternalUserId ?? undefined,
+      requesterExternalUserId: canonicalSenderId ?? body.senderExternalUserId ?? undefined,
       guardianExternalUserId: binding.guardianExternalUserId,
       toolName: 'ingress_message',
       questionText: 'Ingress policy requires guardian approval',
@@ -745,7 +754,7 @@ export async function handleChannelInbound(
       upsertMember({
         assistantId: canonicalAssistantId,
         sourceChannel,
-        externalUserId: body.senderExternalUserId,
+        externalUserId: canonicalSenderId ?? body.senderExternalUserId,
         externalChatId,
         status: 'active',
         policy: 'allow',
@@ -756,7 +765,7 @@ export async function handleChannelInbound(
       const verifyLogLabel = verifyResult.verificationType === 'trusted_contact'
         ? 'Trusted contact verified'
         : 'Guardian verified';
-      log.info({ sourceChannel, externalUserId: body.senderExternalUserId, verificationType: verifyResult.verificationType }, `${verifyLogLabel}: auto-upserted ingress member`);
+      log.info({ sourceChannel, externalUserId: canonicalSenderId, verificationType: verifyResult.verificationType }, `${verifyLogLabel}: auto-upserted ingress member`);
 
       // Emit activated signal when a trusted contact completes verification.
       // Member record is persisted above before this event fires, satisfying
@@ -775,12 +784,12 @@ export async function handleChannelInbound(
           },
           contextPayload: {
             sourceChannel,
-            externalUserId: body.senderExternalUserId,
+            externalUserId: canonicalSenderId ?? body.senderExternalUserId,
             externalChatId,
             senderName: body.senderName ?? null,
             senderUsername: body.senderUsername ?? null,
           },
-          dedupeKey: `trusted-contact:activated:${canonicalAssistantId}:${sourceChannel}:${body.senderExternalUserId}`,
+          dedupeKey: `trusted-contact:activated:${canonicalAssistantId}:${sourceChannel}:${canonicalSenderId ?? body.senderExternalUserId}`,
         });
       }
     }

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -185,13 +185,27 @@ export async function handleChannelInbound(
     log.debug({ raw: assistantId, canonical: canonicalAssistantId }, 'Canonicalized channel assistant ID');
   }
 
+  // Coerce senderExternalUserId to a string at the boundary — the field
+  // comes from unvalidated JSON and may be a number, object, or other
+  // non-string type. Non-string truthy values would throw inside
+  // canonicalizeInboundIdentity when it calls .trim().
+  const rawSenderId = body.senderExternalUserId != null
+    ? String(body.senderExternalUserId)
+    : undefined;
+
   // Canonicalize the sender identity so all trust lookups, member matching,
   // and guardian binding comparisons use a normalized form. Phone-like
   // channels (sms, voice, whatsapp) are normalized to E.164; non-phone
   // channels pass through the platform-stable ID unchanged.
-  const canonicalSenderId = body.senderExternalUserId
-    ? canonicalizeInboundIdentity(sourceChannel, body.senderExternalUserId)
+  const canonicalSenderId = rawSenderId
+    ? canonicalizeInboundIdentity(sourceChannel, rawSenderId)
     : null;
+
+  // Track whether the original payload included a sender identity. A
+  // whitespace-only senderExternalUserId canonicalizes to null but still
+  // represents an explicit (malformed) identity claim that must enter the
+  // ACL deny path rather than bypassing it.
+  const hasSenderIdentityClaim = rawSenderId !== undefined;
 
   // ── Ingress ACL enforcement ──
   // Track the resolved member so the escalate branch can reference it after
@@ -226,13 +240,18 @@ export async function handleChannelInbound(
     sourceMetadata: body.sourceMetadata,
   });
 
-  if (canonicalSenderId) {
-    resolvedMember = findMember({
-      assistantId: canonicalAssistantId,
-      sourceChannel,
-      externalUserId: canonicalSenderId,
-      externalChatId,
-    });
+  if (canonicalSenderId || hasSenderIdentityClaim) {
+    // Only perform member lookup when we have a usable canonical ID.
+    // Whitespace-only senders (hasSenderIdentityClaim=true but
+    // canonicalSenderId=null) skip the lookup and fall into the deny path.
+    if (canonicalSenderId) {
+      resolvedMember = findMember({
+        assistantId: canonicalAssistantId,
+        sourceChannel,
+        externalUserId: canonicalSenderId,
+        externalChatId,
+      });
+    }
 
     if (!resolvedMember) {
       // Determine whether a verification-code bypass is warranted: only allow
@@ -279,7 +298,7 @@ export async function handleChannelInbound(
           sourceChannel,
           externalChatId,
           externalMessageId,
-          senderExternalUserId: body.senderExternalUserId,
+          senderExternalUserId: canonicalSenderId ?? body.senderExternalUserId,
           senderName: body.senderName,
           senderUsername: body.senderUsername,
           replyCallbackUrl: body.replyCallbackUrl,
@@ -364,7 +383,7 @@ export async function handleChannelInbound(
             sourceChannel,
             externalChatId,
             externalMessageId,
-            senderExternalUserId: body.senderExternalUserId,
+            senderExternalUserId: canonicalSenderId ?? body.senderExternalUserId,
             senderName: body.senderName,
             senderUsername: body.senderUsername,
             replyCallbackUrl: body.replyCallbackUrl,

--- a/assistant/src/util/canonicalize-identity.ts
+++ b/assistant/src/util/canonicalize-identity.ts
@@ -1,0 +1,52 @@
+/**
+ * Channel-agnostic inbound identity canonicalization.
+ *
+ * Normalizes raw sender identifiers into a stable canonical form so that
+ * trust lookups, member matching, and guardian binding comparisons are
+ * immune to formatting variance across channels.
+ *
+ * Phone-like channels (sms, voice, whatsapp) normalize to E.164 using the
+ * existing phone utilities. Non-phone channels (telegram, slack, etc.)
+ * pass through the platform-stable ID as-is after whitespace trimming.
+ */
+
+import type { ChannelId } from '../channels/types.js';
+import { normalizePhoneNumber } from './phone.js';
+
+/** Channels whose raw sender IDs are phone numbers. */
+const PHONE_CHANNELS: ReadonlySet<ChannelId> = new Set(['sms', 'voice', 'whatsapp']);
+
+/**
+ * Canonicalize a raw inbound sender identity for the given channel.
+ *
+ * - For phone-like channels: attempts E.164 normalization. Returns the
+ *   normalized E.164 string on success, or the trimmed raw ID if
+ *   normalization fails (defensive: don't discard an identity just because
+ *   it doesn't parse as a phone number).
+ * - For non-phone channels: returns the trimmed raw ID unchanged (these
+ *   platforms provide stable, unique identifiers that don't need normalization).
+ *
+ * Returns `null` only when `rawId` is empty/whitespace-only.
+ */
+export function canonicalizeInboundIdentity(channel: ChannelId, rawId: string): string | null {
+  const trimmed = rawId.trim();
+  if (trimmed.length === 0) return null;
+
+  if (PHONE_CHANNELS.has(channel)) {
+    const e164 = normalizePhoneNumber(trimmed);
+    // Defensive: if normalization fails, preserve the raw ID so downstream
+    // lookups don't silently lose the identity.
+    return e164 ?? trimmed;
+  }
+
+  return trimmed;
+}
+
+/**
+ * Check whether a channel uses phone-number-based identity.
+ * Useful for call sites that need to know whether E.164 normalization
+ * applies without re-importing the channel set.
+ */
+export function isPhoneChannel(channel: ChannelId): boolean {
+  return PHONE_CHANNELS.has(channel);
+}


### PR DESCRIPTION
Part of #10577. Introduces channel-agnostic inbound identity normalization (E.164 for phone-like channels) and a unified actor trust resolver that returns canonical identity, trust classification (guardian/trusted_contact/unknown), and actor metadata. Updates inbound message handler and ingress member store to use normalized identity for lookups.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
