### PR TITLE
fix: always notify guardian on access requests regardless of channel binding

### DIFF
--- a/assistant/docs/trusted-contact-access.md
+++ b/assistant/docs/trusted-contact-access.md
@@ -13,8 +13,15 @@ Design doc defining how unknown users gain access to a Vellum assistant via chan
 ## User Journey
 
 1. **Unknown user messages the assistant** on Telegram (or SMS, or any channel).
-2. **Assistant rejects the message** via the ingress ACL in `inbound-message-handler.ts`. The user has no `assistant_ingress_members` record, so the handler replies: *"Sorry, you haven't been approved to message this assistant. You can ask its Guardian for an invite."* and returns `{ denied: true, reason: 'not_a_member' }`.
-3. **Notification pipeline alerts the guardian.** The rejection triggers `emitNotificationSignal()` with `sourceEventName: 'ingress.access_request'`, routing through the decision engine to all connected channels (vellum macOS app, Telegram, etc.). The guardian sees who is requesting access.
+2. **Assistant rejects the message** via the ingress ACL in `inbound-message-handler.ts`. The user has no `assistant_ingress_members` record, so the handler replies: *"Hmm looks like you don't have access to talk to me. I'll let them know you tried talking to me and get back to you."* and returns `{ denied: true, reason: 'not_a_member' }`.
+3. **Notification pipeline alerts the guardian.** The rejection triggers `notifyGuardianOfAccessRequest()` which creates a canonical access request and calls `emitNotificationSignal()` with `sourceEventName: 'ingress.access_request'`. The notification routes through the decision engine to all connected channels (vellum macOS app, Telegram, etc.). The guardian sees who is requesting access, including a request code for approve/reject and an `open invite flow` option to start the Trusted Contacts invite flow.
+
+   **Guardian binding resolution for access requests** uses a fallback strategy:
+   1. Source-channel active binding first (e.g., Telegram binding for a Telegram access request).
+   2. Any active binding for the assistant on another channel (deterministic: most recently verified first, then alphabetical by channel).
+   3. No guardian identity — the notification pipeline delivers via trusted/vellum channels even when no channel binding exists.
+
+   This ensures unknown inbound access attempts always trigger guardian notification, even when the requester's source channel has no guardian binding.
 4. **Guardian approves the request.** The guardian responds to the notification (via Telegram inline button, macOS app, or IPC). On approval, the assistant creates a verification session via `createOutboundSession()` and generates a 6-digit verification code.
 5. **Guardian receives the verification code.** The assistant delivers the code to the guardian's verified channel (Telegram chat, SMS, etc.).
 6. **Guardian gives the code to the requester out-of-band** (in person, text message, phone call, etc.). This out-of-band transfer is the trust anchor: it proves the requester has a real-world relationship with the guardian.

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -960,7 +960,7 @@ describe('routing invariant: destination hints enable NL approval without guardi
 describe('routing invariant: invite handoff bypass for access requests', () => {
   beforeEach(() => resetTables());
 
-  test('pending access_request + message "open invite flow" returns not_consumed', async () => {
+  test('pending access_request + message "open invite flow" returns not_consumed with skipApprovalInterception', async () => {
     const req = createCanonicalGuardianRequest({
       kind: 'access_request',
       sourceType: 'channel',
@@ -982,6 +982,7 @@ describe('routing invariant: invite handoff bypass for access requests', () => {
     expect(result.consumed).toBe(false);
     expect(result.type).toBe('not_consumed');
     expect(result.decisionApplied).toBe(false);
+    expect(result.skipApprovalInterception).toBe(true);
 
     // Request remains pending — not resolved by the handoff
     const unchanged = getCanonicalGuardianRequest(req.id);

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -952,3 +952,113 @@ describe('routing invariant: destination hints enable NL approval without guardi
     expect(unchanged!.status).toBe('pending');
   });
 });
+
+// ===========================================================================
+// SECTION 10: Invite handoff bypass for access requests
+// ===========================================================================
+
+describe('routing invariant: invite handoff bypass for access requests', () => {
+  beforeEach(() => resetTables());
+
+  test('pending access_request + message "open invite flow" returns not_consumed', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'access_request',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      conversationId: 'conv-access-1',
+      guardianExternalUserId: 'guardian-1',
+      requestCode: 'INV001',
+      toolName: 'ingress_access_request',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await routeGuardianReply(replyCtx({
+      messageText: 'open invite flow',
+      conversationId: 'conv-guardian-thread',
+      pendingRequestIds: [req.id],
+      approvalConversationGenerator: undefined,
+    }));
+
+    expect(result.consumed).toBe(false);
+    expect(result.type).toBe('not_consumed');
+    expect(result.decisionApplied).toBe(false);
+
+    // Request remains pending — not resolved by the handoff
+    const unchanged = getCanonicalGuardianRequest(req.id);
+    expect(unchanged!.status).toBe('pending');
+  });
+
+  test('invite handoff is case-insensitive and punctuation-trimmed', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'access_request',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      guardianExternalUserId: 'guardian-1',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    for (const phrase of ['Open Invite Flow', 'OPEN INVITE FLOW', 'open invite flow.', 'Open invite flow!']) {
+      const result = await routeGuardianReply(replyCtx({
+        messageText: phrase,
+        conversationId: 'conv-test',
+        pendingRequestIds: [req.id],
+        approvalConversationGenerator: undefined,
+      }));
+
+      expect(result.consumed).toBe(false);
+      expect(result.type).toBe('not_consumed');
+    }
+  });
+
+  test('invite handoff does NOT bypass for non-access-request kinds', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      requestCode: 'TAP001',
+      toolName: 'shell',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await routeGuardianReply(replyCtx({
+      messageText: 'open invite flow',
+      conversationId: 'conv-guardian-thread',
+      pendingRequestIds: [req.id],
+      approvalConversationGenerator: undefined,
+    }));
+
+    // Should NOT return not_consumed via the invite handoff path.
+    // Without NL generator and no explicit approve/reject, it falls through
+    // to not_consumed anyway, but the key invariant is the request remains pending.
+    const unchanged = getCanonicalGuardianRequest(req.id);
+    expect(unchanged!.status).toBe('pending');
+  });
+
+  test('explicit approve/reject messages still consume with pending access_request', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'access_request',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      conversationId: 'conv-access-2',
+      guardianExternalUserId: 'guardian-1',
+      requestCode: 'APP001',
+      toolName: 'ingress_access_request',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    // Code-based approve should still work
+    const result = await routeGuardianReply(replyCtx({
+      messageText: 'APP001 approve',
+      conversationId: 'conv-guardian-thread',
+      pendingRequestIds: [req.id],
+      approvalConversationGenerator: undefined,
+    }));
+
+    expect(result.consumed).toBe(true);
+    expect(result.decisionApplied).toBe(true);
+
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe('approved');
+  });
+});

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -80,6 +80,7 @@ mock.module('../runtime/gateway-client.js', () => ({
   },
 }));
 
+import { notifyGuardianOfAccessRequest } from '../runtime/access-request-helper.js';
 import { listCanonicalGuardianRequests } from '../memory/canonical-guardian-store.js';
 import {
   createBinding,
@@ -236,8 +237,9 @@ describe('non-member access request notification', () => {
     expect(pending.length).toBe(1);
   });
 
-  test('deny works without error when no guardian binding exists', async () => {
-    // No guardian binding — should deny without notification
+  test('access request is created and signal emitted even without same-channel guardian binding', async () => {
+    // No guardian binding on any channel — access request should still be
+    // created and notification signal emitted (null guardianExternalUserId).
     const req = buildInboundRequest();
     const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
     const json = await resp.json() as Record<string, unknown>;
@@ -245,20 +247,55 @@ describe('non-member access request notification', () => {
     expect(json.denied).toBe(true);
     expect(json.reason).toBe('not_a_member');
 
-    // Rejection reply was still delivered
+    // Rejection reply indicates guardian was notified
     expect(deliverReplyCalls.length).toBe(1);
+    expect((deliverReplyCalls[0].payload as Record<string, unknown>).text).toContain("let them know");
 
-    // No notification signal was emitted
-    expect(emitSignalCalls.length).toBe(0);
+    // Notification signal was emitted
+    expect(emitSignalCalls.length).toBe(1);
+    expect(emitSignalCalls[0].sourceEventName).toBe('ingress.access_request');
 
-    // No canonical request was created
+    // Canonical request was created with null guardianExternalUserId
     const pending = listCanonicalGuardianRequests({
       status: 'pending',
       requesterExternalUserId: 'user-unknown-456',
       sourceChannel: 'telegram',
       kind: 'access_request',
     });
-    expect(pending.length).toBe(0);
+    expect(pending.length).toBe(1);
+    expect(pending[0].guardianExternalUserId).toBeNull();
+  });
+
+  test('cross-channel fallback: SMS guardian binding resolves for Telegram access request', async () => {
+    // Only an SMS guardian binding exists — no Telegram binding
+    createBinding({
+      assistantId: 'self',
+      channel: 'sms',
+      guardianExternalUserId: 'guardian-sms-user',
+      guardianDeliveryChatId: 'guardian-sms-chat',
+    });
+
+    const req = buildInboundRequest();
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = await resp.json() as Record<string, unknown>;
+
+    expect(json.denied).toBe(true);
+    expect(json.reason).toBe('not_a_member');
+
+    // Notification signal emitted
+    expect(emitSignalCalls.length).toBe(1);
+    const payload = emitSignalCalls[0].contextPayload as Record<string, unknown>;
+    expect(payload.guardianBindingChannel).toBe('sms');
+
+    // Canonical request has the SMS guardian's external user ID
+    const pending = listCanonicalGuardianRequests({
+      status: 'pending',
+      requesterExternalUserId: 'user-unknown-456',
+      sourceChannel: 'telegram',
+      kind: 'access_request',
+    });
+    expect(pending.length).toBe(1);
+    expect(pending[0].guardianExternalUserId).toBe('guardian-sms-user');
   });
 
   test('no notification when senderExternalUserId is absent', async () => {
@@ -279,5 +316,141 @@ describe('non-member access request notification', () => {
 
     // No access request notification should fire (no identity to notify about)
     expect(emitSignalCalls.length).toBe(0);
+  });
+});
+
+describe('access-request-helper unit tests', () => {
+  beforeEach(() => {
+    resetState();
+  });
+
+  test('notifyGuardianOfAccessRequest returns no_sender_id when senderExternalUserId is absent', () => {
+    const result = notifyGuardianOfAccessRequest({
+      canonicalAssistantId: 'self',
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-123',
+      senderExternalUserId: undefined,
+    });
+
+    expect(result.notified).toBe(false);
+    if (!result.notified) {
+      expect(result.reason).toBe('no_sender_id');
+    }
+
+    // No canonical request created
+    const pending = listCanonicalGuardianRequests({ status: 'pending', kind: 'access_request' });
+    expect(pending.length).toBe(0);
+  });
+
+  test('notifyGuardianOfAccessRequest creates request with null guardianExternalUserId when no binding exists', () => {
+    const result = notifyGuardianOfAccessRequest({
+      canonicalAssistantId: 'self',
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-123',
+      senderExternalUserId: 'unknown-user',
+      senderName: 'Bob',
+    });
+
+    expect(result.notified).toBe(true);
+    if (result.notified) {
+      expect(result.created).toBe(true);
+    }
+
+    const pending = listCanonicalGuardianRequests({
+      status: 'pending',
+      requesterExternalUserId: 'unknown-user',
+      kind: 'access_request',
+    });
+    expect(pending.length).toBe(1);
+    expect(pending[0].guardianExternalUserId).toBeNull();
+
+    // Signal was emitted
+    expect(emitSignalCalls.length).toBe(1);
+  });
+
+  test('notifyGuardianOfAccessRequest uses cross-channel binding when source-channel binding is missing', () => {
+    // Only SMS binding exists
+    createBinding({
+      assistantId: 'self',
+      channel: 'sms',
+      guardianExternalUserId: 'guardian-sms',
+      guardianDeliveryChatId: 'sms-chat',
+    });
+
+    const result = notifyGuardianOfAccessRequest({
+      canonicalAssistantId: 'self',
+      sourceChannel: 'telegram',
+      externalChatId: 'tg-chat',
+      senderExternalUserId: 'unknown-tg-user',
+    });
+
+    expect(result.notified).toBe(true);
+
+    const pending = listCanonicalGuardianRequests({
+      status: 'pending',
+      requesterExternalUserId: 'unknown-tg-user',
+      kind: 'access_request',
+    });
+    expect(pending.length).toBe(1);
+    expect(pending[0].guardianExternalUserId).toBe('guardian-sms');
+
+    // Signal payload includes fallback channel
+    const payload = emitSignalCalls[0].contextPayload as Record<string, unknown>;
+    expect(payload.guardianBindingChannel).toBe('sms');
+  });
+
+  test('notifyGuardianOfAccessRequest prefers source-channel binding over cross-channel fallback', () => {
+    // Both Telegram and SMS bindings exist
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-tg',
+      guardianDeliveryChatId: 'tg-chat',
+    });
+    createBinding({
+      assistantId: 'self',
+      channel: 'sms',
+      guardianExternalUserId: 'guardian-sms',
+      guardianDeliveryChatId: 'sms-chat',
+    });
+
+    const result = notifyGuardianOfAccessRequest({
+      canonicalAssistantId: 'self',
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-123',
+      senderExternalUserId: 'unknown-user',
+    });
+
+    expect(result.notified).toBe(true);
+
+    const pending = listCanonicalGuardianRequests({
+      status: 'pending',
+      requesterExternalUserId: 'unknown-user',
+      kind: 'access_request',
+    });
+    expect(pending.length).toBe(1);
+    // Should use the Telegram binding, not SMS fallback
+    expect(pending[0].guardianExternalUserId).toBe('guardian-tg');
+
+    const payload = emitSignalCalls[0].contextPayload as Record<string, unknown>;
+    expect(payload.guardianBindingChannel).toBe('telegram');
+  });
+
+  test('notifyGuardianOfAccessRequest includes requestCode in contextPayload', () => {
+    const result = notifyGuardianOfAccessRequest({
+      canonicalAssistantId: 'self',
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-123',
+      senderExternalUserId: 'unknown-user',
+      senderName: 'Test User',
+    });
+
+    expect(result.notified).toBe(true);
+    expect(emitSignalCalls.length).toBe(1);
+
+    const payload = emitSignalCalls[0].contextPayload as Record<string, unknown>;
+    expect(payload.requestCode).toBeDefined();
+    expect(typeof payload.requestCode).toBe('string');
+    expect((payload.requestCode as string).length).toBe(6);
   });
 });

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -155,9 +155,10 @@ describe('non-member access request notification', () => {
     expect(json.denied).toBe(true);
     expect(json.reason).toBe('not_a_member');
 
-    // Rejection reply was delivered
+    // Rejection reply was delivered — always-notify behavior means the reply
+    // indicates the guardian will be notified, even without a same-channel binding.
     expect(deliverReplyCalls.length).toBe(1);
-    expect((deliverReplyCalls[0].payload as Record<string, unknown>).text).toContain("you haven't been approved");
+    expect((deliverReplyCalls[0].payload as Record<string, unknown>).text).toContain("let them know");
   });
 
   test('guardian is notified when a non-member messages and a guardian binding exists', async () => {

--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -151,6 +151,67 @@ describe('notification decision strategy', () => {
       expect(copy.vellum!.deliveryText).toBeUndefined();
     });
 
+    test('ingress.access_request template includes requester identifier', () => {
+      const signal = makeSignal({
+        sourceEventName: 'ingress.access_request',
+        contextPayload: {
+          senderIdentifier: 'Alice',
+          requestCode: 'A1B2C3',
+        },
+      });
+
+      const copy = composeFallbackCopy(signal, channels);
+      expect(copy.vellum).toBeDefined();
+      expect(copy.vellum!.title).toBe('Access Request');
+      expect(copy.vellum!.body).toContain('Alice');
+      expect(copy.vellum!.body).toContain('requesting access');
+    });
+
+    test('ingress.access_request template includes request code instruction when present', () => {
+      const signal = makeSignal({
+        sourceEventName: 'ingress.access_request',
+        contextPayload: {
+          senderIdentifier: 'Bob',
+          requestCode: 'D4E5F6',
+        },
+      });
+
+      const copy = composeFallbackCopy(signal, channels);
+      expect(copy.vellum).toBeDefined();
+      expect(copy.vellum!.body).toContain('D4E5F6');
+      expect(copy.vellum!.body).toContain('approve');
+      expect(copy.vellum!.body).toContain('reject');
+    });
+
+    test('ingress.access_request template includes invite flow instruction', () => {
+      const signal = makeSignal({
+        sourceEventName: 'ingress.access_request',
+        contextPayload: {
+          senderIdentifier: 'Charlie',
+        },
+      });
+
+      const copy = composeFallbackCopy(signal, channels);
+      expect(copy.vellum).toBeDefined();
+      expect(copy.vellum!.body).toContain('open invite flow');
+    });
+
+    test('ingress.access_request Telegram deliveryText is concise', () => {
+      const signal = makeSignal({
+        sourceEventName: 'ingress.access_request',
+        contextPayload: {
+          senderIdentifier: 'Dave',
+          requestCode: 'ABC123',
+        },
+      });
+
+      const copy = composeFallbackCopy(signal, ['telegram']);
+      expect(copy.telegram).toBeDefined();
+      expect(copy.telegram!.deliveryText).toBeDefined();
+      expect(typeof copy.telegram!.deliveryText).toBe('string');
+      expect(copy.telegram!.deliveryText!.length).toBeGreaterThan(0);
+    });
+
     test('empty payload falls back to default text in template', () => {
       const signal = makeSignal({
         sourceEventName: 'guardian.question',

--- a/assistant/src/memory/channel-guardian-store.ts
+++ b/assistant/src/memory/channel-guardian-store.ts
@@ -37,6 +37,7 @@ export {
   createBinding,
   getActiveBinding,
   type GuardianBinding,
+  listActiveBindingsByAssistant,
   revokeBinding,
 } from './guardian-bindings.js';
 export {

--- a/assistant/src/memory/guardian-bindings.ts
+++ b/assistant/src/memory/guardian-bindings.ts
@@ -5,7 +5,7 @@
  * for a given (assistantId, channel) pair.
  */
 
-import { and, eq } from 'drizzle-orm';
+import { and, asc, desc, eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
 import { getDb } from './db.js';
@@ -101,6 +101,30 @@ export function getActiveBinding(assistantId: string, channel: string): Guardian
     .get();
 
   return row ? rowToBinding(row) : null;
+}
+
+/**
+ * List all active guardian bindings for an assistant across all channels.
+ * Deterministic ordering: verifiedAt DESC (most recently verified first),
+ * then channel ASC (alphabetical tiebreaker).
+ */
+export function listActiveBindingsByAssistant(assistantId: string): GuardianBinding[] {
+  const db = getDb();
+  return db
+    .select()
+    .from(channelGuardianBindings)
+    .where(
+      and(
+        eq(channelGuardianBindings.assistantId, assistantId),
+        eq(channelGuardianBindings.status, 'active'),
+      ),
+    )
+    .orderBy(
+      desc(channelGuardianBindings.verifiedAt),
+      asc(channelGuardianBindings.channel),
+    )
+    .all()
+    .map(rowToBinding);
 }
 
 export function revokeBinding(assistantId: string, channel: string): boolean {

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -54,6 +54,21 @@ const TEMPLATES: Record<string, CopyTemplate> = {
     };
   },
 
+  'ingress.access_request': (payload) => {
+    const requester = str(payload.senderIdentifier, 'Someone');
+    const requestCode = nonEmpty(typeof payload.requestCode === 'string' ? payload.requestCode : undefined);
+    const lines: string[] = [`${requester} is requesting access to the assistant.`];
+    if (requestCode) {
+      const code = requestCode.toUpperCase();
+      lines.push(`Reply "${code} approve" to grant access or "${code} reject" to deny.`);
+    }
+    lines.push('Reply "open invite flow" to start Trusted Contacts invite flow.');
+    return {
+      title: 'Access Request',
+      body: lines.join('\n'),
+    };
+  },
+
   'ingress.escalation': (payload) => ({
     title: 'Escalation',
     body: str(payload.senderIdentifier, 'An incoming message') + ' needs attention',

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -4,6 +4,13 @@
  * Encapsulates the "create/dedupe canonical access request + emit notification"
  * logic so both text-channel and voice-channel ingress paths use identical
  * guardian notification flows.
+ *
+ * Access requests are a special case: they always create a canonical request
+ * and emit a notification signal, even when no same-channel guardian binding
+ * exists. Guardian binding resolution uses a fallback strategy:
+ *   1. Source-channel active binding first.
+ *   2. Any active binding for the assistant (deterministic, most-recently-verified).
+ *   3. No guardian identity (trusted/vellum-only resolution path).
  */
 
 import type { ChannelId } from '../channels/types.js';
@@ -11,6 +18,7 @@ import {
   createCanonicalGuardianRequest,
   listCanonicalGuardianRequests,
 } from '../memory/canonical-guardian-store.js';
+import { listActiveBindingsByAssistant } from '../memory/channel-guardian-store.js';
 import { emitNotificationSignal } from '../notifications/emit-signal.js';
 import { getLogger } from '../util/logger.js';
 import { getGuardianBinding } from './channel-guardian-service.js';
@@ -33,7 +41,7 @@ export interface AccessRequestParams {
 
 export type AccessRequestResult =
   | { notified: true; created: boolean; requestId: string }
-  | { notified: false; reason: 'no_sender_id' | 'no_guardian_binding' };
+  | { notified: false; reason: 'no_sender_id' };
 
 // ---------------------------------------------------------------------------
 // Helper
@@ -45,6 +53,10 @@ export type AccessRequestResult =
  *
  * Returns a result indicating whether the guardian was notified and whether
  * a new request was created or an existing one was deduped.
+ *
+ * Guardian binding resolution: source-channel first, then any active binding
+ * for the assistant, then null (notification pipeline handles delivery via
+ * trusted/vellum channels when no binding exists).
  *
  * This is intentionally synchronous with respect to the canonical store writes
  * and fire-and-forget for the notification signal emission.
@@ -65,10 +77,32 @@ export function notifyGuardianOfAccessRequest(
     return { notified: false, reason: 'no_sender_id' };
   }
 
-  const binding = getGuardianBinding(canonicalAssistantId, sourceChannel);
-  if (!binding) {
-    log.debug({ sourceChannel, canonicalAssistantId }, 'No guardian binding for access request notification');
-    return { notified: false, reason: 'no_guardian_binding' };
+  // Resolve guardian binding with fallback strategy:
+  // 1. Source-channel active binding
+  // 2. Any active binding for the assistant (deterministic order)
+  // 3. null (no guardian identity — notification pipeline uses trusted channels)
+  const sourceBinding = getGuardianBinding(canonicalAssistantId, sourceChannel);
+  let guardianExternalUserId: string | null = null;
+  let guardianBindingChannel: string | null = null;
+
+  if (sourceBinding) {
+    guardianExternalUserId = sourceBinding.guardianExternalUserId;
+    guardianBindingChannel = sourceBinding.channel;
+  } else {
+    const allBindings = listActiveBindingsByAssistant(canonicalAssistantId);
+    if (allBindings.length > 0) {
+      guardianExternalUserId = allBindings[0].guardianExternalUserId;
+      guardianBindingChannel = allBindings[0].channel;
+      log.debug(
+        { sourceChannel, fallbackChannel: guardianBindingChannel, canonicalAssistantId },
+        'Using cross-channel guardian binding fallback for access request',
+      );
+    } else {
+      log.debug(
+        { sourceChannel, canonicalAssistantId },
+        'No guardian binding for access request — proceeding without guardian identity',
+      );
+    }
   }
 
   // Deduplicate: skip creation if there is already a pending canonical request
@@ -99,7 +133,7 @@ export function notifyGuardianOfAccessRequest(
     conversationId: `access-req-${sourceChannel}-${senderExternalUserId}`,
     requesterExternalUserId: senderExternalUserId,
     requesterChatId: externalChatId,
-    guardianExternalUserId: binding.guardianExternalUserId,
+    guardianExternalUserId: guardianExternalUserId ?? undefined,
     toolName: 'ingress_access_request',
     questionText: `${senderIdentifier} is requesting access to the assistant`,
     expiresAt: new Date(Date.now() + GUARDIAN_APPROVAL_TTL_MS).toISOString(),
@@ -118,18 +152,20 @@ export function notifyGuardianOfAccessRequest(
     },
     contextPayload: {
       requestId,
+      requestCode: canonicalRequest.requestCode,
       sourceChannel,
       externalChatId,
       senderExternalUserId,
       senderName: senderName ?? null,
       senderUsername: senderUsername ?? null,
       senderIdentifier,
+      guardianBindingChannel,
     },
     dedupeKey: `access-request:${canonicalRequest.id}`,
   });
 
   log.info(
-    { sourceChannel, senderExternalUserId, senderIdentifier },
+    { sourceChannel, senderExternalUserId, senderIdentifier, guardianBindingChannel },
     'Guardian notified of access request',
   );
 

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -319,7 +319,25 @@ export async function routeGuardianReply(
     }
   }
 
-  // ── 2.5. Deterministic plain-text decisions for known pending targets ──
+  // ── 2.5. Invite handoff bypass for access requests ──
+  // When the guardian sends "open invite flow" and there is at least one
+  // pending access_request, return not_consumed so the message falls through
+  // to the normal assistant turn and can invoke the Trusted Contacts skill.
+  if (messageText.length > 0 && pendingRequests.length > 0) {
+    const normalized = messageText.trim().toLowerCase().replace(/[.!?]+$/g, '');
+    if (normalized === 'open invite flow') {
+      const hasAccessRequest = pendingRequests.some(r => r.kind === 'access_request');
+      if (hasAccessRequest) {
+        log.info(
+          { event: 'router_invite_handoff', pendingCount: pendingRequests.length },
+          'Guardian sent "open invite flow" with pending access_request — passing through to assistant',
+        );
+        return notConsumed();
+      }
+    }
+  }
+
+  // ── 2.6. Deterministic plain-text decisions for known pending targets ──
   // Desktop sessions intentionally do not enable NL classification; when the
   // caller has exactly one known pending request and sends an explicit
   // approve/reject phrase ("approve", "yes", "reject", "no"), apply the

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -85,6 +85,12 @@ export interface GuardianReplyResult {
   requestId?: string;
   /** Detailed result from the canonical decision primitive (when a decision was attempted). */
   canonicalResult?: CanonicalDecisionResult;
+  /**
+   * When true, the caller should skip legacy approval interception for this
+   * message. Set by the invite handoff bypass so that "open invite flow"
+   * reaches the assistant even when other legacy guardian approvals are pending.
+   */
+  skipApprovalInterception?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -332,7 +338,12 @@ export async function routeGuardianReply(
           { event: 'router_invite_handoff', pendingCount: pendingRequests.length },
           'Guardian sent "open invite flow" with pending access_request — passing through to assistant',
         );
-        return notConsumed();
+        return {
+          consumed: false,
+          decisionApplied: false,
+          type: 'not_consumed' as const,
+          skipApprovalInterception: true,
+        };
       }
     }
   }

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -902,6 +902,11 @@ export async function handleChannelInbound(
     senderDisplayName: body.senderName,
   });
 
+  // Hoisted flag: set by the canonical guardian reply router when the invite
+  // handoff bypass fires. Prevents legacy approval interception from swallowing
+  // the message when other approvals are pending in the same chat.
+  let skipApprovalInterception = false;
+
   // ── Canonical guardian reply router ──
   // Attempts to route inbound messages through the canonical decision pipeline
   // before falling through to the legacy approval interception. Handles
@@ -985,13 +990,21 @@ export async function handleChannelInbound(
         requestId: routerResult.requestId,
       });
     }
+
+    if (routerResult.skipApprovalInterception) {
+      skipApprovalInterception = true;
+    }
   }
 
   // ── Approval interception ──
   // Keep this active whenever callback context is available.
+  // Skipped when the canonical router flagged skipApprovalInterception (e.g.
+  // invite handoff bypass) to prevent the legacy interceptor from swallowing
+  // messages that should reach the assistant.
   if (
     replyCallbackUrl &&
-    !result.duplicate
+    !result.duplicate &&
+    !skipApprovalInterception
   ) {
     const approvalResult = await handleApprovalInterception({
       conversationId: result.conversationId,


### PR DESCRIPTION
## Summary
- Access requests from unknown users now always create a canonical guardian request and emit a notification signal, even when no guardian binding exists on the requester's source channel
- Implements 3-tier fallback for guardian binding resolution: source-channel → any active binding → null (trusted/vellum channels)
- Adds `ingress.access_request` copy-composer template with requester identity, request code instructions, and invite flow option
- Adds "open invite flow" bypass in guardian-reply-router so the phrase passes through to the assistant turn
- Comprehensive test coverage for cross-channel fallback, deduplication, template rendering, and invite handoff

## Original prompt
/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/.private/plans/access-request-special-case-notifications-one-pr-plan-2026-02-28.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
