### PR TITLE
gateway: forward to assistant-less daemon endpoints

### DIFF
--- a/gateway/src/__tests__/runtime-client.test.ts
+++ b/gateway/src/__tests__/runtime-client.test.ts
@@ -111,7 +111,7 @@ describe("forwardToRuntime", () => {
     );
 
     const config = makeConfig();
-    const result = await forwardToRuntime(config, "assistant-a", payload);
+    const result = await forwardToRuntime(config, payload);
     expect(result.accepted).toBe(true);
     expect(result.eventId).toBe("evt-1");
     expect(result.assistantMessage?.content).toBe("Hi there!");
@@ -124,7 +124,7 @@ describe("forwardToRuntime", () => {
 
     const config = makeConfig();
     await expect(
-      forwardToRuntime(config, "assistant-a", payload),
+      forwardToRuntime(config, payload),
     ).rejects.toThrow("Runtime returned 400");
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -132,7 +132,7 @@ describe("forwardToRuntime", () => {
 
   test("5xx error retries and eventually succeeds", async () => {
     const config = makeConfig();
-    const expectedUrl = `${config.assistantRuntimeBaseUrl}/v1/assistants/assistant-a/channels/inbound`;
+    const expectedUrl = `${config.assistantRuntimeBaseUrl}/v1/channels/inbound`;
     let inboundCallCount = 0;
     fetchMock = mock(async (input) => {
       const calledUrl =
@@ -151,7 +151,7 @@ describe("forwardToRuntime", () => {
       return new Response(JSON.stringify(successBody), { status: 200 });
     });
 
-    const result = await forwardToRuntime(config, "assistant-a", payload);
+    const result = await forwardToRuntime(config, payload);
     expect(result.accepted).toBe(true);
     const callsToInboundRoute = fetchMock.mock.calls.filter((call) => {
       const calledUrl = call[0];
@@ -167,7 +167,7 @@ describe("forwardToRuntime", () => {
 
     const config = makeConfig();
     await expect(
-      forwardToRuntime(config, "assistant-a", payload),
+      forwardToRuntime(config, payload),
     ).rejects.toThrow("Runtime returned 500");
   });
 
@@ -177,7 +177,7 @@ describe("forwardToRuntime", () => {
     );
 
     const config = makeConfig();
-    const result = await forwardToRuntime(config, "assistant-a", payload);
+    const result = await forwardToRuntime(config, payload);
     const attachments = result.assistantMessage?.attachments ?? [];
     expect(attachments).toHaveLength(1);
     expect(attachments[0].id).toBe("att-1");
@@ -193,7 +193,7 @@ describe("forwardToRuntime", () => {
     );
 
     const config = makeConfig({ runtimeBearerToken: "my-secret-token" });
-    await forwardToRuntime(config, "assistant-a", payload);
+    await forwardToRuntime(config, payload);
 
     const calledInit = (fetchMock.mock.calls[0] as unknown[])[1] as RequestInit;
     const headers = calledInit.headers as Record<string, string>;
@@ -206,7 +206,7 @@ describe("forwardToRuntime", () => {
     );
 
     const config = makeConfig();
-    await forwardToRuntime(config, "assistant-a", payload);
+    await forwardToRuntime(config, payload);
 
     const calledInit = (fetchMock.mock.calls[0] as unknown[])[1] as RequestInit;
     const headers = calledInit.headers as Record<string, string>;
@@ -234,7 +234,7 @@ describe("downloadAttachment", () => {
     );
 
     const config = makeConfig();
-    const result = await downloadAttachment(config, "assistant-a", "att-1");
+    const result = await downloadAttachment(config, "att-1");
     expect(result.id).toBe("att-1");
     expect(result.filename).toBe("chart.png");
     expect(result.data).toBe("iVBORw0KGgo=");
@@ -250,7 +250,7 @@ describe("downloadAttachment", () => {
 
     const config = makeConfig();
     await expect(
-      downloadAttachment(config, "assistant-a", "nonexistent"),
+      downloadAttachment(config, "nonexistent"),
     ).rejects.toThrow("Attachment download failed (404)");
   });
 });

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -68,7 +68,7 @@ afterEach(() => {
 });
 
 describe("runtime proxy handler", () => {
-  test("rewrites /v1/assistants/:assistantId/... to /v1/... for upstream", async () => {
+  test("rewrites legacy /v1/assistants/:assistantId/... to flat /v1/... for upstream", async () => {
     const captured: { url: string }[] = [];
     fetchMock = mock(async (input: string | URL | Request) => {
       captured.push({ url: String(input) });
@@ -82,7 +82,7 @@ describe("runtime proxy handler", () => {
     expect(captured[0].url).toBe("http://localhost:7821/v1/channels/inbound");
   });
 
-  test("forwards request to upstream with correct path and query (assistant-scoped rewrite)", async () => {
+  test("forwards request to upstream with correct path and query (legacy assistant-scoped rewrite)", async () => {
     const captured: { url: string; method: string }[] = [];
     fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
       captured.push({ url: String(input), method: init?.method ?? "GET" });
@@ -97,7 +97,7 @@ describe("runtime proxy handler", () => {
     const res = await handler(req);
 
     expect(res.status).toBe(200);
-    // /v1/assistants/test/health is rewritten to /v1/health
+    // Legacy /v1/assistants/test/health is rewritten to /v1/health
     expect(captured[0].url).toBe("http://localhost:7821/v1/health?foo=bar");
     expect(captured[0].method).toBe("GET");
     const body = await res.json();

--- a/gateway/src/__tests__/telegram-deliver-auth.test.ts
+++ b/gateway/src/__tests__/telegram-deliver-auth.test.ts
@@ -133,12 +133,12 @@ describe("/deliver/telegram attachment delivery without assistantId", () => {
     expect(telegramCall).toBeDefined();
   });
 
-  test("delivers attachments with assistantId using legacy download path", async () => {
+  test("delivers attachments with assistantId using flat download path", async () => {
     const calls: string[] = [];
     fetchMock = mock(async (input: string | URL | Request) => {
       const urlStr = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(urlStr);
-      // Runtime attachment download (legacy path)
+      // Runtime attachment download (flat path)
       if (urlStr.includes("/attachments/att-2")) {
         return new Response(
           JSON.stringify({
@@ -177,10 +177,10 @@ describe("/deliver/telegram attachment delivery without assistantId", () => {
     const body = await res.json();
     expect(body.ok).toBe(true);
 
-    // Should have downloaded via legacy /v1/assistants/my-assistant/attachments/att-2
+    // Should have downloaded via flat /v1/attachments/att-2 (assistantId is ignored)
     const downloadCall = calls.find((u) => u.includes("/attachments/att-2"));
     expect(downloadCall).toBeDefined();
-    expect(downloadCall).toContain("/assistants/my-assistant/");
+    expect(downloadCall).not.toContain("/assistants/");
   });
 });
 

--- a/gateway/src/__tests__/telegram-send-attachments.test.ts
+++ b/gateway/src/__tests__/telegram-send-attachments.test.ts
@@ -103,7 +103,7 @@ describe("sendTelegramAttachments", () => {
       kind: "generated_image",
     };
 
-    await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta]);
 
     // Should have called: 1) runtime download, 2) telegram sendPhoto
     expect(calls).toHaveLength(2);
@@ -141,7 +141,7 @@ describe("sendTelegramAttachments", () => {
       kind: "filesystem",
     };
 
-    await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta]);
 
     expect(calls).toHaveLength(2);
     expect(calls[0]).toContain("/attachments/att-2");
@@ -166,14 +166,14 @@ describe("sendTelegramAttachments", () => {
       kind: "filesystem",
     };
 
-    await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta]);
 
     // Should have sent only the failure notice via sendMessage
     expect(calls).toHaveLength(1);
     expect(calls[0]).toContain("sendMessage");
   });
 
-  test("downloads via assistant-less path when assistantId is undefined", async () => {
+  test("downloads via flat /v1/attachments/ path", async () => {
     const calls: string[] = [];
 
     fetchMock = mock(async (input: string | URL | Request) => {
@@ -203,7 +203,7 @@ describe("sendTelegramAttachments", () => {
       kind: "generated_image",
     };
 
-    await sendTelegramAttachments(config, "chat-1", undefined, [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta]);
 
     expect(calls).toHaveLength(2);
     // Should use /v1/attachments/ path (no assistantId in URL)
@@ -238,7 +238,7 @@ describe("sendTelegramAttachments", () => {
     // Only provide `id` — no filename, mimeType, sizeBytes, or kind
     const meta: RuntimeAttachmentMeta = { id: "att-id-only" };
 
-    await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta]);
 
     expect(calls).toHaveLength(2);
     expect(calls[0]).toContain("/attachments/att-id-only");
@@ -266,7 +266,7 @@ describe("sendTelegramAttachments", () => {
     const config = makeConfig();
     const meta: RuntimeAttachmentMeta = { id: "att-bare" };
 
-    await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta]);
 
     expect(calls).toHaveLength(2);
     expect(calls[0]).toContain("/attachments/att-bare");
@@ -299,7 +299,7 @@ describe("sendTelegramAttachments", () => {
     // No sizeBytes in meta — will be hydrated from download payload (200 > 50 limit)
     const meta: RuntimeAttachmentMeta = { id: "att-big" };
 
-    await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta]);
 
     // Should download, discover size exceeds limit, skip, then send failure notice
     expect(calls.filter((u) => u.includes("/attachments/att-big"))).toHaveLength(1);
@@ -330,7 +330,7 @@ describe("sendTelegramAttachments", () => {
     const config = makeConfig();
     const meta: RuntimeAttachmentMeta = { id: "my-attachment-id" };
 
-    await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta]);
 
     expect(calls).toHaveLength(2);
     // Second call is the Telegram API call with FormData
@@ -368,7 +368,7 @@ describe("sendTelegramAttachments", () => {
       kind: "generated_image",
     };
 
-    await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta]);
 
     expect(calls).toHaveLength(2);
     expect(calls[0]).toContain("/attachments/att-full");
@@ -407,7 +407,7 @@ describe("sendTelegramAttachments", () => {
       { id: "att-ok", filename: "good.png", mimeType: "image/png", sizeBytes: 50, kind: "generated_image" },
     ];
 
-    await sendTelegramAttachments(config, "chat-1", "assistant-a", attachments);
+    await sendTelegramAttachments(config, "chat-1", attachments);
 
     // Should have: download att-fail (fail), download att-ok, sendPhoto for att-ok, sendMessage for notice
     expect(calls.filter((u) => u.includes("sendPhoto"))).toHaveLength(1);

--- a/gateway/src/__tests__/telegram-webhook-handler.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-handler.test.ts
@@ -135,7 +135,7 @@ function installFetchMock() {
     fetchCalls.push({ url, method, body, headers });
 
     // Runtime inbound endpoint
-    if (url.includes("/v1/assistants/") && url.includes("/inbound")) {
+    if (url.includes("/v1/channels/inbound")) {
       return new Response(JSON.stringify({ eventId: "evt-1", duplicate: false }), {
         status: 200,
         headers: { "content-type": "application/json" },
@@ -347,7 +347,7 @@ describe("telegram webhook handler: in-flight dedup", () => {
       } catch { /* not JSON */ }
       fetchCalls.push({ url, method, body });
 
-      if (url.includes("/v1/assistants/") && url.includes("/inbound")) {
+      if (url.includes("/v1/channels/inbound")) {
         inboundCallCount++;
         if (inboundCallCount === 1) {
           await firstBlocks; // hang until test releases
@@ -406,7 +406,7 @@ describe("telegram webhook handler: in-flight dedup", () => {
       } catch { /* not JSON */ }
       fetchCalls.push({ url, method, body });
 
-      if (url.includes("/v1/assistants/") && url.includes("/inbound")) {
+      if (url.includes("/v1/channels/inbound")) {
         callCount++;
         if (callCount === 1) {
           // First call fails

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -70,7 +70,6 @@ export async function handleInbound(
   try {
     const response = await forwardToRuntime(
       config,
-      routing.assistantId,
       {
         sourceChannel: event.sourceChannel,
         interface: event.sourceChannel,

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -45,7 +45,8 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
       }
     }
 
-    // Rewrite /v1/assistants/:assistantId/... → /v1/... for the upstream daemon
+    // The daemon uses flat /v1/... paths. Rewrite any legacy
+    // /v1/assistants/:assistantId/... requests from clients to flat paths.
     let upstreamPath = url.pathname;
     const assistantScopedMatch = url.pathname.match(/^\/v1\/assistants\/[^/]+\/(.+)$/);
     if (assistantScopedMatch) {

--- a/gateway/src/http/routes/telegram-deliver.ts
+++ b/gateway/src/http/routes/telegram-deliver.ts
@@ -124,7 +124,7 @@ export function createTelegramDeliverHandler(config: GatewayConfig) {
       }
 
       if (attachments && attachments.length > 0) {
-        await sendTelegramAttachments(config, chatId, assistantId, attachments);
+        await sendTelegramAttachments(config, chatId, attachments);
       }
     } catch (err) {
       tlog.error({ err, chatId }, "Failed to deliver Telegram reply");

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -338,7 +338,6 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
         try {
           await resetConversation(
             config,
-            routing.assistantId,
             normalized.sourceChannel,
             normalized.message.externalChatId,
           );
@@ -404,7 +403,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
                 fileName: att.fileName,
                 mimeType: att.mimeType,
               });
-              return uploadAttachment(config, routing.assistantId, downloaded);
+              return uploadAttachment(config, downloaded);
             }),
           );
           for (const result of results) {

--- a/gateway/src/http/routes/twilio-sms-webhook.test.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.test.ts
@@ -371,9 +371,8 @@ describe("twilio-sms-webhook", () => {
 
     // resetConversation should have been called
     expect(resetConversationMock).toHaveBeenCalledTimes(1);
-    const [, assistantId, sourceChannel, externalChatId] =
+    const [, sourceChannel, externalChatId] =
       resetConversationMock.mock.calls[0] as unknown[];
-    expect(assistantId).toBe("ast-default");
     expect(sourceChannel).toBe("sms");
     expect(externalChatId).toBe("+15551234567");
 
@@ -554,8 +553,8 @@ describe("twilio-sms-webhook", () => {
     expect(res.status).toBe(200);
     // resetConversation should have been called with the phone-routed assistant
     expect(resetConversationMock).toHaveBeenCalledTimes(1);
-    const [, assistantId] = resetConversationMock.mock.calls[0] as unknown[];
-    expect(assistantId).toBe("ast-beta");
+    const [, sourceChannel] = resetConversationMock.mock.calls[0] as unknown[];
+    expect(sourceChannel).toBe("sms");
     expect(sendSmsReplyMock).toHaveBeenCalledTimes(1);
     const [, , , replyAssistantId] = sendSmsReplyMock.mock.calls[0] as unknown[];
     expect(replyAssistantId).toBe("ast-beta");

--- a/gateway/src/http/routes/twilio-sms-webhook.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.ts
@@ -141,7 +141,6 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
         try {
           await resetConversation(
             config,
-            routing.assistantId,
             normalized.sourceChannel,
             normalized.message.externalChatId,
           );

--- a/gateway/src/http/routes/whatsapp-deliver.ts
+++ b/gateway/src/http/routes/whatsapp-deliver.ts
@@ -130,7 +130,7 @@ export function createWhatsAppDeliverHandler(config: GatewayConfig) {
     }
 
     if (attachments && attachments.length > 0) {
-      const result = await sendWhatsAppAttachments(config, to, assistantId, attachments);
+      const result = await sendWhatsAppAttachments(config, to, attachments);
 
       if (result.allFailed && !textSent) {
         // Nothing was delivered at all -- signal failure so the caller can retry

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -159,7 +159,6 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
           try {
             await resetConversation(
               config,
-              routing.assistantId,
               event.sourceChannel,
               event.message.externalChatId,
             );

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -178,13 +178,12 @@ export type ForwardOptions = {
 
 export async function forwardToRuntime(
   config: GatewayConfig,
-  assistantId: string,
   payload: RuntimeInboundPayload,
   options?: ForwardOptions,
 ): Promise<RuntimeInboundResponse> {
   const isHalfOpenProbe = cbBeforeRequest();
 
-  const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/channels/inbound`;
+  const url = `${config.assistantRuntimeBaseUrl}/v1/channels/inbound`;
 
   const extraHeaders: Record<string, string> = { "Content-Type": "application/json" };
   if (options?.traceId) {
@@ -200,7 +199,7 @@ export async function forwardToRuntime(
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     if (attempt > 0) {
       const delay = config.runtimeInitialBackoffMs * Math.pow(2, attempt - 1);
-      log.debug({ attempt, delay, assistantId }, "Retrying runtime forward");
+      log.debug({ attempt, delay }, "Retrying runtime forward");
       await new Promise((r) => setTimeout(r, delay));
     }
 
@@ -215,7 +214,7 @@ export async function forwardToRuntime(
       if (response.status >= 400 && response.status < 500) {
         const body = await response.text();
         log.warn(
-          { status: response.status, body, assistantId },
+          { status: response.status, body },
           "Runtime returned client error, not retrying",
         );
         // 4xx = client error, not a daemon outage — don't trip the breaker
@@ -227,7 +226,7 @@ export async function forwardToRuntime(
         const body = await response.text();
         lastError = new Error(`Runtime returned ${response.status}: ${body}`);
         log.warn(
-          { status: response.status, attempt, assistantId },
+          { status: response.status, attempt },
           "Runtime returned server error",
         );
         continue;
@@ -235,7 +234,7 @@ export async function forwardToRuntime(
 
       const result = (await response.json()) as RuntimeInboundResponse;
       log.debug(
-        { assistantId, eventId: result.eventId, duplicate: result.duplicate },
+        { eventId: result.eventId, duplicate: result.duplicate },
         "Runtime forward succeeded",
       );
       cbOnSuccess();
@@ -249,7 +248,7 @@ export async function forwardToRuntime(
       }
       lastError = err instanceof Error ? err : new Error(String(err));
       log.warn(
-        { err: lastError, attempt, assistantId },
+        { err: lastError, attempt },
         "Runtime forward attempt failed",
       );
     }
@@ -261,13 +260,12 @@ export async function forwardToRuntime(
 
 export async function resetConversation(
   config: GatewayConfig,
-  assistantId: string,
   sourceChannel: ChannelId,
   externalChatId: string,
 ): Promise<void> {
   cbBeforeRequest();
 
-  const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/channels/conversation`;
+  const url = `${config.assistantRuntimeBaseUrl}/v1/channels/conversation`;
 
   let response: Response;
   try {
@@ -302,41 +300,6 @@ export type UploadAttachmentResponse = {
 };
 
 export async function downloadAttachment(
-  config: GatewayConfig,
-  assistantId: string,
-  attachmentId: string,
-): Promise<RuntimeAttachmentPayload> {
-  cbBeforeRequest();
-
-  const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/attachments/${encodeURIComponent(attachmentId)}`;
-
-  let response: Response;
-  try {
-    response = await fetchImpl(url, {
-      method: "GET",
-      headers: runtimeHeaders(config),
-      signal: AbortSignal.timeout(config.runtimeTimeoutMs),
-    });
-  } catch (err) {
-    cbOnFailure();
-    throw err;
-  }
-
-  if (!response.ok) {
-    const body = await response.text();
-    if (response.status >= 500) cbOnFailure(); else cbOnSuccess();
-    throw new Error(`Attachment download failed (${response.status}): ${body}`);
-  }
-
-  cbOnSuccess();
-  return (await response.json()) as RuntimeAttachmentPayload;
-}
-
-/**
- * Download an attachment without requiring an assistantId.
- * Uses the assistant-less /v1/attachments/:attachmentId endpoint.
- */
-export async function downloadAttachmentById(
   config: GatewayConfig,
   attachmentId: string,
 ): Promise<RuntimeAttachmentPayload> {
@@ -482,12 +445,11 @@ export async function forwardTwilioConnectActionWebhook(
 
 export async function uploadAttachment(
   config: GatewayConfig,
-  assistantId: string,
   input: UploadAttachmentInput,
 ): Promise<UploadAttachmentResponse> {
   cbBeforeRequest();
 
-  const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/attachments`;
+  const url = `${config.assistantRuntimeBaseUrl}/v1/attachments`;
 
   let response: Response;
   try {

--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -1,7 +1,7 @@
 import type { GatewayConfig } from "../config.js";
 import type { ApprovalPayload } from "../http/routes/telegram-deliver.js";
 import { getLogger } from "../logger.js";
-import { downloadAttachment, downloadAttachmentById, type RuntimeAttachmentMeta } from "../runtime/client.js";
+import { downloadAttachment, type RuntimeAttachmentMeta } from "../runtime/client.js";
 import { splitText } from "../util/split-text.js";
 import { callTelegramApi, callTelegramApiMultipart } from "./api.js";
 
@@ -64,7 +64,6 @@ export async function sendTelegramReply(
 export async function sendTelegramAttachments(
   config: GatewayConfig,
   chatId: string,
-  assistantId: string | undefined,
   attachments: RuntimeAttachmentMeta[],
 ): Promise<void> {
   const failures: string[] = [];
@@ -78,11 +77,7 @@ export async function sendTelegramAttachments(
     }
 
     try {
-      // Use the legacy assistant-scoped download path when assistantId is
-      // available; fall back to the assistant-less endpoint otherwise.
-      const payload = assistantId
-        ? await downloadAttachment(config, assistantId, meta.id)
-        : await downloadAttachmentById(config, meta.id);
+      const payload = await downloadAttachment(config, meta.id);
 
       // Hydrate missing metadata from the downloaded payload so that
       // ID-only attachment payloads work correctly. Explicit meta fields

--- a/gateway/src/whatsapp/send.ts
+++ b/gateway/src/whatsapp/send.ts
@@ -1,7 +1,7 @@
 import type { GatewayConfig } from "../config.js";
 import type { ApprovalPayload } from "../http/routes/whatsapp-deliver.js";
 import { getLogger } from "../logger.js";
-import { downloadAttachment, downloadAttachmentById, type RuntimeAttachmentMeta } from "../runtime/client.js";
+import { downloadAttachment, type RuntimeAttachmentMeta } from "../runtime/client.js";
 import { splitText } from "../util/split-text.js";
 import { sendWhatsAppInteractiveMessage, sendWhatsAppTextMessage, uploadWhatsAppMedia, sendWhatsAppMediaMessage, type WhatsAppMediaType } from "./api.js";
 
@@ -86,7 +86,6 @@ export type AttachmentResult = {
 export async function sendWhatsAppAttachments(
   config: GatewayConfig,
   to: string,
-  assistantId: string | undefined,
   attachments: RuntimeAttachmentMeta[],
 ): Promise<AttachmentResult> {
   const failures: string[] = [];
@@ -99,9 +98,7 @@ export async function sendWhatsAppAttachments(
     }
 
     try {
-      const payload = assistantId
-        ? await downloadAttachment(config, assistantId, meta.id)
-        : await downloadAttachmentById(config, meta.id);
+      const payload = await downloadAttachment(config, meta.id);
 
       const mimeType = meta.mimeType ?? payload.mimeType ?? "application/octet-stream";
       const filename = meta.filename ?? payload.filename ?? meta.id;


### PR DESCRIPTION
Updates gateway runtime client to use flat /v1/ daemon paths instead of /v1/assistants/:id/ paths. Part of #10674.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
