### PR TITLE
fix: add requesterChatId to canonical guardian requests for correct delivery targeting

### DIFF
--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -276,7 +276,7 @@ const accessRequestResolver: GuardianRequestResolver = {
     const { request, decision, channelDeliveryContext } = ctx;
     const channel = request.sourceChannel ?? 'unknown';
     const requesterExternalUserId = request.requesterExternalUserId ?? '';
-    const requesterChatId = request.requesterExternalUserId ?? '';
+    const requesterChatId = request.requesterChatId ?? request.requesterExternalUserId ?? '';
     const decidedByExternalUserId = ctx.actor.externalUserId ?? '';
     const assistantId = channelDeliveryContext?.assistantId ?? 'self';
 

--- a/assistant/src/memory/canonical-guardian-store.ts
+++ b/assistant/src/memory/canonical-guardian-store.ts
@@ -29,6 +29,7 @@ export interface CanonicalGuardianRequest {
   sourceChannel: string | null;
   conversationId: string | null;
   requesterExternalUserId: string | null;
+  requesterChatId: string | null;
   guardianExternalUserId: string | null;
   callSessionId: string | null;
   pendingQuestionId: string | null;
@@ -114,6 +115,7 @@ function rowToRequest(row: typeof canonicalGuardianRequests.$inferSelect): Canon
     sourceChannel: row.sourceChannel,
     conversationId: row.conversationId,
     requesterExternalUserId: row.requesterExternalUserId,
+    requesterChatId: row.requesterChatId,
     guardianExternalUserId: row.guardianExternalUserId,
     callSessionId: row.callSessionId,
     pendingQuestionId: row.pendingQuestionId,
@@ -156,6 +158,7 @@ export interface CreateCanonicalGuardianRequestParams {
   sourceChannel?: string;
   conversationId?: string;
   requesterExternalUserId?: string;
+  requesterChatId?: string;
   guardianExternalUserId?: string;
   callSessionId?: string;
   pendingQuestionId?: string;
@@ -182,6 +185,7 @@ export function createCanonicalGuardianRequest(params: CreateCanonicalGuardianRe
     sourceChannel: params.sourceChannel ?? null,
     conversationId: params.conversationId ?? null,
     requesterExternalUserId: params.requesterExternalUserId ?? null,
+    requesterChatId: params.requesterChatId ?? null,
     guardianExternalUserId: params.guardianExternalUserId ?? null,
     callSessionId: params.callSessionId ?? null,
     pendingQuestionId: params.pendingQuestionId ?? null,

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -4,6 +4,7 @@ import {
   createAssistantInboxTables,
   createCallSessionsTables,
   createCanonicalGuardianTables,
+  migrateCanonicalGuardianRequesterChatId,
   createChannelGuardianTables,
   createContactsAndTriageTables,
   createConversationAttentionTables,
@@ -148,6 +149,9 @@ export function initializeDb(): void {
 
   // 24. Canonical guardian requests and deliveries (unified cross-source guardian domain)
   createCanonicalGuardianTables(database);
+
+  // 24b. Add requester_chat_id to canonical_guardian_requests (chat ID != user ID on some channels)
+  migrateCanonicalGuardianRequesterChatId(database);
 
   validateMigrationState(database);
 }

--- a/assistant/src/memory/migrations/122-canonical-guardian-requester-chat-id.ts
+++ b/assistant/src/memory/migrations/122-canonical-guardian-requester-chat-id.ts
@@ -1,0 +1,15 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Add requester_chat_id column to canonical_guardian_requests.
+ *
+ * On channels like Slack, the external chat ID (channel/DM ID) differs from
+ * the sender's external user ID. Without this column the access_request
+ * resolver would deliver approval/denial messages to the wrong destination.
+ *
+ * Uses ALTER TABLE ADD COLUMN with try/catch for idempotency — no registry
+ * entry needed.
+ */
+export function migrateCanonicalGuardianRequesterChatId(database: DrizzleDb): void {
+  try { database.run(/*sql*/ `ALTER TABLE canonical_guardian_requests ADD COLUMN requester_chat_id TEXT`); } catch { /* already exists */ }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -59,6 +59,7 @@ export { migrateReminderRoutingIntent } from './118-reminder-routing-intent.js';
 export { migrateSchemaIndexesAndColumns } from './119-schema-indexes-and-columns.js';
 export { migrateFkCascadeRebuilds } from './120-fk-cascade-rebuilds.js';
 export { createCanonicalGuardianTables } from './121-canonical-guardian-requests.js';
+export { migrateCanonicalGuardianRequesterChatId } from './122-canonical-guardian-requester-chat-id.js';
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -883,6 +883,7 @@ export const canonicalGuardianRequests = sqliteTable('canonical_guardian_request
   sourceChannel: text('source_channel'),
   conversationId: text('conversation_id'),
   requesterExternalUserId: text('requester_external_user_id'),
+  requesterChatId: text('requester_chat_id'),
   guardianExternalUserId: text('guardian_external_user_id'),
   callSessionId: text('call_session_id'),
   pendingQuestionId: text('pending_question_id'),

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1288,6 +1288,7 @@ function notifyGuardianOfAccessRequest(params: {
     sourceChannel,
     conversationId: `access-req-${sourceChannel}-${senderExternalUserId}`,
     requesterExternalUserId: senderExternalUserId,
+    requesterChatId: externalChatId,
     guardianExternalUserId: binding.guardianExternalUserId,
     toolName: 'ingress_access_request',
     questionText: `${senderIdentifier} is requesting access to the assistant`,


### PR DESCRIPTION
## Summary
- Add requesterChatId column to canonical_guardian_requests schema and migration
- Populate requesterChatId when creating canonical access_request records
- Use requesterChatId for delivery in the access_request resolver

Addresses feedback on #10576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
