### PR TITLE
feat: update VButton corner radius to VRadius.lg and refresh preview

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -111,7 +111,7 @@ private struct VButtonStyle: ButtonStyle {
     private var cornerRadius: CGFloat {
         switch style {
         case .outlined: return VRadius.xl
-        default: return VRadius.md
+        default: return VRadius.lg
         }
     }
 
@@ -219,20 +219,22 @@ private struct VButtonStyle: ButtonStyle {
     ZStack {
         VColor.background.ignoresSafeArea()
         VStack(spacing: 16) {
-            VButton(label: "Small", style: .primary, size: .small) {}
-            VButton(label: "Medium", style: .primary, size: .medium) {}
-            VButton(label: "Large", style: .primary, size: .large) {}
-            VButton(label: "Tertiary Small", style: .tertiary, size: .small) {}
-            VButton(label: "Tertiary Large", style: .tertiary, size: .large) {}
-            VButton(label: "Secondary", style: .secondary, size: .small) {}
-            VButton(label: "Secondary Medium", style: .secondary, size: .medium) {}
-            VButton(label: "With Left Icon", leftIcon: "plus", style: .primary, size: .small) {}
-            VButton(label: "With Right Icon", rightIcon: "arrow.right", style: .tertiary, size: .small) {}
-            VButton(label: "Both Icons", leftIcon: "star", rightIcon: "chevron.right", style: .secondary, size: .medium) {}
-            VButton(label: "Legacy Icon", icon: "gear", style: .primary, size: .small) {}
+            VButton(label: "Primary", style: .primary, size: .medium) {}
+            VButton(label: "Secondary", style: .secondary, size: .medium) {}
+            VButton(label: "Tertiary", style: .tertiary, size: .medium) {}
+            VButton(label: "Danger", style: .danger, size: .medium) {}
+            VButton(label: "Ghost", style: .ghost, size: .medium) {}
+            VButton(label: "Record", style: .outlined, size: .large) {}
+            HStack(spacing: 12) {
+                VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success, size: .medium) {}
+                VButton(label: "Disconnect", style: .danger, size: .medium) {}
+            }
+            VButton(label: "Connect", style: .primary, size: .medium) {}
+            VButton(label: "With Icon", leftIcon: "plus", style: .primary, size: .small) {}
             VButton(label: "Full Width", style: .primary, isFullWidth: true) {}
+            VButton(label: "Disabled", style: .primary, isDisabled: true) {}
         }
         .padding()
     }
-    .frame(width: 300, height: 500)
+    .frame(width: 320, height: 580)
 }


### PR DESCRIPTION
- Changes default corner radius from VRadius.md (8px) to VRadius.lg (12px) for all standard button styles, matching the rounder look in design screenshots
- .outlined style keeps VRadius.xl (16px) as before
- Refreshes the preview block to showcase all variants including the new .outlined ("Record") and .success ("Connected") styles, plus the Connected/Disconnect pair side by side
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
