### PR TITLE
fix: guard member trust and display name against group-chat mismatches

### DIFF
--- a/assistant/src/__tests__/trusted-contact-verification.test.ts
+++ b/assistant/src/__tests__/trusted-contact-verification.test.ts
@@ -224,7 +224,9 @@ describe('trusted contact verification → member activation', () => {
     });
 
     // The member record returned by findMember matched on chatId but belongs
-    // to a different user, so member metadata should NOT be used.
+    // to a different user, so member metadata should NOT be used and trust
+    // should NOT be elevated to trusted_contact.
+    expect(trust.trustClass).toBe('unknown');
     expect(trust.actorMetadata.displayName).toBe('Actual Sender');
     expect(trust.actorMetadata.senderDisplayName).toBe('Actual Sender');
     expect(trust.actorMetadata.memberDisplayName).toBeUndefined();

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -145,7 +145,7 @@ export function resolveActorTrust(input: ResolveActorTrustInput): ActorTrustCont
   // externalUserId matches the current sender to avoid misidentification.
   // Canonicalize the stored member ID to handle formatting variance (e.g.
   // phone numbers stored without E.164 normalization).
-  const memberMatchesSender = memberRecord
+  const memberMatchesSender = memberRecord?.externalUserId
     ? canonicalizeInboundIdentity(input.sourceChannel, memberRecord.externalUserId) === canonicalSenderId
     : false;
 

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -162,7 +162,7 @@ export function resolveActorTrust(input: ResolveActorTrustInput): ActorTrustCont
   let trustClass: TrustClass;
   if (isGuardian) {
     trustClass = 'guardian';
-  } else if (memberRecord && memberRecord.status === 'active') {
+  } else if (memberMatchesSender && memberRecord && memberRecord.status === 'active') {
     trustClass = 'trusted_contact';
   } else {
     trustClass = 'unknown';

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -143,7 +143,11 @@ export function resolveActorTrust(input: ResolveActorTrustInput): ActorTrustCont
   // In group chats, findMember may match on externalChatId and return a
   // record for a different user. Only use member metadata when the record's
   // externalUserId matches the current sender to avoid misidentification.
-  const memberMatchesSender = memberRecord?.externalUserId === canonicalSenderId;
+  // Canonicalize the stored member ID to handle formatting variance (e.g.
+  // phone numbers stored without E.164 normalization).
+  const memberMatchesSender = memberRecord
+    ? canonicalizeInboundIdentity(input.sourceChannel, memberRecord.externalUserId) === canonicalSenderId
+    : false;
 
   const memberUsername = memberMatchesSender && typeof memberRecord?.username === 'string' && memberRecord.username.trim().length > 0
     ? memberRecord.username.trim()

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -121,7 +121,7 @@ export function redeemInvite(params: {
     // Sentinel error used to trigger a transaction rollback when the invite
     // was concurrently revoked/expired between pre-validation and write time.
     const STALE_INVITE = Symbol('stale_invite');
-    const canonicalMemberId = canonicalizeInboundIdentity(sourceChannel as ChannelId, existingMember.externalUserId);
+    const canonicalMemberId = existingMember.externalUserId ? canonicalizeInboundIdentity(sourceChannel as ChannelId, existingMember.externalUserId) : null;
     const canonicalCallerId = externalUserId ? canonicalizeInboundIdentity(sourceChannel as ChannelId, externalUserId) : null;
     const memberMatchesSender = !!(canonicalMemberId && canonicalCallerId && canonicalMemberId === canonicalCallerId);
     const preservedDisplayName = memberMatchesSender && existingMember.displayName?.trim().length

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -7,9 +7,11 @@
  * persisted, or returned in the outcome.
  */
 
+import type { ChannelId } from '../channels/types.js';
 import { getSqlite } from '../memory/db.js';
 import { findByTokenHash, hashToken, markInviteExpired, recordInviteUse, redeemInvite as storeRedeemInvite, findActiveVoiceInvites } from '../memory/ingress-invite-store.js';
 import { findMember, upsertMember } from '../memory/ingress-member-store.js';
+import { canonicalizeInboundIdentity } from '../util/canonicalize-identity.js';
 import { hashVoiceCode } from '../util/voice-code.js';
 
 // ---------------------------------------------------------------------------
@@ -119,7 +121,9 @@ export function redeemInvite(params: {
     // Sentinel error used to trigger a transaction rollback when the invite
     // was concurrently revoked/expired between pre-validation and write time.
     const STALE_INVITE = Symbol('stale_invite');
-    const memberMatchesSender = existingMember.externalUserId === externalUserId;
+    const canonicalMemberId = canonicalizeInboundIdentity(sourceChannel as ChannelId, existingMember.externalUserId);
+    const canonicalCallerId = externalUserId ? canonicalizeInboundIdentity(sourceChannel as ChannelId, externalUserId) : null;
+    const memberMatchesSender = !!(canonicalMemberId && canonicalCallerId && canonicalMemberId === canonicalCallerId);
     const preservedDisplayName = memberMatchesSender && existingMember.displayName?.trim().length
       ? existingMember.displayName
       : displayName;

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -119,7 +119,8 @@ export function redeemInvite(params: {
     // Sentinel error used to trigger a transaction rollback when the invite
     // was concurrently revoked/expired between pre-validation and write time.
     const STALE_INVITE = Symbol('stale_invite');
-    const preservedDisplayName = existingMember.displayName?.trim().length
+    const memberMatchesSender = existingMember.externalUserId === externalUserId;
+    const preservedDisplayName = memberMatchesSender && existingMember.displayName?.trim().length
       ? existingMember.displayName
       : displayName;
 

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -783,7 +783,9 @@ export async function handleChannelInbound(
           externalChatId,
         })
         : null;
-      const memberMatchesSender = existingMember?.externalUserId === (canonicalSenderId ?? rawSenderId);
+      const memberMatchesSender = existingMember
+        ? canonicalizeInboundIdentity(sourceChannel, existingMember.externalUserId) === (canonicalSenderId ?? rawSenderId)
+        : false;
       const preservedDisplayName = memberMatchesSender && existingMember?.displayName?.trim().length
         ? existingMember.displayName
         : body.senderName;

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -783,7 +783,7 @@ export async function handleChannelInbound(
           externalChatId,
         })
         : null;
-      const memberMatchesSender = existingMember
+      const memberMatchesSender = existingMember?.externalUserId
         ? canonicalizeInboundIdentity(sourceChannel, existingMember.externalUserId) === (canonicalSenderId ?? rawSenderId)
         : false;
       const preservedDisplayName = memberMatchesSender && existingMember?.displayName?.trim().length

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -783,7 +783,8 @@ export async function handleChannelInbound(
           externalChatId,
         })
         : null;
-      const preservedDisplayName = existingMember?.displayName?.trim().length
+      const memberMatchesSender = existingMember?.externalUserId === (canonicalSenderId ?? rawSenderId);
+      const preservedDisplayName = memberMatchesSender && existingMember?.displayName?.trim().length
         ? existingMember.displayName
         : body.senderName;
 


### PR DESCRIPTION
## Summary
- Guard trust classification in `actor-trust-resolver.ts` behind `memberMatchesSender` so a mismatched member record from a group chat doesn't elevate an unknown sender to `trusted_contact`
- Guard `preservedDisplayName` in `inbound-message-handler.ts` and `invite-redemption-service.ts` so another user's guardian-managed name isn't copied onto the sender during verification/reactivation
- Add `trustClass` assertion to the existing group-chat test to catch the trust elevation bug

Addresses review feedback from Codex and Devin on PR #10665.

## Original prompt
address the feedback in https://github.com/vellum-ai/vellum-assistant/pull/10665

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
