### PR TITLE
assistant: remove assistant-scoped daemon route shape

### DIFF
--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -175,10 +175,6 @@ describe('runtime call routes — HTTP layer', () => {
     return `http://127.0.0.1:${port}/v1/calls${path}`;
   }
 
-  function assistantCallsUrl(assistantId: string, path = ''): string {
-    return `http://127.0.0.1:${port}/v1/assistants/${assistantId}/calls${path}`;
-  }
-
   // ── POST /v1/calls/start ────────────────────────────────────────────
 
   test('POST /v1/calls/start returns 201 with call session', async () => {
@@ -229,27 +225,6 @@ describe('runtime call routes — HTTP layer', () => {
     expect(res.status).toBe(400);
     const body = await res.json() as { error: string };
     expect(body.error).toContain('conversationId');
-
-    await stopServer();
-  });
-
-  test('POST /v1/assistants/:assistantId/calls/start uses assistant-scoped caller number', async () => {
-    await startServer();
-    ensureConversation('conv-start-scoped-1');
-
-    const res = await fetch(assistantCallsUrl('asst-alpha', '/start'), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-      body: JSON.stringify({
-        phoneNumber: '+15559997777',
-        task: 'Check order status',
-        conversationId: 'conv-start-scoped-1',
-      }),
-    });
-
-    expect(res.status).toBe(201);
-    const body = await res.json() as { fromNumber: string };
-    expect(body.fromNumber).toBe('+15550009999');
 
     await stopServer();
   });

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -608,6 +608,19 @@ export class RuntimeHttpServer {
     req: Request,
     url: URL,
   ): Promise<Response> {
+    // Transitional rewrite: the gateway still constructs /v1/assistants/:id/...
+    // URLs for direct daemon calls (runtime/client.ts). Strip the assistant-scoped
+    // prefix and forward to the flat endpoint so those requests keep working.
+    // Remove this rewrite once the gateway is updated to use flat paths (M4).
+    const assistantScopedMatch = endpoint.match(/^assistants\/[^/]+\/(.+)$/);
+    if (assistantScopedMatch) {
+      log.warn(
+        { originalEndpoint: endpoint, rewrittenEndpoint: assistantScopedMatch[1] },
+        'DEPRECATION: received assistant-scoped path; rewriting to flat endpoint. Update the caller to use /v1/<endpoint> directly.',
+      );
+      return this.dispatchEndpoint(assistantScopedMatch[1], req, url);
+    }
+
     const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
     return withErrorHandling(endpoint, async () => {
       if (endpoint === 'health' && req.method === 'GET') return handleHealth();

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -98,7 +98,6 @@ import {
   startCanonicalGuardianExpirySweep,
   stopCanonicalGuardianExpirySweep,
 } from './routes/canonical-guardian-expiry-sweep.js';
-import { canonicalChannelAssistantId } from './routes/channel-route-shared.js';
 import {
   handleChannelDeliveryAck,
   handleChannelInbound,
@@ -522,22 +521,13 @@ export class RuntimeHttpServer {
       }
     }
 
-    // New assistant-less runtime routes: /v1/<endpoint>
-    const newRouteMatch = path.match(/^\/v1\/(?!assistants\/)(.+)$/);
-    if (newRouteMatch) {
-      return this.dispatchEndpoint(newRouteMatch[1], req, url);
+    // Runtime routes: /v1/<endpoint>
+    const routeMatch = path.match(/^\/v1\/(.+)$/);
+    if (routeMatch) {
+      return this.dispatchEndpoint(routeMatch[1], req, url);
     }
 
-    // Legacy: /v1/assistants/:assistantId/<endpoint>
-    const match = path.match(/^\/v1\/assistants\/([^/]+)\/(.+)$/);
-    if (!match) {
-      return httpError('NOT_FOUND', 'Not found', 404);
-    }
-
-    const assistantId = canonicalChannelAssistantId(match[1]);
-    const endpoint = match[2];
-    log.warn({ endpoint, assistantId }, '[deprecated] /v1/assistants/:assistantId/... route used; migrate to /v1/...');
-    return this.dispatchEndpoint(endpoint, req, url, assistantId);
+    return httpError('NOT_FOUND', 'Not found', 404);
   }
 
   private handleBrowserRelayUpgrade(req: Request, server: ReturnType<typeof Bun.serve>): Response {
@@ -617,8 +607,8 @@ export class RuntimeHttpServer {
     endpoint: string,
     req: Request,
     url: URL,
-    assistantId: string = DAEMON_INTERNAL_ASSISTANT_ID,
   ): Promise<Response> {
+    const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
     return withErrorHandling(endpoint, async () => {
       if (endpoint === 'health' && req.method === 'GET') return handleHealth();
       if (endpoint === 'debug' && req.method === 'GET') return handleDebug();

--- a/assistant/src/runtime/middleware/twilio-validation.ts
+++ b/assistant/src/runtime/middleware/twilio-validation.ts
@@ -12,12 +12,10 @@ import { httpError } from '../http-errors.js';
 const log = getLogger('runtime-http');
 
 /**
- * Regex to extract the Twilio webhook subpath from both top-level and
- * assistant-scoped route shapes:
+ * Regex to extract the Twilio webhook subpath:
  *   /v1/calls/twilio/<subpath>
- *   /v1/assistants/<id>/calls/twilio/<subpath>
  */
-export const TWILIO_WEBHOOK_RE = /^\/v1\/(?:assistants\/[^/]+\/)?calls\/twilio\/(.+)$/;
+export const TWILIO_WEBHOOK_RE = /^\/v1\/calls\/twilio\/(.+)$/;
 
 /**
  * Gateway-compatible Twilio webhook paths:


### PR DESCRIPTION
Removes /v1/assistants/:assistantId/ route handling from daemon HTTP server. Only assistant-less routes remain. Part of #10674.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
