### PR TITLE
Preserve guardian-managed member names across trusted-contact reactivation

### DIFF
--- a/assistant/src/__tests__/inbound-invite-redemption.test.ts
+++ b/assistant/src/__tests__/inbound-invite-redemption.test.ts
@@ -364,4 +364,37 @@ describe('inbound invite redemption intercept', () => {
     expect(json.accepted).toBe(true);
     expect(json.denied).toBeUndefined();
   });
+
+  test('reactivation via invite preserves existing guardian-managed member display name', async () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 5 });
+
+    upsertMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-invite-123',
+      externalChatId: 'chat-invite-test',
+      status: 'revoked',
+      policy: 'allow',
+      displayName: 'Jeff',
+    });
+
+    const req = buildInviteRequest(rawToken, {
+      senderName: 'Noa Flaherty',
+    });
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = await resp.json() as Record<string, unknown>;
+
+    expect(json.accepted).toBe(true);
+    expect(json.inviteRedemption).toBe('redeemed');
+
+    const member = findMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-invite-123',
+      externalChatId: 'chat-invite-test',
+    });
+    expect(member).not.toBeNull();
+    expect(member!.status).toBe('active');
+    expect(member!.displayName).toBe('Jeff');
+  });
 });

--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -419,6 +419,54 @@ describe('trusted contact activated notification signal', () => {
     expect(hints.urgency).toBe('low');
   });
 
+  test('re-verification preserves an existing guardian-managed member display name', async () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-user-789',
+      guardianDeliveryChatId: 'guardian-chat-789',
+    });
+
+    upsertMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'requester-user-456',
+      externalChatId: 'chat-123',
+      status: 'revoked',
+      policy: 'allow',
+      displayName: 'Jeff',
+    });
+
+    const session = createOutboundSession({
+      assistantId: 'self',
+      channel: 'telegram',
+      expectedExternalUserId: 'requester-user-456',
+      expectedChatId: 'chat-123',
+      identityBindingStatus: 'bound',
+      destinationAddress: 'chat-123',
+      verificationPurpose: 'trusted_contact',
+    });
+
+    const verifyReq = buildInboundRequest({
+      content: session.secret,
+      externalChatId: 'chat-123',
+      senderExternalUserId: 'requester-user-456',
+      senderName: 'Noa Flaherty',
+    });
+
+    await handleChannelInbound(verifyReq, undefined, TEST_BEARER_TOKEN);
+
+    const member = findMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'requester-user-456',
+      externalChatId: 'chat-123',
+    });
+    expect(member).not.toBeNull();
+    expect(member!.status).toBe('active');
+    expect(member!.displayName).toBe('Jeff');
+  });
+
   test('guardian verification does NOT emit activated signal', async () => {
     // Create an inbound challenge (guardian flow, not trusted contact)
     // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -119,6 +119,9 @@ export function redeemInvite(params: {
     // Sentinel error used to trigger a transaction rollback when the invite
     // was concurrently revoked/expired between pre-validation and write time.
     const STALE_INVITE = Symbol('stale_invite');
+    const preservedDisplayName = existingMember.displayName?.trim().length
+      ? existingMember.displayName
+      : displayName;
 
     let reactivated: ReturnType<typeof upsertMember> | undefined;
     try {
@@ -128,7 +131,8 @@ export function redeemInvite(params: {
           sourceChannel,
           externalUserId,
           externalChatId,
-          displayName,
+          // Reactivation should not overwrite a guardian-managed nickname.
+          displayName: preservedDisplayName,
           username,
           status: 'active',
           policy: 'allow',

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -775,6 +775,18 @@ export async function handleChannelInbound(
     const guardianVerifyOutcome: 'verified' | 'failed' = verifyResult.success ? 'verified' : 'failed';
 
     if (verifyResult.success) {
+      const existingMember = (canonicalSenderId ?? rawSenderId)
+        ? findMember({
+          assistantId: canonicalAssistantId,
+          sourceChannel,
+          externalUserId: canonicalSenderId ?? rawSenderId!,
+          externalChatId,
+        })
+        : null;
+      const preservedDisplayName = existingMember?.displayName?.trim().length
+        ? existingMember.displayName
+        : body.senderName;
+
       upsertMember({
         assistantId: canonicalAssistantId,
         sourceChannel,
@@ -782,7 +794,8 @@ export async function handleChannelInbound(
         externalChatId,
         status: 'active',
         policy: 'allow',
-        displayName: body.senderName,
+        // Keep guardian-curated member name stable across re-verification.
+        displayName: preservedDisplayName,
         username: body.senderUsername,
       });
 


### PR DESCRIPTION
## Summary
- preserve existing `assistant_ingress_members.display_name` during trusted-contact verification reactivation instead of overwriting with channel sender display name
- preserve existing member display name during invite-based reactivation as well
- add regression tests for both reactivation paths to ensure guardian-managed nickname remains authoritative

## Root cause
System-driven upserts in verification and invite reactivation paths unconditionally wrote `displayName` from transient channel sender metadata, clobbering curated member names.

## Validation
- `bun test assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts assistant/src/__tests__/inbound-invite-redemption.test.ts`
- `cd assistant && bunx tsc --noEmit`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
