### PR TITLE
Harden guardian-bound channel approvals

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -2615,6 +2615,56 @@ describe('background channel processing approval prompts', () => {
     deliverPromptSpy.mockRestore();
   });
 
+  test('guardian prompt delivery still works when binding ID formatting differs from sender ID', async () => {
+    // Guardian binding includes extra whitespace; trust resolution canonicalizes
+    // identity and prompt delivery should still treat this sender as the guardian.
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: '  telegram-user-default  ',
+      guardianDeliveryChatId: 'chat-123',
+    });
+
+    const deliverPromptSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockResolvedValue(undefined);
+    const processCalls: Array<{ options?: Record<string, unknown> }> = [];
+
+    const processMessage = mock(async (
+      conversationId: string,
+      _content: string,
+      _attachmentIds?: string[],
+      options?: Record<string, unknown>,
+    ) => {
+      processCalls.push({ options });
+
+      registerPendingInteraction('req-bg-format-1', conversationId, 'host_bash', {
+        input: { command: 'ls -la' },
+        riskLevel: 'medium',
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 350));
+      return { messageId: 'msg-bg-format-1' };
+    });
+
+    const req = makeInboundRequest({
+      content: 'run ls',
+      sourceChannel: 'telegram',
+      replyCallbackUrl: 'https://gateway.test/deliver/telegram',
+      externalMessageId: 'msg-bg-format-1',
+    });
+
+    const res = await handleChannelInbound(req, processMessage as unknown as typeof noopProcessMessage, 'token');
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 700));
+
+    expect(processCalls.length).toBeGreaterThan(0);
+    expect(processCalls[0].options?.isInteractive).toBe(true);
+    expect(deliverPromptSpy).toHaveBeenCalled();
+
+    deliverPromptSpy.mockRestore();
+  });
+
   test('non-guardian channel turns are not interactive to prevent self-approval', async () => {
     // Set up a guardian binding for a DIFFERENT user so the sender is non-guardian
     createBinding({

--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -2709,8 +2709,8 @@ describe('NL approval routing via destination-scoped canonical requests', () => 
     noopProcessMessage.mockClear();
   });
 
-  test('guardian plain-text "yes" resolves a pending_question with no guardianExternalUserId via delivery-scoped hint', async () => {
-    // Simulate a voice-originated pending_question without guardianExternalUserId
+  test('guardian plain-text "yes" fails closed for tool_approval with no guardianExternalUserId', async () => {
+    // Simulate a voice-originated tool approval without guardianExternalUserId
     const guardianChatId = 'guardian-chat-nl-1';
     const guardianUserId = 'guardian-user-nl-1';
 
@@ -2759,12 +2759,12 @@ describe('NL approval routing via destination-scoped canonical requests', () => 
     const body = await res.json() as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
-    expect(body.canonicalRouter).toBe('canonical_decision_applied');
+    expect(body.canonicalRouter).toBe('canonical_decision_stale');
 
-    // Verify the request was resolved
+    // Verify the request remains pending (identity-bound fail-closed).
     const resolved = getCanonicalGuardianRequest(canonicalReq.id);
     expect(resolved).not.toBeNull();
-    expect(resolved!.status).toBe('approved');
+    expect(resolved!.status).toBe('pending');
   });
 
   test('inbound from different chat ID does not auto-match delivery-scoped canonical request', async () => {

--- a/assistant/src/__tests__/daemon-server-session-init.test.ts
+++ b/assistant/src/__tests__/daemon-server-session-init.test.ts
@@ -36,6 +36,7 @@ let lastCreateConversationArgs: unknown;
 // field declarations create own-properties that mask prototype assignments.
 let mockConfirmationToEmitDuringLoop: Record<string, unknown> | undefined;
 let mockMidLoopCallback: ((session: MockSession) => void) | undefined;
+let lastCanonicalGuardianCreateParams: Record<string, unknown> | undefined;
 
 class MockSession {
   public readonly conversationId: string;
@@ -253,7 +254,10 @@ mock.module('../memory/conversation-attention-store.js', () => ({
 
 mock.module('../memory/canonical-guardian-store.js', () => ({
   generateCanonicalRequestCode: () => 'mock-code-0000',
-  createCanonicalGuardianRequest: () => ({ requestCode: 'mock-code-0000', status: 'pending' }),
+  createCanonicalGuardianRequest: (params: Record<string, unknown>) => {
+    lastCanonicalGuardianCreateParams = params;
+    return { requestCode: 'mock-code-0000', status: 'pending' };
+  },
   submitCanonicalRequest: () => ({ requestCode: 'mock-code-0000', status: 'pending' }),
   getCanonicalRequest: () => null,
   resolveCanonicalRequest: () => false,
@@ -342,6 +346,7 @@ describe('DaemonServer initial session hydration', () => {
     lastCreatedWorkingDir = undefined;
     lastCreatedMemoryPolicy = undefined;
     lastCreateConversationArgs = undefined;
+    lastCanonicalGuardianCreateParams = undefined;
     mockConfirmationToEmitDuringLoop = undefined;
     mockMidLoopCallback = undefined;
     pendingInteractions.clear();
@@ -684,6 +689,54 @@ describe('DaemonServer initial session hydration', () => {
     expect(interaction).toBeDefined();
     expect(interaction?.kind).toBe('confirmation');
     expect(interaction?.conversationId).toBe(conversation.id);
+  });
+
+  test('confirmation_request canonical records include bound guardian identity context', async () => {
+    const server = new DaemonServer();
+
+    mockConfirmationToEmitDuringLoop = {
+      type: 'confirmation_request',
+      requestId: 'req-bound-1',
+      toolName: 'host_bash',
+      input: { command: 'ls' },
+      riskLevel: 'high',
+      allowlistOptions: [{ label: 'host_bash:*', description: 'host_bash:*', pattern: 'host_bash:*' }],
+      scopeOptions: [{ label: 'everywhere', scope: 'everywhere' }],
+      persistentDecisionsAllowed: true,
+    };
+
+    await server.processMessage(
+      conversation.id,
+      'run ls',
+      undefined,
+      {
+        isInteractive: false,
+        guardianContext: {
+          sourceChannel: 'telegram',
+          trustClass: 'trusted_contact',
+          guardianExternalUserId: 'guardian-123',
+          requesterExternalUserId: 'trusted-456',
+          requesterChatId: 'chat-789',
+        },
+      },
+      'telegram',
+      'telegram',
+    );
+
+    expect(lastCanonicalGuardianCreateParams).toBeDefined();
+    expect(lastCanonicalGuardianCreateParams).toMatchObject({
+      id: 'req-bound-1',
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      conversationId: conversation.id,
+      guardianExternalUserId: 'guardian-123',
+      requesterExternalUserId: 'trusted-456',
+      requesterChatId: 'chat-789',
+      toolName: 'host_bash',
+      status: 'pending',
+      requestCode: 'mock-code-0000',
+    });
   });
 
   test('finally block does not overwrite IPC client that connected during interactive agent loop (processMessage)', async () => {

--- a/assistant/src/__tests__/guardian-decision-primitive-canonical.test.ts
+++ b/assistant/src/__tests__/guardian-decision-primitive-canonical.test.ts
@@ -248,7 +248,7 @@ describe('applyCanonicalGuardianDecision', () => {
     expect(result.grantMinted).toBe(false);
   });
 
-  test('allows decision when request has no guardian binding', async () => {
+  test('rejects non-trusted decision when tool approval has no guardian binding', async () => {
     const req = createCanonicalGuardianRequest({
       kind: 'tool_approval',
       sourceType: 'channel',
@@ -263,7 +263,9 @@ describe('applyCanonicalGuardianDecision', () => {
       actorContext: guardianActor({ externalUserId: 'anyone' }),
     });
 
-    expect(result.applied).toBe(true);
+    expect(result.applied).toBe(false);
+    if (result.applied) return;
+    expect(result.reason).toBe('identity_mismatch');
   });
 
   // ── Stale / already-resolved (race condition) ──────────────────────

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -761,6 +761,45 @@ describe('routing invariant: disambiguation stays fail-closed', () => {
     const resolved = getCanonicalGuardianRequest(req.id);
     expect(resolved!.status).toBe('approved');
   });
+
+  test('code-based routing is constrained to caller-provided pendingRequestIds scope', async () => {
+    const inScope = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      requestCode: '111AAA',
+      toolName: 'shell',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    const outOfScope = createCanonicalGuardianRequest({
+      kind: 'tool_approval',
+      sourceType: 'channel',
+      conversationId: 'conv-2',
+      guardianExternalUserId: 'guardian-1',
+      requestCode: '222BBB',
+      toolName: 'shell',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    registerPendingToolApprovalInteraction(inScope.id, 'conv-1', 'shell');
+    registerPendingToolApprovalInteraction(outOfScope.id, 'conv-2', 'shell');
+
+    const result = await routeGuardianReply(replyCtx({
+      messageText: '222BBB approve',
+      conversationId: 'conv-guardian-thread',
+      pendingRequestIds: [inScope.id],
+      approvalConversationGenerator: undefined,
+    }));
+
+    expect(result.consumed).toBe(false);
+    expect(result.type).toBe('not_consumed');
+    expect(result.decisionApplied).toBe(false);
+
+    const inScopeAfter = getCanonicalGuardianRequest(inScope.id);
+    const outOfScopeAfter = getCanonicalGuardianRequest(outOfScope.id);
+    expect(inScopeAfter!.status).toBe('pending');
+    expect(outOfScopeAfter!.status).toBe('pending');
+  });
 });
 
 // ===========================================================================

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -271,7 +271,7 @@ describe('routing invariant: identity checks enforced before decisions', () => {
     expect(result.applied).toBe(true);
   });
 
-  test('request with no guardian binding accepts any actor', async () => {
+  test('request with no guardian binding rejects non-trusted actor', async () => {
     const req = createCanonicalGuardianRequest({
       kind: 'tool_approval',
       sourceType: 'channel',
@@ -286,7 +286,9 @@ describe('routing invariant: identity checks enforced before decisions', () => {
       actorContext: guardianActor({ externalUserId: 'anyone' }),
     });
 
-    expect(result.applied).toBe(true);
+    expect(result.applied).toBe(false);
+    if (result.applied) return;
+    expect(result.reason).toBe('identity_mismatch');
   });
 
   test('identity mismatch on code-only message blocks detail leakage', async () => {
@@ -907,14 +909,14 @@ describe('routing invariant: callback buttons route through canonical primitive'
 });
 
 // ===========================================================================
-// SECTION 9: Destination hint-based NL approval for missing guardianExternalUserId
+// SECTION 9: Destination hints do not bypass identity binding for tool_approval
 // ===========================================================================
 
-describe('routing invariant: destination hints enable NL approval without guardianExternalUserId', () => {
+describe('routing invariant: destination hints do not bypass tool_approval identity binding', () => {
   beforeEach(() => resetTables());
 
-  test('explicit pendingRequestIds from destination hints allows deterministic plain-text approval when guardianExternalUserId is missing', async () => {
-    // Voice-originated pending_question: no guardianExternalUserId
+  test('explicit pendingRequestIds still fail closed when guardianExternalUserId is missing', async () => {
+    // Voice-originated tool approval with missing guardian identity binding.
     const req = createCanonicalGuardianRequest({
       kind: 'tool_approval',
       sourceType: 'voice',
@@ -939,11 +941,11 @@ describe('routing invariant: destination hints enable NL approval without guardi
     }));
 
     expect(result.consumed).toBe(true);
-    expect(result.type).toBe('canonical_decision_applied');
-    expect(result.decisionApplied).toBe(true);
+    expect(result.type).toBe('canonical_decision_stale');
+    expect(result.decisionApplied).toBe(false);
 
     const resolved = getCanonicalGuardianRequest(req.id);
-    expect(resolved!.status).toBe('approved');
+    expect(resolved!.status).toBe('pending');
   });
 
   test('without destination hints, missing guardianExternalUserId means no pending requests found', async () => {

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -349,7 +349,28 @@ export async function applyCanonicalGuardianDecision(
   }
 
   // 2c. Validate identity: actor must match guardian_external_user_id
-  // unless the actor is trusted (desktop) or the request has no guardian binding.
+  // unless the actor is trusted (desktop).
+  //
+  // Channel tool-approval requests must always be identity-bound. Treat
+  // missing guardianExternalUserId as unauthorized (fail-closed) so a
+  // non-guardian actor can never approve an unbound request.
+  if (
+    !actorContext.isTrusted &&
+    request.kind === 'tool_approval' &&
+    !request.guardianExternalUserId
+  ) {
+    log.warn(
+      {
+        event: 'canonical_decision_missing_guardian_binding',
+        requestId,
+        kind: request.kind,
+        sourceType: request.sourceType,
+      },
+      'Canonical tool approval missing guardian binding; rejecting decision',
+    );
+    return { applied: false, reason: 'identity_mismatch', detail: 'missing guardian binding' };
+  }
+
   if (
     request.guardianExternalUserId &&
     !actorContext.isTrusted &&

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -93,6 +93,16 @@ function resolveTurnInterface(sourceInterface?: string): InterfaceId {
   return 'vellum';
 }
 
+function resolveCanonicalRequestSourceType(sourceChannel: string | undefined): 'desktop' | 'channel' | 'voice' {
+  if (sourceChannel === 'voice') {
+    return 'voice';
+  }
+  if (sourceChannel === 'vellum') {
+    return 'desktop';
+  }
+  return 'channel';
+}
+
 /**
  * Build an onEvent callback that registers pending interactions when the agent
  * loop emits confirmation_request or secret_request events. This ensures that
@@ -121,12 +131,17 @@ function makePendingInteractionRegistrar(
 
       // Create a canonical guardian request so IPC/HTTP handlers can find it
       // via applyCanonicalGuardianDecision.
+      const guardianContext = session.guardianContext;
+      const sourceChannel = guardianContext?.sourceChannel ?? 'vellum';
       createCanonicalGuardianRequest({
         id: msg.requestId,
         kind: 'tool_approval',
-        sourceType: 'desktop',
-        sourceChannel: 'vellum',
+        sourceType: resolveCanonicalRequestSourceType(sourceChannel),
+        sourceChannel,
         conversationId,
+        requesterExternalUserId: guardianContext?.requesterExternalUserId,
+        requesterChatId: guardianContext?.requesterChatId,
+        guardianExternalUserId: guardianContext?.guardianExternalUserId,
         toolName: msg.toolName,
         status: 'pending',
         requestCode: generateCanonicalRequestCode(),

--- a/assistant/src/runtime/guardian-context-resolver.ts
+++ b/assistant/src/runtime/guardian-context-resolver.ts
@@ -7,6 +7,7 @@
  */
 import type { ChannelId } from '../channels/types.js';
 import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
+import { canonicalizeInboundIdentity } from '../util/canonicalize-identity.js';
 import {
   type DenialReason,
   resolveActorTrust,
@@ -41,11 +42,14 @@ export type ResolveGuardianContextInput = ResolveActorTrustInput;
  */
 export function resolveGuardianContext(input: ResolveGuardianContextInput): GuardianContext {
   const trust = resolveActorTrust(input);
+  const canonicalGuardianExternalUserId = trust.guardianBindingMatch?.guardianExternalUserId
+    ? canonicalizeInboundIdentity(input.sourceChannel, trust.guardianBindingMatch.guardianExternalUserId) ?? undefined
+    : undefined;
   return {
     trustClass: trust.trustClass,
     guardianChatId: trust.guardianBindingMatch?.guardianDeliveryChatId ??
       (trust.trustClass === 'guardian' ? input.externalChatId : undefined),
-    guardianExternalUserId: trust.guardianBindingMatch?.guardianExternalUserId,
+    guardianExternalUserId: canonicalGuardianExternalUserId,
     requesterIdentifier: trust.actorMetadata.identifier,
     requesterDisplayName: trust.actorMetadata.displayName,
     requesterSenderDisplayName: trust.actorMetadata.senderDisplayName,

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -237,6 +237,7 @@ export async function routeGuardianReply(
 ): Promise<GuardianReplyResult> {
   const { messageText, actor, conversationId, callbackData, approvalConversationGenerator, channelDeliveryContext } = ctx;
   const pendingRequests = findPendingCanonicalRequests(actor, ctx.pendingRequestIds, conversationId);
+  const scopedPendingRequestIds = ctx.pendingRequestIds ? new Set(ctx.pendingRequestIds) : null;
 
   // ── 1. Deterministic callback parsing (button presses) ──
   // No conversationId scoping here — the guardian's reply comes from a
@@ -257,6 +258,17 @@ export async function routeGuardianReply(
     const codeResult = parseRequestCode(messageText);
     if (codeResult) {
       const { request } = codeResult;
+      if (scopedPendingRequestIds && !scopedPendingRequestIds.has(request.id)) {
+        log.info(
+          {
+            event: 'router_code_out_of_scope',
+            requestId: request.id,
+            pendingHintCount: scopedPendingRequestIds.size,
+          },
+          'Request code matched a pending request outside the caller-provided scope; ignoring',
+        );
+        return notConsumed();
+      }
 
       if (request.status !== 'pending') {
         log.info(

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -176,6 +176,16 @@ async function tryConsumeInlineApprovalReply(params: {
   return { consumed: true, messageId };
 }
 
+function resolveCanonicalRequestSourceType(sourceChannel: string | undefined): 'desktop' | 'channel' | 'voice' {
+  if (sourceChannel === 'voice') {
+    return 'voice';
+  }
+  if (sourceChannel === 'vellum') {
+    return 'desktop';
+  }
+  return 'channel';
+}
+
 function getInterfaceFilesWithMtimes(interfacesDir: string | null): Array<{ path: string; mtimeMs: number }> {
   if (!interfacesDir || !existsSync(interfacesDir)) return [];
   const results: Array<{ path: string; mtimeMs: number }> = [];
@@ -319,12 +329,17 @@ function makeHubPublisher(
 
       // Create a canonical guardian request so IPC/HTTP handlers can find it
       // via applyCanonicalGuardianDecision.
+      const guardianContext = session.guardianContext;
+      const sourceChannel = guardianContext?.sourceChannel ?? 'vellum';
       createCanonicalGuardianRequest({
         id: msg.requestId,
         kind: 'tool_approval',
-        sourceType: 'desktop',
-        sourceChannel: 'vellum',
+        sourceType: resolveCanonicalRequestSourceType(sourceChannel),
+        sourceChannel,
         conversationId,
+        requesterExternalUserId: guardianContext?.requesterExternalUserId,
+        requesterChatId: guardianContext?.requesterChatId,
+        guardianExternalUserId: guardianContext?.guardianExternalUserId,
         toolName: msg.toolName,
         status: 'pending',
         requestCode: generateCanonicalRequestCode(),

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1401,6 +1401,8 @@ function startPendingApprovalPromptWatcher(params: {
   sourceChannel: ChannelId;
   externalChatId: string;
   guardianTrustClass: GuardianContext['trustClass'];
+  guardianExternalUserId?: string;
+  requesterExternalUserId?: string;
   replyCallbackUrl: string;
   bearerToken?: string;
   assistantId?: string;
@@ -1411,6 +1413,8 @@ function startPendingApprovalPromptWatcher(params: {
     sourceChannel,
     externalChatId,
     guardianTrustClass,
+    guardianExternalUserId,
+    requesterExternalUserId,
     replyCallbackUrl,
     bearerToken,
     assistantId,
@@ -1419,7 +1423,12 @@ function startPendingApprovalPromptWatcher(params: {
 
   // Approval prompt delivery is guardian-only. Non-guardian and unverified
   // actors must never receive approval prompt broadcasts for the conversation.
-  if (guardianTrustClass !== 'guardian') {
+  // We also require an explicit identity match against the bound guardian to
+  // avoid broadcasting prompts when trustClass is stale/mis-scoped.
+  const isBoundGuardianActor = guardianTrustClass === 'guardian'
+    && !!guardianExternalUserId
+    && requesterExternalUserId === guardianExternalUserId;
+  if (!isBoundGuardianActor) {
     return () => {};
   }
 
@@ -1502,6 +1511,8 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
         sourceChannel,
         externalChatId,
         guardianTrustClass: guardianCtx.trustClass,
+        guardianExternalUserId: guardianCtx.guardianExternalUserId,
+        requesterExternalUserId: guardianCtx.requesterExternalUserId,
         replyCallbackUrl,
         bearerToken,
         assistantId,


### PR DESCRIPTION
## Summary
- bind canonical `tool_approval` requests to session guardian context (`guardianExternalUserId`, requester identity/chat, and source channel/type) when confirmation events are registered
- fail closed in the canonical decision primitive for non-trusted `tool_approval` decisions when guardian identity binding is missing
- tighten channel approval prompt watcher gating so prompts are only broadcast when the sender identity matches the bound guardian identity
- update regression tests to lock the new invariant and add coverage for canonical request identity binding in daemon event registration

## Testing
- `cd assistant && bun test src/__tests__/guardian-decision-primitive-canonical.test.ts`
- `cd assistant && bun test src/__tests__/guardian-routing-invariants.test.ts`
- `cd assistant && bun test src/__tests__/daemon-server-session-init.test.ts`
- `cd assistant && bun test src/__tests__/channel-approval-routes.test.ts`
- `cd assistant && bunx tsc --noEmit`