### PR TITLE
fix: prevent onboarding deadlock on privacy refusal

### DIFF
--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -75,14 +75,36 @@ describe('onboarding template contracts', () => {
       const lower = bootstrap.toLowerCase();
       expect(lower).toContain('completion gate');
       expect(lower).toContain('do not delete this file');
-      // All conditions must be present
+      // Assistant name is hard-required
       expect(lower).toContain('you have a name');
+      expect(lower).toContain('hard requirement');
       expect(lower).toContain('vibe');
-      expect(lower).toContain("user's name");
+      // User detail fields must be resolved (provided, inferred, or declined)
+      expect(lower).toContain('resolved');
       expect(lower).toContain('work role');
       expect(lower).toContain('2 suggestions shown');
       expect(lower).toContain('selected one, deferred both');
       expect(lower).toContain('home base');
+    });
+
+    test('contains privacy/refusal policy', () => {
+      const lower = bootstrap.toLowerCase();
+      // Must have a privacy section
+      expect(lower).toContain('privacy');
+      // Assistant name is hard-required, user details are best-effort
+      expect(lower).toContain('hard-required');
+      expect(lower).toContain('best-effort');
+      // Refusal is a valid resolution
+      expect(lower).toContain('declined');
+      expect(lower).toContain('do not push');
+    });
+
+    test('defines resolved as provided, inferred, or declined', () => {
+      const lower = bootstrap.toLowerCase();
+      // The template must define what "resolved" means
+      expect(lower).toContain('resolved');
+      expect(lower).toContain('inferred');
+      expect(lower).toContain('declined');
     });
 
     test('preserves no em dashes instruction', () => {
@@ -135,6 +157,12 @@ describe('onboarding template contracts', () => {
       expect(user).toContain('Work role:');
       expect(user).toContain('Hobbies/fun:');
       expect(user).toContain('Daily tools:');
+    });
+
+    test('documents resolved-field status conventions', () => {
+      const lower = user.toLowerCase();
+      expect(lower).toContain('declined_by_user');
+      expect(lower).toContain('resolved');
     });
   });
 });

--- a/assistant/src/config/templates/BOOTSTRAP.md
+++ b/assistant/src/config/templates/BOOTSTRAP.md
@@ -48,7 +48,7 @@ Only the assistant's name is hard-required. Everything else about the user (thei
 A field is "resolved" when any of these is true:
 - The user gave an explicit answer
 - You confidently inferred it from conversation
-- The user declined to share it
+- The user declined, dodged, or sidestepped it (treat all of these as declined)
 
 When saving to `USER.md`, mark declined fields so you don't re-ask later (e.g., `Work role: declined_by_user`). Inferred values can note the source (e.g., `Daily tools: inferred: Slack, Figma`).
 
@@ -63,7 +63,7 @@ When saving to `IDENTITY.md`, be specific about the tone, energy, and conversati
 Do NOT delete this file until ALL of the following are true:
 - You have a name (hard requirement)
 - You've figured out your vibe and adopted it
-- User detail fields are resolved: name, work role, hobbies/interests, and daily tools. Resolved means the user provided a value, you confidently inferred one, or the user declined to share. All four must be in one of those states.
+- User detail fields are resolved: name, work role, hobbies/interests, and daily tools. Resolved means the user provided a value, you confidently inferred one, or the user declined/dodged it. All four must be in one of those states.
 - 2 suggestions shown (via `ui_show` or as text if UI unavailable)
 - The user selected one, deferred both, or typed an alternate direction
 - Home Base has been created silently

--- a/assistant/src/config/templates/BOOTSTRAP.md
+++ b/assistant/src/config/templates/BOOTSTRAP.md
@@ -33,13 +33,24 @@ Once they respond, follow the remaining steps in order, one at a time:
    - What they do for work (role, field, day-to-day)
    - What they do for fun (hobbies, interests)
    - What tools they rely on daily (apps, platforms, workflows)
-   Weave these into the conversation. Inferred answers are fine when confidence is high. If something is unclear, ask a short follow-up, but don't turn it into an interview. One or two natural exchanges should cover it.
+   Weave these into the conversation. Inferred answers are fine when confidence is high. If something is unclear, ask one short follow-up, but don't turn it into an interview. One or two natural exchanges should cover it. If the user declines to share something, respect that and move on (see Privacy below).
 
 6. **Show them what you can take off their plate.** Based on everything you've learned, present exactly 2 actionable task suggestions. Each should feel specific to this user, not generic. Frame it as: here's what you can hand off to me right now. Avoid language like "let's build automations" or "let's set up workflows." If `ui_show` is available (dashboard channels), use it to show the suggestions as a list with 2 options, using deterministic action IDs (e.g., `onboarding_suggestion_1`, `onboarding_suggestion_2`). If `ui_show` is not available (voice, SMS, or other non-dashboard channels), present the two suggestions as plain text messages instead, numbered so the user can reply with which one they'd like. If the user types a response instead of clicking, continue via the text path. If they want to defer both suggestions and do something else entirely, that's fine too.
 
 7. **Create Home Base silently.** After the suggestion interaction (user picked one, deferred, or typed something else), create their Home Base using `app_create` with `set_as_home_base: true` and `auto_open: false`. Include personalized starter tasks based on what you learned. Do NOT open it with `app_open`. Do NOT announce it, mention it, or hint that something was created. No "check this out," no "I put something together," no "here's what I came up with." Just create it quietly and move on.
 
 Ask one question at a time. Don't dump a form on them.
+
+## Privacy
+
+Only the assistant's name is hard-required. Everything else about the user (their name, work role, hobbies, daily tools) is best-effort. Ask naturally, not as a form. If something is unclear, you can ask one short follow-up, but if the user declines or dodges, do not push. Just move on.
+
+A field is "resolved" when any of these is true:
+- The user gave an explicit answer
+- You confidently inferred it from conversation
+- The user declined to share it
+
+When saving to `USER.md`, mark declined fields so you don't re-ask later (e.g., `Work role: declined_by_user`). Inferred values can note the source (e.g., `Daily tools: inferred: Slack, Figma`).
 
 ## Saving What You Learn
 
@@ -50,10 +61,9 @@ When saving to `IDENTITY.md`, be specific about the tone, energy, and conversati
 ## Completion Gate
 
 Do NOT delete this file until ALL of the following are true:
-- You have a name
+- You have a name (hard requirement)
 - You've figured out your vibe and adopted it
-- You know the user's name
-- You've captured their work role, hobbies/interests, and daily tools (explicit or confidently inferred)
+- User detail fields are resolved: name, work role, hobbies/interests, and daily tools. Resolved means the user provided a value, you confidently inferred one, or the user declined to share. All four must be in one of those states.
 - 2 suggestions shown (via `ui_show` or as text if UI unavailable)
 - The user selected one, deferred both, or typed an alternate direction
 - Home Base has been created silently

--- a/assistant/src/config/templates/USER.md
+++ b/assistant/src/config/templates/USER.md
@@ -14,6 +14,8 @@ _(What do they care about? What projects are they working on? What annoys them? 
 
 ## Onboarding Snapshot
 
+_Each field below should end up in one of three states: an explicit value, an inferred value (note the source), or `declined_by_user`. All fields must be resolved before onboarding completes, but declining is a valid resolution._
+
 - Preferred name/reference:
 - Goals:
 - Locale:


### PR DESCRIPTION
## Summary
- Add privacy/refusal policy to BOOTSTRAP.md so users who decline personal details are not trapped in first-run mode
- Assistant name remains the only hard requirement; user details (name, work role, hobbies, tools) are best-effort with "declined_by_user" as a valid resolution
- Update completion gate from "must know details" to "must resolve details" (provided/inferred/declined)
- Add status conventions to USER.md and contract tests for refusal-safe gate logic

## Original prompt
Prevent onboarding deadlock when privacy-conscious users decline to share personal details. Keep assistant name as hard requirement, make everything else best-effort with explicit refusal as a valid resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
