### PR TITLE
Fix desktop NL approval replies for 'go for it' and stale pending IDs

### DIFF
--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -732,6 +732,33 @@ describe('routing invariant: disambiguation stays fail-closed', () => {
     const resolved = getCanonicalGuardianRequest(req.id);
     expect(resolved!.status).toBe('approved');
   });
+
+  test('single pending request accepts "go for it" as deterministic approval', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      toolName: 'shell',
+      requestCode: 'GO1234',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    registerPendingToolApprovalInteraction(req.id, 'conv-1', 'shell');
+
+    const result = await routeGuardianReply(replyCtx({
+      messageText: 'go for it',
+      conversationId: 'conv-1',
+      pendingRequestIds: [req.id],
+      approvalConversationGenerator: undefined,
+    }));
+
+    expect(result.consumed).toBe(true);
+    expect(result.decisionApplied).toBe(true);
+    expect(result.type).toBe('canonical_decision_applied');
+
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe('approved');
+  });
 });
 
 // ===========================================================================

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -14,7 +14,13 @@ const routeGuardianReplyMock = mock(async () => ({
 })) as any;
 const listPendingByDestinationMock = mock(() => [] as Array<{ id: string; kind?: string }>);
 const listCanonicalMock = mock(() => [] as Array<{ id: string }>);
-const getByConversationMock = mock(() => [] as Array<{ requestId: string; kind: 'confirmation' | 'secret' }>);
+const getByConversationMock = mock(
+  () => [] as Array<{
+    requestId: string;
+    kind: 'confirmation' | 'secret';
+    session?: unknown;
+  }>,
+);
 const addMessageMock = mock(async () => ({ id: 'persisted-message-id' }));
 const getConfigMock = mock(() => ({
   daemon: { standaloneRecording: false },
@@ -71,6 +77,7 @@ interface TestSession {
   hasEscalationHandler: () => boolean;
   setChannelCapabilities: (caps: unknown) => void;
   isProcessing: () => boolean;
+  hasPendingConfirmation: (requestId: string) => boolean;
   hasAnyPendingConfirmation: () => boolean;
   getQueueDepth: () => number;
   denyAllPendingConfirmations: () => void;
@@ -123,6 +130,7 @@ function makeSession(overrides: Partial<TestSession> = {}): TestSession {
     hasEscalationHandler: () => true,
     setChannelCapabilities: () => {},
     isProcessing: () => false,
+    hasPendingConfirmation: () => true,
     hasAnyPendingConfirmation: () => true,
     getQueueDepth: () => 0,
     denyAllPendingConfirmations: mock(() => {}),
@@ -267,5 +275,36 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
     expect(addMessageMock).toHaveBeenCalledTimes(0);
     expect(sent.some((msg) => msg.type === 'message_queued')).toBe(true);
     expect(sent.some((msg) => msg.type === 'message_dequeued')).toBe(false);
+  });
+
+  test('routes only live pending confirmation request ids', async () => {
+    const session = makeSession({
+      hasPendingConfirmation: (requestId: string) => requestId === 'req-live',
+    });
+
+    getByConversationMock.mockReturnValue([
+      { requestId: 'req-stale', kind: 'confirmation', session: {} },
+      { requestId: 'req-live', kind: 'confirmation', session: session as unknown },
+    ]);
+    listPendingByDestinationMock.mockReturnValue([
+      { id: 'req-stale', kind: 'tool_approval' },
+      { id: 'req-live', kind: 'tool_approval' },
+    ]);
+    listCanonicalMock.mockReturnValue([
+      { id: 'req-stale' },
+      { id: 'req-live' },
+    ]);
+    routeGuardianReplyMock.mockResolvedValue({
+      consumed: false,
+      decisionApplied: false,
+      type: 'not_consumed',
+    });
+
+    const { ctx } = createContext(session);
+    await handleUserMessage(makeMessage('allow'), {} as net.Socket, ctx);
+
+    expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
+    const routeCall = (routeGuardianReplyMock as any).mock.calls[0][0] as Record<string, unknown>;
+    expect(routeCall.pendingRequestIds).toEqual(['req-live']);
   });
 });

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -21,6 +21,7 @@ const getByConversationMock = mock(
     session?: unknown;
   }>,
 );
+const resolveMock = mock(() => undefined as unknown);
 const addMessageMock = mock(async () => ({ id: 'persisted-message-id' }));
 const getConfigMock = mock(() => ({
   daemon: { standaloneRecording: false },
@@ -38,6 +39,7 @@ mock.module('../memory/canonical-guardian-store.js', () => ({
 
 mock.module('../runtime/pending-interactions.js', () => ({
   getByConversation: getByConversationMock,
+  resolve: resolveMock,
 }));
 
 mock.module('../memory/conversation-store.js', () => ({
@@ -152,6 +154,7 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
     listPendingByDestinationMock.mockClear();
     listCanonicalMock.mockClear();
     getByConversationMock.mockClear();
+    resolveMock.mockClear();
     addMessageMock.mockClear();
     getConfigMock.mockClear();
   });
@@ -306,5 +309,10 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
     expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
     const routeCall = (routeGuardianReplyMock as any).mock.calls[0][0] as Record<string, unknown>;
     expect(routeCall.pendingRequestIds).toEqual(['req-live']);
+    // Auto-deny clears matching confirmation entries from pending-interactions
+    // so stale IDs are not reused as routing candidates. Only the live
+    // session-scoped interaction should be resolved.
+    expect(resolveMock).toHaveBeenCalledTimes(1);
+    expect(resolveMock).toHaveBeenCalledWith('req-live');
   });
 });

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -471,11 +471,15 @@ export async function handleUserMessage(
       try {
         const pendingInteractionRequestIdsForConversation = pendingInteractions
           .getByConversation(msg.sessionId)
-          .filter((interaction) => interaction.kind === 'confirmation')
+          .filter(
+            (interaction) =>
+              interaction.kind === 'confirmation'
+              && interaction.session === session
+              && session.hasPendingConfirmation(interaction.requestId),
+          )
           .map((interaction) => interaction.requestId);
 
-        const pendingCanonicalRequestIdsForConversation = Array.from(new Set([
-          ...pendingInteractionRequestIdsForConversation,
+        const pendingCanonicalRequestIdsForConversation = [
           ...listPendingCanonicalGuardianRequestsByDestinationConversation(msg.sessionId, ipcChannel)
             .filter((request) => request.kind === 'tool_approval')
             .map((request) => request.id),
@@ -484,9 +488,14 @@ export async function handleUserMessage(
             conversationId: msg.sessionId,
             kind: 'tool_approval',
           }).map((request) => request.id),
+        ].filter((pendingRequestId) => session.hasPendingConfirmation(pendingRequestId));
+
+        const pendingRequestIdsForConversation = Array.from(new Set([
+          ...pendingInteractionRequestIdsForConversation,
+          ...pendingCanonicalRequestIdsForConversation,
         ]));
 
-        if (pendingCanonicalRequestIdsForConversation.length > 0) {
+        if (pendingRequestIdsForConversation.length > 0) {
           const routerResult = await routeGuardianReply({
             messageText: messageText.trim(),
             channel: ipcChannel,
@@ -496,7 +505,7 @@ export async function handleUserMessage(
               isTrusted: true,
             },
             conversationId: msg.sessionId,
-            pendingRequestIds: pendingCanonicalRequestIdsForConversation,
+            pendingRequestIds: pendingRequestIdsForConversation,
             approvalConversationGenerator: desktopApprovalConversationGenerator,
           });
 
@@ -585,6 +594,13 @@ export async function handleUserMessage(
     if (session.hasAnyPendingConfirmation()) {
       rlog.info('Auto-denying pending confirmation(s) due to new user message');
       session.denyAllPendingConfirmations();
+      // Keep the pending-interaction tracker aligned with the prompter so
+      // stale request IDs are not reused as routing candidates.
+      for (const interaction of pendingInteractions.getByConversation(msg.sessionId)) {
+        if (interaction.session === session && interaction.kind === 'confirmation') {
+          pendingInteractions.resolve(interaction.requestId);
+        }
+      }
     }
 
     dispatchUserMessage(

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -551,6 +551,7 @@ const EXPLICIT_APPROVE_PHRASES: ReadonlySet<string> = new Set([
   'yes',
   'y',
   'allow',
+  'go for it',
   'go ahead',
   'proceed',
   'do it',


### PR DESCRIPTION
## Problem
In desktop chat, natural-language confirmation replies could fail to apply even though a prompt was visible. The screenshot repro (`go for it`, then `allow`) is consistent with two issues:

1. `go for it` was not in deterministic approve phrases, so it could fall through to normal message handling.
2. Inline routing could include stale request IDs (from tracker/canonical stores) instead of only live pending confirmations, causing ambiguous/missed targeting.

## Fix
- Add `"go for it"` to deterministic approval phrases in `guardian-reply-router.ts`.
- In `handleUserMessage` inline approval interception, route only request IDs that are **currently live** in the session:
  - confirmation interactions must match the active session
  - all candidate request IDs are filtered through `session.hasPendingConfirmation(requestId)`
- When auto-denying pending confirmations on new user message, clear matching confirmation entries from `pending-interactions` so stale IDs are not reused as future routing candidates.

## Tests
- Added `single pending request accepts "go for it" as deterministic approval` to `guardian-routing-invariants.test.ts`
- Added `routes only live pending confirmation request ids` to `handlers-user-message-approval-consumption.test.ts`

## Validation
- `cd assistant && bun test src/__tests__/handlers-user-message-approval-consumption.test.ts`
- `cd assistant && bun test src/__tests__/guardian-routing-invariants.test.ts`
- `cd assistant && bunx tsc --noEmit`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
