### PR TITLE
fix: preserve trusted-contact identity names for model context

### DIFF
--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -549,6 +549,8 @@ describe('injectInboundActorContext', () => {
       canonicalActorIdentity: 'guardian-user-1',
       actorIdentifier: '+15550001111',
       actorDisplayName: 'Guardian Name',
+      actorSenderDisplayName: 'Guardian Name',
+      actorMemberDisplayName: 'Guardian Name',
       trustClass: 'guardian',
       guardianIdentity: 'guardian-user-1',
     };
@@ -563,7 +565,31 @@ describe('injectInboundActorContext', () => {
     expect(text).toContain('source_channel: sms');
     expect(text).toContain('canonical_actor_identity: guardian-user-1');
     expect(text).toContain('actor_display_name: Guardian Name');
+    expect(text).toContain('actor_sender_display_name: Guardian Name');
+    expect(text).toContain('actor_member_display_name: Guardian Name');
     expect(text).toContain('</inbound_actor_context>');
+  });
+
+  test('adds nickname guidance when member and sender display names differ', () => {
+    const ctx: InboundActorContext = {
+      sourceChannel: 'telegram',
+      canonicalActorIdentity: 'trusted-user-1',
+      actorIdentifier: '@jeff_handle',
+      actorDisplayName: 'Jeff',
+      actorSenderDisplayName: 'Jeffrey',
+      actorMemberDisplayName: 'Jeff',
+      trustClass: 'trusted_contact',
+      guardianIdentity: 'guardian-user-1',
+      memberStatus: 'active',
+      memberPolicy: 'allow',
+    };
+
+    const result = injectInboundActorContext(baseUserMessage, ctx);
+    const text = (result.content[0] as { type: 'text'; text: string }).text;
+    expect(text).toContain('actor_display_name: Jeff');
+    expect(text).toContain('actor_sender_display_name: Jeffrey');
+    expect(text).toContain('actor_member_display_name: Jeff');
+    expect(text).toContain('name_preference_note: actor_member_display_name is the guardian-preferred nickname');
   });
 
   test('includes behavioral guidance for trusted_contact actors', () => {

--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -548,6 +548,7 @@ describe('injectInboundActorContext', () => {
       sourceChannel: 'sms',
       canonicalActorIdentity: 'guardian-user-1',
       actorIdentifier: '+15550001111',
+      actorDisplayName: 'Guardian Name',
       trustClass: 'guardian',
       guardianIdentity: 'guardian-user-1',
     };
@@ -561,6 +562,7 @@ describe('injectInboundActorContext', () => {
     expect(text).toContain('trust_class: guardian');
     expect(text).toContain('source_channel: sms');
     expect(text).toContain('canonical_actor_identity: guardian-user-1');
+    expect(text).toContain('actor_display_name: Guardian Name');
     expect(text).toContain('</inbound_actor_context>');
   });
 

--- a/assistant/src/__tests__/trusted-contact-verification.test.ts
+++ b/assistant/src/__tests__/trusted-contact-verification.test.ts
@@ -165,6 +165,8 @@ describe('trusted contact verification → member activation', () => {
 
     expect(trust.trustClass).toBe('trusted_contact');
     expect(trust.actorMetadata.displayName).toBe('Jeff');
+    expect(trust.actorMetadata.senderDisplayName).toBeUndefined();
+    expect(trust.actorMetadata.memberDisplayName).toBe('Jeff');
     expect(trust.actorMetadata.identifier).toBe('@jeff_handle');
   });
 
@@ -191,6 +193,8 @@ describe('trusted contact verification → member activation', () => {
 
     expect(trust.trustClass).toBe('trusted_contact');
     expect(trust.actorMetadata.displayName).toBe('Jeff');
+    expect(trust.actorMetadata.senderDisplayName).toBe('Jeffrey');
+    expect(trust.actorMetadata.memberDisplayName).toBe('Jeff');
     expect(trust.actorMetadata.username).toBe('jeff_handle');
     expect(trust.actorMetadata.identifier).toBe('@jeff_handle');
   });

--- a/assistant/src/__tests__/trusted-contact-verification.test.ts
+++ b/assistant/src/__tests__/trusted-contact-verification.test.ts
@@ -56,6 +56,7 @@ import {
   createOutboundSession,
   validateAndConsumeChallenge,
 } from '../runtime/channel-guardian-service.js';
+import { resolveActorTrust } from '../runtime/actor-trust-resolver.js';
 
 initializeDb();
 
@@ -141,6 +142,30 @@ describe('trusted contact verification → member activation', () => {
     expect(member!.username).toBe('requester_username');
     expect(member!.assistantId).toBe('self');
     expect(member!.sourceChannel).toBe('telegram');
+  });
+
+  test('resolveActorTrust surfaces member displayName when sender displayName is missing', () => {
+    upsertMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'requester-user-jeff',
+      externalChatId: 'requester-chat-jeff',
+      status: 'active',
+      policy: 'allow',
+      displayName: 'Jeff',
+      username: 'jeff_handle',
+    });
+
+    const trust = resolveActorTrust({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalChatId: 'requester-chat-jeff',
+      senderExternalUserId: 'requester-user-jeff',
+    });
+
+    expect(trust.trustClass).toBe('trusted_contact');
+    expect(trust.actorMetadata.displayName).toBe('Jeff');
+    expect(trust.actorMetadata.identifier).toBe('@jeff_handle');
   });
 
   test('post-verify message is accepted (ACL check passes)', () => {

--- a/assistant/src/__tests__/trusted-contact-verification.test.ts
+++ b/assistant/src/__tests__/trusted-contact-verification.test.ts
@@ -168,6 +168,33 @@ describe('trusted contact verification → member activation', () => {
     expect(trust.actorMetadata.identifier).toBe('@jeff_handle');
   });
 
+  test('resolveActorTrust prioritizes member displayName over sender displayName', () => {
+    upsertMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'requester-user-jeff-priority',
+      externalChatId: 'requester-chat-jeff-priority',
+      status: 'active',
+      policy: 'allow',
+      displayName: 'Jeff',
+      username: 'jeff_handle',
+    });
+
+    const trust = resolveActorTrust({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalChatId: 'requester-chat-jeff-priority',
+      senderExternalUserId: 'requester-user-jeff-priority',
+      senderUsername: 'jeffrey_telegram',
+      senderDisplayName: 'Jeffrey',
+    });
+
+    expect(trust.trustClass).toBe('trusted_contact');
+    expect(trust.actorMetadata.displayName).toBe('Jeff');
+    expect(trust.actorMetadata.username).toBe('jeff_handle');
+    expect(trust.actorMetadata.identifier).toBe('@jeff_handle');
+  });
+
   test('post-verify message is accepted (ACL check passes)', () => {
     // Create and verify a trusted contact
     const session = createOutboundSession({

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -367,6 +367,7 @@ export async function runAgentLoopImpl(
           sourceChannel: gc.sourceChannel,
           externalChatId: gc.requesterChatId,
           senderExternalUserId: gc.requesterExternalUserId,
+          senderDisplayName: gc.requesterSenderDisplayName,
         });
         resolvedInboundActorContext = inboundActorContextFromTrust(actorTrust);
       } else {

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -39,6 +39,7 @@ export interface GuardianRuntimeContext {
   guardianChatId?: string;
   guardianExternalUserId?: string;
   requesterIdentifier?: string;
+  requesterDisplayName?: string;
   requesterExternalUserId?: string;
   requesterChatId?: string;
   denialReason?: 'no_binding' | 'no_identity';
@@ -58,6 +59,8 @@ export interface InboundActorContext {
   canonicalActorIdentity: string | null;
   /** Human-readable actor identifier (e.g. @username or phone). */
   actorIdentifier?: string;
+  /** Human-readable actor display name (e.g. "Jeff"). */
+  actorDisplayName?: string;
   /** Trust classification: guardian, trusted_contact, or unknown. */
   trustClass: 'guardian' | 'trusted_contact' | 'unknown';
   /** Guardian identity for this (assistant, channel) binding. */
@@ -80,6 +83,7 @@ export function inboundActorContextFromGuardian(ctx: GuardianRuntimeContext): In
     sourceChannel: ctx.sourceChannel,
     canonicalActorIdentity: ctx.requesterExternalUserId ?? null,
     actorIdentifier: ctx.requesterIdentifier,
+    actorDisplayName: ctx.requesterDisplayName,
     trustClass: ctx.trustClass,
     guardianIdentity: ctx.guardianExternalUserId,
     denialReason: ctx.denialReason,
@@ -95,6 +99,7 @@ export function inboundActorContextFromTrust(ctx: ActorTrustContext): InboundAct
     sourceChannel: ctx.actorMetadata.channel,
     canonicalActorIdentity: ctx.canonicalSenderId,
     actorIdentifier: ctx.actorMetadata.identifier,
+    actorDisplayName: ctx.actorMetadata.displayName,
     trustClass: ctx.trustClass,
     guardianIdentity: ctx.guardianBindingMatch?.guardianExternalUserId,
     memberStatus: ctx.memberRecord?.status ?? undefined,
@@ -533,6 +538,7 @@ export function buildInboundActorContextBlock(ctx: InboundActorContext): string 
   lines.push(`source_channel: ${ctx.sourceChannel}`);
   lines.push(`canonical_actor_identity: ${ctx.canonicalActorIdentity ?? 'unknown'}`);
   lines.push(`actor_identifier: ${ctx.actorIdentifier ?? 'unknown'}`);
+  lines.push(`actor_display_name: ${ctx.actorDisplayName ?? 'unknown'}`);
   lines.push(`trust_class: ${ctx.trustClass}`);
   lines.push(`guardian_identity: ${ctx.guardianIdentity ?? 'unknown'}`);
   if (ctx.memberStatus) {

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -40,6 +40,8 @@ export interface GuardianRuntimeContext {
   guardianExternalUserId?: string;
   requesterIdentifier?: string;
   requesterDisplayName?: string;
+  requesterSenderDisplayName?: string;
+  requesterMemberDisplayName?: string;
   requesterExternalUserId?: string;
   requesterChatId?: string;
   denialReason?: 'no_binding' | 'no_identity';
@@ -61,6 +63,10 @@ export interface InboundActorContext {
   actorIdentifier?: string;
   /** Human-readable actor display name (e.g. "Jeff"). */
   actorDisplayName?: string;
+  /** Raw sender display name as provided by the channel transport. */
+  actorSenderDisplayName?: string;
+  /** Guardian-managed member display name from ingress membership. */
+  actorMemberDisplayName?: string;
   /** Trust classification: guardian, trusted_contact, or unknown. */
   trustClass: 'guardian' | 'trusted_contact' | 'unknown';
   /** Guardian identity for this (assistant, channel) binding. */
@@ -84,6 +90,8 @@ export function inboundActorContextFromGuardian(ctx: GuardianRuntimeContext): In
     canonicalActorIdentity: ctx.requesterExternalUserId ?? null,
     actorIdentifier: ctx.requesterIdentifier,
     actorDisplayName: ctx.requesterDisplayName,
+    actorSenderDisplayName: ctx.requesterSenderDisplayName,
+    actorMemberDisplayName: ctx.requesterMemberDisplayName,
     trustClass: ctx.trustClass,
     guardianIdentity: ctx.guardianExternalUserId,
     denialReason: ctx.denialReason,
@@ -100,6 +108,8 @@ export function inboundActorContextFromTrust(ctx: ActorTrustContext): InboundAct
     canonicalActorIdentity: ctx.canonicalSenderId,
     actorIdentifier: ctx.actorMetadata.identifier,
     actorDisplayName: ctx.actorMetadata.displayName,
+    actorSenderDisplayName: ctx.actorMetadata.senderDisplayName,
+    actorMemberDisplayName: ctx.actorMetadata.memberDisplayName,
     trustClass: ctx.trustClass,
     guardianIdentity: ctx.guardianBindingMatch?.guardianExternalUserId,
     memberStatus: ctx.memberRecord?.status ?? undefined,
@@ -539,6 +549,8 @@ export function buildInboundActorContextBlock(ctx: InboundActorContext): string 
   lines.push(`canonical_actor_identity: ${ctx.canonicalActorIdentity ?? 'unknown'}`);
   lines.push(`actor_identifier: ${ctx.actorIdentifier ?? 'unknown'}`);
   lines.push(`actor_display_name: ${ctx.actorDisplayName ?? 'unknown'}`);
+  lines.push(`actor_sender_display_name: ${ctx.actorSenderDisplayName ?? 'unknown'}`);
+  lines.push(`actor_member_display_name: ${ctx.actorMemberDisplayName ?? 'unknown'}`);
   lines.push(`trust_class: ${ctx.trustClass}`);
   lines.push(`guardian_identity: ${ctx.guardianIdentity ?? 'unknown'}`);
   if (ctx.memberStatus) {
@@ -548,6 +560,13 @@ export function buildInboundActorContextBlock(ctx: InboundActorContext): string 
     lines.push(`member_policy: ${ctx.memberPolicy}`);
   }
   lines.push(`denial_reason: ${ctx.denialReason ?? 'none'}`);
+  if (
+    ctx.actorMemberDisplayName
+    && ctx.actorSenderDisplayName
+    && ctx.actorMemberDisplayName !== ctx.actorSenderDisplayName
+  ) {
+    lines.push('name_preference_note: actor_member_display_name is the guardian-preferred nickname for this person; actor_sender_display_name is the channel-provided display name.');
+  }
 
   // Behavioral guidance — injected per-turn so it only appears when relevant.
   lines.push('');

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -142,8 +142,10 @@ export function resolveActorTrust(input: ResolveActorTrustInput): ActorTrustCont
   const memberDisplayName = typeof memberRecord?.displayName === 'string' && memberRecord.displayName.trim().length > 0
     ? memberRecord.displayName.trim()
     : undefined;
-  const resolvedUsername = senderUsername ?? memberUsername;
-  const resolvedDisplayName = senderDisplayName ?? memberDisplayName;
+  // Prefer member profile metadata over transient sender metadata so guardian-
+  // curated contact details are canonical for assistant-facing identity.
+  const resolvedUsername = memberUsername ?? senderUsername;
+  const resolvedDisplayName = memberDisplayName ?? senderDisplayName;
   const resolvedIdentifier = resolvedUsername ? `@${resolvedUsername}` : canonicalSenderId ?? undefined;
 
   // Trust classification

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -43,6 +43,8 @@ export interface ActorTrustContext {
   actorMetadata: {
     identifier: string | undefined;
     displayName: string | undefined;
+    senderDisplayName: string | undefined;
+    memberDisplayName: string | undefined;
     username: string | undefined;
     channel: ChannelId;
     trustStatus: TrustClass;
@@ -105,6 +107,8 @@ export function resolveActorTrust(input: ResolveActorTrustInput): ActorTrustCont
       actorMetadata: {
         identifier,
         displayName: senderDisplayName,
+        senderDisplayName,
+        memberDisplayName: undefined,
         username: senderUsername,
         channel: input.sourceChannel,
         trustStatus: 'unknown',
@@ -172,6 +176,8 @@ export function resolveActorTrust(input: ResolveActorTrustInput): ActorTrustCont
     actorMetadata: {
       identifier: resolvedIdentifier,
       displayName: resolvedDisplayName,
+      senderDisplayName,
+      memberDisplayName,
       username: resolvedUsername,
       channel: input.sourceChannel,
       trustStatus: trustClass,
@@ -196,6 +202,8 @@ export function toGuardianRuntimeContextFromTrust(
     guardianExternalUserId: ctx.guardianBindingMatch?.guardianExternalUserId,
     requesterIdentifier: ctx.actorMetadata.identifier,
     requesterDisplayName: ctx.actorMetadata.displayName,
+    requesterSenderDisplayName: ctx.actorMetadata.senderDisplayName,
+    requesterMemberDisplayName: ctx.actorMetadata.memberDisplayName,
     requesterExternalUserId: ctx.canonicalSenderId ?? undefined,
     requesterChatId: externalChatId,
     denialReason: ctx.denialReason,

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -136,6 +136,16 @@ export function resolveActorTrust(input: ResolveActorTrustInput): ActorTrustCont
     externalChatId: input.externalChatId,
   });
 
+  const memberUsername = typeof memberRecord?.username === 'string' && memberRecord.username.trim().length > 0
+    ? memberRecord.username.trim()
+    : undefined;
+  const memberDisplayName = typeof memberRecord?.displayName === 'string' && memberRecord.displayName.trim().length > 0
+    ? memberRecord.displayName.trim()
+    : undefined;
+  const resolvedUsername = senderUsername ?? memberUsername;
+  const resolvedDisplayName = senderDisplayName ?? memberDisplayName;
+  const resolvedIdentifier = resolvedUsername ? `@${resolvedUsername}` : canonicalSenderId ?? undefined;
+
   // Trust classification
   let trustClass: TrustClass;
   if (isGuardian) {
@@ -158,9 +168,9 @@ export function resolveActorTrust(input: ResolveActorTrustInput): ActorTrustCont
     memberRecord,
     trustClass,
     actorMetadata: {
-      identifier,
-      displayName: senderDisplayName,
-      username: senderUsername,
+      identifier: resolvedIdentifier,
+      displayName: resolvedDisplayName,
+      username: resolvedUsername,
       channel: input.sourceChannel,
       trustStatus: trustClass,
     },
@@ -183,6 +193,7 @@ export function toGuardianRuntimeContextFromTrust(
       (ctx.trustClass === 'guardian' ? externalChatId : undefined),
     guardianExternalUserId: ctx.guardianBindingMatch?.guardianExternalUserId,
     requesterIdentifier: ctx.actorMetadata.identifier,
+    requesterDisplayName: ctx.actorMetadata.displayName,
     requesterExternalUserId: ctx.canonicalSenderId ?? undefined,
     requesterChatId: externalChatId,
     denialReason: ctx.denialReason,

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -47,6 +47,8 @@ function parseGuardianRuntimeContext(value: unknown): GuardianRuntimeContext | u
     guardianExternalUserId: typeof raw.guardianExternalUserId === 'string' ? raw.guardianExternalUserId : undefined,
     requesterIdentifier: typeof raw.requesterIdentifier === 'string' ? raw.requesterIdentifier : undefined,
     requesterDisplayName: typeof raw.requesterDisplayName === 'string' ? raw.requesterDisplayName : undefined,
+    requesterSenderDisplayName: typeof raw.requesterSenderDisplayName === 'string' ? raw.requesterSenderDisplayName : undefined,
+    requesterMemberDisplayName: typeof raw.requesterMemberDisplayName === 'string' ? raw.requesterMemberDisplayName : undefined,
     requesterExternalUserId: typeof raw.requesterExternalUserId === 'string' ? raw.requesterExternalUserId : undefined,
     requesterChatId: typeof raw.requesterChatId === 'string' ? raw.requesterChatId : undefined,
     denialReason,

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -46,6 +46,7 @@ function parseGuardianRuntimeContext(value: unknown): GuardianRuntimeContext | u
     guardianChatId: typeof raw.guardianChatId === 'string' ? raw.guardianChatId : undefined,
     guardianExternalUserId: typeof raw.guardianExternalUserId === 'string' ? raw.guardianExternalUserId : undefined,
     requesterIdentifier: typeof raw.requesterIdentifier === 'string' ? raw.requesterIdentifier : undefined,
+    requesterDisplayName: typeof raw.requesterDisplayName === 'string' ? raw.requesterDisplayName : undefined,
     requesterExternalUserId: typeof raw.requesterExternalUserId === 'string' ? raw.requesterExternalUserId : undefined,
     requesterChatId: typeof raw.requesterChatId === 'string' ? raw.requesterChatId : undefined,
     denialReason,

--- a/assistant/src/runtime/guardian-context-resolver.ts
+++ b/assistant/src/runtime/guardian-context-resolver.ts
@@ -24,6 +24,7 @@ export interface GuardianContext {
   guardianChatId?: string;
   guardianExternalUserId?: string;
   requesterIdentifier?: string;
+  requesterDisplayName?: string;
   requesterExternalUserId?: string;
   requesterChatId?: string;
   memberStatus?: string;
@@ -44,6 +45,7 @@ export function resolveGuardianContext(input: ResolveGuardianContextInput): Guar
       (trust.trustClass === 'guardian' ? input.externalChatId : undefined),
     guardianExternalUserId: trust.guardianBindingMatch?.guardianExternalUserId,
     requesterIdentifier: trust.actorMetadata.identifier,
+    requesterDisplayName: trust.actorMetadata.displayName,
     requesterExternalUserId: trust.canonicalSenderId ?? undefined,
     requesterChatId: input.externalChatId,
     memberStatus: trust.memberRecord?.status ?? undefined,
@@ -59,6 +61,7 @@ export function toGuardianRuntimeContext(sourceChannel: ChannelId, ctx: Guardian
     guardianChatId: ctx.guardianChatId,
     guardianExternalUserId: ctx.guardianExternalUserId,
     requesterIdentifier: ctx.requesterIdentifier,
+    requesterDisplayName: ctx.requesterDisplayName,
     requesterExternalUserId: ctx.requesterExternalUserId,
     requesterChatId: ctx.requesterChatId,
     denialReason: ctx.denialReason,

--- a/assistant/src/runtime/guardian-context-resolver.ts
+++ b/assistant/src/runtime/guardian-context-resolver.ts
@@ -25,6 +25,8 @@ export interface GuardianContext {
   guardianExternalUserId?: string;
   requesterIdentifier?: string;
   requesterDisplayName?: string;
+  requesterSenderDisplayName?: string;
+  requesterMemberDisplayName?: string;
   requesterExternalUserId?: string;
   requesterChatId?: string;
   memberStatus?: string;
@@ -46,6 +48,8 @@ export function resolveGuardianContext(input: ResolveGuardianContextInput): Guar
     guardianExternalUserId: trust.guardianBindingMatch?.guardianExternalUserId,
     requesterIdentifier: trust.actorMetadata.identifier,
     requesterDisplayName: trust.actorMetadata.displayName,
+    requesterSenderDisplayName: trust.actorMetadata.senderDisplayName,
+    requesterMemberDisplayName: trust.actorMetadata.memberDisplayName,
     requesterExternalUserId: trust.canonicalSenderId ?? undefined,
     requesterChatId: input.externalChatId,
     memberStatus: trust.memberRecord?.status ?? undefined,
@@ -62,6 +66,8 @@ export function toGuardianRuntimeContext(sourceChannel: ChannelId, ctx: Guardian
     guardianExternalUserId: ctx.guardianExternalUserId,
     requesterIdentifier: ctx.requesterIdentifier,
     requesterDisplayName: ctx.requesterDisplayName,
+    requesterSenderDisplayName: ctx.requesterSenderDisplayName,
+    requesterMemberDisplayName: ctx.requesterMemberDisplayName,
     requesterExternalUserId: ctx.requesterExternalUserId,
     requesterChatId: ctx.requesterChatId,
     denialReason: ctx.denialReason,

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -899,6 +899,7 @@ export async function handleChannelInbound(
     externalChatId,
     senderExternalUserId: rawSenderId,
     senderUsername: body.senderUsername,
+    senderDisplayName: body.senderName,
   });
 
   // ── Canonical guardian reply router ──


### PR DESCRIPTION
## Summary
- plumb Telegram sender display name into inbound trust resolution so actor identity metadata is available on channel turns
- preserve both channel sender name and guardian-managed member name in actor trust/runtime context
- prefer member metadata for canonical actor naming, while exposing sender/member split to the model and adding a nickname guidance note when they differ
- include the new display-name fields in replay parsing so retry sweeps preserve identity context

## Why
A trusted contact could ask "What is my name?" and the assistant would not see the guardian-managed contact name (or any name in some turns). This PR ensures the model receives deterministic identity context with guardian-preferred naming.

## Validation
- bunx tsc --noEmit
- bun test src/__tests__/trusted-contact-verification.test.ts
- bun test src/__tests__/channel-retry-sweep.test.ts
- bun test src/__tests__/session-runtime-assembly.test.ts --test-name-pattern "injectInboundActorContext"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
