### PR TITLE
M1: Guardian-Initiated Voice Invite Canonicalization

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -397,7 +397,7 @@ A complementary access-granting flow where the guardian proactively creates a sh
 | Channel | Status | Prerequisites |
 |---------|--------|--------------|
 | Telegram | Shipped | Bot username resolved from credential metadata or `TELEGRAM_BOT_USERNAME` env |
-| Voice | Shipped | Identity-bound voice code redemption via DTMF/speech in the relay state machine. Gated behind `feature_flags.voice-invite-redemption.enabled` (default OFF). |
+| Voice | Shipped | Identity-bound voice code redemption via DTMF/speech in the relay state machine. Always-on canonical behavior with personalized friend/guardian name prompts. |
 | SMS | Deferred | Needs a deep-link strategy compatible with SMS (short URL or web redemption page) |
 | Slack | Deferred | Needs DM-safe ingress — Socket Mode handles channel messages but DM-initiated invite flows need routing |
 
@@ -413,18 +413,16 @@ Voice invites use a short numeric code (4-10 digits, default 6) instead of a URL
 
 **Call-time redemption subflow (`invite_redemption_pending`):**
 1. Unknown caller dials in. `relay-server.ts` resolves trust via `resolveActorTrust`. Caller is `unknown`, no pending guardian challenge.
-2. If `feature_flags.voice-invite-redemption.enabled` is ON, the relay checks `findActiveVoiceInvites` for invites bound to the caller's phone number.
-3. If active, non-expired invites exist, the relay enters the `invite_redemption_pending` state (reuses the `verification_pending` connection state) and prompts the caller to enter their invite code via DTMF or speech.
+2. The relay checks `findActiveVoiceInvites` for invites bound to the caller's phone number.
+3. If active, non-expired invites exist, the relay enters the `invite_redemption_pending` state (reuses the `verification_pending` connection state) and prompts the caller with personalized copy: `Welcome <friend-name>. Please enter the 6-digit code that <guardian-name> provided you to verify your identity.`
 4. `redeemVoiceInviteCode` validates: identity match, code hash match, expiry, use count. On success, an active member record is upserted and the call transitions to the normal call flow.
-5. On failure, the caller gets up to 3 attempts. After max attempts, the call is terminated.
+5. On invalid/expired code, the caller hears deterministic failure copy: `Sorry, the code you provided is incorrect or has since expired. Please ask <guardian-name> for a new code. Goodbye.` and the call ends immediately.
 
 **Security invariants:**
 - The plaintext voice code is returned exactly once at creation time and never stored.
 - Voice invites are identity-bound: `expectedExternalUserId` must match the caller's E.164 number. An attacker with the code but the wrong phone number cannot redeem.
 - Failure responses are intentionally generic (`invalid_or_expired`) to prevent oracle attacks.
 - Blocked members cannot bypass the guardian's explicit block via invite redemption.
-
-**Feature flag:** `feature_flags.voice-invite-redemption.enabled` (default OFF). When disabled, unknown callers with active voice invites are denied normally — the invite check is skipped entirely.
 
 **Key source files:**
 

--- a/assistant/src/__tests__/ingress-routes-http.test.ts
+++ b/assistant/src/__tests__/ingress-routes-http.test.ts
@@ -492,6 +492,8 @@ describe('voice invite HTTP routes', () => {
       body: JSON.stringify({
         sourceChannel: 'voice',
         expectedExternalUserId: '+15551234567',
+        friendName: 'Alice',
+        guardianName: 'Bob',
         maxUses: 3,
       }),
     });
@@ -514,6 +516,9 @@ describe('voice invite HTTP routes', () => {
     expect(invite.voiceCodeDigits).toBe(6);
     // expectedExternalUserId should be recorded
     expect(invite.expectedExternalUserId).toBe('+15551234567');
+    // friendName and guardianName should be recorded
+    expect(invite.friendName).toBe('Alice');
+    expect(invite.guardianName).toBe('Bob');
   });
 
   test('voice invite creation requires expectedExternalUserId', async () => {
@@ -522,6 +527,8 @@ describe('voice invite HTTP routes', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         sourceChannel: 'voice',
+        friendName: 'Alice',
+        guardianName: 'Bob',
       }),
     });
 
@@ -540,6 +547,8 @@ describe('voice invite HTTP routes', () => {
       body: JSON.stringify({
         sourceChannel: 'voice',
         expectedExternalUserId: 'not-a-phone-number',
+        friendName: 'Alice',
+        guardianName: 'Bob',
       }),
     });
 
@@ -551,6 +560,44 @@ describe('voice invite HTTP routes', () => {
     expect(body.error).toContain('E.164');
   });
 
+  test('voice invite creation requires friendName', async () => {
+    const req = new Request('http://localhost/v1/ingress/invites', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sourceChannel: 'voice',
+        expectedExternalUserId: '+15551234567',
+        guardianName: 'Bob',
+      }),
+    });
+
+    const res = await handleCreateInvite(req);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(400);
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('friendName');
+  });
+
+  test('voice invite creation requires guardianName', async () => {
+    const req = new Request('http://localhost/v1/ingress/invites', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sourceChannel: 'voice',
+        expectedExternalUserId: '+15551234567',
+        friendName: 'Alice',
+      }),
+    });
+
+    const res = await handleCreateInvite(req);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(400);
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('guardianName');
+  });
+
   test('voiceCodeDigits is always 6 — custom values are ignored', async () => {
     const req = new Request('http://localhost/v1/ingress/invites', {
       method: 'POST',
@@ -558,6 +605,8 @@ describe('voice invite HTTP routes', () => {
       body: JSON.stringify({
         sourceChannel: 'voice',
         expectedExternalUserId: '+15551234567',
+        friendName: 'Alice',
+        guardianName: 'Bob',
         voiceCodeDigits: 8,
       }),
     });
@@ -579,6 +628,8 @@ describe('voice invite HTTP routes', () => {
       body: JSON.stringify({
         sourceChannel: 'voice',
         expectedExternalUserId: '+15551234567',
+        friendName: 'Alice',
+        guardianName: 'Bob',
       }),
     });
 
@@ -600,6 +651,8 @@ describe('voice invite HTTP routes', () => {
       body: JSON.stringify({
         sourceChannel: 'voice',
         expectedExternalUserId: '+15551234567',
+        friendName: 'Alice',
+        guardianName: 'Bob',
         maxUses: 1,
       }),
     }));
@@ -648,6 +701,8 @@ describe('voice invite HTTP routes', () => {
       body: JSON.stringify({
         sourceChannel: 'voice',
         expectedExternalUserId: '+15551234567',
+        friendName: 'Alice',
+        guardianName: 'Bob',
         maxUses: 1,
       }),
     }));

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -138,7 +138,9 @@ import { setVoiceBridgeDeps } from '../calls/voice-session-bridge.js';
 import { createBinding, createChallenge } from '../memory/channel-guardian-store.js';
 import { addMessage, getMessages } from '../memory/conversation-store.js';
 import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { createInvite } from '../memory/ingress-invite-store.js';
 import { upsertMember } from '../memory/ingress-member-store.js';
+import { generateVoiceCode, hashVoiceCode } from '../util/voice-code.js';
 import { conversations } from '../memory/schema.js';
 import {
   createOutboundSession,
@@ -205,6 +207,7 @@ function resetTables() {
   db.run('DELETE FROM messages');
   db.run('DELETE FROM conversations');
   db.run('DELETE FROM assistant_ingress_members');
+  db.run('DELETE FROM assistant_ingress_invites');
   db.run('DELETE FROM channel_guardian_verification_challenges');
   db.run('DELETE FROM channel_guardian_bindings');
   db.run('DELETE FROM channel_guardian_rate_limits');
@@ -1741,6 +1744,177 @@ describe('relay-server', () => {
 
     // Let the delayed endSession callback flush
     await new Promise((resolve) => setTimeout(resolve, 2100));
+
+    relay.destroy();
+  });
+
+  // ── Inbound voice invite redemption ──────────────────────────────────
+
+  test('inbound voice invite redemption: personalized welcome prompt with friend/guardian names', async () => {
+    ensureConversation('conv-invite-welcome');
+    const session = createCallSession({
+      conversationId: 'conv-invite-welcome',
+      provider: 'twilio',
+      fromNumber: '+15558887777',
+      toNumber: '+15551111111',
+      assistantId: 'self',
+    });
+
+    // Create a voice invite with friend/guardian names
+    const code = generateVoiceCode(6);
+    const codeHash = hashVoiceCode(code);
+    createInvite({
+      assistantId: 'self',
+      sourceChannel: 'voice',
+      maxUses: 1,
+      expectedExternalUserId: '+15558887777',
+      voiceCodeHash: codeHash,
+      voiceCodeDigits: 6,
+      friendName: 'Alice',
+      guardianName: 'Bob',
+    });
+
+    mockSendMessage.mockImplementation(createMockProviderResponse(['Hello, how can I help?']));
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_invite_welcome',
+      from: '+15558887777',
+      to: '+15551111111',
+    }));
+
+    // Should be in verification-pending state for invite redemption
+    expect(relay.getConnectionState()).toBe('verification_pending');
+
+    // Check that the welcome prompt includes friend/guardian names
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes('Welcome Alice'))).toBe(true);
+    expect(textMessages.some((m) => (m.token ?? '').includes('Bob provided you'))).toBe(true);
+
+    // Enter the correct code via DTMF
+    for (const digit of code) {
+      await relay.handleMessage(JSON.stringify({ type: 'dtmf', digit }));
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Should have transitioned to connected
+    expect(relay.getConnectionState()).toBe('connected');
+
+    // Verify events
+    const events = getCallEvents(session.id);
+    expect(events.some((e) => e.eventType === 'invite_redemption_started')).toBe(true);
+    expect(events.some((e) => e.eventType === 'invite_redemption_succeeded')).toBe(true);
+
+    relay.destroy();
+  });
+
+  test('inbound voice invite redemption: invalid code gets exact failure copy with guardian name and call ends', async () => {
+    ensureConversation('conv-invite-fail');
+    const session = createCallSession({
+      conversationId: 'conv-invite-fail',
+      provider: 'twilio',
+      fromNumber: '+15558886666',
+      toNumber: '+15551111111',
+      assistantId: 'self',
+    });
+
+    // Create a voice invite with friend/guardian names
+    const code = generateVoiceCode(6);
+    const codeHash = hashVoiceCode(code);
+    createInvite({
+      assistantId: 'self',
+      sourceChannel: 'voice',
+      maxUses: 1,
+      expectedExternalUserId: '+15558886666',
+      voiceCodeHash: codeHash,
+      voiceCodeDigits: 6,
+      friendName: 'Carol',
+      guardianName: 'Dave',
+    });
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_invite_fail',
+      from: '+15558886666',
+      to: '+15551111111',
+    }));
+
+    expect(relay.getConnectionState()).toBe('verification_pending');
+
+    // Enter a wrong code
+    for (const digit of '000000') {
+      await relay.handleMessage(JSON.stringify({ type: 'dtmf', digit }));
+    }
+
+    // Call should be marked as failed immediately
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('failed');
+
+    // Should have sent the exact deterministic failure copy with guardian name
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes('Sorry, the code you provided is incorrect or has since expired'))).toBe(true);
+    expect(textMessages.some((m) => (m.token ?? '').includes('Please ask Dave for a new code'))).toBe(true);
+
+    // Verify events
+    const events = getCallEvents(session.id);
+    expect(events.some((e) => e.eventType === 'invite_redemption_failed')).toBe(true);
+
+    // Let the delayed endSession callback flush
+    await new Promise((resolve) => setTimeout(resolve, 3100));
+
+    // Verify end message was sent
+    const endMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string })
+      .filter((m) => m.type === 'end');
+    expect(endMessages.length).toBe(1);
+
+    relay.destroy();
+  });
+
+  test('inbound voice invite redemption: unknown caller with no active invite is still denied', async () => {
+    ensureConversation('conv-invite-no-invite');
+    const session = createCallSession({
+      conversationId: 'conv-invite-no-invite',
+      provider: 'twilio',
+      fromNumber: '+15558885555',
+      toNumber: '+15551111111',
+      assistantId: 'self',
+    });
+
+    // No voice invite created for this caller
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_invite_no_invite',
+      from: '+15558885555',
+      to: '+15551111111',
+    }));
+
+    // Should have been denied (no invite, no challenge, unknown caller)
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('failed');
+
+    // Should have sent a denial message, not an invite prompt
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes('not authorized'))).toBe(true);
+
+    // Let any delayed endSession callback flush
+    await new Promise((resolve) => setTimeout(resolve, 3100));
 
     relay.destroy();
   });

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -10,7 +10,6 @@ import { randomInt } from 'node:crypto';
 
 import type { ServerWebSocket } from 'bun';
 
-import { isAssistantFeatureFlagEnabled } from '../config/assistant-feature-flags.js';
 import { getConfig } from '../config/loader.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { findActiveVoiceInvites } from '../memory/ingress-invite-store.js';
@@ -180,6 +179,8 @@ export class RelayConnection {
   private inviteRedemptionAssistantId: string | null = null;
   private inviteRedemptionFromNumber: string | null = null;
   private inviteRedemptionCodeLength = 6;
+  private inviteRedemptionFriendName: string | null = null;
+  private inviteRedemptionGuardianName: string | null = null;
 
   constructor(ws: ServerWebSocket<RelayWebSocketData>, callSessionId: string) {
     this.ws = ws;
@@ -503,36 +504,30 @@ export class RelayConnection {
         // Before denying, check if there is an active voice invite bound
         // to the caller's phone number. If so, enter the invite redemption
         // subflow instead of denying the call outright.
-        // Gated behind the voice-invite-redemption feature flag (defaults OFF).
-        const voiceInviteEnabled = isAssistantFeatureFlagEnabled(
-          'feature_flags.voice-invite-redemption.enabled',
-          config,
-        );
+        let voiceInvites: ReturnType<typeof findActiveVoiceInvites> = [];
+        try {
+          voiceInvites = findActiveVoiceInvites({
+            assistantId,
+            expectedExternalUserId: msg.from,
+          });
+        } catch (err) {
+          log.warn({ err, callSessionId: this.callSessionId }, 'Failed to check voice invites for unknown caller');
+        }
 
-        if (voiceInviteEnabled) {
-          let voiceInvites: ReturnType<typeof findActiveVoiceInvites> = [];
-          try {
-            voiceInvites = findActiveVoiceInvites({
-              assistantId,
-              expectedExternalUserId: msg.from,
-            });
-          } catch (err) {
-            log.warn({ err, callSessionId: this.callSessionId }, 'Failed to check voice invites for unknown caller');
-          }
+        // Exclude invites that are past their expiresAt even if the DB
+        // status hasn't been lazily flipped to 'expired' yet.
+        const now = Date.now();
+        const nonExpiredInvites = voiceInvites.filter(i => !i.expiresAt || i.expiresAt > now);
 
-          // Exclude invites that are past their expiresAt even if the DB
-          // status hasn't been lazily flipped to 'expired' yet.
-          const now = Date.now();
-          const nonExpiredInvites = voiceInvites.filter(i => !i.expiresAt || i.expiresAt > now);
-
-          if (nonExpiredInvites.length > 0) {
-            log.info(
-              { callSessionId: this.callSessionId, from: msg.from },
-              'Inbound voice ACL: unknown caller has active voice invite — entering redemption flow',
-            );
-            this.startInviteRedemption(assistantId, msg.from);
-            return;
-          }
+        if (nonExpiredInvites.length > 0) {
+          // Use the first matching invite's metadata for personalized prompts
+          const matchedInvite = nonExpiredInvites[0];
+          log.info(
+            { callSessionId: this.callSessionId, from: msg.from },
+            'Inbound voice ACL: unknown caller has active voice invite — entering redemption flow',
+          );
+          this.startInviteRedemption(assistantId, msg.from, matchedInvite.friendName, matchedInvite.guardianName);
+          return;
         }
 
         log.info(
@@ -1001,13 +996,15 @@ export class RelayConnection {
    * who has an active voice invite. Prompts the caller to enter their
    * invite code via DTMF or speech.
    */
-  private startInviteRedemption(assistantId: string, fromNumber: string): void {
+  private startInviteRedemption(assistantId: string, fromNumber: string, friendName: string | null, guardianName: string | null): void {
     this.inviteRedemptionActive = true;
     this.inviteRedemptionAssistantId = assistantId;
     this.inviteRedemptionFromNumber = fromNumber;
+    this.inviteRedemptionFriendName = friendName;
+    this.inviteRedemptionGuardianName = guardianName;
     this.connectionState = 'verification_pending';
     this.verificationAttempts = 0;
-    this.verificationMaxAttempts = 3;
+    this.verificationMaxAttempts = 1;
     this.inviteRedemptionCodeLength = 6;
     this.dtmfBuffer = '';
 
@@ -1017,8 +1014,10 @@ export class RelayConnection {
       maxAttempts: this.verificationMaxAttempts,
     });
 
+    const displayFriend = friendName ?? 'there';
+    const displayGuardian = guardianName ?? 'your contact';
     this.sendTextToken(
-      'Please enter your 6-digit invite code using your keypad, or speak the digits now.',
+      `Welcome ${displayFriend}. Please enter the 6-digit code that ${displayGuardian} provided you to verify your identity.`,
       true,
     );
 
@@ -1073,46 +1072,43 @@ export class RelayConnection {
         this.startNormalCallFlow(this.controller, true);
       }
     } else {
-      this.verificationAttempts++;
+      // On any invalid/expired code, emit exact deterministic failure copy and end call immediately.
+      this.inviteRedemptionActive = false;
 
-      if (this.verificationAttempts >= this.verificationMaxAttempts) {
-        this.inviteRedemptionActive = false;
+      recordCallEvent(this.callSessionId, 'invite_redemption_failed', {
+        attempts: 1,
+      });
+      log.warn(
+        { callSessionId: this.callSessionId },
+        'Voice invite redemption failed — invalid or expired code',
+      );
 
-        recordCallEvent(this.callSessionId, 'invite_redemption_failed', {
-          attempts: this.verificationAttempts,
+      const displayGuardian = this.inviteRedemptionGuardianName ?? 'your contact';
+      this.sendTextToken(
+        `Sorry, the code you provided is incorrect or has since expired. Please ask ${displayGuardian} for a new code. Goodbye.`,
+        true,
+      );
+
+      this.connectionState = 'disconnecting';
+
+      updateCallSession(this.callSessionId, {
+        status: 'failed',
+        endedAt: Date.now(),
+        lastError: 'Voice invite redemption failed — invalid or expired code',
+      });
+
+      const failSession = getCallSession(this.callSessionId);
+      if (failSession) {
+        expirePendingQuestions(this.callSessionId);
+        persistCallCompletionMessage(failSession.conversationId, this.callSessionId).catch((err) => {
+          log.error({ err, conversationId: failSession.conversationId, callSessionId: this.callSessionId }, 'Failed to persist call completion message');
         });
-        log.warn(
-          { callSessionId: this.callSessionId, attempts: this.verificationAttempts },
-          'Voice invite redemption failed — max attempts reached',
-        );
-
-        this.sendTextToken('Too many invalid attempts. Goodbye.', true);
-
-        updateCallSession(this.callSessionId, {
-          status: 'failed',
-          endedAt: Date.now(),
-          lastError: 'Voice invite redemption failed — max attempts exceeded',
-        });
-
-        const failSession = getCallSession(this.callSessionId);
-        if (failSession) {
-          expirePendingQuestions(this.callSessionId);
-          persistCallCompletionMessage(failSession.conversationId, this.callSessionId).catch((err) => {
-            log.error({ err, conversationId: failSession.conversationId, callSessionId: this.callSessionId }, 'Failed to persist call completion message');
-          });
-          fireCallCompletionNotifier(failSession.conversationId, this.callSessionId);
-        }
-
-        setTimeout(() => {
-          this.endSession('Invite redemption failed');
-        }, 2000);
-      } else {
-        log.info(
-          { callSessionId: this.callSessionId, attempt: this.verificationAttempts, maxAttempts: this.verificationMaxAttempts },
-          'Voice invite redemption attempt failed — retrying',
-        );
-        this.sendTextToken('Invalid code. Please try again.', true);
+        fireCallCompletionNotifier(failSession.conversationId, this.callSessionId);
       }
+
+      setTimeout(() => {
+        this.endSession('Invite redemption failed');
+      }, 3000);
     }
   }
 

--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -50,14 +50,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "voice-invite-redemption",
-      "scope": "assistant",
-      "key": "feature_flags.voice-invite-redemption.enabled",
-      "label": "Voice Invite Redemption",
-      "description": "Enable voice invite code redemption for inbound callers with active voice invites",
-      "defaultEnabled": false
-    },
-    {
       "id": "user-hosted-enabled",
       "scope": "macos",
       "key": "user_hosted_enabled",

--- a/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
+++ b/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
@@ -254,6 +254,8 @@ INVITE_JSON=$(curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/ingress/invites" \
   -d '{
     "sourceChannel": "voice",
     "expectedExternalUserId": "<phone_number_E164>",
+    "friendName": "<invitee_first_name>",
+    "guardianName": "<guardian_first_name>",
     "maxUses": 1,
     "note": "<optional note, e.g. the person it is for>"
   }')
@@ -263,6 +265,8 @@ printf '%s\n' "$INVITE_JSON"
 Required fields:
 - `sourceChannel` — must be `"voice"`
 - `expectedExternalUserId` — the invitee's phone number in E.164 format (e.g., `+15551234567`)
+- `friendName` — the invitee's first name (used in the voice greeting)
+- `guardianName` — the guardian's first name (used in the voice greeting)
 
 Optional fields:
 - `maxUses` — how many times the code can be used (default: 1)
@@ -348,6 +352,8 @@ Replace `<invite_id>` with the invite's `id` from the list response. The same re
   - `sourceChannel is required for create` — when creating an invite, always pass `"sourceChannel": "telegram"` for Telegram or `"sourceChannel": "voice"` for voice invites.
   - `expectedExternalUserId is required for voice invites` — voice invites must include the invitee's phone number.
   - `expectedExternalUserId must be in E.164 format` — the phone number must start with `+` followed by country code and number (e.g., `+15551234567`).
+  - `friendName is required for voice invites` — ask for the invitee's first name.
+  - `guardianName is required for voice invites` — ask for the guardian's (your user's) first name.
   - `Invite not found or already revoked` — the invite ID may be invalid or the invite is already revoked.
 
 ## Typical Workflows
@@ -368,9 +374,9 @@ Replace `<invite_id>` with the invite's `id` from the list response. The same re
 
 **"Revoke invite"** / **"Cancel invite link"** — List invites to identify the target, confirm, then revoke by ID.
 
-**"Create a voice invite for +15551234567"** — Create a voice invite with `sourceChannel: "voice"` and the given phone number as `expectedExternalUserId`. Present the invite code and instructions: the person must call from that number and enter the code.
+**"Create a voice invite for +15551234567"** — Ask for the friend's first name and the guardian's first name (if not already known), then create a voice invite with `sourceChannel: "voice"`, the phone number as `expectedExternalUserId`, and both names. Present the invite code and instructions: the person must call from that number and enter the code.
 
-**"Let my mom call in"** / **"Invite someone by phone"** — Ask for the phone number in E.164 format, create a voice invite, and present the code + calling instructions.
+**"Let my mom call in"** / **"Invite someone by phone"** — Ask for the phone number in E.164 format, the friend's first name, and the guardian's first name. Create a voice invite and present the code + calling instructions.
 
 **"Show my voice invites"** / **"List phone invites"** — List invites filtered by `sourceChannel=voice`, present active invites with bound phone number and expiration info.
 

--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -40,6 +40,8 @@ export function handleIngressInvite(
           note: msg.note,
           maxUses: msg.maxUses,
           expiresInMs: msg.expiresInMs,
+          friendName: msg.friendName,
+          guardianName: msg.guardianName,
         });
         if (!result.ok) {
           ctx.send(socket, { type: 'ingress_invite_response', success: false, error: result.error });

--- a/assistant/src/daemon/ipc-contract/inbox.ts
+++ b/assistant/src/daemon/ipc-contract/inbox.ts
@@ -23,6 +23,10 @@ export interface IngressInviteRequest {
   externalChatId?: string;
   /** Filter by status (list only). */
   status?: string;
+  /** Invitee's first name (voice invite create only). */
+  friendName?: string;
+  /** Guardian's first name (voice invite create only). */
+  guardianName?: string;
 }
 
 export interface IngressMemberRequest {

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -37,6 +37,7 @@ import {
   migrateReminderRoutingIntent,
   migrateSchemaIndexesAndColumns,
   migrateVoiceInviteColumns,
+  migrateVoiceInviteDisplayMetadata,
   recoverCrashedMigrations,
   runComplexMigrations,
   runLateMigrations,
@@ -164,6 +165,9 @@ export function initializeDb(): void {
 
   // 26. Voice invite columns on assistant_ingress_invites
   migrateVoiceInviteColumns(database);
+
+  // 27. Voice invite display metadata (friend_name, guardian_name) for personalized prompts
+  migrateVoiceInviteDisplayMetadata(database);
 
   validateMigrationState(database);
 }

--- a/assistant/src/memory/ingress-invite-store.ts
+++ b/assistant/src/memory/ingress-invite-store.ts
@@ -37,6 +37,9 @@ export interface IngressInvite {
   expectedExternalUserId: string | null;
   voiceCodeHash: string | null;
   voiceCodeDigits: number | null;
+  // Display metadata for personalized voice prompts (null for non-voice invites)
+  friendName: string | null;
+  guardianName: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -97,6 +100,8 @@ function rowToInvite(row: typeof assistantIngressInvites.$inferSelect): IngressI
     expectedExternalUserId: row.expectedExternalUserId,
     voiceCodeHash: row.voiceCodeHash,
     voiceCodeDigits: row.voiceCodeDigits,
+    friendName: row.friendName,
+    guardianName: row.guardianName,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -138,6 +143,8 @@ export function createInvite(params: {
   expectedExternalUserId?: string;
   voiceCodeHash?: string;
   voiceCodeDigits?: number;
+  friendName?: string;
+  guardianName?: string;
 }): { invite: IngressInvite; rawToken: string } {
   const db = getDb();
   const now = Date.now();
@@ -162,6 +169,8 @@ export function createInvite(params: {
     expectedExternalUserId: params.expectedExternalUserId ?? null,
     voiceCodeHash: params.voiceCodeHash ?? null,
     voiceCodeDigits: params.voiceCodeDigits ?? null,
+    friendName: params.friendName ?? null,
+    guardianName: params.guardianName ?? null,
     createdAt: now,
     updatedAt: now,
   };

--- a/assistant/src/memory/migrations/124-voice-invite-display-metadata.ts
+++ b/assistant/src/memory/migrations/124-voice-invite-display-metadata.ts
@@ -1,0 +1,14 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Add display metadata columns to assistant_ingress_invites for personalized
+ * voice invite prompts. Both columns are nullable to keep existing invite
+ * rows compatible.
+ *
+ * - friend_name: the name of the person being invited (used in welcome prompt)
+ * - guardian_name: the name of the guardian who created the invite (used in prompts)
+ */
+export function migrateVoiceInviteDisplayMetadata(database: DrizzleDb): void {
+  try { database.run(/*sql*/ `ALTER TABLE assistant_ingress_invites ADD COLUMN friend_name TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE assistant_ingress_invites ADD COLUMN guardian_name TEXT`); } catch { /* already exists */ }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -63,6 +63,7 @@ export { migrateFkCascadeRebuilds } from './120-fk-cascade-rebuilds.js';
 export { createCanonicalGuardianTables } from './121-canonical-guardian-requests.js';
 export { migrateCanonicalGuardianRequesterChatId } from './122-canonical-guardian-requester-chat-id.js';
 export { migrateCanonicalGuardianDeliveriesDestinationIndex } from './123-canonical-guardian-deliveries-destination-index.js';
+export { migrateVoiceInviteDisplayMetadata } from './124-voice-invite-display-metadata.js';
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -946,6 +946,9 @@ export const assistantIngressInvites = sqliteTable('assistant_ingress_invites', 
   expectedExternalUserId: text('expected_external_user_id'),
   voiceCodeHash: text('voice_code_hash'),
   voiceCodeDigits: integer('voice_code_digits'),
+  // Display metadata for personalized voice prompts (nullable — non-voice invites leave these NULL)
+  friendName: text('friend_name'),
+  guardianName: text('guardian_name'),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 });

--- a/assistant/src/runtime/ingress-service.ts
+++ b/assistant/src/runtime/ingress-service.ts
@@ -174,10 +174,10 @@ export function createIngressInvite(params: {
     if (!isValidE164(params.expectedExternalUserId)) {
       return { ok: false, error: 'expectedExternalUserId must be in E.164 format (e.g., +15551234567)' };
     }
-    if (!params.friendName?.trim()) {
+    if (typeof params.friendName !== 'string' || !params.friendName.trim()) {
       return { ok: false, error: 'friendName is required for voice invites' };
     }
-    if (!params.guardianName?.trim()) {
+    if (typeof params.guardianName !== 'string' || !params.guardianName.trim()) {
       return { ok: false, error: 'guardianName is required for voice invites' };
     }
     voiceCode = generateVoiceCode(6);

--- a/assistant/src/runtime/ingress-service.ts
+++ b/assistant/src/runtime/ingress-service.ts
@@ -57,6 +57,8 @@ export interface InviteResponseData {
   expectedExternalUserId?: string;
   voiceCode?: string;
   voiceCodeDigits?: number;
+  friendName?: string;
+  guardianName?: string;
   createdAt: number;
 }
 
@@ -110,6 +112,8 @@ function inviteToResponse(inv: IngressInvite, opts?: { rawToken?: string; voiceC
     ...(inv.expectedExternalUserId ? { expectedExternalUserId: inv.expectedExternalUserId } : {}),
     ...(opts?.voiceCode ? { voiceCode: opts.voiceCode } : {}),
     ...(inv.voiceCodeDigits != null ? { voiceCodeDigits: inv.voiceCodeDigits } : {}),
+    ...(inv.friendName ? { friendName: inv.friendName } : {}),
+    ...(inv.guardianName ? { guardianName: inv.guardianName } : {}),
     createdAt: inv.createdAt,
   };
 }
@@ -149,6 +153,8 @@ export function createIngressInvite(params: {
   // Voice invite parameters
   expectedExternalUserId?: string;
   voiceCodeDigits?: number;
+  friendName?: string;
+  guardianName?: string;
 }): IngressResult<InviteResponseData> {
   if (!params.sourceChannel) {
     return { ok: false, error: 'sourceChannel is required for create' };
@@ -168,6 +174,12 @@ export function createIngressInvite(params: {
     if (!isValidE164(params.expectedExternalUserId)) {
       return { ok: false, error: 'expectedExternalUserId must be in E.164 format (e.g., +15551234567)' };
     }
+    if (!params.friendName?.trim()) {
+      return { ok: false, error: 'friendName is required for voice invites' };
+    }
+    if (!params.guardianName?.trim()) {
+      return { ok: false, error: 'guardianName is required for voice invites' };
+    }
     voiceCode = generateVoiceCode(6);
     voiceCodeHash = hashVoiceCode(voiceCode);
   }
@@ -181,6 +193,8 @@ export function createIngressInvite(params: {
       expectedExternalUserId: params.expectedExternalUserId,
       voiceCodeHash,
       voiceCodeDigits: 6,
+      friendName: params.friendName,
+      guardianName: params.guardianName,
     } : {}),
   });
   // Voice invites must not expose the token — callers must redeem via the

--- a/assistant/src/runtime/routes/ingress-routes.ts
+++ b/assistant/src/runtime/routes/ingress-routes.ts
@@ -147,6 +147,8 @@ export async function handleCreateInvite(req: Request): Promise<Response> {
     expiresInMs: body.expiresInMs as number | undefined,
     expectedExternalUserId: body.expectedExternalUserId as string | undefined,
     voiceCodeDigits: body.voiceCodeDigits as number | undefined,
+    friendName: body.friendName as string | undefined,
+    guardianName: body.guardianName as string | undefined,
   });
 
   if (!result.ok) {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -50,14 +50,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "voice-invite-redemption",
-      "scope": "assistant",
-      "key": "feature_flags.voice-invite-redemption.enabled",
-      "label": "Voice Invite Redemption",
-      "description": "Enable voice invite code redemption for inbound callers with active voice invites",
-      "defaultEnabled": false
-    },
-    {
       "id": "user-hosted-enabled",
       "scope": "macos",
       "key": "user_hosted_enabled",


### PR DESCRIPTION
Remove voice-invite-redemption feature flag gate, add friend_name/guardian_name metadata to invites, thread through store/service/routes, require names for voice invites, update relay copy to exact deterministic text, emit exact failure copy on invalid/expired code. Closes #10695.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
