### PR TITLE
perf: generate conversation title on user message instead of after response

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -12,7 +12,7 @@ import {
 } from '../../memory/canonical-guardian-store.js';
 import { getAttentionStateByConversationIds } from '../../memory/conversation-attention-store.js';
 import * as conversationStore from '../../memory/conversation-store.js';
-import { GENERATING_TITLE, queueGenerateConversationTitle, UNTITLED_FALLBACK } from '../../memory/conversation-title-service.js';
+import { GENERATING_TITLE, UNTITLED_FALLBACK } from '../../memory/conversation-title-service.js';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
 import { routeGuardianReply } from '../../runtime/guardian-reply-router.js';
 import * as pendingInteractions from '../../runtime/pending-interactions.js';
@@ -780,25 +780,8 @@ export async function handleSessionCreate(
 
   // Auto-send the initial message if provided, kick-starting the skill.
   if (msg.initialMessage) {
-    // Queue title generation immediately (matches all other creation paths).
-    // The agent loop success path will also attempt title generation, but
-    // queueGenerateConversationTitle is safe to call redundantly — the
-    // replaceability check prevents double-writes. This ensures the title
-    // is generated even if the agent loop fails or is cancelled.
-    if (title === GENERATING_TITLE) {
-      queueGenerateConversationTitle({
-        conversationId: conversation.id,
-        context: { origin: 'ipc' },
-        userMessage: msg.initialMessage,
-        onTitleUpdated: (newTitle) => {
-          ctx.send(socket, {
-            type: 'session_title_updated',
-            sessionId: conversation.id,
-            title: newTitle,
-          });
-        },
-      });
-    }
+    // Title generation is handled early in the agent loop (before the main
+    // LLM call), so no need to duplicate it here.
 
     ctx.socketToSession.set(socket, conversation.id);
     const sendEvent = (event: ServerMessage) => ctx.send(socket, event);

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -12,7 +12,7 @@ import {
 } from '../../memory/canonical-guardian-store.js';
 import { getAttentionStateByConversationIds } from '../../memory/conversation-attention-store.js';
 import * as conversationStore from '../../memory/conversation-store.js';
-import { GENERATING_TITLE, UNTITLED_FALLBACK } from '../../memory/conversation-title-service.js';
+import { GENERATING_TITLE, queueGenerateConversationTitle, UNTITLED_FALLBACK } from '../../memory/conversation-title-service.js';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
 import { routeGuardianReply } from '../../runtime/guardian-reply-router.js';
 import * as pendingInteractions from '../../runtime/pending-interactions.js';
@@ -780,8 +780,25 @@ export async function handleSessionCreate(
 
   // Auto-send the initial message if provided, kick-starting the skill.
   if (msg.initialMessage) {
-    // Title generation is handled early in the agent loop (before the main
-    // LLM call), so no need to duplicate it here.
+    // Queue title generation eagerly — some processMessage paths (guardian
+    // replies, unknown slash commands) bypass the agent loop entirely, so
+    // we can't rely on the agent loop's early title generation alone.
+    // The agent loop also queues title generation, but isReplaceableTitle
+    // prevents double-writes since the first to complete sets a real title.
+    if (title === GENERATING_TITLE) {
+      queueGenerateConversationTitle({
+        conversationId: conversation.id,
+        context: { origin: 'ipc' },
+        userMessage: msg.initialMessage,
+        onTitleUpdated: (newTitle) => {
+          ctx.send(socket, {
+            type: 'session_title_updated',
+            sessionId: conversation.id,
+            title: newTitle,
+          });
+        },
+      });
+    }
 
     ctx.socketToSession.set(socket, conversation.id);
     const sendEvent = (event: ServerMessage) => ctx.send(socket, event);

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -20,7 +20,7 @@ import { commitAppTurnChanges } from '../memory/app-git-service.js';
 import { getApp, listAppFiles } from '../memory/app-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { getConversationOriginChannel, getConversationOriginInterface, provenanceFromGuardianContext } from '../memory/conversation-store.js';
-import { isReplaceableTitle, queueGenerateConversationTitle, queueRegenerateConversationTitle } from '../memory/conversation-title-service.js';
+import { GENERATING_TITLE, isReplaceableTitle, queueGenerateConversationTitle, queueRegenerateConversationTitle, UNTITLED_FALLBACK } from '../memory/conversation-title-service.js';
 import { stripMemoryRecallMessages } from '../memory/retriever.js';
 import type { PermissionPrompter } from '../permissions/prompter.js';
 import type { ContentBlock,Message } from '../providers/types.js';
@@ -210,6 +210,12 @@ export async function runAgentLoopImpl(
       if (!options?.skipPreMessageRollback) {
         ctx.messages.pop();
         conversationStore.deleteMessageById(userMessageId);
+      }
+      // Replace loading placeholder so the thread isn't stuck as "Generating title..."
+      const blockedConv = conversationStore.getConversation(ctx.conversationId);
+      if (blockedConv?.title === GENERATING_TITLE) {
+        conversationStore.updateConversationTitle(ctx.conversationId, UNTITLED_FALLBACK, 1);
+        onEvent({ type: 'session_title_updated', sessionId: ctx.conversationId, title: UNTITLED_FALLBACK });
       }
       onEvent({ type: 'error', message: `Message blocked by hook "${preMessageResult.blockedBy}"` });
       return;

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -216,24 +216,28 @@ export async function runAgentLoopImpl(
     }
 
     // Generate title early — the user message alone is sufficient context.
-    // Firing here (after hook gating but before the LLM call) removes the
+    // Firing after hook gating but before the main LLM call removes the
     // delay of waiting for the full assistant response. The second-pass
     // regeneration at turn 3 will refine the title with more context.
+    // Deferred via setTimeout so the main agent loop LLM call is queued
+    // first, avoiding rate-limit slot contention.
     const currentConvForTitle = conversationStore.getConversation(ctx.conversationId);
     if (isReplaceableTitle(currentConvForTitle?.title ?? null)) {
-      queueGenerateConversationTitle({
-        conversationId: ctx.conversationId,
-        provider: ctx.provider,
-        userMessage: options?.titleText ?? content,
-        onTitleUpdated: (title) => {
-          onEvent({
-            type: 'session_title_updated',
-            sessionId: ctx.conversationId,
-            title,
-          });
-        },
-        signal: abortController.signal,
-      });
+      setTimeout(() => {
+        queueGenerateConversationTitle({
+          conversationId: ctx.conversationId,
+          provider: ctx.provider,
+          userMessage: options?.titleText ?? content,
+          onTitleUpdated: (title) => {
+            onEvent({
+              type: 'session_title_updated',
+              sessionId: ctx.conversationId,
+              title,
+            });
+          },
+          signal: abortController.signal,
+        });
+      }, 0);
     }
 
     const isFirstMessage = ctx.messages.length === 1;

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -200,6 +200,26 @@ export async function runAgentLoopImpl(
   ctx.profiler.startRequest();
   let turnStarted = false;
 
+  // Generate title early — the user message alone is sufficient context.
+  // Firing here (before the LLM call) removes the delay of waiting for the
+  // full assistant response. The second-pass regeneration at turn 3 will
+  // refine the title with more context if needed.
+  const currentConvForTitle = conversationStore.getConversation(ctx.conversationId);
+  if (isReplaceableTitle(currentConvForTitle?.title ?? null)) {
+    queueGenerateConversationTitle({
+      conversationId: ctx.conversationId,
+      provider: ctx.provider,
+      userMessage: options?.titleText ?? content,
+      onTitleUpdated: (title) => {
+        onEvent({
+          type: 'session_title_updated',
+          sessionId: ctx.conversationId,
+          title,
+        });
+      },
+    });
+  }
+
   try {
     const preMessageResult = await getHookManager().trigger('pre-message', {
       sessionId: ctx.conversationId,
@@ -718,27 +738,6 @@ export async function runAgentLoopImpl(
         type: 'message_complete',
         sessionId: ctx.conversationId,
         ...(emittedAttachments.length > 0 ? { attachments: emittedAttachments } : {}),
-      });
-    }
-
-    // Generate title if the current conversation title is still a replaceable
-    // placeholder. This replaces the previous `isFirstMessage` gate so that
-    // assistant-seeded/system-seeded threads also receive generated titles.
-    const currentConv = conversationStore.getConversation(ctx.conversationId);
-    if (isReplaceableTitle(currentConv?.title ?? null)) {
-      queueGenerateConversationTitle({
-        conversationId: ctx.conversationId,
-        provider: ctx.provider,
-        userMessage: options?.titleText ?? content,
-        assistantResponse: state.firstAssistantText || undefined,
-        onTitleUpdated: (title) => {
-          onEvent({
-            type: 'session_title_updated',
-            sessionId: ctx.conversationId,
-            title,
-          });
-        },
-        signal: abortController.signal,
       });
     }
 

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -226,7 +226,9 @@ export async function runAgentLoopImpl(
     // delay of waiting for the full assistant response. The second-pass
     // regeneration at turn 3 will refine the title with more context.
     // Deferred via setTimeout so the main agent loop LLM call is queued
-    // first, avoiding rate-limit slot contention.
+    // first, avoiding rate-limit slot contention. No abort signal — title
+    // generation should complete even if the user cancels the response,
+    // since the user message is already persisted.
     const currentConvForTitle = conversationStore.getConversation(ctx.conversationId);
     if (isReplaceableTitle(currentConvForTitle?.title ?? null)) {
       setTimeout(() => {
@@ -241,7 +243,6 @@ export async function runAgentLoopImpl(
               title,
             });
           },
-          signal: abortController.signal,
         });
       }, 0);
     }

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -200,26 +200,6 @@ export async function runAgentLoopImpl(
   ctx.profiler.startRequest();
   let turnStarted = false;
 
-  // Generate title early — the user message alone is sufficient context.
-  // Firing here (before the LLM call) removes the delay of waiting for the
-  // full assistant response. The second-pass regeneration at turn 3 will
-  // refine the title with more context if needed.
-  const currentConvForTitle = conversationStore.getConversation(ctx.conversationId);
-  if (isReplaceableTitle(currentConvForTitle?.title ?? null)) {
-    queueGenerateConversationTitle({
-      conversationId: ctx.conversationId,
-      provider: ctx.provider,
-      userMessage: options?.titleText ?? content,
-      onTitleUpdated: (title) => {
-        onEvent({
-          type: 'session_title_updated',
-          sessionId: ctx.conversationId,
-          title,
-        });
-      },
-    });
-  }
-
   try {
     const preMessageResult = await getHookManager().trigger('pre-message', {
       sessionId: ctx.conversationId,
@@ -233,6 +213,27 @@ export async function runAgentLoopImpl(
       }
       onEvent({ type: 'error', message: `Message blocked by hook "${preMessageResult.blockedBy}"` });
       return;
+    }
+
+    // Generate title early — the user message alone is sufficient context.
+    // Firing here (after hook gating but before the LLM call) removes the
+    // delay of waiting for the full assistant response. The second-pass
+    // regeneration at turn 3 will refine the title with more context.
+    const currentConvForTitle = conversationStore.getConversation(ctx.conversationId);
+    if (isReplaceableTitle(currentConvForTitle?.title ?? null)) {
+      queueGenerateConversationTitle({
+        conversationId: ctx.conversationId,
+        provider: ctx.provider,
+        userMessage: options?.titleText ?? content,
+        onTitleUpdated: (title) => {
+          onEvent({
+            type: 'session_title_updated',
+            sessionId: ctx.conversationId,
+            title,
+          });
+        },
+        signal: abortController.signal,
+      });
     }
 
     const isFirstMessage = ctx.messages.length === 1;


### PR DESCRIPTION
## Summary
- Moved title generation from after the full assistant response to immediately when the user message arrives
- Title LLM call now runs in parallel with the main assistant response (~2s), so the sidebar title appears while the assistant is still streaming
- The second-pass title regeneration at turn 3 still refines the title with more context

## Test plan
- [x] Verified title generation takes ~1.9s via instrumented logging
- [ ] Send a message in a new thread — title should appear in sidebar while assistant is still responding
- [ ] Verify second-pass regeneration still works at turn 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
