### PR TITLE
feat: replace SwiftUI Toggle with VToggle throughout macOS app

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/HeartbeatConfigView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/HeartbeatConfigView.swift
@@ -62,9 +62,7 @@ struct HeartbeatConfigView: View {
                                     .foregroundColor(VColor.textMuted)
                             }
                             Spacer()
-                            Toggle("", isOn: $enabled)
-                                .toggleStyle(.switch)
-                                .labelsHidden()
+                            VToggle(isOn: $enabled)
                                 .onChange(of: enabled) { _, newValue in
                                     guard !isApplyingFromServer else { return }
                                     saveConfig(enabled: newValue)
@@ -114,9 +112,7 @@ struct HeartbeatConfigView: View {
                                         .foregroundColor(VColor.textMuted)
                                 }
                                 Spacer()
-                                Toggle("", isOn: $activeHoursEnabled)
-                                    .toggleStyle(.switch)
-                                    .labelsHidden()
+                                VToggle(isOn: $activeHoursEnabled)
                                     .onChange(of: activeHoursEnabled) { _, newValue in
                                         guard !isApplyingFromServer else { return }
                                         if newValue {

--- a/clients/macos/vellum-assistant/Features/Settings/ScheduledTasksView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ScheduledTasksView.swift
@@ -219,12 +219,10 @@ private struct ScheduleRow: View {
                 .buttonStyle(.borderless)
                 .help("Run now")
 
-                Toggle("", isOn: Binding(
+                VToggle(isOn: Binding(
                     get: { schedule.enabled },
                     set: { onToggle($0) }
                 ))
-                .toggleStyle(.switch)
-                .labelsHidden()
 
                 Button {
                     onDelete()

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
@@ -106,7 +106,7 @@ struct SettingsAdvancedDevTab: View {
 
     private func assistantFlagRow(flag: DaemonClient.AssistantFeatureFlag) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.xxs) {
-            Toggle(flag.displayName, isOn: Binding(
+            VToggle(isOn: Binding(
                 get: {
                     assistantFlags.first(where: { $0.key == flag.key })?.enabled ?? flag.enabled
                 },
@@ -139,8 +139,7 @@ struct SettingsAdvancedDevTab: View {
                         }
                     }
                 }
-            ))
-            .toggleStyle(.switch)
+            ), label: flag.displayName)
             .font(VFont.body)
             .foregroundColor(VColor.textSecondary)
 
@@ -171,14 +170,13 @@ struct SettingsAdvancedDevTab: View {
             } else {
                 ForEach(Array(macOSFlagStates.enumerated()), id: \.element.id) { index, entry in
                     VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                        Toggle(entry.label, isOn: Binding(
+                        VToggle(isOn: Binding(
                             get: { macOSFlagStates[index].enabled },
                             set: { newValue in
                                 macOSFlagStates[index].enabled = newValue
                                 MacOSClientFeatureFlagManager.shared.setOverride(entry.key, enabled: newValue)
                             }
-                        ))
-                        .toggleStyle(.switch)
+                        ), label: entry.label)
                         .font(VFont.body)
                         .foregroundColor(VColor.textSecondary)
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -170,12 +170,10 @@ struct SettingsAppearanceTab: View {
                         .font(VFont.body)
                         .foregroundColor(VColor.textSecondary)
                     Spacer()
-                    Toggle("", isOn: Binding(
+                    VToggle(isOn: Binding(
                         get: { store.mediaEmbedsEnabled },
                         set: { store.setMediaEmbedsEnabled($0) }
                     ))
-                    .toggleStyle(.switch)
-                    .labelsHidden()
                 }
 
                 Text("Automatically embed images, videos, and other media shared in chat messages.")

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -60,14 +60,13 @@ struct SettingsPrivacyTab: View {
                         .foregroundColor(VColor.textMuted)
                 }
                 Spacer()
-                Toggle("", isOn: Binding(
+                VToggle(isOn: Binding(
                     get: { collectUsageData },
                     set: { newValue in
                         collectUsageData = newValue
                         Task { await setCollectUsageData(newValue) }
                     }
                 ))
-                .toggleStyle(.switch)
                 .disabled(isLoading || isUpdating || daemonClient == nil)
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
@@ -444,12 +444,10 @@ private struct SkillRow: View {
                 }
             }
 
-            Toggle("", isOn: Binding(
+            VToggle(isOn: Binding(
                 get: { skill.state == "enabled" },
                 set: { newValue in onToggle(newValue) }
             ))
-                .toggleStyle(.switch)
-                .labelsHidden()
         }
         .padding(.vertical, 2)
     }

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -56,15 +56,13 @@ struct ToolPermissionTesterView: View {
 
             // Toggles
             HStack(spacing: VSpacing.xl) {
-                Toggle("Interactive", isOn: $model.isInteractive)
+                VToggle(isOn: $model.isInteractive, label: "Interactive")
                     .font(VFont.body)
                     .foregroundColor(VColor.textSecondary)
-                    .toggleStyle(.switch)
 
-                Toggle("In Temporary Chat", isOn: $model.forcePromptSideEffects)
+                VToggle(isOn: $model.forcePromptSideEffects, label: "In Temporary Chat")
                     .font(VFont.body)
                     .foregroundColor(VColor.textSecondary)
-                    .toggleStyle(.switch)
             }
         }
     }
@@ -94,10 +92,8 @@ struct ToolPermissionTesterView: View {
             } else {
                 // Optional fields have a checkbox
                 HStack(spacing: VSpacing.xs) {
-                    Toggle(isOn: fieldEnabledBinding(for: field.id)) {
-                        fieldNameLabel(field)
-                    }
-                    .toggleStyle(.checkbox)
+                    VToggle(isOn: fieldEnabledBinding(for: field.id))
+                    fieldNameLabel(field)
                 }
 
                 if model.fieldEnabled[field.id] == true {
@@ -144,9 +140,7 @@ struct ToolPermissionTesterView: View {
                 .font(VFont.mono)
 
         case .boolean:
-            Toggle("", isOn: fieldBoolBinding(for: field.id))
-                .toggleStyle(.switch)
-                .labelsHidden()
+            VToggle(isOn: fieldBoolBinding(for: field.id))
 
         case .enumeration(let values):
             Picker("", selection: fieldValueBinding(for: field.id)) {

--- a/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
@@ -248,7 +248,7 @@ private struct TrustRuleFormView: View {
 
                 TextField("Pattern", text: $pattern, prompt: Text("e.g., git *"))
 
-                Toggle("Everywhere", isOn: $isEverywhere)
+                VToggle(isOn: $isEverywhere, label: "Everywhere")
                 if !isEverywhere {
                     TextField("Scope", text: $scope, prompt: Text("e.g., /Users/me/project"))
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -310,9 +310,7 @@ struct VoiceSettingsView: View {
                     .foregroundColor(VColor.textMuted)
             }
             Spacer()
-            Toggle("", isOn: $wakeWordEnabled)
-                .toggleStyle(.switch)
-                .labelsHidden()
+            VToggle(isOn: $wakeWordEnabled)
                 .accessibilityLabel("Enable wake word listening")
         }
         .padding(VSpacing.lg)

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -291,9 +291,7 @@ struct RecordingSourcePickerView: View {
                     .font(VFont.body)
                     .foregroundColor(VColor.textPrimary)
                 Spacer()
-                Toggle("", isOn: $viewModel.includeAudio)
-                    .toggleStyle(ButtonPrimarySwitchStyle())
-                    .labelsHidden()
+                VToggle(isOn: $viewModel.includeAudio)
                     .accessibilityLabel("System audio")
             }
             .padding(.horizontal, VSpacing.xl)
@@ -307,9 +305,7 @@ struct RecordingSourcePickerView: View {
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
                     Spacer()
-                    Toggle("", isOn: $viewModel.includeMicrophone)
-                        .toggleStyle(ButtonPrimarySwitchStyle())
-                        .labelsHidden()
+                    VToggle(isOn: $viewModel.includeMicrophone)
                         .accessibilityLabel("Microphone")
                 }
                 .padding(.horizontal, VSpacing.xl)
@@ -386,36 +382,3 @@ private struct ScrollViewScrollerHider: NSViewRepresentable {
     }
 }
 
-// MARK: - Custom Toggle Style
-
-/// Switch toggle style that fills the track with `VColor.buttonPrimary` when on,
-/// matching the Start Recording button color exactly. Uses the same dimensions
-/// as VToggle for visual consistency.
-private struct ButtonPrimarySwitchStyle: ToggleStyle {
-    private let trackWidth: CGFloat = 40
-    private let trackHeight: CGFloat = 22
-    private let knobSize: CGFloat = 16
-    private let knobPadding: CGFloat = 3
-
-    func makeBody(configuration: Configuration) -> some View {
-        HStack {
-            configuration.label
-            ZStack(alignment: configuration.isOn ? .trailing : .leading) {
-                Capsule()
-                    .fill(configuration.isOn ? VColor.buttonPrimary : VColor.toggleOff)
-                    .frame(width: trackWidth, height: trackHeight)
-                    .overlay(
-                        Capsule()
-                            .stroke(VColor.toggleBorder, lineWidth: 1)
-                    )
-
-                Circle()
-                    .fill(Color.white)
-                    .frame(width: knobSize, height: knobSize)
-                    .padding(.horizontal, knobPadding)
-            }
-            .animation(VAnimation.fast, value: configuration.isOn)
-            .onTapGesture { configuration.isOn.toggle() }
-        }
-    }
-}

--- a/clients/shared/Features/Surfaces/FormSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/FormSurfaceView.swift
@@ -226,11 +226,7 @@ public struct FormSurfaceView: View {
                 )
                 .onSubmit { handleEnterKey() }
             case .toggle:
-                Toggle(isOn: toggleBinding(for: field.id)) {
-                    EmptyView()
-                }
-                .toggleStyle(.switch)
-                .tint(VColor.accent)
+                VToggle(isOn: toggleBinding(for: field.id))
             }
         }
     }


### PR DESCRIPTION
Replaces native SwiftUI Toggle with the VToggle design system component across all macOS settings and feature views for visual consistency.

Files updated:
- RecordingSourcePickerView (removed ButtonPrimarySwitchStyle, replaced 2 toggles)
- VoiceSettingsView (1 toggle)
- HeartbeatConfigView (2 toggles)
- SettingsAdvancedDevTab (2 toggles)
- SettingsAppearanceTab (1 toggle)
- SettingsPrivacyTab (1 toggle)
- TrustRulesView (1 toggle)
- ToolPermissionTesterView (4 toggles)
- SkillsSettingsView (1 toggle)
- ScheduledTasksView (1 toggle)
- FormSurfaceView (1 toggle)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
