### PR TITLE
M1: Voice invite data model + service primitives

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -7,6 +7,7 @@ import {
   migrateCanonicalGuardianDeliveriesDestinationIndex,
   migrateCanonicalGuardianRequesterChatId,
   migrateNormalizePhoneIdentities,
+  migrateVoiceInviteColumns,
   createChannelGuardianTables,
   createContactsAndTriageTables,
   createConversationAttentionTables,
@@ -160,6 +161,9 @@ export function initializeDb(): void {
 
   // 25. Normalize phone-like identity fields to E.164 across guardian and ingress tables
   migrateNormalizePhoneIdentities(database);
+
+  // 26. Voice invite columns on assistant_ingress_invites
+  migrateVoiceInviteColumns(database);
 
   validateMigrationState(database);
 }

--- a/assistant/src/memory/ingress-invite-store.ts
+++ b/assistant/src/memory/ingress-invite-store.ts
@@ -33,6 +33,10 @@ export interface IngressInvite {
   redeemedByExternalUserId: string | null;
   redeemedByExternalChatId: string | null;
   redeemedAt: number | null;
+  // Voice invite fields (null for non-voice invites)
+  expectedExternalUserId: string | null;
+  voiceCodeHash: string | null;
+  voiceCodeDigits: number | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -90,6 +94,9 @@ function rowToInvite(row: typeof assistantIngressInvites.$inferSelect): IngressI
     redeemedByExternalUserId: row.redeemedByExternalUserId,
     redeemedByExternalChatId: row.redeemedByExternalChatId,
     redeemedAt: row.redeemedAt,
+    expectedExternalUserId: row.expectedExternalUserId,
+    voiceCodeHash: row.voiceCodeHash,
+    voiceCodeDigits: row.voiceCodeDigits,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -127,6 +134,10 @@ export function createInvite(params: {
   note?: string;
   maxUses?: number;
   expiresInMs?: number;
+  // Voice invite metadata (all optional — omitted for non-voice invites)
+  expectedExternalUserId?: string;
+  voiceCodeHash?: string;
+  voiceCodeDigits?: number;
 }): { invite: IngressInvite; rawToken: string } {
   const db = getDb();
   const now = Date.now();
@@ -148,6 +159,9 @@ export function createInvite(params: {
     redeemedByExternalUserId: null,
     redeemedByExternalChatId: null,
     redeemedAt: null,
+    expectedExternalUserId: params.expectedExternalUserId ?? null,
+    voiceCodeHash: params.voiceCodeHash ?? null,
+    voiceCodeDigits: params.voiceCodeDigits ?? null,
     createdAt: now,
     updatedAt: now,
   };
@@ -431,4 +445,35 @@ export function findByTokenHash(tokenHash: string): IngressInvite | null {
     .get();
 
   return row ? rowToInvite(row) : null;
+}
+
+// ---------------------------------------------------------------------------
+// findActiveVoiceInvites
+// ---------------------------------------------------------------------------
+
+/**
+ * Find all active voice invites bound to a specific caller identity.
+ * Used by the voice invite redemption flow to locate candidate invites
+ * before code hash matching.
+ */
+export function findActiveVoiceInvites(params: {
+  assistantId: string;
+  expectedExternalUserId: string;
+}): IngressInvite[] {
+  const db = getDb();
+
+  const rows = db
+    .select()
+    .from(assistantIngressInvites)
+    .where(
+      and(
+        eq(assistantIngressInvites.assistantId, params.assistantId),
+        eq(assistantIngressInvites.sourceChannel, 'voice'),
+        eq(assistantIngressInvites.status, 'active'),
+        eq(assistantIngressInvites.expectedExternalUserId, params.expectedExternalUserId),
+      ),
+    )
+    .all();
+
+  return rows.map(rowToInvite);
 }

--- a/assistant/src/memory/migrations/037-voice-invite-columns.ts
+++ b/assistant/src/memory/migrations/037-voice-invite-columns.ts
@@ -1,0 +1,16 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Add voice invite columns to assistant_ingress_invites for guardian-initiated
+ * voice invite codes. All columns are nullable to keep existing invite rows
+ * compatible.
+ *
+ * - expected_external_user_id: E.164 phone number for identity binding
+ * - voice_code_hash: SHA-256 hash of the short numeric code
+ * - voice_code_digits: configurable digit count (default 6)
+ */
+export function migrateVoiceInviteColumns(database: DrizzleDb): void {
+  try { database.run(/*sql*/ `ALTER TABLE assistant_ingress_invites ADD COLUMN expected_external_user_id TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE assistant_ingress_invites ADD COLUMN voice_code_hash TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE assistant_ingress_invites ADD COLUMN voice_code_digits INTEGER DEFAULT 6`); } catch { /* already exists */ }
+}

--- a/assistant/src/memory/migrations/037-voice-invite-columns.ts
+++ b/assistant/src/memory/migrations/037-voice-invite-columns.ts
@@ -7,10 +7,10 @@ import type { DrizzleDb } from '../db-connection.js';
  *
  * - expected_external_user_id: E.164 phone number for identity binding
  * - voice_code_hash: SHA-256 hash of the short numeric code
- * - voice_code_digits: configurable digit count (default 6)
+ * - voice_code_digits: configurable digit count (nullable — NULL for non-voice invites)
  */
 export function migrateVoiceInviteColumns(database: DrizzleDb): void {
   try { database.run(/*sql*/ `ALTER TABLE assistant_ingress_invites ADD COLUMN expected_external_user_id TEXT`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE assistant_ingress_invites ADD COLUMN voice_code_hash TEXT`); } catch { /* already exists */ }
-  try { database.run(/*sql*/ `ALTER TABLE assistant_ingress_invites ADD COLUMN voice_code_digits INTEGER DEFAULT 6`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE assistant_ingress_invites ADD COLUMN voice_code_digits INTEGER`); } catch { /* already exists */ }
 }

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -38,6 +38,7 @@ export { createScopedApprovalGrantsTable } from './033-scoped-approval-grants.js
 export { migrateGuardianActionToolMetadata } from './034-guardian-action-tool-metadata.js';
 export { migrateGuardianActionSupersession } from './035-guardian-action-supersession.js';
 export { migrateNormalizePhoneIdentities } from './036-normalize-phone-identities.js';
+export { migrateVoiceInviteColumns } from './037-voice-invite-columns.js';
 export { createCoreTables } from './100-core-tables.js';
 export { createWatchersAndLogsTables } from './101-watchers-and-logs.js';
 export { addCoreColumns } from './102-alter-table-columns.js';

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -942,6 +942,10 @@ export const assistantIngressInvites = sqliteTable('assistant_ingress_invites', 
   redeemedByExternalUserId: text('redeemed_by_external_user_id'),
   redeemedByExternalChatId: text('redeemed_by_external_chat_id'),
   redeemedAt: integer('redeemed_at'),
+  // Voice invite fields (nullable — non-voice invites leave these NULL)
+  expectedExternalUserId: text('expected_external_user_id'),
+  voiceCodeHash: text('voice_code_hash'),
+  voiceCodeDigits: integer('voice_code_digits').default(6),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 });

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -945,7 +945,7 @@ export const assistantIngressInvites = sqliteTable('assistant_ingress_invites', 
   // Voice invite fields (nullable — non-voice invites leave these NULL)
   expectedExternalUserId: text('expected_external_user_id'),
   voiceCodeHash: text('voice_code_hash'),
-  voiceCodeDigits: integer('voice_code_digits').default(6),
+  voiceCodeDigits: integer('voice_code_digits'),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 });

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -133,6 +133,7 @@ import {
   handleListInvites,
   handleListMembers,
   handleRedeemInvite,
+  handleRedeemVoiceInvite,
   handleRevokeInvite,
   handleRevokeMember,
   handleUpsertMember,
@@ -745,6 +746,7 @@ export class RuntimeHttpServer {
       if (endpoint === 'ingress/invites' && req.method === 'GET') return handleListInvites(url);
       if (endpoint === 'ingress/invites' && req.method === 'POST') return await handleCreateInvite(req);
       if (endpoint === 'ingress/invites/redeem' && req.method === 'POST') return await handleRedeemInvite(req);
+      if (endpoint === 'ingress/invites/redeem-voice' && req.method === 'POST') return await handleRedeemVoiceInvite(req);
       const inviteMatch = endpoint.match(/^ingress\/invites\/([^/]+)$/);
       if (inviteMatch && req.method === 'DELETE') return handleRevokeInvite(inviteMatch[1]);
 

--- a/assistant/src/runtime/ingress-service.ts
+++ b/assistant/src/runtime/ingress-service.ts
@@ -22,9 +22,12 @@ import {
   revokeMember,
   upsertMember,
 } from '../memory/ingress-member-store.js';
+import { generateVoiceCode, hashVoiceCode } from '../util/voice-code.js';
 import {
   type InviteRedemptionOutcome,
+  type VoiceRedemptionOutcome,
   redeemInvite as redeemInviteTyped,
+  redeemVoiceInviteCode as redeemVoiceInviteCodeTyped,
 } from './invite-redemption-service.js';
 
 // ---------------------------------------------------------------------------
@@ -41,6 +44,10 @@ export interface InviteResponseData {
   expiresAt: number | null;
   status: string;
   note?: string;
+  // Voice invite fields (present only for voice invites)
+  expectedExternalUserId?: string;
+  voiceCode?: string;
+  voiceCodeDigits?: number;
   createdAt: number;
 }
 
@@ -61,17 +68,20 @@ export interface MemberResponseData {
 // Mappers
 // ---------------------------------------------------------------------------
 
-function inviteToResponse(inv: IngressInvite, rawToken?: string): InviteResponseData {
+function inviteToResponse(inv: IngressInvite, opts?: { rawToken?: string; voiceCode?: string }): InviteResponseData {
   return {
     id: inv.id,
     sourceChannel: inv.sourceChannel,
-    ...(rawToken ? { token: rawToken } : {}),
+    ...(opts?.rawToken ? { token: opts.rawToken } : {}),
     tokenHash: inv.tokenHash,
     maxUses: inv.maxUses,
     useCount: inv.useCount,
     expiresAt: inv.expiresAt,
     status: inv.status,
     note: inv.note ?? undefined,
+    ...(inv.expectedExternalUserId ? { expectedExternalUserId: inv.expectedExternalUserId } : {}),
+    ...(opts?.voiceCode ? { voiceCode: opts.voiceCode } : {}),
+    ...(inv.voiceCodeDigits != null ? { voiceCodeDigits: inv.voiceCodeDigits } : {}),
     createdAt: inv.createdAt,
   };
 }
@@ -108,17 +118,42 @@ export function createIngressInvite(params: {
   note?: string;
   maxUses?: number;
   expiresInMs?: number;
+  // Voice invite parameters
+  expectedExternalUserId?: string;
+  voiceCodeDigits?: number;
 }): IngressResult<InviteResponseData> {
   if (!params.sourceChannel) {
     return { ok: false, error: 'sourceChannel is required for create' };
   }
+
+  // For voice invites: generate a one-time numeric code, hash it, and pass
+  // the hash to the store. The plaintext code is included in the response
+  // exactly once and never stored.
+  let voiceCode: string | undefined;
+  let voiceCodeHash: string | undefined;
+  const isVoice = params.sourceChannel === 'voice';
+
+  if (isVoice) {
+    if (!params.expectedExternalUserId) {
+      return { ok: false, error: 'expectedExternalUserId is required for voice invites' };
+    }
+    const digits = params.voiceCodeDigits ?? 6;
+    voiceCode = generateVoiceCode(digits);
+    voiceCodeHash = hashVoiceCode(voiceCode);
+  }
+
   const { invite, rawToken } = createInvite({
     sourceChannel: params.sourceChannel,
     note: params.note,
     maxUses: params.maxUses,
     expiresInMs: params.expiresInMs,
+    ...(isVoice ? {
+      expectedExternalUserId: params.expectedExternalUserId,
+      voiceCodeHash,
+      voiceCodeDigits: params.voiceCodeDigits ?? 6,
+    } : {}),
   });
-  return { ok: true, data: inviteToResponse(invite, rawToken) };
+  return { ok: true, data: inviteToResponse(invite, { rawToken, voiceCode }) };
 }
 
 export function listIngressInvites(params: {
@@ -172,6 +207,7 @@ export function redeemIngressInvite(params: {
 // ---------------------------------------------------------------------------
 
 export { type InviteRedemptionOutcome } from './invite-redemption-service.js';
+export { type VoiceRedemptionOutcome } from './invite-redemption-service.js';
 
 export function redeemIngressInviteTyped(params: {
   rawToken: string;
@@ -183,6 +219,15 @@ export function redeemIngressInviteTyped(params: {
   assistantId?: string;
 }): InviteRedemptionOutcome {
   return redeemInviteTyped(params);
+}
+
+export function redeemVoiceInviteCode(params: {
+  assistantId?: string;
+  callerExternalUserId: string;
+  sourceChannel: 'voice';
+  code: string;
+}): VoiceRedemptionOutcome {
+  return redeemVoiceInviteCodeTyped(params);
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/ingress-service.ts
+++ b/assistant/src/runtime/ingress-service.ts
@@ -138,6 +138,9 @@ export function createIngressInvite(params: {
       return { ok: false, error: 'expectedExternalUserId is required for voice invites' };
     }
     const digits = params.voiceCodeDigits ?? 6;
+    if (!Number.isInteger(digits) || digits < 4 || digits > 10) {
+      return { ok: false, error: 'voiceCodeDigits must be an integer between 4 and 10' };
+    }
     voiceCode = generateVoiceCode(digits);
     voiceCodeHash = hashVoiceCode(voiceCode);
   }
@@ -153,7 +156,9 @@ export function createIngressInvite(params: {
       voiceCodeDigits: params.voiceCodeDigits ?? 6,
     } : {}),
   });
-  return { ok: true, data: inviteToResponse(invite, { rawToken, voiceCode }) };
+  // Voice invites must not expose the token — callers must redeem via the
+  // identity-bound voice code flow, not the generic token redemption path.
+  return { ok: true, data: inviteToResponse(invite, { rawToken: isVoice ? undefined : rawToken, voiceCode }) };
 }
 
 export function listIngressInvites(params: {

--- a/assistant/src/runtime/ingress-service.ts
+++ b/assistant/src/runtime/ingress-service.ts
@@ -22,6 +22,7 @@ import {
   revokeMember,
   upsertMember,
 } from '../memory/ingress-member-store.js';
+import { isValidE164 } from '../util/phone.js';
 import { generateVoiceCode, hashVoiceCode } from '../util/voice-code.js';
 import {
   type InviteRedemptionOutcome,
@@ -136,6 +137,9 @@ export function createIngressInvite(params: {
   if (isVoice) {
     if (!params.expectedExternalUserId) {
       return { ok: false, error: 'expectedExternalUserId is required for voice invites' };
+    }
+    if (!isValidE164(params.expectedExternalUserId)) {
+      return { ok: false, error: 'expectedExternalUserId must be in E.164 format (e.g., +15551234567)' };
     }
     const digits = params.voiceCodeDigits ?? 6;
     if (!Number.isInteger(digits) || digits < 4 || digits > 10) {

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -8,8 +8,9 @@
  */
 
 import { getSqlite } from '../memory/db.js';
-import { findByTokenHash, hashToken, markInviteExpired, recordInviteUse,redeemInvite as storeRedeemInvite } from '../memory/ingress-invite-store.js';
+import { findByTokenHash, hashToken, markInviteExpired, recordInviteUse, redeemInvite as storeRedeemInvite, findActiveVoiceInvites } from '../memory/ingress-invite-store.js';
 import { findMember, upsertMember } from '../memory/ingress-member-store.js';
+import { hashVoiceCode } from '../util/voice-code.js';
 
 // ---------------------------------------------------------------------------
 // Outcome type
@@ -19,6 +20,13 @@ export type InviteRedemptionOutcome =
   | { ok: true; type: 'redeemed'; memberId: string; inviteId: string }
   | { ok: true; type: 'already_member'; memberId: string }
   | { ok: false; reason: 'invalid_token' | 'expired' | 'revoked' | 'max_uses_reached' | 'channel_mismatch' | 'missing_identity' };
+
+// Generic failure reasons for voice redemption — intentionally vague to avoid
+// leaking information about which invites exist or which identity is bound.
+export type VoiceRedemptionOutcome =
+  | { ok: true; type: 'redeemed'; memberId: string; inviteId: string }
+  | { ok: true; type: 'already_member'; memberId: string }
+  | { ok: false; reason: 'invalid_or_expired' };
 
 // ---------------------------------------------------------------------------
 // Error-string to typed-reason mapping
@@ -177,5 +185,127 @@ export function redeemInvite(params: {
     type: 'redeemed',
     memberId: result.member.id,
     inviteId: result.invite.id,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// redeemVoiceInviteCode
+// ---------------------------------------------------------------------------
+
+/**
+ * Redeem a voice invite code for a caller identified by their E.164 phone number.
+ *
+ * Unlike token-based redemption, voice redemption:
+ *   1. Filters only active voice invites bound to the caller's identity
+ *      (expectedExternalUserId must match callerExternalUserId).
+ *   2. Validates the short numeric code by hashing it and comparing to the
+ *      stored voiceCodeHash.
+ *   3. Enforces expiry and use limits.
+ *   4. On success: upserts/reactivates a member with status 'active', policy 'allow'.
+ *   5. Consumes one invite use atomically (increment useCount).
+ *
+ * Failure responses are intentionally generic ("invalid_or_expired") to prevent
+ * oracle attacks that could reveal which invites exist or which phone numbers
+ * are bound.
+ */
+export function redeemVoiceInviteCode(params: {
+  assistantId?: string;
+  callerExternalUserId: string;
+  sourceChannel: 'voice';
+  code: string;
+}): VoiceRedemptionOutcome {
+  const { assistantId = 'self', callerExternalUserId, code } = params;
+
+  if (!callerExternalUserId) {
+    return { ok: false, reason: 'invalid_or_expired' };
+  }
+
+  // Find all active voice invites bound to the caller's phone number
+  const candidates = findActiveVoiceInvites({
+    assistantId,
+    expectedExternalUserId: callerExternalUserId,
+  });
+
+  if (candidates.length === 0) {
+    return { ok: false, reason: 'invalid_or_expired' };
+  }
+
+  const codeHash = hashVoiceCode(code);
+  const now = Date.now();
+
+  // Search for a matching invite: code hash match, not expired, uses remaining
+  const invite = candidates.find((inv) => {
+    if (inv.voiceCodeHash !== codeHash) return false;
+    if (inv.expiresAt <= now) return false;
+    if (inv.useCount >= inv.maxUses) return false;
+    return true;
+  });
+
+  if (!invite) {
+    // Mark any expired candidates while we're here
+    for (const inv of candidates) {
+      if (inv.expiresAt <= now && inv.status === 'active') {
+        markInviteExpired(inv.id);
+      }
+    }
+    return { ok: false, reason: 'invalid_or_expired' };
+  }
+
+  // Channel enforcement: voice invites can only be redeemed on the voice channel
+  if (invite.sourceChannel !== 'voice') {
+    return { ok: false, reason: 'invalid_or_expired' };
+  }
+
+  // Check for existing membership
+  const existingMember = findMember({
+    assistantId: invite.assistantId,
+    sourceChannel: 'voice',
+    externalUserId: callerExternalUserId,
+  });
+
+  if (existingMember && existingMember.status === 'active') {
+    return { ok: true, type: 'already_member', memberId: existingMember.id };
+  }
+
+  // Blocked members cannot bypass the guardian's explicit block
+  if (existingMember && existingMember.status === 'blocked') {
+    return { ok: false, reason: 'invalid_or_expired' };
+  }
+
+  // Atomic redemption: upsert member + consume invite use in a transaction
+  const STALE_INVITE = Symbol('stale_invite');
+  let memberId: string | undefined;
+
+  try {
+    getSqlite().transaction(() => {
+      const member = upsertMember({
+        assistantId: invite.assistantId,
+        sourceChannel: 'voice',
+        externalUserId: callerExternalUserId,
+        status: 'active',
+        policy: 'allow',
+        inviteId: invite.id,
+      });
+      memberId = member.id;
+
+      const recorded = recordInviteUse({
+        inviteId: invite.id,
+        externalUserId: callerExternalUserId,
+      });
+
+      if (!recorded) throw STALE_INVITE;
+    }).immediate();
+  } catch (err) {
+    if (err === STALE_INVITE) {
+      return { ok: false, reason: 'invalid_or_expired' };
+    }
+    throw err;
+  }
+
+  return {
+    ok: true,
+    type: 'redeemed',
+    memberId: memberId!,
+    inviteId: invite.id,
   };
 }

--- a/assistant/src/runtime/routes/ingress-routes.ts
+++ b/assistant/src/runtime/routes/ingress-routes.ts
@@ -8,10 +8,11 @@
  *   POST   /v1/ingress/members/:id/block — block a member
  *
  * Invites:
- *   GET    /v1/ingress/invites           — list invites
- *   POST   /v1/ingress/invites           — create an invite
- *   DELETE /v1/ingress/invites/:id       — revoke an invite
- *   POST   /v1/ingress/invites/redeem    — redeem an invite
+ *   GET    /v1/ingress/invites              — list invites
+ *   POST   /v1/ingress/invites              — create an invite (supports voice)
+ *   DELETE /v1/ingress/invites/:id          — revoke an invite
+ *   POST   /v1/ingress/invites/redeem       — redeem an invite (token-based)
+ *   POST   /v1/ingress/invites/redeem-voice — redeem a voice invite code
  */
 
 import {
@@ -20,6 +21,7 @@ import {
   listIngressInvites,
   listIngressMembers,
   redeemIngressInvite,
+  redeemVoiceInviteCode,
   revokeIngressInvite,
   revokeIngressMember,
   upsertIngressMember,
@@ -130,6 +132,11 @@ export function handleListInvites(url: URL): Response {
 
 /**
  * POST /v1/ingress/invites
+ *
+ * For voice invites, pass `sourceChannel: "voice"` with required
+ * `expectedExternalUserId` (E.164 phone) and optional `voiceCodeDigits`.
+ * The response will include a one-time `voiceCode` field that must be
+ * communicated to the invited user out-of-band.
  */
 export async function handleCreateInvite(req: Request): Promise<Response> {
   const body = (await req.json()) as Record<string, unknown>;
@@ -139,6 +146,8 @@ export async function handleCreateInvite(req: Request): Promise<Response> {
     note: body.note as string | undefined,
     maxUses: body.maxUses as number | undefined,
     expiresInMs: body.expiresInMs as number | undefined,
+    expectedExternalUserId: body.expectedExternalUserId as string | undefined,
+    voiceCodeDigits: body.voiceCodeDigits as number | undefined,
   });
 
   if (!result.ok) {
@@ -176,4 +185,44 @@ export async function handleRedeemInvite(req: Request): Promise<Response> {
     return Response.json({ ok: false, error: result.error }, { status: 400 });
   }
   return Response.json({ ok: true, invite: result.data });
+}
+
+/**
+ * POST /v1/ingress/invites/redeem-voice
+ *
+ * Redeem a voice invite code. Requires:
+ * - callerExternalUserId: E.164 phone number of the caller
+ * - code: the short numeric voice code
+ * - assistantId (optional)
+ */
+export async function handleRedeemVoiceInvite(req: Request): Promise<Response> {
+  const body = (await req.json()) as Record<string, unknown>;
+
+  const callerExternalUserId = body.callerExternalUserId as string | undefined;
+  const code = body.code as string | undefined;
+
+  if (!callerExternalUserId || !code) {
+    return Response.json(
+      { ok: false, error: 'callerExternalUserId and code are required' },
+      { status: 400 },
+    );
+  }
+
+  const result = redeemVoiceInviteCode({
+    assistantId: body.assistantId as string | undefined,
+    callerExternalUserId,
+    sourceChannel: 'voice',
+    code,
+  });
+
+  if (!result.ok) {
+    return Response.json({ ok: false, error: result.reason }, { status: 400 });
+  }
+
+  return Response.json({
+    ok: true,
+    type: result.type,
+    memberId: result.memberId,
+    ...(result.type === 'redeemed' ? { inviteId: result.inviteId } : {}),
+  });
 }

--- a/assistant/src/util/voice-code.ts
+++ b/assistant/src/util/voice-code.ts
@@ -1,0 +1,29 @@
+/**
+ * Cryptographic voice invite code generation and hashing.
+ *
+ * Generates short numeric codes (default 6 digits) for voice-channel invite
+ * redemption. The plaintext code is returned once at creation time and never
+ * stored — only its SHA-256 hash is persisted.
+ */
+
+import { createHash, randomInt } from 'node:crypto';
+
+/**
+ * Generate a cryptographically random numeric code of the given length.
+ * Uses node:crypto randomInt for uniform distribution.
+ */
+export function generateVoiceCode(digits: number = 6): string {
+  if (digits < 4 || digits > 10) {
+    throw new Error(`Voice code digit count must be between 4 and 10, got ${digits}`);
+  }
+  const min = Math.pow(10, digits - 1); // e.g. 100000 for 6 digits
+  const max = Math.pow(10, digits);     // e.g. 1000000 for 6 digits
+  return String(randomInt(min, max));
+}
+
+/**
+ * SHA-256 hash a voice code for storage comparison.
+ */
+export function hashVoiceCode(code: string): string {
+  return createHash('sha256').update(code).digest('hex');
+}


### PR DESCRIPTION
Add schema migration, Drizzle schema fields, invite store/service plumbing for voice metadata, one-time voice code generation and hashing, typed voice-code redemption primitive, and API route extension for voice invite creation. Part of #10605.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
