### PR TITLE
feat: re-stylize VSlider with pill track and sage palette

### DIFF
--- a/clients/shared/DesignSystem/Core/Inputs/VSlider.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VSlider.swift
@@ -15,12 +15,12 @@ public struct VSlider: View {
 
     // MARK: - Layout Constants
 
-    private let trackHeight: CGFloat = 24
-    private let thumbWidth: CGFloat = 20
+    private let trackHeight: CGFloat = 28
+    private let thumbWidth: CGFloat = 28
     private let tickMarkWidth: CGFloat = 1
     private let gripLineCount: Int = 3
     private let gripLineWidth: CGFloat = 1
-    private let gripLineHeight: CGFloat = 12
+    private let gripLineHeight: CGFloat = 14
     private let gripLineSpacing: CGFloat = 2.5
 
     // MARK: - State
@@ -74,15 +74,15 @@ public struct VSlider: View {
         ZStack(alignment: .leading) {
             // Unfilled track (edge-to-edge)
             Rectangle()
-                .fill(VColor.ghostHover)
+                .fill(adaptiveColor(light: Moss._100, dark: Moss._700))
                 .frame(height: trackHeight)
 
             // Filled track (from left edge to thumb center)
             Rectangle()
-                .fill(VColor.accent)
+                .fill(adaptiveColor(light: Forest._300, dark: Forest._500))
                 .frame(width: thumbOffset + thumbWidth / 2, height: trackHeight)
         }
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
     }
 
     // MARK: - Thumb


### PR DESCRIPTION
Re-stylize VSlider to match new warm-toned design:

- Pill-shaped track (VRadius.pill corners)  
- Filled portion: muted sage green (Forest._300 light / Forest._500 dark)
- Unfilled portion: warm cream (Moss._100 light / Moss._700 dark)
- Square thumb (28×28, was 20×24)
- Larger grip lines (14px height, was 12px)

Closes #10624
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
