### PR TITLE
fix: restore keyboard focus visibility for VIconButton

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
@@ -13,6 +13,7 @@ public struct VIconButton: View {
     public let action: () -> Void
 
     @State private var isHovered = false
+    @FocusState private var isFocused: Bool
 
     public init(label: String, icon: String = "", customIcon: Image? = nil, isActive: Bool = false, iconOnly: Bool = false, tooltip: String? = nil, action: @escaping () -> Void) {
         self.label = label
@@ -41,7 +42,8 @@ public struct VIconButton: View {
             }
             .foregroundColor(iconForegroundColor)
         }
-        .buttonStyle(VIconButtonStyle(isActive: isActive, isHovered: isHovered))
+        .focused($isFocused)
+        .buttonStyle(VIconButtonStyle(isActive: isActive, isHovered: isHovered, isFocused: isFocused))
         #if os(macOS)
         .onHover { hovering in
             isHovered = hovering


### PR DESCRIPTION
## Summary
- Add @FocusState tracking to VIconButton wrapper
- Pass focus state through to VIconButtonStyle for custom focus border rendering
- Ensures keyboard users see focus rings on all icon buttons

Addresses feedback on #10563.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
