### PR TITLE
fix: use try/catch for stdin.flush() instead of .catch()

### DIFF
--- a/assistant/src/memory/embedding-local.ts
+++ b/assistant/src/memory/embedding-local.ts
@@ -81,9 +81,11 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
       }
       this.pendingRequests.set(id, { resolve });
       this.workerProc.stdin.write(JSON.stringify({ id, texts }) + '\n');
-      this.workerProc.stdin.flush().catch(() => {
+      try {
+        this.workerProc.stdin.flush();
+      } catch {
         // Worker may have exited — pending request will be resolved by stdout reader cleanup
-      });
+      }
     });
   }
 

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -13,6 +13,7 @@ import { loadAllAssistants, saveAssistantEntry, syncConfigToLockfile } from "../
 import type { AssistantEntry } from "../lib/assistant-config";
 import { hatchAws } from "../lib/aws";
 import {
+  GATEWAY_PORT,
   SPECIES_CONFIG,
   VALID_REMOTE_HOSTS,
   VALID_SPECIES,
@@ -21,6 +22,7 @@ import type { RemoteHost, Species } from "../lib/constants";
 import { hatchGcp } from "../lib/gcp";
 import type { PollResult, WatchHatchingResult } from "../lib/gcp";
 import { startLocalDaemon, startGateway, stopLocalProcesses } from "../lib/local";
+import { probePort } from "../lib/port-probe";
 import { isProcessAlive } from "../lib/process";
 import { generateRandomSuffix } from "../lib/random-name";
 import { validateAssistantName } from "../lib/retire-archive";
@@ -543,6 +545,32 @@ async function hatchLocal(species: Species, name: string | null, daemonOnly: boo
   }
 
   const baseDataDir = join(process.env.BASE_DATA_DIR?.trim() || (process.env.HOME ?? userInfo().homedir), ".vellum");
+
+  // Verify required ports are available before starting any services.
+  // A port conflict causes confusing failures (e.g. gateway health check
+  // returns "unreachable" because another process is listening on the port).
+  const RUNTIME_HTTP_PORT = Number(process.env.RUNTIME_HTTP_PORT) || 7821;
+  const QDRANT_PORT = 6333;
+  const requiredPorts = [
+    { name: "daemon", port: RUNTIME_HTTP_PORT },
+    { name: "gateway", port: GATEWAY_PORT },
+    { name: "qdrant", port: QDRANT_PORT },
+  ];
+  const conflicts: string[] = [];
+  await Promise.all(
+    requiredPorts.map(async ({ name, port }) => {
+      if (await probePort(port)) {
+        conflicts.push(`  - Port ${port} (${name}) is already in use`);
+      }
+    }),
+  );
+  if (conflicts.length > 0) {
+    throw new Error(
+      `Cannot hatch — required ports are already in use:\n${conflicts.join("\n")}\n\n` +
+        "Stop the conflicting processes or use environment variables to configure alternative ports " +
+        "(RUNTIME_HTTP_PORT, GATEWAY_PORT).",
+    );
+  }
 
   console.log(`🥚 Hatching local assistant: ${instanceName}`);
   console.log(`   Species: ${species}`);

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -542,35 +542,35 @@ async function hatchLocal(species: Species, name: string | null, daemonOnly: boo
       console.log("🧹 Cleaning up stale local processes (no lock file entry)...\n");
       await stopLocalProcesses();
     }
+
+    // Verify required ports are available before starting any services.
+    // Only check when no local assistants exist — if there are existing local
+    // assistants, their daemon/gateway/qdrant legitimately own these ports.
+    const RUNTIME_HTTP_PORT = Number(process.env.RUNTIME_HTTP_PORT) || 7821;
+    const QDRANT_PORT = 6333;
+    const requiredPorts = [
+      { name: "daemon", port: RUNTIME_HTTP_PORT },
+      { name: "gateway", port: GATEWAY_PORT },
+      { name: "qdrant", port: QDRANT_PORT },
+    ];
+    const conflicts: string[] = [];
+    await Promise.all(
+      requiredPorts.map(async ({ name, port }) => {
+        if (await probePort(port)) {
+          conflicts.push(`  - Port ${port} (${name}) is already in use`);
+        }
+      }),
+    );
+    if (conflicts.length > 0) {
+      throw new Error(
+        `Cannot hatch — required ports are already in use:\n${conflicts.join("\n")}\n\n` +
+          "Stop the conflicting processes or use environment variables to configure alternative ports " +
+          "(RUNTIME_HTTP_PORT, GATEWAY_PORT).",
+      );
+    }
   }
 
   const baseDataDir = join(process.env.BASE_DATA_DIR?.trim() || (process.env.HOME ?? userInfo().homedir), ".vellum");
-
-  // Verify required ports are available before starting any services.
-  // A port conflict causes confusing failures (e.g. gateway health check
-  // returns "unreachable" because another process is listening on the port).
-  const RUNTIME_HTTP_PORT = Number(process.env.RUNTIME_HTTP_PORT) || 7821;
-  const QDRANT_PORT = 6333;
-  const requiredPorts = [
-    { name: "daemon", port: RUNTIME_HTTP_PORT },
-    { name: "gateway", port: GATEWAY_PORT },
-    { name: "qdrant", port: QDRANT_PORT },
-  ];
-  const conflicts: string[] = [];
-  await Promise.all(
-    requiredPorts.map(async ({ name, port }) => {
-      if (await probePort(port)) {
-        conflicts.push(`  - Port ${port} (${name}) is already in use`);
-      }
-    }),
-  );
-  if (conflicts.length > 0) {
-    throw new Error(
-      `Cannot hatch — required ports are already in use:\n${conflicts.join("\n")}\n\n` +
-        "Stop the conflicting processes or use environment variables to configure alternative ports " +
-        "(RUNTIME_HTTP_PORT, GATEWAY_PORT).",
-    );
-  }
 
   console.log(`🥚 Hatching local assistant: ${instanceName}`);
   console.log(`   Species: ${species}`);

--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -381,36 +381,16 @@ async function listAllAssistants(): Promise<void> {
 
   await Promise.all(
     assistants.map(async (a, rowIndex) => {
-      const cloud = resolveCloud(a);
-
-      let status: string;
-      let detail: string | null = null;
-
-      if (cloud === "local") {
-        // For local assistants, use process detection instead of HTTP health
-        // check. The HTTP check is unreliable (localhost may resolve to IPv6
-        // while the gateway listens on IPv4).
-        const procs = await getLocalProcesses(a);
-        const daemonProc = procs.find((p) => p.name === "daemon");
-        if (daemonProc && daemonProc.status.includes("running")) {
-          status = "running";
-        } else {
-          status = "not running";
-        }
-      } else {
-        const health = await checkHealth(a.runtimeUrl);
-        status = health.status;
-        detail = health.detail;
-      }
+      const health = await checkHealth(a.runtimeUrl);
 
       const infoParts = [a.runtimeUrl];
       if (a.cloud) infoParts.push(`cloud: ${a.cloud}`);
       if (a.species) infoParts.push(`species: ${a.species}`);
-      if (detail) infoParts.push(detail);
+      if (health.detail) infoParts.push(health.detail);
 
       const updatedRow: TableRow = {
         name: a.assistantId,
-        status: withStatusEmoji(status),
+        status: withStatusEmoji(health.status),
         info: infoParts.join(" | "),
       };
 

--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -381,16 +381,36 @@ async function listAllAssistants(): Promise<void> {
 
   await Promise.all(
     assistants.map(async (a, rowIndex) => {
-      const health = await checkHealth(a.runtimeUrl);
+      const cloud = resolveCloud(a);
+
+      let status: string;
+      let detail: string | null = null;
+
+      if (cloud === "local") {
+        // For local assistants, use process detection instead of HTTP health
+        // check. The HTTP check is unreliable (localhost may resolve to IPv6
+        // while the gateway listens on IPv4).
+        const procs = await getLocalProcesses(a);
+        const daemonProc = procs.find((p) => p.name === "daemon");
+        if (daemonProc && daemonProc.status.includes("running")) {
+          status = "running";
+        } else {
+          status = "not running";
+        }
+      } else {
+        const health = await checkHealth(a.runtimeUrl);
+        status = health.status;
+        detail = health.detail;
+      }
 
       const infoParts = [a.runtimeUrl];
       if (a.cloud) infoParts.push(`cloud: ${a.cloud}`);
       if (a.species) infoParts.push(`species: ${a.species}`);
-      if (health.detail) infoParts.push(health.detail);
+      if (detail) infoParts.push(detail);
 
       const updatedRow: TableRow = {
         name: a.assistantId,
-        status: withStatusEmoji(health.status),
+        status: withStatusEmoji(status),
         info: infoParts.join(" | "),
       };
 


### PR DESCRIPTION
## Summary
- Bun's `FileSink.flush()` returns a `number` synchronously, not a `Promise`, so calling `.catch()` on it throws `flush().catch is not a function`
- Use `try/catch` instead

## Test plan
- [ ] Verify embedding worker accepts requests without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
