### PR TITLE
M4: Persisted Identity Normalization Migration + Hardening

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -4,6 +4,7 @@ import {
   createAssistantInboxTables,
   createCallSessionsTables,
   createCanonicalGuardianTables,
+  migrateNormalizePhoneIdentities,
   createChannelGuardianTables,
   createContactsAndTriageTables,
   createConversationAttentionTables,
@@ -148,6 +149,9 @@ export function initializeDb(): void {
 
   // 24. Canonical guardian requests and deliveries (unified cross-source guardian domain)
   createCanonicalGuardianTables(database);
+
+  // 25. Normalize phone-like identity fields to E.164 across guardian and ingress tables
+  migrateNormalizePhoneIdentities(database);
 
   validateMigrationState(database);
 }

--- a/assistant/src/memory/migrations/036-normalize-phone-identities.ts
+++ b/assistant/src/memory/migrations/036-normalize-phone-identities.ts
@@ -15,6 +15,10 @@ import { type DrizzleDb, getSqliteFrom } from '../db-connection.js';
  *   - The `expected_phone_e164` column is always a phone number regardless
  *     of channel, so it is normalized unconditionally.
  *
+ * Collision handling: when normalizing a value would collide with an existing
+ * row under the same unique-key scope, the duplicate row is deleted instead
+ * of updated (the canonical row already exists with the target value).
+ *
  * Idempotent: already-normalized values pass through normalizePhoneNumber
  * unchanged, and the checkpoint key prevents re-execution.
  */
@@ -28,12 +32,27 @@ export function migrateNormalizePhoneIdentities(database: DrizzleDb): void {
 
   const PHONE_CHANNELS = ['sms', 'voice', 'whatsapp'];
 
+  /**
+   * Unique key scope definition for collision detection.
+   * `peerColumns` are the other columns in the composite unique index
+   * (besides the column being normalized). When the normalized value
+   * matches an existing row with the same peer-column values, the
+   * current row is a duplicate and should be deleted.
+   * `whereClause` is an optional SQL fragment for partial unique indexes
+   * (e.g., `WHERE external_user_id IS NOT NULL`).
+   */
+  type UniqueKeyScope = {
+    peerColumns: string[];
+    whereClause?: string;
+  };
+
   // Helper: normalize a column's phone-like values in a table filtered by channel.
-  // Returns the number of rows updated.
+  // When uniqueKeyScope is provided, checks for collisions before updating.
   function normalizeColumnByChannel(
     table: string,
     column: string,
     channelColumn: string,
+    uniqueKeyScope?: UniqueKeyScope,
   ): void {
     const tableExists = raw.query(
       `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?`,
@@ -50,8 +69,15 @@ export function migrateNormalizePhoneIdentities(database: DrizzleDb): void {
     ).get(table, channelColumn);
     if (!chanColExists) return;
 
+    const selectColumns = [`id`, column];
+    if (uniqueKeyScope) {
+      for (const peer of uniqueKeyScope.peerColumns) {
+        if (!selectColumns.includes(peer)) selectColumns.push(peer);
+      }
+    }
+
     const rows = raw.query(
-      `SELECT id, ${column} FROM ${table} WHERE ${channelColumn} IN (${PHONE_CHANNELS.map(() => '?').join(',')}) AND ${column} IS NOT NULL`,
+      `SELECT ${selectColumns.join(', ')} FROM ${table} WHERE ${channelColumn} IN (${PHONE_CHANNELS.map(() => '?').join(',')}) AND ${column} IS NOT NULL`,
     ).all(...PHONE_CHANNELS) as Array<{ id: string; [key: string]: string }>;
 
     if (rows.length === 0) return;
@@ -59,12 +85,31 @@ export function migrateNormalizePhoneIdentities(database: DrizzleDb): void {
     const update = raw.prepare(
       `UPDATE ${table} SET ${column} = ? WHERE id = ?`,
     );
+    const deleteRow = raw.prepare(
+      `DELETE FROM ${table} WHERE id = ?`,
+    );
 
     for (const row of rows) {
       const original = row[column];
       if (!original) continue;
       const normalized = normalizePhoneNumber(original);
       if (normalized && normalized !== original) {
+        if (uniqueKeyScope) {
+          // Check if another row already has the normalized value within the same unique-key scope
+          const peerConditions = uniqueKeyScope.peerColumns
+            .map((col) => `${col} = ?`)
+            .join(' AND ');
+          const peerValues = uniqueKeyScope.peerColumns.map((col) => row[col]);
+          const whereExtra = uniqueKeyScope.whereClause ? ` AND (${uniqueKeyScope.whereClause})` : '';
+          const existing = raw.query(
+            `SELECT 1 FROM ${table} WHERE ${column} = ? AND ${peerConditions} AND id != ?${whereExtra}`,
+          ).get(normalized, ...peerValues, row.id);
+          if (existing) {
+            // A canonical row already exists — delete this duplicate
+            deleteRow.run(row.id);
+            continue;
+          }
+        }
         update.run(normalized, row.id);
       }
     }
@@ -72,9 +117,11 @@ export function migrateNormalizePhoneIdentities(database: DrizzleDb): void {
 
   // Helper: normalize a column unconditionally (no channel filter).
   // Used for columns that are always phone numbers (e.g., expected_phone_e164).
+  // When uniqueKeyScope is provided, checks for collisions before updating.
   function normalizeColumnUnconditionally(
     table: string,
     column: string,
+    uniqueKeyScope?: UniqueKeyScope,
   ): void {
     const tableExists = raw.query(
       `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?`,
@@ -86,8 +133,15 @@ export function migrateNormalizePhoneIdentities(database: DrizzleDb): void {
     ).get(table, column);
     if (!colExists) return;
 
+    const selectColumns = [`id`, column];
+    if (uniqueKeyScope) {
+      for (const peer of uniqueKeyScope.peerColumns) {
+        if (!selectColumns.includes(peer)) selectColumns.push(peer);
+      }
+    }
+
     const rows = raw.query(
-      `SELECT id, ${column} FROM ${table} WHERE ${column} IS NOT NULL`,
+      `SELECT ${selectColumns.join(', ')} FROM ${table} WHERE ${column} IS NOT NULL`,
     ).all() as Array<{ id: string; [key: string]: string }>;
 
     if (rows.length === 0) return;
@@ -95,12 +149,29 @@ export function migrateNormalizePhoneIdentities(database: DrizzleDb): void {
     const update = raw.prepare(
       `UPDATE ${table} SET ${column} = ? WHERE id = ?`,
     );
+    const deleteRow = raw.prepare(
+      `DELETE FROM ${table} WHERE id = ?`,
+    );
 
     for (const row of rows) {
       const original = row[column];
       if (!original) continue;
       const normalized = normalizePhoneNumber(original);
       if (normalized && normalized !== original) {
+        if (uniqueKeyScope) {
+          const peerConditions = uniqueKeyScope.peerColumns
+            .map((col) => `${col} = ?`)
+            .join(' AND ');
+          const peerValues = uniqueKeyScope.peerColumns.map((col) => row[col]);
+          const whereExtra = uniqueKeyScope.whereClause ? ` AND (${uniqueKeyScope.whereClause})` : '';
+          const existing = raw.query(
+            `SELECT 1 FROM ${table} WHERE ${column} = ? AND ${peerConditions} AND id != ?${whereExtra}`,
+          ).get(normalized, ...peerValues, row.id);
+          if (existing) {
+            deleteRow.run(row.id);
+            continue;
+          }
+        }
         update.run(normalized, row.id);
       }
     }
@@ -111,6 +182,8 @@ export function migrateNormalizePhoneIdentities(database: DrizzleDb): void {
 
     // ── channel_guardian_bindings ──────────────────────────────────
     // Has `channel` column — only normalize phone-like channels.
+    // Unique index idx_channel_guardian_bindings_active is on (assistant_id, channel)
+    // and does NOT include guardian_external_user_id, so no collision risk.
     normalizeColumnByChannel(
       'channel_guardian_bindings',
       'guardian_external_user_id',
@@ -119,14 +192,22 @@ export function migrateNormalizePhoneIdentities(database: DrizzleDb): void {
 
     // ── assistant_ingress_members ─────────────────────────────────
     // Has `source_channel` column — only normalize phone-like channels.
+    // Unique index idx_ingress_members_user is on (assistant_id, source_channel, external_user_id)
+    // WHERE external_user_id IS NOT NULL — collision possible when two format variants normalize
+    // to the same E.164 within the same (assistant_id, source_channel) scope.
     normalizeColumnByChannel(
       'assistant_ingress_members',
       'external_user_id',
       'source_channel',
+      {
+        peerColumns: ['assistant_id', 'source_channel'],
+        whereClause: 'external_user_id IS NOT NULL',
+      },
     );
 
     // ── channel_guardian_verification_challenges ──────────────────
     // Has `channel` column — normalize identity columns for phone-like channels.
+    // Index idx_channel_guardian_challenges_lookup is non-unique, no collision risk.
     normalizeColumnByChannel(
       'channel_guardian_verification_challenges',
       'expected_external_user_id',
@@ -138,6 +219,7 @@ export function migrateNormalizePhoneIdentities(database: DrizzleDb): void {
       'channel',
     );
     // expected_phone_e164 is always a phone number regardless of channel.
+    // No unique index includes this column, no collision risk.
     normalizeColumnUnconditionally(
       'channel_guardian_verification_challenges',
       'expected_phone_e164',
@@ -145,6 +227,7 @@ export function migrateNormalizePhoneIdentities(database: DrizzleDb): void {
 
     // ── canonical_guardian_requests ───────────────────────────────
     // Has `source_channel` column — only normalize phone-like channels.
+    // All indexes on this table are non-unique, no collision risk.
     normalizeColumnByChannel(
       'canonical_guardian_requests',
       'requester_external_user_id',
@@ -163,10 +246,17 @@ export function migrateNormalizePhoneIdentities(database: DrizzleDb): void {
 
     // ── channel_guardian_rate_limits ──────────────────────────────
     // Has `channel` column — only normalize phone-like channels.
+    // Unique index idx_channel_guardian_rate_limits_actor is on
+    // (assistant_id, channel, actor_external_user_id, actor_chat_id) —
+    // collision possible when two format variants normalize to the same E.164
+    // within the same (assistant_id, channel, actor_chat_id) scope.
     normalizeColumnByChannel(
       'channel_guardian_rate_limits',
       'actor_external_user_id',
       'channel',
+      {
+        peerColumns: ['assistant_id', 'channel', 'actor_chat_id'],
+      },
     );
 
     // Write checkpoint

--- a/assistant/src/memory/migrations/036-normalize-phone-identities.ts
+++ b/assistant/src/memory/migrations/036-normalize-phone-identities.ts
@@ -1,0 +1,182 @@
+import { normalizePhoneNumber } from '../../util/phone.js';
+import { type DrizzleDb, getSqliteFrom } from '../db-connection.js';
+
+/**
+ * One-shot migration: normalize phone-like identity fields to E.164 format.
+ *
+ * Historical records may contain phone numbers in inconsistent formats
+ * (e.g., "(555) 123-4567", "1-555-123-4567", "+1 555 123 4567").
+ * This migration normalizes them to E.164 ("+15551234567") using the same
+ * normalizePhoneNumber utility used at runtime.
+ *
+ * Strategy:
+ *   - Tables with a `channel` column: only process rows where the channel
+ *     is phone-like (sms, voice, whatsapp).
+ *   - The `expected_phone_e164` column is always a phone number regardless
+ *     of channel, so it is normalized unconditionally.
+ *
+ * Idempotent: already-normalized values pass through normalizePhoneNumber
+ * unchanged, and the checkpoint key prevents re-execution.
+ */
+export function migrateNormalizePhoneIdentities(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  const checkpointKey = 'migration_normalize_phone_identities_v1';
+  const checkpoint = raw.query(
+    `SELECT 1 FROM memory_checkpoints WHERE key = ?`,
+  ).get(checkpointKey);
+  if (checkpoint) return;
+
+  const PHONE_CHANNELS = ['sms', 'voice', 'whatsapp'];
+
+  // Helper: normalize a column's phone-like values in a table filtered by channel.
+  // Returns the number of rows updated.
+  function normalizeColumnByChannel(
+    table: string,
+    column: string,
+    channelColumn: string,
+  ): void {
+    const tableExists = raw.query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?`,
+    ).get(table);
+    if (!tableExists) return;
+
+    const colExists = raw.query(
+      `SELECT 1 FROM pragma_table_info(?) WHERE name = ?`,
+    ).get(table, column);
+    if (!colExists) return;
+
+    const chanColExists = raw.query(
+      `SELECT 1 FROM pragma_table_info(?) WHERE name = ?`,
+    ).get(table, channelColumn);
+    if (!chanColExists) return;
+
+    const rows = raw.query(
+      `SELECT id, ${column} FROM ${table} WHERE ${channelColumn} IN (${PHONE_CHANNELS.map(() => '?').join(',')}) AND ${column} IS NOT NULL`,
+    ).all(...PHONE_CHANNELS) as Array<{ id: string; [key: string]: string }>;
+
+    if (rows.length === 0) return;
+
+    const update = raw.prepare(
+      `UPDATE ${table} SET ${column} = ? WHERE id = ?`,
+    );
+
+    for (const row of rows) {
+      const original = row[column];
+      if (!original) continue;
+      const normalized = normalizePhoneNumber(original);
+      if (normalized && normalized !== original) {
+        update.run(normalized, row.id);
+      }
+    }
+  }
+
+  // Helper: normalize a column unconditionally (no channel filter).
+  // Used for columns that are always phone numbers (e.g., expected_phone_e164).
+  function normalizeColumnUnconditionally(
+    table: string,
+    column: string,
+  ): void {
+    const tableExists = raw.query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?`,
+    ).get(table);
+    if (!tableExists) return;
+
+    const colExists = raw.query(
+      `SELECT 1 FROM pragma_table_info(?) WHERE name = ?`,
+    ).get(table, column);
+    if (!colExists) return;
+
+    const rows = raw.query(
+      `SELECT id, ${column} FROM ${table} WHERE ${column} IS NOT NULL`,
+    ).all() as Array<{ id: string; [key: string]: string }>;
+
+    if (rows.length === 0) return;
+
+    const update = raw.prepare(
+      `UPDATE ${table} SET ${column} = ? WHERE id = ?`,
+    );
+
+    for (const row of rows) {
+      const original = row[column];
+      if (!original) continue;
+      const normalized = normalizePhoneNumber(original);
+      if (normalized && normalized !== original) {
+        update.run(normalized, row.id);
+      }
+    }
+  }
+
+  try {
+    raw.exec('BEGIN');
+
+    // ── channel_guardian_bindings ──────────────────────────────────
+    // Has `channel` column — only normalize phone-like channels.
+    normalizeColumnByChannel(
+      'channel_guardian_bindings',
+      'guardian_external_user_id',
+      'channel',
+    );
+
+    // ── assistant_ingress_members ─────────────────────────────────
+    // Has `source_channel` column — only normalize phone-like channels.
+    normalizeColumnByChannel(
+      'assistant_ingress_members',
+      'external_user_id',
+      'source_channel',
+    );
+
+    // ── channel_guardian_verification_challenges ──────────────────
+    // Has `channel` column — normalize identity columns for phone-like channels.
+    normalizeColumnByChannel(
+      'channel_guardian_verification_challenges',
+      'expected_external_user_id',
+      'channel',
+    );
+    normalizeColumnByChannel(
+      'channel_guardian_verification_challenges',
+      'consumed_by_external_user_id',
+      'channel',
+    );
+    // expected_phone_e164 is always a phone number regardless of channel.
+    normalizeColumnUnconditionally(
+      'channel_guardian_verification_challenges',
+      'expected_phone_e164',
+    );
+
+    // ── canonical_guardian_requests ───────────────────────────────
+    // Has `source_channel` column — only normalize phone-like channels.
+    normalizeColumnByChannel(
+      'canonical_guardian_requests',
+      'requester_external_user_id',
+      'source_channel',
+    );
+    normalizeColumnByChannel(
+      'canonical_guardian_requests',
+      'guardian_external_user_id',
+      'source_channel',
+    );
+    normalizeColumnByChannel(
+      'canonical_guardian_requests',
+      'decided_by_external_user_id',
+      'source_channel',
+    );
+
+    // ── channel_guardian_rate_limits ──────────────────────────────
+    // Has `channel` column — only normalize phone-like channels.
+    normalizeColumnByChannel(
+      'channel_guardian_rate_limits',
+      'actor_external_user_id',
+      'channel',
+    );
+
+    // Write checkpoint
+    raw.query(
+      `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,
+    ).run(checkpointKey, Date.now());
+
+    raw.exec('COMMIT');
+  } catch (e) {
+    try { raw.exec('ROLLBACK'); } catch { /* no active transaction */ }
+    throw e;
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -37,6 +37,7 @@ export { migrateNotificationDeliveryThreadDecision } from './032-notification-de
 export { createScopedApprovalGrantsTable } from './033-scoped-approval-grants.js';
 export { migrateGuardianActionToolMetadata } from './034-guardian-action-tool-metadata.js';
 export { migrateGuardianActionSupersession } from './035-guardian-action-supersession.js';
+export { migrateNormalizePhoneIdentities } from './036-normalize-phone-identities.js';
 export { createCoreTables } from './100-core-tables.js';
 export { createWatchersAndLogsTables } from './101-watchers-and-logs.js';
 export { addCoreColumns } from './102-alter-table-columns.js';

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -90,6 +90,11 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     dependsOn: ['migration_embedding_vector_blob_v1'],
     description: 'Rebuild memory_embeddings to make vector_json nullable (pre-100 DBs had NOT NULL)',
   },
+  {
+    key: 'migration_normalize_phone_identities_v1',
+    version: 14,
+    description: 'Normalize phone-like identity fields to E.164 format across guardian bindings, verification challenges, canonical requests, ingress members, and rate limits',
+  },
 ];
 
 export interface MigrationValidationResult {

--- a/assistant/src/memory/schema-migration.ts
+++ b/assistant/src/memory/schema-migration.ts
@@ -21,6 +21,7 @@ export {
   migrateMessagesFtsBackfill,
   migrateNotificationDeliveryPairingColumns,
   migrateNotificationDeliveryThreadDecision,
+  migrateNormalizePhoneIdentities,
   migrateNotificationTablesSchema,
   migrateRemainingTableIndexes,
   migrateReminderRoutingIntent,


### PR DESCRIPTION
Part of #10577. Adds a database migration that normalizes phone-like identity fields (guardian bindings, member records, verification challenges, canonical requests, rate limits) to E.164 format. Only processes records on phone-like channels (sms, voice, whatsapp). Uses the same normalizePhoneNumber utility from M1. Idempotent — already-normalized values are unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
