### PR TITLE
fix: reduce keychain prompts on startup

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -42,7 +42,12 @@ enum APIKeyManager {
     // MARK: - Generic provider access
 
     static func getKey(for provider: String) -> String? {
-        if provider == "anthropic" { migrateIfNeeded() }
+        if provider == "anthropic" {
+            // migrateIfNeeded returns the key if it was already read during
+            // the migration check, avoiding a redundant security CLI spawn
+            // (each spawn triggers a macOS keychain authorization prompt).
+            if let cached = migrateIfNeeded() { return cached }
+        }
         return cliGetKey(service: service, account: provider)
     }
 
@@ -102,9 +107,12 @@ enum APIKeyManager {
     // MARK: - Migration
 
     /// One-time migration from the legacy keychain entry to the daemon-shared entry.
-    private static func migrateIfNeeded() {
-        // Skip if new entry already exists
-        if cliGetKey(service: service, account: "anthropic") != nil { return }
+    /// Returns the current anthropic key if it was read during the check, so the
+    /// caller can reuse it without a second CLI invocation.
+    @discardableResult
+    private static func migrateIfNeeded() -> String? {
+        // Skip if new entry already exists — return the value we just read
+        if let existing = cliGetKey(service: service, account: "anthropic") { return existing }
 
         // Read from legacy entry (uses Security.framework since the old entry was created with SecItemAdd)
         let legacyQuery: [String: Any] = [
@@ -117,7 +125,7 @@ enum APIKeyManager {
         var result: AnyObject?
         guard SecItemCopyMatching(legacyQuery as CFDictionary, &result) == errSecSuccess,
               let data = result as? Data,
-              let key = String(data: data, encoding: .utf8) else { return }
+              let key = String(data: data, encoding: .utf8) else { return nil }
 
         // Write to new entry via CLI (no ACL restrictions)
         cliSetKey(service: service, account: "anthropic", value: key)
@@ -129,6 +137,8 @@ enum APIKeyManager {
             kSecAttrAccount as String: legacyAccount
         ]
         SecItemDelete(deleteQuery as CFDictionary)
+
+        return key
     }
 
     private static func notifyKeyDidChange() {


### PR DESCRIPTION
## Summary
- `APIKeyManager.migrateIfNeeded()` already reads the anthropic key via `/usr/bin/security` CLI to check if migration is needed — but `getKey(for:)` was discarding the result and spawning a **second** `/usr/bin/security` process to read the same value
- Each `/usr/bin/security` process spawn triggers a separate macOS keychain authorization prompt
- Now `migrateIfNeeded()` returns the key it read, and `getKey(for:)` reuses it — eliminating one of the three prompts on startup (3 → 2)

The three prompts were:
1. `migrateIfNeeded()` → `cliGetKey("anthropic")` → process #1
2. `getKey(for:)` → `cliGetKey("anthropic")` → process #2 **(eliminated)**
3. Daemon `loadConfig()` → `getSecureKey("anthropic")` → process #3

## Test plan
- [ ] Build and launch the macOS app
- [ ] Verify only 2 keychain prompts appear on startup instead of 3
- [ ] Verify API key read still works correctly after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
