### PR TITLE
fix: match VDropdown styling exactly to vInputStyle

### DIFF
--- a/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
@@ -44,33 +44,34 @@ public struct VDropdown<T: Hashable>: View {
             }
         } label: {
             HStack {
-                if let label = selectedLabel {
-                    Text(label)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
-                } else {
-                    Text(placeholder)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textMuted)
+                Group {
+                    if let label = selectedLabel {
+                        Text(label)
+                            .foregroundColor(VColor.textPrimary)
+                    } else {
+                        Text(placeholder)
+                            .foregroundColor(VColor.textMuted)
+                    }
                 }
-
-                Spacer()
+                .font(VFont.body)
+                .frame(maxWidth: .infinity, alignment: .leading)
 
                 Image(systemName: "chevron.down")
                     .foregroundColor(VColor.textMuted)
-                    .font(.system(size: 12))
+                    .font(.system(size: 12, weight: .medium))
             }
             .padding(VSpacing.md)
             .background(VColor.inputBackground)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .overlay(
                 RoundedRectangle(cornerRadius: VRadius.md)
-                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                    .stroke(VColor.surfaceBorder, lineWidth: 1)
             )
+            .contentShape(Rectangle())
         }
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
-        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity)
     }
 }
 


### PR DESCRIPTION
Three fixes to make VDropdown visually identical to a VTextField/vInputStyle input:

- **Border**: was `VColor.surfaceBorder.opacity(0.5)`, now `VColor.surfaceBorder` (full opacity) — matching `VInputStyleModifier` exactly
- **Full width**: replaced `Spacer()` + `.fixedSize` with `.frame(maxWidth: .infinity)` on the text and the Menu — ensures the control stretches to fill its container like a text field does
- **Hit area**: added `.contentShape(Rectangle())` so the entire label area is tappable, not just the text
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
