### PR TITLE
fix: align migration DEFAULT with Drizzle schema for reminder routing_intent

### DIFF
--- a/assistant/src/memory/migrations/118-reminder-routing-intent.ts
+++ b/assistant/src/memory/migrations/118-reminder-routing-intent.ts
@@ -4,9 +4,9 @@ import type { DrizzleDb } from '../db-connection.js';
  * Add routing_intent and routing_hints_json columns to reminders table.
  *
  * routing_intent controls how the reminder is delivered at trigger time:
- *   - single_channel (default): deliver to a single best channel
+ *   - single_channel: deliver to a single best channel
  *   - multi_channel: deliver to a subset of channels
- *   - all_channels: deliver to every available channel
+ *   - all_channels (default): deliver to every available channel
  *
  * routing_hints_json stores an opaque JSON object with hints for the
  * routing engine (e.g. preferred channels, exclusions).
@@ -14,7 +14,7 @@ import type { DrizzleDb } from '../db-connection.js';
 export function migrateReminderRoutingIntent(database: DrizzleDb): void {
   try {
     database.run(
-      /*sql*/ `ALTER TABLE reminders ADD COLUMN routing_intent TEXT NOT NULL DEFAULT 'single_channel'`,
+      /*sql*/ `ALTER TABLE reminders ADD COLUMN routing_intent TEXT NOT NULL DEFAULT 'all_channels'`,
     );
   } catch { /* already exists */ }
 


### PR DESCRIPTION
## Summary
- Update migration 118-reminder-routing-intent.ts to use DEFAULT 'all_channels' instead of 'single_channel'
- Ensures databases initialized via migrations use the same default as the Drizzle schema

Addresses feedback on #10562.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
