### PR TITLE
fix: add qdrant and embed-worker kill steps to mac-mini cleanup

### DIFF
--- a/scripts/mac-mini-cleanup.sh
+++ b/scripts/mac-mini-cleanup.sh
@@ -16,7 +16,7 @@ echo "   Only run on environments you are comfortable completely resetting."
 echo ""
 
 # 1. Remove the SSH public key that was added via ssh-copy-id
-echo "1/11 — Removing authorized SSH keys..."
+echo "1/13 — Removing authorized SSH keys..."
 if [ -f ~/.ssh/authorized_keys ]; then
     rm ~/.ssh/authorized_keys
     echo "      ✅ Removed ~/.ssh/authorized_keys"
@@ -25,7 +25,7 @@ else
 fi
 
 # 2. Restore default sshd_config (undo PubkeyAuthentication/PasswordAuthentication changes)
-echo "2/11 — Restoring default sshd_config..."
+echo "2/13 — Restoring default sshd_config..."
 if [ -f /etc/ssh/sshd_config ] && [ -f ~/cleanup/sshd_config_original ]; then
     sudo cp ~/cleanup/sshd_config_original /etc/ssh/sshd_config
     echo "      ✅ Reverted sshd_config changes"
@@ -36,13 +36,13 @@ else
 fi
 
 # 3. Reload SSH daemon
-echo "3/11 — Reloading SSH daemon..."
+echo "3/13 — Reloading SSH daemon..."
 sudo launchctl unload /System/Library/LaunchDaemons/ssh.plist 2>/dev/null || true
 sudo launchctl load /System/Library/LaunchDaemons/ssh.plist 2>/dev/null || true
 echo "      ✅ SSH daemon reloaded"
 
 # 4. Uninstall git
-echo "4/11 — Uninstalling git..."
+echo "4/13 — Uninstalling git..."
 if command -v brew &>/dev/null && brew list git &>/dev/null; then
     brew uninstall git
     echo "      ✅ Git uninstalled via Homebrew"
@@ -55,7 +55,7 @@ else
 fi
 
 # 5. Kill any processes running via "bun run"
-echo "5/11 — Killing bun run processes..."
+echo "5/13 — Killing bun run processes..."
 BUN_PIDS=$(pgrep -f "bun run" 2>/dev/null || true)
 if [ -n "$BUN_PIDS" ]; then
     echo "$BUN_PIDS" | xargs kill -9 2>/dev/null || true
@@ -65,7 +65,7 @@ else
 fi
 
 # 6. Uninstall bun
-echo "6/11 — Uninstalling bun..."
+echo "6/13 — Uninstalling bun..."
 if [ -d ~/.bun ]; then
     rm -rf ~/.bun
     echo "      ✅ Removed ~/.bun directory"
@@ -80,8 +80,18 @@ else
     echo "      ⏭️  Bun not found, skipping"
 fi
 
-# 7. Kill any Vellum processes
-echo "7/11 — Killing Vellum processes..."
+# 7. Kill any qdrant processes
+echo "7/13 — Killing qdrant processes..."
+QDRANT_PIDS=$(pgrep -f "qdrant" 2>/dev/null || true)
+if [ -n "$QDRANT_PIDS" ]; then
+    echo "$QDRANT_PIDS" | xargs kill -9 2>/dev/null || true
+    echo "      ✅ Killed qdrant processes: $QDRANT_PIDS"
+else
+    echo "      ⏭️  No qdrant processes found, skipping"
+fi
+
+# 8. Kill any Vellum processes
+echo "8/13 — Killing Vellum processes..."
 VELLUM_PIDS=$(pgrep -f "Vellum" 2>/dev/null || true)
 if [ -n "$VELLUM_PIDS" ]; then
     echo "$VELLUM_PIDS" | xargs kill -9 2>/dev/null || true
@@ -90,8 +100,8 @@ else
     echo "      ⏭️  No Vellum processes found, skipping"
 fi
 
-# 8. Remove ~/.vellum directory
-echo "8/11 — Removing ~/.vellum directory..."
+# 9. Remove ~/.vellum directory
+echo "9/13 — Removing ~/.vellum directory..."
 if [ -d ~/.vellum ]; then
     rm -rf ~/.vellum
     echo "      ✅ Removed ~/.vellum"
@@ -99,8 +109,18 @@ else
     echo "      ⏭️  No ~/.vellum directory found, skipping"
 fi
 
-# 9. Remove ~/.vellum.lock.json
-echo "9/11 — Removing ~/.vellum.lock.json..."
+# 10. Kill any embedding worker processes
+echo "10/13 — Killing embedding worker processes..."
+EMBED_PIDS=$(pgrep -f "embed-worker" 2>/dev/null || true)
+if [ -n "$EMBED_PIDS" ]; then
+    echo "$EMBED_PIDS" | xargs kill -9 2>/dev/null || true
+    echo "       ✅ Killed embedding worker processes: $EMBED_PIDS"
+else
+    echo "       ⏭️  No embedding worker processes found, skipping"
+fi
+
+# 11. Remove ~/.vellum.lock.json
+echo "11/13 — Removing ~/.vellum.lock.json..."
 if [ -f ~/.vellum.lock.json ]; then
     rm -f ~/.vellum.lock.json
     echo "      ✅ Removed ~/.vellum.lock.json"
@@ -108,8 +128,8 @@ else
     echo "      ⏭️  No ~/.vellum.lock.json found, skipping"
 fi
 
-# 10. Remove Vellum.app
-echo "10/11 — Removing /Applications/Vellum.app..."
+# 12. Remove Vellum.app
+echo "12/13 — Removing /Applications/Vellum.app..."
 if [ -d /Applications/Vellum.app ]; then
     rm -rf /Applications/Vellum.app
     echo "       ✅ Removed /Applications/Vellum.app"
@@ -117,8 +137,8 @@ else
     echo "       ⏭️  No Vellum.app found, skipping"
 fi
 
-# 11. Remove Vellum from the Dock
-echo "11/11 — Removing Vellum from the Dock..."
+# 13. Remove Vellum from the Dock
+echo "13/13 — Removing Vellum from the Dock..."
 DOCK_PLIST="$HOME/Library/Preferences/com.apple.dock.plist"
 if [ -f "$DOCK_PLIST" ]; then
     # Find and remove any Vellum entry from persistent-apps in the Dock plist


### PR DESCRIPTION
## Summary
- Adds step 7 to kill qdrant processes before removing `~/.vellum` data directory
- Adds step 10 to kill embedding worker subprocesses (`embed-worker.mjs`) that run as separate bun processes
- Updates step count from 11 to 13 to account for new steps

## Test plan
- [ ] Run `pgrep -f qdrant` and `pgrep -f embed-worker` on a Mac mini with Vellum running to verify process detection
- [ ] Run the cleanup script on a test Mac mini and verify both processes are terminated
- [ ] Verify no qdrant or embed-worker processes remain after cleanup completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
