### PR TITLE
Fix canonical guardian replies in shared call threads

### DIFF
--- a/assistant/src/__tests__/canonical-guardian-store.test.ts
+++ b/assistant/src/__tests__/canonical-guardian-store.test.ts
@@ -31,6 +31,7 @@ import {
   getCanonicalGuardianRequest,
   listCanonicalGuardianDeliveries,
   listCanonicalGuardianRequests,
+  listPendingCanonicalGuardianRequestsByDestinationConversation,
   resolveCanonicalGuardianRequest,
   updateCanonicalGuardianDelivery,
   updateCanonicalGuardianRequest,
@@ -413,7 +414,7 @@ describe('canonical-guardian-store', () => {
       destinationChannel: 'telegram',
       destinationChatId: 'chat-123',
     });
-    const d2 = createCanonicalGuardianDelivery({
+    createCanonicalGuardianDelivery({
       requestId: req.id,
       destinationChannel: 'sms',
       destinationChatId: 'chat-456',
@@ -438,6 +439,58 @@ describe('canonical-guardian-store', () => {
 
     const deliveries = listCanonicalGuardianDeliveries(req.id);
     expect(deliveries).toHaveLength(0);
+  });
+
+  test('lists pending requests by destination conversation', () => {
+    const pendingReq = createCanonicalGuardianRequest({
+      kind: 'pending_question',
+      sourceType: 'voice',
+    });
+    const resolvedReq = createCanonicalGuardianRequest({
+      kind: 'pending_question',
+      sourceType: 'voice',
+    });
+    updateCanonicalGuardianRequest(resolvedReq.id, { status: 'approved' });
+
+    createCanonicalGuardianDelivery({
+      requestId: pendingReq.id,
+      destinationChannel: 'vellum',
+      destinationConversationId: 'conv-guardian-1',
+    });
+    createCanonicalGuardianDelivery({
+      requestId: resolvedReq.id,
+      destinationChannel: 'vellum',
+      destinationConversationId: 'conv-guardian-1',
+    });
+
+    const pending = listPendingCanonicalGuardianRequestsByDestinationConversation(
+      'conv-guardian-1',
+      'vellum',
+    );
+    expect(pending).toHaveLength(1);
+    expect(pending[0].id).toBe(pendingReq.id);
+  });
+
+  test('destination conversation lookup deduplicates request IDs', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'pending_question',
+      sourceType: 'voice',
+    });
+
+    createCanonicalGuardianDelivery({
+      requestId: req.id,
+      destinationChannel: 'vellum',
+      destinationConversationId: 'conv-guardian-2',
+    });
+    createCanonicalGuardianDelivery({
+      requestId: req.id,
+      destinationChannel: 'telegram',
+      destinationConversationId: 'conv-guardian-2',
+    });
+
+    const pending = listPendingCanonicalGuardianRequestsByDestinationConversation('conv-guardian-2');
+    expect(pending).toHaveLength(1);
+    expect(pending[0].id).toBe(req.id);
   });
 
   test('updates delivery status', () => {

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -198,6 +198,13 @@ describe('routing invariant: all decision paths reference applyCanonicalGuardian
     });
   }
 
+  test('daemon/session-process.ts no longer references legacy guardian-action interception', () => {
+    const fullPath = join(srcRoot, 'daemon/session-process.ts');
+    const source = readFileSync(fullPath, 'utf-8');
+    expect(source).not.toContain("../memory/guardian-action-store.js");
+    expect(source).not.toContain('getPendingDeliveriesByConversation');
+  });
+
   test('guardian-reply-router routes all decisions through applyCanonicalGuardianDecision', () => {
     const fullPath = join(srcRoot, 'runtime/guardian-reply-router.ts');
     const source = readFileSync(fullPath, 'utf-8');

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -550,6 +550,32 @@ describe('routing invariant: disambiguation stays fail-closed', () => {
     expect(resolved!.status).toBe('approved');
   });
 
+  test('single hinted pending request does not auto-approve broad acknowledgment text', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      requestCode: 'GGG777',
+      toolName: 'shell',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await routeGuardianReply(replyCtx({
+      messageText: 'ok, what is this for?',
+      conversationId: 'conv-guardian-thread',
+      pendingRequestIds: [req.id],
+      approvalConversationGenerator: undefined,
+    }));
+
+    expect(result.consumed).toBe(false);
+    expect(result.type).toBe('not_consumed');
+    expect(result.decisionApplied).toBe(false);
+
+    const unchanged = getCanonicalGuardianRequest(req.id);
+    expect(unchanged!.status).toBe('pending');
+  });
+
   test('multiple hinted pending requests with plain-text approve returns disambiguation', async () => {
     const req1 = createCanonicalGuardianRequest({
       kind: 'tool_approval',

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -46,22 +46,22 @@ mock.module('../util/logger.js', () => ({
   truncateForLog: (value: string) => value,
 }));
 
-import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import {
+  applyCanonicalGuardianDecision,
+} from '../approvals/guardian-decision-primitive.js';
+import type { ActorContext } from '../approvals/guardian-request-resolvers.js';
+import {
+  getRegisteredKinds,
+  getResolver,
+} from '../approvals/guardian-request-resolvers.js';
 import {
   createCanonicalGuardianRequest,
   getCanonicalGuardianRequest,
 } from '../memory/canonical-guardian-store.js';
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
 import {
-  applyCanonicalGuardianDecision,
-} from '../approvals/guardian-decision-primitive.js';
-import {
-  getResolver,
-  getRegisteredKinds,
-} from '../approvals/guardian-request-resolvers.js';
-import type { ActorContext } from '../approvals/guardian-request-resolvers.js';
-import {
-  routeGuardianReply,
   type GuardianReplyContext,
+  routeGuardianReply,
 } from '../runtime/guardian-reply-router.js';
 import * as pendingInteractions from '../runtime/pending-interactions.js';
 
@@ -276,7 +276,7 @@ describe('routing invariant: identity checks enforced before decisions', () => {
   });
 
   test('identity mismatch on code-only message blocks detail leakage', async () => {
-    const req = createCanonicalGuardianRequest({
+    createCanonicalGuardianRequest({
       kind: 'tool_approval',
       sourceType: 'channel',
       conversationId: 'conv-1',
@@ -515,6 +515,73 @@ describe('routing invariant: code-only messages return clarification', () => {
 
 describe('routing invariant: disambiguation stays fail-closed', () => {
   beforeEach(() => resetTables());
+
+  test('single hinted pending request accepts explicit plain-text approve without NL generator', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      requestCode: 'DDD444',
+      toolName: 'shell',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    registerPendingToolApprovalInteraction(req.id, 'conv-1', 'shell');
+
+    const result = await routeGuardianReply(replyCtx({
+      messageText: 'approve',
+      conversationId: 'conv-guardian-thread',
+      pendingRequestIds: [req.id],
+      approvalConversationGenerator: undefined,
+    }));
+
+    expect(result.consumed).toBe(true);
+    expect(result.type).toBe('canonical_decision_applied');
+    expect(result.decisionApplied).toBe(true);
+
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe('approved');
+  });
+
+  test('multiple hinted pending requests with plain-text approve returns disambiguation', async () => {
+    const req1 = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      requestCode: 'EEE555',
+      toolName: 'shell',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const req2 = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      requestCode: 'FFF666',
+      toolName: 'file_write',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await routeGuardianReply(replyCtx({
+      messageText: 'approve',
+      conversationId: 'conv-guardian-thread',
+      pendingRequestIds: [req1.id, req2.id],
+      approvalConversationGenerator: undefined,
+    }));
+
+    expect(result.consumed).toBe(true);
+    expect(result.type).toBe('disambiguation_needed');
+    expect(result.decisionApplied).toBe(false);
+    expect(result.replyText).toContain('EEE555');
+    expect(result.replyText).toContain('FFF666');
+
+    const r1 = getCanonicalGuardianRequest(req1.id);
+    const r2 = getCanonicalGuardianRequest(req2.id);
+    expect(r1!.status).toBe('pending');
+    expect(r2!.status).toBe('pending');
+  });
 
   test('multiple pending requests without target return disambiguation (not auto-resolve)', async () => {
     // Create two pending requests for the same guardian

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -205,6 +205,13 @@ describe('routing invariant: all decision paths reference applyCanonicalGuardian
     expect(source).not.toContain('getPendingDeliveriesByConversation');
   });
 
+  test('daemon/session-process.ts seeds router hints from delivery and conversation scopes', () => {
+    const fullPath = join(srcRoot, 'daemon/session-process.ts');
+    const source = readFileSync(fullPath, 'utf-8');
+    expect(source).toContain('listPendingCanonicalGuardianRequestsByDestinationConversation');
+    expect(source).toContain('listCanonicalGuardianRequests');
+  });
+
   test('guardian-reply-router routes all decisions through applyCanonicalGuardianDecision', () => {
     const fullPath = join(srcRoot, 'runtime/guardian-reply-router.ts');
     const source = readFileSync(fullPath, 'utf-8');
@@ -574,6 +581,30 @@ describe('routing invariant: disambiguation stays fail-closed', () => {
 
     const unchanged = getCanonicalGuardianRequest(req.id);
     expect(unchanged!.status).toBe('pending');
+  });
+
+  test('explicit empty pendingRequestIds hint stays fail-closed for trusted actors', async () => {
+    createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      conversationId: 'conv-other',
+      guardianExternalUserId: 'guardian-1',
+      requestCode: 'HHH888',
+      toolName: 'shell',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await routeGuardianReply(replyCtx({
+      messageText: 'approve',
+      actor: trustedActor(),
+      conversationId: 'conv-unrelated',
+      pendingRequestIds: [],
+      approvalConversationGenerator: undefined,
+    }));
+
+    expect(result.consumed).toBe(false);
+    expect(result.type).toBe('not_consumed');
+    expect(result.decisionApplied).toBe(false);
   });
 
   test('multiple hinted pending requests with plain-text approve returns disambiguation', async () => {

--- a/assistant/src/__tests__/notification-decision-fallback.test.ts
+++ b/assistant/src/__tests__/notification-decision-fallback.test.ts
@@ -5,7 +5,7 @@
  * decision-model call is unavailable.
  */
 
-import { describe, expect, mock, test } from 'bun:test';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
 mock.module('../channels/config.js', () => ({
   getDeliverableChannels: () => ['vellum', 'telegram', 'sms'],
@@ -32,13 +32,16 @@ mock.module('../notifications/thread-candidates.js', () => ({
   serializeCandidatesForPrompt: () => undefined,
 }));
 
+let configuredProvider: { sendMessage: () => Promise<unknown> } | null = null;
+let extractedToolUse: unknown = null;
+
 mock.module('../providers/provider-send-message.js', () => ({
-  getConfiguredProvider: () => null,
+  getConfiguredProvider: () => configuredProvider,
   createTimeout: () => ({
     signal: new AbortController().signal,
     cleanup: () => {},
   }),
-  extractToolUse: () => null,
+  extractToolUse: () => extractedToolUse,
   userMessage: (text: string) => ({ role: 'user', content: text }),
 }));
 
@@ -75,6 +78,11 @@ function makeSignal(overrides?: Partial<NotificationSignal>): NotificationSignal
 }
 
 describe('notification decision fallback copy', () => {
+  beforeEach(() => {
+    configuredProvider = null;
+    extractedToolUse = null;
+  });
+
   test('uses human-friendly template copy for guardian.question', async () => {
     const signal = makeSignal();
     const decision = await evaluateSignal(signal, ['vellum'] as NotificationChannel[]);
@@ -99,5 +107,40 @@ describe('notification decision fallback copy', () => {
     expect(decision.renderedCopy.vellum?.body).toContain('A1B2C3');
     expect(decision.renderedCopy.vellum?.body).toContain('approve');
     expect(decision.renderedCopy.vellum?.body).toContain('reject');
+  });
+
+  test('enforcement appends explicit approve/reject instructions when LLM copy only mentions request code', async () => {
+    configuredProvider = {
+      sendMessage: async () => ({ content: [] }),
+    };
+    extractedToolUse = {
+      name: 'record_notification_decision',
+      input: {
+        shouldNotify: true,
+        selectedChannels: ['vellum'],
+        reasoningSummary: 'LLM decision',
+        renderedCopy: {
+          vellum: {
+            title: 'Guardian Question',
+            body: 'Use reference code A1B2C3 for this request.',
+          },
+        },
+        dedupeKey: 'guardian-question-test',
+        confidence: 0.9,
+      },
+    };
+
+    const signal = makeSignal({
+      contextPayload: {
+        questionText: 'What is the gate code?',
+        requestCode: 'A1B2C3',
+      },
+    });
+
+    const decision = await evaluateSignal(signal, ['vellum'] as NotificationChannel[]);
+
+    expect(decision.fallbackUsed).toBe(false);
+    expect(decision.renderedCopy.vellum?.body).toContain('"A1B2C3 approve"');
+    expect(decision.renderedCopy.vellum?.body).toContain('"A1B2C3 reject"');
   });
 });

--- a/assistant/src/__tests__/notification-decision-fallback.test.ts
+++ b/assistant/src/__tests__/notification-decision-fallback.test.ts
@@ -85,4 +85,19 @@ describe('notification decision fallback copy', () => {
     expect(decision.renderedCopy.vellum?.title).not.toBe('guardian.question');
     expect(decision.renderedCopy.vellum?.body).not.toContain('Action required: guardian.question');
   });
+
+  test('enforces request-code instructions for guardian.question when requestCode exists', async () => {
+    const signal = makeSignal({
+      contextPayload: {
+        questionText: 'What is the gate code?',
+        requestCode: 'A1B2C3',
+      },
+    });
+    const decision = await evaluateSignal(signal, ['vellum'] as NotificationChannel[]);
+
+    expect(decision.fallbackUsed).toBe(true);
+    expect(decision.renderedCopy.vellum?.body).toContain('A1B2C3');
+    expect(decision.renderedCopy.vellum?.body).toContain('approve');
+    expect(decision.renderedCopy.vellum?.body).toContain('reject');
+  });
 });

--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -55,6 +55,23 @@ describe('notification decision strategy', () => {
       expect(copy.vellum!.body).toContain('What is the gate code?');
     });
 
+    test('guardian.question template includes request-code instructions when present', () => {
+      const signal = makeSignal({
+        sourceEventName: 'guardian.question',
+        contextPayload: {
+          questionText: 'What is the gate code?',
+          requestCode: 'A1B2C3',
+        },
+      });
+
+      const copy = composeFallbackCopy(signal, channels);
+      expect(copy.vellum).toBeDefined();
+      expect(copy.vellum!.body).toContain('A1B2C3');
+      expect(copy.vellum!.body).toContain('approve');
+      expect(copy.vellum!.body).toContain('reject');
+      expect(copy.telegram!.deliveryText).toContain('A1B2C3');
+    });
+
     test('reminder.fired template uses message from payload', () => {
       const signal = makeSignal({
         sourceEventName: 'reminder.fired',

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -59,7 +59,6 @@ import type { ServerMessage } from './ipc-protocol.js';
 import { initializeProvidersAndTools, registerMessagingProviders,registerWatcherProviders } from './providers-setup.js';
 import { seedInterfaceFiles } from './seed-files.js';
 import { DaemonServer } from './server.js';
-import { setApprovalConversationGenerator, setGuardianActionCopyGenerator, setGuardianFollowUpConversationGenerator } from './session-process.js';
 import { initSlashPairingContext } from './session-slash.js';
 import { installShutdownHandlers } from './shutdown-handlers.js';
 
@@ -320,21 +319,9 @@ export async function runDaemon(): Promise<void> {
         server.persistAndProcessMessage(conversationId, content, attachmentIds, options, sourceChannel, sourceInterface),
       interfacesDir: getInterfacesDir(),
       approvalCopyGenerator: createApprovalCopyGenerator(),
-      approvalConversationGenerator: (() => {
-        const gen = createApprovalConversationGenerator();
-        setApprovalConversationGenerator(gen);
-        return gen;
-      })(),
-      guardianActionCopyGenerator: (() => {
-        const gen = createGuardianActionCopyGenerator();
-        setGuardianActionCopyGenerator(gen);
-        return gen;
-      })(),
-      guardianFollowUpConversationGenerator: (() => {
-        const gen = createGuardianFollowUpConversationGenerator();
-        setGuardianFollowUpConversationGenerator(gen);
-        return gen;
-      })(),
+      approvalConversationGenerator: createApprovalConversationGenerator(),
+      guardianActionCopyGenerator: createGuardianActionCopyGenerator(),
+      guardianFollowUpConversationGenerator: createGuardianFollowUpConversationGenerator(),
       sendMessageDeps: {
         getOrCreateSession: (conversationId) =>
           server.getSessionForMessages(conversationId),

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -13,6 +13,7 @@ import { getCallSession } from '../calls/call-store.js';
 import type { TurnChannelContext, TurnInterfaceContext } from '../channels/types.js';
 import { parseChannelId, parseInterfaceId } from '../channels/types.js';
 import { getConfig } from '../config/loader.js';
+import { listPendingCanonicalGuardianRequestsByDestinationConversation } from '../memory/canonical-guardian-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import {
@@ -34,8 +35,8 @@ import { processGuardianFollowUpTurn } from '../runtime/guardian-action-conversa
 import { executeFollowupAction } from '../runtime/guardian-action-followup-executor.js';
 import { tryMintGuardianActionGrant } from '../runtime/guardian-action-grant-minter.js';
 import { composeGuardianActionMessageGenerative } from '../runtime/guardian-action-message-composer.js';
-import type { ApprovalConversationGenerator, GuardianActionCopyGenerator, GuardianFollowUpConversationGenerator } from '../runtime/http-types.js';
 import { routeGuardianReply } from '../runtime/guardian-reply-router.js';
+import type { ApprovalConversationGenerator, GuardianActionCopyGenerator, GuardianFollowUpConversationGenerator } from '../runtime/http-types.js';
 import { getLogger } from '../util/logger.js';
 import { resolveGuardianInviteIntent } from './guardian-invite-intent.js';
 import { resolveGuardianVerificationIntent } from './guardian-verification-intent.js';
@@ -405,15 +406,20 @@ export async function processMessage(
   await session.ensureActorScopedHistory();
   session.currentActiveSurfaceId = activeSurfaceId;
   session.currentPage = currentPage;
+  const trimmedContent = content.trim();
+  const canonicalPendingRequestsForConversation = trimmedContent.length > 0
+    ? listPendingCanonicalGuardianRequestsByDestinationConversation(session.conversationId, 'vellum')
+    : [];
+  const canonicalPendingRequestIdsForConversation = canonicalPendingRequestsForConversation.map((request) => request.id);
 
   // ── Canonical guardian reply router (desktop/session path) ──
   // Attempts to route inbound messages through the canonical decision pipeline
   // before falling through to the legacy guardian action interception. Handles
   // deterministic request code prefixes and NL classification, with all
   // decisions flowing through applyCanonicalGuardianDecision.
-  if (content.trim().length > 0) {
+  if (trimmedContent.length > 0) {
     const routerResult = await routeGuardianReply({
-      messageText: content.trim(),
+      messageText: trimmedContent,
       channel: 'vellum',
       actor: {
         externalUserId: undefined,
@@ -421,6 +427,7 @@ export async function processMessage(
         isTrusted: true,
       },
       conversationId: session.conversationId,
+      pendingRequestIds: canonicalPendingRequestIdsForConversation,
       // Desktop path: disable NL classification to avoid consuming non-decision
       // messages while a tool confirmation is pending. Deterministic code-prefix
       // and callback parsing remain active.
@@ -470,11 +477,14 @@ export async function processMessage(
   }
 
   // ── Unified guardian action answer interception (mac channel) ──
+  // Skip legacy interception whenever canonical pending requests are already
+  // bound to this conversation. This prevents stale legacy rows from
+  // disambiguating replies intended for the canonical request.
   // Deterministic priority matching: pending → follow-up → expired.
   // When the guardian includes an explicit request code, match it across all
   // states in priority order. When only one actionable request exists,
   // auto-match without requiring a code prefix.
-  {
+  if (canonicalPendingRequestIdsForConversation.length === 0) {
     const allPending = getPendingDeliveriesByConversation(session.conversationId);
     const allFollowup = getFollowupDeliveriesByConversation(session.conversationId);
     const allExpired = getExpiredDeliveriesByConversation(session.conversationId);
@@ -640,9 +650,9 @@ export async function processMessage(
 
           let stateApplied = true;
           if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
-            stateApplied = progressFollowupState(request.id, 'dispatching', turnResult.disposition) !== null;
+            stateApplied = Boolean(progressFollowupState(request.id, 'dispatching', turnResult.disposition));
           } else if (turnResult.disposition === 'decline') {
-            stateApplied = finalizeFollowup(request.id, 'declined') !== null;
+            stateApplied = Boolean(finalizeFollowup(request.id, 'declined'));
           }
 
           if (!stateApplied) {

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -7,36 +7,16 @@
  */
 
 import { createAssistantMessage,createUserMessage } from '../agent/message-types.js';
-import { answerCall } from '../calls/call-domain.js';
-import { isTerminalState } from '../calls/call-state-machine.js';
-import { getCallSession } from '../calls/call-store.js';
 import type { TurnChannelContext, TurnInterfaceContext } from '../channels/types.js';
 import { parseChannelId, parseInterfaceId } from '../channels/types.js';
 import { getConfig } from '../config/loader.js';
 import { listPendingCanonicalGuardianRequestsByDestinationConversation } from '../memory/canonical-guardian-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
-import {
-  finalizeFollowup,
-  getDeliveriesByRequestId,
-  getExpiredDeliveriesByConversation,
-  getFollowupDeliveriesByConversation,
-  getGuardianActionRequest,
-  getPendingDeliveriesByConversation,
-  getPendingRequestByCallSessionId,
-  progressFollowupState,
-  resolveGuardianActionRequest,
-  startFollowupFromExpiredRequest,
-} from '../memory/guardian-action-store.js';
 import { extractPreferences } from '../notifications/preference-extractor.js';
 import { createPreference } from '../notifications/preferences-store.js';
 import type { Message } from '../providers/types.js';
-import { processGuardianFollowUpTurn } from '../runtime/guardian-action-conversation-turn.js';
-import { executeFollowupAction } from '../runtime/guardian-action-followup-executor.js';
-import { tryMintGuardianActionGrant } from '../runtime/guardian-action-grant-minter.js';
-import { composeGuardianActionMessageGenerative } from '../runtime/guardian-action-message-composer.js';
 import { routeGuardianReply } from '../runtime/guardian-reply-router.js';
-import type { ApprovalConversationGenerator, GuardianActionCopyGenerator, GuardianFollowUpConversationGenerator } from '../runtime/http-types.js';
 import { getLogger } from '../util/logger.js';
 import { resolveGuardianInviteIntent } from './guardian-invite-intent.js';
 import { resolveGuardianVerificationIntent } from './guardian-verification-intent.js';
@@ -49,31 +29,6 @@ import { resolveSlash, type SlashContext } from './session-slash.js';
 import type { TraceEmitter } from './trace-emitter.js';
 
 const log = getLogger('session-process');
-
-// ---------------------------------------------------------------------------
-// Module-level generator injection
-// ---------------------------------------------------------------------------
-// The daemon lifecycle creates the generator once and injects it here so the
-// mac/IPC channel path can classify follow-up replies without threading the
-// generator through Session / DaemonServer constructors.
-let _guardianFollowUpGenerator: GuardianFollowUpConversationGenerator | undefined;
-let _guardianActionCopyGenerator: GuardianActionCopyGenerator | undefined;
-let _approvalConversationGenerator: ApprovalConversationGenerator | undefined;
-
-/** Inject the guardian follow-up conversation generator (called from lifecycle.ts). */
-export function setGuardianFollowUpConversationGenerator(gen: GuardianFollowUpConversationGenerator): void {
-  _guardianFollowUpGenerator = gen;
-}
-
-/** Inject the guardian action copy generator (called from lifecycle.ts). */
-export function setGuardianActionCopyGenerator(gen: GuardianActionCopyGenerator): void {
-  _guardianActionCopyGenerator = gen;
-}
-
-/** Inject the approval conversation generator (called from lifecycle.ts). */
-export function setApprovalConversationGenerator(gen: ApprovalConversationGenerator): void {
-  _approvalConversationGenerator = gen;
-}
 
 /** Build a model_info event with fresh config data. */
 function buildModelInfoEvent(): ServerMessage {
@@ -413,10 +368,8 @@ export async function processMessage(
   const canonicalPendingRequestIdsForConversation = canonicalPendingRequestsForConversation.map((request) => request.id);
 
   // ── Canonical guardian reply router (desktop/session path) ──
-  // Attempts to route inbound messages through the canonical decision pipeline
-  // before falling through to the legacy guardian action interception. Handles
-  // deterministic request code prefixes and NL classification, with all
-  // decisions flowing through applyCanonicalGuardianDecision.
+  // Desktop/session guardian replies are canonical-only. Messages consumed
+  // by the router never hit the general agent loop.
   if (trimmedContent.length > 0) {
     const routerResult = await routeGuardianReply({
       messageText: trimmedContent,
@@ -473,280 +426,6 @@ export async function processMessage(
       );
 
       return persisted.id;
-    }
-  }
-
-  // ── Unified guardian action answer interception (mac channel) ──
-  // Skip legacy interception whenever canonical pending requests are already
-  // bound to this conversation. This prevents stale legacy rows from
-  // disambiguating replies intended for the canonical request.
-  // Deterministic priority matching: pending → follow-up → expired.
-  // When the guardian includes an explicit request code, match it across all
-  // states in priority order. When only one actionable request exists,
-  // auto-match without requiring a code prefix.
-  if (canonicalPendingRequestIdsForConversation.length === 0) {
-    const allPending = getPendingDeliveriesByConversation(session.conversationId);
-    const allFollowup = getFollowupDeliveriesByConversation(session.conversationId);
-    const allExpired = getExpiredDeliveriesByConversation(session.conversationId);
-    const totalActionable = allPending.length + allFollowup.length + allExpired.length;
-
-    if (totalActionable > 0) {
-      const guardianIfCtx = session.getTurnInterfaceContext();
-      const guardianChannelMeta = { userMessageChannel: 'vellum' as const, assistantMessageChannel: 'vellum' as const, userMessageInterface: guardianIfCtx?.userMessageInterface ?? 'vellum', assistantMessageInterface: guardianIfCtx?.assistantMessageInterface ?? 'vellum', provenanceActorRole: 'guardian' as const };
-
-      // Try to parse an explicit request code from the message, in priority order
-      type CodeMatch = { delivery: typeof allPending[0]; request: NonNullable<ReturnType<typeof getGuardianActionRequest>>; state: 'pending' | 'followup' | 'expired'; answerText: string };
-      let codeMatch: CodeMatch | null = null;
-      const upperContent = content.toUpperCase();
-      const orderedSets: Array<{ deliveries: typeof allPending; state: 'pending' | 'followup' | 'expired' }> = [
-        { deliveries: allPending, state: 'pending' },
-        { deliveries: allFollowup, state: 'followup' },
-        { deliveries: allExpired, state: 'expired' },
-      ];
-      for (const { deliveries, state } of orderedSets) {
-        for (const d of deliveries) {
-          const req = getGuardianActionRequest(d.requestId);
-          if (req && upperContent.startsWith(req.requestCode)) {
-            codeMatch = { delivery: d, request: req, state, answerText: content.slice(req.requestCode.length).trim() };
-            break;
-          }
-        }
-        if (codeMatch) break;
-      }
-
-      // Explicit code targets a non-pending state: handle terminal superseded
-      if (codeMatch && codeMatch.state !== 'pending') {
-        const targetReq = codeMatch.request;
-        if (targetReq.status === 'expired' && targetReq.expiredReason === 'superseded') {
-          const callSession = getCallSession(targetReq.callSessionId);
-          const callStillActive = callSession && !isTerminalState(callSession.status);
-          if (!callStillActive) {
-            const userMsg = createUserMessage(content, attachments);
-            const persisted = await conversationStore.addMessage(session.conversationId, 'user', JSON.stringify(userMsg.content), guardianChannelMeta);
-            session.messages.push(userMsg);
-            const staleText = await composeGuardianActionMessageGenerative({ scenario: 'guardian_stale_superseded' }, {}, _guardianActionCopyGenerator);
-            const staleMsg = createAssistantMessage(staleText);
-            await conversationStore.addMessage(session.conversationId, 'assistant', JSON.stringify(staleMsg.content), guardianChannelMeta);
-            session.messages.push(staleMsg);
-            onEvent({ type: 'assistant_text_delta', text: staleText });
-            onEvent({ type: 'message_complete', sessionId: session.conversationId });
-            return persisted.id;
-          }
-        }
-      }
-
-      // Auto-match: single actionable request across all states
-      if (!codeMatch && totalActionable === 1) {
-        const singleDelivery = allPending[0] ?? allFollowup[0] ?? allExpired[0];
-        const singleReq = getGuardianActionRequest(singleDelivery.requestId);
-        if (singleReq) {
-          const state: 'pending' | 'followup' | 'expired' = allPending.length === 1 ? 'pending' : allFollowup.length === 1 ? 'followup' : 'expired';
-          let text = content;
-          if (upperContent.startsWith(singleReq.requestCode)) {
-            text = content.slice(singleReq.requestCode.length).trim();
-          }
-          codeMatch = { delivery: singleDelivery, request: singleReq, state, answerText: text };
-        }
-      }
-
-      // Unknown code: message starts with a 6-char alphanumeric token that doesn't match
-      if (!codeMatch && totalActionable > 0) {
-        const possibleCodeMatch = content.match(/^([A-F0-9]{6})\s/i);
-        if (possibleCodeMatch) {
-          const candidateCode = possibleCodeMatch[1].toUpperCase();
-          const allDeliveries = [...allPending, ...allFollowup, ...allExpired];
-          const knownCodes = allDeliveries
-            .map((d) => { const req = getGuardianActionRequest(d.requestId); return req?.requestCode; })
-            .filter((code): code is string => typeof code === 'string');
-          if (!knownCodes.includes(candidateCode)) {
-            const userMsg = createUserMessage(content, attachments);
-            const persisted = await conversationStore.addMessage(session.conversationId, 'user', JSON.stringify(userMsg.content), guardianChannelMeta);
-            session.messages.push(userMsg);
-            const unknownText = await composeGuardianActionMessageGenerative({ scenario: 'guardian_unknown_code', unknownCode: candidateCode }, {}, _guardianActionCopyGenerator);
-            const unknownMsg = createAssistantMessage(unknownText);
-            await conversationStore.addMessage(session.conversationId, 'assistant', JSON.stringify(unknownMsg.content), guardianChannelMeta);
-            session.messages.push(unknownMsg);
-            onEvent({ type: 'assistant_text_delta', text: unknownText });
-            onEvent({ type: 'message_complete', sessionId: session.conversationId });
-            return persisted.id;
-          }
-        }
-      }
-
-      // No match and multiple actionable requests → disambiguation
-      if (!codeMatch && totalActionable > 1) {
-        const userMsg = createUserMessage(content, attachments);
-        const persisted = await conversationStore.addMessage(session.conversationId, 'user', JSON.stringify(userMsg.content), guardianChannelMeta);
-        session.messages.push(userMsg);
-        const allDeliveries = [...allPending, ...allFollowup, ...allExpired];
-        const codes = allDeliveries
-          .map((d) => { const req = getGuardianActionRequest(d.requestId); return req ? req.requestCode : null; })
-          .filter((code): code is string => typeof code === 'string' && code.length > 0);
-        const disambiguationScenario = allPending.length > 0
-          ? 'guardian_pending_disambiguation' as const
-          : allFollowup.length > 0
-            ? 'guardian_followup_disambiguation' as const
-            : 'guardian_expired_disambiguation' as const;
-        const disambiguationText = await composeGuardianActionMessageGenerative(
-          { scenario: disambiguationScenario, requestCodes: codes },
-          { requiredKeywords: codes },
-          _guardianActionCopyGenerator,
-        );
-        const disambiguationMsg = createAssistantMessage(disambiguationText);
-        await conversationStore.addMessage(session.conversationId, 'assistant', JSON.stringify(disambiguationMsg.content), guardianChannelMeta);
-        session.messages.push(disambiguationMsg);
-        onEvent({ type: 'assistant_text_delta', text: disambiguationText });
-        onEvent({ type: 'message_complete', sessionId: session.conversationId });
-        return persisted.id;
-      }
-
-      // Dispatch matched delivery by state
-      if (codeMatch) {
-        const { request, state, answerText } = codeMatch;
-
-        // PENDING state handler
-        if (state === 'pending' && request.status === 'pending') {
-          const userMsg = createUserMessage(content, attachments);
-          const persisted = await conversationStore.addMessage(session.conversationId, 'user', JSON.stringify(userMsg.content), guardianChannelMeta);
-          session.messages.push(userMsg);
-
-          const answerResult = await answerCall({ callSessionId: request.callSessionId, answer: answerText, pendingQuestionId: request.pendingQuestionId });
-
-          if ('ok' in answerResult && answerResult.ok) {
-            const resolved = resolveGuardianActionRequest(request.id, answerText, 'vellum');
-            if (resolved) {
-              await tryMintGuardianActionGrant({ request, answerText, decisionChannel: 'vellum', approvalConversationGenerator: _approvalConversationGenerator });
-            }
-            const replyText = resolved
-              ? 'Your answer has been relayed to the call.'
-              : await composeGuardianActionMessageGenerative({ scenario: 'guardian_stale_answered' }, {}, _guardianActionCopyGenerator);
-            const replyMsg = createAssistantMessage(replyText);
-            await conversationStore.addMessage(session.conversationId, 'assistant', JSON.stringify(replyMsg.content), guardianChannelMeta);
-            session.messages.push(replyMsg);
-            onEvent({ type: 'assistant_text_delta', text: replyText });
-          } else {
-            const errorDetail = 'error' in answerResult ? answerResult.error : 'Unknown error';
-            log.warn({ callSessionId: request.callSessionId, error: errorDetail }, 'answerCall failed for mac guardian answer');
-            const failureText = await composeGuardianActionMessageGenerative({ scenario: 'guardian_answer_delivery_failed' }, {}, _guardianActionCopyGenerator);
-            const failMsg = createAssistantMessage(failureText);
-            await conversationStore.addMessage(session.conversationId, 'assistant', JSON.stringify(failMsg.content), guardianChannelMeta);
-            session.messages.push(failMsg);
-            onEvent({ type: 'assistant_text_delta', text: failureText });
-          }
-          onEvent({ type: 'message_complete', sessionId: session.conversationId });
-          return persisted.id;
-        }
-
-        // FOLLOW-UP state handler
-        if (state === 'followup' && request.followupState === 'awaiting_guardian_choice') {
-          const userMsg = createUserMessage(content, attachments);
-          const persisted = await conversationStore.addMessage(session.conversationId, 'user', JSON.stringify(userMsg.content), guardianChannelMeta);
-          session.messages.push(userMsg);
-
-          const turnResult = await processGuardianFollowUpTurn(
-            { questionText: request.questionText, lateAnswerText: request.lateAnswerText ?? '', guardianReply: answerText },
-            _guardianFollowUpGenerator,
-          );
-
-          let stateApplied = true;
-          if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
-            stateApplied = Boolean(progressFollowupState(request.id, 'dispatching', turnResult.disposition));
-          } else if (turnResult.disposition === 'decline') {
-            stateApplied = Boolean(finalizeFollowup(request.id, 'declined'));
-          }
-
-          if (!stateApplied) {
-            log.warn({ requestId: request.id, disposition: turnResult.disposition }, 'Follow-up state transition failed (already resolved)');
-          }
-
-          const replyText = stateApplied
-            ? turnResult.replyText
-            : await composeGuardianActionMessageGenerative({ scenario: 'guardian_stale_followup' }, {}, _guardianActionCopyGenerator);
-          const replyMsg = createAssistantMessage(replyText);
-          await conversationStore.addMessage(session.conversationId, 'assistant', JSON.stringify(replyMsg.content), guardianChannelMeta);
-          session.messages.push(replyMsg);
-          onEvent({ type: 'assistant_text_delta', text: replyText });
-          onEvent({ type: 'message_complete', sessionId: session.conversationId });
-
-          if (stateApplied && (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back')) {
-            void (async () => {
-              try {
-                const execResult = await executeFollowupAction(request.id, turnResult.disposition as 'call_back' | 'message_back', _guardianActionCopyGenerator);
-                const completionMsg = createAssistantMessage(execResult.guardianReplyText);
-                await conversationStore.addMessage(session.conversationId, 'assistant', JSON.stringify(completionMsg.content), guardianChannelMeta);
-                session.messages.push(completionMsg);
-                onEvent({ type: 'assistant_text_delta', text: execResult.guardianReplyText });
-                onEvent({ type: 'message_complete', sessionId: session.conversationId });
-              } catch (execErr) {
-                log.error({ err: execErr, requestId: request.id }, 'Follow-up action execution or completion message failed');
-              }
-            })();
-          }
-          return persisted.id;
-        }
-
-        // EXPIRED state handler
-        if (state === 'expired' && request.status === 'expired' && request.followupState === 'none') {
-          const userMsg = createUserMessage(content, attachments);
-          const persisted = await conversationStore.addMessage(session.conversationId, 'user', JSON.stringify(userMsg.content), guardianChannelMeta);
-          session.messages.push(userMsg);
-
-          // Superseded remap
-          if (request.expiredReason === 'superseded') {
-            const callSession = getCallSession(request.callSessionId);
-            const callStillActive = callSession && !isTerminalState(callSession.status);
-            const currentPending = callStillActive ? getPendingRequestByCallSessionId(request.callSessionId) : null;
-
-            if (callStillActive && currentPending) {
-              const currentDeliveries = getDeliveriesByRequestId(currentPending.id);
-              const guardianExtUserId = session.guardianContext?.guardianExternalUserId;
-              // When guardianExternalUserId is present, verify the sender has a
-              // matching delivery on the current pending request. When it's absent
-              // (trusted Vellum/HTTP session), allow the remap without delivery check.
-              const senderHasDelivery = guardianExtUserId
-                ? currentDeliveries.some((d) => d.destinationExternalUserId === guardianExtUserId)
-                : true;
-              if (!senderHasDelivery) {
-                log.info({ supersededRequestId: request.id, currentRequestId: currentPending.id, guardianExternalUserId: guardianExtUserId }, 'Superseded remap skipped: sender has no delivery on current pending request');
-              } else {
-                const remapResult = await answerCall({ callSessionId: currentPending.callSessionId, answer: answerText, pendingQuestionId: currentPending.pendingQuestionId });
-                if ('ok' in remapResult && remapResult.ok) {
-                  const resolved = resolveGuardianActionRequest(currentPending.id, answerText, 'vellum');
-                  if (resolved) {
-                    await tryMintGuardianActionGrant({ request: currentPending, answerText, decisionChannel: 'vellum', approvalConversationGenerator: _approvalConversationGenerator });
-                  }
-                  const remapText = await composeGuardianActionMessageGenerative({ scenario: 'guardian_superseded_remap', questionText: currentPending.questionText }, {}, _guardianActionCopyGenerator);
-                  const remapMsg = createAssistantMessage(remapText);
-                  await conversationStore.addMessage(session.conversationId, 'assistant', JSON.stringify(remapMsg.content), guardianChannelMeta);
-                  session.messages.push(remapMsg);
-                  onEvent({ type: 'assistant_text_delta', text: remapText });
-                  onEvent({ type: 'message_complete', sessionId: session.conversationId });
-                  log.info({ supersededRequestId: request.id, remappedToRequestId: currentPending.id }, 'Late approval for superseded request remapped to current pending request');
-                  return persisted.id;
-                }
-                log.warn({ callSessionId: currentPending.callSessionId, error: 'error' in remapResult ? remapResult.error : 'unknown' }, 'Superseded remap answerCall failed, falling through to follow-up');
-              }
-            }
-          }
-
-          const followupResult = startFollowupFromExpiredRequest(request.id, answerText);
-          if (followupResult) {
-            const followupText = await composeGuardianActionMessageGenerative({ scenario: 'guardian_late_answer_followup', questionText: request.questionText, lateAnswerText: answerText }, {}, _guardianActionCopyGenerator);
-            const replyMsg = createAssistantMessage(followupText);
-            await conversationStore.addMessage(session.conversationId, 'assistant', JSON.stringify(replyMsg.content), guardianChannelMeta);
-            session.messages.push(replyMsg);
-            onEvent({ type: 'assistant_text_delta', text: followupText });
-          } else {
-            const staleText = await composeGuardianActionMessageGenerative({ scenario: 'guardian_stale_expired' }, {}, _guardianActionCopyGenerator);
-            const staleMsg = createAssistantMessage(staleText);
-            await conversationStore.addMessage(session.conversationId, 'assistant', JSON.stringify(staleMsg.content), guardianChannelMeta);
-            session.messages.push(staleMsg);
-            onEvent({ type: 'assistant_text_delta', text: staleText });
-          }
-          onEvent({ type: 'message_complete', sessionId: session.conversationId });
-          return persisted.id;
-        }
-      }
     }
   }
 

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -10,7 +10,10 @@ import { createAssistantMessage,createUserMessage } from '../agent/message-types
 import type { TurnChannelContext, TurnInterfaceContext } from '../channels/types.js';
 import { parseChannelId, parseInterfaceId } from '../channels/types.js';
 import { getConfig } from '../config/loader.js';
-import { listPendingCanonicalGuardianRequestsByDestinationConversation } from '../memory/canonical-guardian-store.js';
+import {
+  listCanonicalGuardianRequests,
+  listPendingCanonicalGuardianRequestsByDestinationConversation,
+} from '../memory/canonical-guardian-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import { extractPreferences } from '../notifications/preference-extractor.js';
@@ -362,10 +365,15 @@ export async function processMessage(
   session.currentActiveSurfaceId = activeSurfaceId;
   session.currentPage = currentPage;
   const trimmedContent = content.trim();
-  const canonicalPendingRequestsForConversation = trimmedContent.length > 0
-    ? listPendingCanonicalGuardianRequestsByDestinationConversation(session.conversationId, 'vellum')
+  const canonicalPendingRequestIdsForConversation = trimmedContent.length > 0
+    ? Array.from(new Set([
+        ...listPendingCanonicalGuardianRequestsByDestinationConversation(session.conversationId, 'vellum').map((request) => request.id),
+        ...listCanonicalGuardianRequests({
+          status: 'pending',
+          conversationId: session.conversationId,
+        }).map((request) => request.id),
+      ]))
     : [];
-  const canonicalPendingRequestIdsForConversation = canonicalPendingRequestsForConversation.map((request) => request.id);
 
   // ── Canonical guardian reply router (desktop/session path) ──
   // Desktop/session guardian replies are canonical-only. Messages consumed

--- a/assistant/src/memory/canonical-guardian-store.ts
+++ b/assistant/src/memory/canonical-guardian-store.ts
@@ -400,6 +400,50 @@ export function listCanonicalGuardianDeliveries(requestId: string): CanonicalGua
     .map(rowToDelivery);
 }
 
+/**
+ * List pending canonical requests that were delivered to a specific
+ * destination conversation.
+ *
+ * This bridges inbound guardian replies (which arrive on the destination
+ * conversation) back to their canonical request records. The caller can
+ * optionally scope by destination channel when the same conversation ID
+ * namespace could exist across channels.
+ */
+export function listPendingCanonicalGuardianRequestsByDestinationConversation(
+  destinationConversationId: string,
+  destinationChannel?: string,
+): CanonicalGuardianRequest[] {
+  const db = getDb();
+
+  const deliveryConditions = [eq(canonicalGuardianDeliveries.destinationConversationId, destinationConversationId)];
+  if (destinationChannel) {
+    deliveryConditions.push(eq(canonicalGuardianDeliveries.destinationChannel, destinationChannel));
+  }
+
+  const deliveries = db
+    .select()
+    .from(canonicalGuardianDeliveries)
+    .where(and(...deliveryConditions))
+    .all();
+
+  if (deliveries.length === 0) return [];
+
+  const seenRequestIds = new Set<string>();
+  const pendingRequests: CanonicalGuardianRequest[] = [];
+
+  for (const delivery of deliveries) {
+    if (seenRequestIds.has(delivery.requestId)) continue;
+    seenRequestIds.add(delivery.requestId);
+
+    const request = getCanonicalGuardianRequest(delivery.requestId);
+    if (request && request.status === 'pending') {
+      pendingRequests.push(request);
+    }
+  }
+
+  return pendingRequests;
+}
+
 export interface UpdateCanonicalGuardianDeliveryParams {
   status?: string;
   destinationMessageId?: string;

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -37,10 +37,22 @@ const TEMPLATES: Record<string, CopyTemplate> = {
     body: `${str(payload.name, 'A schedule')} has finished running`,
   }),
 
-  'guardian.question': (payload) => ({
-    title: 'Guardian Question',
-    body: str(payload.questionText, 'A guardian question needs your attention'),
-  }),
+  'guardian.question': (payload) => {
+    const question = str(payload.questionText, 'A guardian question needs your attention');
+    const requestCode = nonEmpty(typeof payload.requestCode === 'string' ? payload.requestCode : undefined);
+    if (!requestCode) {
+      return {
+        title: 'Guardian Question',
+        body: question,
+      };
+    }
+
+    const normalizedCode = requestCode.toUpperCase();
+    return {
+      title: 'Guardian Question',
+      body: `${question}\n\nReference code: ${normalizedCode}. Reply "${normalizedCode} approve" or "${normalizedCode} reject".`,
+    };
+  },
 
   'ingress.escalation': (payload) => ({
     title: 'Escalation',

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -406,6 +406,58 @@ export function validateThreadActions(
   return result;
 }
 
+function ensureGuardianRequestCodeInCopy(
+  copy: RenderedChannelCopy,
+  requestCode: string,
+): RenderedChannelCopy {
+  const instruction = `Reference code: ${requestCode}. Reply "${requestCode} approve" or "${requestCode} reject".`;
+  const hasCode = (text: string | undefined): boolean =>
+    typeof text === 'string' && text.toUpperCase().includes(requestCode);
+
+  const ensureText = (text: string | undefined): string => {
+    const base = typeof text === 'string' ? text.trim() : '';
+    if (hasCode(base)) return base;
+    return base.length > 0 ? `${base}\n\n${instruction}` : instruction;
+  };
+
+  return {
+    ...copy,
+    body: ensureText(copy.body),
+    deliveryText: copy.deliveryText ? ensureText(copy.deliveryText) : copy.deliveryText,
+    threadSeedMessage: copy.threadSeedMessage ? ensureText(copy.threadSeedMessage) : copy.threadSeedMessage,
+  };
+}
+
+/**
+ * Guardian questions that share a conversation require explicit request-code
+ * targeting. Enforce request-code instructions in rendered copy so guardians
+ * can always disambiguate replies even when model copy omits them.
+ */
+function enforceGuardianRequestCode(
+  decision: NotificationDecision,
+  signal: NotificationSignal,
+): NotificationDecision {
+  if (signal.sourceEventName !== 'guardian.question') return decision;
+  const rawCode = signal.contextPayload.requestCode;
+  if (typeof rawCode !== 'string' || rawCode.trim().length === 0) return decision;
+
+  const requestCode = rawCode.trim().toUpperCase();
+  const nextCopy: Partial<Record<NotificationChannel, RenderedChannelCopy>> = {
+    ...decision.renderedCopy,
+  };
+
+  for (const channel of Object.keys(nextCopy) as NotificationChannel[]) {
+    const copy = nextCopy[channel];
+    if (!copy) continue;
+    nextCopy[channel] = ensureGuardianRequestCodeInCopy(copy, requestCode);
+  }
+
+  return {
+    ...decision,
+    renderedCopy: nextCopy,
+  };
+}
+
 // ── Core evaluation function ───────────────────────────────────────────
 
 export async function evaluateSignal(
@@ -444,6 +496,7 @@ export async function evaluateSignal(
   if (!provider) {
     log.warn('Configured provider unavailable for notification decision, using fallback');
     let decision = buildFallbackDecision(signal, availableChannels);
+    decision = enforceGuardianRequestCode(decision, signal);
     decision = enforceConversationAffinity(decision, signal.conversationAffinityHint);
     decision.persistedDecisionId = persistDecision(signal, decision);
     return decision;
@@ -458,6 +511,7 @@ export async function evaluateSignal(
     decision = buildFallbackDecision(signal, availableChannels);
   }
 
+  decision = enforceGuardianRequestCode(decision, signal);
   decision = enforceConversationAffinity(decision, signal.conversationAffinityHint);
   decision.persistedDecisionId = persistDecision(signal, decision);
 

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -411,12 +411,15 @@ function ensureGuardianRequestCodeInCopy(
   requestCode: string,
 ): RenderedChannelCopy {
   const instruction = `Reference code: ${requestCode}. Reply "${requestCode} approve" or "${requestCode} reject".`;
-  const hasCode = (text: string | undefined): boolean =>
-    typeof text === 'string' && text.toUpperCase().includes(requestCode);
+  const hasParserCompatibleInstructions = (text: string | undefined): boolean => {
+    if (typeof text !== 'string') return false;
+    const upper = text.toUpperCase();
+    return upper.includes(`${requestCode} APPROVE`) && upper.includes(`${requestCode} REJECT`);
+  };
 
   const ensureText = (text: string | undefined): string => {
     const base = typeof text === 'string' ? text.trim() : '';
-    if (hasCode(base)) return base;
+    if (hasParserCompatibleInstructions(base)) return base;
     return base.length > 0 ? `${base}\n\n${instruction}` : instruction;
   };
 

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -165,7 +165,10 @@ function findPendingCanonicalRequests(
   conversationId?: string,
 ): CanonicalGuardianRequest[] {
   // When explicit IDs are provided, look them up directly
-  if (pendingRequestIds && pendingRequestIds.length > 0) {
+  if (pendingRequestIds) {
+    if (pendingRequestIds.length === 0) {
+      return [];
+    }
     return pendingRequestIds
       .map(getCanonicalGuardianRequest)
       .filter((r): r is CanonicalGuardianRequest => r?.status === 'pending');

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -17,24 +17,24 @@
  * to allow for incremental migration and independent testability.
  */
 
-import type { ApprovalAction } from './channel-approval-types.js';
-import type {
-  ApprovalConversationContext,
-  ApprovalConversationGenerator,
-} from './http-types.js';
-import { runApprovalConversationTurn } from './approval-conversation-turn.js';
 import {
   applyCanonicalGuardianDecision,
   type CanonicalDecisionResult,
 } from '../approvals/guardian-decision-primitive.js';
 import type { ActorContext, ChannelDeliveryContext } from '../approvals/guardian-request-resolvers.js';
 import {
+  type CanonicalGuardianRequest,
   getCanonicalGuardianRequest,
   getCanonicalGuardianRequestByCode,
   listCanonicalGuardianRequests,
-  type CanonicalGuardianRequest,
 } from '../memory/canonical-guardian-store.js';
 import { getLogger } from '../util/logger.js';
+import { runApprovalConversationTurn } from './approval-conversation-turn.js';
+import type { ApprovalAction } from './channel-approval-types.js';
+import type {
+  ApprovalConversationContext,
+  ApprovalConversationGenerator,
+} from './http-types.js';
 
 const log = getLogger('guardian-reply-router');
 
@@ -168,7 +168,7 @@ function findPendingCanonicalRequests(
   if (pendingRequestIds && pendingRequestIds.length > 0) {
     return pendingRequestIds
       .map(getCanonicalGuardianRequest)
-      .filter((r): r is CanonicalGuardianRequest => r !== null && r.status === 'pending');
+      .filter((r): r is CanonicalGuardianRequest => r?.status === 'pending');
   }
 
   // Query by guardian identity when available
@@ -226,7 +226,8 @@ function notConsumed(): GuardianReplyResult {
 export async function routeGuardianReply(
   ctx: GuardianReplyContext,
 ): Promise<GuardianReplyResult> {
-  const { messageText, channel, actor, conversationId, callbackData, approvalConversationGenerator, channelDeliveryContext } = ctx;
+  const { messageText, actor, conversationId, callbackData, approvalConversationGenerator, channelDeliveryContext } = ctx;
+  const pendingRequests = findPendingCanonicalRequests(actor, ctx.pendingRequestIds, conversationId);
 
   // ── 1. Deterministic callback parsing (button presses) ──
   // No conversationId scoping here — the guardian's reply comes from a
@@ -315,11 +316,37 @@ export async function routeGuardianReply(
     }
   }
 
+  // ── 2.5. Deterministic plain-text decisions for known pending targets ──
+  // Desktop sessions intentionally do not enable NL classification; when the
+  // caller has exactly one known pending request and sends an explicit
+  // approve/reject phrase ("approve", "yes", "reject", "no"), apply the
+  // decision directly instead of falling through to legacy handlers.
+  if (messageText.length > 0 && pendingRequests.length > 0) {
+    const inferredAction = inferDecisionActionFromFreeText(messageText);
+    if (inferredAction) {
+      if (pendingRequests.length === 1) {
+        return applyDecision(
+          pendingRequests[0].id,
+          inferredAction,
+          actor,
+          messageText,
+          channelDeliveryContext,
+        );
+      }
+
+      const disambiguationReply = composeDisambiguationReply(pendingRequests);
+      return {
+        decisionApplied: false,
+        consumed: true,
+        type: 'disambiguation_needed',
+        replyText: disambiguationReply,
+      };
+    }
+  }
+
   // ── 3. NL classification via the conversational approval engine ──
   if (messageText.length > 0 && approvalConversationGenerator) {
-    const allPendingRequests = findPendingCanonicalRequests(actor, ctx.pendingRequestIds, conversationId);
-
-    if (allPendingRequests.length === 0) {
+    if (pendingRequests.length === 0) {
       return notConsumed();
     }
 
@@ -329,14 +356,14 @@ export async function routeGuardianReply(
     // conversationId would incorrectly drop valid pending requests. Identity-
     // based filtering in findPendingCanonicalRequests already constrains
     // results to the correct guardian.
-    const pendingRequests = allPendingRequests;
+    const pendingRequestsForClassification = pendingRequests;
 
     // Build the conversation context for the NL engine
     const engineContext: ApprovalConversationContext = {
-      toolName: pendingRequests[0].toolName ?? 'unknown',
+      toolName: pendingRequestsForClassification[0].toolName ?? 'unknown',
       allowedActions: guardianAllowedActions(),
       role: 'guardian',
-      pendingApprovals: pendingRequests.map(r => ({
+      pendingApprovals: pendingRequestsForClassification.map(r => ({
         requestId: r.id,
         toolName: r.toolName ?? 'unknown',
       })),
@@ -354,12 +381,12 @@ export async function routeGuardianReply(
       // but runApprovalConversationTurn fail-closed because no targetRequestId
       // was provided. In this case, produce a disambiguation reply instead of
       // a generic "I couldn't process that" message.
-      if (pendingRequests.length > 1) {
+      if (pendingRequestsForClassification.length > 1) {
         log.info(
-          { event: 'router_nl_disambiguation_needed', pendingCount: pendingRequests.length },
+          { event: 'router_nl_disambiguation_needed', pendingCount: pendingRequestsForClassification.length },
           'Engine returned keep_pending with multiple pending requests — producing disambiguation',
         );
-        const disambiguationReply = composeDisambiguationReply(pendingRequests, undefined);
+        const disambiguationReply = composeDisambiguationReply(pendingRequestsForClassification, undefined);
         return {
           decisionApplied: false,
           consumed: true,
@@ -385,16 +412,17 @@ export async function routeGuardianReply(
     }
 
     // Resolve the target request
-    const targetId = engineResult.targetRequestId ?? (pendingRequests.length === 1 ? pendingRequests[0].id : undefined);
+    const targetId = engineResult.targetRequestId
+      ?? (pendingRequestsForClassification.length === 1 ? pendingRequestsForClassification[0].id : undefined);
 
     if (!targetId) {
       // Multi-pending and engine didn't pick a target — need disambiguation.
       // Fail-closed: never auto-resolve when the target is ambiguous.
       log.info(
-        { event: 'router_nl_disambiguation_needed', pendingCount: pendingRequests.length },
+        { event: 'router_nl_disambiguation_needed', pendingCount: pendingRequestsForClassification.length },
         'NL engine returned a decision but no target for multi-pending requests',
       );
-      const disambiguationReply = composeDisambiguationReply(pendingRequests, engineResult.replyText);
+      const disambiguationReply = composeDisambiguationReply(pendingRequestsForClassification, engineResult.replyText);
       return {
         decisionApplied: false,
         consumed: true,
@@ -512,7 +540,20 @@ async function applyDecision(
 // Text-to-action inference
 // ---------------------------------------------------------------------------
 
+const APPROVE_PATTERNS = /^(yes|yeah|yep|approve|approved|allow|ok|okay|sure|go ahead|proceed|do it)\b/i;
 const REJECT_PATTERNS = /^(no|deny|reject|decline|cancel|block)\b/i;
+
+/**
+ * Strict free-text decision parser used when no request code is present.
+ * Returns null unless the message starts with an explicit approve/reject cue.
+ */
+function inferDecisionActionFromFreeText(text: string): ApprovalAction | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  if (REJECT_PATTERNS.test(trimmed)) return 'reject';
+  if (APPROVE_PATTERNS.test(trimmed)) return 'approve_once';
+  return null;
+}
 
 /**
  * Infer a guardian decision action from free-text after a request code.

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -540,18 +540,45 @@ async function applyDecision(
 // Text-to-action inference
 // ---------------------------------------------------------------------------
 
-const APPROVE_PATTERNS = /^(yes|yeah|yep|approve|approved|allow|ok|okay|sure|go ahead|proceed|do it)\b/i;
-const REJECT_PATTERNS = /^(no|deny|reject|decline|cancel|block)\b/i;
+const CODE_REJECT_PATTERNS = /^(no|deny|reject|decline|cancel|block)\b/i;
+const EXPLICIT_APPROVE_PHRASES: ReadonlySet<string> = new Set([
+  'approve',
+  'approved',
+  'approve once',
+  'yes',
+  'y',
+  'allow',
+  'go ahead',
+  'proceed',
+  'do it',
+]);
+const EXPLICIT_REJECT_PHRASES: ReadonlySet<string> = new Set([
+  'reject',
+  'deny',
+  'decline',
+  'no',
+  'n',
+  'block',
+  'cancel',
+]);
+
+function normalizeDecisionPhrase(text: string): string {
+  return text
+    .trim()
+    .toLowerCase()
+    .replace(/[.!?]+$/g, '')
+    .replace(/\s+/g, ' ');
+}
 
 /**
  * Strict free-text decision parser used when no request code is present.
  * Returns null unless the message starts with an explicit approve/reject cue.
  */
 function inferDecisionActionFromFreeText(text: string): ApprovalAction | null {
-  const trimmed = text.trim();
-  if (!trimmed) return null;
-  if (REJECT_PATTERNS.test(trimmed)) return 'reject';
-  if (APPROVE_PATTERNS.test(trimmed)) return 'approve_once';
+  const normalized = normalizeDecisionPhrase(text);
+  if (!normalized) return null;
+  if (EXPLICIT_REJECT_PHRASES.has(normalized)) return 'reject';
+  if (EXPLICIT_APPROVE_PHRASES.has(normalized)) return 'approve_once';
   return null;
 }
 
@@ -564,7 +591,7 @@ function inferActionFromText(text: string): ApprovalAction {
     return 'approve_once';
   }
 
-  if (REJECT_PATTERNS.test(text.trim())) {
+  if (CODE_REJECT_PATTERNS.test(text.trim())) {
     return 'reject';
   }
 


### PR DESCRIPTION
## Summary
- route desktop guardian replies through canonical request IDs bound to the active vellum destination conversation
- add deterministic plain-text approve/reject routing when exactly one canonical request is pending (no NL generator required)
- skip legacy guardian-action interception when canonical pending requests are already present for the thread
- enforce guardian request-code instructions in notification copy for `guardian.question` signals

## Root cause
Desktop/session processing called `routeGuardianReply` without an approval conversation generator **and** without canonical pending IDs scoped to the guardian thread.

Because of that, plain replies like `approve` were not consumed by the canonical router and fell through to the legacy guardian-action interception path, which surfaced stale disambiguation codes from unrelated legacy rows.

## Fix details
- Added `listPendingCanonicalGuardianRequestsByDestinationConversation()` in `canonical-guardian-store` to map a destination conversation back to pending canonical requests.
- `session-process` now passes those request IDs into `routeGuardianReply` and bypasses legacy interception when canonical pending requests exist for the thread.
- `guardian-reply-router` now supports strict deterministic plain-text decisions (`approve`/`reject`/`yes`/`no`) when pending targets are known, with fail-closed disambiguation if multiple requests are pending.
- Notification copy now appends request-code instructions for `guardian.question` whenever `contextPayload.requestCode` exists (fallback + post-decision enforcement).

## Verification
- `bun test src/__tests__/canonical-guardian-store.test.ts src/__tests__/guardian-routing-invariants.test.ts src/__tests__/notification-decision-fallback.test.ts src/__tests__/notification-decision-strategy.test.ts`
- `bunx tsc --noEmit`
- `bunx eslint src/__tests__/canonical-guardian-store.test.ts src/__tests__/guardian-routing-invariants.test.ts src/__tests__/notification-decision-fallback.test.ts src/__tests__/notification-decision-strategy.test.ts src/daemon/session-process.ts src/memory/canonical-guardian-store.ts src/notifications/copy-composer.ts src/notifications/decision-engine.ts src/runtime/guardian-reply-router.ts -f json`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
