### PR TITLE
feat: re-stylize VToggle with pill track, circular knob, and updated colors

### DIFF
--- a/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
@@ -11,9 +11,9 @@ public struct VToggle: View {
 
     // MARK: - Layout Constants
 
-    private let trackWidth: CGFloat = 40
-    private let trackHeight: CGFloat = 22
-    private let knobSize: CGFloat = 16
+    private let trackWidth: CGFloat = 50
+    private let trackHeight: CGFloat = 28
+    private let knobSize: CGFloat = 22
     private let knobPadding: CGFloat = 3
 
     public var body: some View {
@@ -43,18 +43,15 @@ public struct VToggle: View {
     private var toggleTrack: some View {
         ZStack(alignment: isOn ? .trailing : .leading) {
             // Track background
-            RoundedRectangle(cornerRadius: VRadius.sm + 2)
+            RoundedRectangle(cornerRadius: trackHeight / 2)
                 .fill(isOn ? Forest._600 : VColor.toggleOff)
                 .frame(width: trackWidth, height: trackHeight)
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.sm + 2)
-                        .stroke(VColor.toggleBorder, lineWidth: 1)
-                )
 
             // Knob
-            RoundedRectangle(cornerRadius: VRadius.sm)
+            RoundedRectangle(cornerRadius: knobSize / 2)
                 .fill(Color.white)
                 .frame(width: knobSize, height: knobSize)
+                .shadow(color: Color.black.opacity(0.15), radius: 3, x: 0, y: 1)
                 .padding(.horizontal, knobPadding)
         }
     }

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -178,7 +178,7 @@ public enum VColor {
     public static let ghostPressed = adaptiveColor(light: Stone._200, dark: Moss._600)
     public static let divider = adaptiveColor(light: Stone._200, dark: Moss._700)
     public static let hoverOverlay = adaptiveColor(light: Color(hex: 0x000000), dark: Moss._200)
-    public static let toggleOff = adaptiveColor(light: Stone._300, dark: Moss._700)
+    public static let toggleOff = adaptiveColor(light: Stone._200, dark: Moss._600)
     public static let toggleBorder = adaptiveColor(light: Stone._400, dark: Moss._600)
 
     // Slash command highlight — green tint for /command tokens in composer and chat


### PR DESCRIPTION
Updates VToggle design system component to match new design:

- Larger pill-shaped track (50x28, was 40x22)
- Circular knob with drop shadow (22px, was 16px rounded rect)
- Full pill corner radius for track
- Updated off-state color (Stone._200 / Moss._600, warmer and lighter)
- Removed border overlay for cleaner look
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
