### PR TITLE
fix: restore NL approvals in macOS chat pending-confirmation path

### DIFF
--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -14,6 +14,7 @@ const routeGuardianReplyMock = mock(async () => ({
 })) as any;
 const listPendingByDestinationMock = mock(() => [] as Array<{ id: string }>);
 const listCanonicalMock = mock(() => [] as Array<{ id: string }>);
+const addMessageMock = mock(async () => ({ id: 'persisted-message-id' }));
 const getConfigMock = mock(() => ({
   daemon: { standaloneRecording: false },
   secretDetection: { customPatterns: [], entropyThreshold: 3.5 },
@@ -26,6 +27,10 @@ mock.module('../runtime/guardian-reply-router.js', () => ({
 mock.module('../memory/canonical-guardian-store.js', () => ({
   listPendingCanonicalGuardianRequestsByDestinationConversation: listPendingByDestinationMock,
   listCanonicalGuardianRequests: listCanonicalMock,
+}));
+
+mock.module('../memory/conversation-store.js', () => ({
+  addMessage: addMessageMock,
 }));
 
 mock.module('../config/loader.js', () => ({
@@ -129,6 +134,7 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
     routeGuardianReplyMock.mockClear();
     listPendingByDestinationMock.mockClear();
     listCanonicalMock.mockClear();
+    addMessageMock.mockClear();
     getConfigMock.mockClear();
   });
 
@@ -153,6 +159,19 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
     expect(typeof routeCall.approvalConversationGenerator).toBe('function');
     expect((session.denyAllPendingConfirmations as any).mock.calls.length).toBe(0);
     expect((session.enqueueMessage as any).mock.calls.length).toBe(0);
+    expect(addMessageMock).toHaveBeenCalledTimes(1);
+    expect(addMessageMock).toHaveBeenCalledWith(
+      'conv-1',
+      'user',
+      expect.any(String),
+      expect.objectContaining({
+        userMessageChannel: 'vellum',
+        assistantMessageChannel: 'vellum',
+        userMessageInterface: 'macos',
+        assistantMessageInterface: 'macos',
+        provenanceActorRole: 'guardian',
+      }),
+    );
     expect(sent.map((msg) => msg.type)).toEqual([
       'message_queued',
       'message_dequeued',
@@ -179,6 +198,7 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
     expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
     expect((session.denyAllPendingConfirmations as any).mock.calls.length).toBe(1);
     expect((session.enqueueMessage as any).mock.calls.length).toBe(1);
+    expect(addMessageMock).toHaveBeenCalledTimes(0);
     expect(sent.some((msg) => msg.type === 'message_queued')).toBe(true);
     expect(sent.some((msg) => msg.type === 'message_dequeued')).toBe(false);
   });

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -188,7 +188,6 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
       'message_queued',
       'message_dequeued',
       'assistant_text_delta',
-      'message_complete',
     ]);
     const assistantDelta = sent.find(
       (msg): msg is Extract<ServerMessage, { type: 'assistant_text_delta' }> => msg.type === 'assistant_text_delta',

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -1,0 +1,185 @@
+import * as net from 'node:net';
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+import type { HandlerContext } from '../daemon/handlers.js';
+import type { UserMessage } from '../daemon/ipc-contract.js';
+import type { ServerMessage } from '../daemon/ipc-protocol.js';
+import { DebouncerMap } from '../util/debounce.js';
+
+const routeGuardianReplyMock = mock(async () => ({
+  consumed: false,
+  decisionApplied: false,
+  type: 'not_consumed' as const,
+})) as any;
+const listPendingByDestinationMock = mock(() => [] as Array<{ id: string }>);
+const listCanonicalMock = mock(() => [] as Array<{ id: string }>);
+const getConfigMock = mock(() => ({
+  daemon: { standaloneRecording: false },
+  secretDetection: { customPatterns: [], entropyThreshold: 3.5 },
+}));
+
+mock.module('../runtime/guardian-reply-router.js', () => ({
+  routeGuardianReply: routeGuardianReplyMock,
+}));
+
+mock.module('../memory/canonical-guardian-store.js', () => ({
+  listPendingCanonicalGuardianRequestsByDestinationConversation: listPendingByDestinationMock,
+  listCanonicalGuardianRequests: listCanonicalMock,
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: getConfigMock,
+}));
+
+mock.module('../daemon/approval-generators.js', () => ({
+  createApprovalConversationGenerator: () => async () => ({
+    disposition: 'keep_pending',
+    replyText: 'pending',
+  }),
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+import { handleUserMessage } from '../daemon/handlers/sessions.js';
+
+interface TestSession {
+  hasEscalationHandler: () => boolean;
+  setChannelCapabilities: (caps: unknown) => void;
+  hasAnyPendingConfirmation: () => boolean;
+  getQueueDepth: () => number;
+  denyAllPendingConfirmations: () => void;
+  enqueueMessage: (...args: unknown[]) => { queued: boolean; rejected?: boolean; requestId: string };
+  traceEmitter: { emit: (...args: unknown[]) => void };
+  setTurnChannelContext: (ctx: unknown) => void;
+  setTurnInterfaceContext: (ctx: unknown) => void;
+  setAssistantId: (assistantId: string) => void;
+  setGuardianContext: (ctx: unknown) => void;
+  setCommandIntent: (intent: unknown) => void;
+  processMessage: (...args: unknown[]) => Promise<string>;
+}
+
+function createContext(session: TestSession): { ctx: HandlerContext; sent: ServerMessage[] } {
+  const sent: ServerMessage[] = [];
+  const ctx: HandlerContext = {
+    sessions: new Map(),
+    socketToSession: new Map(),
+    cuSessions: new Map(),
+    socketToCuSession: new Map(),
+    cuObservationParseSequence: new Map(),
+    socketSandboxOverride: new Map(),
+    sharedRequestTimestamps: [],
+    debounceTimers: new DebouncerMap({ defaultDelayMs: 100 }),
+    suppressConfigReload: false,
+    setSuppressConfigReload: () => {},
+    updateConfigFingerprint: () => {},
+    send: (_socket, msg) => { sent.push(msg); },
+    broadcast: () => {},
+    clearAllSessions: () => 0,
+    getOrCreateSession: async () => session as any,
+    touchSession: () => {},
+  };
+  return { ctx, sent };
+}
+
+function makeMessage(content: string): UserMessage {
+  return {
+    type: 'user_message',
+    sessionId: 'conv-1',
+    content,
+    channel: 'vellum',
+    interface: 'macos',
+  };
+}
+
+function makeSession(overrides: Partial<TestSession> = {}): TestSession {
+  return {
+    hasEscalationHandler: () => true,
+    setChannelCapabilities: () => {},
+    hasAnyPendingConfirmation: () => true,
+    getQueueDepth: () => 0,
+    denyAllPendingConfirmations: mock(() => {}),
+    enqueueMessage: mock(() => ({ queued: true, requestId: 'queued-id' })),
+    traceEmitter: { emit: () => {} },
+    setTurnChannelContext: () => {},
+    setTurnInterfaceContext: () => {},
+    setAssistantId: () => {},
+    setGuardianContext: () => {},
+    setCommandIntent: () => {},
+    processMessage: async () => 'msg-id',
+    ...overrides,
+  };
+}
+
+describe('handleUserMessage pending-confirmation reply interception', () => {
+  beforeEach(() => {
+    routeGuardianReplyMock.mockClear();
+    listPendingByDestinationMock.mockClear();
+    listCanonicalMock.mockClear();
+    getConfigMock.mockClear();
+  });
+
+  test('consumes decision replies before auto-deny', async () => {
+    listPendingByDestinationMock.mockReturnValue([{ id: 'req-1' }]);
+    listCanonicalMock.mockReturnValue([{ id: 'req-1' }]);
+    routeGuardianReplyMock.mockResolvedValue({
+      consumed: true,
+      decisionApplied: true,
+      type: 'canonical_decision_applied',
+      requestId: 'req-1',
+    });
+
+    const session = makeSession();
+    const { ctx, sent } = createContext(session);
+
+    await handleUserMessage(makeMessage('go for it'), {} as net.Socket, ctx);
+
+    expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
+    const routeCall = (routeGuardianReplyMock as any).mock.calls[0][0] as Record<string, unknown>;
+    expect(routeCall.messageText).toBe('go for it');
+    expect(typeof routeCall.approvalConversationGenerator).toBe('function');
+    expect((session.denyAllPendingConfirmations as any).mock.calls.length).toBe(0);
+    expect((session.enqueueMessage as any).mock.calls.length).toBe(0);
+    expect(sent.map((msg) => msg.type)).toEqual([
+      'message_queued',
+      'message_dequeued',
+      'message_complete',
+    ]);
+  });
+
+  test('nl keep_pending falls back to existing auto-deny + queue behavior', async () => {
+    listPendingByDestinationMock.mockReturnValue([{ id: 'req-1' }]);
+    listCanonicalMock.mockReturnValue([{ id: 'req-1' }]);
+    routeGuardianReplyMock.mockResolvedValue({
+      consumed: true,
+      decisionApplied: false,
+      type: 'nl_keep_pending',
+      requestId: 'req-1',
+      replyText: 'Need clarification',
+    });
+
+    const session = makeSession();
+    const { ctx, sent } = createContext(session);
+
+    await handleUserMessage(makeMessage('what does that do?'), {} as net.Socket, ctx);
+
+    expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
+    expect((session.denyAllPendingConfirmations as any).mock.calls.length).toBe(1);
+    expect((session.enqueueMessage as any).mock.calls.length).toBe(1);
+    expect(sent.some((msg) => msg.type === 'message_queued')).toBe(true);
+    expect(sent.some((msg) => msg.type === 'message_dequeued')).toBe(false);
+  });
+});

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -62,6 +62,7 @@ mock.module('../util/logger.js', () => ({
 import { handleUserMessage } from '../daemon/handlers/sessions.js';
 
 interface TestSession {
+  messages: Array<{ role: string; content: unknown[] }>;
   hasEscalationHandler: () => boolean;
   setChannelCapabilities: (caps: unknown) => void;
   hasAnyPendingConfirmation: () => boolean;
@@ -112,6 +113,7 @@ function makeMessage(content: string): UserMessage {
 
 function makeSession(overrides: Partial<TestSession> = {}): TestSession {
   return {
+    messages: [],
     hasEscalationHandler: () => true,
     setChannelCapabilities: () => {},
     hasAnyPendingConfirmation: () => true,
@@ -159,6 +161,9 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
     expect(typeof routeCall.approvalConversationGenerator).toBe('function');
     expect((session.denyAllPendingConfirmations as any).mock.calls.length).toBe(0);
     expect((session.enqueueMessage as any).mock.calls.length).toBe(0);
+    expect(session.messages).toHaveLength(2);
+    expect(session.messages[0]?.role).toBe('user');
+    expect(session.messages[1]?.role).toBe('assistant');
     expect(addMessageMock).toHaveBeenCalledTimes(2);
     expect(addMessageMock).toHaveBeenCalledWith(
       'conv-1',
@@ -214,6 +219,7 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
     expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
     expect((session.denyAllPendingConfirmations as any).mock.calls.length).toBe(1);
     expect((session.enqueueMessage as any).mock.calls.length).toBe(1);
+    expect(session.messages).toHaveLength(0);
     expect(addMessageMock).toHaveBeenCalledTimes(0);
     expect(sent.some((msg) => msg.type === 'message_queued')).toBe(true);
     expect(sent.some((msg) => msg.type === 'message_dequeued')).toBe(false);

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -65,6 +65,7 @@ interface TestSession {
   messages: Array<{ role: string; content: unknown[] }>;
   hasEscalationHandler: () => boolean;
   setChannelCapabilities: (caps: unknown) => void;
+  isProcessing: () => boolean;
   hasAnyPendingConfirmation: () => boolean;
   getQueueDepth: () => number;
   denyAllPendingConfirmations: () => void;
@@ -116,6 +117,7 @@ function makeSession(overrides: Partial<TestSession> = {}): TestSession {
     messages: [],
     hasEscalationHandler: () => true,
     setChannelCapabilities: () => {},
+    isProcessing: () => false,
     hasAnyPendingConfirmation: () => true,
     getQueueDepth: () => 0,
     denyAllPendingConfirmations: mock(() => {}),
@@ -198,6 +200,25 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
       (msg): msg is Extract<ServerMessage, { type: 'assistant_text_delta' }> => msg.type === 'assistant_text_delta',
     );
     expect(assistantDelta?.text).toBe('Decision applied.');
+  });
+
+  test('does not mutate in-memory history while processing', async () => {
+    listPendingByDestinationMock.mockReturnValue([{ id: 'req-1' }]);
+    listCanonicalMock.mockReturnValue([{ id: 'req-1' }]);
+    routeGuardianReplyMock.mockResolvedValue({
+      consumed: true,
+      decisionApplied: true,
+      type: 'canonical_decision_applied',
+      requestId: 'req-1',
+    });
+
+    const session = makeSession({ isProcessing: () => true });
+    const { ctx } = createContext(session);
+
+    await handleUserMessage(makeMessage('approve'), {} as net.Socket, ctx);
+
+    expect(addMessageMock).toHaveBeenCalledTimes(2);
+    expect(session.messages).toHaveLength(0);
   });
 
   test('nl keep_pending falls back to existing auto-deny + queue behavior', async () => {

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -159,7 +159,7 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
     expect(typeof routeCall.approvalConversationGenerator).toBe('function');
     expect((session.denyAllPendingConfirmations as any).mock.calls.length).toBe(0);
     expect((session.enqueueMessage as any).mock.calls.length).toBe(0);
-    expect(addMessageMock).toHaveBeenCalledTimes(1);
+    expect(addMessageMock).toHaveBeenCalledTimes(2);
     expect(addMessageMock).toHaveBeenCalledWith(
       'conv-1',
       'user',
@@ -172,11 +172,28 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
         provenanceActorRole: 'guardian',
       }),
     );
+    expect(addMessageMock).toHaveBeenCalledWith(
+      'conv-1',
+      'assistant',
+      expect.stringContaining('Decision applied.'),
+      expect.objectContaining({
+        userMessageChannel: 'vellum',
+        assistantMessageChannel: 'vellum',
+        userMessageInterface: 'macos',
+        assistantMessageInterface: 'macos',
+        provenanceActorRole: 'guardian',
+      }),
+    );
     expect(sent.map((msg) => msg.type)).toEqual([
       'message_queued',
       'message_dequeued',
+      'assistant_text_delta',
       'message_complete',
     ]);
+    const assistantDelta = sent.find(
+      (msg): msg is Extract<ServerMessage, { type: 'assistant_text_delta' }> => msg.type === 'assistant_text_delta',
+    );
+    expect(assistantDelta?.text).toBe('Decision applied.');
   });
 
   test('nl keep_pending falls back to existing auto-deny + queue behavior', async () => {

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -2,6 +2,7 @@ import * as net from 'node:net';
 
 import { v4 as uuid } from 'uuid';
 
+import { createAssistantMessage, createUserMessage } from '../../agent/message-types.js';
 import { type InterfaceId,isChannelId, parseChannelId, parseInterfaceId } from '../../channels/types.js';
 import { getConfig } from '../../config/loader.js';
 import { getAttachmentsForMessage, getFilePathForAttachment, setAttachmentThumbnail } from '../../memory/attachments-store.js';
@@ -490,6 +491,33 @@ export async function handleUserMessage(
           });
 
           if (routerResult.consumed && routerResult.type !== 'nl_keep_pending') {
+            const consumedChannelMeta = {
+              userMessageChannel: ipcChannel,
+              assistantMessageChannel: ipcChannel,
+              userMessageInterface: ipcInterface,
+              assistantMessageInterface: ipcInterface,
+              provenanceActorRole: 'guardian' as const,
+            };
+
+            const consumedUserMessage = createUserMessage(messageText, msg.attachments ?? []);
+            await conversationStore.addMessage(
+              msg.sessionId,
+              'user',
+              JSON.stringify(consumedUserMessage.content),
+              consumedChannelMeta,
+            );
+
+            const replyText = routerResult.replyText?.trim();
+            if (replyText && replyText.length > 0) {
+              const consumedAssistantMessage = createAssistantMessage(replyText);
+              await conversationStore.addMessage(
+                msg.sessionId,
+                'assistant',
+                JSON.stringify(consumedAssistantMessage.content),
+                consumedChannelMeta,
+              );
+            }
+
             // Mirror the normal queued/dequeued lifecycle so desktop clients can
             // reconcile queued bubble state for this just-sent user message.
             ctx.send(socket, {
@@ -504,10 +532,10 @@ export async function handleUserMessage(
               requestId,
             });
 
-            if (routerResult.replyText && routerResult.replyText.trim().length > 0) {
+            if (replyText && replyText.length > 0) {
               ctx.send(socket, {
                 type: 'assistant_text_delta',
-                text: routerResult.replyText,
+                text: replyText,
                 sessionId: msg.sessionId,
               });
             }

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -6,14 +6,20 @@ import { type InterfaceId,isChannelId, parseChannelId, parseInterfaceId } from '
 import { getConfig } from '../../config/loader.js';
 import { getAttachmentsForMessage, getFilePathForAttachment, setAttachmentThumbnail } from '../../memory/attachments-store.js';
 import { getAttentionStateByConversationIds } from '../../memory/conversation-attention-store.js';
+import {
+  listCanonicalGuardianRequests,
+  listPendingCanonicalGuardianRequestsByDestinationConversation,
+} from '../../memory/canonical-guardian-store.js';
 import * as conversationStore from '../../memory/conversation-store.js';
 import { GENERATING_TITLE, queueGenerateConversationTitle, UNTITLED_FALLBACK } from '../../memory/conversation-title-service.js';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
+import { routeGuardianReply } from '../../runtime/guardian-reply-router.js';
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { compileCustomPatterns, redactSecrets } from '../../security/secret-scanner.js';
 import { getSubagentManager } from '../../subagent/index.js';
 import { silentlyWithLog } from '../../util/silently.js';
 import { truncate } from '../../util/truncate.js';
+import { createApprovalConversationGenerator } from '../approval-generators.js';
 import { getAssistantName } from '../identity-helpers.js';
 import type { UserMessageAttachment } from '../ipc-contract.js';
 import type {
@@ -55,6 +61,8 @@ import {
   renderHistoryContent,
   wireEscalationHandler,
 } from './shared.js';
+
+const desktopApprovalConversationGenerator = createApprovalConversationGenerator();
 
 export async function handleUserMessage(
   msg: UserMessage,
@@ -451,8 +459,74 @@ export async function handleUserMessage(
       }
     }
 
+    // If exactly one live turn is waiting on confirmation (no queued turns),
+    // try to consume this text as an inline approval decision first.
+    if (
+      session.hasAnyPendingConfirmation()
+      && session.getQueueDepth() === 0
+      && messageText.trim().length > 0
+    ) {
+      try {
+        const pendingCanonicalRequestIdsForConversation = Array.from(new Set([
+          ...listPendingCanonicalGuardianRequestsByDestinationConversation(msg.sessionId, ipcChannel).map((request) => request.id),
+          ...listCanonicalGuardianRequests({
+            status: 'pending',
+            conversationId: msg.sessionId,
+          }).map((request) => request.id),
+        ]));
+
+        if (pendingCanonicalRequestIdsForConversation.length > 0) {
+          const routerResult = await routeGuardianReply({
+            messageText: messageText.trim(),
+            channel: ipcChannel,
+            actor: {
+              externalUserId: undefined,
+              channel: ipcChannel,
+              isTrusted: true,
+            },
+            conversationId: msg.sessionId,
+            pendingRequestIds: pendingCanonicalRequestIdsForConversation,
+            approvalConversationGenerator: desktopApprovalConversationGenerator,
+          });
+
+          if (routerResult.consumed && routerResult.type !== 'nl_keep_pending') {
+            // Mirror the normal queued/dequeued lifecycle so desktop clients can
+            // reconcile queued bubble state for this just-sent user message.
+            ctx.send(socket, {
+              type: 'message_queued',
+              sessionId: msg.sessionId,
+              requestId,
+              position: 0,
+            });
+            ctx.send(socket, {
+              type: 'message_dequeued',
+              sessionId: msg.sessionId,
+              requestId,
+            });
+
+            if (routerResult.replyText && routerResult.replyText.trim().length > 0) {
+              ctx.send(socket, {
+                type: 'assistant_text_delta',
+                text: routerResult.replyText,
+                sessionId: msg.sessionId,
+              });
+            }
+            ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+
+            rlog.info(
+              { routerType: routerResult.type, decisionApplied: routerResult.decisionApplied, routerRequestId: routerResult.requestId },
+              'Consumed pending-confirmation reply before auto-deny',
+            );
+            return;
+          }
+        }
+      } catch (err) {
+        rlog.warn({ err }, 'Failed to process pending-confirmation reply; falling back to auto-deny behavior');
+      }
+    }
+
     // If the session has a pending tool confirmation, auto-deny it so the
-    // agent can process the user's follow-up message instead.  The agent
+    // agent can process the user's follow-up message instead. The agent
     // will see the denial and can re-request the tool if still needed.
     if (session.hasAnyPendingConfirmation()) {
       rlog.info('Auto-denying pending confirmation(s) due to new user message');

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -536,7 +536,6 @@ export async function handleUserMessage(
               text: replyText,
               sessionId: msg.sessionId,
             });
-            ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
 
             rlog.info(
               { routerType: routerResult.type, decisionApplied: routerResult.decisionApplied, routerRequestId: routerResult.requestId },

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -507,16 +507,15 @@ export async function handleUserMessage(
               consumedChannelMeta,
             );
 
-            const replyText = routerResult.replyText?.trim();
-            if (replyText && replyText.length > 0) {
-              const consumedAssistantMessage = createAssistantMessage(replyText);
-              await conversationStore.addMessage(
-                msg.sessionId,
-                'assistant',
-                JSON.stringify(consumedAssistantMessage.content),
-                consumedChannelMeta,
-              );
-            }
+            const replyText = (routerResult.replyText?.trim())
+              || (routerResult.decisionApplied ? 'Decision applied.' : 'Request already resolved.');
+            const consumedAssistantMessage = createAssistantMessage(replyText);
+            await conversationStore.addMessage(
+              msg.sessionId,
+              'assistant',
+              JSON.stringify(consumedAssistantMessage.content),
+              consumedChannelMeta,
+            );
 
             // Mirror the normal queued/dequeued lifecycle so desktop clients can
             // reconcile queued bubble state for this just-sent user message.
@@ -532,13 +531,11 @@ export async function handleUserMessage(
               requestId,
             });
 
-            if (replyText && replyText.length > 0) {
-              ctx.send(socket, {
-                type: 'assistant_text_delta',
-                text: replyText,
-                sessionId: msg.sessionId,
-              });
-            }
+            ctx.send(socket, {
+              type: 'assistant_text_delta',
+              text: replyText,
+              sessionId: msg.sessionId,
+            });
             ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
 
             rlog.info(

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -516,9 +516,13 @@ export async function handleUserMessage(
               JSON.stringify(consumedAssistantMessage.content),
               consumedChannelMeta,
             );
-            // Keep in-memory history aligned with persisted transcript so
-            // session-history operations (undo/regenerate) target the same turn.
-            session.messages.push(consumedUserMessage, consumedAssistantMessage);
+            // Avoid mutating in-memory history while an agent loop is active;
+            // the loop owns history reconstruction for the in-flight turn.
+            if (!session.isProcessing()) {
+              // Keep in-memory history aligned with persisted transcript so
+              // session-history operations (undo/regenerate) target the same turn.
+              session.messages.push(consumedUserMessage, consumedAssistantMessage);
+            }
 
             // Mirror the normal queued/dequeued lifecycle so desktop clients can
             // reconcile queued bubble state for this just-sent user message.

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -516,6 +516,9 @@ export async function handleUserMessage(
               JSON.stringify(consumedAssistantMessage.content),
               consumedChannelMeta,
             );
+            // Keep in-memory history aligned with persisted transcript so
+            // session-history operations (undo/regenerate) target the same turn.
+            session.messages.push(consumedUserMessage, consumedAssistantMessage);
 
             // Mirror the normal queued/dequeued lifecycle so desktop clients can
             // reconcile queued bubble state for this just-sent user message.


### PR DESCRIPTION
## Summary
- intercept desktop `user_message` replies when a tool confirmation is pending and queue depth is zero
- run the canonical guardian reply router with conversational classification before the legacy auto-deny fallback
- when a decision reply is consumed, complete it immediately and skip `denyAllPendingConfirmations()`
- preserve existing behavior for `nl_keep_pending` and all fallback/error paths
- add focused regression tests for both decision-consumed and keep-pending fallback flows

## Testing
- `cd assistant && bun test src/__tests__/handlers-user-message-approval-consumption.test.ts`
- `cd assistant && bunx tsc --noEmit`

## Context
This fixes the macOS IPC chat path where pending confirmations were auto-denied before natural-language decision parsing could run.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
