### PR TITLE
feat: lazy thread creation — only add to sidebar on first message

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -541,7 +541,7 @@ extension AppDelegate {
     @objc func openNewChat() {
         guard !isBootstrapping else { return }
         showMainWindow()
-        mainWindow?.threadManager.createThread()
+        mainWindow?.threadManager.enterDraftMode()
         UserDefaults.standard.set(false, forKey: "sidebarExpanded")
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -227,7 +227,7 @@ struct MainWindowView: View {
                 } else if let recent = threadManager.visibleThreads.first {
                     threadManager.selectThread(id: recent.id)
                 } else {
-                    threadManager.createThread()
+                    threadManager.enterDraftMode()
                 }
                 preTemporaryChatThreadId = nil
             } else {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -205,7 +205,7 @@ struct MainWindowView: View {
         } else {
             // Ensure a thread exists
             if threadManager.activeViewModel == nil {
-                threadManager.createThread()
+                threadManager.enterDraftMode()
             }
             windowState.selection = .panel(.voiceMode)
             // Activate directly — voiceInput was set on VoiceModeManager at MainWindow creation
@@ -1155,7 +1155,7 @@ struct MainWindowView: View {
                 },
                 onNewThread: {
                     windowState.selection = nil
-                    threadManager.createThread()
+                    threadManager.enterDraftMode()
                 }
             )
 
@@ -1329,7 +1329,7 @@ struct MainWindowView: View {
 
             SidebarNavRow(icon: "square.and.pencil", label: "New Chat", isActive: false, isExpanded: false) {
                 windowState.selection = nil
-                threadManager.createThread()
+                threadManager.enterDraftMode()
             }
 
             // MARK: Thread Section (collapsed)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -172,7 +172,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         // If we're in draft mode, promote the draft to a real thread so callers
         // get a guaranteed activeThreadId.
         if draftViewModel != nil, activeThreadId == nil {
-            promoteDraft()
+            promoteDraft(fromUserSend: false)
             return
         }
 
@@ -222,7 +222,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         // onUserMessageSent fires for all send types unlike onFirstUserMessage
         // which skips empty text and slash commands.
         viewModel.onUserMessageSent = { [weak self] in
-            self?.promoteDraft()
+            self?.promoteDraft(fromUserSend: true)
         }
         draftViewModel = viewModel
         activeThreadId = nil
@@ -230,8 +230,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         log.info("Entered draft mode")
     }
 
-    /// Promote the draft view model to a real thread (called on first user message).
-    private func promoteDraft() {
+    /// Promote the draft view model to a real thread.
+    /// - Parameter fromUserSend: true when triggered by a user message send,
+    ///   false when triggered by `createThread()` needing a guaranteed `activeThreadId`.
+    private func promoteDraft(fromUserSend: Bool) {
         guard let viewModel = draftViewModel else { return }
 
         let thread = ThreadModel(title: "Untitled")
@@ -245,12 +247,21 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         evictStaleCachedViewModels()
         draftViewModel = nil
 
+        // Increment only on actual user sends, not programmatic createThread() calls.
+        if fromUserSend {
+            completedConversationCount += 1
+        }
+
         // Wire up callbacks now that we have a real thread.
-        // completedConversationCount is incremented via onFirstUserMessage
-        // (not here) so createThread()-triggered promotions don't inflate it.
-        viewModel.onFirstUserMessage = { [weak self] _ in
-            self?.completedConversationCount += 1
-            self?.updateThreadTitle(id: threadId, title: "Untitled")
+        // onFirstUserMessage is already consumed for user-send promotions
+        // (it fires before onUserMessageSent in sendMessage), so only set it
+        // for createThread()-triggered promotions where no message was sent yet.
+        if !fromUserSend {
+            viewModel.onFirstUserMessage = { [weak self] _ in
+                self?.completedConversationCount += 1
+                self?.updateThreadTitle(id: threadId, title: "Untitled")
+                self?.updateLastInteracted(threadId: threadId)
+            }
         }
         viewModel.onUserMessageSent = { [weak self] in
             self?.updateLastInteracted(threadId: threadId)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -30,6 +30,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     @Published var activeThreadId: UUID? {
         didSet {
             if let activeThreadId {
+                // Switching to a real thread discards any draft
+                draftViewModel = nil
+
                 let activeViewModel = getOrCreateViewModel(for: activeThreadId)
                 activeViewModel?.ensureMessageLoopStarted()
                 sessionRestorer.loadHistoryIfNeeded(threadId: activeThreadId)
@@ -57,6 +60,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
     }
 
+    @Published private(set) var draftViewModel: ChatViewModel?
     private var chatViewModels: [UUID: ChatViewModel] = [:]
     /// Maximum number of ChatViewModels to keep in memory. When this limit is
     /// exceeded, the least-recently-accessed VM (that isn't the active thread) is
@@ -136,6 +140,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     var activeViewModel: ChatViewModel? {
+        if activeThreadId == nil, let draftViewModel {
+            return draftViewModel
+        }
         guard let activeThreadId else { return nil }
         return getOrCreateViewModel(for: activeThreadId)
     }
@@ -150,13 +157,21 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         // On normal launches, suppress writes during restoration so the saved
         // value isn't overwritten before restoreLastActiveThread() reads it.
         self.isRestoringThreads = !isFirstLaunch
-        // Create one default thread so the window is never empty
-        createThread()
+        // Enter draft mode so the window shows an empty chat without a sidebar entry
+        enterDraftMode()
         sessionRestorer.delegate = self
         sessionRestorer.startObserving(skipInitialFetch: isFirstLaunch)
     }
 
     func createThread() {
+        // If we're in draft mode with an empty draft, just reuse it.
+        if let draftVM = draftViewModel, draftVM.messages.isEmpty, activeThreadId == nil {
+            return
+        }
+
+        // Discard any existing draft when creating a real thread
+        draftViewModel = nil
+
         // If the active thread is still empty, just keep it instead of creating another.
         // Only reuse when the thread is truly fresh: no messages at all, no persisted
         // session, and not a private thread (which have different persistence semantics).
@@ -187,6 +202,44 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         evictStaleCachedViewModels()
         activeThreadId = thread.id
         log.info("Created thread \(thread.id) with title \"\(thread.title)\"")
+    }
+
+    /// Enter draft mode: show an empty chat without creating a sidebar thread.
+    /// The thread is only created when the user sends their first message.
+    func enterDraftMode() {
+        // If already in draft mode with an empty draft, no-op (reuse existing draft)
+        if let draftVM = draftViewModel, draftVM.messages.isEmpty, activeThreadId == nil {
+            return
+        }
+
+        let viewModel = makeViewModel()
+        viewModel.isHistoryLoaded = true  // No session yet — nothing to load
+        viewModel.onFirstUserMessage = { [weak self] _ in
+            self?.promoteDraft()
+        }
+        draftViewModel = viewModel
+        activeThreadId = nil
+        subscribeToActiveViewModel()
+        log.info("Entered draft mode")
+    }
+
+    /// Promote the draft view model to a real thread (called on first user message).
+    private func promoteDraft() {
+        guard let viewModel = draftViewModel else { return }
+
+        let thread = ThreadModel(title: "Untitled")
+        threads.insert(thread, at: 0)
+        chatViewModels[thread.id] = viewModel
+        subscribeToBusyState(for: thread.id, viewModel: viewModel)
+        subscribeToAssistantActivity(for: thread.id, viewModel: viewModel)
+        subscribeToInteractionState(for: thread.id, viewModel: viewModel)
+        touchVMAccessOrder(thread.id)
+        evictStaleCachedViewModels()
+        draftViewModel = nil
+        completedConversationCount += 1
+        activeThreadId = thread.id
+        updateLastInteracted(threadId: thread.id)
+        log.info("Promoted draft to thread \(thread.id)")
     }
 
     func createPrivateThread() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -53,7 +53,12 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                     }
                 }
             } else {
-                lastActiveThreadIdString = nil
+                // Only clear the persisted thread ID outside of restoration.
+                // During init, enterDraftMode() sets activeThreadId = nil before
+                // restoreLastActiveThread() reads the saved value.
+                if !isRestoringThreads {
+                    lastActiveThreadIdString = nil
+                }
             }
             // Subscribe to the new active view model's changes
             subscribeToActiveViewModel()
@@ -164,13 +169,12 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     func createThread() {
-        // If we're in draft mode with an empty draft, just reuse it.
-        if let draftVM = draftViewModel, draftVM.messages.isEmpty, activeThreadId == nil {
+        // If we're in draft mode, promote the draft to a real thread so callers
+        // get a guaranteed activeThreadId.
+        if draftViewModel != nil, activeThreadId == nil {
+            promoteDraft()
             return
         }
-
-        // Discard any existing draft when creating a real thread
-        draftViewModel = nil
 
         // If the active thread is still empty, just keep it instead of creating another.
         // Only reuse when the thread is truly fresh: no messages at all, no persisted

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -218,7 +218,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
         let viewModel = makeViewModel()
         viewModel.isHistoryLoaded = true  // No session yet — nothing to load
-        viewModel.onFirstUserMessage = { [weak self] _ in
+        // Promote on any first send (text, attachment, slash command).
+        // onUserMessageSent fires for all send types unlike onFirstUserMessage
+        // which skips empty text and slash commands.
+        viewModel.onUserMessageSent = { [weak self] in
             self?.promoteDraft()
         }
         draftViewModel = viewModel
@@ -232,6 +235,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         guard let viewModel = draftViewModel else { return }
 
         let thread = ThreadModel(title: "Untitled")
+        let threadId = thread.id
         threads.insert(thread, at: 0)
         chatViewModels[thread.id] = viewModel
         subscribeToBusyState(for: thread.id, viewModel: viewModel)
@@ -240,7 +244,18 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         touchVMAccessOrder(thread.id)
         evictStaleCachedViewModels()
         draftViewModel = nil
-        completedConversationCount += 1
+
+        // Wire up callbacks now that we have a real thread.
+        // completedConversationCount is incremented via onFirstUserMessage
+        // (not here) so createThread()-triggered promotions don't inflate it.
+        viewModel.onFirstUserMessage = { [weak self] _ in
+            self?.completedConversationCount += 1
+            self?.updateThreadTitle(id: threadId, title: "Untitled")
+        }
+        viewModel.onUserMessageSent = { [weak self] in
+            self?.updateLastInteracted(threadId: threadId)
+        }
+
         activeThreadId = thread.id
         updateLastInteracted(threadId: thread.id)
         log.info("Promoted draft to thread \(thread.id)")


### PR DESCRIPTION
## Summary
- Clicking "+" or "New Chat" now enters a **draft mode** with an empty `ChatViewModel` instead of immediately creating a `ThreadModel` in the sidebar
- The thread only materializes in the sidebar when the user sends their first message, matching ChatGPT/Claude.ai behavior
- Eliminates phantom "New Conversation" entries from clicking "+" without typing

## Changes
- **ThreadManager.swift**: Added `draftViewModel` property, `enterDraftMode()` and `promoteDraft()` methods. Modified `activeViewModel` to return draft VM when in draft mode. Updated `activeThreadId` didSet to discard draft on thread switch. Changed init to use draft mode instead of creating a thread.
- **MainWindowView.swift**: Changed 3 "new chat" entry points ("+", sidebar "New Chat", voice mode fallback) to use `enterDraftMode()`
- **AppDelegate+MenuBar.swift**: Changed menu bar "New Chat" to use `enterDraftMode()`

## Test plan
- [ ] Click "+" → empty chat shown, NO new entry in sidebar
- [ ] Type and send a message → thread appears in sidebar as "Untitled"
- [ ] Click "+" again while draft is empty → stays on same empty draft (no-op)
- [ ] Click "+" while current thread has messages → new empty draft, no sidebar entry
- [ ] Switch to existing thread in sidebar → draft is discarded
- [ ] Voice mode activation without active thread → works with draft VM
- [ ] App restart → no phantom "New Conversation" threads in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
