### PR TITLE
fix: clear persistentThreadId when archiving into draft mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -582,9 +582,8 @@ struct MainWindowView: View {
             // Without this, archiving the active thread while viewing a panel
             // leaves persistentThreadId pointing at the archived (invisible) thread
             // and the sidebar shows no active highlight.
-            if let newId {
-                windowState.persistentThreadId = newId
-            }
+            // Clear it when entering draft mode (nil) so no thread appears active.
+            windowState.persistentThreadId = newId
             if case .panel(.intelligence) = windowState.selection {
                 windowState.selection = nil
             }


### PR DESCRIPTION
## Summary
- Previously `persistentThreadId` was only updated when `newId` was non-nil (`if let newId`), so archiving the active thread into draft mode left the sidebar highlighting the archived (invisible) thread
- Now always assigns `newId` (including nil), correctly clearing the active highlight when entering draft mode

## Test plan
- [ ] Archive the active thread while a side panel is open — sidebar should show no active highlight
- [ ] Archive a thread normally — next thread should be highlighted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
