### PR TITLE
fix: unblock MainActor during hatch so log output streams to UI

### DIFF
--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -442,9 +442,6 @@ final class AssistantCli {
 
         proc.environment = env
 
-        try proc.run()
-        log.info("CLI remote hatch launched with pid \(proc.processIdentifier)")
-
         let stdoutHandle = stdoutPipe.fileHandleForReading
         let stderrHandle = stderrPipe.fileHandleForReading
 
@@ -470,12 +467,20 @@ final class AssistantCli {
             }
         }
 
-        proc.waitUntilExit()
+        try proc.run()
+        log.info("CLI remote hatch launched with pid \(proc.processIdentifier)")
 
-        stdoutHandle.readabilityHandler = nil
-        stderrHandle.readabilityHandler = nil
+        // Use terminationHandler + continuation instead of waitUntilExit()
+        // so the MainActor is suspended (not blocked), allowing queued
+        // onOutput callbacks to update the UI while the process runs.
+        let status: Int32 = try await withCheckedThrowingContinuation { continuation in
+            proc.terminationHandler = { finished in
+                stdoutHandle.readabilityHandler = nil
+                stderrHandle.readabilityHandler = nil
+                continuation.resume(returning: finished.terminationStatus)
+            }
+        }
 
-        let status = proc.terminationStatus
         if status != 0 {
             log.error("CLI remote hatch failed with exit code \(status)")
             throw CLIError.executionFailed("Hatch process exited with code \(status)")
@@ -536,12 +541,14 @@ final class AssistantCli {
             if !trimmed.isEmpty { onOutput(trimmed) }
         }
 
-        proc.waitUntilExit()
+        let status: Int32 = try await withCheckedThrowingContinuation { continuation in
+            proc.terminationHandler = { finished in
+                stdoutHandle.readabilityHandler = nil
+                stderrHandle.readabilityHandler = nil
+                continuation.resume(returning: finished.terminationStatus)
+            }
+        }
 
-        stdoutHandle.readabilityHandler = nil
-        stderrHandle.readabilityHandler = nil
-
-        let status = proc.terminationStatus
         if status != 0 {
             log.error("CLI pair failed with exit code \(status)")
             throw CLIError.executionFailed("Pair process exited with code \(status)")

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -193,7 +193,7 @@ struct HatchingStepView: View {
             anthropicApiKey: apiKey
         )
 
-        Task.detached { [config] in
+        Task {
             do {
                 try await cliLauncher.runRemoteHatch(config: config) { line in
                     Task { @MainActor in
@@ -205,14 +205,10 @@ struct HatchingStepView: View {
                         }
                     }
                 }
-                await MainActor.run {
-                    state.hatchCompleted = true
-                }
+                state.hatchCompleted = true
             } catch {
-                await MainActor.run {
-                    state.hatchLogLines.append("Error: \(error.localizedDescription)")
-                    state.hatchFailed = true
-                }
+                state.hatchLogLines.append("Error: \(error.localizedDescription)")
+                state.hatchFailed = true
             }
         }
     }


### PR DESCRIPTION
## Summary
- `runRemoteHatch` and `runPair` in `AssistantCli` used `proc.waitUntilExit()` which blocked the MainActor thread, preventing log output from streaming to the UI during hatching
- Replaced `waitUntilExit()` with `terminationHandler` + `withCheckedThrowingContinuation` so the MainActor suspends (not blocks), allowing queued `readabilityHandler` callbacks to deliver log lines to `state.hatchLogLines` in real time
- Simplified `HatchingStepView` to use `Task` instead of `Task.detached` since the MainActor is no longer blocked

## Test plan
- [ ] Run through onboarding with "Own API Key" flow → click Hatch → verify log lines stream into the log box in real time
- [ ] Verify egg animation plays smoothly during hatch (not frozen)
- [ ] Verify hatch completion transitions correctly to main app
- [ ] Test cloud provider hatch flows (GCP, AWS) if possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
