### PR TITLE
fix: resolve $bunfs asset gaps for compiled Bun daemon binary

### DIFF
--- a/assistant/src/__tests__/bundled-asset.test.ts
+++ b/assistant/src/__tests__/bundled-asset.test.ts
@@ -1,0 +1,107 @@
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import { resolveBundledDir } from '../util/bundled-asset.js';
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = join(tmpdir(), `bundled-asset-test-${crypto.randomUUID()}`);
+  mkdirSync(tempDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('resolveBundledDir', () => {
+  test('source mode: returns join(callerDir, relativePath) when callerDir is a normal path', () => {
+    const result = resolveBundledDir('/some/source/path', 'templates', 'templates');
+    expect(result).toBe(join('/some/source/path', 'templates'));
+  });
+
+  test('source mode: does not check existsSync for the source path', () => {
+    // Even if the resolved path does not exist, it returns it as-is
+    const result = resolveBundledDir('/nonexistent/path', 'templates', 'templates');
+    expect(result).toBe(join('/nonexistent/path', 'templates'));
+  });
+
+  describe('compiled mode (/$bunfs/ prefix)', () => {
+    // In compiled mode, process.execPath determines fallback locations.
+    // We simulate by creating real directories at the expected fallback paths.
+
+    let savedExecPath: string;
+
+    beforeEach(() => {
+      savedExecPath = process.execPath;
+    });
+
+    afterEach(() => {
+      process.execPath = savedExecPath;
+    });
+
+    test('prefers Contents/Resources/<bundleName> when it exists', () => {
+      // Simulate macOS .app bundle: binary at Contents/MacOS/vellum-daemon
+      const macosDir = join(tempDir, 'Contents', 'MacOS');
+      const resourcesDir = join(tempDir, 'Contents', 'Resources');
+      mkdirSync(macosDir, { recursive: true });
+      mkdirSync(join(resourcesDir, 'templates'), { recursive: true });
+
+      process.execPath = join(macosDir, 'vellum-daemon');
+
+      const result = resolveBundledDir('/$bunfs/root/src/config', 'templates', 'templates');
+      expect(result).toBe(join(resourcesDir, 'templates'));
+    });
+
+    test('falls back to <execDir>/<bundleName> when Resources does not exist', () => {
+      // Simulate standalone binary deployment (no .app bundle)
+      const binDir = join(tempDir, 'bin');
+      mkdirSync(join(binDir, 'templates'), { recursive: true });
+
+      process.execPath = join(binDir, 'vellum-daemon');
+
+      const result = resolveBundledDir('/$bunfs/root/src/config', 'templates', 'templates');
+      expect(result).toBe(join(binDir, 'templates'));
+    });
+
+    test('falls back to source path when neither Resources nor execDir have the asset', () => {
+      const binDir = join(tempDir, 'bin');
+      mkdirSync(binDir, { recursive: true });
+      // Don't create any asset directories
+
+      process.execPath = join(binDir, 'vellum-daemon');
+
+      const result = resolveBundledDir('/$bunfs/root/src/config', 'templates', 'templates');
+      expect(result).toBe(join('/$bunfs/root/src/config', 'templates'));
+    });
+
+    test('Resources path takes priority over execDir path when both exist', () => {
+      const macosDir = join(tempDir, 'Contents', 'MacOS');
+      const resourcesDir = join(tempDir, 'Contents', 'Resources');
+      mkdirSync(macosDir, { recursive: true });
+      mkdirSync(join(resourcesDir, 'hook-templates'), { recursive: true });
+      // Also create at execDir level
+      mkdirSync(join(macosDir, 'hook-templates'), { recursive: true });
+
+      process.execPath = join(macosDir, 'vellum-daemon');
+
+      const result = resolveBundledDir('/$bunfs/root/src/hooks', '../../hook-templates', 'hook-templates');
+      expect(result).toBe(join(resourcesDir, 'hook-templates'));
+    });
+
+    test('works with different bundleName values', () => {
+      const macosDir = join(tempDir, 'Contents', 'MacOS');
+      const resourcesDir = join(tempDir, 'Contents', 'Resources');
+      mkdirSync(macosDir, { recursive: true });
+      mkdirSync(join(resourcesDir, 'prebuilt'), { recursive: true });
+
+      process.execPath = join(macosDir, 'vellum-daemon');
+
+      const result = resolveBundledDir('/$bunfs/root/src/home-base/prebuilt', '.', 'prebuilt');
+      expect(result).toBe(join(resourcesDir, 'prebuilt'));
+    });
+  });
+});

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 
 import type { ResponseTier } from '../daemon/response-tier.js';
 import { listCredentialMetadata } from '../tools/credentials/metadata-store.js';
+import { resolveBundledDir } from '../util/bundled-asset.js';
 import { getLogger } from '../util/logger.js';
 import { getWorkspaceDir, getWorkspacePromptPath, isMacOS } from '../util/platform.js';
 import { isAssistantFeatureFlagEnabled } from './assistant-feature-flags.js';
@@ -26,7 +27,7 @@ const PROMPT_FILES = ['SOUL.md', 'IDENTITY.md', 'USER.md'] as const;
  * signal that onboarding is complete.
  */
 export function ensurePromptFiles(): void {
-  const templatesDir = join(import.meta.dirname ?? __dirname, 'templates');
+  const templatesDir = resolveBundledDir(import.meta.dirname ?? __dirname, 'templates', 'templates');
 
   // Track whether this is a fresh workspace (no core prompt files exist yet).
   const isFirstRun = PROMPT_FILES.every(

--- a/assistant/src/config/update-bulletin-template-path.ts
+++ b/assistant/src/config/update-bulletin-template-path.ts
@@ -1,6 +1,9 @@
 import { join } from 'node:path';
 
+import { resolveBundledDir } from '../util/bundled-asset.js';
+
 /** Returns the path to the bundled UPDATES.md template. Extracted for testability. */
 export function getTemplatePath(): string {
-  return join(import.meta.dirname ?? __dirname, 'templates', 'UPDATES.md');
+  const dir = resolveBundledDir(import.meta.dirname ?? __dirname, 'templates', 'templates');
+  return join(dir, 'UPDATES.md');
 }

--- a/assistant/src/home-base/prebuilt/seed.ts
+++ b/assistant/src/home-base/prebuilt/seed.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { type AppDefinition,createApp, listApps } from '../../memory/app-store.js';
+import { resolveBundledDir } from '../../util/bundled-asset.js';
 import { getLogger } from '../../util/logger.js';
 import {
   HOME_BASE_PREBUILT_DESCRIPTION_PREFIX,
@@ -25,7 +26,7 @@ export interface PrebuiltHomeBaseTaskPayload {
 }
 
 function getPrebuiltDir(): string {
-  return import.meta.dirname ?? __dirname;
+  return resolveBundledDir(import.meta.dirname ?? __dirname, '.', 'prebuilt');
 }
 
 function loadSeedMetadata(): SeedMetadata {

--- a/assistant/src/hooks/templates.ts
+++ b/assistant/src/hooks/templates.ts
@@ -1,6 +1,7 @@
 import { chmodSync, cpSync, type Dirent,readdirSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { resolveBundledDir } from '../util/bundled-asset.js';
 import { pathExists } from '../util/fs.js';
 import { getLogger } from '../util/logger.js';
 import { getHooksDir } from '../util/platform.js';
@@ -15,7 +16,7 @@ const log = getLogger('hooks-templates');
  * - Newly installed hooks are disabled by default.
  */
 export function installTemplates(): void {
-  const templatesDir = join(import.meta.dirname ?? __dirname, '../../hook-templates');
+  const templatesDir = resolveBundledDir(import.meta.dirname ?? __dirname, '../../hook-templates', 'hook-templates');
   if (!pathExists(templatesDir)) return;
 
   const hooksDir = getHooksDir();

--- a/assistant/src/util/bundled-asset.ts
+++ b/assistant/src/util/bundled-asset.ts
@@ -1,0 +1,31 @@
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+/**
+ * Resolve the path to a bundled asset directory, handling compiled Bun binaries
+ * where `import.meta.dirname` points to the `/$bunfs/` virtual filesystem and
+ * non-JS files (.md, .html, .json, etc.) are not embedded.
+ *
+ * Falls back to:
+ *   1. `Contents/Resources/<bundleName>` (macOS .app bundle)
+ *   2. `<execDir>/<bundleName>` (next to the binary, non-app-bundle deployments)
+ *   3. Original resolved path (source mode, or last resort)
+ *
+ * This matches the pattern established by bundled-skills and WASM resolution.
+ *
+ * @param callerDir  `import.meta.dirname ?? __dirname` from the call site
+ * @param relativePath  Relative path from the source file (used in source/dev mode)
+ * @param bundleName  Name of the asset directory in the app bundle
+ */
+export function resolveBundledDir(callerDir: string, relativePath: string, bundleName: string): string {
+  if (callerDir.startsWith('/$bunfs/')) {
+    const execDir = dirname(process.execPath);
+    // macOS .app bundle: binary in Contents/MacOS/, resources in Contents/Resources/
+    const resourcesPath = join(execDir, '..', 'Resources', bundleName);
+    if (existsSync(resourcesPath)) return resourcesPath;
+    // Next to the binary itself (non-app-bundle deployments)
+    const execDirPath = join(execDir, bundleName);
+    if (existsSync(execDirPath)) return execDirPath;
+  }
+  return join(callerDir, relativePath);
+}

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -195,6 +195,14 @@ build_binaries() {
     # Copy bundled skills
     rm -rf "$SCRIPT_DIR/daemon-bin/bundled-skills"
     cp -R "$ASSISTANT_SRC_DIR/src/config/bundled-skills" "$SCRIPT_DIR/daemon-bin/bundled-skills"
+    # Copy non-JS assets not embedded by bun --compile (resolved via resolveBundledDir)
+    rm -rf "$SCRIPT_DIR/daemon-bin/templates"
+    cp -R "$ASSISTANT_SRC_DIR/src/config/templates" "$SCRIPT_DIR/daemon-bin/templates"
+    rm -rf "$SCRIPT_DIR/daemon-bin/hook-templates"
+    cp -R "$ASSISTANT_SRC_DIR/hook-templates" "$SCRIPT_DIR/daemon-bin/hook-templates"
+    rm -rf "$SCRIPT_DIR/daemon-bin/prebuilt"
+    mkdir -p "$SCRIPT_DIR/daemon-bin/prebuilt"
+    cp "$ASSISTANT_SRC_DIR/src/home-base/prebuilt/index.html" "$SCRIPT_DIR/daemon-bin/prebuilt/"
 
     # CLI
     build_bun_binary "$CLI_SRC_DIR" "$CLI_SRC_DIR/src/index.ts" \
@@ -362,6 +370,22 @@ if [ -d "$ASSISTANT_SRC_DIR/src/config/bundled-skills" ]; then
     cp -R "$ASSISTANT_SRC_DIR/src/config/bundled-skills" "$SCRIPT_DIR/daemon-bin/bundled-skills"
 fi
 
+# Always refresh non-JS assets from source (not embedded by bun --compile)
+mkdir -p "$SCRIPT_DIR/daemon-bin"
+if [ -d "$ASSISTANT_SRC_DIR/src/config/templates" ]; then
+    rm -rf "$SCRIPT_DIR/daemon-bin/templates"
+    cp -R "$ASSISTANT_SRC_DIR/src/config/templates" "$SCRIPT_DIR/daemon-bin/templates"
+fi
+if [ -d "$ASSISTANT_SRC_DIR/hook-templates" ]; then
+    rm -rf "$SCRIPT_DIR/daemon-bin/hook-templates"
+    cp -R "$ASSISTANT_SRC_DIR/hook-templates" "$SCRIPT_DIR/daemon-bin/hook-templates"
+fi
+if [ -f "$ASSISTANT_SRC_DIR/src/home-base/prebuilt/index.html" ]; then
+    rm -rf "$SCRIPT_DIR/daemon-bin/prebuilt"
+    mkdir -p "$SCRIPT_DIR/daemon-bin/prebuilt"
+    cp "$ASSISTANT_SRC_DIR/src/home-base/prebuilt/index.html" "$SCRIPT_DIR/daemon-bin/prebuilt/"
+fi
+
 # Also rebuild if daemon binary changed or newly added
 if [ -f "$SCRIPT_DIR/daemon-bin/vellum-daemon" ]; then
     if [ ! -f "$MACOS_DIR/vellum-daemon" ] || [ "$SCRIPT_DIR/daemon-bin/vellum-daemon" -nt "$MACOS_DIR/vellum-daemon" ]; then
@@ -492,6 +516,20 @@ fi
 if [ -d "$SCRIPT_DIR/daemon-bin/bundled-skills" ]; then
     rm -rf "$RESOURCES_DIR/bundled-skills"
     cp -R "$SCRIPT_DIR/daemon-bin/bundled-skills" "$RESOURCES_DIR/bundled-skills"
+fi
+
+# Always refresh non-JS assets in app bundle (not embedded by bun --compile)
+if [ -d "$SCRIPT_DIR/daemon-bin/templates" ]; then
+    rm -rf "$RESOURCES_DIR/templates"
+    cp -R "$SCRIPT_DIR/daemon-bin/templates" "$RESOURCES_DIR/templates"
+fi
+if [ -d "$SCRIPT_DIR/daemon-bin/hook-templates" ]; then
+    rm -rf "$RESOURCES_DIR/hook-templates"
+    cp -R "$SCRIPT_DIR/daemon-bin/hook-templates" "$RESOURCES_DIR/hook-templates"
+fi
+if [ -d "$SCRIPT_DIR/daemon-bin/prebuilt" ]; then
+    rm -rf "$RESOURCES_DIR/prebuilt"
+    cp -R "$SCRIPT_DIR/daemon-bin/prebuilt" "$RESOURCES_DIR/prebuilt"
 fi
 
 # Always refresh feature flag registry for the bundled gateway.


### PR DESCRIPTION
## Summary
- Compiled Bun binaries can't find non-JS assets (templates, hook-templates, prebuilt HTML) because `import.meta.dirname` resolves to `/$bunfs/` virtual filesystem — this broke retire→re-hatch and fresh installs from the macOS app
- Added shared `resolveBundledDir()` utility with `Contents/Resources/` and `execDir` fallbacks, matching the established bundled-skills and WASM resolution patterns
- Updated all 4 affected call sites and `build.sh` to bundle the assets in all three copy phases (full build, incremental refresh, app bundle)
- Added 7 unit tests for the new utility

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
