### PR TITLE
fix: consume inline approval replies in HTTP /v1/messages path

### DIFF
--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -84,6 +84,7 @@ function makeCompletingSession(): Session {
     hasAnyPendingConfirmation: () => false,
     hasPendingConfirmation: () => false,
     denyAllPendingConfirmations: () => {},
+    getQueueDepth: () => 0,
     enqueueMessage: () => ({ queued: false, requestId: 'noop' }),
     runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
       onEvent({ type: 'assistant_text_delta', text: 'Hello!' });
@@ -118,6 +119,7 @@ function makeHangingSession(): Session {
     hasAnyPendingConfirmation: () => false,
     hasPendingConfirmation: () => false,
     denyAllPendingConfirmations: () => {},
+    getQueueDepth: () => enqueuedMessages.length,
     enqueueMessage: (content: string, _attachments: unknown[], onEvent: (msg: ServerMessage) => void, requestId: string) => {
       enqueuedMessages.push({ content, onEvent, requestId });
       return { queued: true, requestId };
@@ -168,6 +170,7 @@ function makePendingApprovalSession(requestId: string, processing: boolean): {
     hasAnyPendingConfirmation: () => pending.size > 0,
     hasPendingConfirmation: (candidateRequestId: string) => pending.has(candidateRequestId),
     denyAllPendingConfirmations: denyAllPendingConfirmationsMock,
+    getQueueDepth: () => 0,
     enqueueMessage: enqueueMessageMock,
     runAgentLoop: runAgentLoopMock,
     handleConfirmationResponse: handleConfirmationResponseMock,

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -14,6 +14,8 @@ import { afterAll, beforeEach, describe, expect, mock,test } from 'bun:test';
 
 import type { ServerMessage } from '../daemon/ipc-protocol.js';
 import type { Session } from '../daemon/session.js';
+import { createCanonicalGuardianRequest } from '../memory/canonical-guardian-store.js';
+import { getOrCreateConversation } from '../memory/conversation-key-store.js';
 
 const testDir = realpathSync(mkdtempSync(join(tmpdir(), 'send-endpoint-busy-test-')));
 
@@ -53,6 +55,7 @@ import { getDb, initializeDb, resetDb } from '../memory/db.js';
 import type { AssistantEvent } from '../runtime/assistant-event.js';
 import { AssistantEventHub } from '../runtime/assistant-event-hub.js';
 import { RuntimeHttpServer } from '../runtime/http-server.js';
+import * as pendingInteractions from '../runtime/pending-interactions.js';
 
 initializeDb();
 
@@ -63,6 +66,7 @@ initializeDb();
 /** Session that completes its agent loop quickly and emits a text delta + message_complete. */
 function makeCompletingSession(): Session {
   let processing = false;
+  const messages: unknown[] = [];
   return {
     isProcessing: () => processing,
     persistUserMessage: (_content: string, _attachments: unknown[], requestId?: string) => {
@@ -77,6 +81,9 @@ function makeCompletingSession(): Session {
     setTurnChannelContext: () => {},
     setTurnInterfaceContext: () => {},
     updateClient: () => {},
+    hasAnyPendingConfirmation: () => false,
+    hasPendingConfirmation: () => false,
+    denyAllPendingConfirmations: () => {},
     enqueueMessage: () => ({ queued: false, requestId: 'noop' }),
     runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
       onEvent({ type: 'assistant_text_delta', text: 'Hello!' });
@@ -85,13 +92,14 @@ function makeCompletingSession(): Session {
     },
     handleConfirmationResponse: () => {},
     handleSecretResponse: () => {},
-    hasAnyPendingConfirmation: () => false,
+    getMessages: () => messages as never[],
   } as unknown as Session;
 }
 
 /** Session that hangs forever in the agent loop (simulates a busy session). */
 function makeHangingSession(): Session {
   let processing = false;
+  const messages: unknown[] = [];
   const enqueuedMessages: Array<{ content: string; onEvent: (msg: ServerMessage) => void; requestId: string }> = [];
   return {
     isProcessing: () => processing,
@@ -107,6 +115,9 @@ function makeHangingSession(): Session {
     setTurnChannelContext: () => {},
     setTurnInterfaceContext: () => {},
     updateClient: () => {},
+    hasAnyPendingConfirmation: () => false,
+    hasPendingConfirmation: () => false,
+    denyAllPendingConfirmations: () => {},
     enqueueMessage: (content: string, _attachments: unknown[], onEvent: (msg: ServerMessage) => void, requestId: string) => {
       enqueuedMessages.push({ content, onEvent, requestId });
       return { queued: true, requestId };
@@ -117,9 +128,60 @@ function makeHangingSession(): Session {
     },
     handleConfirmationResponse: () => {},
     handleSecretResponse: () => {},
-    hasAnyPendingConfirmation: () => false,
+    getMessages: () => messages as never[],
     _enqueuedMessages: enqueuedMessages,
   } as unknown as Session;
+}
+
+function makePendingApprovalSession(requestId: string, processing: boolean): {
+  session: Session;
+  runAgentLoopMock: ReturnType<typeof mock>;
+  enqueueMessageMock: ReturnType<typeof mock>;
+  denyAllPendingConfirmationsMock: ReturnType<typeof mock>;
+  handleConfirmationResponseMock: ReturnType<typeof mock>;
+} {
+  const pending = new Set([requestId]);
+  const messages: unknown[] = [];
+  const runAgentLoopMock = mock(async () => {});
+  const enqueueMessageMock = mock((_content: string, _attachments: unknown[], _onEvent: (msg: ServerMessage) => void, queuedRequestId: string) => ({
+    queued: true,
+    requestId: queuedRequestId,
+  }));
+  const denyAllPendingConfirmationsMock = mock(() => {
+    pending.clear();
+  });
+  const handleConfirmationResponseMock = mock((resolvedRequestId: string) => {
+    pending.delete(resolvedRequestId);
+  });
+
+  const session = {
+    isProcessing: () => processing,
+    persistUserMessage: (_content: string, _attachments: unknown[], reqId?: string) => reqId ?? 'msg-1',
+    memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
+    setChannelCapabilities: () => {},
+    setAssistantId: () => {},
+    setGuardianContext: () => {},
+    setCommandIntent: () => {},
+    setTurnChannelContext: () => {},
+    setTurnInterfaceContext: () => {},
+    updateClient: () => {},
+    hasAnyPendingConfirmation: () => pending.size > 0,
+    hasPendingConfirmation: (candidateRequestId: string) => pending.has(candidateRequestId),
+    denyAllPendingConfirmations: denyAllPendingConfirmationsMock,
+    enqueueMessage: enqueueMessageMock,
+    runAgentLoop: runAgentLoopMock,
+    handleConfirmationResponse: handleConfirmationResponseMock,
+    handleSecretResponse: () => {},
+    getMessages: () => messages as never[],
+  } as unknown as Session;
+
+  return {
+    session,
+    runAgentLoopMock,
+    enqueueMessageMock,
+    denyAllPendingConfirmationsMock,
+    handleConfirmationResponseMock,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -139,6 +201,9 @@ describe('POST /v1/messages — queue-if-busy and hub publishing', () => {
     db.run('DELETE FROM messages');
     db.run('DELETE FROM conversations');
     db.run('DELETE FROM conversation_keys');
+    db.run('DELETE FROM canonical_guardian_deliveries');
+    db.run('DELETE FROM canonical_guardian_requests');
+    pendingInteractions.clear();
     eventHub = new AssistantEventHub();
   });
 
@@ -222,6 +287,116 @@ describe('POST /v1/messages — queue-if-busy and hub publishing', () => {
     const types = publishedEvents.map((e) => e.message.type);
     expect(types).toContain('assistant_text_delta');
     expect(types).toContain('message_complete');
+
+    await stopServer();
+  });
+
+  test('consumes explicit approval text when a single pending confirmation exists (idle)', async () => {
+    const conversationKey = 'conv-inline-idle';
+    const { conversationId } = getOrCreateConversation(conversationKey);
+    const requestId = 'req-inline-idle';
+    const {
+      session,
+      runAgentLoopMock,
+      enqueueMessageMock,
+      denyAllPendingConfirmationsMock,
+      handleConfirmationResponseMock,
+    } = makePendingApprovalSession(requestId, false);
+
+    pendingInteractions.register(requestId, {
+      session,
+      conversationId,
+      kind: 'confirmation',
+    });
+    createCanonicalGuardianRequest({
+      id: requestId,
+      kind: 'tool_approval',
+      sourceType: 'desktop',
+      sourceChannel: 'vellum',
+      conversationId,
+      toolName: 'call_start',
+      status: 'pending',
+      requestCode: 'ABC123',
+      expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    });
+
+    await startServer(() => session);
+
+    const res = await fetch(messagesUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({
+        conversationKey,
+        content: 'yes',
+        sourceChannel: 'vellum',
+        interface: 'macos',
+      }),
+    });
+    const body = await res.json() as { accepted: boolean; messageId?: string; queued?: boolean };
+
+    expect(res.status).toBe(202);
+    expect(body.accepted).toBe(true);
+    expect(body.messageId).toBeDefined();
+    expect(body.queued).toBeUndefined();
+    expect(handleConfirmationResponseMock).toHaveBeenCalledTimes(1);
+    expect(denyAllPendingConfirmationsMock).toHaveBeenCalledTimes(0);
+    expect(enqueueMessageMock).toHaveBeenCalledTimes(0);
+    expect(runAgentLoopMock).toHaveBeenCalledTimes(0);
+
+    await stopServer();
+  });
+
+  test('consumes explicit approval text while busy instead of auto-denying and queueing', async () => {
+    const conversationKey = 'conv-inline-busy';
+    const { conversationId } = getOrCreateConversation(conversationKey);
+    const requestId = 'req-inline-busy';
+    const {
+      session,
+      runAgentLoopMock,
+      enqueueMessageMock,
+      denyAllPendingConfirmationsMock,
+      handleConfirmationResponseMock,
+    } = makePendingApprovalSession(requestId, true);
+
+    pendingInteractions.register(requestId, {
+      session,
+      conversationId,
+      kind: 'confirmation',
+    });
+    createCanonicalGuardianRequest({
+      id: requestId,
+      kind: 'tool_approval',
+      sourceType: 'desktop',
+      sourceChannel: 'vellum',
+      conversationId,
+      toolName: 'call_start',
+      status: 'pending',
+      requestCode: 'DEF456',
+      expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    });
+
+    await startServer(() => session);
+
+    const res = await fetch(messagesUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({
+        conversationKey,
+        content: 'approve',
+        sourceChannel: 'vellum',
+        interface: 'macos',
+      }),
+    });
+    const body = await res.json() as { accepted: boolean; messageId?: string; queued?: boolean };
+
+    expect(res.status).toBe(202);
+    expect(body.accepted).toBe(true);
+    expect(body.messageId).toBeDefined();
+    expect(body.queued).toBeUndefined();
+    expect(handleConfirmationResponseMock).toHaveBeenCalledTimes(1);
+    expect(denyAllPendingConfirmationsMock).toHaveBeenCalledTimes(0);
+    expect(enqueueMessageMock).toHaveBeenCalledTimes(0);
+    expect(runAgentLoopMock).toHaveBeenCalledTimes(0);
 
     await stopServer();
   });

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -401,6 +401,112 @@ describe('POST /v1/messages — queue-if-busy and hub publishing', () => {
     await stopServer();
   });
 
+  test('consumes explicit rejection text when a single pending confirmation exists (idle)', async () => {
+    const conversationKey = 'conv-inline-reject';
+    const { conversationId } = getOrCreateConversation(conversationKey);
+    const requestId = 'req-inline-reject';
+    const {
+      session,
+      runAgentLoopMock,
+      enqueueMessageMock,
+      denyAllPendingConfirmationsMock,
+      handleConfirmationResponseMock,
+    } = makePendingApprovalSession(requestId, false);
+
+    pendingInteractions.register(requestId, {
+      session,
+      conversationId,
+      kind: 'confirmation',
+    });
+    createCanonicalGuardianRequest({
+      id: requestId,
+      kind: 'tool_approval',
+      sourceType: 'desktop',
+      sourceChannel: 'vellum',
+      conversationId,
+      toolName: 'call_start',
+      status: 'pending',
+      requestCode: 'GHI789',
+      expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    });
+
+    await startServer(() => session);
+
+    const res = await fetch(messagesUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({
+        conversationKey,
+        content: 'no',
+        sourceChannel: 'vellum',
+        interface: 'macos',
+      }),
+    });
+    const body = await res.json() as { accepted: boolean; messageId?: string; queued?: boolean };
+
+    expect(res.status).toBe(202);
+    expect(body.accepted).toBe(true);
+    expect(body.messageId).toBeDefined();
+    expect(body.queued).toBeUndefined();
+    // Rejection still flows through handleConfirmationResponse (with reject action)
+    expect(handleConfirmationResponseMock).toHaveBeenCalledTimes(1);
+    expect(denyAllPendingConfirmationsMock).toHaveBeenCalledTimes(0);
+    expect(enqueueMessageMock).toHaveBeenCalledTimes(0);
+    expect(runAgentLoopMock).toHaveBeenCalledTimes(0);
+
+    await stopServer();
+  });
+
+  test('does not consume ambiguous text — falls through to normal message handling', async () => {
+    const conversationKey = 'conv-inline-ambiguous';
+    const { conversationId } = getOrCreateConversation(conversationKey);
+    const requestId = 'req-inline-ambiguous';
+    const {
+      session,
+      runAgentLoopMock,
+    } = makePendingApprovalSession(requestId, false);
+
+    pendingInteractions.register(requestId, {
+      session,
+      conversationId,
+      kind: 'confirmation',
+    });
+    createCanonicalGuardianRequest({
+      id: requestId,
+      kind: 'tool_approval',
+      sourceType: 'desktop',
+      sourceChannel: 'vellum',
+      conversationId,
+      toolName: 'call_start',
+      status: 'pending',
+      requestCode: 'JKL012',
+      expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    });
+
+    await startServer(() => session);
+
+    const res = await fetch(messagesUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({
+        conversationKey,
+        content: 'What is the weather today?',
+        sourceChannel: 'vellum',
+        interface: 'macos',
+      }),
+    });
+    const body = await res.json() as { accepted: boolean; messageId?: string; queued?: boolean };
+
+    // Ambiguous text should NOT be consumed — falls through to normal send path
+    expect(res.status).toBe(202);
+    expect(body.accepted).toBe(true);
+    expect(body.messageId).toBeDefined();
+    // The normal idle send path fires runAgentLoop
+    expect(runAgentLoopMock).toHaveBeenCalledTimes(1);
+
+    await stopServer();
+  });
+
   // ── Busy session: queue-if-busy ─────────────────────────────────────
 
   test('returns 202 with queued: true when session is busy (not 409)', async () => {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -124,40 +124,49 @@ async function tryConsumeInlineApprovalReply(params: {
     return { consumed: false };
   }
 
-  const channelMeta = {
-    userMessageChannel: sourceChannel,
-    assistantMessageChannel: sourceChannel,
-    userMessageInterface: sourceInterface,
-    assistantMessageInterface: sourceInterface,
-    provenanceActorRole: 'guardian' as const,
-  };
+  // Decision has been applied — transcript persistence is best-effort.
+  // If DB writes fail, we still return consumed: true so the approval text
+  // is not re-processed as a new user turn.
+  let messageId: string | undefined;
+  try {
+    const channelMeta = {
+      userMessageChannel: sourceChannel,
+      assistantMessageChannel: sourceChannel,
+      userMessageInterface: sourceInterface,
+      assistantMessageInterface: sourceInterface,
+      provenanceActorRole: 'guardian' as const,
+    };
 
-  const userMessage = createUserMessage(content, attachments);
-  const persistedUser = await conversationStore.addMessage(
-    conversationId,
-    'user',
-    JSON.stringify(userMessage.content),
-    channelMeta,
-  );
+    const userMessage = createUserMessage(content, attachments);
+    const persistedUser = await conversationStore.addMessage(
+      conversationId,
+      'user',
+      JSON.stringify(userMessage.content),
+      channelMeta,
+    );
+    messageId = persistedUser.id;
 
-  const replyText = (routerResult.replyText?.trim())
-    || (routerResult.decisionApplied ? 'Decision applied.' : 'Request already resolved.');
-  const assistantMessage = createAssistantMessage(replyText);
-  await conversationStore.addMessage(
-    conversationId,
-    'assistant',
-    JSON.stringify(assistantMessage.content),
-    channelMeta,
-  );
+    const replyText = (routerResult.replyText?.trim())
+      || (routerResult.decisionApplied ? 'Decision applied.' : 'Request already resolved.');
+    const assistantMessage = createAssistantMessage(replyText);
+    await conversationStore.addMessage(
+      conversationId,
+      'assistant',
+      JSON.stringify(assistantMessage.content),
+      channelMeta,
+    );
 
-  // Avoid mutating in-memory history / emitting stream deltas while a run is active.
-  if (!session.isProcessing()) {
-    session.getMessages().push(userMessage, assistantMessage);
-    onEvent({ type: 'assistant_text_delta', text: replyText, sessionId: conversationId });
-    onEvent({ type: 'message_complete', sessionId: conversationId });
+    // Avoid mutating in-memory history / emitting stream deltas while a run is active.
+    if (!session.isProcessing()) {
+      session.getMessages().push(userMessage, assistantMessage);
+      onEvent({ type: 'assistant_text_delta', text: replyText, sessionId: conversationId });
+      onEvent({ type: 'message_complete', sessionId: conversationId });
+    }
+  } catch (err) {
+    log.warn({ err, conversationId }, 'Failed to persist inline approval transcript entries');
   }
 
-  return { consumed: true, messageId: persistedUser.id };
+  return { consumed: true, messageId };
 }
 
 function getInterfaceFilesWithMtimes(interfacesDir: string | null): Array<{ path: string; mtimeMs: number }> {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -415,20 +415,27 @@ export async function handleSendMessage(
       ? smDeps.resolveAttachments(attachmentIds)
       : [];
 
-    const inlineReplyResult = await tryConsumeInlineApprovalReply({
-      conversationId: mapping.conversationId,
-      sourceChannel,
-      sourceInterface,
-      content: content ?? '',
-      attachments,
-      session,
-      onEvent,
-    });
-    if (inlineReplyResult.consumed) {
-      return Response.json(
-        { accepted: true, ...(inlineReplyResult.messageId ? { messageId: inlineReplyResult.messageId } : {}) },
-        { status: 202 },
-      );
+    // Try to consume the message as an inline approval/rejection reply.
+    // On failure, degrade to the existing queue/auto-deny path rather than
+    // surfacing a 500 — mirrors the IPC handler's catch-and-fallback.
+    try {
+      const inlineReplyResult = await tryConsumeInlineApprovalReply({
+        conversationId: mapping.conversationId,
+        sourceChannel,
+        sourceInterface,
+        content: content ?? '',
+        attachments,
+        session,
+        onEvent,
+      });
+      if (inlineReplyResult.consumed) {
+        return Response.json(
+          { accepted: true, ...(inlineReplyResult.messageId ? { messageId: inlineReplyResult.messageId } : {}) },
+          { status: 202 },
+        );
+      }
+    } catch (err) {
+      log.warn({ err, conversationId: mapping.conversationId }, 'Inline approval consumption failed, falling through to normal send path');
     }
 
     if (session.isProcessing()) {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -4,6 +4,7 @@
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
+import { createAssistantMessage, createUserMessage } from '../../agent/message-types.js';
 import { CHANNEL_IDS, INTERFACE_IDS, parseChannelId, parseInterfaceId } from '../../channels/types.js';
 import { mergeToolResults,renderHistoryContent } from '../../daemon/handlers.js';
 import type { ServerMessage } from '../../daemon/ipc-protocol.js';
@@ -11,6 +12,8 @@ import * as attachmentsStore from '../../memory/attachments-store.js';
 import {
   createCanonicalGuardianRequest,
   generateCanonicalRequestCode,
+  listCanonicalGuardianRequests,
+  listPendingCanonicalGuardianRequestsByDestinationConversation,
 } from '../../memory/canonical-guardian-store.js';
 import {
   getConversationByKey,
@@ -21,6 +24,7 @@ import { getConfiguredProvider } from '../../providers/provider-send-message.js'
 import type { Provider } from '../../providers/types.js';
 import { getLogger } from '../../util/logger.js';
 import { buildAssistantEvent } from '../assistant-event.js';
+import { routeGuardianReply } from '../guardian-reply-router.js';
 import { httpError } from '../http-errors.js';
 import type {
   MessageProcessor,
@@ -34,6 +38,149 @@ import * as pendingInteractions from '../pending-interactions.js';
 const log = getLogger('conversation-routes');
 
 const SUGGESTION_CACHE_MAX = 100;
+
+function hasAnyPendingConfirmation(session: import('../../daemon/session.js').Session): boolean {
+  const maybeMethod = (session as { hasAnyPendingConfirmation?: () => boolean }).hasAnyPendingConfirmation;
+  return typeof maybeMethod === 'function' ? maybeMethod.call(session) : false;
+}
+
+function hasPendingConfirmation(
+  session: import('../../daemon/session.js').Session,
+  requestId: string,
+): boolean {
+  const maybeMethod = (session as { hasPendingConfirmation?: (id: string) => boolean }).hasPendingConfirmation;
+  return typeof maybeMethod === 'function' ? maybeMethod.call(session, requestId) : false;
+}
+
+function pushSessionMessageIfAvailable(
+  session: import('../../daemon/session.js').Session,
+  message: ReturnType<typeof createUserMessage> | ReturnType<typeof createAssistantMessage>,
+): void {
+  const maybeGetMessages = (session as { getMessages?: () => Array<typeof message> }).getMessages;
+  if (typeof maybeGetMessages !== 'function') {
+    return;
+  }
+  maybeGetMessages.call(session).push(message);
+}
+
+function collectLivePendingConfirmationRequestIds(
+  conversationId: string,
+  sourceChannel: string,
+  session: import('../../daemon/session.js').Session,
+): string[] {
+  const pendingInteractionRequestIds = pendingInteractions
+    .getByConversation(conversationId)
+    .filter(
+      (interaction) =>
+        interaction.kind === 'confirmation'
+        && interaction.session === session
+        && hasPendingConfirmation(session, interaction.requestId),
+    )
+    .map((interaction) => interaction.requestId);
+
+  const pendingCanonicalRequestIds = [
+    ...listPendingCanonicalGuardianRequestsByDestinationConversation(conversationId, sourceChannel)
+      .filter((request) => request.kind === 'tool_approval')
+      .map((request) => request.id),
+    ...listCanonicalGuardianRequests({
+      status: 'pending',
+      conversationId,
+      kind: 'tool_approval',
+    }).map((request) => request.id),
+  ].filter((requestId) => hasPendingConfirmation(session, requestId));
+
+  return Array.from(new Set([
+    ...pendingInteractionRequestIds,
+    ...pendingCanonicalRequestIds,
+  ]));
+}
+
+async function tryConsumeInlineApprovalReply(params: {
+  conversationId: string;
+  sourceChannel: string;
+  sourceInterface: string;
+  content: string;
+  attachments: Array<{
+    id: string;
+    filename: string;
+    mimeType: string;
+    data: string;
+  }>;
+  session: import('../../daemon/session.js').Session;
+  onEvent: (msg: ServerMessage) => void;
+}): Promise<{ consumed: boolean; messageId?: string }> {
+  const {
+    conversationId,
+    sourceChannel,
+    sourceInterface,
+    content,
+    attachments,
+    session,
+    onEvent,
+  } = params;
+  const trimmedContent = content.trim();
+
+  if (!hasAnyPendingConfirmation(session) || trimmedContent.length === 0) {
+    return { consumed: false };
+  }
+
+  const pendingRequestIds = collectLivePendingConfirmationRequestIds(conversationId, sourceChannel, session);
+  if (pendingRequestIds.length === 0) {
+    return { consumed: false };
+  }
+
+  const routerResult = await routeGuardianReply({
+    messageText: trimmedContent,
+    channel: sourceChannel,
+    actor: {
+      externalUserId: undefined,
+      channel: sourceChannel,
+      isTrusted: true,
+    },
+    conversationId,
+    pendingRequestIds,
+  });
+
+  if (!routerResult.consumed || routerResult.type === 'nl_keep_pending') {
+    return { consumed: false };
+  }
+
+  const channelMeta = {
+    userMessageChannel: sourceChannel,
+    assistantMessageChannel: sourceChannel,
+    userMessageInterface: sourceInterface,
+    assistantMessageInterface: sourceInterface,
+    provenanceActorRole: 'guardian' as const,
+  };
+
+  const userMessage = createUserMessage(content, attachments);
+  const persistedUser = await conversationStore.addMessage(
+    conversationId,
+    'user',
+    JSON.stringify(userMessage.content),
+    channelMeta,
+  );
+
+  const replyText = (routerResult.replyText?.trim())
+    || (routerResult.decisionApplied ? 'Decision applied.' : 'Request already resolved.');
+  const assistantMessage = createAssistantMessage(replyText);
+  await conversationStore.addMessage(
+    conversationId,
+    'assistant',
+    JSON.stringify(assistantMessage.content),
+    channelMeta,
+  );
+
+  // Avoid mutating in-memory history / emitting stream deltas while a run is active.
+  if (!session.isProcessing()) {
+    pushSessionMessageIfAvailable(session, userMessage);
+    pushSessionMessageIfAvailable(session, assistantMessage);
+    onEvent({ type: 'assistant_text_delta', text: replyText, sessionId: conversationId });
+    onEvent({ type: 'message_complete', sessionId: conversationId });
+  }
+
+  return { consumed: true, messageId: persistedUser.id };
+}
 
 function getInterfaceFilesWithMtimes(interfacesDir: string | null): Array<{ path: string; mtimeMs: number }> {
   if (!interfacesDir || !existsSync(interfacesDir)) return [];
@@ -290,10 +437,26 @@ export async function handleSendMessage(
       ? smDeps.resolveAttachments(attachmentIds)
       : [];
 
+    const inlineReplyResult = await tryConsumeInlineApprovalReply({
+      conversationId: mapping.conversationId,
+      sourceChannel,
+      sourceInterface,
+      content: content ?? '',
+      attachments,
+      session,
+      onEvent,
+    });
+    if (inlineReplyResult.consumed) {
+      return Response.json(
+        { accepted: true, ...(inlineReplyResult.messageId ? { messageId: inlineReplyResult.messageId } : {}) },
+        { status: 202 },
+      );
+    }
+
     if (session.isProcessing()) {
       // If a tool confirmation is pending, auto-deny it so the agent
       // can finish the current turn and process this queued message.
-      if (session.hasAnyPendingConfirmation()) {
+      if (hasAnyPendingConfirmation(session)) {
         session.denyAllPendingConfirmations();
         pendingInteractions.removeBySession(session);
       }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -99,7 +99,14 @@ async function tryConsumeInlineApprovalReply(params: {
   } = params;
   const trimmedContent = content.trim();
 
-  if (!session.hasAnyPendingConfirmation() || trimmedContent.length === 0) {
+  // Only consume inline replies when there are no queued turns, matching
+  // the IPC path guard. With queued messages, "approve"/"no" should be
+  // processed in queue order rather than treated as a confirmation reply.
+  if (
+    !session.hasAnyPendingConfirmation()
+    || session.getQueueDepth() > 0
+    || trimmedContent.length === 0
+  ) {
     return { consumed: false };
   }
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -39,30 +39,6 @@ const log = getLogger('conversation-routes');
 
 const SUGGESTION_CACHE_MAX = 100;
 
-function hasAnyPendingConfirmation(session: import('../../daemon/session.js').Session): boolean {
-  const maybeMethod = (session as { hasAnyPendingConfirmation?: () => boolean }).hasAnyPendingConfirmation;
-  return typeof maybeMethod === 'function' ? maybeMethod.call(session) : false;
-}
-
-function hasPendingConfirmation(
-  session: import('../../daemon/session.js').Session,
-  requestId: string,
-): boolean {
-  const maybeMethod = (session as { hasPendingConfirmation?: (id: string) => boolean }).hasPendingConfirmation;
-  return typeof maybeMethod === 'function' ? maybeMethod.call(session, requestId) : false;
-}
-
-function pushSessionMessageIfAvailable(
-  session: import('../../daemon/session.js').Session,
-  message: ReturnType<typeof createUserMessage> | ReturnType<typeof createAssistantMessage>,
-): void {
-  const maybeGetMessages = (session as { getMessages?: () => Array<typeof message> }).getMessages;
-  if (typeof maybeGetMessages !== 'function') {
-    return;
-  }
-  maybeGetMessages.call(session).push(message);
-}
-
 function collectLivePendingConfirmationRequestIds(
   conversationId: string,
   sourceChannel: string,
@@ -74,10 +50,13 @@ function collectLivePendingConfirmationRequestIds(
       (interaction) =>
         interaction.kind === 'confirmation'
         && interaction.session === session
-        && hasPendingConfirmation(session, interaction.requestId),
+        && session.hasPendingConfirmation(interaction.requestId),
     )
     .map((interaction) => interaction.requestId);
 
+  // Query both by destination conversation (via deliveries table) and by
+  // source conversation (direct field). For desktop/HTTP sessions these
+  // often overlap, but the Set dedup below handles that.
   const pendingCanonicalRequestIds = [
     ...listPendingCanonicalGuardianRequestsByDestinationConversation(conversationId, sourceChannel)
       .filter((request) => request.kind === 'tool_approval')
@@ -87,7 +66,7 @@ function collectLivePendingConfirmationRequestIds(
       conversationId,
       kind: 'tool_approval',
     }).map((request) => request.id),
-  ].filter((requestId) => hasPendingConfirmation(session, requestId));
+  ].filter((requestId) => session.hasPendingConfirmation(requestId));
 
   return Array.from(new Set([
     ...pendingInteractionRequestIds,
@@ -120,7 +99,7 @@ async function tryConsumeInlineApprovalReply(params: {
   } = params;
   const trimmedContent = content.trim();
 
-  if (!hasAnyPendingConfirmation(session) || trimmedContent.length === 0) {
+  if (!session.hasAnyPendingConfirmation() || trimmedContent.length === 0) {
     return { consumed: false };
   }
 
@@ -173,8 +152,7 @@ async function tryConsumeInlineApprovalReply(params: {
 
   // Avoid mutating in-memory history / emitting stream deltas while a run is active.
   if (!session.isProcessing()) {
-    pushSessionMessageIfAvailable(session, userMessage);
-    pushSessionMessageIfAvailable(session, assistantMessage);
+    session.getMessages().push(userMessage, assistantMessage);
     onEvent({ type: 'assistant_text_delta', text: replyText, sessionId: conversationId });
     onEvent({ type: 'message_complete', sessionId: conversationId });
   }
@@ -456,7 +434,7 @@ export async function handleSendMessage(
     if (session.isProcessing()) {
       // If a tool confirmation is pending, auto-deny it so the agent
       // can finish the current turn and process this queued message.
-      if (hasAnyPendingConfirmation(session)) {
+      if (session.hasAnyPendingConfirmation()) {
         session.denyAllPendingConfirmations();
         pendingInteractions.removeBySession(session);
       }


### PR DESCRIPTION
## Summary
- add inline guardian-reply consumption in POST /v1/messages before queue/auto-deny logic
- route explicit approval/rejection text (e.g. yes, approve) through canonical routeGuardianReply for HTTP-backed desktop sessions
- keep busy-turn safety: persist consumed transcript entries but avoid in-flight stream delta emission when a run is active
- retain existing queue-if-busy behavior when the message is not a consumable decision

## Tests
- bun test src/__tests__/send-endpoint-busy.test.ts
- bun test src/__tests__/conversation-routes.test.ts
- bun test src/__tests__/handlers-user-message-approval-consumption.test.ts
- bunx tsc --noEmit

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
