### PR TITLE
feat: invite token placeholder substitution pipeline

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -1909,6 +1909,18 @@ Connected channels are resolved at signal emission time: vellum is always includ
 
 
 
+### Sensitive Tool Output Placeholder Substitution
+
+Some tool outputs contain values that must reach the user's final reply but should never be visible to the LLM (e.g., invite tokens). The system handles this with a three-stage pipeline:
+
+1. **Directive extraction** (`src/tools/sensitive-output-placeholders.ts`): Tool output may include `<vellum-sensitive-output kind="invite_code" value="<raw>" />` directives. The executor strips directives, replaces raw values with deterministic placeholders (`VELLUM_ASSISTANT_INVITE_CODE_<shortId>`), and attaches `sensitiveBindings` metadata to the tool result.
+
+2. **Placeholder-only model context**: The agent loop stores placeholder->value bindings in a per-run `substitutionMap`. Tool results sent to the LLM contain only placeholders — the model generates conversational text referencing them without ever seeing the real values.
+
+3. **Post-generation substitution** (`src/agent/loop.ts`): Before emitting streamed `text_delta` events and before building the final `assistantMessage`, all placeholders are deterministically replaced with their real values. The substitution is chunk-safe for streaming (buffering partial placeholder prefixes across deltas).
+
+Key files: `src/tools/sensitive-output-placeholders.ts`, `src/tools/executor.ts` (extraction hook), `src/agent/loop.ts` (substitution), `src/config/vellum-skills/trusted-contacts/SKILL.md` (invite flow adoption).
+
 ### Notifications
 
 For full notification developer guidance and lifecycle details, see [`assistant/src/notifications/README.md`](src/notifications/README.md).

--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -1194,26 +1194,28 @@ describe('AgentLoop', () => {
     const events: AgentEvent[] = [];
     const history = await loop.run([userMessage], collectEvents(events));
 
-    // The final assistant message in history should contain the resolved real token
+    // The final assistant message in HISTORY should retain placeholders
+    // (so the model never sees real values on subsequent turns)
     const lastAssistant = history[history.length - 1];
     expect(lastAssistant.role).toBe('assistant');
-    const textBlock = lastAssistant.content.find(
+    const historyTextBlock = lastAssistant.content.find(
       (b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text',
     );
-    expect(textBlock).toBeDefined();
-    expect(textBlock!.text).toContain(realToken);
-    expect(textBlock!.text).not.toContain(placeholder);
+    expect(historyTextBlock).toBeDefined();
+    expect(historyTextBlock!.text).toContain(placeholder);
+    expect(historyTextBlock!.text).not.toContain(realToken);
 
-    // The message_complete event should also have the resolved text
+    // The message_complete EVENT should contain the resolved real token
+    // (client-facing emissions carry the substituted values)
     const completeEvents = events.filter(
       (e): e is Extract<AgentEvent, { type: 'message_complete' }> => e.type === 'message_complete',
     );
-    // Find the final message_complete (the one after tools)
     const lastComplete = completeEvents[completeEvents.length - 1];
     const completeText = lastComplete.message.content.find(
       (b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text',
     );
     expect(completeText!.text).toContain(realToken);
+    expect(completeText!.text).not.toContain(placeholder);
 
     // The tool result content in provider history should contain the PLACEHOLDER,
     // NOT the raw token (model never sees the real value)

--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -1167,4 +1167,121 @@ describe('AgentLoop', () => {
     expect(sentBlock).toBeDefined();
     expect(sentBlock!.content).toBe(smallContent);
   });
+
+  // ---------------------------------------------------------------------------
+  // Sensitive output placeholder substitution tests
+  // ---------------------------------------------------------------------------
+
+  // 32. Tool results with sensitiveBindings populate substitution map and
+  //     final assistant message text is resolved with real values.
+  test('resolves sensitive output placeholders in final assistant message', async () => {
+    const placeholder = 'VELLUM_ASSISTANT_INVITE_CODE_TEST1234';
+    const realToken = 'realInviteToken999';
+
+    const { provider, calls } = createMockProvider([
+      toolUseResponse('t1', 'bash', { command: 'create invite' }),
+      // The LLM responds using the placeholder (it never saw the real token)
+      textResponse(`Here is your invite link: https://t.me/bot?start=iv_${placeholder}`),
+    ]);
+
+    const toolExecutor = async () => ({
+      content: `https://t.me/bot?start=iv_${placeholder}`,
+      isError: false,
+      sensitiveBindings: [{ kind: 'invite_code' as const, placeholder, value: realToken }],
+    });
+
+    const loop = new AgentLoop(provider, 'system', {}, dummyTools, toolExecutor);
+    const events: AgentEvent[] = [];
+    const history = await loop.run([userMessage], collectEvents(events));
+
+    // The final assistant message in history should contain the resolved real token
+    const lastAssistant = history[history.length - 1];
+    expect(lastAssistant.role).toBe('assistant');
+    const textBlock = lastAssistant.content.find(
+      (b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text',
+    );
+    expect(textBlock).toBeDefined();
+    expect(textBlock!.text).toContain(realToken);
+    expect(textBlock!.text).not.toContain(placeholder);
+
+    // The message_complete event should also have the resolved text
+    const completeEvents = events.filter(
+      (e): e is Extract<AgentEvent, { type: 'message_complete' }> => e.type === 'message_complete',
+    );
+    // Find the final message_complete (the one after tools)
+    const lastComplete = completeEvents[completeEvents.length - 1];
+    const completeText = lastComplete.message.content.find(
+      (b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text',
+    );
+    expect(completeText!.text).toContain(realToken);
+
+    // The tool result content in provider history should contain the PLACEHOLDER,
+    // NOT the raw token (model never sees the real value)
+    const secondCallMessages = calls[1].messages;
+    const toolResultMsg = secondCallMessages.find(
+      (m) => m.role === 'user' && m.content.some((b) => b.type === 'tool_result'),
+    );
+    expect(toolResultMsg).toBeDefined();
+    const toolResultBlock = toolResultMsg!.content.find(
+      (b): b is Extract<ContentBlock, { type: 'tool_result' }> => b.type === 'tool_result',
+    );
+    expect(toolResultBlock!.content).toContain(placeholder);
+    expect(toolResultBlock!.content).not.toContain(realToken);
+  });
+
+  // 33. Streamed text_delta events have placeholders resolved to real values
+  test('resolves sensitive output placeholders in streamed text_delta events', async () => {
+    const placeholder = 'VELLUM_ASSISTANT_INVITE_CODE_STRM5678';
+    const realToken = 'streamedRealToken';
+
+    const { provider } = createMockProvider([
+      toolUseResponse('t1', 'bash', { command: 'invite' }),
+      // Response text includes the placeholder
+      textResponse(`Link: https://t.me/bot?start=iv_${placeholder}`),
+    ]);
+
+    const toolExecutor = async () => ({
+      content: `https://t.me/bot?start=iv_${placeholder}`,
+      isError: false,
+      sensitiveBindings: [{ kind: 'invite_code' as const, placeholder, value: realToken }],
+    });
+
+    const loop = new AgentLoop(provider, 'system', {}, dummyTools, toolExecutor);
+    const events: AgentEvent[] = [];
+    await loop.run([userMessage], collectEvents(events));
+
+    // Collect all text_delta events from the final turn (after tool result)
+    const textDeltas = events.filter(
+      (e): e is Extract<AgentEvent, { type: 'text_delta' }> => e.type === 'text_delta',
+    );
+    const allStreamedText = textDeltas.map((e) => e.text).join('');
+
+    // Streamed text should contain the real token, not the placeholder
+    expect(allStreamedText).toContain(realToken);
+    expect(allStreamedText).not.toContain(placeholder);
+  });
+
+  // 34. Without sensitive bindings, text passes through unchanged
+  test('text passes through unchanged when no sensitive bindings exist', async () => {
+    const { provider } = createMockProvider([
+      toolUseResponse('t1', 'read_file', { path: '/test.txt' }),
+      textResponse('Normal response with no placeholders.'),
+    ]);
+
+    const toolExecutor = async () => ({
+      content: 'file contents',
+      isError: false,
+      // No sensitiveBindings
+    });
+
+    const loop = new AgentLoop(provider, 'system', {}, dummyTools, toolExecutor);
+    const events: AgentEvent[] = [];
+    const history = await loop.run([userMessage], collectEvents(events));
+
+    const lastAssistant = history[history.length - 1];
+    const textBlock = lastAssistant.content.find(
+      (b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text',
+    );
+    expect(textBlock!.text).toBe('Normal response with no placeholders.');
+  });
 });

--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -1205,8 +1205,8 @@ describe('AgentLoop', () => {
     expect(historyTextBlock!.text).toContain(placeholder);
     expect(historyTextBlock!.text).not.toContain(realToken);
 
-    // The message_complete EVENT should contain the resolved real token
-    // (client-facing emissions carry the substituted values)
+    // The message_complete EVENT should also retain placeholders (persisted
+    // to conversation store; real values leak on session reload otherwise)
     const completeEvents = events.filter(
       (e): e is Extract<AgentEvent, { type: 'message_complete' }> => e.type === 'message_complete',
     );
@@ -1214,8 +1214,8 @@ describe('AgentLoop', () => {
     const completeText = lastComplete.message.content.find(
       (b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text',
     );
-    expect(completeText!.text).toContain(realToken);
-    expect(completeText!.text).not.toContain(placeholder);
+    expect(completeText!.text).toContain(placeholder);
+    expect(completeText!.text).not.toContain(realToken);
 
     // The tool result content in provider history should contain the PLACEHOLDER,
     // NOT the raw token (model never sees the real value)

--- a/assistant/src/__tests__/secret-scanner-executor.test.ts
+++ b/assistant/src/__tests__/secret-scanner-executor.test.ts
@@ -346,4 +346,63 @@ describe('Secret scanner executor integration', () => {
     expect(types).toContain('AWS Access Key');
     expect(types).toContain('GitHub Token');
   });
+
+  // -----------------------------------------------------------------------
+  // sensitive output directive extraction runs before secret detection
+  // -----------------------------------------------------------------------
+  test('sensitive output directives are stripped and replaced with placeholders before secret scanning', async () => {
+    mockConfig.secretDetection.action = 'redact';
+    const rawToken = 'xK9mP2vL4nR7wQ3j';
+    fakeToolResult = {
+      content: `<vellum-sensitive-output kind="invite_code" value="${rawToken}" />\nhttps://t.me/bot?start=iv_${rawToken}`,
+      isError: false,
+    };
+
+    const lifecycleEvents: ToolLifecycleEvent[] = [];
+    const ctx = makeContext({
+      onToolLifecycleEvent: (event) => {
+        lifecycleEvents.push(event);
+      },
+    });
+
+    const result = await executor.execute('bash', {}, ctx);
+
+    // The raw token should NOT appear in the result content
+    expect(result.content).not.toContain(rawToken);
+    // The directive tag should be fully stripped
+    expect(result.content).not.toContain('<vellum-sensitive-output');
+    // A placeholder should be present instead
+    expect(result.content).toMatch(/VELLUM_ASSISTANT_INVITE_CODE_[A-Z0-9]{8}/);
+    // Sensitive bindings should be attached for downstream substitution
+    expect(result.sensitiveBindings).toBeDefined();
+    expect(result.sensitiveBindings).toHaveLength(1);
+    expect(result.sensitiveBindings![0].value).toBe(rawToken);
+    expect(result.sensitiveBindings![0].kind).toBe('invite_code');
+  });
+
+  test('sensitive output bindings are NOT present in lifecycle event result', async () => {
+    mockConfig.secretDetection.action = 'warn';
+    const rawToken = 'testToken999';
+    fakeToolResult = {
+      content: `<vellum-sensitive-output kind="invite_code" value="${rawToken}" />\nhttps://t.me/bot?start=iv_${rawToken}`,
+      isError: false,
+    };
+
+    const lifecycleEvents: ToolLifecycleEvent[] = [];
+    const ctx = makeContext({
+      onToolLifecycleEvent: (event) => {
+        lifecycleEvents.push(event);
+      },
+    });
+
+    await executor.execute('bash', {}, ctx);
+
+    // Find the 'executed' lifecycle event
+    const executedEvents = lifecycleEvents.filter(
+      (e): e is Extract<ToolLifecycleEvent, { type: 'executed' }> => e.type === 'executed',
+    );
+    expect(executedEvents).toHaveLength(1);
+    // The emitted result must NOT contain sensitiveBindings
+    expect((executedEvents[0].result as unknown as Record<string, unknown>).sensitiveBindings).toBeUndefined();
+  });
 });

--- a/assistant/src/__tests__/sensitive-output-placeholders.test.ts
+++ b/assistant/src/__tests__/sensitive-output-placeholders.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  applyStreamingSubstitution,
+  applySubstitutions,
+  extractAndSanitize,
+} from '../tools/sensitive-output-placeholders.js';
+
+describe('extractAndSanitize', () => {
+  test('parses a valid invite_code directive and replaces raw value with placeholder', () => {
+    const rawToken = 'abc123def456';
+    const content = `<vellum-sensitive-output kind="invite_code" value="${rawToken}" />\nhttps://t.me/bot?start=iv_${rawToken}`;
+
+    const { sanitizedContent, bindings } = extractAndSanitize(content);
+
+    expect(bindings).toHaveLength(1);
+    expect(bindings[0].kind).toBe('invite_code');
+    expect(bindings[0].value).toBe(rawToken);
+    expect(bindings[0].placeholder).toMatch(/^VELLUM_ASSISTANT_INVITE_CODE_[A-Z0-9]{8}$/);
+
+    // Directive tag should be stripped
+    expect(sanitizedContent).not.toContain('<vellum-sensitive-output');
+    // Raw token should be replaced with placeholder
+    expect(sanitizedContent).not.toContain(rawToken);
+    expect(sanitizedContent).toContain(bindings[0].placeholder);
+    // The link structure should be preserved
+    expect(sanitizedContent).toContain(`https://t.me/bot?start=iv_${bindings[0].placeholder}`);
+  });
+
+  test('ignores malformed directives safely', () => {
+    const content = 'Some text <vellum-sensitive-output broken />';
+    const { sanitizedContent, bindings } = extractAndSanitize(content);
+
+    expect(bindings).toHaveLength(0);
+    expect(sanitizedContent).toBe(content);
+  });
+
+  test('ignores unknown kind values', () => {
+    const content = '<vellum-sensitive-output kind="unknown_kind" value="secret123" />';
+    const { sanitizedContent, bindings } = extractAndSanitize(content);
+
+    expect(bindings).toHaveLength(0);
+    expect(sanitizedContent).toBe(content);
+  });
+
+  test('drops empty values', () => {
+    const content = '<vellum-sensitive-output kind="invite_code" value="" />';
+    const { sanitizedContent, bindings } = extractAndSanitize(content);
+
+    expect(bindings).toHaveLength(0);
+    // Directive should remain since no valid binding was extracted
+    expect(sanitizedContent).toBe(content);
+  });
+
+  test('deduplicates identical values into a single binding', () => {
+    const rawToken = 'token123';
+    const content = [
+      `<vellum-sensitive-output kind="invite_code" value="${rawToken}" />`,
+      `<vellum-sensitive-output kind="invite_code" value="${rawToken}" />`,
+      `Link1: https://t.me/bot?start=iv_${rawToken}`,
+      `Link2: https://t.me/bot?start=iv_${rawToken}`,
+    ].join('\n');
+
+    const { sanitizedContent, bindings } = extractAndSanitize(content);
+
+    expect(bindings).toHaveLength(1);
+    expect(bindings[0].value).toBe(rawToken);
+
+    // Both occurrences of the raw token should be replaced with the same placeholder
+    const placeholderCount = sanitizedContent.split(bindings[0].placeholder).length - 1;
+    expect(placeholderCount).toBe(2);
+    expect(sanitizedContent).not.toContain(rawToken);
+  });
+
+  test('supports multiple distinct bindings', () => {
+    const token1 = 'firstToken123';
+    const token2 = 'secondToken456';
+    const content = [
+      `<vellum-sensitive-output kind="invite_code" value="${token1}" />`,
+      `<vellum-sensitive-output kind="invite_code" value="${token2}" />`,
+      `Link1: https://t.me/bot?start=iv_${token1}`,
+      `Link2: https://t.me/bot?start=iv_${token2}`,
+    ].join('\n');
+
+    const { sanitizedContent, bindings } = extractAndSanitize(content);
+
+    expect(bindings).toHaveLength(2);
+    expect(bindings[0].value).toBe(token1);
+    expect(bindings[1].value).toBe(token2);
+
+    // Both raw tokens should be replaced
+    expect(sanitizedContent).not.toContain(token1);
+    expect(sanitizedContent).not.toContain(token2);
+    expect(sanitizedContent).toContain(bindings[0].placeholder);
+    expect(sanitizedContent).toContain(bindings[1].placeholder);
+  });
+
+  test('returns content unchanged when no directives are present', () => {
+    const content = 'Just a normal tool output with no directives.';
+    const { sanitizedContent, bindings } = extractAndSanitize(content);
+
+    expect(bindings).toHaveLength(0);
+    expect(sanitizedContent).toBe(content);
+  });
+
+  test('placeholder format matches required pattern', () => {
+    const content = '<vellum-sensitive-output kind="invite_code" value="tok123" />';
+    const { bindings } = extractAndSanitize(content);
+
+    expect(bindings).toHaveLength(1);
+    // Must be exactly: VELLUM_ASSISTANT_INVITE_CODE_ followed by 8 uppercase alphanumeric chars
+    expect(bindings[0].placeholder).toMatch(/^VELLUM_ASSISTANT_INVITE_CODE_[A-Z0-9]{8}$/);
+  });
+});
+
+describe('applySubstitutions', () => {
+  test('replaces placeholders with real values', () => {
+    const map = new Map([
+      ['VELLUM_ASSISTANT_INVITE_CODE_ABCD1234', 'realtoken123'],
+    ]);
+
+    const text = 'Your link: https://t.me/bot?start=iv_VELLUM_ASSISTANT_INVITE_CODE_ABCD1234';
+    const result = applySubstitutions(text, map);
+
+    expect(result).toBe('Your link: https://t.me/bot?start=iv_realtoken123');
+  });
+
+  test('replaces multiple placeholders', () => {
+    const map = new Map([
+      ['VELLUM_ASSISTANT_INVITE_CODE_AAAA1111', 'token1'],
+      ['VELLUM_ASSISTANT_INVITE_CODE_BBBB2222', 'token2'],
+    ]);
+
+    const text = 'Link1: VELLUM_ASSISTANT_INVITE_CODE_AAAA1111, Link2: VELLUM_ASSISTANT_INVITE_CODE_BBBB2222';
+    const result = applySubstitutions(text, map);
+
+    expect(result).toBe('Link1: token1, Link2: token2');
+  });
+
+  test('returns text unchanged when map is empty', () => {
+    const map = new Map<string, string>();
+    const text = 'No placeholders here.';
+    expect(applySubstitutions(text, map)).toBe(text);
+  });
+});
+
+describe('applyStreamingSubstitution', () => {
+  test('resolves complete placeholders in a single chunk', () => {
+    const map = new Map([
+      ['VELLUM_ASSISTANT_INVITE_CODE_ABCD1234', 'realtoken'],
+    ]);
+
+    const { emit, pending } = applyStreamingSubstitution(
+      'Your code: VELLUM_ASSISTANT_INVITE_CODE_ABCD1234 is ready.',
+      map,
+    );
+
+    expect(emit).toContain('realtoken');
+    expect(emit).not.toContain('VELLUM_ASSISTANT_INVITE_CODE_ABCD1234');
+    // No pending text since the placeholder was complete
+    expect(pending).toBe('');
+  });
+
+  test('buffers text that could be an incomplete placeholder prefix', () => {
+    const map = new Map([
+      ['VELLUM_ASSISTANT_INVITE_CODE_ABCD1234', 'realtoken'],
+    ]);
+
+    // Chunk ends mid-placeholder
+    const { emit, pending } = applyStreamingSubstitution(
+      'Your code: VELLUM_ASSISTANT_',
+      map,
+    );
+
+    // The ambiguous tail should be buffered
+    expect(pending.length).toBeGreaterThan(0);
+    // emit should not contain the partial placeholder
+    expect(emit).not.toContain('VELLUM_ASSISTANT_');
+  });
+
+  test('handles split-chunk placeholder by concatenating pending with next chunk', () => {
+    const map = new Map([
+      ['VELLUM_ASSISTANT_INVITE_CODE_ABCD1234', 'realtoken'],
+    ]);
+
+    // First chunk: partial placeholder
+    const result1 = applyStreamingSubstitution(
+      'Link: VELLUM_ASSISTANT_',
+      map,
+    );
+
+    // Second chunk completes the placeholder
+    const combined = result1.pending + 'INVITE_CODE_ABCD1234 done.';
+    const result2 = applyStreamingSubstitution(combined, map);
+
+    expect(result2.emit).toContain('realtoken');
+    expect(result2.emit).toContain('done.');
+    expect(result2.pending).toBe('');
+  });
+
+  test('returns text unchanged when map is empty', () => {
+    const map = new Map<string, string>();
+    const { emit, pending } = applyStreamingSubstitution('Hello world', map);
+
+    expect(emit).toBe('Hello world');
+    expect(pending).toBe('');
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -265,21 +265,25 @@ export class AgentLoop {
           streamingPending = '';
         }
 
-        // Apply sensitive-output placeholder substitution to final message text
-        const finalContent = substitutionMap.size > 0
+        // Build the assistant message for provider history (placeholder-only,
+        // so the model never sees real sensitive values on subsequent turns).
+        const assistantMessage: Message = {
+          role: 'assistant',
+          content: response.content,
+        };
+        history.push(assistantMessage);
+
+        // Apply sensitive-output placeholder substitution for the client-facing
+        // message_complete event. The history retains placeholders; the emitted
+        // event carries the resolved real values.
+        const clientContent = substitutionMap.size > 0
           ? response.content.map((block) =>
               block.type === 'text'
                 ? { ...block, text: applySubstitutions(block.text, substitutionMap) }
                 : block)
           : response.content;
 
-        const assistantMessage: Message = {
-          role: 'assistant',
-          content: finalContent,
-        };
-        history.push(assistantMessage);
-
-        await onEvent({ type: 'message_complete', message: assistantMessage });
+        await onEvent({ type: 'message_complete', message: { role: 'assistant', content: clientContent } });
 
         // Check for tool use
         toolUseBlocks = response.content.filter(

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -4,6 +4,8 @@ import { truncateOversizedToolResults } from '../context/tool-result-truncation.
 import { getHookManager } from '../hooks/manager.js';
 import type { ContentBlock,Message, Provider, ToolDefinition } from '../providers/types.js';
 import type { ToolResultContent } from '../providers/types.js';
+import { applyStreamingSubstitution, applySubstitutions } from '../tools/sensitive-output-placeholders.js';
+import type { SensitiveOutputBinding } from '../tools/sensitive-output-placeholders.js';
 import { getLogger, isDebug, truncateForLog } from '../util/logger.js';
 
 const log = getLogger('agent-loop');
@@ -63,14 +65,14 @@ export class AgentLoop {
   private tools: ToolDefinition[];
   private resolveTools: ((history: Message[]) => ToolDefinition[]) | null;
   private resolveSystemPrompt: ((history: Message[]) => ResolvedSystemPrompt) | null;
-  private toolExecutor: ((name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean }; status?: string; contentBlocks?: ContentBlock[] }>) | null;
+  private toolExecutor: ((name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean }; status?: string; contentBlocks?: ContentBlock[]; sensitiveBindings?: SensitiveOutputBinding[] }>) | null;
 
   constructor(
     provider: Provider,
     systemPrompt: string,
     config?: Partial<AgentLoopConfig>,
     tools?: ToolDefinition[],
-    toolExecutor?: (name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean }; status?: string; contentBlocks?: ContentBlock[] }>,
+    toolExecutor?: (name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean }; status?: string; contentBlocks?: ContentBlock[]; sensitiveBindings?: SensitiveOutputBinding[] }>,
     resolveTools?: (history: Message[]) => ToolDefinition[],
     resolveSystemPrompt?: (history: Message[]) => ResolvedSystemPrompt,
   ) {
@@ -96,6 +98,12 @@ export class AgentLoop {
     let lastLlmCallTime = 0;
     const debug = isDebug();
     const rlog = requestId ? log.child({ requestId }) : log;
+
+    // Per-run substitution map for sensitive output placeholders.
+    // Bindings are accumulated from tool results; placeholders are
+    // resolved in streamed deltas and final assistant message text.
+    const substitutionMap = new Map<string, string>();
+    let streamingPending = '';
 
     while (true) {
       if (signal?.aborted) break;
@@ -188,7 +196,17 @@ export class AgentLoop {
             config: providerConfig,
             onEvent: (event) => {
               if (event.type === 'text_delta') {
-                onEvent({ type: 'text_delta', text: event.text });
+                // Apply sensitive-output placeholder substitution (chunk-safe)
+                if (substitutionMap.size > 0) {
+                  const combined = streamingPending + event.text;
+                  const { emit, pending } = applyStreamingSubstitution(combined, substitutionMap);
+                  streamingPending = pending;
+                  if (emit.length > 0) {
+                    onEvent({ type: 'text_delta', text: emit });
+                  }
+                } else {
+                  onEvent({ type: 'text_delta', text: event.text });
+                }
               } else if (event.type === 'thinking_delta') {
                 onEvent({ type: 'thinking_delta', thinking: event.thinking });
               } else if (event.type === 'input_json_delta') {
@@ -238,9 +256,26 @@ export class AgentLoop {
           durationMs: providerDurationMs,
         });
 
+        // Flush any buffered streaming text from the substitution pipeline
+        if (streamingPending.length > 0) {
+          const flushed = applySubstitutions(streamingPending, substitutionMap);
+          if (flushed.length > 0) {
+            onEvent({ type: 'text_delta', text: flushed });
+          }
+          streamingPending = '';
+        }
+
+        // Apply sensitive-output placeholder substitution to final message text
+        const finalContent = substitutionMap.size > 0
+          ? response.content.map((block) =>
+              block.type === 'text'
+                ? { ...block, text: applySubstitutions(block.text, substitutionMap) }
+                : block)
+          : response.content;
+
         const assistantMessage: Message = {
           role: 'assistant',
-          content: response.content,
+          content: finalContent,
         };
         history.push(assistantMessage);
 
@@ -389,6 +424,17 @@ export class AgentLoop {
           }
         } else {
           toolResults = await toolExecutionPromise;
+        }
+
+        // Merge sensitive output bindings from tool results into the
+        // per-run substitution map. Bindings carry placeholder->value pairs
+        // that are resolved in streamed text deltas and final message text.
+        for (const { result } of toolResults) {
+          if (result.sensitiveBindings) {
+            for (const binding of result.sensitiveBindings) {
+              substitutionMap.set(binding.placeholder, binding.value);
+            }
+          }
         }
 
         // Collect result blocks preserving tool_use order (Promise.all maintains order)

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -265,25 +265,18 @@ export class AgentLoop {
           streamingPending = '';
         }
 
-        // Build the assistant message for provider history (placeholder-only,
-        // so the model never sees real sensitive values on subsequent turns).
+        // Build the assistant message with placeholder-only text.
+        // Both provider history and persisted conversation store must retain
+        // placeholders so the model never sees real sensitive values — neither
+        // on subsequent loop turns nor on session reload from the database.
+        // Substitution to real values happens only in streamed text_delta events.
         const assistantMessage: Message = {
           role: 'assistant',
           content: response.content,
         };
         history.push(assistantMessage);
 
-        // Apply sensitive-output placeholder substitution for the client-facing
-        // message_complete event. The history retains placeholders; the emitted
-        // event carries the resolved real values.
-        const clientContent = substitutionMap.size > 0
-          ? response.content.map((block) =>
-              block.type === 'text'
-                ? { ...block, text: applySubstitutions(block.text, substitutionMap) }
-                : block)
-          : response.content;
-
-        await onEvent({ type: 'message_complete', message: { role: 'assistant', content: clientContent } });
+        await onEvent({ type: 'message_complete', message: assistantMessage });
 
         // Check for tool use
         toolUseBlocks = response.content.filter(

--- a/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
+++ b/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
@@ -123,7 +123,7 @@ curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/ingress/members/<member_id>/block
 
 Use this when the guardian wants to invite someone to message the assistant on Telegram without needing their user ID upfront. The invite link is a shareable Telegram deep link — when someone opens it, they automatically get trusted-contact access.
 
-**Important**: Do **not** print the raw create-invite JSON response to chat. It includes a high-entropy `token` field that can be redacted in tool output. Instead, extract values in-shell and only print the final deep link.
+**Important**: The shell snippet below emits a `<vellum-sensitive-output>` directive containing the raw invite token. The tool executor automatically strips this directive and replaces the raw token with a placeholder so the LLM never sees it. The placeholder is resolved back to the real token in the final assistant reply.
 
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
@@ -150,6 +150,7 @@ if [ -z "$INVITE_TOKEN" ]; then
   exit 1
 fi
 
+echo "<vellum-sensitive-output kind=\"invite_code\" value=\"$INVITE_TOKEN\" />"
 echo "https://t.me/$BOT_USERNAME?start=iv_$INVITE_TOKEN"
 ```
 

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -13,6 +13,7 @@ import { resolveExecutionTarget } from './execution-target.js';
 import { executeWithTimeout,safeTimeoutMs } from './execution-timeout.js';
 import { PermissionChecker } from './permission-checker.js';
 import { SecretDetectionHandler } from './secret-detection-handler.js';
+import { extractAndSanitize } from './sensitive-output-placeholders.js';
 import { applyEdit } from './shared/filesystem/edit-engine.js';
 import { sandboxPolicy } from './shared/filesystem/path-policy.js';
 import { MAX_FILE_SIZE_BYTES } from './shared/filesystem/size-guard.js';
@@ -182,6 +183,15 @@ export class ToolExecutor {
         );
       }
 
+      // Sensitive output extraction: strip directives, replace raw values
+      // with placeholders, and attach bindings for agent-loop substitution.
+      // Runs before secret detection so that raw sensitive values are already
+      // replaced and won't trigger entropy-based redaction.
+      const { sanitizedContent, bindings } = extractAndSanitize(execResult.content);
+      if (bindings.length > 0) {
+        execResult = { ...execResult, content: sanitizedContent, sensitiveBindings: bindings };
+      }
+
       // Secret detection on tool output
       const secretResult = await this.secretDetectionHandler.handle(
         execResult, name, input, context, executionTarget,
@@ -193,6 +203,8 @@ export class ToolExecutor {
       execResult = secretResult.result;
 
       const durationMs = Date.now() - startTime;
+      // Strip sensitiveBindings from lifecycle event to prevent raw values leaking
+      const { sensitiveBindings: _sb, ...safeResult } = execResult;
       emitLifecycleEvent(context, {
         type: 'executed',
         toolName: name,
@@ -205,7 +217,7 @@ export class ToolExecutor {
         riskLevel,
         decision,
         durationMs,
-        result: execResult,
+        result: safeResult,
       });
 
       void getHookManager().trigger('post-tool-execute', {

--- a/assistant/src/tools/sensitive-output-placeholders.ts
+++ b/assistant/src/tools/sensitive-output-placeholders.ts
@@ -1,0 +1,203 @@
+/**
+ * Sensitive output placeholder extraction and substitution.
+ *
+ * Tool outputs may contain `<vellum-sensitive-output kind="..." value="..." />`
+ * directives. This module:
+ * 1. Parses and strips those directives from tool output.
+ * 2. Replaces any raw sensitive values remaining in the output with stable,
+ *    high-uniqueness placeholders so the LLM never sees the real values.
+ * 3. Returns bindings (placeholder -> real value) for deterministic
+ *    post-generation substitution in the agent loop.
+ *
+ * Raw sensitive values MUST NOT be logged or emitted in lifecycle events.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SensitiveOutputKind = 'invite_code';
+
+export interface SensitiveOutputBinding {
+  kind: SensitiveOutputKind;
+  placeholder: string;
+  value: string;
+}
+
+// ---------------------------------------------------------------------------
+// Directive regex
+// ---------------------------------------------------------------------------
+
+const DIRECTIVE_RE =
+  /<vellum-sensitive-output\s+kind="([^"]+)"\s+value="([^"]+)"\s*\/>/g;
+
+// ---------------------------------------------------------------------------
+// Placeholder generation
+// ---------------------------------------------------------------------------
+
+const KIND_PREFIX: Record<SensitiveOutputKind, string> = {
+  invite_code: 'VELLUM_ASSISTANT_INVITE_CODE_',
+};
+
+const VALID_KINDS = new Set<string>(Object.keys(KIND_PREFIX));
+
+/**
+ * Generate an 8-char uppercase base-36 short ID.
+ * Provides ~41 bits of entropy — sufficient for intra-request uniqueness.
+ */
+function generateShortId(): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let id = '';
+  for (let i = 0; i < 8; i++) {
+    id += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return id;
+}
+
+function makePlaceholder(kind: SensitiveOutputKind): string {
+  return `${KIND_PREFIX[kind]}${generateShortId()}`;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface SanitizeResult {
+  sanitizedContent: string;
+  bindings: SensitiveOutputBinding[];
+}
+
+/**
+ * Extract `<vellum-sensitive-output>` directives from tool output content,
+ * strip them, replace any remaining occurrences of the raw sensitive values
+ * with placeholders, and return the bindings for downstream substitution.
+ *
+ * Guarantees:
+ * - Directives are fully removed from the returned content.
+ * - Empty values are silently dropped.
+ * - Duplicate values produce a single binding (same placeholder).
+ * - Unknown kinds are silently ignored.
+ */
+export function extractAndSanitize(content: string): SanitizeResult {
+  const bindings: SensitiveOutputBinding[] = [];
+  const seenValues = new Map<string, SensitiveOutputBinding>();
+
+  // Step 1: parse directives
+  let match: RegExpExecArray | null;
+  // Reset lastIndex for safety since the regex is global
+  DIRECTIVE_RE.lastIndex = 0;
+  while ((match = DIRECTIVE_RE.exec(content)) !== null) {
+    const kind = match[1];
+    const value = match[2];
+
+    if (!value || value.trim().length === 0) continue;
+    if (!VALID_KINDS.has(kind)) continue;
+
+    const typedKind = kind as SensitiveOutputKind;
+    if (!seenValues.has(value)) {
+      const binding: SensitiveOutputBinding = {
+        kind: typedKind,
+        placeholder: makePlaceholder(typedKind),
+        value,
+      };
+      bindings.push(binding);
+      seenValues.set(value, binding);
+    }
+  }
+
+  if (bindings.length === 0) {
+    return { sanitizedContent: content, bindings: [] };
+  }
+
+  // Step 2: strip directive tags
+  let sanitized = content.replace(DIRECTIVE_RE, '');
+
+  // Step 3: replace raw values with placeholders throughout remaining content
+  for (const binding of bindings) {
+    sanitized = sanitized.split(binding.value).join(binding.placeholder);
+  }
+
+  return { sanitizedContent: sanitized, bindings };
+}
+
+/**
+ * Apply placeholder->value substitution to a text string.
+ * Used by the agent loop to resolve placeholders in streamed deltas
+ * and final message content.
+ */
+export function applySubstitutions(
+  text: string,
+  substitutionMap: ReadonlyMap<string, string>,
+): string {
+  if (substitutionMap.size === 0) return text;
+
+  let result = text;
+  for (const [placeholder, value] of substitutionMap) {
+    result = result.split(placeholder).join(value);
+  }
+  return result;
+}
+
+/**
+ * Chunk-safe substitution for streaming text deltas.
+ *
+ * Because a placeholder like `VELLUM_ASSISTANT_INVITE_CODE_AB12CD34` may be
+ * split across consecutive streamed chunks, this function buffers a trailing
+ * segment that could be the start of an incomplete placeholder and returns it
+ * as `pending`. The caller must prepend `pending` to the next chunk.
+ *
+ * Returns `{ emit, pending }`:
+ * - `emit`: text safe to send to the client (all complete placeholders resolved).
+ * - `pending`: trailing text that might be an incomplete placeholder prefix.
+ */
+export function applyStreamingSubstitution(
+  text: string,
+  substitutionMap: ReadonlyMap<string, string>,
+): { emit: string; pending: string } {
+  if (substitutionMap.size === 0) {
+    return { emit: text, pending: '' };
+  }
+
+  // First, resolve any complete placeholders
+  let resolved = text;
+  for (const [placeholder, value] of substitutionMap) {
+    resolved = resolved.split(placeholder).join(value);
+  }
+
+  // Check if the tail of resolved text could be an incomplete placeholder prefix.
+  // All current placeholders start with "VELLUM_ASSISTANT_".
+  const PREFIX = 'VELLUM_ASSISTANT_';
+  const minSuffixLen = 1; // At minimum, one char of the prefix
+
+  // Walk backwards from the end to find a trailing partial match of any placeholder prefix
+  let pendingStart = resolved.length;
+  for (let i = Math.max(0, resolved.length - getMaxPlaceholderLength(substitutionMap)); i < resolved.length; i++) {
+    const tail = resolved.slice(i);
+    // Check if any placeholder starts with this tail
+    if (tail.length >= minSuffixLen && PREFIX.startsWith(tail)) {
+      pendingStart = i;
+      break;
+    }
+    // Also check if any full placeholder key starts with this tail
+    for (const placeholder of substitutionMap.keys()) {
+      if (placeholder.startsWith(tail) && tail.length < placeholder.length) {
+        pendingStart = i;
+        break;
+      }
+    }
+    if (pendingStart !== resolved.length) break;
+  }
+
+  return {
+    emit: resolved.slice(0, pendingStart),
+    pending: resolved.slice(pendingStart),
+  };
+}
+
+function getMaxPlaceholderLength(map: ReadonlyMap<string, string>): number {
+  let max = 0;
+  for (const key of map.keys()) {
+    if (key.length > max) max = key.length;
+  }
+  return max;
+}

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -1,6 +1,7 @@
 import type { SecretPromptResult } from '../permissions/secret-prompter.js';
 import type { AllowlistOption, RiskLevel, ScopeOption } from '../permissions/types.js';
 import type { ContentBlock,ToolDefinition } from '../providers/types.js';
+import type { SensitiveOutputBinding } from './sensitive-output-placeholders.js';
 
 export type ExecutionTarget = 'sandbox' | 'host';
 
@@ -163,6 +164,14 @@ export interface ToolExecutionResult {
   status?: string;
   /** Optional rich content blocks (e.g. images) to include alongside text in the tool result. */
   contentBlocks?: ContentBlock[];
+  /**
+   * Runtime-internal sensitive output bindings (placeholder -> real value).
+   * Populated by the executor when tool output contains
+   * `<vellum-sensitive-output>` directives. The agent loop merges these
+   * into a per-run substitution map for deterministic post-generation
+   * replacement. MUST NOT be emitted in client-facing events or logs.
+   */
+  sensitiveBindings?: SensitiveOutputBinding[];
 }
 
 export interface Tool {


### PR DESCRIPTION
## Summary
- Implement a sensitive output placeholder substitution pipeline that prevents raw invite tokens from reaching the LLM while ensuring they appear in the final user-facing reply
- Add `<vellum-sensitive-output>` directive parsing in tool executor, per-run substitution map in agent loop, and chunk-safe streaming replacement
- Update trusted-contacts skill to emit the directive tag, eliminating brittle secret-scanner workarounds

## Original prompt
/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/.private/plans/invite-token-placeholder-substitution-one-pr-plan-2026-02-27.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
