### PR TITLE
feat: non-guardian tool grant escalation via canonical request

### DIFF
--- a/assistant/src/__tests__/tool-grant-request-escalation.test.ts
+++ b/assistant/src/__tests__/tool-grant-request-escalation.test.ts
@@ -1,0 +1,510 @@
+/**
+ * Tests for the non-guardian tool grant escalation path:
+ *
+ * 1. ToolApprovalHandler grant-miss escalation behavior
+ * 2. tool_grant_request resolver registration and behavior
+ * 3. Canonical decision primitive grant minting for tool_grant_request kind
+ * 4. End-to-end: deny -> approve -> consume grant flow
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'tool-grant-escalation-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  isDebug: () => false,
+  truncateForLog: (value: string) => value,
+}));
+
+// Mock guardian control-plane policy — not targeting control-plane by default
+mock.module('../tools/guardian-control-plane-policy.js', () => ({
+  enforceGuardianOnlyPolicy: () => ({ denied: false }),
+}));
+
+// Mock task run rules — no task run rules by default
+mock.module('../tasks/ephemeral-permissions.js', () => ({
+  getTaskRunRules: () => [],
+}));
+
+// Mock tool registry — return a fake tool for 'bash'
+const fakeTool = {
+  name: 'bash',
+  description: 'Run a shell command',
+  category: 'shell',
+  defaultRiskLevel: 'high',
+  getDefinition: () => ({ name: 'bash', description: 'Run a shell command', input_schema: {} }),
+  execute: async () => ({ content: 'ok', isError: false }),
+};
+
+mock.module('../tools/registry.js', () => ({
+  getTool: (name: string) => (name === 'bash' ? fakeTool : undefined),
+  getAllTools: () => [fakeTool],
+}));
+
+// Mock notification emission — capture calls without running the full pipeline
+const emittedSignals: Array<Record<string, unknown>> = [];
+mock.module('../notifications/emit-signal.js', () => ({
+  emitNotificationSignal: async (params: Record<string, unknown>) => {
+    emittedSignals.push(params);
+    return { signalId: 'test-signal', deduplicated: false, dispatched: true, reason: 'ok', deliveryResults: [] };
+  },
+  registerBroadcastFn: () => {},
+}));
+
+// Mock channel guardian service — provide a guardian binding for 'self' + 'telegram'
+mock.module('../runtime/channel-guardian-service.js', () => ({
+  getGuardianBinding: (assistantId: string, channel: string) => {
+    if (assistantId === 'self' && channel === 'telegram') {
+      return {
+        id: 'binding-1',
+        assistantId: 'self',
+        channel: 'telegram',
+        guardianExternalUserId: 'guardian-1',
+        guardianDeliveryChatId: 'guardian-chat-1',
+        status: 'active',
+      };
+    }
+    return null;
+  },
+  createOutboundSession: () => ({
+    sessionId: 'test-session',
+    secret: '123456',
+  }),
+}));
+
+// Mock gateway client — capture delivery calls
+const deliveredReplies: Array<{ chatId: string; text: string }> = [];
+mock.module('../runtime/gateway-client.js', () => ({
+  deliverChannelReply: async (_url: string, payload: { chatId: string; text: string }) => {
+    deliveredReplies.push(payload);
+  },
+}));
+
+import { mintGrantFromDecision, type MintGrantParams } from '../approvals/approval-primitive.js';
+import {
+  applyCanonicalGuardianDecision,
+} from '../approvals/guardian-decision-primitive.js';
+import { getRegisteredKinds, getResolver } from '../approvals/guardian-request-resolvers.js';
+import type { ActorContext } from '../approvals/guardian-request-resolvers.js';
+import {
+  createCanonicalGuardianRequest,
+  getCanonicalGuardianRequest,
+  listCanonicalGuardianRequests,
+} from '../memory/canonical-guardian-store.js';
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { scopedApprovalGrants } from '../memory/schema.js';
+import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
+import { ToolApprovalHandler } from '../tools/tool-approval-handler.js';
+import type { ToolContext, ToolLifecycleEvent } from '../tools/types.js';
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.delete(scopedApprovalGrants).run();
+  db.run('DELETE FROM canonical_guardian_deliveries');
+  db.run('DELETE FROM canonical_guardian_requests');
+}
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mintParams(overrides: Partial<MintGrantParams> = {}): MintGrantParams {
+  const futureExpiry = new Date(Date.now() + 60_000).toISOString();
+  return {
+    assistantId: 'self',
+    scopeMode: 'tool_signature',
+    requestChannel: 'telegram',
+    decisionChannel: 'telegram',
+    expiresAt: futureExpiry,
+    ...overrides,
+  };
+}
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: testDir,
+    sessionId: 'session-1',
+    conversationId: 'conv-1',
+    assistantId: 'self',
+    requestId: 'req-1',
+    guardianActorRole: 'non-guardian',
+    executionChannel: 'telegram',
+    requesterExternalUserId: 'requester-1',
+    ...overrides,
+  };
+}
+
+function guardianActor(overrides: Partial<ActorContext> = {}): ActorContext {
+  return {
+    externalUserId: 'guardian-1',
+    channel: 'telegram',
+    isTrusted: false,
+    ...overrides,
+  };
+}
+
+// ===========================================================================
+// TESTS
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// 1. tool_grant_request resolver registration
+// ---------------------------------------------------------------------------
+
+describe('tool_grant_request resolver registration', () => {
+  test('tool_grant_request resolver is registered', () => {
+    const kinds = getRegisteredKinds();
+    expect(kinds).toContain('tool_grant_request');
+  });
+
+  test('getResolver returns resolver for tool_grant_request', () => {
+    const resolver = getResolver('tool_grant_request');
+    expect(resolver).toBeDefined();
+    expect(resolver!.kind).toBe('tool_grant_request');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Grant-miss escalation behavior in ToolApprovalHandler
+// ---------------------------------------------------------------------------
+
+describe('ToolApprovalHandler / grant-miss escalation', () => {
+  const handler = new ToolApprovalHandler();
+  const events: ToolLifecycleEvent[] = [];
+  const emitLifecycleEvent = (event: ToolLifecycleEvent) => { events.push(event); };
+
+  beforeEach(() => {
+    resetTables();
+    events.length = 0;
+    emittedSignals.length = 0;
+    deliveredReplies.length = 0;
+  });
+
+  test('non-guardian + grant miss + host tool creates canonical tool_grant_request', async () => {
+    const toolName = 'bash';
+    const input = { command: 'cat /etc/passwd' };
+
+    const context = makeContext({ guardianActorRole: 'non-guardian' });
+    const result = await handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+
+    expect(result.allowed).toBe(false);
+    if (result.allowed) return;
+
+    // A canonical tool_grant_request should have been created
+    const requests = listCanonicalGuardianRequests({
+      kind: 'tool_grant_request',
+      status: 'pending',
+    });
+    expect(requests.length).toBe(1);
+    expect(requests[0].toolName).toBe('bash');
+    expect(requests[0].requesterExternalUserId).toBe('requester-1');
+    expect(requests[0].guardianExternalUserId).toBe('guardian-1');
+
+    // Notification signal should have been emitted
+    expect(emittedSignals.length).toBe(1);
+    expect(emittedSignals[0].sourceEventName).toBe('guardian.question');
+  });
+
+  test('non-guardian grant-miss response includes request code', async () => {
+    const toolName = 'bash';
+    const input = { command: 'deploy' };
+
+    const context = makeContext({ guardianActorRole: 'non-guardian' });
+    const result = await handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+
+    expect(result.allowed).toBe(false);
+    if (result.allowed) return;
+    expect(result.result.content).toContain('request has been sent to the guardian');
+    expect(result.result.content).toContain('request code:');
+    expect(result.result.content).toContain('Please retry after the guardian approves');
+  });
+
+  test('non-guardian duplicate grant-miss deduplicates the request', async () => {
+    const toolName = 'bash';
+    const input = { command: 'rm -rf /' };
+
+    const context = makeContext({ guardianActorRole: 'non-guardian' });
+
+    // First invocation creates the request
+    await handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+
+    const firstRequests = listCanonicalGuardianRequests({
+      kind: 'tool_grant_request',
+      status: 'pending',
+    });
+    expect(firstRequests.length).toBe(1);
+
+    // Reset notification tracking
+    emittedSignals.length = 0;
+
+    // Second invocation with same tool+input deduplicates
+    const result = await handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+
+    expect(result.allowed).toBe(false);
+    if (result.allowed) return;
+    expect(result.result.content).toContain('already pending');
+
+    // Still only one canonical request
+    const requests = listCanonicalGuardianRequests({
+      kind: 'tool_grant_request',
+      status: 'pending',
+    });
+    expect(requests.length).toBe(1);
+
+    // No duplicate notification
+    expect(emittedSignals.length).toBe(0);
+  });
+
+  test('unverified_channel does NOT create escalation request', async () => {
+    const toolName = 'bash';
+    const input = { command: 'ls' };
+
+    const context = makeContext({
+      guardianActorRole: 'unverified_channel',
+      executionChannel: 'telegram',
+      requesterExternalUserId: 'unknown-user',
+    });
+    const result = await handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+
+    expect(result.allowed).toBe(false);
+    if (result.allowed) return;
+    // Should get the generic denial message, not escalation
+    expect(result.result.content).toContain('verified channel identity');
+
+    // No canonical request should have been created
+    const requests = listCanonicalGuardianRequests({
+      kind: 'tool_grant_request',
+      status: 'pending',
+    });
+    expect(requests.length).toBe(0);
+  });
+
+  test('non-guardian without executionChannel falls back to generic denial', async () => {
+    const toolName = 'bash';
+    const input = { command: 'deploy' };
+
+    const context = makeContext({
+      guardianActorRole: 'non-guardian',
+      executionChannel: undefined, // no channel info
+    });
+    const result = await handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+
+    expect(result.allowed).toBe(false);
+    if (result.allowed) return;
+    // Generic denial, no escalation attempted
+    expect(result.result.content).toContain('guardian approval');
+    expect(result.result.content).not.toContain('request has been sent');
+
+    const requests = listCanonicalGuardianRequests({
+      kind: 'tool_grant_request',
+      status: 'pending',
+    });
+    expect(requests.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Canonical decision and grant minting for tool_grant_request kind
+// ---------------------------------------------------------------------------
+
+describe('applyCanonicalGuardianDecision / tool_grant_request', () => {
+  beforeEach(() => {
+    resetTables();
+    deliveredReplies.length = 0;
+  });
+
+  test('approving tool_grant_request with tool metadata mints a grant', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_grant_request',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      conversationId: 'conv-1',
+      requesterExternalUserId: 'requester-1',
+      guardianExternalUserId: 'guardian-1',
+      toolName: 'bash',
+      inputDigest: 'sha256:testdigest',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: guardianActor(),
+    });
+
+    expect(result.applied).toBe(true);
+    if (!result.applied) return;
+    expect(result.grantMinted).toBe(true);
+
+    // Verify canonical request is approved
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe('approved');
+    expect(resolved!.decidedByExternalUserId).toBe('guardian-1');
+  });
+
+  test('rejecting tool_grant_request does NOT mint a grant', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_grant_request',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      conversationId: 'conv-1',
+      requesterExternalUserId: 'requester-1',
+      guardianExternalUserId: 'guardian-1',
+      toolName: 'bash',
+      inputDigest: 'sha256:testdigest',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'reject',
+      actorContext: guardianActor(),
+    });
+
+    expect(result.applied).toBe(true);
+    if (!result.applied) return;
+    expect(result.grantMinted).toBe(false);
+
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe('denied');
+  });
+
+  test('identity mismatch blocks tool_grant_request approval', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_grant_request',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      conversationId: 'conv-1',
+      requesterExternalUserId: 'requester-1',
+      guardianExternalUserId: 'guardian-1',
+      toolName: 'bash',
+      inputDigest: 'sha256:testdigest',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: guardianActor({ externalUserId: 'imposter-99' }),
+    });
+
+    expect(result.applied).toBe(false);
+    if (result.applied) return;
+    expect(result.reason).toBe('identity_mismatch');
+
+    const unchanged = getCanonicalGuardianRequest(req.id);
+    expect(unchanged!.status).toBe('pending');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. End-to-end: deny -> approve -> consume grant flow
+// ---------------------------------------------------------------------------
+
+describe('end-to-end: tool grant escalation -> approval -> consume', () => {
+  const handler = new ToolApprovalHandler();
+  const events: ToolLifecycleEvent[] = [];
+  const emitLifecycleEvent = (event: ToolLifecycleEvent) => { events.push(event); };
+
+  beforeEach(() => {
+    resetTables();
+    events.length = 0;
+    emittedSignals.length = 0;
+  });
+
+  test('first invocation denied + request created; guardian approves; second invocation succeeds; replay denied', async () => {
+    const toolName = 'bash';
+    const input = { command: 'echo secret' };
+    const inputDigest = computeToolApprovalDigest(toolName, input);
+
+    const context = makeContext({ guardianActorRole: 'non-guardian' });
+
+    // Step 1: First invocation is denied, but a tool_grant_request is created
+    const firstResult = await handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+    expect(firstResult.allowed).toBe(false);
+
+    // Verify the canonical request was created
+    const pendingRequests = listCanonicalGuardianRequests({
+      kind: 'tool_grant_request',
+      status: 'pending',
+      toolName: 'bash',
+    });
+    expect(pendingRequests.length).toBe(1);
+    const canonicalRequestId = pendingRequests[0].id;
+
+    // Step 2: Guardian approves the canonical request -> grant is minted
+    const approvalResult = await applyCanonicalGuardianDecision({
+      requestId: canonicalRequestId,
+      action: 'approve_once',
+      actorContext: guardianActor(),
+    });
+    expect(approvalResult.applied).toBe(true);
+    if (!approvalResult.applied) return;
+    expect(approvalResult.grantMinted).toBe(true);
+
+    // Verify request is now approved
+    const resolvedRequest = getCanonicalGuardianRequest(canonicalRequestId);
+    expect(resolvedRequest!.status).toBe('approved');
+
+    // Step 3: Second identical invocation consumes the grant and succeeds
+    const secondResult = await handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+    expect(secondResult.allowed).toBe(true);
+    if (!secondResult.allowed) return;
+    expect(secondResult.grantConsumed).toBe(true);
+
+    // Step 4: Replay is denied (one-time grant semantics)
+    const replayResult = await handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+    expect(replayResult.allowed).toBe(false);
+  });
+});

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -440,6 +440,77 @@ const accessRequestResolver: GuardianRequestResolver = {
   },
 };
 
+/**
+ * Resolves `tool_grant_request` requests — asynchronous grant escalation for
+ * non-guardian channel actors.
+ *
+ * Unlike `tool_approval`, this kind does NOT require a pending interaction in
+ * the session tracker. The request represents an async escalation: the
+ * requester's tool call was already denied, and the canonical request exists
+ * solely so the guardian can mint a scoped grant.
+ *
+ * On approve: the canonical decision primitive mints the grant (step 6 in
+ * applyCanonicalGuardianDecision). This resolver optionally notifies the
+ * requester to retry.
+ *
+ * On reject: optionally notifies the requester that their request was denied.
+ */
+const toolGrantRequestResolver: GuardianRequestResolver = {
+  kind: 'tool_grant_request',
+
+  async resolve(ctx: ResolverContext): Promise<ResolverResult> {
+    const { request, decision, channelDeliveryContext } = ctx;
+    const requesterChatId = request.requesterChatId ?? request.requesterExternalUserId ?? '';
+    const assistantId = channelDeliveryContext?.assistantId ?? 'self';
+
+    if (decision.action === 'reject') {
+      log.info(
+        { event: 'resolver_tool_grant_request_denied', requestId: request.id, toolName: request.toolName },
+        'Tool grant request resolver: deny',
+      );
+
+      if (channelDeliveryContext && requesterChatId) {
+        try {
+          await deliverChannelReply(channelDeliveryContext.replyCallbackUrl, {
+            chatId: requesterChatId,
+            text: `Your request to use "${request.toolName}" has been denied by the guardian.`,
+            assistantId,
+          }, channelDeliveryContext.bearerToken);
+        } catch (err) {
+          log.error({ err, requesterChatId }, 'Failed to notify requester of tool grant request denial');
+        }
+      }
+
+      return { ok: true, applied: true };
+    }
+
+    // On approve: grant minting is handled by the canonical decision primitive
+    // (step 6). This resolver only handles requester notification.
+    log.info(
+      {
+        event: 'resolver_tool_grant_request_approved',
+        requestId: request.id,
+        toolName: request.toolName,
+      },
+      'Tool grant request resolver: approved (grant minting deferred to canonical primitive)',
+    );
+
+    if (channelDeliveryContext && requesterChatId) {
+      try {
+        await deliverChannelReply(channelDeliveryContext.replyCallbackUrl, {
+          chatId: requesterChatId,
+          text: `Your request to use "${request.toolName}" has been approved. Please retry your request.`,
+          assistantId,
+        }, channelDeliveryContext.bearerToken);
+      } catch (err) {
+        log.error({ err, requesterChatId }, 'Failed to notify requester of tool grant request approval');
+      }
+    }
+
+    return { ok: true, applied: true, grantMinted: false };
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Registry
 // ---------------------------------------------------------------------------
@@ -465,3 +536,4 @@ export function getRegisteredKinds(): string[] {
 registerResolver(pendingInteractionResolver);
 registerResolver(pendingQuestionResolver);
 registerResolver(accessRequestResolver);
+registerResolver(toolGrantRequestResolver);

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -114,6 +114,7 @@ export function createToolExecutor(
       executionChannel: ctx.guardianContext?.sourceChannel,
       callSessionId: ctx.callSessionId,
       requesterExternalUserId: ctx.guardianContext?.requesterExternalUserId,
+      requesterChatId: ctx.guardianContext?.requesterChatId,
       onOutput,
       signal: ctx.abortController?.signal,
       sandboxOverride: ctx.sandboxOverride,

--- a/assistant/src/runtime/tool-grant-request-helper.ts
+++ b/assistant/src/runtime/tool-grant-request-helper.ts
@@ -1,0 +1,191 @@
+/**
+ * Tool grant request creation and guardian notification helper.
+ *
+ * Encapsulates the "create/dedupe canonical tool_grant_request + emit notification"
+ * logic so non-guardian channel actors can escalate tool invocations that require
+ * guardian approval. Modeled after the access-request-helper pattern.
+ *
+ * Invariants preserved:
+ * - Unverified actors are fail-closed (caller must gate before calling).
+ * - Guardians cannot self-approve (grant minting uses guardian identity).
+ * - Notification routing goes through emitNotificationSignal().
+ */
+
+import type { ChannelId } from '../channels/types.js';
+import {
+  createCanonicalGuardianDelivery,
+  createCanonicalGuardianRequest,
+  listCanonicalGuardianRequests,
+} from '../memory/canonical-guardian-store.js';
+import { emitNotificationSignal } from '../notifications/emit-signal.js';
+import { getLogger } from '../util/logger.js';
+import { getGuardianBinding } from './channel-guardian-service.js';
+import { GUARDIAN_APPROVAL_TTL_MS } from './routes/channel-route-shared.js';
+
+const log = getLogger('tool-grant-request-helper');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ToolGrantRequestParams {
+  assistantId: string;
+  sourceChannel: ChannelId;
+  conversationId: string;
+  requesterExternalUserId: string;
+  requesterChatId?: string;
+  requesterIdentifier?: string;
+  toolName: string;
+  inputDigest: string;
+  questionText: string;
+}
+
+export type ToolGrantRequestResult =
+  | { created: true; requestId: string; requestCode: string | null }
+  | { deduped: true; requestId: string; requestCode: string | null }
+  | { failed: true; reason: 'no_guardian_binding' | 'missing_identity' };
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Create/dedupe a canonical tool_grant_request and emit a notification signal
+ * so the guardian can approve or deny the tool invocation.
+ *
+ * Returns a result indicating whether a new request was created, an existing
+ * one was deduped, or the escalation failed (no binding, missing identity).
+ */
+export function createOrReuseToolGrantRequest(
+  params: ToolGrantRequestParams,
+): ToolGrantRequestResult {
+  const {
+    assistantId,
+    sourceChannel,
+    conversationId,
+    requesterExternalUserId,
+    requesterChatId,
+    requesterIdentifier,
+    toolName,
+    inputDigest,
+    questionText,
+  } = params;
+
+  if (!requesterExternalUserId) {
+    return { failed: true, reason: 'missing_identity' };
+  }
+
+  const binding = getGuardianBinding(assistantId, sourceChannel);
+  if (!binding) {
+    log.debug(
+      { sourceChannel, assistantId },
+      'No guardian binding for tool grant request escalation',
+    );
+    return { failed: true, reason: 'no_guardian_binding' };
+  }
+
+  // Deduplicate: skip creation if there is already a pending canonical request
+  // for the same requester + conversation + tool + input digest.
+  const existing = listCanonicalGuardianRequests({
+    status: 'pending',
+    requesterExternalUserId,
+    conversationId,
+    kind: 'tool_grant_request',
+    toolName,
+  });
+  const dedupeMatch = existing.find((r) => r.inputDigest === inputDigest);
+  if (dedupeMatch) {
+    log.debug(
+      {
+        sourceChannel,
+        requesterExternalUserId,
+        toolName,
+        existingId: dedupeMatch.id,
+      },
+      'Skipping duplicate tool grant request notification',
+    );
+    return { deduped: true, requestId: dedupeMatch.id, requestCode: dedupeMatch.requestCode };
+  }
+
+  const senderLabel = requesterIdentifier || requesterExternalUserId;
+  const requestId = `tool-grant-${assistantId}-${sourceChannel}-${requesterExternalUserId}-${Date.now()}`;
+
+  const canonicalRequest = createCanonicalGuardianRequest({
+    id: requestId,
+    kind: 'tool_grant_request',
+    sourceType: 'channel',
+    sourceChannel,
+    conversationId,
+    requesterExternalUserId,
+    requesterChatId: requesterChatId ?? undefined,
+    guardianExternalUserId: binding.guardianExternalUserId,
+    toolName,
+    inputDigest,
+    questionText,
+    expiresAt: new Date(Date.now() + GUARDIAN_APPROVAL_TTL_MS).toISOString(),
+  });
+
+  // Emit notification so guardian is alerted. Uses 'guardian.question' as
+  // sourceEventName so that existing request-code guidance in the notification
+  // pipeline is preserved.
+  const signalPromise = emitNotificationSignal({
+    sourceEventName: 'guardian.question',
+    sourceChannel,
+    sourceSessionId: conversationId,
+    assistantId,
+    attentionHints: {
+      requiresAction: true,
+      urgency: 'high',
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
+    contextPayload: {
+      requestId: canonicalRequest.id,
+      requestCode: canonicalRequest.requestCode,
+      sourceChannel,
+      requesterExternalUserId,
+      requesterChatId: requesterChatId ?? null,
+      requesterIdentifier: senderLabel,
+      toolName,
+      questionText,
+    },
+    dedupeKey: `tool-grant-request:${canonicalRequest.id}`,
+    onThreadCreated: (info) => {
+      createCanonicalGuardianDelivery({
+        requestId: canonicalRequest.id,
+        destinationChannel: 'vellum',
+        destinationConversationId: info.conversationId,
+      });
+    },
+  });
+
+  // Record deliveries from the notification pipeline results (fire-and-forget).
+  void signalPromise.then((signalResult) => {
+    for (const result of signalResult.deliveryResults) {
+      if (result.channel === 'vellum') continue; // handled in onThreadCreated
+      if (result.channel !== 'telegram' && result.channel !== 'sms') continue;
+      createCanonicalGuardianDelivery({
+        requestId: canonicalRequest.id,
+        destinationChannel: result.channel,
+        destinationChatId: result.destination.length > 0 ? result.destination : undefined,
+      });
+    }
+  });
+
+  log.info(
+    {
+      sourceChannel,
+      requesterExternalUserId,
+      toolName,
+      requestId: canonicalRequest.id,
+      requestCode: canonicalRequest.requestCode,
+    },
+    'Guardian notified of tool grant request',
+  );
+
+  return {
+    created: true,
+    requestId: canonicalRequest.id,
+    requestCode: canonicalRequest.requestCode,
+  };
+}

--- a/assistant/src/runtime/tool-grant-request-helper.ts
+++ b/assistant/src/runtime/tool-grant-request-helper.ts
@@ -85,7 +85,9 @@ export function createOrReuseToolGrantRequest(
   }
 
   // Deduplicate: skip creation if there is already a pending canonical request
-  // for the same requester + conversation + tool + input digest.
+  // for the same requester + conversation + tool + input digest + guardian.
+  // Guardian identity is included so that after a guardian rebind, old requests
+  // tied to the previous guardian don't block creation of a new approvable request.
   const existing = listCanonicalGuardianRequests({
     status: 'pending',
     requesterExternalUserId,
@@ -93,7 +95,9 @@ export function createOrReuseToolGrantRequest(
     kind: 'tool_grant_request',
     toolName,
   });
-  const dedupeMatch = existing.find((r) => r.inputDigest === inputDigest);
+  const dedupeMatch = existing.find(
+    (r) => r.inputDigest === inputDigest && r.guardianExternalUserId === binding.guardianExternalUserId,
+  );
   if (dedupeMatch) {
     log.debug(
       {

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -1,4 +1,5 @@
 import { consumeGrantForInvocation } from '../approvals/approval-primitive.js';
+import { createOrReuseToolGrantRequest } from '../runtime/tool-grant-request-helper.js';
 import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
 import { getTaskRunRules } from '../tasks/ephemeral-permissions.js';
 import { getLogger } from '../util/logger.js';
@@ -266,7 +267,48 @@ export class ToolApprovalHandler {
       }
 
       // No matching grant or race condition — deny.
-      const reason = guardianApprovalDeniedMessage(context.guardianActorRole, name);
+      //
+      // For verified non-guardian actors with sufficient context, escalate to
+      // the guardian by creating a canonical tool_grant_request. Unverified
+      // actors remain fail-closed with no escalation.
+      let escalationMessage: string | undefined;
+      if (
+        context.guardianActorRole === 'non-guardian'
+        && context.assistantId
+        && context.executionChannel
+        && context.requesterExternalUserId
+      ) {
+        const inputDigest = deferredConsumeParams?.inputDigest
+          ?? computeToolApprovalDigest(name, input);
+        const escalation = createOrReuseToolGrantRequest({
+          assistantId: context.assistantId,
+          sourceChannel: context.executionChannel as import('../channels/types.js').ChannelId,
+          conversationId: context.conversationId,
+          requesterExternalUserId: context.requesterExternalUserId,
+          requesterChatId: undefined,
+          toolName: name,
+          inputDigest,
+          questionText: `Trusted contact is requesting permission to use "${name}"`,
+        });
+
+        if ('created' in escalation) {
+          const codeSuffix = escalation.requestCode
+            ? ` (request code: ${escalation.requestCode})`
+            : '';
+          escalationMessage = `Permission denied for "${name}": this action requires guardian approval. `
+            + `A request has been sent to the guardian${codeSuffix}. `
+            + `Please retry after the guardian approves.`;
+        } else if ('deduped' in escalation) {
+          const codeSuffix = escalation.requestCode
+            ? ` (request code: ${escalation.requestCode})`
+            : '';
+          escalationMessage = `Permission denied for "${name}": guardian approval is already pending${codeSuffix}. `
+            + `Please retry after the guardian approves.`;
+        }
+        // If escalation.failed, fall through to generic denial message.
+      }
+
+      const reason = escalationMessage ?? guardianApprovalDeniedMessage(context.guardianActorRole, name);
       log.warn({
         toolName: name,
         sessionId: context.sessionId,
@@ -275,6 +317,7 @@ export class ToolApprovalHandler {
         executionTarget,
         reason: 'guardian_approval_required',
         grantMissReason: grantResult.reason,
+        escalated: !!escalationMessage,
       }, 'Guardian approval gate blocked untrusted actor tool invocation (no matching grant)');
       const durationMs = Date.now() - startTime;
       emitLifecycleEvent({

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -285,7 +285,7 @@ export class ToolApprovalHandler {
           sourceChannel: context.executionChannel as import('../channels/types.js').ChannelId,
           conversationId: context.conversationId,
           requesterExternalUserId: context.requesterExternalUserId,
-          requesterChatId: undefined,
+          requesterChatId: context.requesterChatId,
           toolName: name,
           inputDigest,
           questionText: `Trusted contact is requesting permission to use "${name}"`,

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -144,6 +144,8 @@ export interface ToolContext {
   callSessionId?: string;
   /** External user ID of the requester (non-guardian actor). Used for scoped grant consumption. */
   requesterExternalUserId?: string;
+  /** Chat ID of the requester (non-guardian actor). Used for tool grant request escalation notifications. */
+  requesterChatId?: string;
 }
 
 export interface DiffInfo {


### PR DESCRIPTION
## Summary
- Introduces a channel-agnostic guardian escalation path for non-guardian grant misses
- When a verified non-guardian attempts a privileged tool action without a scoped grant, the system now creates a canonical tool_grant_request and notifies the guardian (instead of silently denying)
- After guardian approval, a scoped grant is minted and the requester can retry successfully

## Changes
- **New file: assistant/src/runtime/tool-grant-request-helper.ts** -- Creates/deduplicates canonical tool_grant_request records and emits guardian notification signals
- **Edit: assistant/src/approvals/guardian-request-resolvers.ts** -- Added tool_grant_request resolver that handles approve/reject without requiring pending interactions
- **Edit: assistant/src/tools/tool-approval-handler.ts** -- Wired escalation path in the grant-miss branch for non-guardian actors (unverified actors remain fail-closed)
- **New test: assistant/src/__tests__/tool-grant-request-escalation.test.ts** -- 11 tests covering escalation creation, deduplication, resolver behavior, canonical grant minting, and end-to-end deny-approve-consume flow

## Invariants preserved
- Non-guardian channels remain non-interactive
- Unverified actors remain fail-closed (no escalation)
- Self-approval protection unchanged
- All decisions route through applyCanonicalGuardianDecision()
- All notifications route through emitNotificationSignal()
- Voice ASK_GUARDIAN_APPROVAL behavior unchanged

## Original prompt
non-guardian-tool-approval-escalation-one-pr-plan-2026-02-28.md

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
