### PR TITLE
fix: hide native Menu indicator from VDropdown — single chevron only

### DIFF
--- a/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
@@ -69,6 +69,7 @@ public struct VDropdown<T: Hashable>: View {
             )
         }
         .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
         .fixedSize(horizontal: false, vertical: true)
     }
 }


### PR DESCRIPTION
The Menu's native disclosure indicator was doubling up with the custom chevron.down icon. Adding .menuIndicator(.hidden) removes the native one so only our custom caret on the right remains.

The dropdown label now looks identical to VTextField — same padding, background, border radius, single chevron on the right.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
