### PR TITLE
fix: require externalUserId for identity binding in shared-chat verification

### DIFF
--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -231,11 +231,19 @@ export function validateAndConsumeChallenge(
       }
     }
 
-    // For Telegram: verify actorChatId matches expectedChatId
-    // AND/OR actorExternalUserId matches expectedExternalUserId
+    // For chat-based channels (Telegram, Slack, etc.): when both
+    // expectedExternalUserId and expectedChatId are set, require the
+    // externalUserId match — chatId alone is insufficient because chat IDs
+    // can be shared (e.g. Slack channel IDs, Telegram group chat IDs) and
+    // would let any participant in the same chat satisfy identity binding.
+    // Fall back to chatId-only match only when expectedExternalUserId is
+    // not available (legacy sessions or channels without user-level identity).
     if (challenge.expectedChatId != null) {
-      if (actorChatId === challenge.expectedChatId ||
-          actorExternalUserId === challenge.expectedExternalUserId) {
+      if (challenge.expectedExternalUserId != null) {
+        if (actorExternalUserId === challenge.expectedExternalUserId) {
+          identityMatch = true;
+        }
+      } else if (actorChatId === challenge.expectedChatId) {
         identityMatch = true;
       }
     }


### PR DESCRIPTION
## Summary
- Tighten identity check in `validateAndConsumeChallenge` to require `externalUserId` match when both `expectedExternalUserId` and `expectedChatId` are set
- Previously, `chatId` alone could satisfy identity binding, which is unsafe in shared-chat environments (Slack channels, Telegram groups) where chatId is shared among participants
- Fall back to chatId-only match only when `expectedExternalUserId` is not available (legacy/no user-level identity)

## Test plan
- [x] All 175 channel-guardian tests pass
- [x] All 10 access-request-decision tests pass
- [x] All 10 guardian-grant-minting tests pass
- [x] All 65 channel-approval-routes tests pass
- [x] All 6 trusted-contact-lifecycle-notifications tests pass
- [x] Type check passes

Addresses Codex P1 review feedback on #10587.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
