### PR TITLE
assistant: define internal assistant scope contract

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -1954,3 +1954,16 @@ Key files: `src/tools/sensitive-output-placeholders.ts`, `src/tools/executor.ts`
 ### Notifications
 
 For full notification developer guidance and lifecycle details, see [`assistant/src/notifications/README.md`](src/notifications/README.md).
+
+### Assistant Identity Boundary
+
+The daemon uses a single fixed internal scope constant — `DAEMON_INTERNAL_ASSISTANT_ID` (`'self'`), exported from `src/runtime/assistant-scope.ts` — for all assistant-scoped storage and routing within the daemon process. Public/external assistant IDs (e.g., those assigned during hatch, invite links, or platform registration) are an **edge concern** owned by the gateway and platform layers.
+
+**Boundary rule:** Daemon code must never derive internal scoping decisions from externally-provided assistant IDs. When a daemon path needs an assistant scope and none is provided, it defaults to `DAEMON_INTERNAL_ASSISTANT_ID`. The gateway is responsible for mapping public assistant IDs to internal routing before forwarding requests to the daemon.
+
+**Key files:**
+
+| File | Purpose |
+|------|---------|
+| `src/runtime/assistant-scope.ts` | Exports `DAEMON_INTERNAL_ASSISTANT_ID` constant |
+| `src/__tests__/assistant-id-boundary-guard.test.ts` | Guard tests enforcing the identity boundary |

--- a/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
+++ b/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
+
+/**
+ * Guard tests for the assistant identity boundary.
+ *
+ * The daemon uses a fixed internal scope constant (`DAEMON_INTERNAL_ASSISTANT_ID`)
+ * for all assistant-scoped storage. Public assistant IDs are an edge concern
+ * handled by the gateway/platform layer — they must not leak into daemon
+ * scoping logic.
+ */
+describe('assistant ID boundary', () => {
+  test('DAEMON_INTERNAL_ASSISTANT_ID equals "self"', () => {
+    expect(DAEMON_INTERNAL_ASSISTANT_ID).toBe('self');
+  });
+
+  test.todo('no normalizeAssistantId in daemon scoping paths');
+
+  test.todo('daemon storage keys never contain external assistant IDs');
+});

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -12,6 +12,7 @@
 import { v4 as uuid } from 'uuid';
 
 import { getDeliverableChannels } from '../channels/config.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { getActiveBinding } from '../memory/channel-guardian-store.js';
 import { getLogger } from '../util/logger.js';
 import { type BroadcastFn, VellumAdapter } from './adapters/macos.js';
@@ -170,7 +171,7 @@ export interface EmitSignalResult {
  */
 export async function emitNotificationSignal(params: EmitSignalParams): Promise<EmitSignalResult> {
   const signalId = uuid();
-  const assistantId = params.assistantId ?? 'self';
+  const assistantId = params.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
 
   const signal: NotificationSignal = {
     signalId,

--- a/assistant/src/runtime/assistant-scope.ts
+++ b/assistant/src/runtime/assistant-scope.ts
@@ -1,0 +1,10 @@
+/**
+ * Canonical internal scope ID for all daemon-side assistant-scoped storage.
+ *
+ * The daemon uses a single fixed identity (`'self'`) for its own assistant
+ * scope. Public/external assistant IDs are an edge concern owned by the
+ * gateway and platform layers (hatch, invite links, etc.). Daemon code
+ * should never derive scoping decisions from externally-provided assistant
+ * IDs — use this constant instead.
+ */
+export const DAEMON_INTERNAL_ASSISTANT_ID = 'self' as const;


### PR DESCRIPTION
Introduces DAEMON_INTERNAL_ASSISTANT_ID constant, architecture boundary docs, and guard test skeleton. Part of #10674.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
