### PR TITLE
fix: eliminate race condition between proc.run() and terminationHandler

### DIFF
--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -467,17 +467,24 @@ final class AssistantCli {
             }
         }
 
-        try proc.run()
-        log.info("CLI remote hatch launched with pid \(proc.processIdentifier)")
-
         // Use terminationHandler + continuation instead of waitUntilExit()
         // so the MainActor is suspended (not blocked), allowing queued
         // onOutput callbacks to update the UI while the process runs.
+        // proc.run() is called INSIDE the continuation to avoid a race
+        // where the process exits before terminationHandler is set.
         let status: Int32 = try await withCheckedThrowingContinuation { continuation in
             proc.terminationHandler = { finished in
                 stdoutHandle.readabilityHandler = nil
                 stderrHandle.readabilityHandler = nil
                 continuation.resume(returning: finished.terminationStatus)
+            }
+            do {
+                try proc.run()
+                log.info("CLI remote hatch launched with pid \(proc.processIdentifier)")
+            } catch {
+                stdoutHandle.readabilityHandler = nil
+                stderrHandle.readabilityHandler = nil
+                continuation.resume(throwing: error)
             }
         }
 
@@ -521,9 +528,6 @@ final class AssistantCli {
         env["VELLUM_DESKTOP_APP"] = "1"
         proc.environment = env
 
-        try proc.run()
-        log.info("CLI pair launched with pid \(proc.processIdentifier)")
-
         let stdoutHandle = stdoutPipe.fileHandleForReading
         let stderrHandle = stderrPipe.fileHandleForReading
 
@@ -541,11 +545,21 @@ final class AssistantCli {
             if !trimmed.isEmpty { onOutput(trimmed) }
         }
 
+        // proc.run() is called INSIDE the continuation to avoid a race
+        // where the process exits before terminationHandler is set.
         let status: Int32 = try await withCheckedThrowingContinuation { continuation in
             proc.terminationHandler = { finished in
                 stdoutHandle.readabilityHandler = nil
                 stderrHandle.readabilityHandler = nil
                 continuation.resume(returning: finished.terminationStatus)
+            }
+            do {
+                try proc.run()
+                log.info("CLI pair launched with pid \(proc.processIdentifier)")
+            } catch {
+                stdoutHandle.readabilityHandler = nil
+                stderrHandle.readabilityHandler = nil
+                continuation.resume(throwing: error)
             }
         }
 


### PR DESCRIPTION
## Summary
- Follows up on #10600 to fix a race condition flagged in review
- `proc.run()` was called before `terminationHandler` was set inside `withCheckedThrowingContinuation` — if the process exits instantly (bad args, crash, permission error), the continuation never resumes and the UI hangs indefinitely
- Moved `proc.run()` inside the continuation closure after `terminationHandler` is set, with proper error handling for launch failures
- Applied to both `runRemoteHatch` and `runPair`

## Test plan
- [ ] Run onboarding hatch flow — verify logs stream and hatch completes
- [ ] Simulate fast process exit (e.g. missing CLI binary scenario) — verify error is surfaced, not a hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
