### PR TITLE
Fix Telegram invite redemption when /start payload omits iv_ prefix

### DIFF
--- a/assistant/src/__tests__/channel-invite-transport.test.ts
+++ b/assistant/src/__tests__/channel-invite-transport.test.ts
@@ -170,7 +170,16 @@ describe('channel-invite-transport', () => {
       expect(token).toBeUndefined();
     });
 
-    test('returns undefined when commandIntent payload has no prefix', () => {
+    test('extracts token from commandIntent payload without iv_ prefix when it matches invite token shape', () => {
+      const rawToken = 'AbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_ABCDE';
+      const token = telegramInviteTransport.extractInboundToken({
+        commandIntent: { type: 'start', payload: rawToken },
+        content: `/start ${rawToken}`,
+      });
+      expect(token).toBe(rawToken);
+    });
+
+    test('returns undefined when commandIntent payload has no prefix and is not invite-shaped', () => {
       const token = telegramInviteTransport.extractInboundToken({
         commandIntent: { type: 'start', payload: 'abc123' },
         content: '/start abc123',
@@ -216,6 +225,14 @@ describe('channel-invite-transport', () => {
       expect(token).toBe('token123');
     });
 
+    test('extracts token from raw content without iv_ prefix when it matches invite token shape', () => {
+      const rawToken = 'AbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_ABCDE';
+      const token = telegramInviteTransport.extractInboundToken({
+        content: `/start ${rawToken}`,
+      });
+      expect(token).toBe(rawToken);
+    });
+
     test('returns undefined for empty content', () => {
       const token = telegramInviteTransport.extractInboundToken({
         content: '',
@@ -233,6 +250,13 @@ describe('channel-invite-transport', () => {
     test('returns undefined for /start without iv_ prefix in content', () => {
       const token = telegramInviteTransport.extractInboundToken({
         content: '/start gv_abc123',
+      });
+      expect(token).toBeUndefined();
+    });
+
+    test('returns undefined for /start with non-token payload in content', () => {
+      const token = telegramInviteTransport.extractInboundToken({
+        content: '/start hello',
       });
       expect(token).toBeUndefined();
     });

--- a/assistant/src/__tests__/inbound-invite-redemption.test.ts
+++ b/assistant/src/__tests__/inbound-invite-redemption.test.ts
@@ -190,6 +190,32 @@ describe('inbound invite redemption intercept', () => {
     expect(replyText).toContain("Welcome! You've been granted access via invite link.");
   });
 
+  test('non-member with valid invite token in bare /start payload is redeemed (compat path)', async () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 5 });
+
+    const req = buildInboundRequest({
+      content: `/start ${rawToken}`,
+      sourceMetadata: {
+        commandIntent: { type: 'start', payload: rawToken },
+      },
+    });
+
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = await resp.json() as Record<string, unknown>;
+
+    expect(json.accepted).toBe(true);
+    expect(json.inviteRedemption).toBe('redeemed');
+    expect(json.denied).toBeUndefined();
+
+    const member = findMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-invite-123',
+    });
+    expect(member).not.toBeNull();
+    expect(member!.status).toBe('active');
+  });
+
   test('non-member with invalid token gets refusal text', async () => {
     const req = buildInviteRequest('completely-bogus-token-xyz');
     const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);

--- a/assistant/src/runtime/channel-invite-transports/telegram.ts
+++ b/assistant/src/runtime/channel-invite-transports/telegram.ts
@@ -2,10 +2,12 @@
  * Telegram channel invite transport adapter.
  *
  * Builds `https://t.me/<botUsername>?start=iv_<token>` deep links and
- * extracts invite tokens from `/start iv_<token>` command payloads.
+ * extracts invite tokens from `/start` command payloads.
  *
- * The `iv_` prefix distinguishes invite tokens from `gv_` (guardian
- * verification) tokens that use the same `/start` deep-link mechanism.
+ * The canonical format uses `iv_` to distinguish invite tokens from `gv_`
+ * (guardian verification) tokens that use the same `/start` deep-link
+ * mechanism. For defensive compatibility, bare raw invite tokens are also
+ * accepted when they match the invite-token shape.
  */
 
 import type { ChannelId } from '../../channels/types.js';
@@ -38,6 +40,34 @@ function getTelegramBotUsername(): string | undefined {
 // ---------------------------------------------------------------------------
 
 const INVITE_TOKEN_PREFIX = 'iv_';
+const LEGACY_RAW_INVITE_TOKEN_RE = /^[A-Za-z0-9_-]{32,128}$/;
+
+function extractTokenFromStartPayload(payload: string): string | undefined {
+  const trimmed = payload.trim();
+  if (trimmed.length === 0) return undefined;
+
+  // Canonical format: /start iv_<token>
+  if (trimmed.startsWith(INVITE_TOKEN_PREFIX)) {
+    const token = trimmed.slice(INVITE_TOKEN_PREFIX.length);
+    if (token.length > 0 && token.trim().length > 0) {
+      return token;
+    }
+    return undefined;
+  }
+
+  // Keep guardian bootstrap tokens on their own control-plane path.
+  if (trimmed.startsWith('gv_')) {
+    return undefined;
+  }
+
+  // Backward/defensive compatibility: accept bare raw invite tokens in
+  // /start payloads. This covers links shared without the iv_ prefix.
+  if (LEGACY_RAW_INVITE_TOKEN_RE.test(trimmed)) {
+    return trimmed;
+  }
+
+  return undefined;
+}
 
 // ---------------------------------------------------------------------------
 // Transport implementation
@@ -75,23 +105,15 @@ export const telegramInviteTransport: ChannelInviteTransport = {
       params.commandIntent.type === 'start' &&
       typeof params.commandIntent.payload === 'string'
     ) {
-      const payload = params.commandIntent.payload;
-      if (payload.startsWith(INVITE_TOKEN_PREFIX)) {
-        const token = payload.slice(INVITE_TOKEN_PREFIX.length);
-        // Reject empty or whitespace-only tokens
-        if (token.length > 0 && token.trim().length > 0) {
-          return token;
-        }
-      }
-      return undefined;
+      return extractTokenFromStartPayload(params.commandIntent.payload);
     }
 
-    // Fallback: raw content parsing for `/start iv_<token>` messages.
+    // Fallback: raw content parsing for `/start <payload>` messages.
     // This handles cases where the gateway forwards the raw command text
     // without a structured commandIntent.
-    const match = params.content.match(/^\/start\s+iv_(\S+)/);
+    const match = params.content.match(/^\/start\s+(\S+)/i);
     if (match && match[1] && match[1].length > 0) {
-      return match[1];
+      return extractTokenFromStartPayload(match[1]);
     }
 
     return undefined;


### PR DESCRIPTION
## Summary
- accept Telegram `/start` invite payloads in both canonical `iv_<token>` form and compatibility bare-token form
- keep `gv_` bootstrap tokens excluded so guardian bootstrap routing remains unchanged
- extend inbound invite redemption coverage to validate bare-token `/start` payload redemption

## Root cause
Invite redemption extraction only recognized `iv_`-prefixed payloads. If a shared link used `?start=<token>` (without `iv_`), inbound `/start` fell through ACL and returned "Sorry, you haven't been approved to message this assistant."

## Validation
- `export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bun test src/__tests__/channel-invite-transport.test.ts src/__tests__/inbound-invite-redemption.test.ts`

## Notes
- intentionally left unrelated local change in `.claude/commands/update.md` untouched

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
