### PR TITLE
Fix voice approval misses when guardian approves from desktop

### DIFF
--- a/assistant/src/__tests__/guardian-decision-primitive-canonical.test.ts
+++ b/assistant/src/__tests__/guardian-decision-primitive-canonical.test.ts
@@ -34,6 +34,7 @@ import {
   createCanonicalGuardianRequest,
   getCanonicalGuardianRequest,
 } from '../memory/canonical-guardian-store.js';
+import { scopedApprovalGrants } from '../memory/schema.js';
 import {
   applyCanonicalGuardianDecision,
   mintCanonicalRequestGrant,
@@ -481,6 +482,37 @@ describe('applyCanonicalGuardianDecision', () => {
     const resolved = getCanonicalGuardianRequest(req.id);
     expect(resolved!.status).toBe('approved');
   });
+
+  test('trusted desktop actor still mints scoped grant for approved canonical request', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'unknown_kind',
+      sourceType: 'voice',
+      sourceChannel: 'voice',
+      conversationId: 'conv-voice-1',
+      callSessionId: 'call-voice-1',
+      toolName: 'host_bash',
+      inputDigest: 'sha256:voice-digest-1',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: trustedActor(),
+    });
+
+    expect(result.applied).toBe(true);
+    if (!result.applied) return;
+    expect(result.grantMinted).toBe(true);
+
+    const db = getDb();
+    const grants = db.select().from(scopedApprovalGrants).all();
+    expect(grants.length).toBe(1);
+    expect(grants[0].toolName).toBe('host_bash');
+    expect(grants[0].conversationId).toBe('conv-voice-1');
+    expect(grants[0].callSessionId).toBe('call-voice-1');
+    expect(grants[0].guardianExternalUserId).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -507,6 +539,29 @@ describe('mintCanonicalRequestGrant', () => {
     });
 
     expect(result.minted).toBe(true);
+  });
+
+  test('mints grant when guardianExternalUserId is omitted', () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      conversationId: 'conv-2',
+      toolName: 'shell',
+      inputDigest: 'sha256:xyz',
+    });
+
+    const result = mintCanonicalRequestGrant({
+      request: req,
+      actorChannel: 'vellum',
+    });
+
+    expect(result.minted).toBe(true);
+
+    const db = getDb();
+    const grants = db.select().from(scopedApprovalGrants).all();
+    expect(grants.length).toBe(1);
+    expect(grants[0].guardianExternalUserId).toBeNull();
   });
 
   test('skips grant for request without tool metadata', () => {

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -224,7 +224,7 @@ export function applyGuardianDecision(params: ApplyGuardianDecisionParams): Appl
 export function mintCanonicalRequestGrant(params: {
   request: CanonicalGuardianRequest;
   actorChannel: string;
-  guardianExternalUserId: string;
+  guardianExternalUserId?: string;
 }): { minted: boolean } {
   const { request, actorChannel, guardianExternalUserId } = params;
 
@@ -242,7 +242,7 @@ export function mintCanonicalRequestGrant(params: {
     executionChannel: null,
     conversationId: request.conversationId ?? null,
     callSessionId: request.callSessionId ?? null,
-    guardianExternalUserId,
+    guardianExternalUserId: guardianExternalUserId ?? null,
     requesterExternalUserId: request.requesterExternalUserId ?? null,
     expiresAt: new Date(Date.now() + GRANT_TTL_MS).toISOString(),
   });
@@ -443,11 +443,11 @@ export async function applyCanonicalGuardianDecision(
   // would allow the tool to execute without the intended resolver action
   // (e.g. answerCall) having succeeded.
   let grantMinted = false;
-  if (effectiveAction !== 'reject' && actorContext.externalUserId && !resolverFailed) {
+  if (effectiveAction !== 'reject' && !resolverFailed) {
     const grantResult = mintCanonicalRequestGrant({
       request: resolved,
       actorChannel: actorContext.channel,
-      guardianExternalUserId: actorContext.externalUserId,
+      guardianExternalUserId: actorContext.externalUserId ?? resolved.guardianExternalUserId ?? undefined,
     });
     grantMinted = grantResult.minted;
   }


### PR DESCRIPTION
## Summary
- fix canonical guardian decision grant minting so trusted desktop actors (no external user ID) still mint scoped grants
- allow canonical grant minting with nullable guardianExternalUserId for trusted contexts
- add regression tests covering trusted-desktop grant minting and nullable guardian identity minting

## Root Cause
Voice guardian decisions that come from the desktop UI run through applyCanonicalGuardianDecision() with:
- actorContext.isTrusted = true
- actorContext.externalUserId = undefined

The canonical flow only minted grants when actorContext.externalUserId was present. That meant the decision was recorded as approved, but no scoped grant was created. Subsequent voice tool execution retried grant consumption (approval_primitive_consume_miss) until timeout and denied execution.

## Fix
- remove the actorContext.externalUserId gate for canonical grant minting
- mint using actorContext.externalUserId ?? resolved.guardianExternalUserId ?? undefined
- support omitted guardian IDs in mintCanonicalRequestGrant() by writing guardianExternalUserId: null

## Validation
- cd assistant && bun test src/__tests__/guardian-decision-primitive-canonical.test.ts
- cd assistant && bunx tsc --noEmit

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10630" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
