### PR TITLE
Fix channel-agnostic NL guardian approvals via destination-chat canonical request lookup

### DIFF
--- a/assistant/src/__tests__/canonical-guardian-store.test.ts
+++ b/assistant/src/__tests__/canonical-guardian-store.test.ts
@@ -31,6 +31,7 @@ import {
   getCanonicalGuardianRequest,
   listCanonicalGuardianDeliveries,
   listCanonicalGuardianRequests,
+  listPendingCanonicalGuardianRequestsByDestinationChat,
   listPendingCanonicalGuardianRequestsByDestinationConversation,
   resolveCanonicalGuardianRequest,
   updateCanonicalGuardianDelivery,
@@ -516,5 +517,120 @@ describe('canonical-guardian-store', () => {
   test('returns null when updating nonexistent delivery', () => {
     const updated = updateCanonicalGuardianDelivery('nonexistent', { status: 'sent' });
     expect(updated).toBeNull();
+  });
+
+  // ── listPendingCanonicalGuardianRequestsByDestinationChat ──────────
+
+  test('returns pending requests matching (destinationChannel, destinationChatId)', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'pending_question',
+      sourceType: 'voice',
+    });
+    createCanonicalGuardianDelivery({
+      requestId: req.id,
+      destinationChannel: 'telegram',
+      destinationChatId: 'guardian-chat-100',
+    });
+
+    const pending = listPendingCanonicalGuardianRequestsByDestinationChat(
+      'telegram',
+      'guardian-chat-100',
+    );
+    expect(pending).toHaveLength(1);
+    expect(pending[0].id).toBe(req.id);
+  });
+
+  test('excludes non-pending requests from destination chat lookup', () => {
+    const pendingReq = createCanonicalGuardianRequest({
+      kind: 'pending_question',
+      sourceType: 'voice',
+    });
+    const resolvedReq = createCanonicalGuardianRequest({
+      kind: 'pending_question',
+      sourceType: 'voice',
+    });
+    updateCanonicalGuardianRequest(resolvedReq.id, { status: 'approved' });
+
+    createCanonicalGuardianDelivery({
+      requestId: pendingReq.id,
+      destinationChannel: 'telegram',
+      destinationChatId: 'guardian-chat-200',
+    });
+    createCanonicalGuardianDelivery({
+      requestId: resolvedReq.id,
+      destinationChannel: 'telegram',
+      destinationChatId: 'guardian-chat-200',
+    });
+
+    const pending = listPendingCanonicalGuardianRequestsByDestinationChat(
+      'telegram',
+      'guardian-chat-200',
+    );
+    expect(pending).toHaveLength(1);
+    expect(pending[0].id).toBe(pendingReq.id);
+  });
+
+  test('deduplicates when multiple delivery rows point to same request', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'pending_question',
+      sourceType: 'voice',
+    });
+
+    // Two delivery rows targeting the same chat for the same request
+    createCanonicalGuardianDelivery({
+      requestId: req.id,
+      destinationChannel: 'telegram',
+      destinationChatId: 'guardian-chat-300',
+      destinationMessageId: 'msg-1',
+    });
+    createCanonicalGuardianDelivery({
+      requestId: req.id,
+      destinationChannel: 'telegram',
+      destinationChatId: 'guardian-chat-300',
+      destinationMessageId: 'msg-2',
+    });
+
+    const pending = listPendingCanonicalGuardianRequestsByDestinationChat(
+      'telegram',
+      'guardian-chat-300',
+    );
+    expect(pending).toHaveLength(1);
+    expect(pending[0].id).toBe(req.id);
+  });
+
+  test('channel mismatch does not match in destination chat lookup', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'pending_question',
+      sourceType: 'voice',
+    });
+    createCanonicalGuardianDelivery({
+      requestId: req.id,
+      destinationChannel: 'telegram',
+      destinationChatId: 'guardian-chat-400',
+    });
+
+    const pending = listPendingCanonicalGuardianRequestsByDestinationChat(
+      'sms',
+      'guardian-chat-400',
+    );
+    expect(pending).toHaveLength(0);
+  });
+
+  test('chat mismatch does not match in destination chat lookup', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'pending_question',
+      sourceType: 'voice',
+    });
+    createCanonicalGuardianDelivery({
+      requestId: req.id,
+      destinationChannel: 'telegram',
+      destinationChatId: 'guardian-chat-500',
+    });
+
+    const pending = listPendingCanonicalGuardianRequestsByDestinationChat(
+      'telegram',
+      'different-chat-id',
+    );
+    expect(pending).toHaveLength(0);
   });
 });

--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -67,6 +67,11 @@ mock.module('../memory/ingress-member-store.js', () => ({
   updateLastSeen: () => {},
 }));
 import type { Session } from '../daemon/session.js';
+import {
+  createCanonicalGuardianDelivery,
+  createCanonicalGuardianRequest,
+  getCanonicalGuardianRequest,
+} from '../memory/canonical-guardian-store.js';
 import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
 import {
   createApprovalRequest,
@@ -110,6 +115,9 @@ function ensureConversation(conversationId: string): void {
 
 function resetTables(): void {
   const db = getDb();
+  db.run('DELETE FROM scoped_approval_grants');
+  db.run('DELETE FROM canonical_guardian_deliveries');
+  db.run('DELETE FROM canonical_guardian_requests');
   db.run('DELETE FROM channel_guardian_approval_requests');
   db.run('DELETE FROM channel_guardian_verification_challenges');
   db.run('DELETE FROM channel_guardian_bindings');
@@ -2688,5 +2696,126 @@ describe('background channel processing approval prompts', () => {
     expect(deliverPromptSpy).not.toHaveBeenCalled();
 
     deliverPromptSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// NL approval routing via destination-scoped canonical requests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('NL approval routing via destination-scoped canonical requests', () => {
+  beforeEach(() => {
+    resetTables();
+    noopProcessMessage.mockClear();
+  });
+
+  test('guardian plain-text "yes" resolves a pending_question with no guardianExternalUserId via delivery-scoped hint', async () => {
+    // Simulate a voice-originated pending_question without guardianExternalUserId
+    const guardianChatId = 'guardian-chat-nl-1';
+    const guardianUserId = 'guardian-user-nl-1';
+
+    // Ensure the conversation exists so the resolver finds it
+    ensureConversation('conv-voice-nl-1');
+
+    // Create guardian binding for Telegram
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: guardianUserId,
+      guardianDeliveryChatId: guardianChatId,
+    });
+
+    // Create canonical tool_approval request WITHOUT guardianExternalUserId
+    // but WITH a conversationId (required by the tool_approval resolver)
+    const canonicalReq = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'voice',
+      sourceChannel: 'twilio',
+      conversationId: 'conv-voice-nl-1',
+      toolName: 'shell',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      // guardianExternalUserId intentionally omitted
+    });
+
+    // Register pending interaction so resolver can find it
+    registerPendingInteraction(canonicalReq.id, 'conv-voice-nl-1', 'shell');
+
+    // Create canonical delivery row targeting guardian chat
+    createCanonicalGuardianDelivery({
+      requestId: canonicalReq.id,
+      destinationChannel: 'telegram',
+      destinationChatId: guardianChatId,
+    });
+
+    // Send inbound guardian text reply "yes" from that chat
+    const req = makeInboundRequest({
+      sourceChannel: 'telegram',
+      externalChatId: guardianChatId,
+      senderExternalUserId: guardianUserId,
+      content: 'yes',
+      externalMessageId: `msg-nl-approve-${Date.now()}`,
+    });
+    const res = await handleChannelInbound(req, noopProcessMessage as any, TEST_BEARER_TOKEN);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.canonicalRouter).toBe('canonical_decision_applied');
+
+    // Verify the request was resolved
+    const resolved = getCanonicalGuardianRequest(canonicalReq.id);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.status).toBe('approved');
+  });
+
+  test('inbound from different chat ID does not auto-match delivery-scoped canonical request', async () => {
+    const guardianChatId = 'guardian-chat-nl-2';
+    const guardianUserId = 'guardian-user-nl-2';
+    const differentChatId = 'different-chat-999';
+
+    // Create guardian binding for the guardian user on the different chat
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: guardianUserId,
+      guardianDeliveryChatId: differentChatId,
+    });
+
+    // Create canonical pending_question WITHOUT guardianExternalUserId
+    const canonicalReq = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'voice',
+      sourceChannel: 'twilio',
+      toolName: 'shell',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    // Delivery targets the original guardian chat, NOT the different chat
+    createCanonicalGuardianDelivery({
+      requestId: canonicalReq.id,
+      destinationChannel: 'telegram',
+      destinationChatId: guardianChatId,
+    });
+
+    // Send from differentChatId — delivery-scoped lookup should not match
+    const req = makeInboundRequest({
+      sourceChannel: 'telegram',
+      externalChatId: differentChatId,
+      senderExternalUserId: guardianUserId,
+      content: 'approve',
+      externalMessageId: `msg-nl-mismatch-${Date.now()}`,
+    });
+    const res = await handleChannelInbound(req, noopProcessMessage as any, TEST_BEARER_TOKEN);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    // Should NOT have been consumed by canonical router since there are no
+    // delivery-scoped pending requests for this chat, and identity-based
+    // fallback finds no match either (no guardianExternalUserId on request)
+    expect(body.canonicalRouter).toBeUndefined();
+
+    // Request should remain pending
+    const unchanged = getCanonicalGuardianRequest(canonicalReq.id);
+    expect(unchanged).not.toBeNull();
+    expect(unchanged!.status).toBe('pending');
   });
 });

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -878,3 +878,77 @@ describe('routing invariant: callback buttons route through canonical primitive'
     expect(resolved!.status).toBe('approved');
   });
 });
+
+// ===========================================================================
+// SECTION 9: Destination hint-based NL approval for missing guardianExternalUserId
+// ===========================================================================
+
+describe('routing invariant: destination hints enable NL approval without guardianExternalUserId', () => {
+  beforeEach(() => resetTables());
+
+  test('explicit pendingRequestIds from destination hints allows deterministic plain-text approval when guardianExternalUserId is missing', async () => {
+    // Voice-originated pending_question: no guardianExternalUserId
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'voice',
+      sourceChannel: 'twilio',
+      conversationId: 'conv-voice-1',
+      toolName: 'shell',
+      requestCode: 'NL1234',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      // guardianExternalUserId intentionally omitted
+    });
+    registerPendingToolApprovalInteraction(req.id, 'conv-voice-1', 'shell');
+
+    // The channel inbound router would compute pendingRequestIds from
+    // delivery-scoped lookup and pass them here. Simulate that.
+    const result = await routeGuardianReply(replyCtx({
+      messageText: 'approve',
+      channel: 'telegram',
+      actor: guardianActor({ externalUserId: 'guardian-tg-user' }),
+      conversationId: 'conv-guardian-chat',
+      pendingRequestIds: [req.id],
+      approvalConversationGenerator: undefined,
+    }));
+
+    expect(result.consumed).toBe(true);
+    expect(result.type).toBe('canonical_decision_applied');
+    expect(result.decisionApplied).toBe(true);
+
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe('approved');
+  });
+
+  test('without destination hints, missing guardianExternalUserId means no pending requests found', async () => {
+    // Voice-originated request: no guardianExternalUserId
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'voice',
+      sourceChannel: 'twilio',
+      conversationId: 'conv-voice-2',
+      toolName: 'shell',
+      requestCode: 'NL5678',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    // No pendingRequestIds passed — identity-based fallback uses
+    // actor.externalUserId which does not match any request's
+    // guardianExternalUserId (since it's null).
+    const result = await routeGuardianReply(replyCtx({
+      messageText: 'approve',
+      channel: 'telegram',
+      actor: guardianActor({ externalUserId: 'guardian-tg-user' }),
+      conversationId: 'conv-guardian-chat',
+      // pendingRequestIds: undefined — no delivery hints
+      approvalConversationGenerator: undefined,
+    }));
+
+    // Identity-based lookup finds nothing because the request has no
+    // guardianExternalUserId, so the router returns not_consumed.
+    expect(result.consumed).toBe(false);
+    expect(result.type).toBe('not_consumed');
+
+    const unchanged = getCanonicalGuardianRequest(req.id);
+    expect(unchanged!.status).toBe('pending');
+  });
+});

--- a/assistant/src/memory/canonical-guardian-store.ts
+++ b/assistant/src/memory/canonical-guardian-store.ts
@@ -448,6 +448,51 @@ export function listPendingCanonicalGuardianRequestsByDestinationConversation(
   return pendingRequests;
 }
 
+/**
+ * List pending canonical requests that were delivered to a specific
+ * destination chat (channel + chatId pair).
+ *
+ * This bridges inbound guardian replies (which arrive on a specific chat)
+ * back to their canonical request records. Unlike the conversation-based
+ * variant, this uses the chat-level addressing that channel transports
+ * (Telegram, SMS) natively provide — critical for voice-originated
+ * `pending_question` requests that lack `guardianExternalUserId`.
+ */
+export function listPendingCanonicalGuardianRequestsByDestinationChat(
+  destinationChannel: string,
+  destinationChatId: string,
+): CanonicalGuardianRequest[] {
+  const db = getDb();
+
+  const deliveries = db
+    .select()
+    .from(canonicalGuardianDeliveries)
+    .where(
+      and(
+        eq(canonicalGuardianDeliveries.destinationChannel, destinationChannel),
+        eq(canonicalGuardianDeliveries.destinationChatId, destinationChatId),
+      ),
+    )
+    .all();
+
+  if (deliveries.length === 0) return [];
+
+  const seenRequestIds = new Set<string>();
+  const pendingRequests: CanonicalGuardianRequest[] = [];
+
+  for (const delivery of deliveries) {
+    if (seenRequestIds.has(delivery.requestId)) continue;
+    seenRequestIds.add(delivery.requestId);
+
+    const request = getCanonicalGuardianRequest(delivery.requestId);
+    if (request && request.status === 'pending') {
+      pendingRequests.push(request);
+    }
+  }
+
+  return pendingRequests;
+}
+
 export interface UpdateCanonicalGuardianDeliveryParams {
   status?: string;
   destinationMessageId?: string;

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -4,6 +4,7 @@ import {
   createAssistantInboxTables,
   createCallSessionsTables,
   createCanonicalGuardianTables,
+  migrateCanonicalGuardianDeliveriesDestinationIndex,
   migrateCanonicalGuardianRequesterChatId,
   migrateNormalizePhoneIdentities,
   createChannelGuardianTables,
@@ -153,6 +154,9 @@ export function initializeDb(): void {
 
   // 24b. Add requester_chat_id to canonical_guardian_requests (chat ID != user ID on some channels)
   migrateCanonicalGuardianRequesterChatId(database);
+
+  // 24c. Composite index on canonical_guardian_deliveries(destination_channel, destination_chat_id) for chat-based lookups
+  migrateCanonicalGuardianDeliveriesDestinationIndex(database);
 
   // 25. Normalize phone-like identity fields to E.164 across guardian and ingress tables
   migrateNormalizePhoneIdentities(database);

--- a/assistant/src/memory/migrations/123-canonical-guardian-deliveries-destination-index.ts
+++ b/assistant/src/memory/migrations/123-canonical-guardian-deliveries-destination-index.ts
@@ -1,0 +1,15 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Add composite index on canonical_guardian_deliveries(destination_channel, destination_chat_id).
+ *
+ * The listPendingCanonicalGuardianRequestsByDestinationChat helper queries
+ * deliveries by (destination_channel, destination_chat_id) to bridge inbound
+ * guardian replies back to canonical requests. Without an index these
+ * degrade to full table scans as delivery history grows.
+ */
+export function migrateCanonicalGuardianDeliveriesDestinationIndex(database: DrizzleDb): void {
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_deliveries_destination ON canonical_guardian_deliveries(destination_channel, destination_chat_id)`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -61,6 +61,7 @@ export { migrateSchemaIndexesAndColumns } from './119-schema-indexes-and-columns
 export { migrateFkCascadeRebuilds } from './120-fk-cascade-rebuilds.js';
 export { createCanonicalGuardianTables } from './121-canonical-guardian-requests.js';
 export { migrateCanonicalGuardianRequesterChatId } from './122-canonical-guardian-requester-chat-id.js';
+export { migrateCanonicalGuardianDeliveriesDestinationIndex } from './123-canonical-guardian-deliveries-destination-index.js';
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -14,6 +14,7 @@ import * as attachmentsStore from '../../memory/attachments-store.js';
 import * as channelDeliveryStore from '../../memory/channel-delivery-store.js';
 import {
   createCanonicalGuardianRequest,
+  listCanonicalGuardianRequests,
   listPendingCanonicalGuardianRequestsByDestinationChat,
 } from '../../memory/canonical-guardian-store.js';
 import { recordConversationSeenSignal } from '../../memory/conversation-attention-store.js';
@@ -914,16 +915,31 @@ export async function handleChannelInbound(
     // Compute destination-scoped pending request hints so the router can
     // discover canonical requests delivered to this chat even when the
     // request lacks a guardianExternalUserId (e.g. voice-originated
-    // pending_question requests).  Pass undefined (not []) when empty so
-    // the identity-based fallback in findPendingCanonicalRequests stays
-    // active — an explicit empty array is fail-closed.
+    // pending_question requests).
+    //
+    // When delivery-scoped matches exist, union them with any identity-
+    // based pending requests so that requests without delivery rows (e.g.
+    // tool_approval requests created inline) are not silently excluded.
+    // Pass undefined (not []) when there are zero combined results so the
+    // router's own identity-based fallback stays active.
     const deliveryScopedPendingRequests = listPendingCanonicalGuardianRequestsByDestinationChat(
       sourceChannel,
       externalChatId,
     );
-    const pendingRequestIds = deliveryScopedPendingRequests.length > 0
-      ? deliveryScopedPendingRequests.map(r => r.id)
-      : undefined;
+    let pendingRequestIds: string[] | undefined;
+    if (deliveryScopedPendingRequests.length > 0) {
+      const deliveryIds = new Set(deliveryScopedPendingRequests.map(r => r.id));
+      // Also include identity-based pending requests so we don't hide them
+      const identityId = canonicalSenderId ?? rawSenderId!;
+      const identityPending = listCanonicalGuardianRequests({
+        status: 'pending',
+        guardianExternalUserId: identityId,
+      });
+      for (const r of identityPending) {
+        deliveryIds.add(r.id);
+      }
+      pendingRequestIds = [...deliveryIds];
+    }
 
     const routerResult = await routeGuardianReply({
       messageText: trimmedContent,

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -14,6 +14,7 @@ import * as attachmentsStore from '../../memory/attachments-store.js';
 import * as channelDeliveryStore from '../../memory/channel-delivery-store.js';
 import {
   createCanonicalGuardianRequest,
+  listPendingCanonicalGuardianRequestsByDestinationChat,
 } from '../../memory/canonical-guardian-store.js';
 import { recordConversationSeenSignal } from '../../memory/conversation-attention-store.js';
 import * as conversationStore from '../../memory/conversation-store.js';
@@ -910,6 +911,20 @@ export async function handleChannelInbound(
     rawSenderId &&
     guardianCtx.actorRole === 'guardian'
   ) {
+    // Compute destination-scoped pending request hints so the router can
+    // discover canonical requests delivered to this chat even when the
+    // request lacks a guardianExternalUserId (e.g. voice-originated
+    // pending_question requests).  Pass undefined (not []) when empty so
+    // the identity-based fallback in findPendingCanonicalRequests stays
+    // active — an explicit empty array is fail-closed.
+    const deliveryScopedPendingRequests = listPendingCanonicalGuardianRequestsByDestinationChat(
+      sourceChannel,
+      externalChatId,
+    );
+    const pendingRequestIds = deliveryScopedPendingRequests.length > 0
+      ? deliveryScopedPendingRequests.map(r => r.id)
+      : undefined;
+
     const routerResult = await routeGuardianReply({
       messageText: trimmedContent,
       channel: sourceChannel,
@@ -920,6 +935,7 @@ export async function handleChannelInbound(
       },
       conversationId: result.conversationId,
       callbackData: body.callbackData,
+      pendingRequestIds,
       approvalConversationGenerator,
       channelDeliveryContext: {
         replyCallbackUrl,


### PR DESCRIPTION
## Summary
- Add canonical pending-request lookup by destination chat/channel
- Index canonical deliveries for destination lookup
- Wire inbound channel guardian router to pass destination-scoped pending request IDs
- Add regression tests for NL approvals on delivery-scoped canonical requests

## Original prompt
/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/.private/plans/guardian-nl-approvals-restoration-post-10598-one-pr-plan-2026-02-28.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
