### PR TITLE
Add .agents to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ dist
 temp.sh
 context.md
 CLAUDE.md
+.agents
 .codex
 .vellum
 


### PR DESCRIPTION
## Summary
- Add `.agents` directory to `.gitignore` to prevent it from being tracked

## Original prompt
add .agents to .gitignore of vellum-assistant repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
