### PR TITLE
Fix invite-link UX by preserving ingress invite tokens in entropy redaction

### DIFF
--- a/assistant/src/__tests__/secret-scanner.test.ts
+++ b/assistant/src/__tests__/secret-scanner.test.ts
@@ -683,6 +683,30 @@ describe('entropy-based detection', () => {
     expect(matches).toHaveLength(0);
     expect(redactSecrets(input)).toBe(input);
   });
+
+  test('does not redact ingress invite token in create response JSON', () => {
+    const token = 'AbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_ABCDE';
+    const input = JSON.stringify({
+      ok: true,
+      invite: {
+        sourceChannel: 'telegram',
+        token,
+      },
+    }, null, 2);
+    const entropyMatches = scanText(input).filter((m) => m.type.startsWith('High-Entropy'));
+    expect(entropyMatches).toHaveLength(0);
+    expect(redactSecrets(input)).toBe(input);
+  });
+
+  test('still redacts high-entropy token field outside invite context', () => {
+    const token = 'AbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_ABCDE';
+    const input = JSON.stringify({
+      service: 'payments',
+      token,
+    }, null, 2);
+    const entropyMatches = scanText(input).filter((m) => m.type.startsWith('High-Entropy'));
+    expect(entropyMatches.length).toBeGreaterThan(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/security/secret-scanner.ts
+++ b/assistant/src/security/secret-scanner.ts
@@ -365,6 +365,41 @@ function hasSecretContext(text: string, matchStart: number): boolean {
   return SECRET_CONTEXT_RES.some((re) => re.test(prefix));
 }
 
+const INVITE_TOKEN_PREFIXES = new Set(['iv_', 'gv_']);
+const INVITE_OBJECT_RE = /"invite"\s*:\s*\{/i;
+const INVITE_CHANNEL_RE = /"sourceChannel"\s*:\s*"(telegram|sms|whatsapp|voice)"/i;
+const TOKEN_FIELD_PREFIX_RE = /"token"\s*:\s*"$/i;
+
+/**
+ * Skip entropy matches for ingress invite tokens.
+ *
+ * Invite tokens are intentionally shareable values. Redacting them in create-
+ * invite responses degrades UX (the assistant can't present a usable link).
+ * Keep this narrowly scoped to known invite contexts.
+ */
+function isInviteFlowToken(text: string, startIndex: number, endIndex: number): boolean {
+  const candidate = text.slice(startIndex, endIndex);
+  if (INVITE_TOKEN_PREFIXES.has(candidate.slice(0, 3))) {
+    return true;
+  }
+
+  const directPrefix = text.slice(Math.max(0, startIndex - 3), startIndex);
+  if (INVITE_TOKEN_PREFIXES.has(directPrefix)) {
+    return true;
+  }
+
+  const beforeTail = text.slice(Math.max(0, startIndex - 48), startIndex);
+  if (!TOKEN_FIELD_PREFIX_RE.test(beforeTail)) {
+    return false;
+  }
+
+  const windowStart = Math.max(0, startIndex - 260);
+  const windowEnd = Math.min(text.length, endIndex + 260);
+  const contextWindow = text.slice(windowStart, windowEnd);
+
+  return INVITE_OBJECT_RE.test(contextWindow) && INVITE_CHANNEL_RE.test(contextWindow);
+}
+
 /**
  * Check if a string is purely hex characters.
  */
@@ -409,6 +444,7 @@ function scanEntropy(
     // Skip placeholders and allowlisted values
     if (isPlaceholder(value)) continue;
     if (isAllowlisted(value)) continue;
+    if (isInviteFlowToken(text, startIndex, endIndex)) continue;
 
     const entropy = shannonEntropy(value);
     if (entropy < config.hexThreshold) continue;
@@ -442,6 +478,7 @@ function scanEntropy(
 
     if (isPlaceholder(value)) continue;
     if (isAllowlisted(value)) continue;
+    if (isInviteFlowToken(text, startIndex, endIndex)) continue;
 
     const entropy = shannonEntropy(value);
     if (entropy < config.base64Threshold) continue;


### PR DESCRIPTION
## Summary
- add a narrow entropy-scanner exemption for ingress invite tokens (`iv_` / `gv_`) and create-invite JSON payloads
- keep existing high-entropy token redaction behavior outside invite contexts
- add regression tests for invite create response JSON and non-invite token fields

## Testing
- `cd assistant && bun test src/__tests__/secret-scanner.test.ts --bail`
