### PR TITLE
assistant: remove daemon-side assistant-id normalization from runtime logic

### DIFF
--- a/assistant/src/__tests__/access-request-decision.test.ts
+++ b/assistant/src/__tests__/access-request-decision.test.ts
@@ -31,7 +31,6 @@ mock.module('../util/platform.js', () => ({
   getDbPath: () => join(testDir, 'test.db'),
   getLogPath: () => join(testDir, 'test.log'),
   ensureDataDir: () => {},
-  normalizeAssistantId: (id: string) => id === 'self' ? 'self' : id,
   readHttpToken: () => 'test-bearer-token',
 }));
 

--- a/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
+++ b/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 
@@ -15,7 +17,25 @@ describe('assistant ID boundary', () => {
     expect(DAEMON_INTERNAL_ASSISTANT_ID).toBe('self');
   });
 
-  test.todo('no normalizeAssistantId in daemon scoping paths');
+  test('no normalizeAssistantId imports in daemon scoping paths', () => {
+    // Key daemon/runtime files that previously used normalizeAssistantId
+    // should now use DAEMON_INTERNAL_ASSISTANT_ID instead.
+    const daemonScopingFiles = [
+      'runtime/actor-trust-resolver.ts',
+      'runtime/guardian-outbound-actions.ts',
+      'daemon/handlers/config-channels.ts',
+      'runtime/routes/channel-route-shared.ts',
+      'calls/relay-server.ts',
+    ];
+
+    const srcDir = join(import.meta.dir, '..');
+    for (const relPath of daemonScopingFiles) {
+      const content = readFileSync(join(srcDir, relPath), 'utf-8');
+      expect(content).not.toContain("import { normalizeAssistantId }");
+      expect(content).not.toContain("import { normalizeAssistantId,");
+      expect(content).not.toContain("normalizeAssistantId(");
+    }
+  });
 
   test.todo('daemon storage keys never contain external assistant IDs');
 });

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -22,7 +22,6 @@ mock.module('../util/platform.js', () => ({
   getDbPath: () => join(testDir, 'test.db'),
   getLogPath: () => join(testDir, 'test.log'),
   ensureDataDir: () => {},
-  normalizeAssistantId: (id: string) => id === 'self' ? 'self' : id,
   readHttpToken: () => 'test-bearer-token',
 }));
 

--- a/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
+++ b/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
@@ -32,7 +32,6 @@ mock.module('../util/platform.js', () => ({
   getDbPath: () => join(testDir, 'test.db'),
   getLogPath: () => join(testDir, 'test.log'),
   ensureDataDir: () => {},
-  normalizeAssistantId: (id: string) => id === 'self' ? 'self' : id,
   readHttpToken: () => 'test-bearer-token',
 }));
 

--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -35,7 +35,6 @@ mock.module('../util/platform.js', () => ({
   getDbPath: () => join(testDir, 'test.db'),
   getLogPath: () => join(testDir, 'test.log'),
   ensureDataDir: () => {},
-  normalizeAssistantId: (id: string) => id === 'self' ? 'self' : id,
   readHttpToken: () => 'test-bearer-token',
 }));
 

--- a/assistant/src/__tests__/inbound-invite-redemption.test.ts
+++ b/assistant/src/__tests__/inbound-invite-redemption.test.ts
@@ -28,7 +28,6 @@ mock.module('../util/platform.js', () => ({
   getDbPath: () => join(testDir, 'test.db'),
   getLogPath: () => join(testDir, 'test.log'),
   ensureDataDir: () => {},
-  normalizeAssistantId: (id: string) => id === 'self' ? 'self' : id,
   readHttpToken: () => 'test-bearer-token',
 }));
 

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -30,7 +30,6 @@ mock.module('../util/platform.js', () => ({
   getDbPath: () => join(testDir, 'test.db'),
   getLogPath: () => join(testDir, 'test.log'),
   ensureDataDir: () => {},
-  normalizeAssistantId: (id: string) => id === 'self' ? 'self' : id,
   readHttpToken: () => 'test-bearer-token',
 }));
 

--- a/assistant/src/__tests__/session-init.benchmark.test.ts
+++ b/assistant/src/__tests__/session-init.benchmark.test.ts
@@ -103,7 +103,6 @@ mock.module('../util/platform.js', () => ({
   getTCPPort: () => 8765,
   isIOSPairingEnabled: () => false,
   isTCPEnabled: () => false,
-  normalizeAssistantId: (id: string) => id,
   readHttpToken: () => null,
   readLockfile: () => null,
   readPlatformToken: () => null,

--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -34,7 +34,6 @@ mock.module('../util/platform.js', () => ({
   getDbPath: () => join(testDir, 'test.db'),
   getLogPath: () => join(testDir, 'test.log'),
   ensureDataDir: () => {},
-  normalizeAssistantId: (id: string) => id === 'self' ? 'self' : id,
   readHttpToken: () => 'test-bearer-token',
 }));
 

--- a/assistant/src/__tests__/trusted-contact-multichannel.test.ts
+++ b/assistant/src/__tests__/trusted-contact-multichannel.test.ts
@@ -29,7 +29,6 @@ mock.module('../util/platform.js', () => ({
   getDbPath: () => join(testDir, 'test.db'),
   getLogPath: () => join(testDir, 'test.log'),
   ensureDataDir: () => {},
-  normalizeAssistantId: (id: string) => id === 'self' ? 'self' : id,
   readHttpToken: () => 'test-bearer-token',
 }));
 

--- a/assistant/src/__tests__/trusted-contact-verification.test.ts
+++ b/assistant/src/__tests__/trusted-contact-verification.test.ts
@@ -32,7 +32,6 @@ mock.module('../util/platform.js', () => ({
   getDbPath: () => join(testDir, 'test.db'),
   getLogPath: () => join(testDir, 'test.log'),
   ensureDataDir: () => {},
-  normalizeAssistantId: (id: string) => id === 'self' ? 'self' : id,
   readHttpToken: () => 'test-bearer-token',
 }));
 

--- a/assistant/src/__tests__/update-bulletin.test.ts
+++ b/assistant/src/__tests__/update-bulletin.test.ts
@@ -53,7 +53,6 @@ mock.module('../util/platform.js', () => ({
   getInterfacesDir: () => '',
   getClipboardCommand: () => null,
   readLockfile: () => null,
-  normalizeAssistantId: (id: string) => id,
   writeLockfile: () => {},
   readPlatformToken: () => null,
   readSessionToken: () => null,

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -15,6 +15,7 @@ import { answerCall } from '../calls/call-domain.js';
 import type { CanonicalGuardianRequest } from '../memory/canonical-guardian-store.js';
 import { emitNotificationSignal } from '../notifications/emit-signal.js';
 import { addRule } from '../permissions/trust-store.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import type { ApprovalAction } from '../runtime/channel-approval-types.js';
 import { createOutboundSession } from '../runtime/channel-guardian-service.js';
 import { deliverChannelReply } from '../runtime/gateway-client.js';
@@ -278,7 +279,7 @@ const accessRequestResolver: GuardianRequestResolver = {
     const requesterExternalUserId = request.requesterExternalUserId ?? '';
     const requesterChatId = request.requesterChatId ?? request.requesterExternalUserId ?? '';
     const decidedByExternalUserId = ctx.actor.externalUserId ?? '';
-    const assistantId = channelDeliveryContext?.assistantId ?? 'self';
+    const assistantId = channelDeliveryContext?.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
 
     if (decision.action === 'reject') {
       log.info(
@@ -461,7 +462,7 @@ const toolGrantRequestResolver: GuardianRequestResolver = {
   async resolve(ctx: ResolverContext): Promise<ResolverResult> {
     const { request, decision, channelDeliveryContext } = ctx;
     const requesterChatId = request.requesterChatId ?? request.requesterExternalUserId ?? '';
-    const assistantId = channelDeliveryContext?.assistantId ?? 'self';
+    const assistantId = channelDeliveryContext?.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
 
     if (decision.action === 'reject') {
       log.info(

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -22,6 +22,7 @@ import {
 import { revokeScopedApprovalGrantsForContext } from '../memory/scoped-approval-grants.js';
 import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
 import { getLogger } from '../util/logger.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { readHttpToken } from '../util/platform.js';
 import { getMaxCallDurationMs, getUserConsultationTimeoutMs, SILENCE_TIMEOUT_MS } from './call-constants.js';
 import { persistCallCompletionMessage } from './call-conversation-messages.js';
@@ -247,7 +248,7 @@ export class CallController {
     this.task = task;
     this.isInbound = !task;
     this.broadcast = opts?.broadcast;
-    this.assistantId = opts?.assistantId ?? 'self';
+    this.assistantId = opts?.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
     this.guardianContext = opts?.guardianContext ?? null;
 
     // Resolve the conversation ID from the call session

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -31,7 +31,7 @@ import { redeemVoiceInviteCode } from '../runtime/ingress-service.js';
 import { findActiveVoiceInvites } from '../memory/ingress-invite-store.js';
 import { parseJsonSafe } from '../util/json.js';
 import { getLogger } from '../util/logger.js';
-import { normalizeAssistantId } from '../util/platform.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { CallController } from './call-controller.js';
 import { persistCallCompletionMessage } from './call-conversation-messages.js';
 import { addPointerMessage, formatDuration } from './call-pointer-messages.js';
@@ -427,7 +427,7 @@ export class RelayConnection {
     // calls (created via createInboundVoiceSession) never do. Relying on
     // task == null is unreliable: task-less outbound sessions would
     // incorrectly bypass outbound verification.
-    const assistantId = normalizeAssistantId(session?.assistantId ?? 'self');
+    const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
     const isInbound = session?.initiatedFromConversationId == null;
 
     // Create and attach the session-backed voice controller. Seed guardian

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -19,6 +19,7 @@ import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.
 import { resolveChannelCapabilities } from '../daemon/session-runtime-assembly.js';
 import { buildAssistantEvent } from '../runtime/assistant-event.js';
 import { assistantEventHub } from '../runtime/assistant-event-hub.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { checkIngressForSecrets } from '../security/secret-ingress.js';
 import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
 import { IngressBlockedError } from '../util/errors.js';
@@ -306,7 +307,7 @@ export async function startVoiceTurn(opts: VoiceTurnOptions): Promise<VoiceTurnH
     ...session.memoryPolicy,
     strictSideEffects,
   };
-  session.setAssistantId(opts.assistantId ?? 'self');
+  session.setAssistantId(opts.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID);
   session.callSessionId = opts.callSessionId;
   session.setGuardianContext(opts.guardianContext ?? null);
   session.setCommandIntent(null);
@@ -330,7 +331,7 @@ export async function startVoiceTurn(opts: VoiceTurnOptions): Promise<VoiceTurnH
         ? (msg as { sessionId: string }).sessionId
         : undefined;
     const resolvedSessionId = msgSessionId ?? opts.conversationId;
-    const event = buildAssistantEvent('self', msg, resolvedSessionId);
+    const event = buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, msg, resolvedSessionId);
     hubChain = (async () => {
       await hubChain;
       try {
@@ -364,7 +365,7 @@ export async function startVoiceTurn(opts: VoiceTurnOptions): Promise<VoiceTurnH
             toolName: msg.toolName,
             inputDigest,
             consumingRequestId: msg.requestId,
-            assistantId: opts.assistantId ?? 'self',
+            assistantId: opts.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
             executionChannel: 'voice',
             conversationId: opts.conversationId,
             callSessionId: opts.callSessionId,

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -17,7 +17,7 @@ import {
   resendOutbound,
   startOutbound,
 } from '../../runtime/guardian-outbound-actions.js';
-import { normalizeAssistantId } from '../../util/platform.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../../runtime/assistant-scope.js';
 import type {
   ChannelReadinessRequest,
   GuardianVerificationRequest,
@@ -64,7 +64,7 @@ export function createGuardianChallenge(
   rebind?: boolean,
   sessionId?: string,
 ): GuardianVerificationResult {
-  const resolvedAssistantId = normalizeAssistantId(assistantId ?? 'self');
+  const resolvedAssistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const resolvedChannel = channel ?? 'telegram';
 
   const existingBinding = getGuardianBinding(resolvedAssistantId, resolvedChannel);
@@ -91,7 +91,7 @@ export function getGuardianStatus(
   channel?: ChannelId,
   assistantId?: string,
 ): GuardianVerificationResult {
-  const resolvedAssistantId = normalizeAssistantId(assistantId ?? 'self');
+  const resolvedAssistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const resolvedChannel = channel ?? 'telegram';
 
   const binding = getGuardianBinding(resolvedAssistantId, resolvedChannel);
@@ -161,9 +161,7 @@ export function handleGuardianVerification(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
-  // Normalize the assistant ID so challenges are always stored under the
-  // same key the inbound-call path will use for lookups (typically "self").
-  const assistantId = normalizeAssistantId(msg.assistantId ?? 'self');
+  const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const channel = msg.channel ?? 'telegram';
 
   try {

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -1,6 +1,7 @@
 import * as net from 'node:net';
 
 import { type Confidence, recordConversationSeenSignal, type SignalType } from '../../memory/conversation-attention-store.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../../runtime/assistant-scope.js';
 import { updateDeliveryClientOutcome } from '../../notifications/deliveries-store.js';
 import type { ClientMessage } from '../ipc-protocol.js';
 import { handleRideShotgunStart, handleRideShotgunStop } from '../ride-shotgun-handler.js';
@@ -104,7 +105,7 @@ const inlineHandlers = defineHandlers({
     try {
       recordConversationSeenSignal({
         conversationId: msg.conversationId,
-        assistantId: 'self',
+        assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
         sourceChannel: msg.sourceChannel,
         signalType: msg.signalType as SignalType,
         confidence: msg.confidence as Confidence,

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -3,6 +3,7 @@ import * as net from 'node:net';
 import { v4 as uuid } from 'uuid';
 
 import { createAssistantMessage, createUserMessage } from '../../agent/message-types.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../../runtime/assistant-scope.js';
 import { type InterfaceId,isChannelId, parseChannelId, parseInterfaceId } from '../../channels/types.js';
 import { getConfig } from '../../config/loader.js';
 import { getAttachmentsForMessage, getFilePathForAttachment, setAttachmentThumbnail } from '../../memory/attachments-store.js';
@@ -181,7 +182,7 @@ export async function handleUserMessage(
         userMessageInterface: ipcInterface,
         assistantMessageInterface: ipcInterface,
       });
-      session.setAssistantId('self');
+      session.setAssistantId(DAEMON_INTERNAL_ASSISTANT_ID);
       // IPC/desktop user IS the guardian — default to guardian trust so
       // messages are not tagged as unknown provenance.
       session.setGuardianContext({ trustClass: 'guardian', sourceChannel: ipcChannel });

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -18,6 +18,7 @@ import * as conversationStore from '../memory/conversation-store.js';
 import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import { RateLimitProvider } from '../providers/ratelimit.js';
 import { getFailoverProvider, initializeProviders } from '../providers/registry.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import * as pendingInteractions from '../runtime/pending-interactions.js';
 import { checkIngressForSecrets } from '../security/secret-ingress.js';
 import { getSubagentManager } from '../subagent/index.js';
@@ -811,7 +812,7 @@ export class DaemonServer {
 
     const resolvedChannel = resolveTurnChannel(sourceChannel, options?.transport?.channelId);
     const resolvedInterface = resolveTurnInterface(sourceInterface);
-    session.setAssistantId(options?.assistantId ?? 'self');
+    session.setAssistantId(options?.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID);
     session.setGuardianContext(options?.guardianContext ?? null);
     await session.ensureActorScopedHistory();
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel, sourceInterface));

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -10,6 +10,7 @@
 import { v4 as uuid } from 'uuid';
 
 import type { AgentEvent,AgentLoop, CheckpointDecision } from '../agent/loop.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { createAssistantMessage } from '../agent/message-types.js';
 import type { ChannelId, InterfaceId, TurnChannelContext, TurnInterfaceContext } from '../channels/types.js';
 import { getConfig } from '../config/loader.js';
@@ -363,7 +364,7 @@ export async function runAgentLoopImpl(
       const gc = ctx.guardianContext;
       if (gc.requesterExternalUserId && gc.requesterChatId) {
         const actorTrust = resolveActorTrust({
-          assistantId: ctx.assistantId ?? 'self',
+          assistantId: ctx.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
           sourceChannel: gc.sourceChannel,
           externalChatId: gc.requesterChatId,
           senderExternalUserId: gc.requesterExternalUserId,

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -10,6 +10,7 @@
 import { and, desc, eq, inArray, lt } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { getLogger } from '../util/logger.js';
 import { getDb, rawChanges } from './db.js';
 import {
@@ -160,7 +161,7 @@ export function createGuardianActionRequest(params: {
 
   const row = {
     id,
-    assistantId: params.assistantId ?? 'self',
+    assistantId: params.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
     kind: params.kind,
     sourceChannel: params.sourceChannel,
     sourceConversationId: params.sourceConversationId,

--- a/assistant/src/memory/guardian-approvals.ts
+++ b/assistant/src/memory/guardian-approvals.ts
@@ -9,6 +9,7 @@
 import { and, count, desc, eq, gt, lte } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { getDb } from './db.js';
 import { channelGuardianApprovalRequests } from './schema.js';
 
@@ -100,7 +101,7 @@ export function createApprovalRequest(params: {
     runId: params.runId,
     requestId: params.requestId ?? null,
     conversationId: params.conversationId,
-    assistantId: params.assistantId ?? 'self',
+    assistantId: params.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
     channel: params.channel,
     requesterExternalUserId: params.requesterExternalUserId,
     requesterChatId: params.requesterChatId,
@@ -402,7 +403,7 @@ export function listPendingApprovalRequests(params: {
   const db = getDb();
 
   const conditions = [
-    eq(channelGuardianApprovalRequests.assistantId, params.assistantId ?? 'self'),
+    eq(channelGuardianApprovalRequests.assistantId, params.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID),
   ];
   if (params.channel) {
     conditions.push(eq(channelGuardianApprovalRequests.channel, params.channel));

--- a/assistant/src/memory/ingress-invite-store.ts
+++ b/assistant/src/memory/ingress-invite-store.ts
@@ -10,6 +10,7 @@ import { createHash, randomBytes, randomUUID } from 'node:crypto';
 
 import { and, desc, eq } from 'drizzle-orm';
 
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { getDb } from './db.js';
 import { assistantIngressInvites, assistantIngressMembers } from './schema.js';
 
@@ -147,7 +148,7 @@ export function createInvite(params: {
 
   const row = {
     id,
-    assistantId: params.assistantId ?? 'self',
+    assistantId: params.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
     sourceChannel: params.sourceChannel,
     tokenHash: tokenH,
     createdBySessionId: params.createdBySessionId ?? null,
@@ -183,7 +184,7 @@ export function listInvites(params: {
   offset?: number;
 }): IngressInvite[] {
   const db = getDb();
-  const assistantId = params.assistantId ?? 'self';
+  const assistantId = params.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
 
   const conditions = [eq(assistantIngressInvites.assistantId, assistantId)];
 

--- a/assistant/src/memory/ingress-member-store.ts
+++ b/assistant/src/memory/ingress-member-store.ts
@@ -8,6 +8,7 @@
 import { and, desc, eq, or } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { getDb } from './db.js';
 import { assistantIngressMembers } from './schema.js';
 
@@ -78,7 +79,7 @@ export function upsertMember(params: {
   createdBySessionId?: string;
   assistantId?: string;
 }): IngressMember {
-  const assistantId = params.assistantId ?? 'self';
+  const assistantId = params.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
 
   if (!params.externalUserId && !params.externalChatId) {
     throw new Error('At least one of externalUserId or externalChatId must be provided');
@@ -181,7 +182,7 @@ export function listMembers(params?: {
   offset?: number;
 }): IngressMember[] {
   const db = getDb();
-  const assistantId = params?.assistantId ?? 'self';
+  const assistantId = params?.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
 
   const conditions = [eq(assistantIngressMembers.assistantId, assistantId)];
   if (params?.sourceChannel) {
@@ -304,7 +305,7 @@ export function findMember(params: {
   }
 
   const db = getDb();
-  const assistantId = params.assistantId ?? 'self';
+  const assistantId = params.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
 
   // Prefer lookup by externalUserId when available, fall back to externalChatId
   const matchConditions = [];

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -17,7 +17,7 @@ import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.
 import type { IngressMember } from '../memory/ingress-member-store.js';
 import { findMember } from '../memory/ingress-member-store.js';
 import { canonicalizeInboundIdentity } from '../util/canonicalize-identity.js';
-import { normalizeAssistantId } from '../util/platform.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
 import { getGuardianBinding } from './channel-guardian-service.js';
 
 // ---------------------------------------------------------------------------
@@ -76,7 +76,7 @@ export interface ResolveActorTrustInput {
  * 5. Classify: guardian > trusted_contact (active member) > unknown.
  */
 export function resolveActorTrust(input: ResolveActorTrustInput): ActorTrustContext {
-  const assistantId = normalizeAssistantId(input.assistantId);
+  const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
 
   const rawUserId = typeof input.senderExternalUserId === 'string' && input.senderExternalUserId.trim().length > 0
     ? input.senderExternalUserId.trim()

--- a/assistant/src/runtime/guardian-outbound-actions.ts
+++ b/assistant/src/runtime/guardian-outbound-actions.ts
@@ -16,7 +16,8 @@ import { sendMessage as sendSms } from '../messaging/providers/sms/client.js';
 import { getCredentialMetadata } from '../tools/credentials/metadata-store.js';
 import { getLogger } from '../util/logger.js';
 import { normalizePhoneNumber } from '../util/phone.js';
-import { normalizeAssistantId, readHttpToken } from '../util/platform.js';
+import { readHttpToken } from '../util/platform.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
 import {
   countRecentSendsToDestination,
   createOutboundSession,
@@ -243,7 +244,7 @@ function initiateGuardianVoiceCall(
 // ---------------------------------------------------------------------------
 
 export function startOutbound(params: StartOutboundParams): OutboundActionResult {
-  const assistantId = normalizeAssistantId(params.assistantId ?? 'self');
+  const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const channel = params.channel;
   const originConversationId = params.originConversationId;
 
@@ -541,7 +542,7 @@ function startOutboundVoice(
 // ---------------------------------------------------------------------------
 
 export function resendOutbound(params: ResendOutboundParams): OutboundActionResult {
-  const assistantId = normalizeAssistantId(params.assistantId ?? 'self');
+  const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const channel = params.channel;
   const originConversationId = params.originConversationId;
 
@@ -707,7 +708,7 @@ export function resendOutbound(params: ResendOutboundParams): OutboundActionResu
 // ---------------------------------------------------------------------------
 
 export function cancelOutbound(params: CancelOutboundParams): OutboundActionResult {
-  const assistantId = normalizeAssistantId(params.assistantId ?? 'self');
+  const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const channel = params.channel;
 
   const session = findActiveSession(assistantId, channel);

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -39,6 +39,7 @@ import * as externalConversationStore from '../memory/external-conversation-stor
 import { consumeCallback, consumeCallbackError } from '../security/oauth-callback-registry.js';
 import { getLogger } from '../util/logger.js';
 import { buildAssistantEvent } from './assistant-event.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
 import { assistantEventHub } from './assistant-event-hub.js';
 import { sweepFailedEvents } from './channel-retry-sweep.js';
 import { httpError } from './http-errors.js';
@@ -270,7 +271,7 @@ export class RuntimeHttpServer {
             ipcBroadcast(msg);
             // Also publish to the event hub so HTTP/SSE clients (e.g. macOS
             // app with localHttpEnabled) receive pairing approval requests.
-            void assistantEventHub.publish(buildAssistantEvent('self', msg));
+            void assistantEventHub.publish(buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, msg));
           }
         : undefined,
     };
@@ -616,7 +617,7 @@ export class RuntimeHttpServer {
     endpoint: string,
     req: Request,
     url: URL,
-    assistantId: string = 'self',
+    assistantId: string = DAEMON_INTERNAL_ASSISTANT_ID,
   ): Promise<Response> {
     return withErrorHandling(endpoint, async () => {
       if (endpoint === 'health' && req.method === 'GET') return handleHealth();
@@ -690,7 +691,7 @@ export class RuntimeHttpServer {
         try {
           recordConversationSeenSignal({
             conversationId,
-            assistantId: 'self',
+            assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
             sourceChannel: (body.sourceChannel as string) ?? 'vellum',
             signalType: (body.signalType as string ?? 'macos_conversation_opened') as SignalType,
             confidence: (body.confidence as string ?? 'explicit') as Confidence,

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ChannelId } from '../channels/types.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
 import { getSqlite } from '../memory/db.js';
 import { findByTokenHash, hashToken, markInviteExpired, recordInviteUse, redeemInvite as storeRedeemInvite, findActiveVoiceInvites } from '../memory/ingress-invite-store.js';
 import { findMember, upsertMember } from '../memory/ingress-member-store.js';
@@ -223,7 +224,7 @@ export function redeemVoiceInviteCode(params: {
   sourceChannel: 'voice';
   code: string;
 }): VoiceRedemptionOutcome {
-  const { assistantId = 'self', callerExternalUserId, code } = params;
+  const { assistantId = DAEMON_INTERNAL_ASSISTANT_ID, callerExternalUserId, code } = params;
 
   if (!callerExternalUserId) {
     return { ok: false, reason: 'invalid_or_expired' };

--- a/assistant/src/runtime/routes/call-routes.ts
+++ b/assistant/src/runtime/routes/call-routes.ts
@@ -11,6 +11,7 @@
 import { answerCall, cancelCall, getCallStatus, relayInstruction,startCall } from '../../calls/call-domain.js';
 import { getConfig } from '../../config/loader.js';
 import { VALID_CALLER_IDENTITY_MODES } from '../../config/schema.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import { httpError, httpErrorCodeFromStatus } from '../http-errors.js';
 
 // ── Idempotency cache ─────────────────────────────────────────────────────────
@@ -41,7 +42,7 @@ function pruneIdempotencyCache(): void {
  * Optional `idempotencyKey`: if supplied, duplicate requests with the same key
  * within 5 minutes return the cached 201 response without starting a second call.
  */
-export async function handleStartCall(req: Request, assistantId: string = 'self'): Promise<Response> {
+export async function handleStartCall(req: Request, assistantId: string = DAEMON_INTERNAL_ASSISTANT_ID): Promise<Response> {
   if (!getConfig().calls.enabled) {
     return httpError('FORBIDDEN', 'Calls feature is disabled via configuration. Set calls.enabled to true to use this feature.', 403);
   }

--- a/assistant/src/runtime/routes/channel-route-shared.ts
+++ b/assistant/src/runtime/routes/channel-route-shared.ts
@@ -4,7 +4,7 @@
 import { timingSafeEqual } from 'node:crypto';
 
 import type { ChannelId } from '../../channels/types.js';
-import { normalizeAssistantId } from '../../util/platform.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import type {
   ApprovalAction,
   ApprovalDecisionResult,
@@ -15,8 +15,8 @@ export type { ActorTrustClass, DenialReason, GuardianContext } from '../guardian
 export { toGuardianRuntimeContext } from '../guardian-context-resolver.js';
 
 /** Canonicalize assistantId for channel ingress paths. */
-export function canonicalChannelAssistantId(assistantId: string): string {
-  return normalizeAssistantId(assistantId);
+export function canonicalChannelAssistantId(_assistantId: string): string {
+  return DAEMON_INTERNAL_ASSISTANT_ID;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/conversation-attention-routes.ts
+++ b/assistant/src/runtime/routes/conversation-attention-routes.ts
@@ -10,6 +10,7 @@ import {
 } from '../../memory/conversation-attention-store.js';
 import * as conversationStore from '../../memory/conversation-store.js';
 import { truncate } from '../../util/truncate.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import { httpError } from '../http-errors.js';
 
 export function handleListConversationAttention(url: URL): Response {
@@ -27,7 +28,7 @@ export function handleListConversationAttention(url: URL): Response {
   }
 
   const attentionStates = listConversationAttention({
-    assistantId: 'self',
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     state: stateParam as AttentionFilterState,
     sourceChannel: channel,
     source: sourceParam !== 'all' ? sourceParam : undefined,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -21,6 +21,7 @@ import { getConfiguredProvider } from '../../providers/provider-send-message.js'
 import type { Provider } from '../../providers/types.js';
 import { getLogger } from '../../util/logger.js';
 import { buildAssistantEvent } from '../assistant-event.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import { httpError } from '../http-errors.js';
 import type {
   MessageProcessor,
@@ -203,7 +204,7 @@ function makeHubPublisher(
         ? (msg as { sessionId: string }).sessionId
         : undefined;
     const resolvedSessionId = msgSessionId ?? conversationId;
-    const event = buildAssistantEvent('self', msg, resolvedSessionId);
+    const event = buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, msg, resolvedSessionId);
     hubChain = (async () => {
       await hubChain;
       try {

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -11,6 +11,7 @@ import { getOrCreateConversation } from '../../memory/conversation-key-store.js'
 import { formatSseFrame, formatSseHeartbeat } from '../assistant-event.js';
 import type { AssistantEventSubscription } from '../assistant-event-hub.js';
 import { AssistantEventHub,assistantEventHub } from '../assistant-event-hub.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import { httpError } from '../http-errors.js';
 
 /** Keep-alive comment sent to idle clients every 30 s by default. */
@@ -50,8 +51,6 @@ export function handleSubscribeAssistantEvents(
   // closures are in place before events can arrive.  `controllerRef` is set
   // synchronously inside ReadableStream's start(), so it is non-null by the
   // time any event or eviction fires.
-  // 'self' is the assistantId used by buildAssistantEvent('self', ...) for
-  // all HTTP and voice session events.
   let controllerRef: ReadableStreamDefaultController<Uint8Array> | null = null;
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   let sub!: AssistantEventSubscription;
@@ -63,7 +62,7 @@ export function handleSubscribeAssistantEvents(
 
   try {
     sub = hub.subscribe(
-      { assistantId: 'self', sessionId: mapping.conversationId },
+      { assistantId: DAEMON_INTERNAL_ASSISTANT_ID, sessionId: mapping.conversationId },
       (event) => {
         const controller = controllerRef;
         if (!controller) return;

--- a/assistant/src/runtime/routes/inbound-conversation.ts
+++ b/assistant/src/runtime/routes/inbound-conversation.ts
@@ -3,9 +3,10 @@
  */
 import { deleteConversationKey } from '../../memory/conversation-key-store.js';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import { httpError } from '../http-errors.js';
 
-export async function handleDeleteConversation(req: Request, assistantId: string = 'self'): Promise<Response> {
+export async function handleDeleteConversation(req: Request, assistantId: string = DAEMON_INTERNAL_ASSISTANT_ID): Promise<Response> {
   const body = await req.json() as {
     sourceChannel?: string;
     externalChatId?: string;
@@ -26,14 +27,14 @@ export async function handleDeleteConversation(req: Request, assistantId: string
   const legacyKey = `${sourceChannel}:${externalChatId}`;
   const scopedKey = `asst:${assistantId}:${sourceChannel}:${externalChatId}`;
   deleteConversationKey(scopedKey);
-  if (assistantId === 'self') {
+  if (assistantId === DAEMON_INTERNAL_ASSISTANT_ID) {
     deleteConversationKey(legacyKey);
   }
   // external_conversation_bindings is currently assistant-agnostic
   // (unique by sourceChannel + externalChatId). Restrict mutations to the
   // canonical self-assistant route so multi-assistant legacy routes do not
   // clobber each other's bindings.
-  if (assistantId === 'self') {
+  if (assistantId === DAEMON_INTERNAL_ASSISTANT_ID) {
     externalConversationStore.deleteBindingByChannelChat(sourceChannel, externalChatId);
   }
 

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -27,6 +27,7 @@ import { canonicalizeInboundIdentity } from '../../util/canonicalize-identity.js
 import { IngressBlockedError } from '../../util/errors.js';
 import { getLogger } from '../../util/logger.js';
 import { readHttpToken } from '../../util/platform.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import { notifyGuardianOfAccessRequest } from '../access-request-helper.js';
 import {
   buildApprovalUIMetadata,
@@ -97,7 +98,7 @@ export async function handleChannelInbound(
   req: Request,
   processMessage?: MessageProcessor,
   bearerToken?: string,
-  assistantId: string = 'self',
+  assistantId: string = DAEMON_INTERNAL_ASSISTANT_ID,
   gatewayOriginSecret?: string,
   approvalCopyGenerator?: ApprovalCopyGenerator,
   approvalConversationGenerator?: ApprovalConversationGenerator,
@@ -580,7 +581,7 @@ export async function handleChannelInbound(
   // external_conversation_bindings is assistant-agnostic. Restrict writes to
   // self so assistant-scoped legacy routes do not overwrite each other's
   // channel binding metadata for the same chat.
-  if (canonicalAssistantId === 'self') {
+  if (canonicalAssistantId === DAEMON_INTERNAL_ASSISTANT_ID) {
     externalConversationStore.upsertBinding({
       conversationId: result.conversationId,
       sourceChannel,
@@ -1438,7 +1439,7 @@ function startPendingApprovalPromptWatcher(params: {
             replyCallbackUrl,
             chatId: externalChatId,
             sourceChannel,
-            assistantId: assistantId ?? 'self',
+            assistantId: assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
             bearerToken,
             prompt,
             uiMetadata: buildApprovalUIMetadata(prompt, info),

--- a/assistant/src/tools/calls/call-start.ts
+++ b/assistant/src/tools/calls/call-start.ts
@@ -1,5 +1,6 @@
 import { startCall } from '../../calls/call-domain.js';
 import { getConfig } from '../../config/loader.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../../runtime/assistant-scope.js';
 import { findActiveSession } from '../../runtime/channel-guardian-service.js';
 import { normalizePhoneNumber } from '../../util/phone.js';
 import type { ToolContext, ToolExecutionResult } from '../types.js';
@@ -16,7 +17,7 @@ export async function executeCallStart(
     ? normalizePhoneNumber(input.phone_number)
     : null;
   if (requestedPhone) {
-    const assistantId = context.assistantId ?? 'self';
+    const assistantId = context.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
     const activeVoiceVerification = findActiveSession(assistantId, 'voice');
     const verificationDestination = activeVoiceVerification?.destinationAddress ?? activeVoiceVerification?.expectedPhoneE164;
     if (verificationDestination === requestedPhone) {

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -1,4 +1,5 @@
 import { consumeGrantForInvocation } from '../approvals/approval-primitive.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { createOrReuseToolGrantRequest } from '../runtime/tool-grant-request-helper.js';
 import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
 import { getTaskRunRules } from '../tasks/ephemeral-permissions.js';
@@ -128,7 +129,7 @@ export class ToolApprovalHandler {
         toolName: name,
         inputDigest,
         consumingRequestId: context.requestId ?? `preexec-${context.sessionId}-${Date.now()}`,
-        assistantId: context.assistantId ?? 'self',
+        assistantId: context.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
         executionChannel: context.executionChannel,
         conversationId: context.conversationId,
         callSessionId: context.callSessionId,


### PR DESCRIPTION
Replaces assistantId fallback patterns and normalizeAssistantId() calls in daemon internals with DAEMON_INTERNAL_ASSISTANT_ID constant. Part of #10674.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
