### PR TITLE
assistant: enforce identity boundary via guard tests

### DIFF
--- a/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
+++ b/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
@@ -33,15 +33,20 @@ function getRepoRoot(): string {
 /**
  * Directories containing daemon/runtime source files that must not reference
  * `normalizeAssistantId` or hardcode assistant scope strings.
+ *
+ * Each directory gets both a `*.ts` glob (top-level files) and a `**\/*.ts`
+ * glob (nested files) so that `git grep` matches at all directory depths.
  */
-const SCANNED_DIR_GLOBS = [
-  'assistant/src/runtime/**/*.ts',
-  'assistant/src/daemon/**/*.ts',
-  'assistant/src/memory/**/*.ts',
-  'assistant/src/approvals/**/*.ts',
-  'assistant/src/calls/**/*.ts',
-  'assistant/src/tools/**/*.ts',
+const SCANNED_DIRS = [
+  'assistant/src/runtime',
+  'assistant/src/daemon',
+  'assistant/src/memory',
+  'assistant/src/approvals',
+  'assistant/src/calls',
+  'assistant/src/tools',
 ];
+
+const SCANNED_DIR_GLOBS = SCANNED_DIRS.flatMap((dir) => [`${dir}/*.ts`, `${dir}/**/*.ts`]);
 
 function isTestFile(filePath: string): boolean {
   return (
@@ -152,7 +157,10 @@ describe('assistant ID boundary', () => {
 
     // Check that there's no regex extracting assistantId from a /v1/assistants/ path
     // for use as a route handler (as opposed to the rewrite pattern).
-    const routeHandlerRegex = /\/v1\/assistants\/\(\[/;
+    // Match both literal slashes (/v1/assistants/([) and escaped slashes in regex
+    // literals (\/v1\/assistants\/([) so we catch patterns like:
+    //   endpoint.match(/^\/v1\/assistants\/([^/]+)\/(.+)$/)
+    const routeHandlerRegex = /\\?\/v1\\?\/assistants\\?\/\(\[/;
     const match = content.match(routeHandlerRegex);
     expect(
       match,

--- a/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
+++ b/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, test } from 'bun:test';
+import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+
+import { describe, expect, test } from 'bun:test';
 
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 
@@ -11,11 +13,66 @@ import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
  * for all assistant-scoped storage. Public assistant IDs are an edge concern
  * handled by the gateway/platform layer — they must not leak into daemon
  * scoping logic.
+ *
+ * These tests prevent regressions by scanning source files for banned patterns:
+ *  - No `normalizeAssistantId` usage in daemon/runtime scoping modules
+ *  - No assistant-scoped route handlers in the daemon HTTP server
+ *  - No hardcoded `'self'` string for assistant scoping (use the constant)
+ *  - The constant itself equals `'self'`
  */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Resolve repo root (tests run from assistant/). */
+function getRepoRoot(): string {
+  return join(process.cwd(), '..');
+}
+
+/**
+ * Directories containing daemon/runtime source files that must not reference
+ * `normalizeAssistantId` or hardcode assistant scope strings.
+ */
+const SCANNED_DIR_GLOBS = [
+  'assistant/src/runtime/**/*.ts',
+  'assistant/src/daemon/**/*.ts',
+  'assistant/src/memory/**/*.ts',
+  'assistant/src/approvals/**/*.ts',
+  'assistant/src/calls/**/*.ts',
+  'assistant/src/tools/**/*.ts',
+];
+
+function isTestFile(filePath: string): boolean {
+  return (
+    filePath.includes('/__tests__/') ||
+    filePath.endsWith('.test.ts') ||
+    filePath.endsWith('.test.js') ||
+    filePath.endsWith('.spec.ts') ||
+    filePath.endsWith('.spec.js')
+  );
+}
+
+function isMigrationFile(filePath: string): boolean {
+  return filePath.includes('/migrations/');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 describe('assistant ID boundary', () => {
+  // -------------------------------------------------------------------------
+  // Rule (d): The DAEMON_INTERNAL_ASSISTANT_ID constant equals 'self'
+  // -------------------------------------------------------------------------
+
   test('DAEMON_INTERNAL_ASSISTANT_ID equals "self"', () => {
     expect(DAEMON_INTERNAL_ASSISTANT_ID).toBe('self');
   });
+
+  // -------------------------------------------------------------------------
+  // Rule (a): No normalizeAssistantId in daemon scoping paths — spot check
+  // -------------------------------------------------------------------------
 
   test('no normalizeAssistantId imports in daemon scoping paths', () => {
     // Key daemon/runtime files that previously used normalizeAssistantId
@@ -37,5 +94,176 @@ describe('assistant ID boundary', () => {
     }
   });
 
-  test.todo('daemon storage keys never contain external assistant IDs');
+  // -------------------------------------------------------------------------
+  // Rule (a): No normalizeAssistantId in daemon/runtime directories — broad scan
+  // -------------------------------------------------------------------------
+
+  test('no normalizeAssistantId usage across daemon/runtime source directories', () => {
+    const repoRoot = getRepoRoot();
+
+    // Scan all daemon/runtime source directories for any reference to
+    // normalizeAssistantId. The function is defined in util/platform.ts for
+    // gateway use — it must not appear in daemon scoping modules.
+    let grepOutput = '';
+    try {
+      grepOutput = execFileSync(
+        'git',
+        ['grep', '-lE', 'normalizeAssistantId', '--', ...SCANNED_DIR_GLOBS],
+        { encoding: 'utf-8', cwd: repoRoot },
+      ).trim();
+    } catch (err) {
+      // Exit code 1 means no matches — happy path
+      if ((err as { status?: number }).status === 1) {
+        return;
+      }
+      throw err;
+    }
+
+    const files = grepOutput.split('\n').filter((f) => f.length > 0);
+    const violations = files.filter((f) => !isTestFile(f));
+
+    if (violations.length > 0) {
+      const message = [
+        'Found daemon/runtime source files that reference `normalizeAssistantId`.',
+        'Daemon code should use the `DAEMON_INTERNAL_ASSISTANT_ID` constant instead.',
+        'The `normalizeAssistantId` function is for gateway/platform use only (defined in util/platform.ts).',
+        '',
+        'Violations:',
+        ...violations.map((f) => `  - ${f}`),
+      ].join('\n');
+
+      expect(violations, message).toEqual([]);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Rule (b): No assistant-scoped route registration in daemon HTTP server
+  // -------------------------------------------------------------------------
+
+  test('no /v1/assistants/:assistantId/ route handler registration in daemon HTTP server', () => {
+    const httpServerPath = join(import.meta.dir, '..', 'runtime', 'http-server.ts');
+    const content = readFileSync(httpServerPath, 'utf-8');
+
+    // The transitional rewrite in dispatchEndpoint is acceptable — it strips
+    // the assistant-scoped prefix and recurses. What we guard against is a
+    // regex that extracts an assistantId for routing purposes, like:
+    //   /^\/v1\/assistants\/([^/]+)\/(.+)$/
+    // which would mean the server is treating the assistantId as meaningful.
+
+    // Check that there's no regex extracting assistantId from a /v1/assistants/ path
+    // for use as a route handler (as opposed to the rewrite pattern).
+    const routeHandlerRegex = /\/v1\/assistants\/\(\[/;
+    const match = content.match(routeHandlerRegex);
+    expect(
+      match,
+      'Found a route pattern matching /v1/assistants/([^/]+)/... that extracts an assistantId. ' +
+        'The daemon HTTP server should not have assistant-scoped route handlers — ' +
+        'use flat /v1/<endpoint> paths instead. The transitional rewrite in dispatchEndpoint ' +
+        'is the only acceptable place for the assistants/ prefix.',
+    ).toBeNull();
+
+    // Also verify that the routeRequest method does not contain a direct
+    // /v1/assistants/ route match (i.e., the pattern is only in dispatchEndpoint
+    // as a rewrite, not in routeRequest as a handler).
+    const lines = content.split('\n');
+    let inRouteRequest = false;
+    const routeRequestViolations: string[] = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].includes('private async routeRequest(')) {
+        inRouteRequest = true;
+      }
+      if (inRouteRequest && lines[i].includes('private async handleAuthenticatedRequest(')) {
+        // Moved past routeRequest into the next method
+        break;
+      }
+      if (inRouteRequest && lines[i].includes('/v1/assistants/')) {
+        routeRequestViolations.push(`  line ${i + 1}: ${lines[i].trim()}`);
+      }
+    }
+
+    expect(
+      routeRequestViolations,
+      'Found /v1/assistants/ references in routeRequest — this method should not ' +
+        'handle assistant-scoped paths directly.\n' +
+        routeRequestViolations.join('\n'),
+    ).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Rule (c): No hardcoded 'self' for assistant scoping in daemon files
+  // -------------------------------------------------------------------------
+
+  test('no hardcoded \'self\' string for assistant scoping in daemon source files', () => {
+    const repoRoot = getRepoRoot();
+
+    // Search for patterns where 'self' is used as an assistant ID value.
+    // We look for assignment / default / comparison patterns that suggest
+    // using the raw string instead of the DAEMON_INTERNAL_ASSISTANT_ID constant.
+    //
+    // Patterns matched:
+    //   assistantId: 'self'
+    //   assistantId = 'self'
+    //   assistantId ?? 'self'
+    //   ?? 'self'   (fallback to self)
+    //   || 'self'   (fallback to self)
+    //
+    // Excluded:
+    //   - Test files (they may legitimately assert against the value)
+    //   - Migration files (SQL literals like DEFAULT 'self' are fine)
+    //   - IPC contract files (comments documenting default values are fine)
+    //   - CSP headers ('self' in Content-Security-Policy has nothing to do with assistant IDs)
+    const pattern = `(assistantId|assistant_id).*['"]self['"]`;
+
+    let grepOutput = '';
+    try {
+      grepOutput = execFileSync(
+        'git',
+        ['grep', '-nE', pattern, '--', ...SCANNED_DIR_GLOBS],
+        { encoding: 'utf-8', cwd: repoRoot },
+      ).trim();
+    } catch (err) {
+      // Exit code 1 means no matches — happy path
+      if ((err as { status?: number }).status === 1) {
+        return;
+      }
+      throw err;
+    }
+
+    const lines = grepOutput.split('\n').filter((l) => l.length > 0);
+    const violations = lines.filter((line) => {
+      const filePath = line.split(':')[0];
+      if (isTestFile(filePath)) return false;
+      if (isMigrationFile(filePath)) return false;
+
+      // Allow comments (lines where the code portion starts with //)
+      const parts = line.split(':');
+      // parts[0] = file, parts[1] = line number, rest = content
+      const content = parts.slice(2).join(':').trim();
+      if (content.startsWith('//') || content.startsWith('*') || content.startsWith('/*')) {
+        return false;
+      }
+
+      return true;
+    });
+
+    if (violations.length > 0) {
+      const message = [
+        "Found daemon/runtime source files with hardcoded 'self' for assistant scoping.",
+        'Use the `DAEMON_INTERNAL_ASSISTANT_ID` constant from `runtime/assistant-scope.ts` instead.',
+        '',
+        'Violations:',
+        ...violations.map((v) => `  - ${v}`),
+      ].join('\n');
+
+      expect(violations, message).toEqual([]);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Rule (d): Daemon storage keys don't contain external assistant IDs
+  // (verified by the constant value test above — if the constant is 'self',
+  // all daemon storage keyed by DAEMON_INTERNAL_ASSISTANT_ID uses the fixed
+  // internal value rather than externally-provided IDs).
+  // -------------------------------------------------------------------------
 });

--- a/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
+++ b/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
@@ -170,31 +170,37 @@ describe('assistant ID boundary', () => {
         'is the only acceptable place for the assistants/ prefix.',
     ).toBeNull();
 
-    // Also verify that the routeRequest method does not contain a direct
-    // /v1/assistants/ route match (i.e., the pattern is only in dispatchEndpoint
-    // as a rewrite, not in routeRequest as a handler).
+    // Scan the entire file for assistant-scoped path literals. The only
+    // acceptable occurrence is the transitional rewrite in dispatchEndpoint
+    // (the `assistantScopedMatch` regex and surrounding deprecation log).
+    // Any other reference — in routeRequest, handleAuthenticatedRequest, or
+    // anywhere else — would mean the daemon is treating assistant IDs as
+    // meaningful routing state.
     const lines = content.split('\n');
-    let inRouteRequest = false;
-    const routeRequestViolations: string[] = [];
+    const violations: string[] = [];
+
+    // Allowlist: lines that are part of the transitional dispatchEndpoint
+    // rewrite. We identify them by the `assistantScopedMatch` variable name
+    // or the "Transitional rewrite" comment.
+    const isTransitionalRewriteLine = (line: string): boolean =>
+      line.includes('assistantScopedMatch') ||
+      line.includes('Transitional rewrite');
 
     for (let i = 0; i < lines.length; i++) {
-      if (lines[i].includes('private async routeRequest(')) {
-        inRouteRequest = true;
-      }
-      if (inRouteRequest && lines[i].includes('private async handleAuthenticatedRequest(')) {
-        // Moved past routeRequest into the next method
-        break;
-      }
-      if (inRouteRequest && lines[i].includes('/v1/assistants/')) {
-        routeRequestViolations.push(`  line ${i + 1}: ${lines[i].trim()}`);
+      const line = lines[i];
+      // Match both literal /v1/assistants/ and escaped \/v1\/assistants\/
+      if (line.includes('/v1/assistants/') || line.includes('\\/v1\\/assistants\\/')) {
+        if (!isTransitionalRewriteLine(line)) {
+          violations.push(`  line ${i + 1}: ${line.trim()}`);
+        }
       }
     }
 
     expect(
-      routeRequestViolations,
-      'Found /v1/assistants/ references in routeRequest — this method should not ' +
-        'handle assistant-scoped paths directly.\n' +
-        routeRequestViolations.join('\n'),
+      violations,
+      'Found /v1/assistants/ references outside the transitional dispatchEndpoint rewrite — ' +
+        'the daemon HTTP server should not have assistant-scoped path literals.\n' +
+        violations.join('\n'),
     ).toEqual([]);
   });
 

--- a/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
+++ b/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
@@ -202,6 +202,37 @@ describe('assistant ID boundary', () => {
         'the daemon HTTP server should not have assistant-scoped path literals.\n' +
         violations.join('\n'),
     ).toEqual([]);
+
+    // Guard against prefix-less assistants/ route patterns that extract an
+    // assistantId.  dispatchEndpoint receives the endpoint *after* the /v1/
+    // prefix has been stripped, so a regex like `assistants\/([^/]+)` would
+    // capture an external assistant ID from the path — violating the
+    // assistant-scoping boundary.
+    //
+    // The transitional rewrite `assistants\/[^/]+\/(.+)` is allowlisted
+    // because it only captures the trailing path (not the assistantId).
+    const prefixLessViolations: string[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      // Match regex patterns like assistants\/([^/]+) that capture the ID
+      // segment.  We look for the escaped-slash form used inside JS regex
+      // literals (e.g. /^assistants\/([^/]+)\//).
+      if (/assistants\\\/\(\[/.test(line)) {
+        // Allowlist the transitional rewrite which only captures the
+        // trailing path, not the assistantId itself.
+        if (!isTransitionalRewriteLine(line)) {
+          prefixLessViolations.push(`  line ${i + 1}: ${line.trim()}`);
+        }
+      }
+    }
+
+    expect(
+      prefixLessViolations,
+      'Found prefix-less assistants/([^/]+) route pattern that extracts an assistantId. ' +
+        'The daemon should not parse assistant IDs from URL paths — use ' +
+        'DAEMON_INTERNAL_ASSISTANT_ID instead.\n' +
+        prefixLessViolations.join('\n'),
+    ).toEqual([]);
   });
 
   // -------------------------------------------------------------------------

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -45,6 +45,7 @@ import {
   type PendingApprovalInfo,
 } from '../runtime/channel-approvals.js';
 import type { ApplyGuardianDecisionResult } from '../runtime/guardian-decision-types.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
 import { getLogger } from '../util/logger.js';
 import { mintGrantFromDecision } from './approval-primitive.js';
@@ -233,7 +234,7 @@ export function mintCanonicalRequestGrant(params: {
   }
 
   const result = mintGrantFromDecision({
-    assistantId: 'self',
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     scopeMode: 'tool_signature',
     toolName: request.toolName,
     inputDigest: request.inputDigest,

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -14,6 +14,7 @@ import { getOrCreateConversation } from '../memory/conversation-key-store.js';
 import { queueGenerateConversationTitle } from '../memory/conversation-title-service.js';
 import { upsertBinding } from '../memory/external-conversation-store.js';
 import { revokeScopedApprovalGrantsForContext } from '../memory/scoped-approval-grants.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { isGuardian } from '../runtime/channel-guardian-service.js';
 import { getSecureKey } from '../security/secure-keys.js';
 import { getLogger } from '../util/logger.js';
@@ -208,7 +209,7 @@ export type CreateInboundVoiceSessionResult = {
 export function createInboundVoiceSession(
   input: CreateInboundVoiceSessionInput,
 ): CreateInboundVoiceSessionResult {
-  const { callSid, fromNumber, toNumber, assistantId = 'self' } = input;
+  const { callSid, fromNumber, toNumber, assistantId = DAEMON_INTERNAL_ASSISTANT_ID } = input;
 
   // Check if a session already exists for this CallSid (replay protection)
   const existing = getCallSessionByCallSid(callSid);
@@ -219,7 +220,7 @@ export function createInboundVoiceSession(
 
   // Create a dedicated voice conversation keyed by CallSid so inbound calls
   // get their own conversation thread.
-  const voiceConvKey = assistantId && assistantId !== 'self'
+  const voiceConvKey = assistantId && assistantId !== DAEMON_INTERNAL_ASSISTANT_ID
     ? `asst:${assistantId}:voice:inbound:${callSid}`
     : `voice:inbound:${callSid}`;
   const { conversationId: voiceConversationId } = getOrCreateConversation(voiceConvKey);
@@ -272,7 +273,7 @@ export function createInboundVoiceSession(
  * Initiate a new outbound call.
  */
 export async function startCall(input: StartCallInput): Promise<StartCallResult | CallError> {
-  const { phoneNumber, task, context: callContext, conversationId, callerIdentityMode, assistantId = 'self' } = input;
+  const { phoneNumber, task, context: callContext, conversationId, callerIdentityMode, assistantId = DAEMON_INTERNAL_ASSISTANT_ID } = input;
 
   if (!phoneNumber || typeof phoneNumber !== 'string') {
     return { ok: false, error: 'phone_number is required and must be a string', status: 400 };
@@ -644,7 +645,7 @@ export type StartGuardianVerificationCallResult =
 export async function startGuardianVerificationCall(
   input: StartGuardianVerificationCallInput,
 ): Promise<StartGuardianVerificationCallResult> {
-  const { phoneNumber, guardianVerificationSessionId, assistantId = 'self', originConversationId } = input;
+  const { phoneNumber, guardianVerificationSessionId, assistantId = DAEMON_INTERNAL_ASSISTANT_ID, originConversationId } = input;
 
   if (!phoneNumber || !E164_REGEX.test(phoneNumber)) {
     return { ok: false, error: 'phone_number must be in E.164 format', status: 400 };

--- a/assistant/src/daemon/ipc-contract/integrations.ts
+++ b/assistant/src/daemon/ipc-contract/integrations.ts
@@ -87,7 +87,7 @@ export interface GuardianVerificationRequest {
   action: 'create_challenge' | 'status' | 'revoke' | 'start_outbound' | 'resend_outbound' | 'cancel_outbound';
   channel?: ChannelId;  // Defaults to 'telegram'
   sessionId?: string;
-  assistantId?: string;  // Defaults to 'self'
+  assistantId?: string;  // Defaults to DAEMON_INTERNAL_ASSISTANT_ID
   rebind?: boolean;  // When true, allows creating a challenge even if a binding already exists
   /** E.164 phone number for SMS/voice, Telegram handle/chat-id. Used by outbound actions. */
   destination?: string;

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -7,6 +7,7 @@ import { parseChannelId, parseInterfaceId } from '../channels/types.js';
 import { CHANNEL_IDS, INTERFACE_IDS, isChannelId } from '../channels/types.js';
 import { getConfig } from '../config/loader.js';
 import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { getLogger } from '../util/logger.js';
 import { createRowMapper } from '../util/row-mapper.js';
 import { deleteOrphanAttachments } from './attachments-store.js';
@@ -299,7 +300,7 @@ export async function addMessage(conversationId: string, role: string, content: 
     try {
       projectAssistantMessage({
         conversationId,
-        assistantId: 'self',
+        assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
         messageId: message.id,
         messageAt: message.createdAt,
       });

--- a/assistant/src/memory/delivery-crud.ts
+++ b/assistant/src/memory/delivery-crud.ts
@@ -8,6 +8,7 @@
 import { and, desc, eq, isNotNull } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { getConversationByKey, getOrCreateConversation, setConversationKeyIfAbsent } from './conversation-key-store.js';
 import { getDb } from './db.js';
 import { channelInboundEvents, conversations } from './schema.js';
@@ -73,7 +74,7 @@ export function recordInbound(
   const scopedMapping = assistantId ? getConversationByKey(scopedKey) : null;
   if (scopedMapping) {
     mapping = { conversationId: scopedMapping.conversationId, created: false };
-  } else if (assistantId === 'self') {
+  } else if (assistantId === DAEMON_INTERNAL_ASSISTANT_ID) {
     const legacyMapping = getConversationByKey(legacyKey);
     if (legacyMapping) {
       mapping = { conversationId: legacyMapping.conversationId, created: false };

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -1,5 +1,7 @@
 import { blob, index,integer, real, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core';
 
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
+
 export const conversations = sqliteTable('conversations', {
   id: text('id').primaryKey(),
   title: text('title'),
@@ -683,7 +685,7 @@ export const channelGuardianApprovalRequests = sqliteTable('channel_guardian_app
   runId: text('run_id').notNull(),
   requestId: text('request_id'),
   conversationId: text('conversation_id').notNull(),
-  assistantId: text('assistant_id').notNull().default('self'),
+  assistantId: text('assistant_id').notNull().default(DAEMON_INTERNAL_ASSISTANT_ID),
   channel: text('channel').notNull(),
   requesterExternalUserId: text('requester_external_user_id').notNull(),
   requesterChatId: text('requester_chat_id').notNull(),
@@ -819,7 +821,7 @@ export const mediaEventFeedback = sqliteTable('media_event_feedback', {
 
 export const guardianActionRequests = sqliteTable('guardian_action_requests', {
   id: text('id').primaryKey(),
-  assistantId: text('assistant_id').notNull().default('self'),
+  assistantId: text('assistant_id').notNull().default(DAEMON_INTERNAL_ASSISTANT_ID),
   kind: text('kind').notNull(),                                  // 'ask_guardian'
   sourceChannel: text('source_channel').notNull(),               // 'voice'
   sourceConversationId: text('source_conversation_id').notNull(),
@@ -930,7 +932,7 @@ export const canonicalGuardianDeliveries = sqliteTable('canonical_guardian_deliv
 
 export const assistantIngressInvites = sqliteTable('assistant_ingress_invites', {
   id: text('id').primaryKey(),
-  assistantId: text('assistant_id').notNull().default('self'),
+  assistantId: text('assistant_id').notNull().default(DAEMON_INTERNAL_ASSISTANT_ID),
   sourceChannel: text('source_channel').notNull(),
   tokenHash: text('token_hash').notNull(),
   createdBySessionId: text('created_by_session_id'),
@@ -952,7 +954,7 @@ export const assistantIngressInvites = sqliteTable('assistant_ingress_invites', 
 
 export const assistantIngressMembers = sqliteTable('assistant_ingress_members', {
   id: text('id').primaryKey(),
-  assistantId: text('assistant_id').notNull().default('self'),
+  assistantId: text('assistant_id').notNull().default(DAEMON_INTERNAL_ASSISTANT_ID),
   sourceChannel: text('source_channel').notNull(),
   externalUserId: text('external_user_id'),
   externalChatId: text('external_chat_id'),
@@ -974,7 +976,7 @@ export const assistantInboxThreadState = sqliteTable('assistant_inbox_thread_sta
   conversationId: text('conversation_id')
     .primaryKey()
     .references(() => conversations.id, { onDelete: 'cascade' }),
-  assistantId: text('assistant_id').notNull().default('self'),
+  assistantId: text('assistant_id').notNull().default(DAEMON_INTERNAL_ASSISTANT_ID),
   sourceChannel: text('source_channel').notNull(),
   externalChatId: text('external_chat_id').notNull(),
   externalUserId: text('external_user_id'),


### PR DESCRIPTION
Adds guard tests preventing re-introduction of normalizeAssistantId in daemon scoping, assistant-scoped routes, and hardcoded self strings. Part of #10674.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
