### PR TITLE
Fix inline approval-consumed lifecycle with request-level terminal event

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1302,6 +1302,15 @@ exports[`IPC message snapshots ServerMessage types message_complete serializes t
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types message_request_complete serializes to expected JSON 1`] = `
+{
+  "requestId": "req-inline-001",
+  "runStillActive": true,
+  "sessionId": "sess-001",
+  "type": "message_request_complete",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types session_info serializes to expected JSON 1`] = `
 {
   "correlationId": "corr-001",

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -1,0 +1,263 @@
+import * as net from 'node:net';
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+import type { HandlerContext } from '../daemon/handlers.js';
+import type { UserMessage } from '../daemon/ipc-contract.js';
+import type { ServerMessage } from '../daemon/ipc-protocol.js';
+import { DebouncerMap } from '../util/debounce.js';
+
+const routeGuardianReplyMock = mock(async () => ({
+  consumed: false,
+  decisionApplied: false,
+  type: 'not_consumed' as const,
+})) as any;
+const listPendingByDestinationMock = mock(() => [] as Array<{ id: string; kind?: string }>);
+const listCanonicalMock = mock(() => [] as Array<{ id: string }>);
+const getByConversationMock = mock(() => [] as Array<{ requestId: string; kind: 'confirmation' | 'secret' }>);
+const addMessageMock = mock(async () => ({ id: 'persisted-message-id' }));
+const getConfigMock = mock(() => ({
+  daemon: { standaloneRecording: false },
+  secretDetection: { customPatterns: [], entropyThreshold: 3.5 },
+}));
+
+mock.module('../runtime/guardian-reply-router.js', () => ({
+  routeGuardianReply: routeGuardianReplyMock,
+}));
+
+mock.module('../memory/canonical-guardian-store.js', () => ({
+  listPendingCanonicalGuardianRequestsByDestinationConversation: listPendingByDestinationMock,
+  listCanonicalGuardianRequests: listCanonicalMock,
+}));
+
+mock.module('../runtime/pending-interactions.js', () => ({
+  getByConversation: getByConversationMock,
+}));
+
+mock.module('../memory/conversation-store.js', () => ({
+  addMessage: addMessageMock,
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: getConfigMock,
+}));
+
+mock.module('../daemon/approval-generators.js', () => ({
+  createApprovalConversationGenerator: () => async () => ({
+    disposition: 'keep_pending',
+    replyText: 'pending',
+  }),
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+import { handleUserMessage } from '../daemon/handlers/sessions.js';
+
+interface TestSession {
+  messages: Array<{ role: string; content: unknown[] }>;
+  hasEscalationHandler: () => boolean;
+  setChannelCapabilities: (caps: unknown) => void;
+  isProcessing: () => boolean;
+  hasAnyPendingConfirmation: () => boolean;
+  getQueueDepth: () => number;
+  denyAllPendingConfirmations: () => void;
+  enqueueMessage: (...args: unknown[]) => { queued: boolean; rejected?: boolean; requestId: string };
+  traceEmitter: { emit: (...args: unknown[]) => void };
+  setTurnChannelContext: (ctx: unknown) => void;
+  setTurnInterfaceContext: (ctx: unknown) => void;
+  setAssistantId: (assistantId: string) => void;
+  setGuardianContext: (ctx: unknown) => void;
+  setCommandIntent: (intent: unknown) => void;
+  processMessage: (...args: unknown[]) => Promise<string>;
+}
+
+function createContext(session: TestSession): { ctx: HandlerContext; sent: ServerMessage[] } {
+  const sent: ServerMessage[] = [];
+  const ctx: HandlerContext = {
+    sessions: new Map(),
+    socketToSession: new Map(),
+    cuSessions: new Map(),
+    socketToCuSession: new Map(),
+    cuObservationParseSequence: new Map(),
+    socketSandboxOverride: new Map(),
+    sharedRequestTimestamps: [],
+    debounceTimers: new DebouncerMap({ defaultDelayMs: 100 }),
+    suppressConfigReload: false,
+    setSuppressConfigReload: () => {},
+    updateConfigFingerprint: () => {},
+    send: (_socket, msg) => { sent.push(msg); },
+    broadcast: () => {},
+    clearAllSessions: () => 0,
+    getOrCreateSession: async () => session as any,
+    touchSession: () => {},
+  };
+  return { ctx, sent };
+}
+
+function makeMessage(content: string): UserMessage {
+  return {
+    type: 'user_message',
+    sessionId: 'conv-1',
+    content,
+    channel: 'vellum',
+    interface: 'macos',
+  };
+}
+
+function makeSession(overrides: Partial<TestSession> = {}): TestSession {
+  return {
+    messages: [],
+    hasEscalationHandler: () => true,
+    setChannelCapabilities: () => {},
+    isProcessing: () => false,
+    hasAnyPendingConfirmation: () => true,
+    getQueueDepth: () => 0,
+    denyAllPendingConfirmations: mock(() => {}),
+    enqueueMessage: mock(() => ({ queued: true, requestId: 'queued-id' })),
+    traceEmitter: { emit: () => {} },
+    setTurnChannelContext: () => {},
+    setTurnInterfaceContext: () => {},
+    setAssistantId: () => {},
+    setGuardianContext: () => {},
+    setCommandIntent: () => {},
+    processMessage: async () => 'msg-id',
+    ...overrides,
+  };
+}
+
+describe('handleUserMessage pending-confirmation reply interception', () => {
+  beforeEach(() => {
+    routeGuardianReplyMock.mockClear();
+    listPendingByDestinationMock.mockClear();
+    listCanonicalMock.mockClear();
+    getByConversationMock.mockClear();
+    addMessageMock.mockClear();
+    getConfigMock.mockClear();
+  });
+
+  test('consumes decision replies before auto-deny', async () => {
+    listPendingByDestinationMock.mockReturnValue([{ id: 'req-1', kind: 'tool_approval' }]);
+    listCanonicalMock.mockReturnValue([{ id: 'req-1' }]);
+    routeGuardianReplyMock.mockResolvedValue({
+      consumed: true,
+      decisionApplied: true,
+      type: 'canonical_decision_applied',
+      requestId: 'req-1',
+    });
+
+    const session = makeSession();
+    const { ctx, sent } = createContext(session);
+
+    await handleUserMessage(makeMessage('go for it'), {} as net.Socket, ctx);
+
+    expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
+    const routeCall = (routeGuardianReplyMock as any).mock.calls[0][0] as Record<string, unknown>;
+    expect(routeCall.messageText).toBe('go for it');
+    expect(typeof routeCall.approvalConversationGenerator).toBe('function');
+    expect((session.denyAllPendingConfirmations as any).mock.calls.length).toBe(0);
+    expect((session.enqueueMessage as any).mock.calls.length).toBe(0);
+    expect(session.messages).toHaveLength(2);
+    expect(session.messages[0]?.role).toBe('user');
+    expect(session.messages[1]?.role).toBe('assistant');
+    expect(addMessageMock).toHaveBeenCalledTimes(2);
+    expect(addMessageMock).toHaveBeenCalledWith(
+      'conv-1',
+      'user',
+      expect.any(String),
+      expect.objectContaining({
+        userMessageChannel: 'vellum',
+        assistantMessageChannel: 'vellum',
+        userMessageInterface: 'macos',
+        assistantMessageInterface: 'macos',
+        provenanceActorRole: 'guardian',
+      }),
+    );
+    expect(addMessageMock).toHaveBeenCalledWith(
+      'conv-1',
+      'assistant',
+      expect.stringContaining('Decision applied.'),
+      expect.objectContaining({
+        userMessageChannel: 'vellum',
+        assistantMessageChannel: 'vellum',
+        userMessageInterface: 'macos',
+        assistantMessageInterface: 'macos',
+        provenanceActorRole: 'guardian',
+      }),
+    );
+    expect(sent.map((msg) => msg.type)).toEqual([
+      'message_queued',
+      'message_dequeued',
+      'assistant_text_delta',
+      'message_request_complete',
+    ]);
+    const assistantDelta = sent.find(
+      (msg): msg is Extract<ServerMessage, { type: 'assistant_text_delta' }> => msg.type === 'assistant_text_delta',
+    );
+    expect(assistantDelta?.text).toBe('Decision applied.');
+    const requestComplete = sent.find(
+      (msg): msg is Extract<ServerMessage, { type: 'message_request_complete' }> => msg.type === 'message_request_complete',
+    );
+    expect(requestComplete?.runStillActive).toBe(false);
+  });
+
+  test('does not mutate in-memory history while processing', async () => {
+    listPendingByDestinationMock.mockReturnValue([{ id: 'req-1', kind: 'tool_approval' }]);
+    listCanonicalMock.mockReturnValue([{ id: 'req-1' }]);
+    routeGuardianReplyMock.mockResolvedValue({
+      consumed: true,
+      decisionApplied: true,
+      type: 'canonical_decision_applied',
+      requestId: 'req-1',
+    });
+
+    const session = makeSession({ isProcessing: () => true });
+    const { ctx, sent } = createContext(session);
+
+    await handleUserMessage(makeMessage('approve'), {} as net.Socket, ctx);
+
+    expect(addMessageMock).toHaveBeenCalledTimes(2);
+    expect(session.messages).toHaveLength(0);
+    const requestComplete = sent.find(
+      (msg): msg is Extract<ServerMessage, { type: 'message_request_complete' }> => msg.type === 'message_request_complete',
+    );
+    expect(requestComplete?.runStillActive).toBe(true);
+  });
+
+  test('nl keep_pending falls back to existing auto-deny + queue behavior', async () => {
+    listPendingByDestinationMock.mockReturnValue([{ id: 'req-1', kind: 'tool_approval' }]);
+    listCanonicalMock.mockReturnValue([{ id: 'req-1' }]);
+    routeGuardianReplyMock.mockResolvedValue({
+      consumed: true,
+      decisionApplied: false,
+      type: 'nl_keep_pending',
+      requestId: 'req-1',
+      replyText: 'Need clarification',
+    });
+
+    const session = makeSession();
+    const { ctx, sent } = createContext(session);
+
+    await handleUserMessage(makeMessage('what does that do?'), {} as net.Socket, ctx);
+
+    expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
+    expect((session.denyAllPendingConfirmations as any).mock.calls.length).toBe(1);
+    expect((session.enqueueMessage as any).mock.calls.length).toBe(1);
+    expect(session.messages).toHaveLength(0);
+    expect(addMessageMock).toHaveBeenCalledTimes(0);
+    expect(sent.some((msg) => msg.type === 'message_queued')).toBe(true);
+    expect(sent.some((msg) => msg.type === 'message_dequeued')).toBe(false);
+  });
+});

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -230,6 +230,14 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
 
     expect(addMessageMock).toHaveBeenCalledTimes(2);
     expect(session.messages).toHaveLength(0);
+    // assistant_text_delta must NOT be sent when the session is processing —
+    // it would contaminate the agent's in-flight streaming message on the client.
+    expect(sent.some((msg) => msg.type === 'assistant_text_delta')).toBe(false);
+    expect(sent.map((msg) => msg.type)).toEqual([
+      'message_queued',
+      'message_dequeued',
+      'message_request_complete',
+    ]);
     const requestComplete = sent.find(
       (msg): msg is Extract<ServerMessage, { type: 'message_request_complete' }> => msg.type === 'message_request_complete',
     );

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -830,6 +830,12 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
       { filename: 'chart.png', mimeType: 'image/png', data: 'iVBORw0K' },
     ],
   },
+  message_request_complete: {
+    type: 'message_request_complete',
+    sessionId: 'sess-001',
+    requestId: 'req-inline-001',
+    runStillActive: true,
+  },
   session_info: {
     type: 'session_info',
     sessionId: 'sess-001',
@@ -2178,6 +2184,13 @@ describe('IPC message snapshots', () => {
     test('message_complete has type field and optional sessionId', () => {
       const complete = serverMessages.message_complete;
       expect(complete.type).toBe('message_complete');
+    });
+
+    test('message_request_complete has sessionId and requestId fields', () => {
+      const complete = serverMessages.message_request_complete;
+      expect(complete.type).toBe('message_request_complete');
+      expect((complete as unknown as { sessionId: string }).sessionId).toBe('sess-001');
+      expect((complete as unknown as { requestId: string }).requestId).toBe('req-inline-001');
     });
   });
 

--- a/assistant/src/__tests__/runtime-events-sse-parity.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse-parity.test.ts
@@ -10,6 +10,7 @@
  *   - tool_input_delta
  *   - tool_output_chunk
  *   - tool_result
+ *   - message_request_complete (request-level terminal)
  *   - message_complete   (terminal)
  *   - generation_handoff (terminal)
  *   - generation_cancelled (terminal)
@@ -272,6 +273,24 @@ describe('SSE IPC parity — streaming/delta message types', () => {
     const event = await publishAndReadFrame('parity-message-complete-nosession', msg);
 
     expect(event.message.type).toBe('message_complete');
+  });
+
+  // ── message_request_complete (request-level terminal) ───────────────────
+
+  test('preserves message_request_complete payload', async () => {
+    const msg = {
+      type: 'message_request_complete' as const,
+      sessionId: 'conv-msg-request-complete',
+      requestId: 'req-123',
+      runStillActive: true,
+    };
+    const event = await publishAndReadFrame('parity-message-request-complete', msg);
+
+    expect(event.message.type).toBe('message_request_complete');
+    const m = event.message as typeof msg;
+    expect(m.sessionId).toBe('conv-msg-request-complete');
+    expect(m.requestId).toBe('req-123');
+    expect(m.runStillActive).toBe(true);
   });
 
   // ── generation_handoff (terminal) ────────────────────────────────────────

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -492,6 +492,18 @@ export async function startCli(): Promise<void> {
         break;
       }
 
+      case 'message_request_complete': {
+        // Request-level terminal for inline approval consumption.
+        // When no agent turn remains active, clear busy state and re-prompt.
+        if (msg.runStillActive === false) {
+          spinner.stop();
+          generating = false;
+          process.stdout.write('\n\n');
+          prompt();
+        }
+        break;
+      }
+
       case 'generation_handoff': {
         // The current request's generation is done; show usage and re-prompt.
         // Always clear `generating` — this CLI client's generation is finished

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -495,7 +495,7 @@ export async function startCli(): Promise<void> {
       case 'message_request_complete': {
         // Request-level terminal for inline approval consumption.
         // When no agent turn remains active, clear busy state and re-prompt.
-        if (msg.runStillActive === false) {
+        if (msg.runStillActive !== true) {
           spinner.stop();
           generating = false;
           process.stdout.write('\n\n');

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -2,18 +2,26 @@ import * as net from 'node:net';
 
 import { v4 as uuid } from 'uuid';
 
+import { createAssistantMessage, createUserMessage } from '../../agent/message-types.js';
 import { type InterfaceId,isChannelId, parseChannelId, parseInterfaceId } from '../../channels/types.js';
 import { getConfig } from '../../config/loader.js';
 import { getAttachmentsForMessage, getFilePathForAttachment, setAttachmentThumbnail } from '../../memory/attachments-store.js';
 import { getAttentionStateByConversationIds } from '../../memory/conversation-attention-store.js';
+import {
+  listCanonicalGuardianRequests,
+  listPendingCanonicalGuardianRequestsByDestinationConversation,
+} from '../../memory/canonical-guardian-store.js';
 import * as conversationStore from '../../memory/conversation-store.js';
 import { GENERATING_TITLE, queueGenerateConversationTitle, UNTITLED_FALLBACK } from '../../memory/conversation-title-service.js';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
+import { routeGuardianReply } from '../../runtime/guardian-reply-router.js';
+import * as pendingInteractions from '../../runtime/pending-interactions.js';
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { compileCustomPatterns, redactSecrets } from '../../security/secret-scanner.js';
 import { getSubagentManager } from '../../subagent/index.js';
 import { silentlyWithLog } from '../../util/silently.js';
 import { truncate } from '../../util/truncate.js';
+import { createApprovalConversationGenerator } from '../approval-generators.js';
 import { getAssistantName } from '../identity-helpers.js';
 import type { UserMessageAttachment } from '../ipc-contract.js';
 import type {
@@ -55,6 +63,8 @@ import {
   renderHistoryContent,
   wireEscalationHandler,
 } from './shared.js';
+
+const desktopApprovalConversationGenerator = createApprovalConversationGenerator();
 
 export async function handleUserMessage(
   msg: UserMessage,
@@ -451,8 +461,119 @@ export async function handleUserMessage(
       }
     }
 
+    // If exactly one live turn is waiting on confirmation (no queued turns),
+    // try to consume this text as an inline approval decision first.
+    if (
+      session.hasAnyPendingConfirmation()
+      && session.getQueueDepth() === 0
+      && messageText.trim().length > 0
+    ) {
+      try {
+        const pendingInteractionRequestIdsForConversation = pendingInteractions
+          .getByConversation(msg.sessionId)
+          .filter((interaction) => interaction.kind === 'confirmation')
+          .map((interaction) => interaction.requestId);
+
+        const pendingCanonicalRequestIdsForConversation = Array.from(new Set([
+          ...pendingInteractionRequestIdsForConversation,
+          ...listPendingCanonicalGuardianRequestsByDestinationConversation(msg.sessionId, ipcChannel)
+            .filter((request) => request.kind === 'tool_approval')
+            .map((request) => request.id),
+          ...listCanonicalGuardianRequests({
+            status: 'pending',
+            conversationId: msg.sessionId,
+            kind: 'tool_approval',
+          }).map((request) => request.id),
+        ]));
+
+        if (pendingCanonicalRequestIdsForConversation.length > 0) {
+          const routerResult = await routeGuardianReply({
+            messageText: messageText.trim(),
+            channel: ipcChannel,
+            actor: {
+              externalUserId: undefined,
+              channel: ipcChannel,
+              isTrusted: true,
+            },
+            conversationId: msg.sessionId,
+            pendingRequestIds: pendingCanonicalRequestIdsForConversation,
+            approvalConversationGenerator: desktopApprovalConversationGenerator,
+          });
+
+          if (routerResult.consumed && routerResult.type !== 'nl_keep_pending') {
+            const consumedChannelMeta = {
+              userMessageChannel: ipcChannel,
+              assistantMessageChannel: ipcChannel,
+              userMessageInterface: ipcInterface,
+              assistantMessageInterface: ipcInterface,
+              provenanceActorRole: 'guardian' as const,
+            };
+
+            const consumedUserMessage = createUserMessage(messageText, msg.attachments ?? []);
+            await conversationStore.addMessage(
+              msg.sessionId,
+              'user',
+              JSON.stringify(consumedUserMessage.content),
+              consumedChannelMeta,
+            );
+
+            const replyText = (routerResult.replyText?.trim())
+              || (routerResult.decisionApplied ? 'Decision applied.' : 'Request already resolved.');
+            const consumedAssistantMessage = createAssistantMessage(replyText);
+            await conversationStore.addMessage(
+              msg.sessionId,
+              'assistant',
+              JSON.stringify(consumedAssistantMessage.content),
+              consumedChannelMeta,
+            );
+            // Avoid mutating in-memory history while an agent loop is active;
+            // the loop owns history reconstruction for the in-flight turn.
+            if (!session.isProcessing()) {
+              // Keep in-memory history aligned with persisted transcript so
+              // session-history operations (undo/regenerate) target the same turn.
+              session.messages.push(consumedUserMessage, consumedAssistantMessage);
+            }
+
+            // Mirror the normal queued/dequeued lifecycle so desktop clients can
+            // reconcile queued bubble state for this just-sent user message.
+            ctx.send(socket, {
+              type: 'message_queued',
+              sessionId: msg.sessionId,
+              requestId,
+              position: 0,
+            });
+            ctx.send(socket, {
+              type: 'message_dequeued',
+              sessionId: msg.sessionId,
+              requestId,
+            });
+
+            ctx.send(socket, {
+              type: 'assistant_text_delta',
+              text: replyText,
+              sessionId: msg.sessionId,
+            });
+            ctx.send(socket, {
+              type: 'message_request_complete',
+              sessionId: msg.sessionId,
+              requestId,
+              runStillActive: session.isProcessing(),
+            });
+
+            rlog.info(
+              { routerType: routerResult.type, decisionApplied: routerResult.decisionApplied, routerRequestId: routerResult.requestId },
+              'Consumed pending-confirmation reply before auto-deny',
+            );
+            return;
+          }
+        }
+      } catch (err) {
+        rlog.warn({ err }, 'Failed to process pending-confirmation reply; falling back to auto-deny behavior');
+      }
+    }
+
     // If the session has a pending tool confirmation, auto-deny it so the
-    // agent can process the user's follow-up message instead.  The agent
+    // agent can process the user's follow-up message instead. The agent
     // will see the denial and can re-request the tool if still needed.
     if (session.hasAnyPendingConfirmation()) {
       rlog.info('Auto-denying pending confirmation(s) due to new user message');

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -548,11 +548,18 @@ export async function handleUserMessage(
               requestId,
             });
 
-            ctx.send(socket, {
-              type: 'assistant_text_delta',
-              text: replyText,
-              sessionId: msg.sessionId,
-            });
+            // Only emit the reply delta when no agent turn is in-flight.
+            // When the agent is active, currentAssistantMessageId on the client
+            // points to the agent's streaming message and this delta would
+            // contaminate it.  The reply is already persisted to the DB, so the
+            // client will see it on the next transcript reload / session switch.
+            if (!session.isProcessing()) {
+              ctx.send(socket, {
+                type: 'assistant_text_delta',
+                text: replyText,
+                sessionId: msg.sessionId,
+              });
+            }
             ctx.send(socket, {
               type: 'message_request_complete',
               sessionId: msg.sessionId,

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -267,6 +267,7 @@
     "message_dequeued",
     "message_queued",
     "message_queued_deleted",
+    "message_request_complete",
     "model_info",
     "navigate_settings",
     "notification_intent",

--- a/assistant/src/daemon/ipc-contract/messages.ts
+++ b/assistant/src/daemon/ipc-contract/messages.ts
@@ -173,6 +173,21 @@ export interface MessageDequeued {
   requestId: string;
 }
 
+/**
+ * Request-level terminal signal for a user message lifecycle.
+ *
+ * Unlike `message_complete`, this does not imply the active assistant turn
+ * has completed. It is used for paths that consume a request inline while a
+ * separate in-flight turn may still be running.
+ */
+export interface MessageRequestComplete {
+  type: 'message_request_complete';
+  sessionId: string;
+  requestId: string;
+  /** True when an existing turn is still running after this request is finalized. */
+  runStillActive?: boolean;
+}
+
 export interface MessageQueuedDeleted {
   type: 'message_queued_deleted';
   sessionId: string;
@@ -241,6 +256,7 @@ export type _MessagesServerMessages =
   | SecretDetected
   | MessageQueued
   | MessageDequeued
+  | MessageRequestComplete
   | MessageQueuedDeleted
   | SuggestionResponse
   | TraceEvent;

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -2375,6 +2375,82 @@ final class ChatViewModelTests: XCTestCase {
 
     // MARK: - Send Direct Queued Message
 
+    // MARK: - Streaming State Finalization on messageRequestComplete
+
+    func testMessageRequestCompleteFinalizesAssistantStream() {
+        // Simulate inline approval consumption: text delta creates an assistant
+        // message, then messageRequestComplete with runStillActive=false should
+        // flush the buffer and finalize the streaming state.
+        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        // Inline approval: queued → dequeued → text delta → request complete
+        viewModel.inputText = "approve"
+        viewModel.sendMessage()
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-approve", position: 0)))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-approve")))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Decision applied.")))
+
+        // Flush the buffer so the text lands on the message (simulates timer fire)
+        viewModel.flushStreamingBuffer()
+        let assistantIdx = viewModel.messages.firstIndex(where: { $0.role == .assistant })!
+        XCTAssertTrue(viewModel.messages[assistantIdx].isStreaming, "Should still be streaming before request complete")
+
+        // messageRequestComplete with runStillActive=false should finalize
+        viewModel.handleServerMessage(
+            .messageRequestComplete(
+                MessageRequestCompleteMessage(
+                    sessionId: "sess-1",
+                    requestId: "req-approve",
+                    runStillActive: false
+                )
+            )
+        )
+
+        XCTAssertFalse(viewModel.messages[assistantIdx].isStreaming, "Streaming should be finalized after request complete")
+        XCTAssertEqual(viewModel.messages[assistantIdx].text, "Decision applied.")
+        XCTAssertFalse(viewModel.isSending)
+        XCTAssertFalse(viewModel.isThinking)
+    }
+
+    func testMessageRequestCompletePreservesAgentStreamWhenRunStillActive() {
+        // When runStillActive=true, the agent's in-flight streaming message must
+        // NOT be finalized — the agent is still producing text deltas.
+        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        // Agent starts streaming its response
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Working on your request...")))
+        viewModel.flushStreamingBuffer()
+        let agentMsgIdx = viewModel.messages.firstIndex(where: { $0.role == .assistant })!
+        XCTAssertTrue(viewModel.messages[agentMsgIdx].isStreaming)
+
+        // Inline approval arrives mid-stream: queued → dequeued → request complete (no delta)
+        viewModel.inputText = "yes"
+        viewModel.sendMessage()
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-yes", position: 0)))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-yes")))
+        viewModel.handleServerMessage(
+            .messageRequestComplete(
+                MessageRequestCompleteMessage(
+                    sessionId: "sess-1",
+                    requestId: "req-yes",
+                    runStillActive: true
+                )
+            )
+        )
+
+        // The agent's assistant message should still be streaming
+        XCTAssertTrue(viewModel.messages[agentMsgIdx].isStreaming,
+                       "Agent's streaming message must not be finalized when runStillActive=true")
+        XCTAssertTrue(viewModel.isSending, "isSending should remain true while agent is active")
+        XCTAssertTrue(viewModel.isThinking, "isThinking should remain true while agent is active")
+    }
+
+    // MARK: - Send Direct Queued Message
+
     func testSendDirectQueuedMessageSavesContentAndStops() {
         // Set up a session with a sending state and a queued message
         viewModel.sessionId = "sess-1"

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -764,6 +764,69 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(messageBAfterComplete.status, .sent, "Message B should be .sent after messageComplete, not .processing")
     }
 
+    func testProcessingStatusResetToSentOnMessageRequestComplete() {
+        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
+        viewModel.inputText = "Message A"
+        viewModel.sendMessage()
+
+        viewModel.inputText = "Message B"
+        viewModel.sendMessage()
+
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to A")))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
+
+        let messageBAfterDequeue = viewModel.messages.first(where: { $0.text == "Message B" })!
+        XCTAssertEqual(messageBAfterDequeue.status, .processing)
+        XCTAssertTrue(viewModel.isSending)
+        XCTAssertTrue(viewModel.isThinking)
+
+        viewModel.handleServerMessage(
+            .messageRequestComplete(
+                MessageRequestCompleteMessage(
+                    sessionId: "sess-1",
+                    requestId: "req-B",
+                    runStillActive: false
+                )
+            )
+        )
+
+        let messageBAfterComplete = viewModel.messages.first(where: { $0.text == "Message B" })!
+        XCTAssertEqual(messageBAfterComplete.status, .sent, "Message B should be .sent after messageRequestComplete")
+        XCTAssertFalse(viewModel.isSending, "isSending should clear when request completed and no run remains active")
+        XCTAssertFalse(viewModel.isThinking, "isThinking should clear when request completed and no run remains active")
+    }
+
+    func testMessageRequestCompleteKeepsBusyStateWhenRunStillActive() {
+        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
+        viewModel.inputText = "Message A"
+        viewModel.sendMessage()
+
+        viewModel.inputText = "Message B"
+        viewModel.sendMessage()
+
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to A")))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
+
+        viewModel.handleServerMessage(
+            .messageRequestComplete(
+                MessageRequestCompleteMessage(
+                    sessionId: "sess-1",
+                    requestId: "req-B",
+                    runStillActive: true
+                )
+            )
+        )
+
+        let messageBAfterComplete = viewModel.messages.first(where: { $0.text == "Message B" })!
+        XCTAssertEqual(messageBAfterComplete.status, .sent, "Message B should be finalized even while another run remains active")
+        XCTAssertTrue(viewModel.isSending, "isSending should stay true while runStillActive is true")
+        XCTAssertTrue(viewModel.isThinking, "isThinking should stay true while runStillActive is true")
+    }
+
     func testProcessingStatusResetToSentOnGenerationCancelled() {
         viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
         viewModel.inputText = "Message A"

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -834,7 +834,14 @@ extension ChatViewModel {
                let index = messages.firstIndex(where: { $0.id == messageId }) {
                 activeRequestIdToMessageId[msg.requestId] = messageId
                 messages[index].status = .processing
-                currentTurnUserText = messages[index].text.trimmingCharacters(in: .whitespacesAndNewlines)
+                // Only update currentTurnUserText when no agent turn is already
+                // in-flight. Synthetic dequeues from inline approval consumption
+                // arrive while the agent owns currentTurnUserText; overwriting it
+                // with the approval text (e.g. "approve") would break the error
+                // handler's secret_blocked message lookup.
+                if currentAssistantMessageId == nil {
+                    currentTurnUserText = messages[index].text.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
                 // Clear attachment binary payloads now that the daemon has persisted them.
                 // Keep thumbnailImage for display; the full data can be re-fetched via HTTP if needed.
                 // Only clear for lazy-loadable attachments (sizeBytes != nil); locally-created
@@ -863,6 +870,21 @@ extension ChatViewModel {
                messages[index].role == .user,
                messages[index].status == .processing {
                 messages[index].status = .sent
+            }
+            // When no agent turn is in-flight, finalize the assistant message
+            // created by the preceding assistant_text_delta so it doesn't remain
+            // stuck in streaming state or cause subsequent deltas to append to it.
+            if msg.runStillActive != true {
+                flushStreamingBuffer()
+                if let existingId = currentAssistantMessageId,
+                   let index = messages.firstIndex(where: { $0.id == existingId }) {
+                    messages[index].isStreaming = false
+                    messages[index].streamingCodePreview = nil
+                    messages[index].streamingCodeToolName = nil
+                }
+                currentAssistantMessageId = nil
+                currentAssistantHasText = false
+                lastContentWasToolCall = false
             }
             if msg.runStillActive == false && pendingQueuedCount == 0 {
                 isSending = false

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -887,7 +887,7 @@ extension ChatViewModel {
                 currentAssistantHasText = false
                 lastContentWasToolCall = false
             }
-            if msg.runStillActive == false && pendingQueuedCount == 0 {
+            if msg.runStillActive != true && pendingQueuedCount == 0 {
                 isSending = false
                 isThinking = false
             }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -839,7 +839,10 @@ extension ChatViewModel {
                 // arrive while the agent owns currentTurnUserText; overwriting it
                 // with the approval text (e.g. "approve") would break the error
                 // handler's secret_blocked message lookup.
-                if currentAssistantMessageId == nil {
+                // Also guard on currentTurnUserText == nil to handle the case where
+                // the agent is processing but hasn't streamed text yet (so
+                // currentAssistantMessageId is still nil).
+                if currentAssistantMessageId == nil && currentTurnUserText == nil {
                     currentTurnUserText = messages[index].text.trimmingCharacters(in: .whitespacesAndNewlines)
                 }
                 // Clear attachment binary payloads now that the daemon has persisted them.

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -565,6 +565,7 @@ extension ChatViewModel {
                 pendingQueuedCount = 0
                 pendingMessageIds = []
                 requestIdToMessageId = [:]
+                activeRequestIdToMessageId = [:]
                 pendingLocalDeletions.removeAll()
                 for i in messages.indices {
                     if case .queued = messages[i].status, messages[i].role == .user {
@@ -690,6 +691,7 @@ extension ChatViewModel {
                     }
                 }
             }
+            activeRequestIdToMessageId.removeAll()
             dispatchPendingSendDirect()
             // Refresh guardian prompts on message completion (cheap consistency check)
             refreshGuardianPrompts()
@@ -753,6 +755,7 @@ extension ChatViewModel {
                 pendingQueuedCount = 0
                 pendingMessageIds = []
                 requestIdToMessageId = [:]
+                activeRequestIdToMessageId = [:]
                 pendingLocalDeletions.removeAll()
                 for i in messages.indices {
                     if case .queued = messages[i].status, messages[i].role == .user {
@@ -805,7 +808,9 @@ extension ChatViewModel {
             guard belongsToSession(msg.sessionId) else { return }
             pendingQueuedCount = max(0, pendingQueuedCount - 1)
             // Remove the message from the UI
-            if let messageId = requestIdToMessageId.removeValue(forKey: msg.requestId) {
+            let messageId = requestIdToMessageId.removeValue(forKey: msg.requestId)
+                ?? activeRequestIdToMessageId.removeValue(forKey: msg.requestId)
+            if let messageId {
                 messages.removeAll { $0.id == messageId }
             }
             // Recompute positions for remaining queued messages
@@ -827,6 +832,7 @@ extension ChatViewModel {
             // so assistantTextDelta tags the response correctly.
             if let messageId = requestIdToMessageId.removeValue(forKey: msg.requestId),
                let index = messages.firstIndex(where: { $0.id == messageId }) {
+                activeRequestIdToMessageId[msg.requestId] = messageId
                 messages[index].status = .processing
                 currentTurnUserText = messages[index].text.trimmingCharacters(in: .whitespacesAndNewlines)
                 // Clear attachment binary payloads now that the daemon has persisted them.
@@ -850,8 +856,24 @@ extension ChatViewModel {
             isThinking = true
             isSending = true
 
+        case .messageRequestComplete(let msg):
+            guard belongsToSession(msg.sessionId) else { return }
+            if let messageId = activeRequestIdToMessageId.removeValue(forKey: msg.requestId),
+               let index = messages.firstIndex(where: { $0.id == messageId }),
+               messages[index].role == .user,
+               messages[index].status == .processing {
+                messages[index].status = .sent
+            }
+            if msg.runStillActive == false && pendingQueuedCount == 0 {
+                isSending = false
+                isThinking = false
+            }
+
         case .generationHandoff(let handoff):
             guard belongsToSession(handoff.sessionId) else { return }
+            if let requestId = handoff.requestId {
+                activeRequestIdToMessageId.removeValue(forKey: requestId)
+            }
             isThinking = false
             // Flush buffered text so it lands on the current assistant message
             // before we clear the ID and hand off to the next queued turn.
@@ -965,6 +987,7 @@ extension ChatViewModel {
                         }
                         pendingMessageIds.removeAll { $0 == blockedMessageId }
                         requestIdToMessageId = requestIdToMessageId.filter { $0.value != blockedMessageId }
+                        activeRequestIdToMessageId = activeRequestIdToMessageId.filter { $0.value != blockedMessageId }
                         pendingLocalDeletions.remove(blockedMessageId)
                         messages.remove(at: blockedMessageIndex)
                     }
@@ -985,6 +1008,7 @@ extension ChatViewModel {
                 pendingQueuedCount = 0
                 pendingMessageIds = []
                 requestIdToMessageId = [:]
+                activeRequestIdToMessageId = [:]
                 for i in messages.indices {
                     if case .queued = messages[i].status, messages[i].role == .user {
                         messages[i].status = .sent
@@ -999,6 +1023,7 @@ extension ChatViewModel {
                 isSending = false
                 pendingMessageIds = []
                 requestIdToMessageId = [:]
+                activeRequestIdToMessageId = [:]
             }
 
         case .confirmationRequest(let msg):
@@ -1443,6 +1468,7 @@ extension ChatViewModel {
                 pendingQueuedCount = 0
                 pendingMessageIds = []
                 requestIdToMessageId = [:]
+                activeRequestIdToMessageId = [:]
                 for i in messages.indices {
                     if case .queued = messages[i].status, messages[i].role == .user {
                         messages[i].status = .sent
@@ -1471,6 +1497,7 @@ extension ChatViewModel {
                     // No queued work remains — safe to tear down everything.
                     pendingMessageIds = []
                     requestIdToMessageId = [:]
+                    activeRequestIdToMessageId = [:]
                 } else {
                     // The daemon drains queued work after a session_error
                     // (session.ts calls drainQueue in `finally`), so preserve

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -883,6 +883,7 @@ extension ChatViewModel {
                     messages[index].streamingCodeToolName = nil
                 }
                 currentAssistantMessageId = nil
+                currentTurnUserText = nil
                 currentAssistantHasText = false
                 lastContentWasToolCall = false
             }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -381,6 +381,8 @@ public final class ChatViewModel: ObservableObject {
     public var isCancelling: Bool = false
     /// Maps daemon requestId to the user message UUID in the messages array.
     var requestIdToMessageId: [String: UUID] = [:]
+    /// Maps requestId to the currently processing user message UUID after dequeue.
+    var activeRequestIdToMessageId: [String: UUID] = [:]
     /// FIFO queue of user message UUIDs awaiting requestId assignment from the daemon.
     var pendingMessageIds: [UUID] = []
     /// Messages deleted locally before the daemon's `message_queued` ack arrived.
@@ -797,6 +799,7 @@ public final class ChatViewModel: ObservableObject {
                 self?.pendingQueuedCount = 0
                 self?.pendingMessageIds.removeAll()
                 self?.requestIdToMessageId.removeAll()
+                self?.activeRequestIdToMessageId.removeAll()
                 self?.pendingLocalDeletions.removeAll()
                 // If a run was in progress when the connection dropped, the
                 // client may have missed the messageComplete (or the full
@@ -1454,6 +1457,7 @@ public final class ChatViewModel: ObservableObject {
             pendingQueuedCount = 0
             pendingMessageIds = []
             requestIdToMessageId = [:]
+            activeRequestIdToMessageId = [:]
             pendingLocalDeletions.removeAll()
             for i in messages.indices {
                 if case .queued = messages[i].status, messages[i].role == .user {
@@ -1499,6 +1503,7 @@ public final class ChatViewModel: ObservableObject {
             pendingQueuedCount = 0
             pendingMessageIds = []
             requestIdToMessageId = [:]
+            activeRequestIdToMessageId = [:]
             pendingLocalDeletions.removeAll()
             // Reset processing/queued messages to sent
             for i in messages.indices {
@@ -1561,6 +1566,7 @@ public final class ChatViewModel: ObservableObject {
             self.pendingQueuedCount = 0
             self.pendingMessageIds = []
             self.requestIdToMessageId = [:]
+            self.activeRequestIdToMessageId = [:]
             self.pendingLocalDeletions.removeAll()
             // Reset queued/processing messages to sent (matches other cancel-failure paths)
             for i in self.messages.indices {
@@ -1768,6 +1774,7 @@ public final class ChatViewModel: ObservableObject {
         pendingQueuedCount = 0
         pendingMessageIds = []
         requestIdToMessageId = [:]
+        activeRequestIdToMessageId = [:]
         pendingLocalDeletions.removeAll()
         for i in messages.indices {
             if case .queued = messages[i].status, messages[i].role == .user {

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -3019,6 +3019,20 @@ public struct IPCMessageDequeued: Codable, Sendable {
     }
 }
 
+public struct IPCMessageRequestComplete: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let requestId: String
+    public let runStillActive: Bool?
+
+    public init(type: String, sessionId: String, requestId: String, runStillActive: Bool? = nil) {
+        self.type = type
+        self.sessionId = sessionId
+        self.requestId = requestId
+        self.runStillActive = runStillActive
+    }
+}
+
 public struct IPCMessageQueued: Codable, Sendable {
     public let type: String
     public let sessionId: String

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1003,6 +1003,17 @@ extension IPCMessageDequeued {
     }
 }
 
+/// Request-level terminal signal for a queued/dequeued lifecycle.
+/// Does not imply the active assistant turn has completed.
+/// Backed by generated `IPCMessageRequestComplete`.
+public typealias MessageRequestCompleteMessage = IPCMessageRequestComplete
+
+extension IPCMessageRequestComplete {
+    public init(sessionId: String, requestId: String, runStillActive: Bool? = nil) {
+        self.init(type: "message_request_complete", sessionId: sessionId, requestId: requestId, runStillActive: runStillActive)
+    }
+}
+
 /// Notifies client that a queued message was successfully deleted.
 /// Backed by generated `IPCMessageQueuedDeleted`.
 public typealias MessageQueuedDeletedMessage = IPCMessageQueuedDeleted
@@ -2245,6 +2256,7 @@ public enum ServerMessage: Decodable, Sendable {
     case appDataResponse(AppDataResponseMessage)
     case messageQueued(MessageQueuedMessage)
     case messageDequeued(MessageDequeuedMessage)
+    case messageRequestComplete(MessageRequestCompleteMessage)
     case messageQueuedDeleted(MessageQueuedDeletedMessage)
     case skillsListResponse(SkillsListResponseMessage)
     case skillDetailResponse(SkillDetailResponseMessage)
@@ -2479,6 +2491,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "message_dequeued":
             let message = try MessageDequeuedMessage(from: decoder)
             self = .messageDequeued(message)
+        case "message_request_complete":
+            let message = try MessageRequestCompleteMessage(from: decoder)
+            self = .messageRequestComplete(message)
         case "message_queued_deleted":
             let message = try MessageQueuedDeletedMessage(from: decoder)
             self = .messageQueuedDeleted(message)


### PR DESCRIPTION
## Summary
- add a new server IPC message `message_request_complete` (`sessionId`, `requestId`, optional `runStillActive`) for request-level terminal signaling
- in `handleUserMessage`, when natural-language guardian reply is consumed inline, emit `message_queued` + `message_dequeued` + `assistant_text_delta` + `message_request_complete` (instead of relying on synthetic `message_complete` semantics)
- tighten pending-request targeting before routing inline decisions:
  - include `pending-interactions` confirmation request IDs for the session
  - restrict canonical lookups to `kind: tool_approval`
- wire the new message through shared Swift IPC decoding/types (`IPCContractGenerated.swift`, `IPCMessages.swift`)
- update chat request bookkeeping:
  - track active dequeued request IDs separately from queued request IDs
  - finalize only the matched processing user bubble on `message_request_complete`
  - clear `isSending`/`isThinking` only when `runStillActive == false` and queue is empty

## Why this angle
Review feedback on #10604 highlighted that consumed inline approval replies are request-terminal, not run-terminal. This change makes that distinction explicit in the IPC contract and client state machine so inline approvals cannot accidentally end an unrelated in-flight run.

## Tests
- `cd assistant && bun test src/__tests__/handlers-user-message-approval-consumption.test.ts`
- `cd assistant && bun test src/__tests__/runtime-events-sse-parity.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `cd clients/macos && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter 'ChatViewModelTests/testProcessingStatusResetToSentOnMessageRequestComplete|ChatViewModelTests/testMessageRequestCompleteKeepsBusyStateWhenRunStillActive'`

## Notes
- I also ran `swift test --filter ChatViewModelTests` and hit a pre-existing unrelated crash in `testErrorFinalizesStreamingAssistantMessage` (`Swift/ContiguousArrayBuffer.swift:600: Fatal error: Index out of range`).
- Apple refs checked (2026-02-28): no new Apple framework/API usage introduced; this PR changes chat IPC/state-machine behavior only.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
