### PR TITLE
fix: consolidate voice invite redemption into /v1/ingress/invites/redeem

### DIFF
--- a/assistant/src/__tests__/ingress-routes-http.test.ts
+++ b/assistant/src/__tests__/ingress-routes-http.test.ts
@@ -31,7 +31,6 @@ import {
   handleListInvites,
   handleListMembers,
   handleRedeemInvite,
-  handleRedeemVoiceInvite,
   handleRevokeInvite,
   handleRevokeMember,
   handleUpsertMember,
@@ -557,7 +556,7 @@ describe('voice invite HTTP routes', () => {
     expect(invite.token).toBeUndefined();
   });
 
-  test('POST /v1/ingress/invites/redeem-voice — redeems a voice invite code', async () => {
+  test('POST /v1/ingress/invites/redeem — redeems a voice invite code via unified endpoint', async () => {
     // Create a voice invite
     const createRes = await handleCreateInvite(new Request('http://localhost/v1/ingress/invites', {
       method: 'POST',
@@ -570,8 +569,8 @@ describe('voice invite HTTP routes', () => {
     }));
     const created = await createRes.json() as { invite: { voiceCode: string } };
 
-    // Redeem the voice code
-    const redeemReq = new Request('http://localhost/v1/ingress/invites/redeem-voice', {
+    // Redeem the voice code via the unified /redeem endpoint
+    const redeemReq = new Request('http://localhost/v1/ingress/invites/redeem', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -580,7 +579,7 @@ describe('voice invite HTTP routes', () => {
       }),
     });
 
-    const res = await handleRedeemVoiceInvite(redeemReq);
+    const res = await handleRedeemInvite(redeemReq);
     const body = await res.json() as Record<string, unknown>;
 
     expect(res.status).toBe(200);
@@ -590,21 +589,22 @@ describe('voice invite HTTP routes', () => {
     expect(typeof body.inviteId).toBe('string');
   });
 
-  test('POST /v1/ingress/invites/redeem-voice — missing fields returns 400', async () => {
-    const req = new Request('http://localhost/v1/ingress/invites/redeem-voice', {
+  test('POST /v1/ingress/invites/redeem — voice code missing fields returns 400', async () => {
+    const req = new Request('http://localhost/v1/ingress/invites/redeem', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ callerExternalUserId: '+15551234567' }),
     });
 
-    const res = await handleRedeemVoiceInvite(req);
+    const res = await handleRedeemInvite(req);
     const body = await res.json() as Record<string, unknown>;
 
+    // No `code` and no `token` → falls through to token-based path which requires token
     expect(res.status).toBe(400);
     expect(body.ok).toBe(false);
   });
 
-  test('POST /v1/ingress/invites/redeem-voice — wrong code returns 400', async () => {
+  test('POST /v1/ingress/invites/redeem — wrong voice code returns 400', async () => {
     // Create a voice invite
     await handleCreateInvite(new Request('http://localhost/v1/ingress/invites', {
       method: 'POST',
@@ -616,7 +616,7 @@ describe('voice invite HTTP routes', () => {
       }),
     }));
 
-    const req = new Request('http://localhost/v1/ingress/invites/redeem-voice', {
+    const req = new Request('http://localhost/v1/ingress/invites/redeem', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -625,7 +625,7 @@ describe('voice invite HTTP routes', () => {
       }),
     });
 
-    const res = await handleRedeemVoiceInvite(req);
+    const res = await handleRedeemInvite(req);
     const body = await res.json() as Record<string, unknown>;
 
     expect(res.status).toBe(400);

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -133,7 +133,6 @@ import {
   handleListInvites,
   handleListMembers,
   handleRedeemInvite,
-  handleRedeemVoiceInvite,
   handleRevokeInvite,
   handleRevokeMember,
   handleUpsertMember,
@@ -746,7 +745,6 @@ export class RuntimeHttpServer {
       if (endpoint === 'ingress/invites' && req.method === 'GET') return handleListInvites(url);
       if (endpoint === 'ingress/invites' && req.method === 'POST') return await handleCreateInvite(req);
       if (endpoint === 'ingress/invites/redeem' && req.method === 'POST') return await handleRedeemInvite(req);
-      if (endpoint === 'ingress/invites/redeem-voice' && req.method === 'POST') return await handleRedeemVoiceInvite(req);
       const inviteMatch = endpoint.match(/^ingress\/invites\/([^/]+)$/);
       if (inviteMatch && req.method === 'DELETE') return handleRevokeInvite(inviteMatch[1]);
 

--- a/assistant/src/runtime/routes/ingress-routes.ts
+++ b/assistant/src/runtime/routes/ingress-routes.ts
@@ -8,11 +8,10 @@
  *   POST   /v1/ingress/members/:id/block — block a member
  *
  * Invites:
- *   GET    /v1/ingress/invites              — list invites
- *   POST   /v1/ingress/invites              — create an invite (supports voice)
- *   DELETE /v1/ingress/invites/:id          — revoke an invite
- *   POST   /v1/ingress/invites/redeem       — redeem an invite (token-based)
- *   POST   /v1/ingress/invites/redeem-voice — redeem a voice invite code
+ *   GET    /v1/ingress/invites        — list invites
+ *   POST   /v1/ingress/invites        — create an invite (supports voice)
+ *   DELETE /v1/ingress/invites/:id    — revoke an invite
+ *   POST   /v1/ingress/invites/redeem — redeem an invite (token or voice code)
  */
 
 import {
@@ -170,10 +169,50 @@ export function handleRevokeInvite(inviteId: string): Response {
 
 /**
  * POST /v1/ingress/invites/redeem
+ *
+ * Unified invite redemption endpoint. Supports two modes:
+ *
+ * 1. **Token-based** (existing): pass `token`, `sourceChannel`, `externalUserId`, etc.
+ * 2. **Voice code** (new): pass `code` and `callerExternalUserId` (E.164 phone).
+ *    Optionally pass `assistantId`.
+ *
+ * The presence of `code` in the body selects voice-code redemption.
  */
 export async function handleRedeemInvite(req: Request): Promise<Response> {
   const body = (await req.json()) as Record<string, unknown>;
 
+  // Voice-code redemption path: triggered when `code` is present
+  if (body.code != null) {
+    const callerExternalUserId = body.callerExternalUserId as string | undefined;
+    const code = body.code as string | undefined;
+
+    if (!callerExternalUserId || !code) {
+      return Response.json(
+        { ok: false, error: 'callerExternalUserId and code are required' },
+        { status: 400 },
+      );
+    }
+
+    const result = redeemVoiceInviteCode({
+      assistantId: body.assistantId as string | undefined,
+      callerExternalUserId,
+      sourceChannel: 'voice',
+      code,
+    });
+
+    if (!result.ok) {
+      return Response.json({ ok: false, error: result.reason }, { status: 400 });
+    }
+
+    return Response.json({
+      ok: true,
+      type: result.type,
+      memberId: result.memberId,
+      ...(result.type === 'redeemed' ? { inviteId: result.inviteId } : {}),
+    });
+  }
+
+  // Token-based redemption path (default)
   const result = redeemIngressInvite({
     token: body.token as string | undefined,
     externalUserId: body.externalUserId as string | undefined,
@@ -185,44 +224,4 @@ export async function handleRedeemInvite(req: Request): Promise<Response> {
     return Response.json({ ok: false, error: result.error }, { status: 400 });
   }
   return Response.json({ ok: true, invite: result.data });
-}
-
-/**
- * POST /v1/ingress/invites/redeem-voice
- *
- * Redeem a voice invite code. Requires:
- * - callerExternalUserId: E.164 phone number of the caller
- * - code: the short numeric voice code
- * - assistantId (optional)
- */
-export async function handleRedeemVoiceInvite(req: Request): Promise<Response> {
-  const body = (await req.json()) as Record<string, unknown>;
-
-  const callerExternalUserId = body.callerExternalUserId as string | undefined;
-  const code = body.code as string | undefined;
-
-  if (!callerExternalUserId || !code) {
-    return Response.json(
-      { ok: false, error: 'callerExternalUserId and code are required' },
-      { status: 400 },
-    );
-  }
-
-  const result = redeemVoiceInviteCode({
-    assistantId: body.assistantId as string | undefined,
-    callerExternalUserId,
-    sourceChannel: 'voice',
-    code,
-  });
-
-  if (!result.ok) {
-    return Response.json({ ok: false, error: result.reason }, { status: 400 });
-  }
-
-  return Response.json({
-    ok: true,
-    type: result.type,
-    memberId: result.memberId,
-    ...(result.type === 'redeemed' ? { inviteId: result.inviteId } : {}),
-  });
 }


### PR DESCRIPTION
## Summary
- Merged the separate `POST /v1/ingress/invites/redeem-voice` endpoint into the existing `POST /v1/ingress/invites/redeem` endpoint
- The unified endpoint detects voice-code redemption when `code` is present in the request body, falling back to token-based redemption otherwise
- This eliminates the need for a new gateway route — the existing gateway wiring for `/v1/ingress/invites/redeem` now handles both flows

## Original prompt
help me address the feedback in https://github.com/vellum-ai/vellum-assistant/pull/10643#discussion_r2867487336. Ideally we would not need a separate redeem-voice route and could just leverage the existing redeem route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
