### PR TITLE
M4: Tests + docs + hard boundaries (voice invite)

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -392,26 +392,56 @@ A complementary access-granting flow where the guardian proactively creates a sh
 
 **Inbound intercept points:** Invite token extraction runs early in the inbound handler, before ACL denial, so valid invites short-circuit the membership check. Two intercept branches handle: (a) non-members — the invite creates their first member record; (b) inactive members (revoked/pending) — the invite reactivates them.
 
-**Deferred channel adapters:**
+**Channel adapter status:**
 
 | Channel | Status | Prerequisites |
 |---------|--------|--------------|
 | Telegram | Shipped | Bot username resolved from credential metadata or `TELEGRAM_BOT_USERNAME` env |
+| Voice | Shipped | Identity-bound voice code redemption via DTMF/speech in the relay state machine. Gated behind `feature_flags.voice-invite-redemption.enabled` (default OFF). |
 | SMS | Deferred | Needs a deep-link strategy compatible with SMS (short URL or web redemption page) |
 | Slack | Deferred | Needs DM-safe ingress — Socket Mode handles channel messages but DM-initiated invite flows need routing |
-| Voice | Deferred | Needs DTMF or speech-based token capture integrated with the voice relay state machine |
+
+### Voice Invite Flow (invite_redemption_pending)
+
+Voice invites use a short numeric code (4-10 digits, default 6) instead of a URL token. The guardian creates an invite bound to the invitee's E.164 phone number; the invitee redeems it by entering the code during an inbound voice call.
+
+**Creation flow:**
+1. Guardian creates a voice invite via `POST /v1/ingress/invites` with `sourceChannel: "voice"` and `expectedExternalUserId` (E.164 phone).
+2. `ingress-service.ts` generates a cryptographically random numeric code (`generateVoiceCode`), hashes it with SHA-256 (`hashVoiceCode`), and stores only the hash.
+3. The one-time plaintext `voiceCode` is returned in the creation response. The raw token is NOT returned for voice invites — redemption uses the identity-bound code flow exclusively.
+4. Guardian communicates the code to the invitee out-of-band.
+
+**Call-time redemption subflow (`invite_redemption_pending`):**
+1. Unknown caller dials in. `relay-server.ts` resolves trust via `resolveActorTrust`. Caller is `unknown`, no pending guardian challenge.
+2. If `feature_flags.voice-invite-redemption.enabled` is ON, the relay checks `findActiveVoiceInvites` for invites bound to the caller's phone number.
+3. If active, non-expired invites exist, the relay enters the `invite_redemption_pending` state (reuses the `verification_pending` connection state) and prompts the caller to enter their invite code via DTMF or speech.
+4. `redeemVoiceInviteCode` validates: identity match, code hash match, expiry, use count. On success, an active member record is upserted and the call transitions to the normal call flow.
+5. On failure, the caller gets up to 3 attempts. After max attempts, the call is terminated.
+
+**Security invariants:**
+- The plaintext voice code is returned exactly once at creation time and never stored.
+- Voice invites are identity-bound: `expectedExternalUserId` must match the caller's E.164 number. An attacker with the code but the wrong phone number cannot redeem.
+- Failure responses are intentionally generic (`invalid_or_expired`) to prevent oracle attacks.
+- Blocked members cannot bypass the guardian's explicit block via invite redemption.
+
+**Feature flag:** `feature_flags.voice-invite-redemption.enabled` (default OFF). When disabled, unknown callers with active voice invites are denied normally — the invite check is skipped entirely.
 
 **Key source files:**
 
 | File | Purpose |
 |------|---------|
-| `src/runtime/invite-redemption-service.ts` | Core redemption engine — token validation, member creation, discriminated-union outcomes |
+| `src/runtime/invite-redemption-service.ts` | Core redemption engine — token validation, voice code redemption, member creation, discriminated-union outcomes |
 | `src/runtime/invite-redemption-templates.ts` | Deterministic reply templates for each redemption outcome |
 | `src/runtime/channel-invite-transport.ts` | Transport adapter registry with `buildShareableInvite` / `extractInboundToken` interface |
 | `src/runtime/channel-invite-transports/telegram.ts` | Telegram adapter — `t.me/<bot>?start=iv_<token>` deep links, `/start iv_<token>` extraction |
+| `src/runtime/channel-invite-transports/voice.ts` | Voice transport adapter — code-based redemption metadata |
 | `src/daemon/guardian-invite-intent.ts` | Intent detection — routes create/list/revoke requests into the trusted-contacts skill |
 | `src/runtime/ingress-service.ts` | Shared business logic for invite/member operations (used by both HTTP routes and IPC) |
+| `src/runtime/routes/ingress-routes.ts` | HTTP API handlers for member/invite management including voice invite creation and redemption |
 | `src/runtime/routes/inbound-message-handler.ts` | Invite token intercept in the inbound flow (non-member and inactive-member branches) |
+| `src/calls/relay-server.ts` | Voice relay state machine — `invite_redemption_pending` subflow, feature flag gate |
+| `src/util/voice-code.ts` | Cryptographic voice code generation and SHA-256 hashing |
+| `src/memory/ingress-invite-store.ts` | Invite persistence including `findActiveVoiceInvites` for identity-bound lookup |
 
 ### Update Bulletin System
 

--- a/assistant/src/__tests__/ingress-routes-http.test.ts
+++ b/assistant/src/__tests__/ingress-routes-http.test.ts
@@ -31,6 +31,7 @@ import {
   handleListInvites,
   handleListMembers,
   handleRedeemInvite,
+  handleRedeemVoiceInvite,
   handleRevokeInvite,
   handleRevokeMember,
   handleUpsertMember,
@@ -439,5 +440,233 @@ describe('ingress service shared logic', () => {
     const revoked = await revokeRes.json() as { invite: { id: string; status: string } };
     expect(revoked.invite.status).toBe('revoked');
     expect(revoked.invite.id).toBe(created.invite.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Voice invite routes
+// ---------------------------------------------------------------------------
+
+describe('voice invite HTTP routes', () => {
+  beforeEach(resetTables);
+
+  test('POST /v1/ingress/invites with sourceChannel voice — creates invite with voiceCode, stores hash only', async () => {
+    const req = new Request('http://localhost/v1/ingress/invites', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sourceChannel: 'voice',
+        expectedExternalUserId: '+15551234567',
+        maxUses: 3,
+      }),
+    });
+
+    const res = await handleCreateInvite(req);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(201);
+    expect(body.ok).toBe(true);
+    const invite = body.invite as Record<string, unknown>;
+    expect(invite.sourceChannel).toBe('voice');
+    // Voice code should be returned (6 digits by default)
+    expect(typeof invite.voiceCode).toBe('string');
+    expect((invite.voiceCode as string).length).toBe(6);
+    expect(/^\d{6}$/.test(invite.voiceCode as string)).toBe(true);
+    // Hash should be stored
+    expect(typeof invite.tokenHash).toBe('string');
+    expect((invite.tokenHash as string).length).toBeGreaterThan(0);
+    // voiceCodeDigits should be recorded
+    expect(invite.voiceCodeDigits).toBe(6);
+    // expectedExternalUserId should be recorded
+    expect(invite.expectedExternalUserId).toBe('+15551234567');
+  });
+
+  test('voice invite creation requires expectedExternalUserId', async () => {
+    const req = new Request('http://localhost/v1/ingress/invites', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sourceChannel: 'voice',
+      }),
+    });
+
+    const res = await handleCreateInvite(req);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(400);
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('expectedExternalUserId');
+  });
+
+  test('voice invite creation validates E.164 format', async () => {
+    const req = new Request('http://localhost/v1/ingress/invites', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sourceChannel: 'voice',
+        expectedExternalUserId: 'not-a-phone-number',
+      }),
+    });
+
+    const res = await handleCreateInvite(req);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(400);
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('E.164');
+  });
+
+  test('voiceCodeDigits validation — rejects values below 4', async () => {
+    const req = new Request('http://localhost/v1/ingress/invites', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sourceChannel: 'voice',
+        expectedExternalUserId: '+15551234567',
+        voiceCodeDigits: 3,
+      }),
+    });
+
+    const res = await handleCreateInvite(req);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(400);
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('voiceCodeDigits');
+  });
+
+  test('voiceCodeDigits validation — rejects values above 10', async () => {
+    const req = new Request('http://localhost/v1/ingress/invites', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sourceChannel: 'voice',
+        expectedExternalUserId: '+15551234567',
+        voiceCodeDigits: 11,
+      }),
+    });
+
+    const res = await handleCreateInvite(req);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(400);
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('voiceCodeDigits');
+  });
+
+  test('voiceCodeDigits validation — accepts custom digit count within range', async () => {
+    const req = new Request('http://localhost/v1/ingress/invites', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sourceChannel: 'voice',
+        expectedExternalUserId: '+15551234567',
+        voiceCodeDigits: 8,
+      }),
+    });
+
+    const res = await handleCreateInvite(req);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(201);
+    expect(body.ok).toBe(true);
+    const invite = body.invite as Record<string, unknown>;
+    expect((invite.voiceCode as string).length).toBe(8);
+    expect(invite.voiceCodeDigits).toBe(8);
+  });
+
+  test('voice invites do NOT return token in response', async () => {
+    const req = new Request('http://localhost/v1/ingress/invites', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sourceChannel: 'voice',
+        expectedExternalUserId: '+15551234567',
+      }),
+    });
+
+    const res = await handleCreateInvite(req);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(201);
+    const invite = body.invite as Record<string, unknown>;
+    // Voice invites must not expose the raw token — callers redeem via
+    // the identity-bound voice code flow
+    expect(invite.token).toBeUndefined();
+  });
+
+  test('POST /v1/ingress/invites/redeem-voice — redeems a voice invite code', async () => {
+    // Create a voice invite
+    const createRes = await handleCreateInvite(new Request('http://localhost/v1/ingress/invites', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sourceChannel: 'voice',
+        expectedExternalUserId: '+15551234567',
+        maxUses: 1,
+      }),
+    }));
+    const created = await createRes.json() as { invite: { voiceCode: string } };
+
+    // Redeem the voice code
+    const redeemReq = new Request('http://localhost/v1/ingress/invites/redeem-voice', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        callerExternalUserId: '+15551234567',
+        code: created.invite.voiceCode,
+      }),
+    });
+
+    const res = await handleRedeemVoiceInvite(redeemReq);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.type).toBe('redeemed');
+    expect(typeof body.memberId).toBe('string');
+    expect(typeof body.inviteId).toBe('string');
+  });
+
+  test('POST /v1/ingress/invites/redeem-voice — missing fields returns 400', async () => {
+    const req = new Request('http://localhost/v1/ingress/invites/redeem-voice', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ callerExternalUserId: '+15551234567' }),
+    });
+
+    const res = await handleRedeemVoiceInvite(req);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(400);
+    expect(body.ok).toBe(false);
+  });
+
+  test('POST /v1/ingress/invites/redeem-voice — wrong code returns 400', async () => {
+    // Create a voice invite
+    await handleCreateInvite(new Request('http://localhost/v1/ingress/invites', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sourceChannel: 'voice',
+        expectedExternalUserId: '+15551234567',
+        maxUses: 1,
+      }),
+    }));
+
+    const req = new Request('http://localhost/v1/ingress/invites/redeem-voice', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        callerExternalUserId: '+15551234567',
+        code: '000000',
+      }),
+    });
+
+    const res = await handleRedeemVoiceInvite(req);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(400);
+    expect(body.ok).toBe(false);
   });
 });

--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -1,0 +1,328 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'voice-invite-redemption-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { getSqlite, initializeDb, resetDb } from '../memory/db.js';
+import { createInvite, revokeInvite } from '../memory/ingress-invite-store.js';
+import { upsertMember } from '../memory/ingress-member-store.js';
+import { redeemVoiceInviteCode } from '../runtime/invite-redemption-service.js';
+import { generateVoiceCode, hashVoiceCode } from '../util/voice-code.js';
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+function resetTables() {
+  getSqlite().run('DELETE FROM assistant_ingress_members');
+  getSqlite().run('DELETE FROM assistant_ingress_invites');
+}
+
+// ---------------------------------------------------------------------------
+// generateVoiceCode
+// ---------------------------------------------------------------------------
+
+describe('generateVoiceCode', () => {
+  test('generates a code with the default 6 digits', () => {
+    const code = generateVoiceCode();
+    expect(code.length).toBe(6);
+    expect(/^\d{6}$/.test(code)).toBe(true);
+  });
+
+  test('generates a code with the requested digit count', () => {
+    for (const digits of [4, 5, 6, 7, 8, 9, 10]) {
+      const code = generateVoiceCode(digits);
+      expect(code.length).toBe(digits);
+      expect(new RegExp(`^\\d{${digits}}$`).test(code)).toBe(true);
+    }
+  });
+
+  test('throws for digit count below 4', () => {
+    expect(() => generateVoiceCode(3)).toThrow(/between 4 and 10/);
+  });
+
+  test('throws for digit count above 10', () => {
+    expect(() => generateVoiceCode(11)).toThrow(/between 4 and 10/);
+  });
+
+  test('produces different codes across multiple calls (randomness)', () => {
+    // Generate many codes and check that we don't get the same one every time.
+    // With 6 digits there are 900,000 possibilities, so getting 10 identical
+    // codes would be astronomically unlikely.
+    const codes = new Set<string>();
+    for (let i = 0; i < 10; i++) {
+      codes.add(generateVoiceCode());
+    }
+    // At least 2 distinct values in 10 tries
+    expect(codes.size).toBeGreaterThanOrEqual(2);
+  });
+
+  test('generated code is within the valid numeric range', () => {
+    for (let i = 0; i < 20; i++) {
+      const code = generateVoiceCode(6);
+      const num = parseInt(code, 10);
+      // 6 digits: range [100000, 999999]
+      expect(num).toBeGreaterThanOrEqual(100000);
+      expect(num).toBeLessThanOrEqual(999999);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hashVoiceCode
+// ---------------------------------------------------------------------------
+
+describe('hashVoiceCode', () => {
+  test('produces a deterministic hash', () => {
+    const code = '123456';
+    const hash1 = hashVoiceCode(code);
+    const hash2 = hashVoiceCode(code);
+    expect(hash1).toBe(hash2);
+  });
+
+  test('produces a hex-encoded SHA-256 hash (64 chars)', () => {
+    const hash = hashVoiceCode('654321');
+    expect(hash.length).toBe(64);
+    expect(/^[0-9a-f]{64}$/.test(hash)).toBe(true);
+  });
+
+  test('different codes produce different hashes', () => {
+    const hash1 = hashVoiceCode('111111');
+    const hash2 = hashVoiceCode('222222');
+    expect(hash1).not.toBe(hash2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// redeemVoiceInviteCode
+// ---------------------------------------------------------------------------
+
+describe('redeemVoiceInviteCode', () => {
+  beforeEach(resetTables);
+
+  /**
+   * Helper: create a voice invite with a known code and return the
+   * invite record plus the plaintext code.
+   */
+  function createVoiceInvite(opts: {
+    callerPhone?: string;
+    maxUses?: number;
+    expiresInMs?: number;
+    voiceCodeDigits?: number;
+    assistantId?: string;
+  } = {}) {
+    const digits = opts.voiceCodeDigits ?? 6;
+    const code = generateVoiceCode(digits);
+    const codeHash = hashVoiceCode(code);
+
+    const { invite } = createInvite({
+      assistantId: opts.assistantId ?? 'self',
+      sourceChannel: 'voice',
+      maxUses: opts.maxUses ?? 1,
+      expiresInMs: opts.expiresInMs,
+      expectedExternalUserId: opts.callerPhone ?? '+15551234567',
+      voiceCodeHash: codeHash,
+      voiceCodeDigits: digits,
+    });
+
+    return { invite, code };
+  }
+
+  test('happy path: correct caller + correct code redeems successfully', () => {
+    const phone = '+15551234567';
+    const { code } = createVoiceInvite({ callerPhone: phone });
+
+    const result = redeemVoiceInviteCode({
+      callerExternalUserId: phone,
+      sourceChannel: 'voice',
+      code,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result).toMatchObject({
+      ok: true,
+      type: 'redeemed',
+      memberId: expect.any(String),
+      inviteId: expect.any(String),
+    });
+  });
+
+  test('wrong caller identity fails with generic error', () => {
+    const { code } = createVoiceInvite({ callerPhone: '+15551234567' });
+
+    const result = redeemVoiceInviteCode({
+      callerExternalUserId: '+19999999999',
+      sourceChannel: 'voice',
+      code,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'invalid_or_expired' });
+  });
+
+  test('wrong code fails with generic error', () => {
+    createVoiceInvite({ callerPhone: '+15551234567' });
+
+    const result = redeemVoiceInviteCode({
+      callerExternalUserId: '+15551234567',
+      sourceChannel: 'voice',
+      code: '000000',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'invalid_or_expired' });
+  });
+
+  test('expired invite fails', () => {
+    const phone = '+15551234567';
+    const { code } = createVoiceInvite({ callerPhone: phone, expiresInMs: -1 });
+
+    const result = redeemVoiceInviteCode({
+      callerExternalUserId: phone,
+      sourceChannel: 'voice',
+      code,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'invalid_or_expired' });
+  });
+
+  test('max uses exhausted fails', () => {
+    const phone = '+15551234567';
+    const { code } = createVoiceInvite({ callerPhone: phone, maxUses: 1 });
+
+    // First redemption succeeds
+    const first = redeemVoiceInviteCode({
+      callerExternalUserId: phone,
+      sourceChannel: 'voice',
+      code,
+    });
+    expect(first.ok).toBe(true);
+
+    // Second redemption fails — max uses exhausted
+    const second = redeemVoiceInviteCode({
+      callerExternalUserId: phone,
+      sourceChannel: 'voice',
+      code,
+    });
+    expect(second).toEqual({ ok: false, reason: 'invalid_or_expired' });
+  });
+
+  test('revoked invite fails', () => {
+    const phone = '+15551234567';
+    const { invite, code } = createVoiceInvite({ callerPhone: phone });
+
+    revokeInvite(invite.id);
+
+    const result = redeemVoiceInviteCode({
+      callerExternalUserId: phone,
+      sourceChannel: 'voice',
+      code,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'invalid_or_expired' });
+  });
+
+  test('voice-only invite cannot be redeemed if sourceChannel on invite is not voice', () => {
+    // Create a non-voice invite with voice code metadata to simulate a
+    // hypothetical misconfiguration. The redemption service filters by
+    // sourceChannel='voice', so non-voice invites are invisible.
+    const code = generateVoiceCode(6);
+    const codeHash = hashVoiceCode(code);
+
+    createInvite({
+      sourceChannel: 'telegram',
+      maxUses: 1,
+      expectedExternalUserId: '+15551234567',
+      voiceCodeHash: codeHash,
+      voiceCodeDigits: 6,
+    });
+
+    const result = redeemVoiceInviteCode({
+      callerExternalUserId: '+15551234567',
+      sourceChannel: 'voice',
+      code,
+    });
+
+    // findActiveVoiceInvites filters by sourceChannel='voice', so the
+    // telegram invite won't be found.
+    expect(result).toEqual({ ok: false, reason: 'invalid_or_expired' });
+  });
+
+  test('already-member caller gets already_member outcome', () => {
+    const phone = '+15551234567';
+    const { code } = createVoiceInvite({ callerPhone: phone });
+
+    // Pre-create an active member for this phone on voice channel
+    upsertMember({
+      sourceChannel: 'voice',
+      externalUserId: phone,
+      status: 'active',
+      policy: 'allow',
+    });
+
+    const result = redeemVoiceInviteCode({
+      callerExternalUserId: phone,
+      sourceChannel: 'voice',
+      code,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result).toMatchObject({
+      ok: true,
+      type: 'already_member',
+      memberId: expect.any(String),
+    });
+  });
+
+  test('blocked member gets generic failure to avoid leaking membership status', () => {
+    const phone = '+15551234567';
+    const { code } = createVoiceInvite({ callerPhone: phone });
+
+    upsertMember({
+      sourceChannel: 'voice',
+      externalUserId: phone,
+      status: 'blocked',
+      policy: 'deny',
+    });
+
+    const result = redeemVoiceInviteCode({
+      callerExternalUserId: phone,
+      sourceChannel: 'voice',
+      code,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'invalid_or_expired' });
+  });
+
+  test('empty callerExternalUserId fails', () => {
+    const result = redeemVoiceInviteCode({
+      callerExternalUserId: '',
+      sourceChannel: 'voice',
+      code: '123456',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'invalid_or_expired' });
+  });
+});

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -10,6 +10,7 @@ import { randomInt } from 'node:crypto';
 
 import type { ServerWebSocket } from 'bun';
 
+import { isAssistantFeatureFlagEnabled } from '../config/assistant-feature-flags.js';
 import { getConfig } from '../config/loader.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { revokeScopedApprovalGrantsForContext } from '../memory/scoped-approval-grants.js';
@@ -505,29 +506,37 @@ export class RelayConnection {
         // Before denying, check if there is an active voice invite bound
         // to the caller's phone number. If so, enter the invite redemption
         // subflow instead of denying the call outright.
-        let voiceInvites: ReturnType<typeof findActiveVoiceInvites> = [];
-        try {
-          voiceInvites = findActiveVoiceInvites({
-            assistantId,
-            expectedExternalUserId: msg.from,
-          });
-        } catch (err) {
-          log.warn({ err, callSessionId: this.callSessionId }, 'Failed to check voice invites for unknown caller');
-        }
+        // Gated behind the voice-invite-redemption feature flag (defaults OFF).
+        const voiceInviteEnabled = isAssistantFeatureFlagEnabled(
+          'feature_flags.voice-invite-redemption.enabled',
+          config,
+        );
 
-        // Exclude invites that are past their expiresAt even if the DB
-        // status hasn't been lazily flipped to 'expired' yet.
-        const now = Date.now();
-        const nonExpiredInvites = voiceInvites.filter(i => !i.expiresAt || i.expiresAt > now);
+        if (voiceInviteEnabled) {
+          let voiceInvites: ReturnType<typeof findActiveVoiceInvites> = [];
+          try {
+            voiceInvites = findActiveVoiceInvites({
+              assistantId,
+              expectedExternalUserId: msg.from,
+            });
+          } catch (err) {
+            log.warn({ err, callSessionId: this.callSessionId }, 'Failed to check voice invites for unknown caller');
+          }
 
-        if (nonExpiredInvites.length > 0) {
-          log.info(
-            { callSessionId: this.callSessionId, from: msg.from },
-            'Inbound voice ACL: unknown caller has active voice invite — entering redemption flow',
-          );
-          const inviteCodeLength = Math.min(...nonExpiredInvites.map(i => i.voiceCodeDigits ?? 6));
-          this.startInviteRedemption(assistantId, msg.from, inviteCodeLength);
-          return;
+          // Exclude invites that are past their expiresAt even if the DB
+          // status hasn't been lazily flipped to 'expired' yet.
+          const now = Date.now();
+          const nonExpiredInvites = voiceInvites.filter(i => !i.expiresAt || i.expiresAt > now);
+
+          if (nonExpiredInvites.length > 0) {
+            log.info(
+              { callSessionId: this.callSessionId, from: msg.from },
+              'Inbound voice ACL: unknown caller has active voice invite — entering redemption flow',
+            );
+            const inviteCodeLength = Math.min(...nonExpiredInvites.map(i => i.voiceCodeDigits ?? 6));
+            this.startInviteRedemption(assistantId, msg.from, inviteCodeLength);
+            return;
+          }
         }
 
         log.info(

--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -50,6 +50,14 @@
       "defaultEnabled": true
     },
     {
+      "id": "voice-invite-redemption",
+      "scope": "assistant",
+      "key": "feature_flags.voice-invite-redemption.enabled",
+      "label": "Voice Invite Redemption",
+      "description": "Enable voice invite code redemption for inbound callers with active voice invites",
+      "defaultEnabled": false
+    },
+    {
       "id": "user-hosted-enabled",
       "scope": "macos",
       "key": "user_hosted_enabled",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -50,6 +50,14 @@
       "defaultEnabled": true
     },
     {
+      "id": "voice-invite-redemption",
+      "scope": "assistant",
+      "key": "feature_flags.voice-invite-redemption.enabled",
+      "label": "Voice Invite Redemption",
+      "description": "Enable voice invite code redemption for inbound callers with active voice invites",
+      "defaultEnabled": false
+    },
+    {
       "id": "user-hosted-enabled",
       "scope": "macos",
       "key": "user_hosted_enabled",


### PR DESCRIPTION
Add unit tests for voice code generation/hashing and redemption service, integration tests for voice invite API routes, update ARCHITECTURE.md with voice invite flow documentation, and add feature_flags.voice-invite-redemption.enabled guard in relay-server. Part of #10605.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
