### PR TITLE
Fix inline approval streaming state contamination

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1302,6 +1302,15 @@ exports[`IPC message snapshots ServerMessage types message_complete serializes t
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types message_request_complete serializes to expected JSON 1`] = `
+{
+  "requestId": "req-inline-001",
+  "runStillActive": true,
+  "sessionId": "sess-001",
+  "type": "message_request_complete",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types session_info serializes to expected JSON 1`] = `
 {
   "correlationId": "corr-001",

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -1,0 +1,263 @@
+import * as net from 'node:net';
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+import type { HandlerContext } from '../daemon/handlers.js';
+import type { UserMessage } from '../daemon/ipc-contract.js';
+import type { ServerMessage } from '../daemon/ipc-protocol.js';
+import { DebouncerMap } from '../util/debounce.js';
+
+const routeGuardianReplyMock = mock(async () => ({
+  consumed: false,
+  decisionApplied: false,
+  type: 'not_consumed' as const,
+})) as any;
+const listPendingByDestinationMock = mock(() => [] as Array<{ id: string; kind?: string }>);
+const listCanonicalMock = mock(() => [] as Array<{ id: string }>);
+const getByConversationMock = mock(() => [] as Array<{ requestId: string; kind: 'confirmation' | 'secret' }>);
+const addMessageMock = mock(async () => ({ id: 'persisted-message-id' }));
+const getConfigMock = mock(() => ({
+  daemon: { standaloneRecording: false },
+  secretDetection: { customPatterns: [], entropyThreshold: 3.5 },
+}));
+
+mock.module('../runtime/guardian-reply-router.js', () => ({
+  routeGuardianReply: routeGuardianReplyMock,
+}));
+
+mock.module('../memory/canonical-guardian-store.js', () => ({
+  listPendingCanonicalGuardianRequestsByDestinationConversation: listPendingByDestinationMock,
+  listCanonicalGuardianRequests: listCanonicalMock,
+}));
+
+mock.module('../runtime/pending-interactions.js', () => ({
+  getByConversation: getByConversationMock,
+}));
+
+mock.module('../memory/conversation-store.js', () => ({
+  addMessage: addMessageMock,
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: getConfigMock,
+}));
+
+mock.module('../daemon/approval-generators.js', () => ({
+  createApprovalConversationGenerator: () => async () => ({
+    disposition: 'keep_pending',
+    replyText: 'pending',
+  }),
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+import { handleUserMessage } from '../daemon/handlers/sessions.js';
+
+interface TestSession {
+  messages: Array<{ role: string; content: unknown[] }>;
+  hasEscalationHandler: () => boolean;
+  setChannelCapabilities: (caps: unknown) => void;
+  isProcessing: () => boolean;
+  hasAnyPendingConfirmation: () => boolean;
+  getQueueDepth: () => number;
+  denyAllPendingConfirmations: () => void;
+  enqueueMessage: (...args: unknown[]) => { queued: boolean; rejected?: boolean; requestId: string };
+  traceEmitter: { emit: (...args: unknown[]) => void };
+  setTurnChannelContext: (ctx: unknown) => void;
+  setTurnInterfaceContext: (ctx: unknown) => void;
+  setAssistantId: (assistantId: string) => void;
+  setGuardianContext: (ctx: unknown) => void;
+  setCommandIntent: (intent: unknown) => void;
+  processMessage: (...args: unknown[]) => Promise<string>;
+}
+
+function createContext(session: TestSession): { ctx: HandlerContext; sent: ServerMessage[] } {
+  const sent: ServerMessage[] = [];
+  const ctx: HandlerContext = {
+    sessions: new Map(),
+    socketToSession: new Map(),
+    cuSessions: new Map(),
+    socketToCuSession: new Map(),
+    cuObservationParseSequence: new Map(),
+    socketSandboxOverride: new Map(),
+    sharedRequestTimestamps: [],
+    debounceTimers: new DebouncerMap({ defaultDelayMs: 100 }),
+    suppressConfigReload: false,
+    setSuppressConfigReload: () => {},
+    updateConfigFingerprint: () => {},
+    send: (_socket, msg) => { sent.push(msg); },
+    broadcast: () => {},
+    clearAllSessions: () => 0,
+    getOrCreateSession: async () => session as any,
+    touchSession: () => {},
+  };
+  return { ctx, sent };
+}
+
+function makeMessage(content: string): UserMessage {
+  return {
+    type: 'user_message',
+    sessionId: 'conv-1',
+    content,
+    channel: 'vellum',
+    interface: 'macos',
+  };
+}
+
+function makeSession(overrides: Partial<TestSession> = {}): TestSession {
+  return {
+    messages: [],
+    hasEscalationHandler: () => true,
+    setChannelCapabilities: () => {},
+    isProcessing: () => false,
+    hasAnyPendingConfirmation: () => true,
+    getQueueDepth: () => 0,
+    denyAllPendingConfirmations: mock(() => {}),
+    enqueueMessage: mock(() => ({ queued: true, requestId: 'queued-id' })),
+    traceEmitter: { emit: () => {} },
+    setTurnChannelContext: () => {},
+    setTurnInterfaceContext: () => {},
+    setAssistantId: () => {},
+    setGuardianContext: () => {},
+    setCommandIntent: () => {},
+    processMessage: async () => 'msg-id',
+    ...overrides,
+  };
+}
+
+describe('handleUserMessage pending-confirmation reply interception', () => {
+  beforeEach(() => {
+    routeGuardianReplyMock.mockClear();
+    listPendingByDestinationMock.mockClear();
+    listCanonicalMock.mockClear();
+    getByConversationMock.mockClear();
+    addMessageMock.mockClear();
+    getConfigMock.mockClear();
+  });
+
+  test('consumes decision replies before auto-deny', async () => {
+    listPendingByDestinationMock.mockReturnValue([{ id: 'req-1', kind: 'tool_approval' }]);
+    listCanonicalMock.mockReturnValue([{ id: 'req-1' }]);
+    routeGuardianReplyMock.mockResolvedValue({
+      consumed: true,
+      decisionApplied: true,
+      type: 'canonical_decision_applied',
+      requestId: 'req-1',
+    });
+
+    const session = makeSession();
+    const { ctx, sent } = createContext(session);
+
+    await handleUserMessage(makeMessage('go for it'), {} as net.Socket, ctx);
+
+    expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
+    const routeCall = (routeGuardianReplyMock as any).mock.calls[0][0] as Record<string, unknown>;
+    expect(routeCall.messageText).toBe('go for it');
+    expect(typeof routeCall.approvalConversationGenerator).toBe('function');
+    expect((session.denyAllPendingConfirmations as any).mock.calls.length).toBe(0);
+    expect((session.enqueueMessage as any).mock.calls.length).toBe(0);
+    expect(session.messages).toHaveLength(2);
+    expect(session.messages[0]?.role).toBe('user');
+    expect(session.messages[1]?.role).toBe('assistant');
+    expect(addMessageMock).toHaveBeenCalledTimes(2);
+    expect(addMessageMock).toHaveBeenCalledWith(
+      'conv-1',
+      'user',
+      expect.any(String),
+      expect.objectContaining({
+        userMessageChannel: 'vellum',
+        assistantMessageChannel: 'vellum',
+        userMessageInterface: 'macos',
+        assistantMessageInterface: 'macos',
+        provenanceActorRole: 'guardian',
+      }),
+    );
+    expect(addMessageMock).toHaveBeenCalledWith(
+      'conv-1',
+      'assistant',
+      expect.stringContaining('Decision applied.'),
+      expect.objectContaining({
+        userMessageChannel: 'vellum',
+        assistantMessageChannel: 'vellum',
+        userMessageInterface: 'macos',
+        assistantMessageInterface: 'macos',
+        provenanceActorRole: 'guardian',
+      }),
+    );
+    expect(sent.map((msg) => msg.type)).toEqual([
+      'message_queued',
+      'message_dequeued',
+      'assistant_text_delta',
+      'message_request_complete',
+    ]);
+    const assistantDelta = sent.find(
+      (msg): msg is Extract<ServerMessage, { type: 'assistant_text_delta' }> => msg.type === 'assistant_text_delta',
+    );
+    expect(assistantDelta?.text).toBe('Decision applied.');
+    const requestComplete = sent.find(
+      (msg): msg is Extract<ServerMessage, { type: 'message_request_complete' }> => msg.type === 'message_request_complete',
+    );
+    expect(requestComplete?.runStillActive).toBe(false);
+  });
+
+  test('does not mutate in-memory history while processing', async () => {
+    listPendingByDestinationMock.mockReturnValue([{ id: 'req-1', kind: 'tool_approval' }]);
+    listCanonicalMock.mockReturnValue([{ id: 'req-1' }]);
+    routeGuardianReplyMock.mockResolvedValue({
+      consumed: true,
+      decisionApplied: true,
+      type: 'canonical_decision_applied',
+      requestId: 'req-1',
+    });
+
+    const session = makeSession({ isProcessing: () => true });
+    const { ctx, sent } = createContext(session);
+
+    await handleUserMessage(makeMessage('approve'), {} as net.Socket, ctx);
+
+    expect(addMessageMock).toHaveBeenCalledTimes(2);
+    expect(session.messages).toHaveLength(0);
+    const requestComplete = sent.find(
+      (msg): msg is Extract<ServerMessage, { type: 'message_request_complete' }> => msg.type === 'message_request_complete',
+    );
+    expect(requestComplete?.runStillActive).toBe(true);
+  });
+
+  test('nl keep_pending falls back to existing auto-deny + queue behavior', async () => {
+    listPendingByDestinationMock.mockReturnValue([{ id: 'req-1', kind: 'tool_approval' }]);
+    listCanonicalMock.mockReturnValue([{ id: 'req-1' }]);
+    routeGuardianReplyMock.mockResolvedValue({
+      consumed: true,
+      decisionApplied: false,
+      type: 'nl_keep_pending',
+      requestId: 'req-1',
+      replyText: 'Need clarification',
+    });
+
+    const session = makeSession();
+    const { ctx, sent } = createContext(session);
+
+    await handleUserMessage(makeMessage('what does that do?'), {} as net.Socket, ctx);
+
+    expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
+    expect((session.denyAllPendingConfirmations as any).mock.calls.length).toBe(1);
+    expect((session.enqueueMessage as any).mock.calls.length).toBe(1);
+    expect(session.messages).toHaveLength(0);
+    expect(addMessageMock).toHaveBeenCalledTimes(0);
+    expect(sent.some((msg) => msg.type === 'message_queued')).toBe(true);
+    expect(sent.some((msg) => msg.type === 'message_dequeued')).toBe(false);
+  });
+});

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -230,6 +230,15 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
 
     expect(addMessageMock).toHaveBeenCalledTimes(2);
     expect(session.messages).toHaveLength(0);
+    // assistant_text_delta must NOT be sent when the session is processing;
+    // the client's currentAssistantMessageId points to the agent's in-flight
+    // message and the delta would contaminate it.
+    expect(sent.some((msg) => msg.type === 'assistant_text_delta')).toBe(false);
+    expect(sent.map((msg) => msg.type)).toEqual([
+      'message_queued',
+      'message_dequeued',
+      'message_request_complete',
+    ]);
     const requestComplete = sent.find(
       (msg): msg is Extract<ServerMessage, { type: 'message_request_complete' }> => msg.type === 'message_request_complete',
     );

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -830,6 +830,12 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
       { filename: 'chart.png', mimeType: 'image/png', data: 'iVBORw0K' },
     ],
   },
+  message_request_complete: {
+    type: 'message_request_complete',
+    sessionId: 'sess-001',
+    requestId: 'req-inline-001',
+    runStillActive: true,
+  },
   session_info: {
     type: 'session_info',
     sessionId: 'sess-001',
@@ -2178,6 +2184,13 @@ describe('IPC message snapshots', () => {
     test('message_complete has type field and optional sessionId', () => {
       const complete = serverMessages.message_complete;
       expect(complete.type).toBe('message_complete');
+    });
+
+    test('message_request_complete has sessionId and requestId fields', () => {
+      const complete = serverMessages.message_request_complete;
+      expect(complete.type).toBe('message_request_complete');
+      expect((complete as unknown as { sessionId: string }).sessionId).toBe('sess-001');
+      expect((complete as unknown as { requestId: string }).requestId).toBe('req-inline-001');
     });
   });
 

--- a/assistant/src/__tests__/runtime-events-sse-parity.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse-parity.test.ts
@@ -10,6 +10,7 @@
  *   - tool_input_delta
  *   - tool_output_chunk
  *   - tool_result
+ *   - message_request_complete (request-level terminal)
  *   - message_complete   (terminal)
  *   - generation_handoff (terminal)
  *   - generation_cancelled (terminal)
@@ -272,6 +273,24 @@ describe('SSE IPC parity — streaming/delta message types', () => {
     const event = await publishAndReadFrame('parity-message-complete-nosession', msg);
 
     expect(event.message.type).toBe('message_complete');
+  });
+
+  // ── message_request_complete (request-level terminal) ───────────────────
+
+  test('preserves message_request_complete payload', async () => {
+    const msg = {
+      type: 'message_request_complete' as const,
+      sessionId: 'conv-msg-request-complete',
+      requestId: 'req-123',
+      runStillActive: true,
+    };
+    const event = await publishAndReadFrame('parity-message-request-complete', msg);
+
+    expect(event.message.type).toBe('message_request_complete');
+    const m = event.message as typeof msg;
+    expect(m.sessionId).toBe('conv-msg-request-complete');
+    expect(m.requestId).toBe('req-123');
+    expect(m.runStillActive).toBe(true);
   });
 
   // ── generation_handoff (terminal) ────────────────────────────────────────

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -492,6 +492,18 @@ export async function startCli(): Promise<void> {
         break;
       }
 
+      case 'message_request_complete': {
+        // Request-level terminal for inline approval consumption.
+        // When no agent turn remains active, clear busy state and re-prompt.
+        if (parsed.runStillActive === false) {
+          spinner.stop();
+          generating = false;
+          process.stdout.write('\n\n');
+          prompt();
+        }
+        break;
+      }
+
       case 'generation_handoff': {
         // The current request's generation is done; show usage and re-prompt.
         // Always clear `generating` — this CLI client's generation is finished

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -495,7 +495,7 @@ export async function startCli(): Promise<void> {
       case 'message_request_complete': {
         // Request-level terminal for inline approval consumption.
         // When no agent turn remains active, clear busy state and re-prompt.
-        if (parsed.runStillActive === false) {
+        if (msg.runStillActive === false) {
           spinner.stop();
           generating = false;
           process.stdout.write('\n\n');

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -2,18 +2,26 @@ import * as net from 'node:net';
 
 import { v4 as uuid } from 'uuid';
 
+import { createAssistantMessage, createUserMessage } from '../../agent/message-types.js';
 import { type InterfaceId,isChannelId, parseChannelId, parseInterfaceId } from '../../channels/types.js';
 import { getConfig } from '../../config/loader.js';
 import { getAttachmentsForMessage, getFilePathForAttachment, setAttachmentThumbnail } from '../../memory/attachments-store.js';
 import { getAttentionStateByConversationIds } from '../../memory/conversation-attention-store.js';
+import {
+  listCanonicalGuardianRequests,
+  listPendingCanonicalGuardianRequestsByDestinationConversation,
+} from '../../memory/canonical-guardian-store.js';
 import * as conversationStore from '../../memory/conversation-store.js';
 import { GENERATING_TITLE, queueGenerateConversationTitle, UNTITLED_FALLBACK } from '../../memory/conversation-title-service.js';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
+import { routeGuardianReply } from '../../runtime/guardian-reply-router.js';
+import * as pendingInteractions from '../../runtime/pending-interactions.js';
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { compileCustomPatterns, redactSecrets } from '../../security/secret-scanner.js';
 import { getSubagentManager } from '../../subagent/index.js';
 import { silentlyWithLog } from '../../util/silently.js';
 import { truncate } from '../../util/truncate.js';
+import { createApprovalConversationGenerator } from '../approval-generators.js';
 import { getAssistantName } from '../identity-helpers.js';
 import type { UserMessageAttachment } from '../ipc-contract.js';
 import type {
@@ -55,6 +63,8 @@ import {
   renderHistoryContent,
   wireEscalationHandler,
 } from './shared.js';
+
+const desktopApprovalConversationGenerator = createApprovalConversationGenerator();
 
 export async function handleUserMessage(
   msg: UserMessage,
@@ -451,8 +461,119 @@ export async function handleUserMessage(
       }
     }
 
+    // If exactly one live turn is waiting on confirmation (no queued turns),
+    // try to consume this text as an inline approval decision first.
+    if (
+      session.hasAnyPendingConfirmation()
+      && session.getQueueDepth() === 0
+      && messageText.trim().length > 0
+    ) {
+      try {
+        const pendingInteractionRequestIdsForConversation = pendingInteractions
+          .getByConversation(msg.sessionId)
+          .filter((interaction) => interaction.kind === 'confirmation')
+          .map((interaction) => interaction.requestId);
+
+        const pendingCanonicalRequestIdsForConversation = Array.from(new Set([
+          ...pendingInteractionRequestIdsForConversation,
+          ...listPendingCanonicalGuardianRequestsByDestinationConversation(msg.sessionId, ipcChannel)
+            .filter((request) => request.kind === 'tool_approval')
+            .map((request) => request.id),
+          ...listCanonicalGuardianRequests({
+            status: 'pending',
+            conversationId: msg.sessionId,
+            kind: 'tool_approval',
+          }).map((request) => request.id),
+        ]));
+
+        if (pendingCanonicalRequestIdsForConversation.length > 0) {
+          const routerResult = await routeGuardianReply({
+            messageText: messageText.trim(),
+            channel: ipcChannel,
+            actor: {
+              externalUserId: undefined,
+              channel: ipcChannel,
+              isTrusted: true,
+            },
+            conversationId: msg.sessionId,
+            pendingRequestIds: pendingCanonicalRequestIdsForConversation,
+            approvalConversationGenerator: desktopApprovalConversationGenerator,
+          });
+
+          if (routerResult.consumed && routerResult.type !== 'nl_keep_pending') {
+            const consumedChannelMeta = {
+              userMessageChannel: ipcChannel,
+              assistantMessageChannel: ipcChannel,
+              userMessageInterface: ipcInterface,
+              assistantMessageInterface: ipcInterface,
+              provenanceActorRole: 'guardian' as const,
+            };
+
+            const consumedUserMessage = createUserMessage(messageText, msg.attachments ?? []);
+            await conversationStore.addMessage(
+              msg.sessionId,
+              'user',
+              JSON.stringify(consumedUserMessage.content),
+              consumedChannelMeta,
+            );
+
+            const replyText = (routerResult.replyText?.trim())
+              || (routerResult.decisionApplied ? 'Decision applied.' : 'Request already resolved.');
+            const consumedAssistantMessage = createAssistantMessage(replyText);
+            await conversationStore.addMessage(
+              msg.sessionId,
+              'assistant',
+              JSON.stringify(consumedAssistantMessage.content),
+              consumedChannelMeta,
+            );
+            // Avoid mutating in-memory history while an agent loop is active;
+            // the loop owns history reconstruction for the in-flight turn.
+            if (!session.isProcessing()) {
+              // Keep in-memory history aligned with persisted transcript so
+              // session-history operations (undo/regenerate) target the same turn.
+              session.messages.push(consumedUserMessage, consumedAssistantMessage);
+            }
+
+            // Mirror the normal queued/dequeued lifecycle so desktop clients can
+            // reconcile queued bubble state for this just-sent user message.
+            ctx.send(socket, {
+              type: 'message_queued',
+              sessionId: msg.sessionId,
+              requestId,
+              position: 0,
+            });
+            ctx.send(socket, {
+              type: 'message_dequeued',
+              sessionId: msg.sessionId,
+              requestId,
+            });
+
+            ctx.send(socket, {
+              type: 'assistant_text_delta',
+              text: replyText,
+              sessionId: msg.sessionId,
+            });
+            ctx.send(socket, {
+              type: 'message_request_complete',
+              sessionId: msg.sessionId,
+              requestId,
+              runStillActive: session.isProcessing(),
+            });
+
+            rlog.info(
+              { routerType: routerResult.type, decisionApplied: routerResult.decisionApplied, routerRequestId: routerResult.requestId },
+              'Consumed pending-confirmation reply before auto-deny',
+            );
+            return;
+          }
+        }
+      } catch (err) {
+        rlog.warn({ err }, 'Failed to process pending-confirmation reply; falling back to auto-deny behavior');
+      }
+    }
+
     // If the session has a pending tool confirmation, auto-deny it so the
-    // agent can process the user's follow-up message instead.  The agent
+    // agent can process the user's follow-up message instead. The agent
     // will see the denial and can re-request the tool if still needed.
     if (session.hasAnyPendingConfirmation()) {
       rlog.info('Auto-denying pending confirmation(s) due to new user message');

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -548,11 +548,18 @@ export async function handleUserMessage(
               requestId,
             });
 
-            ctx.send(socket, {
-              type: 'assistant_text_delta',
-              text: replyText,
-              sessionId: msg.sessionId,
-            });
+            // Only emit the reply delta when no agent turn is in-flight.
+            // When the agent is active, currentAssistantMessageId on the client
+            // points to the agent's streaming message and this delta would
+            // contaminate it.  The reply is already persisted to the DB, so the
+            // client will see it on the next transcript reload / session switch.
+            if (!session.isProcessing()) {
+              ctx.send(socket, {
+                type: 'assistant_text_delta',
+                text: replyText,
+                sessionId: msg.sessionId,
+              });
+            }
             ctx.send(socket, {
               type: 'message_request_complete',
               sessionId: msg.sessionId,

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -267,6 +267,7 @@
     "message_dequeued",
     "message_queued",
     "message_queued_deleted",
+    "message_request_complete",
     "model_info",
     "navigate_settings",
     "notification_intent",

--- a/assistant/src/daemon/ipc-contract/messages.ts
+++ b/assistant/src/daemon/ipc-contract/messages.ts
@@ -173,6 +173,21 @@ export interface MessageDequeued {
   requestId: string;
 }
 
+/**
+ * Request-level terminal signal for a user message lifecycle.
+ *
+ * Unlike `message_complete`, this does not imply the active assistant turn
+ * has completed. It is used for paths that consume a request inline while a
+ * separate in-flight turn may still be running.
+ */
+export interface MessageRequestComplete {
+  type: 'message_request_complete';
+  sessionId: string;
+  requestId: string;
+  /** True when an existing turn is still running after this request is finalized. */
+  runStillActive?: boolean;
+}
+
 export interface MessageQueuedDeleted {
   type: 'message_queued_deleted';
   sessionId: string;
@@ -241,6 +256,7 @@ export type _MessagesServerMessages =
   | SecretDetected
   | MessageQueued
   | MessageDequeued
+  | MessageRequestComplete
   | MessageQueuedDeleted
   | SuggestionResponse
   | TraceEvent;

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -827,6 +827,83 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isThinking, "isThinking should stay true while runStillActive is true")
     }
 
+    func testMessageRequestCompleteFinalizesAssistantStream() {
+        // Simulates the inline approval flow: message_queued → message_dequeued →
+        // assistant_text_delta("Decision applied.") → message_request_complete.
+        // The handler must flush the streaming buffer and finalize the assistant
+        // message so it doesn't remain stuck in isStreaming state.
+        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
+        viewModel.inputText = "approve"
+        viewModel.sendMessage()
+
+        // Simulate queued/dequeued lifecycle for the approval message
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-approve", position: 0)))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-approve")))
+
+        // Server sends the reply text as assistant_text_delta (buffered, not yet flushed)
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Decision applied.")))
+
+        // Now message_request_complete arrives with runStillActive=false.
+        // The handler calls flushStreamingBuffer() which creates the assistant
+        // message from the buffered delta, then finalizes it.
+        viewModel.handleServerMessage(
+            .messageRequestComplete(
+                MessageRequestCompleteMessage(
+                    sessionId: "sess-1",
+                    requestId: "req-approve",
+                    runStillActive: false
+                )
+            )
+        )
+
+        // The assistant message should exist and be finalized (not streaming)
+        let finalizedMsg = viewModel.messages.last(where: { $0.role == .assistant })
+        XCTAssertNotNil(finalizedMsg, "assistant message should exist after messageRequestComplete flushes buffer")
+        XCTAssertFalse(finalizedMsg!.isStreaming, "assistant message should not be streaming after messageRequestComplete")
+        // currentAssistantMessageId should be cleared so subsequent deltas don't append here
+        XCTAssertFalse(viewModel.isSending, "isSending should clear when no run is active")
+        XCTAssertFalse(viewModel.isThinking, "isThinking should clear when no run is active")
+    }
+
+    func testMessageRequestCompletePreservesAgentStreamWhenRunStillActive() {
+        // When runStillActive=true, the agent's in-flight assistant message
+        // must NOT be finalized — the agent still owns currentAssistantMessageId.
+        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
+        viewModel.inputText = "Message A"
+        viewModel.sendMessage()
+
+        // Agent starts responding (sets currentAssistantMessageId via buffer flush)
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Agent is working...")))
+        viewModel.flushStreamingBuffer()
+
+        let agentMsg = viewModel.messages.last(where: { $0.role == .assistant })
+        XCTAssertNotNil(agentMsg, "flush should create the agent's assistant message")
+        let agentMsgId = agentMsg!.id
+
+        // Now an inline approval arrives while the agent is still running
+        viewModel.inputText = "approve"
+        viewModel.sendMessage()
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-approve", position: 0)))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-approve")))
+
+        // Server does NOT send assistant_text_delta (gated on isProcessing on server side)
+        // message_request_complete with runStillActive=true
+        viewModel.handleServerMessage(
+            .messageRequestComplete(
+                MessageRequestCompleteMessage(
+                    sessionId: "sess-1",
+                    requestId: "req-approve",
+                    runStillActive: true
+                )
+            )
+        )
+
+        // Agent's assistant message should still exist and not be finalized
+        let agentMsgAfter = viewModel.messages.first(where: { $0.id == agentMsgId })
+        XCTAssertNotNil(agentMsgAfter, "agent message should still exist")
+        XCTAssertTrue(viewModel.isSending, "isSending should stay true while agent is active")
+    }
+
     func testProcessingStatusResetToSentOnGenerationCancelled() {
         viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
         viewModel.inputText = "Message A"

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -764,6 +764,69 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(messageBAfterComplete.status, .sent, "Message B should be .sent after messageComplete, not .processing")
     }
 
+    func testProcessingStatusResetToSentOnMessageRequestComplete() {
+        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
+        viewModel.inputText = "Message A"
+        viewModel.sendMessage()
+
+        viewModel.inputText = "Message B"
+        viewModel.sendMessage()
+
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to A")))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
+
+        let messageBAfterDequeue = viewModel.messages.first(where: { $0.text == "Message B" })!
+        XCTAssertEqual(messageBAfterDequeue.status, .processing)
+        XCTAssertTrue(viewModel.isSending)
+        XCTAssertTrue(viewModel.isThinking)
+
+        viewModel.handleServerMessage(
+            .messageRequestComplete(
+                MessageRequestCompleteMessage(
+                    sessionId: "sess-1",
+                    requestId: "req-B",
+                    runStillActive: false
+                )
+            )
+        )
+
+        let messageBAfterComplete = viewModel.messages.first(where: { $0.text == "Message B" })!
+        XCTAssertEqual(messageBAfterComplete.status, .sent, "Message B should be .sent after messageRequestComplete")
+        XCTAssertFalse(viewModel.isSending, "isSending should clear when request completed and no run remains active")
+        XCTAssertFalse(viewModel.isThinking, "isThinking should clear when request completed and no run remains active")
+    }
+
+    func testMessageRequestCompleteKeepsBusyStateWhenRunStillActive() {
+        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
+        viewModel.inputText = "Message A"
+        viewModel.sendMessage()
+
+        viewModel.inputText = "Message B"
+        viewModel.sendMessage()
+
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to A")))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
+
+        viewModel.handleServerMessage(
+            .messageRequestComplete(
+                MessageRequestCompleteMessage(
+                    sessionId: "sess-1",
+                    requestId: "req-B",
+                    runStillActive: true
+                )
+            )
+        )
+
+        let messageBAfterComplete = viewModel.messages.first(where: { $0.text == "Message B" })!
+        XCTAssertEqual(messageBAfterComplete.status, .sent, "Message B should be finalized even while another run remains active")
+        XCTAssertTrue(viewModel.isSending, "isSending should stay true while runStillActive is true")
+        XCTAssertTrue(viewModel.isThinking, "isThinking should stay true while runStillActive is true")
+    }
+
     func testProcessingStatusResetToSentOnGenerationCancelled() {
         viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
         viewModel.inputText = "Message A"

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -565,6 +565,7 @@ extension ChatViewModel {
                 pendingQueuedCount = 0
                 pendingMessageIds = []
                 requestIdToMessageId = [:]
+                activeRequestIdToMessageId = [:]
                 pendingLocalDeletions.removeAll()
                 for i in messages.indices {
                     if case .queued = messages[i].status, messages[i].role == .user {
@@ -681,6 +682,7 @@ extension ChatViewModel {
                     }
                 }
             }
+            activeRequestIdToMessageId.removeAll()
             dispatchPendingSendDirect()
             // Refresh guardian prompts on message completion (cheap consistency check)
             refreshGuardianPrompts()
@@ -744,6 +746,7 @@ extension ChatViewModel {
                 pendingQueuedCount = 0
                 pendingMessageIds = []
                 requestIdToMessageId = [:]
+                activeRequestIdToMessageId = [:]
                 pendingLocalDeletions.removeAll()
                 for i in messages.indices {
                     if case .queued = messages[i].status, messages[i].role == .user {
@@ -796,7 +799,9 @@ extension ChatViewModel {
             guard belongsToSession(msg.sessionId) else { return }
             pendingQueuedCount = max(0, pendingQueuedCount - 1)
             // Remove the message from the UI
-            if let messageId = requestIdToMessageId.removeValue(forKey: msg.requestId) {
+            let messageId = requestIdToMessageId.removeValue(forKey: msg.requestId)
+                ?? activeRequestIdToMessageId.removeValue(forKey: msg.requestId)
+            if let messageId {
                 messages.removeAll { $0.id == messageId }
             }
             // Recompute positions for remaining queued messages
@@ -818,6 +823,7 @@ extension ChatViewModel {
             // so assistantTextDelta tags the response correctly.
             if let messageId = requestIdToMessageId.removeValue(forKey: msg.requestId),
                let index = messages.firstIndex(where: { $0.id == messageId }) {
+                activeRequestIdToMessageId[msg.requestId] = messageId
                 messages[index].status = .processing
                 currentTurnUserText = messages[index].text.trimmingCharacters(in: .whitespacesAndNewlines)
                 // Clear attachment binary payloads now that the daemon has persisted them.
@@ -841,8 +847,24 @@ extension ChatViewModel {
             isThinking = true
             isSending = true
 
+        case .messageRequestComplete(let msg):
+            guard belongsToSession(msg.sessionId) else { return }
+            if let messageId = activeRequestIdToMessageId.removeValue(forKey: msg.requestId),
+               let index = messages.firstIndex(where: { $0.id == messageId }),
+               messages[index].role == .user,
+               messages[index].status == .processing {
+                messages[index].status = .sent
+            }
+            if msg.runStillActive == false && pendingQueuedCount == 0 {
+                isSending = false
+                isThinking = false
+            }
+
         case .generationHandoff(let handoff):
             guard belongsToSession(handoff.sessionId) else { return }
+            if let requestId = handoff.requestId {
+                activeRequestIdToMessageId.removeValue(forKey: requestId)
+            }
             isThinking = false
             // Flush buffered text so it lands on the current assistant message
             // before we clear the ID and hand off to the next queued turn.
@@ -956,6 +978,7 @@ extension ChatViewModel {
                         }
                         pendingMessageIds.removeAll { $0 == blockedMessageId }
                         requestIdToMessageId = requestIdToMessageId.filter { $0.value != blockedMessageId }
+                        activeRequestIdToMessageId = activeRequestIdToMessageId.filter { $0.value != blockedMessageId }
                         pendingLocalDeletions.remove(blockedMessageId)
                         messages.remove(at: blockedMessageIndex)
                     }
@@ -976,6 +999,7 @@ extension ChatViewModel {
                 pendingQueuedCount = 0
                 pendingMessageIds = []
                 requestIdToMessageId = [:]
+                activeRequestIdToMessageId = [:]
                 for i in messages.indices {
                     if case .queued = messages[i].status, messages[i].role == .user {
                         messages[i].status = .sent
@@ -990,6 +1014,7 @@ extension ChatViewModel {
                 isSending = false
                 pendingMessageIds = []
                 requestIdToMessageId = [:]
+                activeRequestIdToMessageId = [:]
             }
 
         case .confirmationRequest(let msg):
@@ -1434,6 +1459,7 @@ extension ChatViewModel {
                 pendingQueuedCount = 0
                 pendingMessageIds = []
                 requestIdToMessageId = [:]
+                activeRequestIdToMessageId = [:]
                 for i in messages.indices {
                     if case .queued = messages[i].status, messages[i].role == .user {
                         messages[i].status = .sent
@@ -1462,6 +1488,7 @@ extension ChatViewModel {
                     // No queued work remains — safe to tear down everything.
                     pendingMessageIds = []
                     requestIdToMessageId = [:]
+                    activeRequestIdToMessageId = [:]
                 } else {
                     // The daemon drains queued work after a session_error
                     // (session.ts calls drainQueue in `finally`), so preserve

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -855,6 +855,21 @@ extension ChatViewModel {
                messages[index].status == .processing {
                 messages[index].status = .sent
             }
+            // When no agent turn is in-flight, finalize the assistant message
+            // created by the preceding assistant_text_delta so it doesn't remain
+            // stuck in streaming state or cause subsequent deltas to append to it.
+            if msg.runStillActive != true {
+                flushStreamingBuffer()
+                if let existingId = currentAssistantMessageId,
+                   let index = messages.firstIndex(where: { $0.id == existingId }) {
+                    messages[index].isStreaming = false
+                    messages[index].streamingCodePreview = nil
+                    messages[index].streamingCodeToolName = nil
+                }
+                currentAssistantMessageId = nil
+                currentAssistantHasText = false
+                lastContentWasToolCall = false
+            }
             if msg.runStillActive == false && pendingQueuedCount == 0 {
                 isSending = false
                 isThinking = false

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -825,7 +825,14 @@ extension ChatViewModel {
                let index = messages.firstIndex(where: { $0.id == messageId }) {
                 activeRequestIdToMessageId[msg.requestId] = messageId
                 messages[index].status = .processing
-                currentTurnUserText = messages[index].text.trimmingCharacters(in: .whitespacesAndNewlines)
+                // Only update currentTurnUserText when no agent turn is already
+                // in-flight. Synthetic dequeues from inline approval consumption
+                // arrive while the agent owns currentTurnUserText; overwriting it
+                // with the approval text (e.g. "approve") would break the error
+                // handler's secret_blocked message lookup.
+                if currentAssistantMessageId == nil {
+                    currentTurnUserText = messages[index].text.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
                 // Clear attachment binary payloads now that the daemon has persisted them.
                 // Keep thumbnailImage for display; the full data can be re-fetched via HTTP if needed.
                 // Only clear for lazy-loadable attachments (sizeBytes != nil); locally-created

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -374,6 +374,8 @@ public final class ChatViewModel: ObservableObject {
     public var isCancelling: Bool = false
     /// Maps daemon requestId to the user message UUID in the messages array.
     var requestIdToMessageId: [String: UUID] = [:]
+    /// Maps requestId to the currently processing user message UUID after dequeue.
+    var activeRequestIdToMessageId: [String: UUID] = [:]
     /// FIFO queue of user message UUIDs awaiting requestId assignment from the daemon.
     var pendingMessageIds: [UUID] = []
     /// Messages deleted locally before the daemon's `message_queued` ack arrived.
@@ -790,6 +792,7 @@ public final class ChatViewModel: ObservableObject {
                 self?.pendingQueuedCount = 0
                 self?.pendingMessageIds.removeAll()
                 self?.requestIdToMessageId.removeAll()
+                self?.activeRequestIdToMessageId.removeAll()
                 self?.pendingLocalDeletions.removeAll()
                 // If a run was in progress when the connection dropped, the
                 // client may have missed the messageComplete (or the full
@@ -1416,6 +1419,7 @@ public final class ChatViewModel: ObservableObject {
             pendingQueuedCount = 0
             pendingMessageIds = []
             requestIdToMessageId = [:]
+            activeRequestIdToMessageId = [:]
             pendingLocalDeletions.removeAll()
             for i in messages.indices {
                 if case .queued = messages[i].status, messages[i].role == .user {
@@ -1461,6 +1465,7 @@ public final class ChatViewModel: ObservableObject {
             pendingQueuedCount = 0
             pendingMessageIds = []
             requestIdToMessageId = [:]
+            activeRequestIdToMessageId = [:]
             pendingLocalDeletions.removeAll()
             // Reset processing/queued messages to sent
             for i in messages.indices {
@@ -1523,6 +1528,7 @@ public final class ChatViewModel: ObservableObject {
             self.pendingQueuedCount = 0
             self.pendingMessageIds = []
             self.requestIdToMessageId = [:]
+            self.activeRequestIdToMessageId = [:]
             self.pendingLocalDeletions.removeAll()
             // Reset queued/processing messages to sent (matches other cancel-failure paths)
             for i in self.messages.indices {
@@ -1730,6 +1736,7 @@ public final class ChatViewModel: ObservableObject {
         pendingQueuedCount = 0
         pendingMessageIds = []
         requestIdToMessageId = [:]
+        activeRequestIdToMessageId = [:]
         pendingLocalDeletions.removeAll()
         for i in messages.indices {
             if case .queued = messages[i].status, messages[i].role == .user {

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -3026,6 +3026,20 @@ public struct IPCMessageDequeued: Codable, Sendable {
     }
 }
 
+public struct IPCMessageRequestComplete: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let requestId: String
+    public let runStillActive: Bool?
+
+    public init(type: String, sessionId: String, requestId: String, runStillActive: Bool? = nil) {
+        self.type = type
+        self.sessionId = sessionId
+        self.requestId = requestId
+        self.runStillActive = runStillActive
+    }
+}
+
 public struct IPCMessageQueued: Codable, Sendable {
     public let type: String
     public let sessionId: String

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1003,6 +1003,17 @@ extension IPCMessageDequeued {
     }
 }
 
+/// Request-level terminal signal for a queued/dequeued lifecycle.
+/// Does not imply the active assistant turn has completed.
+/// Backed by generated `IPCMessageRequestComplete`.
+public typealias MessageRequestCompleteMessage = IPCMessageRequestComplete
+
+extension IPCMessageRequestComplete {
+    public init(sessionId: String, requestId: String, runStillActive: Bool? = nil) {
+        self.init(type: "message_request_complete", sessionId: sessionId, requestId: requestId, runStillActive: runStillActive)
+    }
+}
+
 /// Notifies client that a queued message was successfully deleted.
 /// Backed by generated `IPCMessageQueuedDeleted`.
 public typealias MessageQueuedDeletedMessage = IPCMessageQueuedDeleted
@@ -2245,6 +2256,7 @@ public enum ServerMessage: Decodable, Sendable {
     case appDataResponse(AppDataResponseMessage)
     case messageQueued(MessageQueuedMessage)
     case messageDequeued(MessageDequeuedMessage)
+    case messageRequestComplete(MessageRequestCompleteMessage)
     case messageQueuedDeleted(MessageQueuedDeletedMessage)
     case skillsListResponse(SkillsListResponseMessage)
     case skillDetailResponse(SkillDetailResponseMessage)
@@ -2479,6 +2491,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "message_dequeued":
             let message = try MessageDequeuedMessage(from: decoder)
             self = .messageDequeued(message)
+        case "message_request_complete":
+            let message = try MessageRequestCompleteMessage(from: decoder)
+            self = .messageRequestComplete(message)
         case "message_queued_deleted":
             let message = try MessageQueuedDeletedMessage(from: decoder)
             self = .messageQueuedDeleted(message)


### PR DESCRIPTION
## Summary
- Gate `assistant_text_delta` emission on `!session.isProcessing()` in the inline approval path to prevent reply text from contaminating the agent's in-flight message
- Add streaming state cleanup to `messageRequestComplete` handler (flush buffer, clear `isStreaming`, clear `currentAssistantMessageId`) when `runStillActive != true`
- Add server test asserting no `assistant_text_delta` when session is processing, and two Swift tests verifying stream finalization and agent stream preservation

## Context
Addresses Codex and Devin review feedback on #10644: the `messageRequestComplete` handler didn't clean up assistant streaming state, causing inline approval `assistant_text_delta` to append to the agent's in-flight message.

## Original prompt
help me iterate on the feedback on this PR https://github.com/vellum-ai/vellum-assistant/pull/10644

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
