### PR TITLE
M3: Enforce Trusted-Contact ACL for Inbound Voice + Shared Access-Request Helper

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -541,6 +541,38 @@ export class RelayConnection {
         return;
       }
 
+      // Members with policy: 'deny' have status: 'active' so resolveActorTrust
+      // classifies them as trusted_contact, but the guardian has explicitly
+      // denied their access. Block them the same way the text-channel path does.
+      if (actorTrust.memberRecord?.policy === 'deny') {
+        log.info(
+          { callSessionId: this.callSessionId, from: msg.from, memberId: actorTrust.memberRecord.id, trustClass: actorTrust.trustClass },
+          'Inbound voice ACL: member policy deny',
+        );
+
+        recordCallEvent(this.callSessionId, 'inbound_acl_denied', {
+          from: msg.from,
+          trustClass: actorTrust.trustClass,
+          memberId: actorTrust.memberRecord.id,
+          memberPolicy: actorTrust.memberRecord.policy,
+        });
+
+        this.sendTextToken('This number is not authorized to use this assistant.', true);
+
+        this.connectionState = 'disconnecting';
+
+        updateCallSession(this.callSessionId, {
+          status: 'failed',
+          endedAt: Date.now(),
+          lastError: 'Inbound voice ACL: member policy deny',
+        });
+
+        setTimeout(() => {
+          this.endSession('Inbound voice ACL: member policy deny');
+        }, 3000);
+        return;
+      }
+
       // Guardian and trusted-contact callers proceed normally.
       // Update the controller's guardian context with the trust-resolved
       // context so downstream policy gates have accurate actor metadata.

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -477,7 +477,10 @@ export class RelayConnection {
       // Resolve the caller's trust classification before allowing the call
       // to proceed. Guardian and trusted-contact callers pass through;
       // unknown callers are denied with deterministic voice copy and an
-      // access request is created for the guardian.
+      // access request is created for the guardian — unless there is a
+      // pending voice guardian challenge, in which case the caller is
+      // expected to be unknown (no binding yet) and should enter the
+      // verification flow.
       const actorTrust = resolveActorTrust({
         assistantId,
         sourceChannel: 'voice',
@@ -485,7 +488,12 @@ export class RelayConnection {
         senderExternalUserId: msg.from || undefined,
       });
 
-      if (actorTrust.trustClass === 'unknown') {
+      // Check for a pending voice guardian challenge before the ACL deny
+      // gate. An unknown caller with a pending challenge is expected —
+      // they need to complete verification to establish a binding.
+      const pendingChallenge = getPendingChallenge(assistantId, 'voice');
+
+      if (actorTrust.trustClass === 'unknown' && !pendingChallenge) {
         log.info(
           { callSessionId: this.callSessionId, from: msg.from, trustClass: actorTrust.trustClass },
           'Inbound voice ACL: unknown caller denied',
@@ -509,11 +517,15 @@ export class RelayConnection {
           log.error({ err, callSessionId: this.callSessionId }, 'Failed to create access request for denied voice caller');
         }
 
-        // Deny with deterministic voice copy and end the call
+        // Deny with deterministic voice copy and end the call.
+        // Mark as disconnecting so handlePrompt ignores caller input
+        // during the delay before the session ends.
         this.sendTextToken(
           'This number is not authorized. Your request has been forwarded to the account guardian.',
           true,
         );
+
+        this.connectionState = 'disconnecting';
 
         updateCallSession(this.callSessionId, {
           status: 'failed',
@@ -530,17 +542,13 @@ export class RelayConnection {
       // Guardian and trusted-contact callers proceed normally.
       // Update the controller's guardian context with the trust-resolved
       // context so downstream policy gates have accurate actor metadata.
-      if (this.controller) {
+      if (this.controller && actorTrust.trustClass !== 'unknown') {
         const resolvedGuardianContext = toGuardianRuntimeContext(
           'voice',
           toGuardianContextCompat(actorTrust, msg.from),
         );
         this.controller.setGuardianContext(resolvedGuardianContext);
       }
-
-      // For inbound calls, check if there's a pending voice guardian
-      // challenge that the caller needs to complete before proceeding.
-      const pendingChallenge = getPendingChallenge(assistantId, 'voice');
 
       if (pendingChallenge) {
         this.startInboundGuardianVerification(assistantId, msg.from);

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -506,13 +506,15 @@ export class RelayConnection {
         });
 
         // Create/dedupe canonical access request via the shared helper
+        let guardianNotified = false;
         try {
-          notifyGuardianOfAccessRequest({
+          const accessResult = notifyGuardianOfAccessRequest({
             canonicalAssistantId: assistantId,
             sourceChannel: 'voice',
             externalChatId: msg.from,
             senderExternalUserId: actorTrust.canonicalSenderId ?? msg.from,
           });
+          guardianNotified = accessResult.notified;
         } catch (err) {
           log.error({ err, callSessionId: this.callSessionId }, 'Failed to create access request for denied voice caller');
         }
@@ -520,10 +522,10 @@ export class RelayConnection {
         // Deny with deterministic voice copy and end the call.
         // Mark as disconnecting so handlePrompt ignores caller input
         // during the delay before the session ends.
-        this.sendTextToken(
-          'This number is not authorized. Your request has been forwarded to the account guardian.',
-          true,
-        );
+        const denialMessage = guardianNotified
+          ? 'This number is not authorized. Your request has been forwarded to the account guardian.'
+          : 'This number is not authorized to use this assistant.';
+        this.sendTextToken(denialMessage, true);
 
         this.connectionState = 'disconnecting';
 

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -13,6 +13,8 @@ import type { ServerWebSocket } from 'bun';
 import { getConfig } from '../config/loader.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { revokeScopedApprovalGrantsForContext } from '../memory/scoped-approval-grants.js';
+import { notifyGuardianOfAccessRequest } from '../runtime/access-request-helper.js';
+import { resolveActorTrust, toGuardianContextCompat } from '../runtime/actor-trust-resolver.js';
 import {
   getPendingChallenge,
   validateAndConsumeChallenge,
@@ -471,6 +473,71 @@ export class RelayConnection {
     if (!isInbound && verificationConfig.enabled) {
       await this.startVerification(session, verificationConfig);
     } else if (isInbound) {
+      // ── Trusted-contact ACL enforcement for inbound voice ──
+      // Resolve the caller's trust classification before allowing the call
+      // to proceed. Guardian and trusted-contact callers pass through;
+      // unknown callers are denied with deterministic voice copy and an
+      // access request is created for the guardian.
+      const actorTrust = resolveActorTrust({
+        assistantId,
+        sourceChannel: 'voice',
+        externalChatId: msg.from,
+        senderExternalUserId: msg.from || undefined,
+      });
+
+      if (actorTrust.trustClass === 'unknown') {
+        log.info(
+          { callSessionId: this.callSessionId, from: msg.from, trustClass: actorTrust.trustClass },
+          'Inbound voice ACL: unknown caller denied',
+        );
+
+        recordCallEvent(this.callSessionId, 'inbound_acl_denied', {
+          from: msg.from,
+          trustClass: actorTrust.trustClass,
+          denialReason: actorTrust.denialReason,
+        });
+
+        // Create/dedupe canonical access request via the shared helper
+        try {
+          notifyGuardianOfAccessRequest({
+            canonicalAssistantId: assistantId,
+            sourceChannel: 'voice',
+            externalChatId: msg.from,
+            senderExternalUserId: actorTrust.canonicalSenderId ?? msg.from,
+          });
+        } catch (err) {
+          log.error({ err, callSessionId: this.callSessionId }, 'Failed to create access request for denied voice caller');
+        }
+
+        // Deny with deterministic voice copy and end the call
+        this.sendTextToken(
+          'This number is not authorized. Your request has been forwarded to the account guardian.',
+          true,
+        );
+
+        updateCallSession(this.callSessionId, {
+          status: 'failed',
+          endedAt: Date.now(),
+          lastError: 'Inbound voice ACL: caller not authorized',
+        });
+
+        setTimeout(() => {
+          this.endSession('Inbound voice ACL denied');
+        }, 3000);
+        return;
+      }
+
+      // Guardian and trusted-contact callers proceed normally.
+      // Update the controller's guardian context with the trust-resolved
+      // context so downstream policy gates have accurate actor metadata.
+      if (this.controller) {
+        const resolvedGuardianContext = toGuardianRuntimeContext(
+          'voice',
+          toGuardianContextCompat(actorTrust, msg.from),
+        );
+        this.controller.setGuardianContext(resolvedGuardianContext);
+      }
+
       // For inbound calls, check if there's a pending voice guardian
       // challenge that the caller needs to complete before proceeding.
       const pendingChallenge = getPendingChallenge(assistantId, 'voice');

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -1,0 +1,136 @@
+/**
+ * Shared access-request creation and notification helper.
+ *
+ * Encapsulates the "create/dedupe canonical access request + emit notification"
+ * logic so both text-channel and voice-channel ingress paths use identical
+ * guardian notification flows.
+ */
+
+import type { ChannelId } from '../channels/types.js';
+import {
+  createCanonicalGuardianRequest,
+  listCanonicalGuardianRequests,
+} from '../memory/canonical-guardian-store.js';
+import { emitNotificationSignal } from '../notifications/emit-signal.js';
+import { getLogger } from '../util/logger.js';
+import { getGuardianBinding } from './channel-guardian-service.js';
+import { GUARDIAN_APPROVAL_TTL_MS } from './routes/channel-route-shared.js';
+
+const log = getLogger('access-request-helper');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AccessRequestParams {
+  canonicalAssistantId: string;
+  sourceChannel: ChannelId;
+  externalChatId: string;
+  senderExternalUserId?: string;
+  senderName?: string;
+  senderUsername?: string;
+}
+
+export type AccessRequestResult =
+  | { notified: true; created: boolean; requestId: string }
+  | { notified: false; reason: 'no_sender_id' | 'no_guardian_binding' };
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Create/dedupe a canonical access request and emit a notification signal
+ * so the guardian can approve or deny the unknown sender.
+ *
+ * Returns a result indicating whether the guardian was notified and whether
+ * a new request was created or an existing one was deduped.
+ *
+ * This is intentionally synchronous with respect to the canonical store writes
+ * and fire-and-forget for the notification signal emission.
+ */
+export function notifyGuardianOfAccessRequest(
+  params: AccessRequestParams,
+): AccessRequestResult {
+  const {
+    canonicalAssistantId,
+    sourceChannel,
+    externalChatId,
+    senderExternalUserId,
+    senderName,
+    senderUsername,
+  } = params;
+
+  if (!senderExternalUserId) {
+    return { notified: false, reason: 'no_sender_id' };
+  }
+
+  const binding = getGuardianBinding(canonicalAssistantId, sourceChannel);
+  if (!binding) {
+    log.debug({ sourceChannel, canonicalAssistantId }, 'No guardian binding for access request notification');
+    return { notified: false, reason: 'no_guardian_binding' };
+  }
+
+  // Deduplicate: skip creation if there is already a pending canonical request
+  // for the same requester on this channel. Still return notified: true with
+  // the existing request ID so callers know the guardian was already notified.
+  const existingCanonical = listCanonicalGuardianRequests({
+    status: 'pending',
+    requesterExternalUserId: senderExternalUserId,
+    sourceChannel,
+    kind: 'access_request',
+  });
+  if (existingCanonical.length > 0) {
+    log.debug(
+      { sourceChannel, senderExternalUserId, existingId: existingCanonical[0].id },
+      'Skipping duplicate access request notification',
+    );
+    return { notified: true, created: false, requestId: existingCanonical[0].id };
+  }
+
+  const senderIdentifier = senderName || senderUsername || senderExternalUserId;
+  const requestId = `access-req-${canonicalAssistantId}-${sourceChannel}-${senderExternalUserId}-${Date.now()}`;
+
+  const canonicalRequest = createCanonicalGuardianRequest({
+    id: requestId,
+    kind: 'access_request',
+    sourceType: 'channel',
+    sourceChannel,
+    conversationId: `access-req-${sourceChannel}-${senderExternalUserId}`,
+    requesterExternalUserId: senderExternalUserId,
+    guardianExternalUserId: binding.guardianExternalUserId,
+    toolName: 'ingress_access_request',
+    questionText: `${senderIdentifier} is requesting access to the assistant`,
+    expiresAt: new Date(Date.now() + GUARDIAN_APPROVAL_TTL_MS).toISOString(),
+  });
+
+  void emitNotificationSignal({
+    sourceEventName: 'ingress.access_request',
+    sourceChannel,
+    sourceSessionId: `access-req-${sourceChannel}-${senderExternalUserId}`,
+    assistantId: canonicalAssistantId,
+    attentionHints: {
+      requiresAction: true,
+      urgency: 'high',
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
+    contextPayload: {
+      requestId,
+      sourceChannel,
+      externalChatId,
+      senderExternalUserId,
+      senderName: senderName ?? null,
+      senderUsername: senderUsername ?? null,
+      senderIdentifier,
+    },
+    dedupeKey: `access-request:${canonicalRequest.id}`,
+  });
+
+  log.info(
+    { sourceChannel, senderExternalUserId, senderIdentifier },
+    'Guardian notified of access request',
+  );
+
+  return { notified: true, created: true, requestId: canonicalRequest.id };
+}

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -14,7 +14,6 @@ import * as attachmentsStore from '../../memory/attachments-store.js';
 import * as channelDeliveryStore from '../../memory/channel-delivery-store.js';
 import {
   createCanonicalGuardianRequest,
-  listCanonicalGuardianRequests,
 } from '../../memory/canonical-guardian-store.js';
 import { recordConversationSeenSignal } from '../../memory/conversation-attention-store.js';
 import * as conversationStore from '../../memory/conversation-store.js';
@@ -26,6 +25,7 @@ import { canonicalizeInboundIdentity } from '../../util/canonicalize-identity.js
 import { IngressBlockedError } from '../../util/errors.js';
 import { getLogger } from '../../util/logger.js';
 import { readHttpToken } from '../../util/platform.js';
+import { notifyGuardianOfAccessRequest } from '../access-request-helper.js';
 import {
   buildApprovalUIMetadata,
   getApprovalInfoByConversation,
@@ -313,11 +313,11 @@ export async function handleChannelInbound(
         log.info({ sourceChannel, externalUserId: canonicalSenderId }, 'Ingress ACL: no member record, denying');
 
         // Notify the guardian about the access request so they can approve/deny.
-        // Only fires when a guardian binding exists and no duplicate pending
-        // request already exists for this requester.
+        // Uses the shared helper which handles guardian binding lookup,
+        // deduplication, canonical request creation, and notification emission.
         let guardianNotified = false;
         try {
-          guardianNotified = notifyGuardianOfAccessRequest({
+          const accessResult = notifyGuardianOfAccessRequest({
             canonicalAssistantId,
             sourceChannel,
             externalChatId,
@@ -325,6 +325,7 @@ export async function handleChannelInbound(
             senderName: body.senderName,
             senderUsername: body.senderUsername,
           });
+          guardianNotified = accessResult.notified;
         } catch (err) {
           log.error({ err, sourceChannel, externalChatId }, 'Failed to notify guardian of access request');
         }
@@ -403,7 +404,7 @@ export async function handleChannelInbound(
           let guardianNotified = false;
           if (resolvedMember.status !== 'blocked') {
             try {
-              guardianNotified = notifyGuardianOfAccessRequest({
+              const accessResult = notifyGuardianOfAccessRequest({
                 canonicalAssistantId,
                 sourceChannel,
                 externalChatId,
@@ -411,6 +412,7 @@ export async function handleChannelInbound(
                 senderName: body.senderName,
                 senderUsername: body.senderUsername,
               });
+              guardianNotified = accessResult.notified;
             } catch (err) {
               log.error({ err, sourceChannel, externalChatId }, 'Failed to notify guardian of access request');
             }
@@ -1246,105 +1248,6 @@ async function handleInviteTokenIntercept(params: {
   // Failed redemption — inform the user and deny
   channelDeliveryStore.markProcessed(dedupResult.eventId);
   return Response.json({ accepted: true, eventId: dedupResult.eventId, denied: true, inviteRedemption: outcome.reason });
-}
-
-// ---------------------------------------------------------------------------
-// Non-member access request notification
-// ---------------------------------------------------------------------------
-
-/**
- * Fire-and-forget: look up the guardian binding and, if present, create an
- * approval request + emit a notification signal so the guardian can
- * approve/deny the unknown user. Deduplicates by checking for an existing
- * pending approval for the same (requester, assistant, channel).
- */
-function notifyGuardianOfAccessRequest(params: {
-  canonicalAssistantId: string;
-  sourceChannel: ChannelId;
-  externalChatId: string;
-  senderExternalUserId?: string;
-  senderName?: string;
-  senderUsername?: string;
-}): boolean {
-  const {
-    canonicalAssistantId,
-    sourceChannel,
-    externalChatId,
-    senderExternalUserId,
-    senderName,
-    senderUsername,
-  } = params;
-
-  if (!senderExternalUserId) return false;
-
-  const binding = getGuardianBinding(canonicalAssistantId, sourceChannel);
-  if (!binding) {
-    log.debug({ sourceChannel, canonicalAssistantId }, 'No guardian binding for access request notification');
-    return false;
-  }
-
-  // Deduplicate: skip if there is already a pending canonical request for
-  // the same requester on this channel.  Still return true — the guardian
-  // was already notified for this request.
-  const existingCanonical = listCanonicalGuardianRequests({
-    status: 'pending',
-    requesterExternalUserId: senderExternalUserId,
-    sourceChannel,
-    kind: 'access_request',
-  });
-  if (existingCanonical.length > 0) {
-    log.debug(
-      { sourceChannel, senderExternalUserId, existingId: existingCanonical[0].id },
-      'Skipping duplicate access request notification',
-    );
-    return true;
-  }
-
-  const senderIdentifier = senderName || senderUsername || senderExternalUserId;
-  const requestId = `access-req-${canonicalAssistantId}-${sourceChannel}-${senderExternalUserId}-${Date.now()}`;
-
-  const canonicalRequest = createCanonicalGuardianRequest({
-    id: requestId,
-    kind: 'access_request',
-    sourceType: 'channel',
-    sourceChannel,
-    conversationId: `access-req-${sourceChannel}-${senderExternalUserId}`,
-    requesterExternalUserId: senderExternalUserId,
-    guardianExternalUserId: binding.guardianExternalUserId,
-    toolName: 'ingress_access_request',
-    questionText: `${senderIdentifier} is requesting access to the assistant`,
-    expiresAt: new Date(Date.now() + GUARDIAN_APPROVAL_TTL_MS).toISOString(),
-  });
-
-  void emitNotificationSignal({
-    sourceEventName: 'ingress.access_request',
-    sourceChannel,
-    sourceSessionId: `access-req-${sourceChannel}-${senderExternalUserId}`,
-    assistantId: canonicalAssistantId,
-    attentionHints: {
-      requiresAction: true,
-      urgency: 'high',
-      isAsyncBackground: false,
-      visibleInSourceNow: false,
-    },
-    contextPayload: {
-      requestId,
-      sourceChannel,
-      externalChatId,
-      senderExternalUserId,
-      senderName: senderName ?? null,
-      senderUsername: senderUsername ?? null,
-      senderIdentifier,
-    },
-    dedupeKey: `access-request:${canonicalRequest.id}`,
-  });
-
-  log.info(
-    { sourceChannel, senderExternalUserId, senderIdentifier },
-    'Guardian notified of non-member access request',
-  );
-
-  return true;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of #10577. Extracts shared access-request creation/dedupe helper from text-channel path and wires it into inbound voice setup. Unknown callers are denied with deterministic voice copy, a canonical access request is created, and a notification is emitted. Guardian and trusted-contact callers pass through normally.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
