### PR TITLE
Remove legacy guardian actorRole in favor of canonical trust context

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -631,7 +631,7 @@ describe('call-controller', () => {
   test('handleCallerUtterance: passes guardian context to startVoiceTurn', async () => {
     const guardianCtx = {
       sourceChannel: 'voice' as const,
-      actorRole: 'non-guardian' as const,
+      trustClass: 'trusted_contact' as const,
       guardianExternalUserId: '+15550009999',
       guardianChatId: '+15550009999',
       requesterExternalUserId: '+15550002222',
@@ -683,13 +683,13 @@ describe('call-controller', () => {
   test('setGuardianContext: subsequent turns use updated guardian context', async () => {
     const initialCtx = {
       sourceChannel: 'voice' as const,
-      actorRole: 'unverified_channel' as const,
+      trustClass: 'unknown' as const,
       denialReason: 'no_binding' as const,
     };
 
     const upgradedCtx = {
       sourceChannel: 'voice' as const,
-      actorRole: 'guardian' as const,
+      trustClass: 'guardian' as const,
       guardianExternalUserId: '+15550003333',
       guardianChatId: '+15550003333',
     };

--- a/assistant/src/__tests__/channel-retry-sweep.test.ts
+++ b/assistant/src/__tests__/channel-retry-sweep.test.ts
@@ -1,0 +1,130 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { eq } from 'drizzle-orm';
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'channel-retry-sweep-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { channelInboundEvents, messages } from '../memory/schema.js';
+import { sweepFailedEvents } from '../runtime/channel-retry-sweep.js';
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    // Best effort cleanup
+  }
+});
+
+function resetTables(): void {
+  const db = getDb();
+  db.run('DELETE FROM channel_inbound_events');
+  db.run('DELETE FROM conversation_keys');
+  db.run('DELETE FROM messages');
+  db.run('DELETE FROM conversations');
+}
+
+function seedFailedLegacyEvent(actorRole: 'guardian' | 'non-guardian' | 'unverified_channel'): string {
+  const inbound = channelDeliveryStore.recordInbound('telegram', 'chat-legacy', `msg-${actorRole}`);
+  channelDeliveryStore.storePayload(inbound.eventId, {
+    content: 'retry me',
+    sourceChannel: 'telegram',
+    interface: 'telegram',
+    guardianCtx: {
+      actorRole,
+      sourceChannel: 'telegram',
+      requesterExternalUserId: 'legacy-user',
+      requesterChatId: 'chat-legacy',
+    },
+  });
+
+  const db = getDb();
+  db.update(channelInboundEvents)
+    .set({
+      processingStatus: 'failed',
+      processingAttempts: 1,
+      retryAfter: Date.now() - 1,
+    })
+    .where(eq(channelInboundEvents.id, inbound.eventId))
+    .run();
+
+  return inbound.eventId;
+}
+
+describe('channel-retry-sweep', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test('replays legacy guardianCtx.actorRole with preserved trust semantics', async () => {
+    const cases: Array<{
+      actorRole: 'guardian' | 'non-guardian' | 'unverified_channel';
+      expectedTrustClass: 'guardian' | 'trusted_contact' | 'unknown';
+      expectedInteractive: boolean;
+    }> = [
+      { actorRole: 'guardian', expectedTrustClass: 'guardian', expectedInteractive: true },
+      { actorRole: 'non-guardian', expectedTrustClass: 'trusted_contact', expectedInteractive: false },
+      { actorRole: 'unverified_channel', expectedTrustClass: 'unknown', expectedInteractive: false },
+    ];
+
+    for (const c of cases) {
+      const eventId = seedFailedLegacyEvent(c.actorRole);
+      let capturedOptions: {
+        guardianContext?: { trustClass?: string };
+        isInteractive?: boolean;
+      } | undefined;
+
+      await sweepFailedEvents(
+        async (conversationId, _content, _attachmentIds, options) => {
+          capturedOptions = options as {
+            guardianContext?: { trustClass?: string };
+            isInteractive?: boolean;
+          };
+          const messageId = `message-${c.actorRole}`;
+          const db = getDb();
+          db.insert(messages).values({
+            id: messageId,
+            conversationId,
+            role: 'user',
+            content: JSON.stringify([{ type: 'text', text: 'retry me' }]),
+            createdAt: Date.now(),
+          }).run();
+          return { messageId };
+        },
+        undefined,
+      );
+
+      expect(capturedOptions?.guardianContext?.trustClass).toBe(c.expectedTrustClass);
+      expect(capturedOptions?.isInteractive).toBe(c.expectedInteractive);
+
+      const db = getDb();
+      const row = db.select().from(channelInboundEvents).where(eq(channelInboundEvents.id, eventId)).get();
+      expect(row?.processingStatus).toBe('processed');
+    }
+  });
+});

--- a/assistant/src/__tests__/conversation-routes.test.ts
+++ b/assistant/src/__tests__/conversation-routes.test.ts
@@ -49,7 +49,7 @@ describe('handleSendMessage', () => {
     expect(body.messageId).toBe('msg-legacy-fallback');
     expect(capturedSourceChannel).toBe('telegram');
     expect(capturedOptions?.guardianContext).toEqual({
-      actorRole: 'guardian',
+      trustClass: 'guardian',
       sourceChannel: 'telegram',
     });
   });

--- a/assistant/src/__tests__/guardian-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/guardian-control-plane-policy.test.ts
@@ -380,7 +380,7 @@ describe('enforceGuardianOnlyPolicy', () => {
   test('non-guardian actor denied for guardian endpoint', () => {
     const result = enforceGuardianOnlyPolicy('bash', {
       command: 'curl http://localhost:3000/v1/integrations/guardian/outbound/start',
-    }, 'non-guardian');
+    }, 'trusted_contact');
     expect(result.denied).toBe(true);
     expect(result.reason).toContain('restricted to guardian users');
   });
@@ -388,7 +388,7 @@ describe('enforceGuardianOnlyPolicy', () => {
   test('unverified_channel actor denied for guardian endpoint', () => {
     const result = enforceGuardianOnlyPolicy('network_request', {
       url: 'https://api.example.com/v1/integrations/guardian/challenge',
-    }, 'unverified_channel');
+    }, 'unknown');
     expect(result.denied).toBe(true);
     expect(result.reason).toContain('restricted to guardian users');
   });
@@ -419,14 +419,14 @@ describe('enforceGuardianOnlyPolicy', () => {
   test('non-guardian actor is NOT denied for unrelated endpoint', () => {
     const result = enforceGuardianOnlyPolicy('bash', {
       command: 'curl http://localhost:3000/v1/messages',
-    }, 'non-guardian');
+    }, 'trusted_contact');
     expect(result.denied).toBe(false);
   });
 
   test('non-guardian actor is NOT denied for unrelated tool', () => {
     const result = enforceGuardianOnlyPolicy('file_read', {
       path: 'README.md',
-    }, 'non-guardian');
+    }, 'trusted_contact');
     expect(result.denied).toBe(false);
   });
 });
@@ -445,7 +445,7 @@ describe('ToolExecutor guardian-only policy gate', () => {
     const result = await executor.execute(
       'bash',
       { command: 'curl -X POST http://localhost:3000/v1/integrations/guardian/outbound/start' },
-      makeContext({ guardianActorRole: 'non-guardian' }),
+      makeContext({ guardianTrustClass: 'trusted_contact' }),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain('restricted to guardian users');
@@ -456,7 +456,7 @@ describe('ToolExecutor guardian-only policy gate', () => {
     const result = await executor.execute(
       'network_request',
       { url: 'https://api.example.com/v1/integrations/guardian/challenge' },
-      makeContext({ guardianActorRole: 'unverified_channel' }),
+      makeContext({ guardianTrustClass: 'unknown' }),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain('restricted to guardian users');
@@ -467,18 +467,18 @@ describe('ToolExecutor guardian-only policy gate', () => {
     const result = await executor.execute(
       'bash',
       { command: 'curl -X POST http://localhost:3000/v1/integrations/guardian/outbound/start' },
-      makeContext({ guardianActorRole: 'guardian' }),
+      makeContext({ guardianTrustClass: 'guardian' }),
     );
     expect(result.isError).toBe(false);
     expect(result.content).toBe('ok');
   });
 
-  test('undefined guardianActorRole is NOT blocked from guardian endpoint', async () => {
+  test('undefined guardianTrustClass is NOT blocked from guardian endpoint', async () => {
     const executor = new ToolExecutor(makePrompter());
     const result = await executor.execute(
       'bash',
       { command: 'curl http://localhost:3000/v1/integrations/guardian/status' },
-      makeContext(), // no guardianActorRole set
+      makeContext(), // no guardianTrustClass set
     );
     expect(result.isError).toBe(false);
     expect(result.content).toBe('ok');
@@ -489,7 +489,7 @@ describe('ToolExecutor guardian-only policy gate', () => {
     const result = await executor.execute(
       'bash',
       { command: 'curl http://localhost:3000/v1/messages' },
-      makeContext({ guardianActorRole: 'non-guardian' }),
+      makeContext({ guardianTrustClass: 'trusted_contact' }),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain('requires guardian approval');
@@ -500,7 +500,7 @@ describe('ToolExecutor guardian-only policy gate', () => {
     const result = await executor.execute(
       'file_read',
       { path: 'README.md' },
-      makeContext({ guardianActorRole: 'non-guardian' }),
+      makeContext({ guardianTrustClass: 'trusted_contact' }),
     );
     expect(result.isError).toBe(false);
     expect(result.content).toBe('ok');
@@ -513,7 +513,7 @@ describe('ToolExecutor guardian-only policy gate', () => {
       'bash',
       { command: 'curl http://localhost:3000/v1/integrations/guardian/outbound/cancel' },
       makeContext({
-        guardianActorRole: 'non-guardian',
+        guardianTrustClass: 'trusted_contact',
         onToolLifecycleEvent: (event: ToolLifecycleEvent) => {
           if (event.type === 'permission_denied') {
             capturedEvent = event as ToolPermissionDeniedEvent;
@@ -531,7 +531,7 @@ describe('ToolExecutor guardian-only policy gate', () => {
     const result = await executor.execute(
       'web_fetch',
       { url: 'http://localhost:3000/v1/integrations/guardian/outbound/resend' },
-      makeContext({ guardianActorRole: 'non-guardian' }),
+      makeContext({ guardianTrustClass: 'trusted_contact' }),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain('restricted to guardian users');
@@ -542,7 +542,7 @@ describe('ToolExecutor guardian-only policy gate', () => {
     const result = await executor.execute(
       'browser_navigate',
       { url: 'http://localhost:3000/v1/integrations/guardian/status' },
-      makeContext({ guardianActorRole: 'non-guardian' }),
+      makeContext({ guardianTrustClass: 'trusted_contact' }),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain('restricted to guardian users');
@@ -553,7 +553,7 @@ describe('ToolExecutor guardian-only policy gate', () => {
     const result = await executor.execute(
       'host_bash',
       { command: 'curl -X POST https://internal:8080/v1/integrations/guardian/challenge' },
-      makeContext({ guardianActorRole: 'non-guardian' }),
+      makeContext({ guardianTrustClass: 'trusted_contact' }),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain('restricted to guardian users');
@@ -573,7 +573,7 @@ describe('ToolExecutor guardian-only policy gate', () => {
       const result = await executor.execute(
         'network_request',
         { url: `https://api.example.com${path}` },
-        makeContext({ guardianActorRole: 'non-guardian' }),
+        makeContext({ guardianTrustClass: 'trusted_contact' }),
       );
       expect(result.isError).toBe(true);
       expect(result.content).toContain('restricted to guardian users');
@@ -585,7 +585,7 @@ describe('ToolExecutor guardian-only policy gate', () => {
     const result = await executor.execute(
       'host_file_read',
       { path: '/Users/noaflaherty/.ssh/config' },
-      makeContext({ guardianActorRole: 'non-guardian' }),
+      makeContext({ guardianTrustClass: 'trusted_contact' }),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain('requires guardian approval');
@@ -596,7 +596,7 @@ describe('ToolExecutor guardian-only policy gate', () => {
     const result = await executor.execute(
       'reminder_create',
       { fire_at: '2026-02-27T12:00:00-05:00', label: 'test', message: 'hello' },
-      makeContext({ guardianActorRole: 'unverified_channel' }),
+      makeContext({ guardianTrustClass: 'unknown' }),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain('verified channel identity');
@@ -607,7 +607,7 @@ describe('ToolExecutor guardian-only policy gate', () => {
     const result = await executor.execute(
       'reminder_create',
       { fire_at: '2026-02-27T12:00:00-05:00', label: 'test', message: 'hello' },
-      makeContext({ guardianActorRole: 'guardian' }),
+      makeContext({ guardianTrustClass: 'guardian' }),
     );
     expect(result.isError).toBe(false);
     expect(result.content).toBe('ok');

--- a/assistant/src/__tests__/guardian-grant-minting.test.ts
+++ b/assistant/src/__tests__/guardian-grant-minting.test.ts
@@ -137,7 +137,7 @@ function registerPendingInteraction(
 
 function makeGuardianContext(): GuardianContext {
   return {
-    actorRole: 'guardian',
+    trustClass: 'guardian',
     denialReason: undefined,
   };
 }

--- a/assistant/src/__tests__/guardian-grant-minting.test.ts
+++ b/assistant/src/__tests__/guardian-grant-minting.test.ts
@@ -530,3 +530,70 @@ describe('guardian grant minting on tool-approval decisions', () => {
     composeSpy.mockRestore();
   });
 });
+
+describe('approval interception trust-class regression coverage', () => {
+  let deliverSpy: ReturnType<typeof spyOn>;
+  let composeSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    resetTables();
+    deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    composeSpy = spyOn(approvalMessageComposer, 'composeApprovalMessageGenerative')
+      .mockResolvedValue('test message');
+  });
+
+  test('identity-known unknown sender does not auto-deny pending approval', async () => {
+    const requestId = 'req-unknown-no-auto-deny-1';
+    const sessionMock = registerPendingInteraction(requestId, CONVERSATION_ID, TOOL_NAME, TOOL_INPUT);
+    createTestGuardianApproval(requestId);
+
+    const result = await handleApprovalInterception({
+      conversationId: CONVERSATION_ID,
+      content: 'approve',
+      externalChatId: REQUESTER_CHAT,
+      sourceChannel: 'telegram',
+      senderExternalUserId: 'intruder-user-1',
+      replyCallbackUrl: 'https://gateway.test/deliver',
+      guardianCtx: {
+        trustClass: 'unknown',
+      },
+      assistantId: ASSISTANT_ID,
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.type).toBe('assistant_turn');
+    expect(sessionMock).not.toHaveBeenCalled();
+
+    deliverSpy.mockRestore();
+    composeSpy.mockRestore();
+  });
+
+  test('legacy unverified sender still auto-denies pending approval', async () => {
+    const requestId = 'req-unknown-auto-deny-1';
+    const sessionMock = registerPendingInteraction(requestId, CONVERSATION_ID, TOOL_NAME, TOOL_INPUT);
+    createTestGuardianApproval(requestId);
+
+    const result = await handleApprovalInterception({
+      conversationId: CONVERSATION_ID,
+      content: 'approve',
+      externalChatId: REQUESTER_CHAT,
+      sourceChannel: 'telegram',
+      senderExternalUserId: undefined,
+      replyCallbackUrl: 'https://gateway.test/deliver',
+      guardianCtx: {
+        trustClass: 'unknown',
+        denialReason: 'no_identity',
+      },
+      assistantId: ASSISTANT_ID,
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.type).toBe('decision_applied');
+    expect(sessionMock).toHaveBeenCalled();
+    expect(sessionMock.mock.calls[0]?.[0]).toBe(requestId);
+    expect(sessionMock.mock.calls[0]?.[1]).toBe('deny');
+
+    deliverSpy.mockRestore();
+    composeSpy.mockRestore();
+  });
+});

--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -4448,7 +4448,7 @@ describe('Memory regressions', () => {
       role: 'user',
       content: 'Untrusted sender says preferences should not become durable profile memory.',
       metadata: JSON.stringify({
-        provenanceActorRole: 'non-guardian',
+        provenanceTrustClass: 'trusted_contact',
         provenanceSourceChannel: 'telegram',
       }),
       createdAt: conv.createdAt + 1,
@@ -4516,7 +4516,7 @@ describe('Memory regressions', () => {
           conversationId: 'conv-relation-provenance-gate',
           role: 'user',
           content: JSON.stringify([{ type: 'text', text: 'Trusted guardian message for relation backfill.' }]),
-          metadata: JSON.stringify({ provenanceActorRole: 'guardian', provenanceSourceChannel: 'telegram' }),
+          metadata: JSON.stringify({ provenanceTrustClass: 'guardian', provenanceSourceChannel: 'telegram' }),
           createdAt: now + 1,
         },
         {
@@ -4524,7 +4524,7 @@ describe('Memory regressions', () => {
           conversationId: 'conv-relation-provenance-gate',
           role: 'user',
           content: JSON.stringify([{ type: 'text', text: 'Untrusted message that should be excluded from relation backfill extraction.' }]),
-          metadata: JSON.stringify({ provenanceActorRole: 'non-guardian', provenanceSourceChannel: 'telegram' }),
+          metadata: JSON.stringify({ provenanceTrustClass: 'trusted_contact', provenanceSourceChannel: 'telegram' }),
           createdAt: now + 2,
         },
       ]).run();
@@ -4566,7 +4566,7 @@ describe('Memory regressions', () => {
     const conv = createConversation('provenance-preserve');
     const metadata = {
       userMessageChannel: 'telegram' as const,
-      provenanceActorRole: 'non-guardian' as const,
+      provenanceTrustClass: 'trusted_contact' as const,
       provenanceSourceChannel: 'telegram' as const,
       provenanceGuardianExternalUserId: 'guardian-123',
       provenanceRequesterIdentifier: 'Alice',
@@ -4582,7 +4582,7 @@ describe('Memory regressions', () => {
 
     expect(stored).toBeTruthy();
     const parsed = JSON.parse(stored!.metadata!);
-    expect(parsed.provenanceActorRole).toBe('non-guardian');
+    expect(parsed.provenanceTrustClass).toBe('trusted_contact');
     expect(parsed.provenanceSourceChannel).toBe('telegram');
     expect(parsed.provenanceGuardianExternalUserId).toBe('guardian-123');
     expect(parsed.provenanceRequesterIdentifier).toBe('Alice');
@@ -4590,13 +4590,13 @@ describe('Memory regressions', () => {
 
   test('messageMetadataSchema validates provenance fields', () => {
     const valid = messageMetadataSchema.safeParse({
-      provenanceActorRole: 'guardian',
+      provenanceTrustClass: 'guardian',
       provenanceSourceChannel: 'macos',
     });
     expect(valid.success).toBe(true);
 
     const validNonGuardian = messageMetadataSchema.safeParse({
-      provenanceActorRole: 'non-guardian',
+      provenanceTrustClass: 'trusted_contact',
       provenanceSourceChannel: 'telegram',
       provenanceGuardianExternalUserId: 'g-123',
       provenanceRequesterIdentifier: 'Bob',
@@ -4604,41 +4604,41 @@ describe('Memory regressions', () => {
     expect(validNonGuardian.success).toBe(true);
 
     const validUnverified = messageMetadataSchema.safeParse({
-      provenanceActorRole: 'unverified_channel',
+      provenanceTrustClass: 'unknown',
     });
     expect(validUnverified.success).toBe(true);
   });
 
   test('provenanceFromGuardianContext returns unverified_channel default when no context', () => {
     const result = provenanceFromGuardianContext(null);
-    expect(result.provenanceActorRole).toBe('unverified_channel');
+    expect(result.provenanceTrustClass).toBe('unknown');
     expect(result.provenanceSourceChannel).toBeUndefined();
 
     const result2 = provenanceFromGuardianContext(undefined);
-    expect(result2.provenanceActorRole).toBe('unverified_channel');
+    expect(result2.provenanceTrustClass).toBe('unknown');
   });
 
   test('provenanceFromGuardianContext extracts fields from guardian context', () => {
     const ctx = {
       sourceChannel: 'telegram' as const,
-      actorRole: 'non-guardian' as const,
+      trustClass: 'trusted_contact' as const,
       guardianExternalUserId: 'g-456',
       requesterIdentifier: 'Charlie',
     };
     const result = provenanceFromGuardianContext(ctx);
-    expect(result.provenanceActorRole).toBe('non-guardian');
+    expect(result.provenanceTrustClass).toBe('trusted_contact');
     expect(result.provenanceSourceChannel).toBe('telegram');
     expect(result.provenanceGuardianExternalUserId).toBe('g-456');
     expect(result.provenanceRequesterIdentifier).toBe('Charlie');
   });
 
-  test('indexMessageNow receives provenanceActorRole when metadata includes it', async () => {
+  test('indexMessageNow receives provenanceTrustClass when metadata includes it', async () => {
     const conv = createConversation('provenance-indexer');
     const metadata = {
-      provenanceActorRole: 'non-guardian' as const,
+      provenanceTrustClass: 'trusted_contact' as const,
       provenanceSourceChannel: 'telegram' as const,
     };
-    // addMessage parses metadata and passes provenanceActorRole to indexMessageNow.
+    // addMessage parses metadata and passes provenanceTrustClass to indexMessageNow.
     // We verify indirectly: the message is persisted with metadata and segments are indexed.
     const msg = await addMessage(conv.id, 'user', 'Test provenance indexing message with enough content to segment', metadata);
     expect(msg.id).toBeTruthy();
@@ -4683,7 +4683,7 @@ describe('Memory regressions', () => {
       role: 'user',
       content: JSON.stringify([{ type: 'text', text: 'Untrusted user preference for dark mode.' }]),
       createdAt: now,
-      provenanceActorRole: 'non-guardian',
+      provenanceTrustClass: 'trusted_contact',
     }, DEFAULT_CONFIG.memory);
 
     expect(result.indexedSegments).toBeGreaterThan(0);
@@ -4733,7 +4733,7 @@ describe('Memory regressions', () => {
       role: 'user',
       content: JSON.stringify([{ type: 'text', text: 'Trusted guardian preference for light mode.' }]),
       createdAt: now,
-      provenanceActorRole: 'guardian',
+      provenanceTrustClass: 'guardian',
     }, DEFAULT_CONFIG.memory);
 
     expect(result.indexedSegments).toBeGreaterThan(0);
@@ -4779,7 +4779,7 @@ describe('Memory regressions', () => {
       role: 'user',
       content: JSON.stringify([{ type: 'text', text: 'Legacy message with no provenance info.' }]),
       createdAt: now,
-      // provenanceActorRole is intentionally omitted (undefined) for backwards compat
+      // provenanceTrustClass is intentionally omitted (undefined) for backwards compat
     }, DEFAULT_CONFIG.memory);
 
     expect(result.indexedSegments).toBeGreaterThan(0);
@@ -4824,7 +4824,7 @@ describe('Memory regressions', () => {
       role: 'user',
       content: JSON.stringify([{ type: 'text', text: 'Unverified channel preference for compact layout.' }]),
       createdAt: now,
-      provenanceActorRole: 'unverified_channel',
+      provenanceTrustClass: 'unknown',
     }, DEFAULT_CONFIG.memory);
 
     expect(result.indexedSegments).toBeGreaterThan(0);

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -16,6 +16,7 @@
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { createHash, randomUUID } from 'node:crypto';
 
 import { afterAll, beforeEach, describe, expect, type Mock,mock, test } from 'bun:test';
 
@@ -49,6 +50,7 @@ const mockConfig = {
   provider: 'anthropic',
   providerOrder: ['anthropic'],
   apiKeys: { anthropic: 'test-key' },
+  secretDetection: { enabled: false },
   calls: {
     enabled: true,
     provider: 'twilio',
@@ -132,12 +134,14 @@ import {
 } from '../calls/call-store.js';
 import type { RelayWebSocketData } from '../calls/relay-server.js';
 import { activeRelayConnections,RelayConnection } from '../calls/relay-server.js';
-import { createBinding } from '../memory/channel-guardian-store.js';
-import { getMessages } from '../memory/conversation-store.js';
+import { setVoiceBridgeDeps } from '../calls/voice-session-bridge.js';
+import { createBinding, createChallenge } from '../memory/channel-guardian-store.js';
+import { addMessage, getMessages } from '../memory/conversation-store.js';
 import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { upsertMember } from '../memory/ingress-member-store.js';
 import { conversations } from '../memory/schema.js';
 import {
-  createVerificationChallenge,
+  createOutboundSession,
   getGuardianBinding,
 } from '../runtime/channel-guardian-service.js';
 
@@ -200,10 +204,49 @@ function resetTables() {
   db.run('DELETE FROM tool_invocations');
   db.run('DELETE FROM messages');
   db.run('DELETE FROM conversations');
+  db.run('DELETE FROM assistant_ingress_members');
   db.run('DELETE FROM channel_guardian_verification_challenges');
   db.run('DELETE FROM channel_guardian_bindings');
   db.run('DELETE FROM channel_guardian_rate_limits');
   ensuredConvIds = new Set();
+}
+
+function addTrustedVoiceContact(phoneNumber: string, assistantId: string = 'self'): void {
+  upsertMember({
+    assistantId,
+    sourceChannel: 'voice',
+    externalUserId: phoneNumber,
+    externalChatId: phoneNumber,
+    status: 'active',
+    policy: 'allow',
+  });
+}
+
+function createVoiceVerificationSession(
+  assistantId: string,
+  expectedPhoneE164: string,
+  sessionId?: string,
+): string {
+  const { secret } = createOutboundSession({
+    assistantId,
+    channel: 'voice',
+    expectedExternalUserId: expectedPhoneE164,
+    expectedChatId: expectedPhoneE164,
+    expectedPhoneE164,
+    sessionId,
+  });
+  return secret;
+}
+
+function createPendingVoiceGuardianChallenge(assistantId: string, secret: string = '123456'): string {
+  createChallenge({
+    id: randomUUID(),
+    assistantId,
+    channel: 'voice',
+    challengeHash: createHash('sha256').update(secret).digest('hex'),
+    expiresAt: Date.now() + 10 * 60 * 1000,
+  });
+  return secret;
 }
 
 function getLatestAssistantText(conversationId: string): string | null {
@@ -235,17 +278,88 @@ describe('relay-server', () => {
     mockConfig.calls.verification.maxAttempts = 3;
     mockConfig.calls.verification.codeLength = 6;
     mockConfig.calls.callerIdentity.userNumber = undefined;
+    setVoiceBridgeDeps({
+      getOrCreateSession: async (conversationId) => {
+        const session = {
+          callSessionId: undefined as string | undefined,
+          currentRequestId: undefined as string | undefined,
+          memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
+          isProcessing: () => false,
+          persistUserMessage: async (content: string, _attachments: unknown[], requestId?: string) => {
+            session.currentRequestId = requestId;
+            const message = await addMessage(
+              conversationId,
+              'user',
+              JSON.stringify([{ type: 'text', text: content }]),
+              {
+                userMessageChannel: 'voice',
+                assistantMessageChannel: 'voice',
+                userMessageInterface: 'voice',
+                assistantMessageInterface: 'voice',
+              },
+            );
+            return message.id;
+          },
+          setChannelCapabilities: () => {},
+          setAssistantId: () => {},
+          setGuardianContext: () => {},
+          setCommandIntent: () => {},
+          setTurnChannelContext: () => {},
+          setVoiceCallControlPrompt: () => {},
+          updateClient: () => {},
+          handleConfirmationResponse: () => {},
+          handleSecretResponse: () => {},
+          abort: () => {},
+          runAgentLoop: async (
+            _content: string,
+            _messageId: string,
+            onEvent: (event: { type: string; sessionId?: string; text?: string }) => void,
+          ) => {
+            const tokens: string[] = [];
+            await mockSendMessage([], [], '', {
+              onEvent: (event: { type: string; text?: string }) => {
+                if (event.type !== 'text_delta' || typeof event.text !== 'string') return;
+                tokens.push(event.text);
+                onEvent({ type: 'assistant_text_delta', sessionId: conversationId, text: event.text });
+              },
+            });
+
+            const fullText = tokens.join('');
+            if (fullText.length > 0) {
+              await addMessage(
+                conversationId,
+                'assistant',
+                JSON.stringify([{ type: 'text', text: fullText }]),
+                {
+                  userMessageChannel: 'voice',
+                  assistantMessageChannel: 'voice',
+                  userMessageInterface: 'voice',
+                  assistantMessageInterface: 'voice',
+                },
+              );
+            }
+
+            onEvent({ type: 'message_complete', sessionId: conversationId });
+          },
+        };
+        return session as unknown as import('../daemon/session.js').Session;
+      },
+      resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
+    });
   });
 
   // ── Setup message handling ──────────────────────────────────────
 
   test('handleMessage: setup message associates callSid and records event', async () => {
     ensureConversation('conv-relay-1');
+    ensureConversation('conv-relay-1-origin');
     const session = createCallSession({
       conversationId: 'conv-relay-1',
       provider: 'twilio',
       fromNumber: '+15551111111',
       toNumber: '+15552222222',
+      initiatedFromConversationId: 'conv-relay-1-origin',
     });
 
     const { relay } = createMockWs(session.id);
@@ -277,12 +391,14 @@ describe('relay-server', () => {
 
   test('handleMessage: setup triggers initial assistant greeting turn', async () => {
     ensureConversation('conv-relay-setup-greet');
+    ensureConversation('conv-relay-setup-greet-origin');
     const session = createCallSession({
       conversationId: 'conv-relay-setup-greet',
       provider: 'twilio',
       fromNumber: '+15551111111',
       toNumber: '+15552222222',
       task: 'Confirm appointment time',
+      initiatedFromConversationId: 'conv-relay-setup-greet-origin',
     });
 
     mockSendMessage.mockImplementation(createMockProviderResponse(['Hello, I am calling to confirm your appointment.']));
@@ -398,11 +514,13 @@ describe('relay-server', () => {
 
   test('handleMessage: final prompt routes to orchestrator and records event', async () => {
     ensureConversation('conv-relay-prompt');
+    ensureConversation('conv-relay-prompt-origin');
     const session = createCallSession({
       conversationId: 'conv-relay-prompt',
       provider: 'twilio',
       fromNumber: '+15551111111',
       toNumber: '+15552222222',
+      initiatedFromConversationId: 'conv-relay-prompt-origin',
     });
 
     const { ws, relay } = createMockWs(session.id);
@@ -858,6 +976,7 @@ describe('relay-server', () => {
 
     // Enable verification to prove inbound calls skip it
     mockConfig.calls.verification.enabled = true;
+    addTrustedVoiceContact('+15559999999');
 
     mockSendMessage.mockImplementation(createMockProviderResponse(['Hello, how can I help you today?']));
 
@@ -896,6 +1015,7 @@ describe('relay-server', () => {
     });
 
     mockSendMessage.mockImplementation(createMockProviderResponse(['Sure, let me help with that.']));
+    addTrustedVoiceContact('+15559999999');
 
     const { relay } = createMockWs(session.id);
 
@@ -941,6 +1061,7 @@ describe('relay-server', () => {
     });
 
     let turnCount = 0;
+    addTrustedVoiceContact('+15559999999');
     mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
       turnCount++;
       let tokens: string[];
@@ -1016,8 +1137,7 @@ describe('relay-server', () => {
     });
 
     // Create a pending voice guardian challenge
-    const challenge = createVerificationChallenge('test-assistant', 'voice');
-    const secret = challenge.secret;
+    const secret = createPendingVoiceGuardianChallenge('test-assistant');
 
     mockSendMessage.mockImplementation(createMockProviderResponse(['Hello, how can I help you?']));
 
@@ -1079,8 +1199,7 @@ describe('relay-server', () => {
       assistantId: 'test-assistant',
     });
 
-    const challenge = createVerificationChallenge('test-assistant', 'voice');
-    const secret = challenge.secret;
+    const secret = createPendingVoiceGuardianChallenge('test-assistant');
 
     mockSendMessage.mockImplementation(createMockProviderResponse(['Hello, verified caller!']));
 
@@ -1151,15 +1270,15 @@ describe('relay-server', () => {
       to: '+15551111111',
     }));
 
-    const runtimeContext = (relay.getController() as unknown as { guardianContext?: { sourceChannel?: string; actorRole?: string; guardianExternalUserId?: string } })?.guardianContext;
+    const runtimeContext = (relay.getController() as unknown as { guardianContext?: { sourceChannel?: string; trustClass?: string; guardianExternalUserId?: string } })?.guardianContext;
     expect(runtimeContext?.sourceChannel).toBe('voice');
-    expect(runtimeContext?.actorRole).toBe('guardian');
+    expect(runtimeContext?.trustClass).toBe('guardian');
     expect(runtimeContext?.guardianExternalUserId).toBe('+15550001111');
 
     relay.destroy();
   });
 
-  test('inbound call: caller not matching voice guardian binding is classified as non-guardian', async () => {
+  test('inbound call: caller not matching voice guardian binding is classified as trusted contact', async () => {
     ensureConversation('conv-guardian-role-mismatch');
     const session = createCallSession({
       conversationId: 'conv-guardian-role-mismatch',
@@ -1175,6 +1294,7 @@ describe('relay-server', () => {
       guardianExternalUserId: '+15550009999',
       guardianDeliveryChatId: '+15550009999',
     });
+    addTrustedVoiceContact('+15550002222', 'test-assistant');
 
     mockSendMessage.mockImplementation(createMockProviderResponse(['Hello there.']));
 
@@ -1190,13 +1310,13 @@ describe('relay-server', () => {
     const runtimeContext = (relay.getController() as unknown as {
       guardianContext?: {
         sourceChannel?: string;
-        actorRole?: string;
+        trustClass?: string;
         guardianExternalUserId?: string;
         requesterExternalUserId?: string;
       };
     })?.guardianContext;
     expect(runtimeContext?.sourceChannel).toBe('voice');
-    expect(runtimeContext?.actorRole).toBe('non-guardian');
+    expect(runtimeContext?.trustClass).toBe('trusted_contact');
     expect(runtimeContext?.guardianExternalUserId).toBe('+15550009999');
     expect(runtimeContext?.requesterExternalUserId).toBe('+15550002222');
 
@@ -1236,12 +1356,12 @@ describe('relay-server', () => {
     const runtimeContext = (relay.getController() as unknown as {
       guardianContext?: {
         sourceChannel?: string;
-        actorRole?: string;
+        trustClass?: string;
         guardianExternalUserId?: string;
       };
     })?.guardianContext;
     expect(runtimeContext?.sourceChannel).toBe('voice');
-    expect(runtimeContext?.actorRole).toBe('guardian');
+    expect(runtimeContext?.trustClass).toBe('guardian');
     expect(runtimeContext?.guardianExternalUserId).toBe('+15550001111');
 
     relay.destroy();
@@ -1283,11 +1403,11 @@ describe('relay-server', () => {
     const runtimeContext = (relay.getController() as unknown as {
       guardianContext?: {
         sourceChannel?: string;
-        actorRole?: string;
+        trustClass?: string;
       };
     })?.guardianContext;
     expect(runtimeContext?.sourceChannel).toBe('voice');
-    expect(runtimeContext?.actorRole).toBe('unverified_channel');
+    expect(runtimeContext?.trustClass).toBe('unknown');
 
     relay.destroy();
   });
@@ -1302,8 +1422,8 @@ describe('relay-server', () => {
       assistantId: 'test-assistant',
     });
 
-    const challenge = createVerificationChallenge('test-assistant', 'voice');
-    const spokenCode = challenge.secret.split('').join(' ');
+    const secret = createPendingVoiceGuardianChallenge('test-assistant');
+    const spokenCode = secret.split('').join(' ');
 
     const { relay } = createMockWs(session.id);
 
@@ -1315,9 +1435,9 @@ describe('relay-server', () => {
     }));
 
     const preVerify = (relay.getController() as unknown as {
-      guardianContext?: { actorRole?: string };
+      guardianContext?: { trustClass?: string };
     })?.guardianContext;
-    expect(preVerify?.actorRole).toBe('unverified_channel');
+    expect(preVerify?.trustClass).toBe('unknown');
 
     await relay.handleMessage(JSON.stringify({
       type: 'prompt',
@@ -1329,10 +1449,10 @@ describe('relay-server', () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     const postVerify = (relay.getController() as unknown as {
-      guardianContext?: { sourceChannel?: string; actorRole?: string; guardianExternalUserId?: string };
+      guardianContext?: { sourceChannel?: string; trustClass?: string; guardianExternalUserId?: string };
     })?.guardianContext;
     expect(postVerify?.sourceChannel).toBe('voice');
-    expect(postVerify?.actorRole).toBe('guardian');
+    expect(postVerify?.trustClass).toBe('guardian');
     expect(postVerify?.guardianExternalUserId).toBe(session.fromNumber);
 
     relay.destroy();
@@ -1348,7 +1468,7 @@ describe('relay-server', () => {
       assistantId: 'test-assistant',
     });
 
-    createVerificationChallenge('test-assistant', 'voice');
+    createPendingVoiceGuardianChallenge('test-assistant');
 
     const { ws, relay } = createMockWs(session.id);
 
@@ -1389,7 +1509,7 @@ describe('relay-server', () => {
       assistantId: 'test-assistant',
     });
 
-    createVerificationChallenge('test-assistant', 'voice');
+    createPendingVoiceGuardianChallenge('test-assistant');
 
     const { ws, relay } = createMockWs(session.id);
 
@@ -1451,6 +1571,7 @@ describe('relay-server', () => {
     // Do NOT create any pending challenge
 
     mockSendMessage.mockImplementation(createMockProviderResponse(['Welcome to the line.']));
+    addTrustedVoiceContact('+15559999999', 'test-assistant');
 
     const { ws, relay } = createMockWs(session.id);
 
@@ -1486,7 +1607,7 @@ describe('relay-server', () => {
       assistantId: 'test-assistant',
     });
 
-    createVerificationChallenge('test-assistant', 'voice');
+    createPendingVoiceGuardianChallenge('test-assistant');
 
     const { ws, relay } = createMockWs(session.id);
 
@@ -1536,8 +1657,7 @@ describe('relay-server', () => {
       initiatedFromConversationId: 'conv-gv-pointer-success-origin',
     });
 
-    const challenge = createVerificationChallenge('test-assistant', 'voice');
-    const secret = challenge.secret;
+    const secret = createVoiceVerificationSession('test-assistant', '+15559999999', 'gv-session-ptr-success');
 
     const { relay } = createMockWs(session.id);
 
@@ -1586,7 +1706,7 @@ describe('relay-server', () => {
       initiatedFromConversationId: 'conv-gv-pointer-fail-origin',
     });
 
-    createVerificationChallenge('test-assistant', 'voice');
+    createVoiceVerificationSession('test-assistant', '+15559999999', 'gv-session-ptr-fail');
 
     const { relay } = createMockWs(session.id);
 

--- a/assistant/src/__tests__/session-load-history-repair.test.ts
+++ b/assistant/src/__tests__/session-load-history-repair.test.ts
@@ -252,30 +252,30 @@ describe('loadFromDb history repair', () => {
         id: 'm1',
         role: 'user',
         content: JSON.stringify([{ type: 'text', text: 'Guardian secret question' }]),
-        metadata: JSON.stringify({ provenanceActorRole: 'guardian', provenanceSourceChannel: 'telegram' }),
+        metadata: JSON.stringify({ provenanceTrustClass: 'guardian', provenanceSourceChannel: 'telegram' }),
       },
       {
         id: 'm2',
         role: 'assistant',
         content: JSON.stringify([{ type: 'text', text: 'Guardian-only answer' }]),
-        metadata: JSON.stringify({ provenanceActorRole: 'guardian', provenanceSourceChannel: 'telegram' }),
+        metadata: JSON.stringify({ provenanceTrustClass: 'guardian', provenanceSourceChannel: 'telegram' }),
       },
       {
         id: 'm3',
         role: 'user',
         content: JSON.stringify([{ type: 'text', text: 'Untrusted follow-up' }]),
-        metadata: JSON.stringify({ provenanceActorRole: 'unverified_channel', provenanceSourceChannel: 'telegram' }),
+        metadata: JSON.stringify({ provenanceTrustClass: 'unknown', provenanceSourceChannel: 'telegram' }),
       },
       {
         id: 'm4',
         role: 'assistant',
         content: JSON.stringify([{ type: 'text', text: 'Untrusted-safe reply' }]),
-        metadata: JSON.stringify({ provenanceActorRole: 'unverified_channel', provenanceSourceChannel: 'telegram' }),
+        metadata: JSON.stringify({ provenanceTrustClass: 'unknown', provenanceSourceChannel: 'telegram' }),
       },
     ];
 
     const session = makeSession();
-    session.setGuardianContext({ actorRole: 'unverified_channel', sourceChannel: 'telegram' });
+    session.setGuardianContext({ trustClass: 'unknown', sourceChannel: 'telegram' });
     await session.loadFromDb();
     const messages = session.getMessages();
 
@@ -300,35 +300,35 @@ describe('loadFromDb history repair', () => {
         id: 'm1',
         role: 'user',
         content: JSON.stringify([{ type: 'text', text: 'Guardian question' }]),
-        metadata: JSON.stringify({ provenanceActorRole: 'guardian', provenanceSourceChannel: 'telegram' }),
+        metadata: JSON.stringify({ provenanceTrustClass: 'guardian', provenanceSourceChannel: 'telegram' }),
       },
       {
         id: 'm2',
         role: 'assistant',
         content: JSON.stringify([{ type: 'text', text: 'Guardian answer' }]),
-        metadata: JSON.stringify({ provenanceActorRole: 'guardian', provenanceSourceChannel: 'telegram' }),
+        metadata: JSON.stringify({ provenanceTrustClass: 'guardian', provenanceSourceChannel: 'telegram' }),
       },
       {
         id: 'm3',
         role: 'user',
         content: JSON.stringify([{ type: 'text', text: 'Unverified ping' }]),
-        metadata: JSON.stringify({ provenanceActorRole: 'unverified_channel', provenanceSourceChannel: 'telegram' }),
+        metadata: JSON.stringify({ provenanceTrustClass: 'unknown', provenanceSourceChannel: 'telegram' }),
       },
       {
         id: 'm4',
         role: 'assistant',
         content: JSON.stringify([{ type: 'text', text: 'Unverified reply' }]),
-        metadata: JSON.stringify({ provenanceActorRole: 'unverified_channel', provenanceSourceChannel: 'telegram' }),
+        metadata: JSON.stringify({ provenanceTrustClass: 'unknown', provenanceSourceChannel: 'telegram' }),
       },
     ];
 
     const session = makeSession();
 
-    session.setGuardianContext({ actorRole: 'guardian', sourceChannel: 'telegram' });
+    session.setGuardianContext({ trustClass: 'guardian', sourceChannel: 'telegram' });
     await session.ensureActorScopedHistory();
     expect(session.getMessages()).toHaveLength(4);
 
-    session.setGuardianContext({ actorRole: 'unverified_channel', sourceChannel: 'telegram' });
+    session.setGuardianContext({ trustClass: 'unknown', sourceChannel: 'telegram' });
     await session.ensureActorScopedHistory();
     const downgradedMessages = session.getMessages();
     expect(downgradedMessages).toHaveLength(2);
@@ -350,35 +350,35 @@ describe('loadFromDb history repair', () => {
         id: 'm1',
         role: 'user',
         content: JSON.stringify([{ type: 'text', text: 'Guardian-only question' }]),
-        metadata: JSON.stringify({ provenanceActorRole: 'guardian', provenanceSourceChannel: 'telegram' }),
+        metadata: JSON.stringify({ provenanceTrustClass: 'guardian', provenanceSourceChannel: 'telegram' }),
       },
       {
         id: 'm2',
         role: 'assistant',
         content: JSON.stringify([{ type: 'text', text: 'Guardian-only answer' }]),
-        metadata: JSON.stringify({ provenanceActorRole: 'guardian', provenanceSourceChannel: 'telegram' }),
+        metadata: JSON.stringify({ provenanceTrustClass: 'guardian', provenanceSourceChannel: 'telegram' }),
       },
       {
         id: 'm3',
         role: 'user',
         content: JSON.stringify([{ type: 'text', text: 'Unverified ping' }]),
-        metadata: JSON.stringify({ provenanceActorRole: 'unverified_channel', provenanceSourceChannel: 'telegram' }),
+        metadata: JSON.stringify({ provenanceTrustClass: 'unknown', provenanceSourceChannel: 'telegram' }),
       },
       {
         id: 'm4',
         role: 'assistant',
         content: JSON.stringify([{ type: 'text', text: 'Unverified reply' }]),
-        metadata: JSON.stringify({ provenanceActorRole: 'unverified_channel', provenanceSourceChannel: 'telegram' }),
+        metadata: JSON.stringify({ provenanceTrustClass: 'unknown', provenanceSourceChannel: 'telegram' }),
       },
     ];
 
     const session = makeSession();
 
-    session.setGuardianContext({ actorRole: 'unverified_channel', sourceChannel: 'telegram' });
+    session.setGuardianContext({ trustClass: 'unknown', sourceChannel: 'telegram' });
     await session.ensureActorScopedHistory();
     expect(session.getMessages()).toHaveLength(2);
 
-    session.setGuardianContext({ actorRole: 'guardian', sourceChannel: 'telegram' });
+    session.setGuardianContext({ trustClass: 'guardian', sourceChannel: 'telegram' });
     await session.persistUserMessage('Guardian follow-up', []);
     const messagesAfterPersist = session.getMessages();
 

--- a/assistant/src/__tests__/tool-approval-handler.test.ts
+++ b/assistant/src/__tests__/tool-approval-handler.test.ts
@@ -100,7 +100,7 @@ function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
     conversationId: 'conv-1',
     assistantId: 'self',
     requestId: 'req-1',
-    guardianActorRole: 'non-guardian',
+    guardianTrustClass: 'trusted_contact',
     ...overrides,
   };
 }
@@ -134,7 +134,7 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
     );
     expect(mintResult.ok).toBe(true);
 
-    const context = makeContext({ guardianActorRole: 'non-guardian' });
+    const context = makeContext({ guardianTrustClass: 'trusted_contact' });
     const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
@@ -149,7 +149,7 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
     const toolName = 'bash';
     const input = { command: 'rm -rf /' };
 
-    const context = makeContext({ guardianActorRole: 'non-guardian' });
+    const context = makeContext({ guardianTrustClass: 'trusted_contact' });
     const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
@@ -177,7 +177,7 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
       }),
     );
 
-    const context = makeContext({ guardianActorRole: 'unverified_channel' });
+    const context = makeContext({ guardianTrustClass: 'unknown' });
     const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
@@ -189,7 +189,7 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
     const toolName = 'bash';
     const input = { command: 'deploy' };
 
-    const context = makeContext({ guardianActorRole: 'unverified_channel' });
+    const context = makeContext({ guardianTrustClass: 'unknown' });
     const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
@@ -212,7 +212,7 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
       }),
     );
 
-    const context = makeContext({ guardianActorRole: 'non-guardian' });
+    const context = makeContext({ guardianTrustClass: 'trusted_contact' });
 
     // First invocation — should consume the grant and allow
     const first = await handler.checkPreExecutionGates(
@@ -241,7 +241,7 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
       }),
     );
 
-    const context = makeContext({ guardianActorRole: 'non-guardian' });
+    const context = makeContext({ guardianTrustClass: 'trusted_contact' });
     const result = await handler.checkPreExecutionGates(
       toolName, invokeInput, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
@@ -264,7 +264,7 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
       }),
     );
 
-    const context = makeContext({ guardianActorRole: 'non-guardian' });
+    const context = makeContext({ guardianTrustClass: 'trusted_contact' });
     const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
@@ -277,7 +277,7 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
     const input = { command: 'deploy' };
 
     // No grants minted at all
-    const context = makeContext({ guardianActorRole: 'guardian' });
+    const context = makeContext({ guardianTrustClass: 'guardian' });
     const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
@@ -290,7 +290,7 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
     const toolName = 'bash';
     const input = { command: 'deploy' };
 
-    const context = makeContext({ guardianActorRole: undefined });
+    const context = makeContext({ guardianTrustClass: undefined });
     const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
@@ -309,7 +309,7 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
       }),
     );
 
-    const context = makeContext({ guardianActorRole: 'non-guardian', requestId: 'req-1' });
+    const context = makeContext({ guardianTrustClass: 'trusted_contact', requestId: 'req-1' });
     const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
@@ -333,7 +333,7 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
 
     // Context conversationId does not match the grant's conversationId
     const context = makeContext({
-      guardianActorRole: 'non-guardian',
+      guardianTrustClass: 'trusted_contact',
       conversationId: 'conv-1',
     });
     const result = await handler.checkPreExecutionGates(
@@ -349,7 +349,7 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
 
     // executionChannel defaults to undefined (non-voice)
     const context = makeContext({
-      guardianActorRole: 'non-guardian',
+      guardianTrustClass: 'trusted_contact',
       executionChannel: 'telegram',
     });
 
@@ -383,7 +383,7 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
     }, 300);
 
     const context = makeContext({
-      guardianActorRole: 'non-guardian',
+      guardianTrustClass: 'trusted_contact',
       executionChannel: 'voice',
     });
 
@@ -408,7 +408,7 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
     setTimeout(() => controller.abort(), 200);
 
     const context = makeContext({
-      guardianActorRole: 'non-guardian',
+      guardianTrustClass: 'trusted_contact',
       executionChannel: 'voice',
       signal: controller.signal,
     });

--- a/assistant/src/__tests__/tool-grant-request-escalation.test.ts
+++ b/assistant/src/__tests__/tool-grant-request-escalation.test.ts
@@ -147,7 +147,7 @@ function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
     conversationId: 'conv-1',
     assistantId: 'self',
     requestId: 'req-1',
-    guardianActorRole: 'non-guardian',
+    guardianTrustClass: 'trusted_contact',
     executionChannel: 'telegram',
     requesterExternalUserId: 'requester-1',
     ...overrides,
@@ -204,7 +204,7 @@ describe('ToolApprovalHandler / grant-miss escalation', () => {
     const toolName = 'bash';
     const input = { command: 'cat /etc/passwd' };
 
-    const context = makeContext({ guardianActorRole: 'non-guardian' });
+    const context = makeContext({ guardianTrustClass: 'trusted_contact' });
     const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
@@ -231,7 +231,7 @@ describe('ToolApprovalHandler / grant-miss escalation', () => {
     const toolName = 'bash';
     const input = { command: 'deploy' };
 
-    const context = makeContext({ guardianActorRole: 'non-guardian' });
+    const context = makeContext({ guardianTrustClass: 'trusted_contact' });
     const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
@@ -247,7 +247,7 @@ describe('ToolApprovalHandler / grant-miss escalation', () => {
     const toolName = 'bash';
     const input = { command: 'rm -rf /' };
 
-    const context = makeContext({ guardianActorRole: 'non-guardian' });
+    const context = makeContext({ guardianTrustClass: 'trusted_contact' });
 
     // First invocation creates the request
     await handler.checkPreExecutionGates(
@@ -288,7 +288,7 @@ describe('ToolApprovalHandler / grant-miss escalation', () => {
     const input = { command: 'ls' };
 
     const context = makeContext({
-      guardianActorRole: 'unverified_channel',
+      guardianTrustClass: 'unknown',
       executionChannel: 'telegram',
       requesterExternalUserId: 'unknown-user',
     });
@@ -314,7 +314,7 @@ describe('ToolApprovalHandler / grant-miss escalation', () => {
     const input = { command: 'deploy' };
 
     const context = makeContext({
-      guardianActorRole: 'non-guardian',
+      guardianTrustClass: 'trusted_contact',
       executionChannel: undefined, // no channel info
     });
     const result = await handler.checkPreExecutionGates(
@@ -449,7 +449,7 @@ describe('end-to-end: tool grant escalation -> approval -> consume', () => {
     const input = { command: 'echo secret' };
     const _inputDigest = computeToolApprovalDigest(toolName, input);
 
-    const context = makeContext({ guardianActorRole: 'non-guardian' });
+    const context = makeContext({ guardianTrustClass: 'trusted_contact' });
 
     // Step 1: First invocation is denied, but a tool_grant_request is created
     const firstResult = await handler.checkPreExecutionGates(

--- a/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
+++ b/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
@@ -266,7 +266,7 @@ describe('voice bridge confirmation handling (grant consumption via primitive)',
 
     const guardianContext: GuardianRuntimeContext = {
       sourceChannel: 'voice',
-      actorRole: 'non-guardian',
+      trustClass: 'trusted_contact',
       requesterExternalUserId: 'caller-123',
     };
 
@@ -307,7 +307,7 @@ describe('voice bridge confirmation handling (grant consumption via primitive)',
 
     const guardianContext: GuardianRuntimeContext = {
       sourceChannel: 'voice',
-      actorRole: 'non-guardian',
+      trustClass: 'trusted_contact',
       requesterExternalUserId: 'caller-123',
     };
 
@@ -343,7 +343,7 @@ describe('voice bridge confirmation handling (grant consumption via primitive)',
 
     const guardianContext: GuardianRuntimeContext = {
       sourceChannel: 'voice',
-      actorRole: 'non-guardian',
+      trustClass: 'trusted_contact',
     };
 
     await startVoiceTurn({
@@ -373,7 +373,7 @@ describe('voice bridge confirmation handling (grant consumption via primitive)',
 
     const guardianContext: GuardianRuntimeContext = {
       sourceChannel: 'voice',
-      actorRole: 'guardian',
+      trustClass: 'guardian',
     };
 
     await startVoiceTurn({
@@ -407,7 +407,7 @@ describe('voice bridge confirmation handling (grant consumption via primitive)',
 
     const guardianContext: GuardianRuntimeContext = {
       sourceChannel: 'voice',
-      actorRole: 'non-guardian',
+      trustClass: 'trusted_contact',
       requesterExternalUserId: 'caller-123',
     };
 

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -304,7 +304,7 @@ describe('voice-session-bridge', () => {
       isInbound: true,
       guardianContext: {
         sourceChannel: 'voice',
-        actorRole: 'non-guardian',
+        trustClass: 'trusted_contact',
         guardianExternalUserId: '+15550009999',
         guardianChatId: '+15550009999',
         requesterExternalUserId: '+15550002222',
@@ -340,7 +340,7 @@ describe('voice-session-bridge', () => {
       isInbound: true,
       guardianContext: {
         sourceChannel: 'voice',
-        actorRole: 'unverified_channel',
+        trustClass: 'unknown',
         denialReason: 'no_binding',
       },
       onTextDelta: () => {},
@@ -374,7 +374,7 @@ describe('voice-session-bridge', () => {
       isInbound: true,
       guardianContext: {
         sourceChannel: 'voice',
-        actorRole: 'guardian',
+        trustClass: 'guardian',
         guardianExternalUserId: '+15550001111',
         guardianChatId: '+15550001111',
       },
@@ -407,7 +407,7 @@ describe('voice-session-bridge', () => {
 
     const guardianCtx = {
       sourceChannel: 'voice' as const,
-      actorRole: 'guardian' as const,
+      trustClass: 'guardian' as const,
       guardianExternalUserId: '+15550001111',
       guardianChatId: '+15550001111',
     };
@@ -450,7 +450,7 @@ describe('voice-session-bridge', () => {
       isInbound: true,
       guardianContext: {
         sourceChannel: 'voice',
-        actorRole: 'non-guardian',
+        trustClass: 'trusted_contact',
       },
       onTextDelta: () => {},
       onComplete: () => {},
@@ -499,7 +499,7 @@ describe('voice-session-bridge', () => {
       isInbound: true,
       guardianContext: {
         sourceChannel: 'voice',
-        actorRole: 'non-guardian',
+        trustClass: 'trusted_contact',
       },
       onTextDelta: () => {},
       onComplete: () => {},
@@ -574,7 +574,7 @@ describe('voice-session-bridge', () => {
       isInbound: true,
       guardianContext: {
         sourceChannel: 'voice',
-        actorRole: 'non-guardian',
+        trustClass: 'trusted_contact',
         guardianExternalUserId: '+15550009999',
         guardianChatId: '+15550009999',
         requesterExternalUserId: '+15550002222',
@@ -644,7 +644,7 @@ describe('voice-session-bridge', () => {
       isInbound: true,
       guardianContext: {
         sourceChannel: 'voice',
-        actorRole: 'unverified_channel',
+        trustClass: 'unknown',
         denialReason: 'no_binding',
       },
       onTextDelta: () => {},
@@ -768,7 +768,7 @@ describe('voice-session-bridge', () => {
       isInbound: true,
       guardianContext: {
         sourceChannel: 'voice',
-        actorRole: 'guardian',
+        trustClass: 'guardian',
         guardianExternalUserId: '+15550001111',
         guardianChatId: '+15550001111',
       },
@@ -835,7 +835,7 @@ describe('voice-session-bridge', () => {
       isInbound: true,
       guardianContext: {
         sourceChannel: 'voice',
-        actorRole: 'guardian',
+        trustClass: 'guardian',
         guardianExternalUserId: '+15550001111',
         guardianChatId: '+15550001111',
       },

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -857,7 +857,7 @@ export class CallController {
   }
 
   private isCallerGuardian(): boolean {
-    return this.guardianContext?.actorRole === 'guardian';
+    return this.guardianContext?.trustClass === 'guardian';
   }
 
   /**

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -14,15 +14,14 @@ import { getConfig } from '../config/loader.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { revokeScopedApprovalGrantsForContext } from '../memory/scoped-approval-grants.js';
 import { notifyGuardianOfAccessRequest } from '../runtime/access-request-helper.js';
-import { resolveActorTrust, toGuardianContextCompat } from '../runtime/actor-trust-resolver.js';
+import {
+  resolveActorTrust,
+  toGuardianRuntimeContextFromTrust,
+} from '../runtime/actor-trust-resolver.js';
 import {
   getPendingChallenge,
   validateAndConsumeChallenge,
 } from '../runtime/channel-guardian-service.js';
-import {
-  resolveGuardianContext,
-  toGuardianRuntimeContext,
-} from '../runtime/guardian-context-resolver.js';
 import {
   composeVerificationVoice,
   GUARDIAN_VERIFY_TEMPLATE_KEYS,
@@ -428,15 +427,13 @@ export class RelayConnection {
     // calls msg.from is the caller; for outbound calls msg.to is the
     // recipient (msg.from is the assistant's Twilio number).
     const otherPartyNumber = isInbound ? msg.from : msg.to;
-    const initialGuardianContext = toGuardianRuntimeContext(
-      'voice',
-      resolveGuardianContext({
-        assistantId,
-        sourceChannel: 'voice',
-        externalChatId: otherPartyNumber,
-        senderExternalUserId: otherPartyNumber || undefined,
-      }),
-    );
+    const initialActorTrust = resolveActorTrust({
+      assistantId,
+      sourceChannel: 'voice',
+      externalChatId: otherPartyNumber,
+      senderExternalUserId: otherPartyNumber || undefined,
+    });
+    const initialGuardianContext = toGuardianRuntimeContextFromTrust(initialActorTrust, otherPartyNumber);
 
     const controller = new CallController(this.callSessionId, this, session?.task ?? null, {
       broadcast: globalBroadcast,
@@ -613,10 +610,7 @@ export class RelayConnection {
       // Update the controller's guardian context with the trust-resolved
       // context so downstream policy gates have accurate actor metadata.
       if (this.controller && actorTrust.trustClass !== 'unknown') {
-        const resolvedGuardianContext = toGuardianRuntimeContext(
-          'voice',
-          toGuardianContextCompat(actorTrust, msg.from),
-        );
+        const resolvedGuardianContext = toGuardianRuntimeContextFromTrust(actorTrust, msg.from);
         this.controller.setGuardianContext(resolvedGuardianContext);
       }
 
@@ -876,16 +870,14 @@ export class RelayConnection {
       } else {
         // Inbound: proceed to normal call flow
         if (this.controller) {
+          const verifiedActorTrust = resolveActorTrust({
+            assistantId: this.guardianChallengeAssistantId,
+            sourceChannel: 'voice',
+            externalChatId: this.guardianVerificationFromNumber,
+            senderExternalUserId: this.guardianVerificationFromNumber,
+          });
           this.controller.setGuardianContext(
-            toGuardianRuntimeContext(
-              'voice',
-              resolveGuardianContext({
-                assistantId: this.guardianChallengeAssistantId,
-                sourceChannel: 'voice',
-                externalChatId: this.guardianVerificationFromNumber,
-                senderExternalUserId: this.guardianVerificationFromNumber,
-              }),
-            ),
+            toGuardianRuntimeContextFromTrust(verifiedActorTrust, this.guardianVerificationFromNumber),
           );
           this.startNormalCallFlow(this.controller, true);
         }

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -250,8 +250,8 @@ export async function startVoiceTurn(opts: VoiceTurnOptions): Promise<VoiceTurnH
   // - guardian: permission prompts auto-allow (parity with guardian chat)
   // - everyone else (including unknown): fail-closed strict side-effects
   //   with auto-deny confirmations.
-  const actorRole = opts.guardianContext?.actorRole;
-  const isGuardian = actorRole === 'guardian';
+  const trustClass = opts.guardianContext?.trustClass;
+  const isGuardian = trustClass === 'guardian';
   const forceStrictSideEffects = isGuardian ? undefined : true;
 
   // Replace the [CALL_OPENING] marker with a neutral instruction before
@@ -264,7 +264,7 @@ export async function startVoiceTurn(opts: VoiceTurnOptions): Promise<VoiceTurnH
 
   // Build the call-control protocol prompt so the model knows how to emit
   // control markers (ASK_GUARDIAN, END_CALL, etc.) and recognize opener turns.
-  const isCallerGuardian = opts.guardianContext?.actorRole === 'guardian';
+  const isCallerGuardian = opts.guardianContext?.trustClass === 'guardian';
 
   const voiceCallControlPrompt = buildVoiceCallControlPrompt({
     isInbound: opts.isInbound,

--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -303,9 +303,9 @@ async function executeApprove(
     }
   }
   session.setAssistantId(assistantId);
-  // The guardian approved this escalation, so tag as guardian to avoid
-  // 'unverified_channel' blocking memory extraction.
-  session.setGuardianContext({ actorRole: 'guardian', sourceChannel: sourceChannel ?? 'vellum' });
+  // The guardian approved this escalation, so tag as guardian trust to avoid
+  // unknown-provenance memory gating.
+  session.setGuardianContext({ trustClass: 'guardian', sourceChannel: sourceChannel ?? 'vellum' });
   session.setCommandIntent(null);
 
   // Process the message through the agent loop (no IPC event callback
@@ -379,7 +379,7 @@ async function executeDeny(
   // Store a system note about the denial in the conversation
   const denialInterface = isInterfaceId(sourceChannel) ? sourceChannel : undefined;
   await addMessage(conversationId, 'assistant', denialText, {
-    provenanceActorRole: 'guardian' as const,
+    provenanceTrustClass: 'guardian' as const,
     userMessageChannel: sourceChannel,
     assistantMessageChannel: sourceChannel,
     ...(denialInterface ? { userMessageInterface: denialInterface, assistantMessageInterface: denialInterface } : {}),

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -172,9 +172,9 @@ export async function handleUserMessage(
         assistantMessageInterface: ipcInterface,
       });
       session.setAssistantId('self');
-      // IPC/desktop user IS the guardian — default to guardian role so messages
-      // are not tagged 'unverified_channel' (which blocks memory extraction).
-      session.setGuardianContext({ actorRole: 'guardian', sourceChannel: ipcChannel });
+      // IPC/desktop user IS the guardian — default to guardian trust so
+      // messages are not tagged as unknown provenance.
+      session.setGuardianContext({ trustClass: 'guardian', sourceChannel: ipcChannel });
       session.setCommandIntent(null);
       // Fire-and-forget: don't block the IPC handler so the connection can
       // continue receiving messages (e.g. cancel, confirmations, or

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -258,7 +258,7 @@ export async function runAgentLoopImpl(
         conflictGate: ctx.conflictGate,
         scopeId: ctx.memoryPolicy.scopeId,
         includeDefaultFallback: ctx.memoryPolicy.includeDefaultFallback,
-        guardianActorRole: ctx.guardianContext?.actorRole,
+        guardianTrustClass: ctx.guardianContext?.trustClass,
         isInteractive: options?.isInteractive ?? (!ctx.hasNoClient && !ctx.headlessLock),
       },
       content,
@@ -355,10 +355,9 @@ export async function runAgentLoopImpl(
 
     // Resolve the inbound actor context for the model's <inbound_actor_context>
     // block. When the session carries enough identity info, use the unified
-    // actor trust resolver so trusted_contact classifications propagate
-    // correctly (the legacy guardian-context path collapses non-guardian to
-    // 'unknown'). The guardian context is still used for policy gating — only
-    // the model context block uses the trust-resolved output.
+    // actor trust resolver so member status/policy and guardian binding details
+    // are fresh for this turn. The session runtime context remains the source
+    // for policy gating; this block is model-facing grounding metadata.
     let resolvedInboundActorContext: InboundActorContext | null = null;
     if (ctx.guardianContext) {
       const gc = ctx.guardianContext;

--- a/assistant/src/daemon/session-lifecycle.ts
+++ b/assistant/src/daemon/session-lifecycle.ts
@@ -24,30 +24,38 @@ import { resetSkillToolProjection } from './session-skill-tools.js';
 
 const log = getLogger('session-lifecycle');
 
-type GuardianActorRole = GuardianRuntimeContext['actorRole'];
+type GuardianTrustClass = GuardianRuntimeContext['trustClass'];
 
-function parseProvenanceActorRole(metadata: string | null): GuardianActorRole | undefined {
+function parseProvenanceTrustClass(metadata: string | null): GuardianTrustClass | undefined {
   if (!metadata) return undefined;
   try {
-    const parsed = JSON.parse(metadata) as { provenanceActorRole?: unknown };
-    const role = parsed?.provenanceActorRole;
-    if (role === 'guardian' || role === 'non-guardian' || role === 'unverified_channel') {
-      return role;
+    const parsed = JSON.parse(metadata) as {
+      provenanceTrustClass?: unknown;
+      provenanceActorRole?: unknown;
+    };
+    const trustClass = parsed?.provenanceTrustClass;
+    if (trustClass === 'guardian' || trustClass === 'trusted_contact' || trustClass === 'unknown') {
+      return trustClass;
     }
+    // Legacy fallback for rows persisted before provenanceTrustClass existed.
+    const legacyRole = parsed?.provenanceActorRole;
+    if (legacyRole === 'guardian') return 'guardian';
+    if (legacyRole === 'non-guardian') return 'trusted_contact';
+    if (legacyRole === 'unverified_channel') return 'unknown';
   } catch {
     // Ignore malformed metadata and treat as unknown provenance.
   }
   return undefined;
 }
 
-function isUntrustedActorRole(role: GuardianActorRole | undefined): boolean {
-  return role === 'non-guardian' || role === 'unverified_channel';
+function isUntrustedTrustClass(trustClass: GuardianTrustClass | undefined): boolean {
+  return trustClass === 'trusted_contact' || trustClass === 'unknown';
 }
 
 function filterMessagesForUntrustedActor(messages: conversationStore.MessageRow[]): conversationStore.MessageRow[] {
   return messages.filter((m) => {
-    const provenanceRole = parseProvenanceActorRole(m.metadata);
-    return provenanceRole === 'non-guardian' || provenanceRole === 'unverified_channel';
+    const provenanceTrustClass = parseProvenanceTrustClass(m.metadata);
+    return provenanceTrustClass === 'trusted_contact' || provenanceTrustClass === 'unknown';
   });
 }
 
@@ -59,8 +67,8 @@ export interface LoadFromDbContext {
   usageStats: UsageStats;
   contextCompactedMessageCount: number;
   contextCompactedAt: number | null;
-  guardianContext?: { actorRole: GuardianActorRole };
-  loadedHistoryActorRole?: GuardianActorRole;
+  guardianContext?: { trustClass: GuardianTrustClass };
+  loadedHistoryTrustClass?: GuardianTrustClass;
 }
 
 export interface AbortContext {
@@ -89,17 +97,17 @@ export interface DisposeContext extends AbortContext {
 // ── loadFromDb ───────────────────────────────────────────────────────
 
 export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
-  const actorRole = ctx.guardianContext?.actorRole;
+  const trustClass = ctx.guardianContext?.trustClass;
   const allDbMessages = conversationStore.getMessages(ctx.conversationId);
-  const dbMessages = isUntrustedActorRole(actorRole)
+  const dbMessages = isUntrustedTrustClass(trustClass)
     ? filterMessagesForUntrustedActor(allDbMessages)
     : allDbMessages;
 
   const conv = conversationStore.getConversation(ctx.conversationId);
-  const contextSummary = !isUntrustedActorRole(actorRole)
+  const contextSummary = !isUntrustedTrustClass(trustClass)
     ? conv?.contextSummary?.trim() || null
     : null;
-  if (isUntrustedActorRole(actorRole)) {
+  if (isUntrustedTrustClass(trustClass)) {
     // Compacted summaries may include trusted/guardian-only details, so we
     // disable summary-based context for untrusted actor views.
     ctx.contextCompactedMessageCount = 0;
@@ -145,7 +153,7 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
     };
   }
 
-  ctx.loadedHistoryActorRole = actorRole;
+  ctx.loadedHistoryTrustClass = trustClass;
 
   log.info({ conversationId: ctx.conversationId, count: ctx.messages.length }, 'Loaded messages from DB');
 }

--- a/assistant/src/daemon/session-memory.ts
+++ b/assistant/src/daemon/session-memory.ts
@@ -34,7 +34,7 @@ export interface MemoryPrepareContext {
   conflictGate: ConflictGate;
   scopeId: string;
   includeDefaultFallback: boolean;
-  guardianActorRole?: 'guardian' | 'non-guardian' | 'unverified_channel';
+  guardianTrustClass?: 'guardian' | 'trusted_contact' | 'unknown';
   /** When false (e.g. scheduled tasks), skip conflict clarification prompts. */
   isInteractive?: boolean;
 }
@@ -64,7 +64,7 @@ export async function prepareMemoryContext(
   // Provenance-based trust gating: untrusted actors skip all memory operations
   // (recall, dynamic profile, conflict gate) to prevent untrusted content from
   // influencing memory-augmented responses.
-  const isTrustedActor = ctx.guardianActorRole === 'guardian' || ctx.guardianActorRole === undefined;
+  const isTrustedActor = ctx.guardianTrustClass === 'guardian' || ctx.guardianTrustClass === undefined;
 
   if (!isTrustedActor) {
     return {

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -402,7 +402,7 @@ export async function processMessage(
         assistantMessageChannel: 'vellum' as const,
         userMessageInterface: guardianIfCtx?.userMessageInterface ?? 'vellum',
         assistantMessageInterface: guardianIfCtx?.assistantMessageInterface ?? 'vellum',
-        provenanceActorRole: 'guardian' as const,
+        provenanceTrustClass: 'guardian' as const,
       };
 
       const userMsg = createUserMessage(content, attachments);

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -35,7 +35,7 @@ export interface ChannelCapabilities {
 /** Guardian identity/trust context for external chat channels. */
 export interface GuardianRuntimeContext {
   sourceChannel: ChannelId;
-  actorRole: 'guardian' | 'non-guardian' | 'unverified_channel';
+  trustClass: 'guardian' | 'trusted_contact' | 'unknown';
   guardianChatId?: string;
   guardianExternalUserId?: string;
   requesterIdentifier?: string;
@@ -73,33 +73,14 @@ export interface InboundActorContext {
 /**
  * Construct an InboundActorContext from a legacy GuardianRuntimeContext.
  *
- * Maps the legacy actor role to the new trust classification:
- * - guardian -> guardian
- * - non-guardian -> unknown (the legacy context carries no membership
- *   evidence, so we cannot distinguish known members from arbitrary
- *   non-guardian senders; default to unknown for safety)
- * - unverified_channel -> unknown
- *
- * The new ActorTrustContext path (via `inboundActorContextFromTrust`)
- * resolves `trusted_contact` correctly using ingress member records.
+ * Maps the runtime trust class into the model-facing inbound actor context.
  */
 export function inboundActorContextFromGuardian(ctx: GuardianRuntimeContext): InboundActorContext {
-  let trustClass: InboundActorContext['trustClass'];
-  switch (ctx.actorRole) {
-    case 'guardian':
-      trustClass = 'guardian';
-      break;
-    case 'non-guardian':
-    case 'unverified_channel':
-      trustClass = 'unknown';
-      break;
-  }
-
   return {
     sourceChannel: ctx.sourceChannel,
     canonicalActorIdentity: ctx.requesterExternalUserId ?? null,
     actorIdentifier: ctx.requesterIdentifier,
-    trustClass,
+    trustClass: ctx.trustClass,
     guardianIdentity: ctx.guardianExternalUserId,
     denialReason: ctx.denialReason,
   };

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -56,7 +56,7 @@ export interface ToolSetupContext extends SurfaceSessionContext {
   headlessLock?: boolean;
   /** When set, this session is executing a task run. Used to retrieve ephemeral permission rules. */
   taskRunId?: string;
-  /** Guardian runtime context for the session — actorRole is propagated into ToolContext for control-plane policy enforcement. */
+  /** Guardian runtime context for the session — trustClass is propagated into ToolContext for control-plane policy enforcement. */
   guardianContext?: GuardianRuntimeContext;
   /** Voice/call session ID, if the session originates from a call. Propagated into ToolContext for scoped grant consumption. */
   callSessionId?: string;
@@ -110,7 +110,7 @@ export function createToolExecutor(
       assistantId: ctx.assistantId,
       requestId: ctx.currentRequestId,
       taskRunId: ctx.taskRunId,
-      guardianActorRole: ctx.guardianContext?.actorRole,
+      guardianTrustClass: ctx.guardianContext?.trustClass,
       executionChannel: ctx.guardianContext?.sourceChannel,
       callSessionId: ctx.callSessionId,
       requesterExternalUserId: ctx.guardianContext?.requesterExternalUserId,

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -140,7 +140,7 @@ export class Session {
   /** @internal */ currentPage?: string;
   /** @internal */ channelCapabilities?: ChannelCapabilities;
   /** @internal */ guardianContext?: GuardianRuntimeContext;
-  /** @internal */ loadedHistoryActorRole?: GuardianRuntimeContext['actorRole'];
+  /** @internal */ loadedHistoryTrustClass?: GuardianRuntimeContext['trustClass'];
   /** @internal */ voiceCallControlPrompt?: string;
   /** @internal */ assistantId?: string;
   /** @internal */ commandIntent?: { type: string; payload?: string; languageCode?: string };
@@ -338,8 +338,8 @@ export class Session {
   }
 
   async ensureActorScopedHistory(): Promise<void> {
-    const currentRole = this.guardianContext?.actorRole;
-    if (this.loadedHistoryActorRole === currentRole) return;
+    const currentTrustClass = this.guardianContext?.trustClass;
+    if (this.loadedHistoryTrustClass === currentTrustClass) return;
     await this.loadFromDb();
   }
 

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -39,7 +39,7 @@ export const messageMetadataSchema = z.object({
   assistantMessageInterface: interfaceIdSchema.optional(),
   subagentNotification: subagentNotificationSchema.optional(),
   // Provenance fields for trust-aware memory gating (M3)
-  provenanceActorRole: z.enum(['guardian', 'non-guardian', 'unverified_channel']).optional(),
+  provenanceTrustClass: z.enum(['guardian', 'trusted_contact', 'unknown']).optional(),
   provenanceSourceChannel: channelIdSchema.optional(),
   provenanceGuardianExternalUserId: z.string().optional(),
   provenanceRequesterIdentifier: z.string().optional(),
@@ -49,14 +49,14 @@ export type MessageMetadata = z.infer<typeof messageMetadataSchema>;
 
 /**
  * Extract provenance metadata fields from a GuardianRuntimeContext.
- * When no guardian context is provided, defaults to 'unverified_channel'
- * because the absence of guardian context means we cannot verify trust —
+ * When no guardian context is provided, defaults to 'unknown' because the
+ * absence of trust context means we cannot verify trust —
  * callers with actual guardian trust should always supply a real context.
  */
 export function provenanceFromGuardianContext(ctx: GuardianRuntimeContext | null | undefined): Record<string, unknown> {
-  if (!ctx) return { provenanceActorRole: 'unverified_channel' };
+  if (!ctx) return { provenanceTrustClass: 'unknown' };
   return {
-    provenanceActorRole: ctx.actorRole,
+    provenanceTrustClass: ctx.trustClass,
     provenanceSourceChannel: ctx.sourceChannel,
     provenanceGuardianExternalUserId: ctx.guardianExternalUserId,
     provenanceRequesterIdentifier: ctx.requesterIdentifier,
@@ -280,7 +280,7 @@ export async function addMessage(conversationId: string, role: string, content: 
       const config = getConfig();
       const scopeId = getConversationMemoryScopeId(conversationId);
       const parsed = metadata ? messageMetadataSchema.safeParse(metadata) : null;
-      const provenanceActorRole = parsed?.success ? parsed.data.provenanceActorRole : undefined;
+      const provenanceTrustClass = parsed?.success ? parsed.data.provenanceTrustClass : undefined;
       indexMessageNow({
         messageId: message.id,
         conversationId: message.conversationId,
@@ -288,7 +288,7 @@ export async function addMessage(conversationId: string, role: string, content: 
         content: message.content,
         createdAt: message.createdAt,
         scopeId,
-        provenanceActorRole,
+        provenanceTrustClass,
       }, config.memory);
     } catch (err) {
       log.warn({ err, conversationId, messageId: message.id }, 'Failed to index message for memory');

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -23,7 +23,7 @@ export interface IndexMessageInput {
   createdAt: number;
   scopeId?: string;
   // Provenance for trust-aware extraction gating (M3)
-  provenanceActorRole?: 'guardian' | 'non-guardian' | 'unverified_channel';
+  provenanceTrustClass?: 'guardian' | 'trusted_contact' | 'unknown';
 }
 
 export interface IndexMessageResult {
@@ -39,7 +39,7 @@ export function indexMessageNow(
 
   // Provenance-based trust gating: only guardian and legacy (undefined) actors
   // are trusted for extraction and conflict resolution.
-  const isTrustedActor = input.provenanceActorRole === 'guardian' || input.provenanceActorRole === undefined;
+  const isTrustedActor = input.provenanceTrustClass === 'guardian' || input.provenanceTrustClass === undefined;
 
   const text = extractTextFromStoredMessageContent(input.content);
   if (text.length === 0) {
@@ -123,7 +123,7 @@ export function indexMessageNow(
   }
 
   if (!isTrustedActor && (shouldExtract || shouldResolveConflicts)) {
-    log.info(`Skipping extraction/conflict jobs for untrusted actor (role=${input.provenanceActorRole})`);
+    log.info(`Skipping extraction/conflict jobs for untrusted actor (trustClass=${input.provenanceTrustClass})`);
   }
 
   enqueueSummaryRollupJobsIfDue();

--- a/assistant/src/memory/job-handlers/backfill.ts
+++ b/assistant/src/memory/job-handlers/backfill.ts
@@ -24,21 +24,28 @@ const BACKFILL_CHECKPOINT_ID_KEY = 'memory:backfill:last_message_id';
 const RELATION_BACKFILL_CHECKPOINT_KEY = 'memory:relation_backfill:last_created_at';
 const RELATION_BACKFILL_CHECKPOINT_ID_KEY = 'memory:relation_backfill:last_message_id';
 
-type ProvenanceActorRole = 'guardian' | 'non-guardian' | 'unverified_channel';
+type ProvenanceTrustClass = 'guardian' | 'trusted_contact' | 'unknown';
 
-function parseProvenanceActorRole(rawMetadata: string | null): ProvenanceActorRole | undefined {
+function parseProvenanceTrustClass(rawMetadata: string | null): ProvenanceTrustClass | undefined {
   if (!rawMetadata) return undefined;
   try {
     const parsedJson: unknown = JSON.parse(rawMetadata);
     const parsed = messageMetadataSchema.safeParse(parsedJson);
-    return parsed.success ? parsed.data.provenanceActorRole : undefined;
+    if (!parsed.success) return undefined;
+    if (parsed.data.provenanceTrustClass) return parsed.data.provenanceTrustClass;
+    // Legacy fallback for rows written before provenanceTrustClass existed.
+    const legacyRole = (parsedJson as { provenanceActorRole?: unknown }).provenanceActorRole;
+    if (legacyRole === 'guardian') return 'guardian';
+    if (legacyRole === 'non-guardian') return 'trusted_contact';
+    if (legacyRole === 'unverified_channel') return 'unknown';
+    return undefined;
   } catch {
     return undefined;
   }
 }
 
-function isTrustedActorRole(actorRole: ProvenanceActorRole | undefined): boolean {
-  return actorRole === 'guardian' || actorRole === undefined;
+function isTrustedTrustClass(trustClass: ProvenanceTrustClass | undefined): boolean {
+  return trustClass === 'guardian' || trustClass === undefined;
 }
 
 export function backfillJob(job: MemoryJob, config: AssistantConfig): void {
@@ -68,7 +75,7 @@ export function backfillJob(job: MemoryJob, config: AssistantConfig): void {
         scopeId = getConversationMemoryScopeId(message.conversationId);
         scopeCache.set(message.conversationId, scopeId);
       }
-      const provenanceActorRole = parseProvenanceActorRole(message.metadata ?? null);
+      const provenanceTrustClass = parseProvenanceTrustClass(message.metadata ?? null);
       indexMessageNow({
         messageId: message.id,
         conversationId: message.conversationId,
@@ -76,7 +83,7 @@ export function backfillJob(job: MemoryJob, config: AssistantConfig): void {
         content: message.content,
         createdAt: message.createdAt,
         scopeId,
-        provenanceActorRole,
+        provenanceTrustClass,
       }, config.memory);
     }
     const lastMessage = batch[batch.length - 1];
@@ -139,8 +146,8 @@ export function backfillEntityRelationsJob(job: MemoryJob, config: AssistantConf
   let queuedExtractEntityJobs = 0;
   let skippedUntrusted = 0;
   for (const message of batch) {
-    const provenanceActorRole = parseProvenanceActorRole(message.metadata ?? null);
-    if (!isTrustedActorRole(provenanceActorRole)) {
+    const provenanceTrustClass = parseProvenanceTrustClass(message.metadata ?? null);
+    if (!isTrustedTrustClass(provenanceTrustClass)) {
       skippedUntrusted += 1;
       continue;
     }

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -10,25 +10,22 @@
  * - `guardian`: sender matches the active guardian binding for this channel.
  * - `trusted_contact`: sender is an active ingress member (not the guardian).
  * - `unknown`: sender has no member record or no identity could be established.
- *
- * The legacy `ActorRole` enum (`guardian` / `non-guardian` / `unverified_channel`)
- * is still required by existing policy gates. The `toLegacyActorRole()` mapper
- * converts the new trust classification to the legacy enum.
  */
 
 import type { ChannelId } from '../channels/types.js';
+import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
 import type { IngressMember } from '../memory/ingress-member-store.js';
 import { findMember } from '../memory/ingress-member-store.js';
 import { canonicalizeInboundIdentity } from '../util/canonicalize-identity.js';
 import { normalizeAssistantId } from '../util/platform.js';
 import { getGuardianBinding } from './channel-guardian-service.js';
-import type { ActorRole, DenialReason, GuardianContext } from './guardian-context-resolver.js';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 export type TrustClass = 'guardian' | 'trusted_contact' | 'unknown';
+export type DenialReason = 'no_binding' | 'no_identity';
 
 export interface ActorTrustContext {
   /** Canonical (normalized) sender identity. Null when identity could not be established. */
@@ -171,51 +168,19 @@ export function resolveActorTrust(input: ResolveActorTrustInput): ActorTrustCont
   };
 }
 
-// ---------------------------------------------------------------------------
-// Legacy compatibility mapper
-// ---------------------------------------------------------------------------
-
 /**
- * Map the new trust classification to the legacy ActorRole enum used by
- * existing policy gates. This preserves backward compatibility while the
- * codebase migrates to the unified trust model.
- *
- * Mapping:
- * - guardian => 'guardian'
- * - trusted_contact => 'non-guardian' (existing gates treat active members as non-guardian)
- * - unknown (no_identity) => 'unverified_channel'
- * - unknown (no_binding) => 'unverified_channel'
- * - unknown (with binding, not guardian) => 'non-guardian'
+ * Convert an ActorTrustContext into the runtime trust context shape used by
+ * sessions/tooling.
  */
-export function toLegacyActorRole(ctx: ActorTrustContext): ActorRole {
-  if (ctx.trustClass === 'guardian') return 'guardian';
-  if (ctx.trustClass === 'trusted_contact') return 'non-guardian';
-
-  // unknown: distinguish between unverified_channel and non-guardian
-  if (ctx.denialReason === 'no_identity' || ctx.denialReason === 'no_binding') {
-    return 'unverified_channel';
-  }
-
-  // Has a binding, has identity, but not guardian and not a member => non-guardian
-  if (ctx.guardianBindingMatch && ctx.canonicalSenderId) {
-    return 'non-guardian';
-  }
-
-  return 'unverified_channel';
-}
-
-/**
- * Convert an ActorTrustContext into the legacy GuardianContext shape that
- * existing route-level code expects. This is a bridge for incremental
- * migration — new code should consume ActorTrustContext directly.
- */
-export function toGuardianContextCompat(ctx: ActorTrustContext, externalChatId: string): GuardianContext {
-  const actorRole = toLegacyActorRole(ctx);
-
+export function toGuardianRuntimeContextFromTrust(
+  ctx: ActorTrustContext,
+  externalChatId: string,
+): GuardianRuntimeContext {
   return {
-    actorRole,
+    sourceChannel: ctx.actorMetadata.channel,
+    trustClass: ctx.trustClass,
     guardianChatId: ctx.guardianBindingMatch?.guardianDeliveryChatId ??
-      (actorRole === 'guardian' ? externalChatId : undefined),
+      (ctx.trustClass === 'guardian' ? externalChatId : undefined),
     guardianExternalUserId: ctx.guardianBindingMatch?.guardianExternalUserId,
     requesterIdentifier: ctx.actorMetadata.identifier,
     requesterExternalUserId: ctx.canonicalSenderId ?? undefined,

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -14,7 +14,16 @@ const log = getLogger('runtime-http');
 function parseGuardianRuntimeContext(value: unknown): GuardianRuntimeContext | undefined {
   if (!value || typeof value !== 'object') return undefined;
   const raw = value as Record<string, unknown>;
-  const trustClass = raw.trustClass;
+  const trustClass = raw.trustClass
+    ?? (
+      raw.actorRole === 'guardian'
+        ? 'guardian'
+        : raw.actorRole === 'non-guardian'
+          ? 'trusted_contact'
+          : raw.actorRole === 'unverified_channel'
+            ? 'unknown'
+            : undefined
+    );
   if (
     trustClass !== 'guardian'
     && trustClass !== 'trusted_contact'

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -14,11 +14,11 @@ const log = getLogger('runtime-http');
 function parseGuardianRuntimeContext(value: unknown): GuardianRuntimeContext | undefined {
   if (!value || typeof value !== 'object') return undefined;
   const raw = value as Record<string, unknown>;
-  const actorRole = raw.actorRole;
+  const trustClass = raw.trustClass;
   if (
-    actorRole !== 'guardian'
-    && actorRole !== 'non-guardian'
-    && actorRole !== 'unverified_channel'
+    trustClass !== 'guardian'
+    && trustClass !== 'trusted_contact'
+    && trustClass !== 'unknown'
   ) {
     return undefined;
   }
@@ -33,7 +33,7 @@ function parseGuardianRuntimeContext(value: unknown): GuardianRuntimeContext | u
       : undefined;
   return {
     sourceChannel,
-    actorRole,
+    trustClass,
     guardianChatId: typeof raw.guardianChatId === 'string' ? raw.guardianChatId : undefined,
     guardianExternalUserId: typeof raw.guardianExternalUserId === 'string' ? raw.guardianExternalUserId : undefined,
     requesterIdentifier: typeof raw.requesterIdentifier === 'string' ? raw.requesterIdentifier : undefined,
@@ -117,7 +117,7 @@ export async function sweepFailedEvents(
           },
           assistantId,
           guardianContext,
-          isInteractive: guardianContext?.actorRole === 'guardian',
+          isInteractive: guardianContext?.trustClass === 'guardian',
         },
         sourceChannel,
         sourceInterface,

--- a/assistant/src/runtime/guardian-context-resolver.ts
+++ b/assistant/src/runtime/guardian-context-resolver.ts
@@ -1,128 +1,61 @@
 /**
- * Shared guardian actor-role resolution for inbound channels.
+ * Shared inbound trust resolution for channel actors.
  *
- * This module centralizes how we classify an inbound actor as
- * guardian/non-guardian/unverified so every channel path uses the same
- * source-of-truth logic.
- *
- * Guardian binding comparisons now use canonicalized identities (E.164 for
- * phone-like channels) to eliminate formatting-variance mismatches.
+ * This module provides a compact route-level shape used by channel routes
+ * while delegating canonical classification to the unified actor trust
+ * resolver.
  */
 import type { ChannelId } from '../channels/types.js';
 import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
-import { canonicalizeInboundIdentity } from '../util/canonicalize-identity.js';
-import { normalizeAssistantId } from '../util/platform.js';
-import { getGuardianBinding } from './channel-guardian-service.js';
+import {
+  type DenialReason,
+  resolveActorTrust,
+  type ResolveActorTrustInput,
+  type TrustClass,
+} from './actor-trust-resolver.js';
+export type { DenialReason } from './actor-trust-resolver.js';
 
-/** Sub-reason for unverified-channel denials. */
-export type DenialReason = 'no_binding' | 'no_identity';
-export type ActorRole = 'guardian' | 'non-guardian' | 'unverified_channel';
+/** Trust classification used by route-level channel logic. */
+export type ActorTrustClass = TrustClass;
 
 /** Guardian actor context used by route-level approval logic. */
 export interface GuardianContext {
-  actorRole: ActorRole;
+  trustClass: ActorTrustClass;
   guardianChatId?: string;
   guardianExternalUserId?: string;
   requesterIdentifier?: string;
   requesterExternalUserId?: string;
   requesterChatId?: string;
+  memberStatus?: string;
+  memberPolicy?: string;
   denialReason?: DenialReason;
 }
 
-export interface ResolveGuardianContextInput {
-  assistantId: string;
-  sourceChannel: ChannelId;
-  externalChatId: string;
-  senderExternalUserId?: string;
-  senderUsername?: string;
-}
+export type ResolveGuardianContextInput = ResolveActorTrustInput;
 
 /**
- * Resolve guardian actor role from canonical binding state + sender identity.
- *
- * Behavior:
- * - sender matches active binding -> guardian
- * - active binding exists but sender differs -> non-guardian
- * - no sender identity -> unverified_channel (no_identity)
- * - no binding -> unverified_channel (no_binding)
- *
- * Identity comparison is normalization-safe: both the sender ID and the
- * guardian binding ID are canonicalized for the source channel before
- * comparison, so formatting differences (e.g. `+1 (555) 123-4567` vs
- * `+15551234567`) do not cause false non-guardian classifications.
+ * Resolve route-level trust context from canonical identity state.
  */
 export function resolveGuardianContext(input: ResolveGuardianContextInput): GuardianContext {
-  const assistantId = normalizeAssistantId(input.assistantId);
-  const rawUserId = typeof input.senderExternalUserId === 'string' && input.senderExternalUserId.trim().length > 0
-    ? input.senderExternalUserId.trim()
-    : undefined;
-  const senderUsername = typeof input.senderUsername === 'string' && input.senderUsername.trim().length > 0
-    ? input.senderUsername.trim()
-    : undefined;
-
-  // Canonicalize sender identity for normalization-safe comparisons.
-  // canonicalizeInboundIdentity returns string | null; coerce to
-  // string | undefined so assignments to optional (string | undefined)
-  // fields in GuardianContext don't produce a type mismatch.
-  const canonicalSenderId = rawUserId
-    ? (canonicalizeInboundIdentity(input.sourceChannel, rawUserId) ?? undefined)
-    : undefined;
-
-  const requesterIdentifier = senderUsername ? `@${senderUsername}` : canonicalSenderId;
-
-  if (!canonicalSenderId) {
-    return {
-      actorRole: 'unverified_channel',
-      denialReason: 'no_identity',
-      requesterIdentifier,
-      requesterExternalUserId: undefined,
-      requesterChatId: input.externalChatId,
-    };
-  }
-
-  const binding = getGuardianBinding(assistantId, input.sourceChannel);
-  if (!binding) {
-    return {
-      actorRole: 'unverified_channel',
-      denialReason: 'no_binding',
-      requesterIdentifier,
-      requesterExternalUserId: canonicalSenderId,
-      requesterChatId: input.externalChatId,
-    };
-  }
-
-  // Canonicalize the stored guardian identity for the same channel so
-  // phone-format variance in the binding record doesn't cause mismatches.
-  const canonicalGuardianId = canonicalizeInboundIdentity(
-    input.sourceChannel,
-    binding.guardianExternalUserId,
-  ) ?? undefined;
-
-  if (canonicalGuardianId === canonicalSenderId) {
-    return {
-      actorRole: 'guardian',
-      guardianChatId: binding.guardianDeliveryChatId || input.externalChatId,
-      guardianExternalUserId: binding.guardianExternalUserId,
-      requesterIdentifier,
-      requesterExternalUserId: canonicalSenderId,
-      requesterChatId: input.externalChatId,
-    };
-  }
-
+  const trust = resolveActorTrust(input);
   return {
-    actorRole: 'non-guardian',
-    guardianChatId: binding.guardianDeliveryChatId,
-    guardianExternalUserId: binding.guardianExternalUserId,
-    requesterIdentifier,
-    requesterExternalUserId: canonicalSenderId,
+    trustClass: trust.trustClass,
+    guardianChatId: trust.guardianBindingMatch?.guardianDeliveryChatId ??
+      (trust.trustClass === 'guardian' ? input.externalChatId : undefined),
+    guardianExternalUserId: trust.guardianBindingMatch?.guardianExternalUserId,
+    requesterIdentifier: trust.actorMetadata.identifier,
+    requesterExternalUserId: trust.canonicalSenderId ?? undefined,
     requesterChatId: input.externalChatId,
+    memberStatus: trust.memberRecord?.status ?? undefined,
+    memberPolicy: trust.memberRecord?.policy ?? undefined,
+    denialReason: trust.denialReason,
   };
 }
 
 export function toGuardianRuntimeContext(sourceChannel: ChannelId, ctx: GuardianContext): GuardianRuntimeContext {
   return {
     sourceChannel,
-    actorRole: ctx.actorRole,
+    trustClass: ctx.trustClass,
     guardianChatId: ctx.guardianChatId,
     guardianExternalUserId: ctx.guardianExternalUserId,
     requesterIdentifier: ctx.requesterIdentifier,

--- a/assistant/src/runtime/routes/channel-route-shared.ts
+++ b/assistant/src/runtime/routes/channel-route-shared.ts
@@ -11,7 +11,7 @@ import type {
   ApprovalUIMetadata,
 } from '../channel-approval-types.js';
 import type { DenialReason } from '../guardian-context-resolver.js';
-export type { ActorRole, DenialReason, GuardianContext } from '../guardian-context-resolver.js';
+export type { ActorTrustClass, DenialReason, GuardianContext } from '../guardian-context-resolver.js';
 export { toGuardianRuntimeContext } from '../guardian-context-resolver.js';
 
 /** Canonicalize assistantId for channel ingress paths. */

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -23,7 +23,7 @@ export {
 } from './channel-inbound-routes.js';
 export {
   _setTestPollMaxWait,
-  type ActorRole,
+  type ActorTrustClass,
   type DenialReason,
   GATEWAY_ORIGIN_HEADER,
   type GuardianContext,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -283,7 +283,7 @@ export async function handleSendMessage(
     const session = await smDeps.getOrCreateSession(mapping.conversationId);
     // HTTP API is a trusted local ingress (same as IPC) — set guardian context
     // so that memory extraction is not silently disabled by unverified provenance.
-    session.setGuardianContext({ actorRole: 'guardian', sourceChannel: sourceChannel ?? 'http' });
+    session.setGuardianContext({ trustClass: 'guardian', sourceChannel: sourceChannel ?? 'http' });
     const onEvent = makeHubPublisher(smDeps, mapping.conversationId, session);
 
     const attachments = hasAttachments
@@ -353,7 +353,7 @@ export async function handleSendMessage(
       mapping.conversationId,
       content ?? '',
       hasAttachments ? attachmentIds : undefined,
-      { guardianContext: { actorRole: 'guardian', sourceChannel } },
+      { guardianContext: { trustClass: 'guardian', sourceChannel } },
       sourceChannel,
       sourceInterface,
     );

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -100,7 +100,7 @@ export async function handleApprovalInterception(
   // request targeting this chat, the message might be a decision on behalf
   // of a non-guardian requester.
   if (
-    guardianCtx.actorRole === 'guardian' &&
+    guardianCtx.trustClass === 'guardian' &&
     senderExternalUserId
   ) {
     // Callback/button path: deterministic and takes priority.
@@ -161,7 +161,7 @@ export async function handleApprovalInterception(
     if (guardianApproval) {
       // Validate that the sender is the specific guardian who was assigned
       // this approval request. This is a defense-in-depth check — the
-      // actorRole check above already verifies the sender is a guardian,
+      // trustClass check above already verifies the sender is a guardian,
       // but this catches edge cases like binding rotation between request
       // creation and decision.
       if (senderExternalUserId !== guardianApproval.guardianExternalUserId) {
@@ -550,7 +550,7 @@ export async function handleApprovalInterception(
 
   // When the sender is from an unverified channel, auto-deny any pending
   // confirmation and block self-approval.
-  if (guardianCtx.actorRole === 'unverified_channel') {
+  if (guardianCtx.trustClass === 'unknown') {
     const pending = getApprovalInfoByConversation(conversationId);
     if (pending.length > 0) {
       handleChannelDecision(
@@ -569,7 +569,7 @@ export async function handleApprovalInterception(
   // When the sender is a non-guardian and there's a pending guardian approval
   // for this conversation's request, block self-approval. The non-guardian must
   // wait for the guardian to decide.
-  if (guardianCtx.actorRole === 'non-guardian') {
+  if (guardianCtx.trustClass === 'trusted_contact') {
     const pending = getApprovalInfoByConversation(conversationId);
     if (pending.length > 0) {
       const guardianApprovalForRequest = getPendingApprovalForRequest(pending[0].requestId);

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -548,9 +548,15 @@ export async function handleApprovalInterception(
   const pendingPrompt = getChannelApprovalPrompt(conversationId);
   if (!pendingPrompt) return { handled: false };
 
-  // When the sender is from an unverified channel, auto-deny any pending
-  // confirmation and block self-approval.
-  if (guardianCtx.trustClass === 'unknown') {
+  // Legacy unverified-channel equivalent:
+  // unknown trust + explicit denial reason (`no_identity` / `no_binding`).
+  // Unknown without a denial reason means identity-known, non-member sender
+  // in a shared channel; that case must not force-reject someone else's request.
+  const isLegacyUnverifiedSender = guardianCtx.trustClass === 'unknown' && !!guardianCtx.denialReason;
+
+  // When the sender is from a legacy-unverified channel actor, auto-deny any
+  // pending confirmation and block self-approval.
+  if (isLegacyUnverifiedSender) {
     const pending = getApprovalInfoByConversation(conversationId);
     if (pending.length > 0) {
       handleChannelDecision(
@@ -569,7 +575,12 @@ export async function handleApprovalInterception(
   // When the sender is a non-guardian and there's a pending guardian approval
   // for this conversation's request, block self-approval. The non-guardian must
   // wait for the guardian to decide.
-  if (guardianCtx.trustClass === 'trusted_contact') {
+  //
+  // Include identity-known, non-member senders (`unknown` without denialReason)
+  // so shared-channel participants can't approve/deny someone else's pending request.
+  const isIdentityKnownNonGuardian = guardianCtx.trustClass === 'trusted_contact'
+    || (guardianCtx.trustClass === 'unknown' && !guardianCtx.denialReason);
+  if (isIdentityKnownNonGuardian) {
     const pending = getApprovalInfoByConversation(conversationId);
     if (pending.length > 0) {
       const guardianApprovalForRequest = getPendingApprovalForRequest(pending[0].requestId);

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -910,7 +910,7 @@ export async function handleChannelInbound(
     replyCallbackUrl &&
     (trimmedContent.length > 0 || hasCallbackData) &&
     rawSenderId &&
-    guardianCtx.actorRole === 'guardian'
+    guardianCtx.trustClass === 'guardian'
   ) {
     // Compute destination-scoped pending request hints so the router can
     // discover canonical requests delivered to this chat even when the
@@ -1369,7 +1369,7 @@ function startPendingApprovalPromptWatcher(params: {
   conversationId: string;
   sourceChannel: ChannelId;
   externalChatId: string;
-  guardianActorRole: GuardianContext['actorRole'];
+  guardianTrustClass: GuardianContext['trustClass'];
   replyCallbackUrl: string;
   bearerToken?: string;
   assistantId?: string;
@@ -1379,7 +1379,7 @@ function startPendingApprovalPromptWatcher(params: {
     conversationId,
     sourceChannel,
     externalChatId,
-    guardianActorRole,
+    guardianTrustClass,
     replyCallbackUrl,
     bearerToken,
     assistantId,
@@ -1388,7 +1388,7 @@ function startPendingApprovalPromptWatcher(params: {
 
   // Approval prompt delivery is guardian-only. Non-guardian and unverified
   // actors must never receive approval prompt broadcasts for the conversation.
-  if (guardianActorRole !== 'guardian') {
+  if (guardianTrustClass !== 'guardian') {
     return () => {};
   }
 
@@ -1470,7 +1470,7 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
         conversationId,
         sourceChannel,
         externalChatId,
-        guardianActorRole: guardianCtx.actorRole,
+        guardianTrustClass: guardianCtx.trustClass,
         replyCallbackUrl,
         bearerToken,
         assistantId,
@@ -1494,7 +1494,7 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
           },
           assistantId,
           guardianContext: toGuardianRuntimeContext(sourceChannel, guardianCtx),
-          isInteractive: guardianCtx.actorRole === 'guardian',
+          isInteractive: guardianCtx.trustClass === 'guardian',
           ...(cmdIntent ? { commandIntent: cmdIntent } : {}),
         },
         sourceChannel,

--- a/assistant/src/tools/guardian-control-plane-policy.ts
+++ b/assistant/src/tools/guardian-control-plane-policy.ts
@@ -124,13 +124,13 @@ export function isGuardianControlPlaneInvocation(
 export function enforceGuardianOnlyPolicy(
   toolName: string,
   input: Record<string, unknown>,
-  actorRole: string | undefined,
+  trustClass: string | undefined,
 ): { denied: boolean; reason?: string } {
   if (!isGuardianControlPlaneInvocation(toolName, input)) {
     return { denied: false };
   }
 
-  if (actorRole === 'guardian' || actorRole === undefined) {
+  if (trustClass === 'guardian' || trustClass === undefined) {
     return { denied: false };
   }
 

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -10,8 +10,8 @@ import type { ExecutionTarget, Tool, ToolContext, ToolExecutionResult, ToolLifec
 
 const log = getLogger('tool-approval-handler');
 
-function isUntrustedGuardianActorRole(role: ToolContext['guardianActorRole']): boolean {
-  return role === 'non-guardian' || role === 'unverified_channel';
+function isUntrustedGuardianTrustClass(role: ToolContext['guardianTrustClass']): boolean {
+  return role === 'trusted_contact' || role === 'unknown';
 }
 
 function requiresGuardianApprovalForActor(
@@ -26,10 +26,10 @@ function requiresGuardianApprovalForActor(
 }
 
 function guardianApprovalDeniedMessage(
-  actorRole: ToolContext['guardianActorRole'],
+  trustClass: ToolContext['guardianTrustClass'],
   toolName: string,
 ): string {
-  if (actorRole === 'unverified_channel') {
+  if (trustClass === 'unknown') {
     return `Permission denied for "${toolName}": this action requires guardian approval from a verified channel identity.`;
   }
   return `Permission denied for "${toolName}": this action requires guardian approval and the current actor is not the guardian.`;
@@ -82,13 +82,13 @@ export class ToolApprovalHandler {
     }
 
     // Reject tool invocations targeting guardian control-plane endpoints from non-guardian actors.
-    const guardianCheck = enforceGuardianOnlyPolicy(name, input, context.guardianActorRole);
+    const guardianCheck = enforceGuardianOnlyPolicy(name, input, context.guardianTrustClass);
     if (guardianCheck.denied) {
       log.warn({
         toolName: name,
         sessionId: context.sessionId,
         conversationId: context.conversationId,
-        actorRole: context.guardianActorRole,
+        trustClass: context.guardianTrustClass,
         reason: 'guardian_only_policy',
       }, 'Guardian-only policy blocked tool invocation');
       const durationMs = Date.now() - startTime;
@@ -118,7 +118,7 @@ export class ToolApprovalHandler {
     let deferredConsumeParams: Parameters<typeof consumeGrantForInvocation>[0] | null = null;
 
     if (
-      isUntrustedGuardianActorRole(context.guardianActorRole)
+      isUntrustedGuardianTrustClass(context.guardianTrustClass)
       && requiresGuardianApprovalForActor(name, input, executionTarget)
     ) {
       const inputDigest = computeToolApprovalDigest(name, input);
@@ -233,7 +233,7 @@ export class ToolApprovalHandler {
           toolName: name,
           sessionId: context.sessionId,
           conversationId: context.conversationId,
-          actorRole: context.guardianActorRole,
+          trustClass: context.guardianTrustClass,
           executionTarget,
           grantId: grantResult.grant.id,
         }, 'Scoped grant consumed — allowing untrusted actor tool invocation');
@@ -273,7 +273,7 @@ export class ToolApprovalHandler {
       // actors remain fail-closed with no escalation.
       let escalationMessage: string | undefined;
       if (
-        context.guardianActorRole === 'non-guardian'
+        context.guardianTrustClass === 'trusted_contact'
         && context.assistantId
         && context.executionChannel
         && context.requesterExternalUserId
@@ -308,12 +308,12 @@ export class ToolApprovalHandler {
         // If escalation.failed, fall through to generic denial message.
       }
 
-      const reason = escalationMessage ?? guardianApprovalDeniedMessage(context.guardianActorRole, name);
+      const reason = escalationMessage ?? guardianApprovalDeniedMessage(context.guardianTrustClass, name);
       log.warn({
         toolName: name,
         sessionId: context.sessionId,
         conversationId: context.conversationId,
-        actorRole: context.guardianActorRole,
+        trustClass: context.guardianTrustClass,
         executionTarget,
         reason: 'guardian_approval_required',
         grantMissReason: grantResult.reason,

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -137,8 +137,8 @@ export interface ToolContext {
   proxyApprovalCallback?: import('./network/script-proxy/types.js').ProxyApprovalCallback;
   /** Optional principal identifier propagated to sub-tool confirmation flows. */
   principal?: string;
-  /** Guardian actor role for the session — used by the guardian control-plane policy gate. */
-  guardianActorRole?: 'guardian' | 'non-guardian' | 'unverified_channel';
+  /** Inbound trust classification for the session — used by trust/policy gates. */
+  guardianTrustClass?: 'guardian' | 'trusted_contact' | 'unknown';
   /** Channel through which the tool invocation originates (e.g. 'telegram', 'voice'). Used for scoped grant consumption. */
   executionChannel?: string;
   /** Voice/call session ID, if the invocation originates from a call. Used for scoped grant consumption. */


### PR DESCRIPTION
## Summary
- Removes runtime and tooling dependence on legacy `guardianContext.actorRole` and standardizes on canonical trust classes: `guardian`, `trusted_contact`, and `unknown`.
- Threads trust-class metadata through session runtime assembly, tool context, ingress trust resolution, memory provenance, and voice/call handling.
- Updates policy gates (tool approval and guardian control-plane access) to use trust-class semantics.
- Updates relay/voice tests and trust fixtures to align with inbound trusted-contact ACL behavior and pending challenge handling.

## Validation
- bunx tsc --noEmit
- bun test src/__tests__/conversation-routes.test.ts
- bun test src/__tests__/tool-approval-handler.test.ts
- bun test src/__tests__/voice-session-bridge.test.ts
- bun test src/__tests__/session-load-history-repair.test.ts
- bun test src/__tests__/guardian-control-plane-policy.test.ts
- bun test src/__tests__/tool-grant-request-escalation.test.ts
- bun test src/__tests__/relay-server.test.ts
