### PR TITLE
feat: replace native Picker with VDropdown in Permissions Simulator

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -149,25 +149,11 @@ struct ToolPermissionTesterView: View {
                 .labelsHidden()
 
         case .enumeration(let values):
-            Picker("", selection: fieldValueBinding(for: field.id)) {
-                Text("Select\u{2026}")
-                    .foregroundColor(VColor.textMuted)
-                    .tag("")
-                ForEach(values, id: \.self) { value in
-                    Text(value)
-                        .font(VFont.mono)
-                        .tag(value)
-                }
-            }
-            .labelsHidden()
-            .font(VFont.mono)
-            .padding(.vertical, VSpacing.xs)
-            .padding(.horizontal, VSpacing.sm)
-            .background(VColor.inputBackground)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.sm)
-                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+            VDropdown(
+                placeholder: "Select\u{2026}",
+                selection: fieldValueBinding(for: field.id),
+                options: values.map { (label: $0, value: $0) },
+                emptyValue: ""
             )
 
         case .json:
@@ -329,25 +315,11 @@ struct ToolPermissionTesterView: View {
                 .vInputStyle()
                 .font(VFont.mono)
         } else {
-            Picker("", selection: $model.toolName) {
-                Text("Select a tool\u{2026}")
-                    .foregroundColor(VColor.textMuted)
-                    .tag("")
-                ForEach(model.availableToolNames, id: \.self) { name in
-                    Text(name)
-                        .font(VFont.mono)
-                        .tag(name)
-                }
-            }
-            .labelsHidden()
-            .font(VFont.mono)
-            .padding(.vertical, VSpacing.xs)
-            .padding(.horizontal, VSpacing.sm)
-            .background(VColor.inputBackground)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.sm)
-                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+            VDropdown(
+                placeholder: "Select a Tool\u{2026}",
+                selection: $model.toolName,
+                options: model.availableToolNames.map { (label: $0, value: $0) },
+                emptyValue: ""
             )
         }
     }


### PR DESCRIPTION
Replaces the two native SwiftUI Picker usages in ToolPermissionTesterView with the new VDropdown component from the design system. This gives both the tool-name selector and the enum-field selector the consistent full-width styled appearance matching the design reference.

Closes #10615
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
