### PR TITLE
M3: Guardian UX + skill + intent routing (voice invite management)

### DIFF
--- a/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
+++ b/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "Trusted Contacts"
-description: "Manage trusted contacts and Telegram invite links — list, allow, revoke, block users, and create/list/revoke invite links for external channels"
+description: "Manage trusted contacts and invite links — list, allow, revoke, block users, and create/list/revoke invite links for Telegram and voice (phone call) channels"
 user-invocable: true
 metadata: {"vellum": {"emoji": "\ud83d\udc65"}}
 ---
 
-You are helping your user manage trusted contacts and invite links for the Vellum Assistant. Trusted contacts control who is allowed to send messages to the assistant through external channels like Telegram and SMS. Invite links let the guardian share a Telegram deep link that automatically grants access when opened. All operations go through the gateway HTTP API using `curl` with bearer auth.
+You are helping your user manage trusted contacts and invite links for the Vellum Assistant. Trusted contacts control who is allowed to send messages to the assistant through external channels like Telegram, SMS, and voice (phone calls). Invite links let the guardian share a Telegram deep link that automatically grants access when opened. Voice invites let the guardian authorize a specific phone number to call in — the invitee must call from that phone number AND enter a one-time numeric code. All operations go through the gateway HTTP API using `curl` with bearer auth.
 
 ## Prerequisites
 
@@ -18,8 +18,9 @@ You are helping your user manage trusted contacts and invite links for the Vellu
 - **Member**: A user identity (external user ID or chat ID) from a specific channel that has been registered with a policy.
 - **Policy**: Controls what the member can do — `allow` (can message freely) or `deny` (blocked from messaging).
 - **Status**: The member's lifecycle state — `active` (currently effective), `revoked` (access removed), or `blocked` (explicitly denied).
-- **Source channel**: The messaging platform the contact uses (e.g., `telegram`, `sms`).
+- **Source channel**: The messaging platform the contact uses (e.g., `telegram`, `sms`, `voice`).
 - **Invite link**: A shareable Telegram deep link that, when opened by someone, automatically grants them trusted-contact access. Each invite has a token, usage limits, and optional expiration.
+- **Voice invite**: An invite bound to a specific phone number for phone-call access. The guardian provides the invitee's phone number (E.164 format, e.g., `+15551234567`), and the system generates a numeric code. The invitee must call from that exact phone number AND enter the code when prompted. Both conditions must be met — the call must originate from the bound number, and the correct code must be entered. SMS-based invites are not supported.
 
 ## Available Actions
 
@@ -215,9 +216,94 @@ curl -s -X DELETE "$INTERNAL_GATEWAY_BASE_URL/v1/ingress/invites/<invite_id>" \
 
 Replace `<invite_id>` with the invite's `id` from the list response.
 
+### 8. Create a voice invite
+
+Use this when the guardian wants to authorize a specific phone number to call the assistant. Voice invites are identity-bound: the invitee must call from the specified phone number AND enter a one-time numeric code.
+
+**Important**: The response includes a `voiceCode` field that is only returned at creation time and cannot be retrieved later. Extract and present it clearly.
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+
+INVITE_JSON=$(curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/ingress/invites" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "sourceChannel": "voice",
+    "expectedExternalUserId": "<phone_number_E164>",
+    "maxUses": 1,
+    "note": "<optional note, e.g. the person it is for>"
+  }')
+printf '%s\n' "$INVITE_JSON"
+```
+
+Required fields:
+- `sourceChannel` — must be `"voice"`
+- `expectedExternalUserId` — the invitee's phone number in E.164 format (e.g., `+15551234567`)
+
+Optional fields:
+- `maxUses` — how many times the code can be used (default: 1)
+- `expiresInMs` — expiration time in milliseconds from now (e.g., `86400000` for 24 hours). Defaults to 7 days if omitted.
+- `voiceCodeDigits` — number of digits in the code (4-10, default: 6)
+- `note` — a human-readable label for the invite (e.g., "For Mom", "Dr. Smith")
+
+The create response contains `{ ok: true, invite: { id, voiceCode, expectedExternalUserId, ... } }`. The `voiceCode` is the numeric code the invitee must enter — it is only returned at creation time.
+
+**Presenting to the guardian**: Give the guardian clear instructions to relay to the invitee:
+
+> Voice invite created for **<phone_number>**:
+>
+> **Invite code: `<voiceCode>`**
+>
+> Share these instructions with the person you are inviting:
+> 1. Call the assistant's phone number from **<phone_number>** (the call must come from this exact number)
+> 2. When prompted, enter the code **<voiceCode>**
+> 3. Once verified, they will be added as a trusted contact and can call the assistant directly in the future
+>
+> This code can be used <maxUses> time(s)<and expires in X hours/days if applicable>.
+
+If the user provides a phone number without the `+` country code prefix, ask them to confirm the full E.164 number (e.g., US numbers should be `+1XXXXXXXXXX`).
+
+**Note**: SMS-based invites are not currently supported. Only voice (phone call) invites are available for phone-based access.
+
+### 9. List voice invites
+
+Use this to show the guardian their active voice invites.
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/ingress/invites?sourceChannel=voice" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Optional query parameters:
+- `status` — filter by status (`active`, `revoked`, `redeemed`, `expired`)
+
+The response format is the same as regular invites but voice invites also include:
+- `expectedExternalUserId` — the bound phone number
+- `voiceCodeDigits` — length of the code (the code itself is not retrievable after creation)
+
+**Presenting results**: Format as a readable list. Show the note (or "unnamed" as fallback), bound phone number, status, uses remaining, and expiration. Highlight which invites are still active.
+
+### 10. Revoke a voice invite
+
+Use this when the guardian wants to cancel an active voice invite. **Always confirm before revoking.**
+
+Ask the user: *"I'll revoke the voice invite for [phone number or note]. The code will no longer work. Should I proceed?"*
+
+First, list voice invites to find the invite's `id`, then revoke:
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+curl -s -X DELETE "$INTERNAL_GATEWAY_BASE_URL/v1/ingress/invites/<invite_id>" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Replace `<invite_id>` with the invite's `id` from the list response. The same revoke endpoint is used for both Telegram and voice invites.
+
 ## Confirmation Requirements
 
-**All mutating actions (allow, revoke, block, revoke invite) require explicit user confirmation before execution.** This is a safety measure — modifying who can access the assistant should always be a deliberate choice. Creating an invite link does not require confirmation since it does not grant access until someone opens it.
+**All mutating actions (allow, revoke, block, revoke invite) require explicit user confirmation before execution.** This is a safety measure — modifying who can access the assistant should always be a deliberate choice. Creating an invite (Telegram link or voice invite) does not require confirmation since it does not grant access until the invitee redeems it.
 
 - Clearly state what action you are about to take and who it affects.
 - Wait for the user to confirm before running the curl command.
@@ -231,7 +317,9 @@ Replace `<invite_id>` with the invite's `id` from the list response.
   - `At least one of externalUserId or externalChatId is required` — ask the user for the contact's channel-specific identifier.
   - `Member not found or cannot be revoked` — the member ID may be invalid or the member is already revoked.
   - `Member not found or already blocked` — the member ID may be invalid or the member is already blocked.
-  - `sourceChannel is required for create` — when creating an invite, always pass `"sourceChannel": "telegram"`.
+  - `sourceChannel is required for create` — when creating an invite, always pass `"sourceChannel": "telegram"` for Telegram or `"sourceChannel": "voice"` for voice invites.
+  - `expectedExternalUserId is required for voice invites` — voice invites must include the invitee's phone number.
+  - `expectedExternalUserId must be in E.164 format` — the phone number must start with `+` followed by country code and number (e.g., `+15551234567`).
   - `Invite not found or already revoked` — the invite ID may be invalid or the invite is already revoked.
 
 ## Typical Workflows
@@ -251,3 +339,11 @@ Replace `<invite_id>` with the invite's `id` from the list response.
 **"Show my invites"** / **"List active invite links"** — List invites filtered by `sourceChannel=telegram`, present active invites with uses remaining and expiration info.
 
 **"Revoke invite"** / **"Cancel invite link"** — List invites to identify the target, confirm, then revoke by ID.
+
+**"Create a voice invite for +15551234567"** — Create a voice invite with `sourceChannel: "voice"` and the given phone number as `expectedExternalUserId`. Present the invite code and instructions: the person must call from that number and enter the code.
+
+**"Let my mom call in"** / **"Invite someone by phone"** — Ask for the phone number in E.164 format, create a voice invite, and present the code + calling instructions.
+
+**"Show my voice invites"** / **"List phone invites"** — List invites filtered by `sourceChannel=voice`, present active invites with bound phone number and expiration info.
+
+**"Revoke voice invite"** / **"Cancel the phone invite for +15551234567"** — List voice invites, identify the target by phone number or note, confirm, then revoke by ID.

--- a/assistant/src/daemon/guardian-invite-intent.ts
+++ b/assistant/src/daemon/guardian-invite-intent.ts
@@ -31,7 +31,7 @@ const CREATE_VOICE_INVITE_PATTERNS: RegExp[] = [
   /\b(?:make|generate|get|set\s+up)\s+(?:a\s+|an\s+)?voice\s+invite\b/i,
   /\binvite\s+(?:someone|somebody|a\s+friend|a\s+person)\s+(?:on|to|via|through|by)\s+(?:phone|voice|call)\b/i,
   /\b(?:create|make|generate|get|set\s+up)\s+(?:a\s+|an\s+)?(?:phone|call)\s+invite\b/i,
-  /\binvite\s+.*(?:phone|voice|call)\s*(?:code)?\b/i,
+  /\binvite\s+(?:code\s+)?(?:for|via|by|on|through)\s+(?:phone|voice|call)\b/i,
   /\b(?:phone|voice|call)\s+invite\s*(?:code)?\b/i,
   /\blet\s+.*\s+call\s+(?:in|me)\b/i,
 ];

--- a/assistant/src/daemon/guardian-invite-intent.ts
+++ b/assistant/src/daemon/guardian-invite-intent.ts
@@ -33,7 +33,6 @@ const CREATE_VOICE_INVITE_PATTERNS: RegExp[] = [
   /\b(?:create|make|generate|get|set\s+up)\s+(?:a\s+|an\s+)?(?:phone|call)\s+invite\b/i,
   /\binvite\s+(?:code\s+)?(?:for|via|by|on|through)\s+(?:phone|voice|call)\b/i,
   /\b(?:phone|voice|call)\s+invite\s*(?:code)?\b/i,
-  /\blet\s+.*\s+call\s+(?:in|me)\b/i,
 ];
 
 const LIST_INVITE_PATTERNS: RegExp[] = [

--- a/assistant/src/daemon/guardian-invite-intent.ts
+++ b/assistant/src/daemon/guardian-invite-intent.ts
@@ -7,7 +7,7 @@
 
 export type GuardianInviteIntentResult =
   | { kind: 'none' }
-  | { kind: 'invite_management'; rewrittenContent: string; action?: 'create' | 'list' | 'revoke' };
+  | { kind: 'invite_management'; rewrittenContent: string; action?: 'create' | 'list' | 'revoke' | 'voice_create' | 'voice_list' | 'voice_revoke' };
 
 // ── Direct invite patterns ────────────────────────────────────────────────
 // These capture imperative requests to manage Telegram invite links.
@@ -22,6 +22,20 @@ const CREATE_INVITE_PATTERNS: RegExp[] = [
   /\binvite\s+(?:link\s+)?for\s+telegram\b/i,
 ];
 
+// ── Voice invite patterns ─────────────────────────────────────────────────
+// These capture imperative requests to manage voice (phone call) invite codes.
+
+const CREATE_VOICE_INVITE_PATTERNS: RegExp[] = [
+  /\bcreate\s+(?:an?\s+)?voice\s+invite\b/i,
+  /\bvoice\s+invite\s+(?:for|to)\s+\+?\d/i,
+  /\b(?:make|generate|get|set\s+up)\s+(?:a\s+|an\s+)?voice\s+invite\b/i,
+  /\binvite\s+(?:someone|somebody|a\s+friend|a\s+person)\s+(?:on|to|via|through|by)\s+(?:phone|voice|call)\b/i,
+  /\b(?:create|make|generate|get|set\s+up)\s+(?:a\s+|an\s+)?(?:phone|call)\s+invite\b/i,
+  /\binvite\s+.*(?:phone|voice|call)\s*(?:code)?\b/i,
+  /\b(?:phone|voice|call)\s+invite\s*(?:code)?\b/i,
+  /\blet\s+.*\s+call\s+(?:in|me)\b/i,
+];
+
 const LIST_INVITE_PATTERNS: RegExp[] = [
   /\b(?:show|list|view|see|display)\s+(?:my\s+)?(?:active\s+)?invite(?:s|\s*links?)\b/i,
   /\b(?:show|list|view|see|display)\s+(?:my\s+)?(?:telegram\s+)?invite(?:s|\s*links?)\b/i,
@@ -29,10 +43,22 @@ const LIST_INVITE_PATTERNS: RegExp[] = [
   /\bhow\s+many\s+invite(?:s|\s*links?)\b/i,
 ];
 
+const LIST_VOICE_INVITE_PATTERNS: RegExp[] = [
+  /\b(?:show|list|view|see|display)\s+(?:my\s+)?(?:active\s+)?voice\s+invite(?:s)?\b/i,
+  /\b(?:show|list|view|see|display)\s+(?:my\s+)?(?:phone|call)\s+invite(?:s)?\b/i,
+  /\bwhat\s+voice\s+invite(?:s)?\s+(?:do\s+I\s+have|are\s+active|exist)\b/i,
+];
+
 const REVOKE_INVITE_PATTERNS: RegExp[] = [
   /\b(?:revoke|cancel|disable|invalidate|delete|remove)\s+(?:the\s+|my\s+|an?\s+)?invite\s*(?:link)?\b/i,
   /\b(?:revoke|cancel|disable|invalidate|delete|remove)\s+(?:the\s+|my\s+|an?\s+)?(?:telegram\s+)?invite\s*(?:link)?\b/i,
   /\binvite\s*(?:link)?\s+(?:revoke|cancel|disable|invalidate|delete|remove)\b/i,
+];
+
+const REVOKE_VOICE_INVITE_PATTERNS: RegExp[] = [
+  /\b(?:revoke|cancel|disable|invalidate|delete|remove)\s+(?:the\s+|my\s+|an?\s+)?voice\s+invite\b/i,
+  /\b(?:revoke|cancel|disable|invalidate|delete|remove)\s+(?:the\s+|my\s+|an?\s+)?(?:phone|call)\s+invite\b/i,
+  /\bvoice\s+invite\s+(?:revoke|cancel|disable|invalidate|delete|remove)\b/i,
 ];
 
 // ── Conceptual / question patterns ──────────────────────────────────────
@@ -58,12 +84,20 @@ function isConceptualQuestion(text: string): boolean {
   // Allow actionable requests through even though they start with
   // question-like words — these are imperative invite management requests.
   if (LIST_INVITE_PATTERNS.some((p) => p.test(cleaned))) return false;
+  if (LIST_VOICE_INVITE_PATTERNS.some((p) => p.test(cleaned))) return false;
   if (CREATE_INVITE_PATTERNS.some((p) => p.test(cleaned))) return false;
+  if (CREATE_VOICE_INVITE_PATTERNS.some((p) => p.test(cleaned))) return false;
   if (REVOKE_INVITE_PATTERNS.some((p) => p.test(cleaned))) return false;
+  if (REVOKE_VOICE_INVITE_PATTERNS.some((p) => p.test(cleaned))) return false;
   return CONCEPTUAL_PATTERNS.some((p) => p.test(cleaned));
 }
 
-function detectAction(text: string): 'create' | 'list' | 'revoke' | undefined {
+function detectAction(text: string): 'create' | 'list' | 'revoke' | 'voice_create' | 'voice_list' | 'voice_revoke' | undefined {
+  // Voice-specific patterns take precedence when the user explicitly mentions
+  // voice/phone/call — avoids misrouting to the Telegram invite flow.
+  if (REVOKE_VOICE_INVITE_PATTERNS.some((p) => p.test(text))) return 'voice_revoke';
+  if (LIST_VOICE_INVITE_PATTERNS.some((p) => p.test(text))) return 'voice_list';
+  if (CREATE_VOICE_INVITE_PATTERNS.some((p) => p.test(text))) return 'voice_create';
   // Check revoke and list before create — create patterns include the broad
   // `telegram invite link` matcher that would otherwise swallow revoke/list inputs.
   if (REVOKE_INVITE_PATTERNS.some((p) => p.test(text))) return 'revoke';
@@ -109,6 +143,9 @@ export function resolveGuardianInviteIntent(text: string): GuardianInviteIntentR
     create: 'The user wants to create a Telegram invite link. Create the invite, look up the bot username, and present the shareable deep link with copy-paste instructions.',
     list: 'The user wants to see their invite links. List all invites (especially active ones for Telegram) and present them in a readable format.',
     revoke: 'The user wants to revoke an invite link. List invites to identify the target, confirm with the user, then revoke it.',
+    voice_create: 'The user wants to create a voice (phone call) invite. Ask for the phone number if not provided, create a voice invite with sourceChannel "voice", and present the invite code with clear instructions: the invitee must call from the bound phone number AND enter the code when prompted.',
+    voice_list: 'The user wants to see their voice invites. List all invites with sourceChannel "voice" and present them in a readable format showing phone number, status, and code usage.',
+    voice_revoke: 'The user wants to revoke a voice invite. List voice invites to identify the target, confirm with the user, then revoke it.',
   };
 
   const rewrittenContent = [

--- a/assistant/src/runtime/channel-invite-transports/voice.ts
+++ b/assistant/src/runtime/channel-invite-transports/voice.ts
@@ -1,0 +1,58 @@
+/**
+ * Voice channel invite transport adapter.
+ *
+ * Voice invites are identity-bound: the invitee must call from a specific
+ * phone number and enter a numeric code. Unlike Telegram invites, there is
+ * no shareable deep link — the guardian relays the code and calling
+ * instructions verbally or via another channel.
+ *
+ * The transport builds human-readable instruction text and provides a
+ * no-op token extractor since voice invite redemption uses the dedicated
+ * voice-code path rather than generic token extraction.
+ */
+
+import type { ChannelId } from '../../channels/types.js';
+import {
+  type ChannelInviteTransport,
+  type InviteSharePayload,
+  registerTransport,
+} from '../channel-invite-transport.js';
+
+// ---------------------------------------------------------------------------
+// Transport implementation
+// ---------------------------------------------------------------------------
+
+export const voiceInviteTransport: ChannelInviteTransport = {
+  channel: 'voice' as ChannelId,
+
+  buildShareableInvite(params: {
+    rawToken: string;
+    sourceChannel: ChannelId;
+  }): InviteSharePayload {
+    // Voice invites do not produce a clickable URL. The "url" field contains
+    // a placeholder — callers should use displayText for presentation.
+    return {
+      url: '',
+      displayText: [
+        'Voice invite created.',
+        'The invitee must call the assistant\'s phone number from the authorized number and enter their invite code when prompted.',
+      ].join(' '),
+    };
+  },
+
+  extractInboundToken(_params: {
+    commandIntent?: Record<string, unknown>;
+    content: string;
+    sourceMetadata?: Record<string, unknown>;
+  }): string | undefined {
+    // Voice invite redemption bypasses generic token extraction — it uses
+    // the identity-bound voice-code flow in invite-redemption-service.ts.
+    return undefined;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Auto-register on import
+// ---------------------------------------------------------------------------
+
+registerTransport(voiceInviteTransport);

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -76,6 +76,7 @@ import { deliverGeneratedApprovalPrompt } from './guardian-approval-prompt.js';
 import { routeGuardianReply } from '../guardian-reply-router.js';
 
 import '../channel-invite-transports/telegram.js';
+import '../channel-invite-transports/voice.js';
 
 const log = getLogger('runtime-http');
 


### PR DESCRIPTION
Extend invite intent routing to recognize voice invite requests, update trusted-contacts skill with voice invite workflows (create/list/revoke), add voice invite transport for delivering invite instructions. Part of #10605.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
