### PR TITLE
feat: add VDropdown generic dropdown component to design system

### DIFF
--- a/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+/// A generic dropdown component styled to match VTextField.
+/// Uses SwiftUI `Menu` for native macOS popup behavior.
+public struct VDropdown<T: Hashable>: View {
+    public let placeholder: String
+    @Binding public var selection: T
+    public let options: [(label: String, value: T)]
+    /// When selection equals emptyValue, the placeholder text is shown instead of a selected label.
+    public var emptyValue: T? = nil
+
+    public init(
+        placeholder: String,
+        selection: Binding<T>,
+        options: [(label: String, value: T)],
+        emptyValue: T? = nil
+    ) {
+        self.placeholder = placeholder
+        self._selection = selection
+        self.options = options
+        self.emptyValue = emptyValue
+    }
+
+    private var selectedLabel: String? {
+        if let emptyValue = emptyValue, selection == emptyValue {
+            return nil
+        }
+        return options.first(where: { $0.value == selection })?.label
+    }
+
+    public var body: some View {
+        Menu {
+            ForEach(options, id: \.value) { option in
+                Button {
+                    selection = option.value
+                } label: {
+                    HStack {
+                        Text(option.label)
+                        if option.value == selection {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+            }
+        } label: {
+            HStack {
+                if let label = selectedLabel {
+                    Text(label)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                } else {
+                    Text(placeholder)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textMuted)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.down")
+                    .foregroundColor(VColor.textMuted)
+                    .font(.system(size: 12))
+            }
+            .padding(VSpacing.md)
+            .background(VColor.inputBackground)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+            )
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+#if DEBUG
+struct VDropdown_Preview: PreviewProvider {
+    static var previews: some View {
+        VDropdownPreviewWrapper()
+            .frame(width: 350, height: 160)
+            .previewDisplayName("VDropdown")
+    }
+}
+
+private struct VDropdownPreviewWrapper: View {
+    @State private var selection = ""
+
+    private let options = [
+        (label: "Option A", value: "a"),
+        (label: "Option B", value: "b"),
+        (label: "Option C", value: "c")
+    ]
+
+    var body: some View {
+        ZStack {
+            VColor.background.ignoresSafeArea()
+            VStack(spacing: 16) {
+                VDropdown(
+                    placeholder: "Select an option...",
+                    selection: $selection,
+                    options: options,
+                    emptyValue: ""
+                )
+
+                Text("Selected: \"\(selection)\"")
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.textMuted)
+            }
+            .padding()
+        }
+    }
+}
+#endif

--- a/clients/shared/DesignSystem/Gallery/Sections/InputsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/InputsGallerySection.swift
@@ -11,6 +11,7 @@ struct InputsGallerySection: View {
     @State private var sliderSmallValue: Double = 5
     @State private var toggleA: Bool = true
     @State private var toggleB: Bool = false
+    @State private var dropdownValue = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xxl) {
@@ -164,6 +165,52 @@ struct InputsGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.md) {
                         Text("Without label").font(VFont.caption).foregroundColor(VColor.textMuted)
                         VToggle(isOn: $toggleB)
+                    }
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - VDropdown
+            GallerySectionHeader(
+                title: "VDropdown",
+                description: "Generic dropdown picker styled like VTextField, using native Menu for macOS popup behavior."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    Text("Live value: \"\(dropdownValue)\"")
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textMuted)
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Empty state (placeholder visible)").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VDropdown(
+                            placeholder: "Select an option...",
+                            selection: .constant(""),
+                            options: [
+                                (label: "Option A", value: "a"),
+                                (label: "Option B", value: "b"),
+                                (label: "Option C", value: "c")
+                            ],
+                            emptyValue: ""
+                        )
+                    }
+
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Selected state (interactive)").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VDropdown(
+                            placeholder: "Select an option...",
+                            selection: $dropdownValue,
+                            options: [
+                                (label: "Option A", value: "a"),
+                                (label: "Option B", value: "b"),
+                                (label: "Option C", value: "c")
+                            ],
+                            emptyValue: ""
+                        )
                     }
                 }
             }


### PR DESCRIPTION
Adds VDropdown<T: Hashable> to Core/Inputs in the design system. Full-width styled button using Menu for native macOS popup behavior, matching the visual design with placeholder text and chevron. Also adds gallery section to InputsGallerySection.

Closes #10614
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
