### PR TITLE
Fix Telegram invite link generation at source (canonical share URL)

### DIFF
--- a/assistant/src/__tests__/channel-invite-transport.test.ts
+++ b/assistant/src/__tests__/channel-invite-transport.test.ts
@@ -71,7 +71,7 @@ describe('channel-invite-transport', () => {
 
   describe('telegram buildShareableInvite', () => {
     test('produces a valid Telegram deep link', () => {
-      const result = telegramInviteTransport.buildShareableInvite({
+      const result = telegramInviteTransport.buildShareableInvite!({
         rawToken: 'abc123_test-token',
         sourceChannel: 'telegram',
       });
@@ -81,15 +81,15 @@ describe('channel-invite-transport', () => {
     });
 
     test('deep link is deterministic for the same token', () => {
-      const a = telegramInviteTransport.buildShareableInvite({ rawToken: 'tok1', sourceChannel: 'telegram' });
-      const b = telegramInviteTransport.buildShareableInvite({ rawToken: 'tok1', sourceChannel: 'telegram' });
+      const a = telegramInviteTransport.buildShareableInvite!({ rawToken: 'tok1', sourceChannel: 'telegram' });
+      const b = telegramInviteTransport.buildShareableInvite!({ rawToken: 'tok1', sourceChannel: 'telegram' });
       expect(a.url).toBe(b.url);
       expect(a.displayText).toBe(b.displayText);
     });
 
     test('uses the configured bot username', () => {
       mockBotUsername = 'my_custom_bot';
-      const result = telegramInviteTransport.buildShareableInvite({
+      const result = telegramInviteTransport.buildShareableInvite!({
         rawToken: 'token',
         sourceChannel: 'telegram',
       });
@@ -103,7 +103,7 @@ describe('channel-invite-transport', () => {
       delete process.env.TELEGRAM_BOT_USERNAME;
       try {
         expect(() =>
-          telegramInviteTransport.buildShareableInvite({
+          telegramInviteTransport.buildShareableInvite!({
             rawToken: 'token',
             sourceChannel: 'telegram',
           }),
@@ -118,7 +118,7 @@ describe('channel-invite-transport', () => {
       const prev = process.env.TELEGRAM_BOT_USERNAME;
       process.env.TELEGRAM_BOT_USERNAME = 'env_bot';
       try {
-        const result = telegramInviteTransport.buildShareableInvite({
+        const result = telegramInviteTransport.buildShareableInvite!({
           rawToken: 'token',
           sourceChannel: 'telegram',
         });

--- a/assistant/src/__tests__/ingress-routes-http.test.ts
+++ b/assistant/src/__tests__/ingress-routes-http.test.ts
@@ -279,6 +279,42 @@ describe('ingress invite HTTP routes', () => {
     expect((invite.token as string).length).toBeGreaterThan(0);
   });
 
+  test('POST /v1/ingress/invites — includes canonical share URL when bot username is configured', async () => {
+    const prevBotUsername = process.env.TELEGRAM_BOT_USERNAME;
+    process.env.TELEGRAM_BOT_USERNAME = 'test_invite_bot';
+
+    try {
+      const req = new Request('http://localhost/v1/ingress/invites', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sourceChannel: 'telegram',
+          note: 'Share link test',
+        }),
+      });
+
+      const res = await handleCreateInvite(req);
+      const body = await res.json() as Record<string, unknown>;
+      const invite = body.invite as Record<string, unknown>;
+      const token = invite.token as string;
+      const share = invite.share as Record<string, unknown>;
+
+      expect(res.status).toBe(201);
+      expect(body.ok).toBe(true);
+      expect(typeof token).toBe('string');
+      expect(token.length).toBeGreaterThan(0);
+      expect(share).toBeDefined();
+      expect(share.url).toBe(`https://t.me/test_invite_bot?start=iv_${token}`);
+      expect(typeof share.displayText).toBe('string');
+    } finally {
+      if (prevBotUsername === undefined) {
+        delete process.env.TELEGRAM_BOT_USERNAME;
+      } else {
+        process.env.TELEGRAM_BOT_USERNAME = prevBotUsername;
+      }
+    }
+  });
+
   test('POST /v1/ingress/invites — missing sourceChannel returns 400', async () => {
     const req = new Request('http://localhost/v1/ingress/invites', {
       method: 'POST',

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -1061,16 +1061,14 @@ export class RelayConnection {
       );
 
       if (this.controller) {
+        const redeemedActorTrust = resolveActorTrust({
+          assistantId: this.inviteRedemptionAssistantId,
+          sourceChannel: 'voice',
+          externalChatId: this.inviteRedemptionFromNumber,
+          senderExternalUserId: this.inviteRedemptionFromNumber,
+        });
         this.controller.setGuardianContext(
-          toGuardianRuntimeContext(
-            'voice',
-            resolveGuardianContext({
-              assistantId: this.inviteRedemptionAssistantId,
-              sourceChannel: 'voice',
-              externalChatId: this.inviteRedemptionFromNumber,
-              senderExternalUserId: this.inviteRedemptionFromNumber,
-            }),
-          ),
+          toGuardianRuntimeContextFromTrust(redeemedActorTrust, this.inviteRedemptionFromNumber),
         );
         this.startNormalCallFlow(this.controller, true);
       }

--- a/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
+++ b/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
@@ -20,7 +20,7 @@ You are helping your user manage trusted contacts and invite links for the Vellu
 - **Status**: The member's lifecycle state — `active` (currently effective), `revoked` (access removed), or `blocked` (explicitly denied).
 - **Source channel**: The messaging platform the contact uses (e.g., `telegram`, `sms`, `voice`).
 - **Invite link**: A shareable Telegram deep link that, when opened by someone, automatically grants them trusted-contact access. Each invite has a token, usage limits, and optional expiration.
-- **Voice invite**: An invite bound to a specific phone number for phone-call access. The guardian provides the invitee's phone number (E.164 format, e.g., `+15551234567`), and the system generates a numeric code. The invitee must call from that exact phone number AND enter the code when prompted. Both conditions must be met — the call must originate from the bound number, and the correct code must be entered. SMS-based invites are not supported.
+- **Voice invite**: An invite bound to a specific phone number for phone-call access. The guardian provides the invitee's phone number (E.164 format, e.g., `+15551234567`), and the system generates a numeric code. The invitee must call from that exact phone number AND enter the code when prompted. Both conditions must be met — the call must originate from the bound number, and the correct code must be entered. Voice invites do not have a Telegram-style deep link and do not use `/start` payload tokens. SMS-based invites are not supported.
 
 ## Available Actions
 
@@ -270,7 +270,9 @@ Optional fields:
 - ~~`voiceCodeDigits`~~ — always 6 digits; this parameter is accepted but ignored
 - `note` — a human-readable label for the invite (e.g., "For Mom", "Dr. Smith")
 
-The create response contains `{ ok: true, invite: { id, voiceCode, expectedExternalUserId, ... } }`. The `voiceCode` is the numeric code the invitee must enter — it is only returned at creation time.
+The create response contains `{ ok: true, invite: { id, voiceCode, expectedExternalUserId, ... } }`.
+- `voiceCode` is the numeric code the invitee must enter and is only returned at creation time.
+- Voice invite responses do **not** include `token` or `share.url`. Do not try to build or send a deep link for voice invites.
 
 **Presenting to the guardian**: Give the guardian clear instructions to relay to the invitee:
 
@@ -284,6 +286,8 @@ The create response contains `{ ok: true, invite: { id, voiceCode, expectedExter
 > 3. Once verified, they will be added as a trusted contact and can call the assistant directly in the future
 >
 > This code can be used <maxUses> time(s)<and expires in X hours/days if applicable>.
+
+There is no "open link" step for voice invites. The invite is redeemed only during a live phone call from the bound number.
 
 If the user provides a phone number without the `+` country code prefix, ask them to confirm the full E.164 number (e.g., US numbers should be `+1XXXXXXXXXX`).
 
@@ -305,6 +309,7 @@ Optional query parameters:
 The response format is the same as regular invites but voice invites also include:
 - `expectedExternalUserId` — the bound phone number
 - `voiceCodeDigits` — always 6 (the code itself is not retrievable after creation)
+- `token` and `share` are not present for voice invites
 
 **Presenting results**: Format as a readable list. Show the note (or "unnamed" as fallback), bound phone number, status, uses remaining, and expiration. Highlight which invites are still active.
 

--- a/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
+++ b/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
@@ -129,14 +129,6 @@ Use this when the guardian wants to invite someone to message the assistant on T
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
 
-BOT_CONFIG_JSON=$(curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/telegram/config" \
-  -H "Authorization: Bearer $TOKEN")
-BOT_USERNAME=$(printf '%s' "$BOT_CONFIG_JSON" | tr -d '\n' | sed -n 's/.*"botUsername"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
-if [ -z "$BOT_USERNAME" ]; then
-  echo "error:no_bot_username"
-  exit 1
-fi
-
 INVITE_JSON=$(curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/ingress/invites" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
@@ -145,14 +137,40 @@ INVITE_JSON=$(curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/ingress/invites" \
     "maxUses": 1,
     "note": "<optional note, e.g. the person it is for>"
   }')
-INVITE_TOKEN=$(printf '%s' "$INVITE_JSON" | tr -d '\n' | sed -n 's/.*"token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+
+INVITE_TOKEN=$(printf '%s' "$INVITE_JSON" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+invite = data.get('invite', {})
+print(invite.get('token', ''), end='')
+")
+INVITE_URL=$(printf '%s' "$INVITE_JSON" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+invite = data.get('invite', {})
+share = invite.get('share') or {}
+print(share.get('url', ''), end='')
+")
+
 if [ -z "$INVITE_TOKEN" ]; then
   printf '%s\n' "$INVITE_JSON"
   exit 1
 fi
 
+# Prefer backend-provided canonical link when available.
+if [ -z "$INVITE_URL" ]; then
+  BOT_CONFIG_JSON=$(curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/telegram/config" \
+    -H "Authorization: Bearer $TOKEN")
+  BOT_USERNAME=$(printf '%s' "$BOT_CONFIG_JSON" | tr -d '\n' | sed -n 's/.*"botUsername"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+  if [ -z "$BOT_USERNAME" ]; then
+    echo "error:no_share_url_or_bot_username"
+    exit 1
+  fi
+  INVITE_URL="https://t.me/$BOT_USERNAME?start=iv_$INVITE_TOKEN"
+fi
+
 echo "<vellum-sensitive-output kind=\"invite_code\" value=\"$INVITE_TOKEN\" />"
-echo "https://t.me/$BOT_USERNAME?start=iv_$INVITE_TOKEN"
+echo "$INVITE_URL"
 ```
 
 Optional fields:
@@ -160,7 +178,11 @@ Optional fields:
 - `expiresInMs` — expiration time in milliseconds from now (e.g., `86400000` for 24 hours). Defaults to 7 days (`604800000`) if omitted.
 - `note` — a human-readable label for the invite (e.g., "For Mom", "Family group").
 
-The create response contains `{ ok: true, invite: { id, token, ... } }`. The `token` field is the raw invite token — it is only returned at creation time and cannot be retrieved later.
+The create response contains `{ ok: true, invite: { id, token, share?, ... } }`.
+- `token` is the raw invite token and is only returned at creation time.
+- `share.url` is the canonical shareable deep link (when channel transport config is available).
+
+Always use `invite.share.url` when present. Do not manually construct `?start=` links if the API already provided one.
 
 **Presenting to the guardian**: Give the guardian the link with clear copy-paste instructions:
 

--- a/assistant/src/runtime/ingress-service.ts
+++ b/assistant/src/runtime/ingress-service.ts
@@ -5,6 +5,7 @@
  * both the HTTP routes and the IPC handlers call the same logic.
  */
 
+import { isChannelId } from '../channels/types.js';
 import {
   createInvite,
   type IngressInvite,
@@ -30,6 +31,8 @@ import {
   redeemInvite as redeemInviteTyped,
   redeemVoiceInviteCode as redeemVoiceInviteCodeTyped,
 } from './invite-redemption-service.js';
+import { getTransport } from './channel-invite-transport.js';
+import './channel-invite-transports/telegram.js';
 
 // ---------------------------------------------------------------------------
 // Response shapes — used by both HTTP routes and IPC handlers
@@ -39,6 +42,10 @@ export interface InviteResponseData {
   id: string;
   sourceChannel: string;
   token?: string;
+  share?: {
+    url: string;
+    displayText: string;
+  };
   tokenHash: string;
   maxUses: number;
   useCount: number;
@@ -69,11 +76,30 @@ export interface MemberResponseData {
 // Mappers
 // ---------------------------------------------------------------------------
 
+function buildSharePayload(sourceChannel: string, rawToken?: string): InviteResponseData['share'] | undefined {
+  if (!rawToken || !isChannelId(sourceChannel)) return undefined;
+  const transport = getTransport(sourceChannel);
+  if (!transport?.buildShareableInvite) return undefined;
+
+  try {
+    return transport.buildShareableInvite({
+      rawToken,
+      sourceChannel,
+    });
+  } catch {
+    // Missing channel-specific config (e.g. Telegram bot username) should
+    // not fail invite creation — callers can still use the raw token.
+    return undefined;
+  }
+}
+
 function inviteToResponse(inv: IngressInvite, opts?: { rawToken?: string; voiceCode?: string }): InviteResponseData {
+  const share = buildSharePayload(inv.sourceChannel, opts?.rawToken);
   return {
     id: inv.id,
     sourceChannel: inv.sourceChannel,
     ...(opts?.rawToken ? { token: opts.rawToken } : {}),
+    ...(share ? { share } : {}),
     tokenHash: inv.tokenHash,
     maxUses: inv.maxUses,
     useCount: inv.useCount,

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -230,7 +230,7 @@ export async function handleChannelInbound(
     typeof (rawCommandIntentForAcl as Record<string, unknown>).payload === 'string' &&
     ((rawCommandIntentForAcl as Record<string, unknown>).payload as string).startsWith('gv_');
 
-  // Parse invite token from /start iv_<token> commands using the transport
+  // Parse invite token from /start payloads using the channel transport
   // adapter. The token is extracted once here so both the ACL bypass and
   // the intercept handler can reference it without re-parsing.
   const commandIntentForAcl = rawCommandIntentForAcl && typeof rawCommandIntentForAcl === 'object' && !Array.isArray(rawCommandIntentForAcl)
@@ -292,7 +292,7 @@ export async function handleChannelInbound(
       }
 
       // ── Invite token intercept (non-member) ──
-      // /start iv_<token> deep links grant access without guardian approval.
+      // /start invite deep links grant access without guardian approval.
       // Intercept here — before the deny gate — so valid invites short-circuit
       // the ACL rejection and never reach the agent pipeline.
       if (inviteToken && denyNonMember) {


### PR DESCRIPTION
## Summary
- fix the root cause of legacy-shaped Telegram invite links by returning a canonical share URL from invite creation
- update trusted-contacts invite flow and guardian invite rewrite instructions to use `invite.share.url` instead of manually constructing `?start=` links
- broaden invite-intent matching for natural phrases like "invite my friend Jeff on telegram"
- keep invite token parsing strict (no bare-token parser compatibility fallback)

## Root cause
The assistant was generating links via model-authored shell commands that manually built `https://t.me/<bot>?start=<token>` instead of the required `iv_` payload shape.

## Validation
- `cd assistant && bun test src/__tests__/guardian-invite-intent.test.ts src/__tests__/ingress-routes-http.test.ts src/__tests__/channel-invite-transport.test.ts src/__tests__/inbound-invite-redemption.test.ts`
- `cd assistant && bunx tsc --noEmit`

## Notes
This PR intentionally does **not** add parser compatibility for legacy bare `?start=` tokens; it fixes generation to emit canonical links.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
