### PR TITLE
fix: use latest-assistant selection and fix dead fallback in /update

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -67,7 +67,8 @@ PY
      cd ..
    )}"
 
-   # Resolve default assistant ID from lockfile (prefer first valid entry).
+   # Resolve default assistant ID from lockfile (sort by hatchedAt descending
+   # to match CLI loadLatestAssistant() behavior — most recently hatched wins).
    GATEWAY_DEFAULT_ASSISTANT_ID="${GATEWAY_DEFAULT_ASSISTANT_ID:-$(
      python3 - <<'PY'
 import json, os
@@ -75,12 +76,10 @@ lock_path = os.path.expanduser("~/.vellum.lock.json")
 try:
     with open(lock_path, "r", encoding="utf-8") as f:
         data = json.load(f)
-    for item in (data.get("assistants") or []):
-        if isinstance(item, dict):
-            aid = (item.get("assistantId") or "").strip()
-            if aid:
-                print(aid)
-                break
+    assistants = [a for a in (data.get("assistants") or []) if isinstance(a, dict) and (a.get("assistantId") or "").strip()]
+    assistants.sort(key=lambda a: a.get("hatchedAt") or "", reverse=True)
+    if assistants:
+        print(assistants[0]["assistantId"].strip())
 except Exception:
     pass
 PY
@@ -180,8 +179,10 @@ PY
    echo "  Daemon:   $DAEMON_STATUS"
    echo "  Gateway:  $GATEWAY_STATUS"
    # Extract routing config from gateway startup log
-   GATEWAY_POLICY=$(grep -o 'unmappedPolicy: "[^"]*"' ~/.vellum/gateway-dev.log 2>/dev/null | tail -1 || echo "unknown")
-   GATEWAY_HAS_DEFAULT=$(grep -o 'hasDefaultAssistant: [a-z]*' ~/.vellum/gateway-dev.log 2>/dev/null | tail -1 || echo "unknown")
+   GATEWAY_POLICY=$(grep -o 'unmappedPolicy: "[^"]*"' ~/.vellum/gateway-dev.log 2>/dev/null | tail -1)
+   GATEWAY_HAS_DEFAULT=$(grep -o 'hasDefaultAssistant: [a-z]*' ~/.vellum/gateway-dev.log 2>/dev/null | tail -1)
+   GATEWAY_POLICY="${GATEWAY_POLICY:-unknown}"
+   GATEWAY_HAS_DEFAULT="${GATEWAY_HAS_DEFAULT:-unknown}"
    echo "  Gateway routing: $GATEWAY_POLICY, $GATEWAY_HAS_DEFAULT"
    echo "  Gateway log: ~/.vellum/gateway-dev.log"
    echo "======================="

--- a/assistant/src/__tests__/inbound-invite-redemption.test.ts
+++ b/assistant/src/__tests__/inbound-invite-redemption.test.ts
@@ -364,4 +364,37 @@ describe('inbound invite redemption intercept', () => {
     expect(json.accepted).toBe(true);
     expect(json.denied).toBeUndefined();
   });
+
+  test('reactivation via invite preserves existing guardian-managed member display name', async () => {
+    const { rawToken } = createInvite({ sourceChannel: 'telegram', maxUses: 5 });
+
+    upsertMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-invite-123',
+      externalChatId: 'chat-invite-test',
+      status: 'revoked',
+      policy: 'allow',
+      displayName: 'Jeff',
+    });
+
+    const req = buildInviteRequest(rawToken, {
+      senderName: 'Noa Flaherty',
+    });
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = await resp.json() as Record<string, unknown>;
+
+    expect(json.accepted).toBe(true);
+    expect(json.inviteRedemption).toBe('redeemed');
+
+    const member = findMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-invite-123',
+      externalChatId: 'chat-invite-test',
+    });
+    expect(member).not.toBeNull();
+    expect(member!.status).toBe('active');
+    expect(member!.displayName).toBe('Jeff');
+  });
 });

--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -419,6 +419,54 @@ describe('trusted contact activated notification signal', () => {
     expect(hints.urgency).toBe('low');
   });
 
+  test('re-verification preserves an existing guardian-managed member display name', async () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-user-789',
+      guardianDeliveryChatId: 'guardian-chat-789',
+    });
+
+    upsertMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'requester-user-456',
+      externalChatId: 'chat-123',
+      status: 'revoked',
+      policy: 'allow',
+      displayName: 'Jeff',
+    });
+
+    const session = createOutboundSession({
+      assistantId: 'self',
+      channel: 'telegram',
+      expectedExternalUserId: 'requester-user-456',
+      expectedChatId: 'chat-123',
+      identityBindingStatus: 'bound',
+      destinationAddress: 'chat-123',
+      verificationPurpose: 'trusted_contact',
+    });
+
+    const verifyReq = buildInboundRequest({
+      content: session.secret,
+      externalChatId: 'chat-123',
+      senderExternalUserId: 'requester-user-456',
+      senderName: 'Noa Flaherty',
+    });
+
+    await handleChannelInbound(verifyReq, undefined, TEST_BEARER_TOKEN);
+
+    const member = findMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'requester-user-456',
+      externalChatId: 'chat-123',
+    });
+    expect(member).not.toBeNull();
+    expect(member!.status).toBe('active');
+    expect(member!.displayName).toBe('Jeff');
+  });
+
   test('guardian verification does NOT emit activated signal', async () => {
     // Create an inbound challenge (guardian flow, not trusted contact)
     // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -119,6 +119,9 @@ export function redeemInvite(params: {
     // Sentinel error used to trigger a transaction rollback when the invite
     // was concurrently revoked/expired between pre-validation and write time.
     const STALE_INVITE = Symbol('stale_invite');
+    const preservedDisplayName = existingMember.displayName?.trim().length
+      ? existingMember.displayName
+      : displayName;
 
     let reactivated: ReturnType<typeof upsertMember> | undefined;
     try {
@@ -128,7 +131,8 @@ export function redeemInvite(params: {
           sourceChannel,
           externalUserId,
           externalChatId,
-          displayName,
+          // Reactivation should not overwrite a guardian-managed nickname.
+          displayName: preservedDisplayName,
           username,
           status: 'active',
           policy: 'allow',

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -775,6 +775,18 @@ export async function handleChannelInbound(
     const guardianVerifyOutcome: 'verified' | 'failed' = verifyResult.success ? 'verified' : 'failed';
 
     if (verifyResult.success) {
+      const existingMember = (canonicalSenderId ?? rawSenderId)
+        ? findMember({
+          assistantId: canonicalAssistantId,
+          sourceChannel,
+          externalUserId: canonicalSenderId ?? rawSenderId!,
+          externalChatId,
+        })
+        : null;
+      const preservedDisplayName = existingMember?.displayName?.trim().length
+        ? existingMember.displayName
+        : body.senderName;
+
       upsertMember({
         assistantId: canonicalAssistantId,
         sourceChannel,
@@ -782,7 +794,8 @@ export async function handleChannelInbound(
         externalChatId,
         status: 'active',
         policy: 'allow',
-        displayName: body.senderName,
+        // Keep guardian-curated member name stable across re-verification.
+        displayName: preservedDisplayName,
         username: body.senderUsername,
       });
 


### PR DESCRIPTION
Address review feedback from PR #10603:

1. Sort assistants by hatchedAt descending to match CLI loadLatestAssistant() behavior
2. Fix dead || echo unknown fallback by using ${VAR:-unknown} pattern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
