### PR TITLE
M2: Friend-Initiated In-Call Guardian Approval Flow

### DIFF
--- a/assistant/src/__tests__/guardian-actions-endpoint.test.ts
+++ b/assistant/src/__tests__/guardian-actions-endpoint.test.ts
@@ -262,6 +262,27 @@ describe('HTTP handleGuardianActionDecision', () => {
     expect(mockApplyCanonicalGuardianDecision).toHaveBeenCalledTimes(1);
   });
 
+  test('applies decision for voice access_request kind through canonical primitive', async () => {
+    createTestCanonicalRequest({
+      conversationId: 'conv-voice-access',
+      requestId: 'req-voice-access-1',
+      kind: 'access_request',
+      toolName: 'ingress_access_request',
+      guardianExternalUserId: 'guardian-voice-42',
+    });
+    mockApplyCanonicalGuardianDecision.mockResolvedValueOnce({ applied: true, requestId: 'req-voice-access-1', grantMinted: false });
+
+    const req = new Request('http://localhost/v1/guardian-actions/decision', {
+      method: 'POST',
+      body: JSON.stringify({ requestId: 'req-voice-access-1', action: 'approve_once' }),
+    });
+    const res = await handleGuardianActionDecision(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.applied).toBe(true);
+    expect(mockApplyCanonicalGuardianDecision).toHaveBeenCalledTimes(1);
+  });
+
   test('returns stale reason from canonical decision primitive', async () => {
     createTestCanonicalRequest({ conversationId: 'conv-stale', requestId: 'req-stale-1' });
     mockApplyCanonicalGuardianDecision.mockResolvedValueOnce({ applied: false, reason: 'already_resolved' });

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -437,6 +437,34 @@ describe('access-request-helper unit tests', () => {
     expect(payload.guardianBindingChannel).toBe('telegram');
   });
 
+  test('notifyGuardianOfAccessRequest for voice channel includes senderName in contextPayload', () => {
+    const result = notifyGuardianOfAccessRequest({
+      canonicalAssistantId: 'self',
+      sourceChannel: 'voice',
+      externalChatId: '+15559998888',
+      senderExternalUserId: '+15559998888',
+      senderName: 'Alice Caller',
+    });
+
+    expect(result.notified).toBe(true);
+    expect(emitSignalCalls.length).toBe(1);
+
+    const payload = emitSignalCalls[0].contextPayload as Record<string, unknown>;
+    expect(payload.sourceChannel).toBe('voice');
+    expect(payload.senderName).toBe('Alice Caller');
+    expect(payload.senderExternalUserId).toBe('+15559998888');
+    expect(payload.senderIdentifier).toBe('Alice Caller');
+
+    // Canonical request should exist
+    const pending = listCanonicalGuardianRequests({
+      status: 'pending',
+      requesterExternalUserId: '+15559998888',
+      sourceChannel: 'voice',
+      kind: 'access_request',
+    });
+    expect(pending.length).toBe(1);
+  });
+
   test('notifyGuardianOfAccessRequest includes requestCode in contextPayload', () => {
     const result = notifyGuardianOfAccessRequest({
       canonicalAssistantId: 'self',

--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -196,6 +196,45 @@ describe('notification decision strategy', () => {
       expect(copy.vellum!.body).toContain('open invite flow');
     });
 
+    test('ingress.access_request template includes caller name for voice-originated requests', () => {
+      const signal = makeSignal({
+        sourceEventName: 'ingress.access_request',
+        contextPayload: {
+          senderIdentifier: '+15559998888',
+          senderName: 'Alice Smith',
+          sourceChannel: 'voice',
+          requestCode: 'V1C2E3',
+        },
+      });
+
+      const copy = composeFallbackCopy(signal, channels);
+      expect(copy.vellum).toBeDefined();
+      expect(copy.vellum!.title).toBe('Access Request');
+      // Voice-originated requests should include the caller name and phone number
+      expect(copy.vellum!.body).toContain('Alice Smith');
+      expect(copy.vellum!.body).toContain('+15559998888');
+      expect(copy.vellum!.body).toContain('calling');
+    });
+
+    test('ingress.access_request template falls back to non-voice copy when sourceChannel is not voice', () => {
+      const signal = makeSignal({
+        sourceEventName: 'ingress.access_request',
+        contextPayload: {
+          senderIdentifier: 'user-123',
+          senderName: 'Bob Jones',
+          sourceChannel: 'telegram',
+          requestCode: 'T1G2M3',
+        },
+      });
+
+      const copy = composeFallbackCopy(signal, channels);
+      expect(copy.vellum).toBeDefined();
+      // Non-voice should use the standard "requesting access" text, not "calling"
+      expect(copy.vellum!.body).toContain('user-123');
+      expect(copy.vellum!.body).toContain('requesting access');
+      expect(copy.vellum!.body).not.toContain('calling');
+    });
+
     test('ingress.access_request Telegram deliveryText is concise', () => {
       const signal = makeSignal({
         sourceEventName: 'ingress.access_request',

--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -197,11 +197,16 @@ describe('notification decision strategy', () => {
     });
 
     test('ingress.access_request template includes caller name for voice-originated requests', () => {
+      // In production, senderIdentifier resolves to senderName for voice
+      // calls (senderName || senderUsername || senderExternalUserId), so
+      // both values are the caller's name. The phone number arrives via
+      // senderExternalUserId and should appear in the parenthetical.
       const signal = makeSignal({
         sourceEventName: 'ingress.access_request',
         contextPayload: {
-          senderIdentifier: '+15559998888',
+          senderIdentifier: 'Alice Smith',
           senderName: 'Alice Smith',
+          senderExternalUserId: '+15559998888',
           sourceChannel: 'voice',
           requestCode: 'V1C2E3',
         },
@@ -210,9 +215,9 @@ describe('notification decision strategy', () => {
       const copy = composeFallbackCopy(signal, channels);
       expect(copy.vellum).toBeDefined();
       expect(copy.vellum!.title).toBe('Access Request');
-      // Voice-originated requests should include the caller name and phone number
+      // Voice-originated requests should include the caller name and phone number in parentheses
       expect(copy.vellum!.body).toContain('Alice Smith');
-      expect(copy.vellum!.body).toContain('+15559998888');
+      expect(copy.vellum!.body).toContain('(+15559998888)');
       expect(copy.vellum!.body).toContain('calling');
     });
 

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -135,6 +135,7 @@ import {
 import type { RelayWebSocketData } from '../calls/relay-server.js';
 import { activeRelayConnections,RelayConnection } from '../calls/relay-server.js';
 import { setVoiceBridgeDeps } from '../calls/voice-session-bridge.js';
+import { listCanonicalGuardianRequests, resolveCanonicalGuardianRequest } from '../memory/canonical-guardian-store.js';
 import { createBinding, createChallenge } from '../memory/channel-guardian-store.js';
 import { addMessage, getMessages } from '../memory/conversation-store.js';
 import { getDb, initializeDb, resetDb } from '../memory/db.js';
@@ -211,6 +212,8 @@ function resetTables() {
   db.run('DELETE FROM channel_guardian_verification_challenges');
   db.run('DELETE FROM channel_guardian_bindings');
   db.run('DELETE FROM channel_guardian_rate_limits');
+  db.run('DELETE FROM canonical_guardian_requests');
+  db.run('DELETE FROM canonical_guardian_deliveries');
   ensuredConvIds = new Set();
 }
 
@@ -1881,7 +1884,7 @@ describe('relay-server', () => {
     relay.destroy();
   });
 
-  test('inbound voice invite redemption: unknown caller with no active invite is still denied', async () => {
+  test('inbound voice: unknown caller with no active invite enters name capture flow', async () => {
     ensureConversation('conv-invite-no-invite');
     const session = createCallSession({
       conversationId: 'conv-invite-no-invite',
@@ -1902,19 +1905,480 @@ describe('relay-server', () => {
       to: '+15551111111',
     }));
 
-    // Should have been denied (no invite, no challenge, unknown caller)
+    // Should be in the name capture state (not denied)
+    expect(relay.getConnectionState()).toBe('awaiting_name');
+
+    // Should have sent the name capture prompt
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes("don't recognize this number"))).toBe(true);
+    expect(textMessages.some((m) => (m.token ?? '').includes('Can I get your name'))).toBe(true);
+
+    // Verify event was recorded
+    const events = getCallEvents(session.id);
+    expect(events.some((e) => e.eventType === 'inbound_acl_name_capture_started')).toBe(true);
+
+    relay.destroy();
+  });
+
+  // ── Friend-initiated in-call guardian approval flow ────────────────────
+
+  test('name capture flow: caller provides name and enters guardian decision wait', async () => {
+    ensureConversation('conv-name-capture');
+    const session = createCallSession({
+      conversationId: 'conv-name-capture',
+      provider: 'twilio',
+      fromNumber: '+15558884444',
+      toNumber: '+15551111111',
+      assistantId: 'self',
+    });
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_name_capture',
+      from: '+15558884444',
+      to: '+15551111111',
+    }));
+
+    // Should be in name capture state
+    expect(relay.getConnectionState()).toBe('awaiting_name');
+
+    // Caller speaks their name
+    await relay.handleMessage(JSON.stringify({
+      type: 'prompt',
+      voicePrompt: 'My name is John',
+      lang: 'en-US',
+      last: true,
+    }));
+
+    // Should have transitioned to awaiting guardian decision
+    expect(relay.getConnectionState()).toBe('awaiting_guardian_decision');
+
+    // Should have sent the hold message
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes("I've let my guardian know"))).toBe(true);
+    expect(textMessages.some((m) => (m.token ?? '').includes('Please hold'))).toBe(true);
+
+    // Verify events were recorded
+    const events = getCallEvents(session.id);
+    expect(events.some((e) => e.eventType === 'inbound_acl_name_captured')).toBe(true);
+
+    // Session should be in waiting_on_user status
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('waiting_on_user');
+
+    relay.destroy();
+  });
+
+  test('name capture flow: DTMF input is ignored during awaiting_name state', async () => {
+    ensureConversation('conv-name-dtmf-ignore');
+    const session = createCallSession({
+      conversationId: 'conv-name-dtmf-ignore',
+      provider: 'twilio',
+      fromNumber: '+15558883333',
+      toNumber: '+15551111111',
+      assistantId: 'self',
+    });
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_name_dtmf_ignore',
+      from: '+15558883333',
+      to: '+15551111111',
+    }));
+
+    expect(relay.getConnectionState()).toBe('awaiting_name');
+    const msgCountBefore = ws.sentMessages.length;
+
+    // DTMF should be ignored during name capture
+    await relay.handleMessage(JSON.stringify({ type: 'dtmf', digit: '5' }));
+
+    // No new messages should be sent (DTMF is ignored)
+    expect(ws.sentMessages.length).toBe(msgCountBefore);
+    expect(relay.getConnectionState()).toBe('awaiting_name');
+
+    relay.destroy();
+  });
+
+  test('name capture flow: voice prompts ignored during guardian decision wait', async () => {
+    ensureConversation('conv-wait-prompt-ignore');
+    const session = createCallSession({
+      conversationId: 'conv-wait-prompt-ignore',
+      provider: 'twilio',
+      fromNumber: '+15558882222',
+      toNumber: '+15551111111',
+      assistantId: 'self',
+    });
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_wait_prompt_ignore',
+      from: '+15558882222',
+      to: '+15551111111',
+    }));
+
+    // Provide name to enter guardian decision wait
+    await relay.handleMessage(JSON.stringify({
+      type: 'prompt',
+      voicePrompt: 'Jane Doe',
+      lang: 'en-US',
+      last: true,
+    }));
+
+    expect(relay.getConnectionState()).toBe('awaiting_guardian_decision');
+    const msgCountBefore = ws.sentMessages.length;
+
+    // Voice prompts during guardian wait should be ignored
+    await relay.handleMessage(JSON.stringify({
+      type: 'prompt',
+      voicePrompt: 'Are you still there?',
+      lang: 'en-US',
+      last: true,
+    }));
+
+    // No new messages sent
+    expect(ws.sentMessages.length).toBe(msgCountBefore);
+    expect(relay.getConnectionState()).toBe('awaiting_guardian_decision');
+
+    relay.destroy();
+  });
+
+  test('blocked caller gets immediate denial even with name capture flow', async () => {
+    ensureConversation('conv-blocked-deny');
+    const session = createCallSession({
+      conversationId: 'conv-blocked-deny',
+      provider: 'twilio',
+      fromNumber: '+15558881111',
+      toNumber: '+15551111111',
+      assistantId: 'self',
+    });
+
+    // Create a blocked member
+    upsertMember({
+      assistantId: 'self',
+      sourceChannel: 'voice',
+      externalUserId: '+15558881111',
+      externalChatId: '+15558881111',
+      status: 'blocked',
+      policy: 'allow',
+    });
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_blocked_deny',
+      from: '+15558881111',
+      to: '+15551111111',
+    }));
+
+    // Blocked callers should NOT enter name capture — they get immediate denial
+    expect(relay.getConnectionState()).toBe('disconnecting');
+
     const updated = getCallSession(session.id);
     expect(updated).not.toBeNull();
     expect(updated!.status).toBe('failed');
 
-    // Should have sent a denial message, not an invite prompt
     const textMessages = ws.sentMessages
       .map((raw) => JSON.parse(raw) as { type: string; token?: string })
       .filter((m) => m.type === 'text');
     expect(textMessages.some((m) => (m.token ?? '').includes('not authorized'))).toBe(true);
 
-    // Let any delayed endSession callback flush
+    // Let delayed endSession callback flush
     await new Promise((resolve) => setTimeout(resolve, 3100));
+
+    relay.destroy();
+  });
+
+  test('name capture flow: access request creates canonical request for guardian', async () => {
+    ensureConversation('conv-access-req-canonical');
+    const session = createCallSession({
+      conversationId: 'conv-access-req-canonical',
+      provider: 'twilio',
+      fromNumber: '+15557770001',
+      toNumber: '+15551111111',
+      assistantId: 'self',
+    });
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_access_req_canonical',
+      from: '+15557770001',
+      to: '+15551111111',
+    }));
+
+    expect(relay.getConnectionState()).toBe('awaiting_name');
+
+    // Provide name
+    await relay.handleMessage(JSON.stringify({
+      type: 'prompt',
+      voicePrompt: 'Sarah Connor',
+      lang: 'en-US',
+      last: true,
+    }));
+
+    expect(relay.getConnectionState()).toBe('awaiting_guardian_decision');
+
+    // A canonical access request should have been created
+    const pending = listCanonicalGuardianRequests({
+      status: 'pending',
+      requesterExternalUserId: '+15557770001',
+      sourceChannel: 'voice',
+      kind: 'access_request',
+    });
+    expect(pending.length).toBe(1);
+    expect(pending[0].requesterExternalUserId).toBe('+15557770001');
+
+    relay.destroy();
+  });
+
+  test('name capture flow: approved access request activates caller and continues call', async () => {
+    ensureConversation('conv-access-approved');
+    const session = createCallSession({
+      conversationId: 'conv-access-approved',
+      provider: 'twilio',
+      fromNumber: '+15557770002',
+      toNumber: '+15551111111',
+      assistantId: 'self',
+    });
+
+    mockSendMessage.mockImplementation(createMockProviderResponse(['I can help you with that.']));
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_access_approved',
+      from: '+15557770002',
+      to: '+15551111111',
+    }));
+
+    // Provide name to enter wait state
+    await relay.handleMessage(JSON.stringify({
+      type: 'prompt',
+      voicePrompt: 'Bob Smith',
+      lang: 'en-US',
+      last: true,
+    }));
+
+    expect(relay.getConnectionState()).toBe('awaiting_guardian_decision');
+
+    // Find the canonical request and simulate guardian approval
+    const pending = listCanonicalGuardianRequests({
+      status: 'pending',
+      requesterExternalUserId: '+15557770002',
+      sourceChannel: 'voice',
+      kind: 'access_request',
+    });
+    expect(pending.length).toBe(1);
+
+    // Resolve the request to approved status
+    resolveCanonicalGuardianRequest(pending[0].id, 'pending', {
+      status: 'approved',
+      answerText: undefined,
+      decidedByExternalUserId: undefined,
+    });
+
+    // Wait for the poll interval to detect the approval (poll is every 2 seconds)
+    await new Promise((resolve) => setTimeout(resolve, 2500));
+
+    // Should have transitioned to connected state
+    expect(relay.getConnectionState()).toBe('connected');
+
+    // Verify events
+    const events = getCallEvents(session.id);
+    expect(events.some((e) => e.eventType === 'inbound_acl_access_approved')).toBe(true);
+
+    // Session should be in_progress
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('in_progress');
+
+    relay.destroy();
+  });
+
+  test('name capture flow: denied access request ends call with deterministic copy', async () => {
+    ensureConversation('conv-access-denied');
+    const session = createCallSession({
+      conversationId: 'conv-access-denied',
+      provider: 'twilio',
+      fromNumber: '+15557770003',
+      toNumber: '+15551111111',
+      assistantId: 'self',
+    });
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_access_denied',
+      from: '+15557770003',
+      to: '+15551111111',
+    }));
+
+    // Provide name
+    await relay.handleMessage(JSON.stringify({
+      type: 'prompt',
+      voicePrompt: 'Eve',
+      lang: 'en-US',
+      last: true,
+    }));
+
+    expect(relay.getConnectionState()).toBe('awaiting_guardian_decision');
+
+    // Simulate guardian denial
+    const pending = listCanonicalGuardianRequests({
+      status: 'pending',
+      requesterExternalUserId: '+15557770003',
+      sourceChannel: 'voice',
+      kind: 'access_request',
+    });
+    expect(pending.length).toBe(1);
+
+    resolveCanonicalGuardianRequest(pending[0].id, 'pending', {
+      status: 'denied',
+      answerText: undefined,
+      decidedByExternalUserId: undefined,
+    });
+
+    // Wait for poll to detect the denial
+    await new Promise((resolve) => setTimeout(resolve, 2500));
+
+    // Should be disconnecting
+    expect(relay.getConnectionState()).toBe('disconnecting');
+
+    // Should have sent the denial message
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes("my guardian says I'm not allowed"))).toBe(true);
+
+    // Session should be failed
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('failed');
+
+    // Verify event
+    const events = getCallEvents(session.id);
+    expect(events.some((e) => e.eventType === 'inbound_acl_access_denied')).toBe(true);
+
+    // Let the delayed endSession callback flush
+    await new Promise((resolve) => setTimeout(resolve, 3100));
+
+    relay.destroy();
+  });
+
+  test('name capture flow: timeout ends call with deterministic copy', async () => {
+    // Override the consultation timeout to a very short value for testing
+    mockConfig.calls.userConsultTimeoutSeconds = 2; // 2 seconds
+
+    ensureConversation('conv-access-timeout');
+    const session = createCallSession({
+      conversationId: 'conv-access-timeout',
+      provider: 'twilio',
+      fromNumber: '+15557770004',
+      toNumber: '+15551111111',
+      assistantId: 'self',
+    });
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_access_timeout',
+      from: '+15557770004',
+      to: '+15551111111',
+    }));
+
+    // Provide name
+    await relay.handleMessage(JSON.stringify({
+      type: 'prompt',
+      voicePrompt: 'Timeout Tester',
+      lang: 'en-US',
+      last: true,
+    }));
+
+    expect(relay.getConnectionState()).toBe('awaiting_guardian_decision');
+
+    // Wait for timeout (2 seconds + buffer)
+    await new Promise((resolve) => setTimeout(resolve, 2500));
+
+    // Should be disconnecting after timeout
+    expect(relay.getConnectionState()).toBe('disconnecting');
+
+    // Should have sent the timeout message
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes("can't get ahold of my guardian"))).toBe(true);
+    expect(textMessages.some((m) => (m.token ?? '').includes("let them know you called"))).toBe(true);
+
+    // Session should be failed
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('failed');
+
+    // Verify event
+    const events = getCallEvents(session.id);
+    expect(events.some((e) => e.eventType === 'inbound_acl_access_timeout')).toBe(true);
+
+    // Let the delayed endSession callback flush
+    await new Promise((resolve) => setTimeout(resolve, 3100));
+
+    // Restore default timeout
+    mockConfig.calls.userConsultTimeoutSeconds = 120;
+
+    relay.destroy();
+  });
+
+  test('name capture flow: transport close during guardian wait cleans up timers', async () => {
+    ensureConversation('conv-access-transport-close');
+    const session = createCallSession({
+      conversationId: 'conv-access-transport-close',
+      provider: 'twilio',
+      fromNumber: '+15557770005',
+      toNumber: '+15551111111',
+      assistantId: 'self',
+    });
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_access_transport_close',
+      from: '+15557770005',
+      to: '+15551111111',
+    }));
+
+    // Provide name
+    await relay.handleMessage(JSON.stringify({
+      type: 'prompt',
+      voicePrompt: 'Disconnector',
+      lang: 'en-US',
+      last: true,
+    }));
+
+    expect(relay.getConnectionState()).toBe('awaiting_guardian_decision');
+
+    // Simulate transport close while waiting for guardian
+    relay.handleTransportClosed(1000, 'caller hung up');
+
+    // Session should be completed (normal close)
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('completed');
 
     relay.destroy();
   });

--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -82,6 +82,7 @@ mock.module('../runtime/approval-message-composer.js', () => ({
   composeApprovalMessageGenerative: async () => 'mock generative message',
 }));
 
+import { getResolver } from '../approvals/guardian-request-resolvers.js';
 import {
   createApprovalRequest,
   createBinding,
@@ -487,6 +488,16 @@ describe('trusted contact activated notification signal', () => {
       (c) => c.sourceEventName === 'ingress.trusted_contact.activated',
     );
     expect(activatedSignals.length).toBe(0);
+  });
+
+  test('voice access_request resolver has registered handler for access_request kind', () => {
+    // The access_request resolver is registered during module load. When the
+    // source channel is 'voice', it should directly activate the member via
+    // upsertMember (no verification session). This test validates the resolver
+    // is registered and accessible.
+    const resolver = getResolver('access_request');
+    expect(resolver).toBeDefined();
+    expect(resolver!.kind).toBe('access_request');
   });
 
   test('member is persisted BEFORE activated signal is emitted', async () => {

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -13,6 +13,7 @@
 
 import { answerCall } from '../calls/call-domain.js';
 import type { CanonicalGuardianRequest } from '../memory/canonical-guardian-store.js';
+import { upsertMember } from '../memory/ingress-member-store.js';
 import { emitNotificationSignal } from '../notifications/emit-signal.js';
 import { addRule } from '../permissions/trust-store.js';
 import type { ApprovalAction } from '../runtime/channel-approval-types.js';
@@ -340,7 +341,40 @@ const accessRequestResolver: GuardianRequestResolver = {
       return { ok: true, applied: true };
     }
 
-    // On approve: mint an identity-bound verification session so the
+    // Voice approvals: directly activate the trusted contact without minting
+    // a verification session. The caller is already on the line and the
+    // relay server's in-call wait loop will detect the approved status.
+    if (channel === 'voice') {
+      try {
+        upsertMember({
+          assistantId,
+          sourceChannel: 'voice',
+          externalUserId: requesterExternalUserId,
+          externalChatId: requesterChatId,
+          status: 'active',
+          policy: 'allow',
+        });
+      } catch (err) {
+        log.error(
+          { err, requesterExternalUserId },
+          'Access request resolver: failed to activate voice caller as trusted contact',
+        );
+      }
+
+      log.info(
+        {
+          event: 'resolver_access_request_voice_approved',
+          requestId: request.id,
+          channel,
+          requesterExternalUserId,
+        },
+        'Access request resolver: voice approval — direct trusted-contact activation (no verification session)',
+      );
+
+      return { ok: true, applied: true };
+    }
+
+    // Non-voice approvals: mint an identity-bound verification session so the
     // requester can verify their identity.
     const session = createOutboundSession({
       assistantId,

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -26,6 +26,46 @@ import { getLogger } from '../util/logger.js';
 const log = getLogger('guardian-request-resolvers');
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the canonical assistant ID from an access_request's conversationId.
+ *
+ * Access request conversationIds follow the format:
+ *   `access-req-${canonicalAssistantId}-${sourceChannel}-${senderExternalUserId}`
+ *
+ * When both sourceChannel and requesterExternalUserId are known, we strip the
+ * prefix and suffix to recover the assistantId. Falls back to the
+ * channelDeliveryContext value or `'self'` when parsing is not possible.
+ */
+function resolveAssistantIdFromRequest(
+  request: CanonicalGuardianRequest,
+  channelDeliveryContext: ChannelDeliveryContext | undefined,
+): string {
+  // Prefer channelDeliveryContext when available (channel decision path).
+  if (channelDeliveryContext?.assistantId) {
+    return channelDeliveryContext.assistantId;
+  }
+
+  // Extract from conversationId for access_request kind.
+  const convId = request.conversationId;
+  const channel = request.sourceChannel;
+  const requester = request.requesterExternalUserId;
+
+  if (convId && channel && requester) {
+    const prefix = 'access-req-';
+    const suffix = `-${channel}-${requester}`;
+    if (convId.startsWith(prefix) && convId.endsWith(suffix)) {
+      const extracted = convId.slice(prefix.length, convId.length - suffix.length);
+      if (extracted) return extracted;
+    }
+  }
+
+  return 'self';
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -279,7 +319,7 @@ const accessRequestResolver: GuardianRequestResolver = {
     const requesterExternalUserId = request.requesterExternalUserId ?? '';
     const requesterChatId = request.requesterChatId ?? request.requesterExternalUserId ?? '';
     const decidedByExternalUserId = ctx.actor.externalUserId ?? '';
-    const assistantId = channelDeliveryContext?.assistantId ?? 'self';
+    const assistantId = resolveAssistantIdFromRequest(request, channelDeliveryContext);
 
     if (decision.action === 'reject') {
       log.info(
@@ -495,7 +535,7 @@ const toolGrantRequestResolver: GuardianRequestResolver = {
   async resolve(ctx: ResolverContext): Promise<ResolverResult> {
     const { request, decision, channelDeliveryContext } = ctx;
     const requesterChatId = request.requesterChatId ?? request.requesterExternalUserId ?? '';
-    const assistantId = channelDeliveryContext?.assistantId ?? 'self';
+    const assistantId = resolveAssistantIdFromRequest(request, channelDeliveryContext);
 
     if (decision.action === 'reject') {
       log.info(

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -11,8 +11,10 @@ import { randomInt } from 'node:crypto';
 import type { ServerWebSocket } from 'bun';
 
 import { getConfig } from '../config/loader.js';
+import { getCanonicalGuardianRequest } from '../memory/canonical-guardian-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { findActiveVoiceInvites } from '../memory/ingress-invite-store.js';
+import { upsertMember } from '../memory/ingress-member-store.js';
 import { revokeScopedApprovalGrantsForContext } from '../memory/scoped-approval-grants.js';
 import { notifyGuardianOfAccessRequest } from '../runtime/access-request-helper.js';
 import {
@@ -31,6 +33,7 @@ import { redeemVoiceInviteCode } from '../runtime/ingress-service.js';
 import { parseJsonSafe } from '../util/json.js';
 import { getLogger } from '../util/logger.js';
 import { normalizeAssistantId } from '../util/platform.js';
+import { getUserConsultationTimeoutMs } from './call-constants.js';
 import { CallController } from './call-controller.js';
 import { persistCallCompletionMessage } from './call-conversation-messages.js';
 import { addPointerMessage, formatDuration } from './call-pointer-messages.js';
@@ -143,7 +146,7 @@ export function setRelayBroadcast(fn: (msg: import('../daemon/ipc-contract.js').
 /**
  * Manages a single WebSocket connection for one call.
  */
-export type RelayConnectionState = 'connected' | 'verification_pending' | 'disconnecting';
+export type RelayConnectionState = 'connected' | 'verification_pending' | 'awaiting_name' | 'awaiting_guardian_decision' | 'disconnecting';
 
 export class RelayConnection {
   private ws: ServerWebSocket<RelayWebSocketData>;
@@ -181,6 +184,15 @@ export class RelayConnection {
   private inviteRedemptionCodeLength = 6;
   private inviteRedemptionFriendName: string | null = null;
   private inviteRedemptionGuardianName: string | null = null;
+
+  // In-call guardian approval wait state (friend-initiated)
+  private accessRequestWaitActive = false;
+  private accessRequestId: string | null = null;
+  private accessRequestAssistantId: string | null = null;
+  private accessRequestFromNumber: string | null = null;
+  private accessRequestPollTimer: ReturnType<typeof setInterval> | null = null;
+  private accessRequestTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
+  private accessRequestCallerName: string | null = null;
 
   constructor(ws: ServerWebSocket<RelayWebSocketData>, callSessionId: string) {
     this.ws = ws;
@@ -305,6 +317,15 @@ export class RelayConnection {
       this.controller.destroy();
       this.controller = null;
     }
+    if (this.accessRequestPollTimer) {
+      clearInterval(this.accessRequestPollTimer);
+      this.accessRequestPollTimer = null;
+    }
+    if (this.accessRequestTimeoutTimer) {
+      clearTimeout(this.accessRequestTimeoutTimer);
+      this.accessRequestTimeoutTimer = null;
+    }
+    this.accessRequestWaitActive = false;
     this.abortController.abort();
     log.info({ callSessionId: this.callSessionId }, 'RelayConnection destroyed');
   }
@@ -316,6 +337,9 @@ export class RelayConnection {
    * we still finalize the call lifecycle from the relay close signal.
    */
   handleTransportClosed(code?: number, reason?: string): void {
+    // Clean up access request wait state on disconnect to stop polling
+    this.clearAccessRequestWait();
+
     const session = getCallSession(this.callSessionId);
     if (!session) return;
     if (isTerminalState(session.status)) return;
@@ -501,9 +525,9 @@ export class RelayConnection {
       const pendingChallenge = getPendingChallenge(assistantId, 'voice');
 
       if (actorTrust.trustClass === 'unknown' && !pendingChallenge) {
-        // Before denying, check if there is an active voice invite bound
-        // to the caller's phone number. If so, enter the invite redemption
-        // subflow instead of denying the call outright.
+        // Before entering the name capture flow, check if there is an
+        // active voice invite bound to the caller's phone number. If so,
+        // enter the invite redemption subflow instead.
         let voiceInvites: ReturnType<typeof findActiveVoiceInvites> = [];
         try {
           voiceInvites = findActiveVoiceInvites({
@@ -530,54 +554,49 @@ export class RelayConnection {
           return;
         }
 
-        log.info(
-          { callSessionId: this.callSessionId, from: msg.from, trustClass: actorTrust.trustClass },
-          'Inbound voice ACL: unknown caller denied',
-        );
+        // Blocked members get immediate denial — the guardian already made
+        // an explicit decision to block them.
+        if (actorTrust.memberRecord?.status === 'blocked') {
+          log.info(
+            { callSessionId: this.callSessionId, from: msg.from, trustClass: actorTrust.trustClass },
+            'Inbound voice ACL: blocked caller denied',
+          );
 
-        recordCallEvent(this.callSessionId, 'inbound_acl_denied', {
-          from: msg.from,
-          trustClass: actorTrust.trustClass,
-          denialReason: actorTrust.denialReason,
-        });
+          recordCallEvent(this.callSessionId, 'inbound_acl_denied', {
+            from: msg.from,
+            trustClass: actorTrust.trustClass,
+            denialReason: actorTrust.denialReason,
+          });
 
-        // For revoked/pending members, notify the guardian so they can
-        // re-approve. Blocked members are intentionally excluded — the
-        // guardian already made an explicit decision to block them.
-        let guardianNotified = false;
-        if (actorTrust.memberRecord?.status !== 'blocked') {
-          try {
-            const accessResult = notifyGuardianOfAccessRequest({
-              canonicalAssistantId: assistantId,
-              sourceChannel: 'voice',
-              externalChatId: msg.from,
-              senderExternalUserId: actorTrust.canonicalSenderId ?? msg.from,
-            });
-            guardianNotified = accessResult.notified;
-          } catch (err) {
-            log.error({ err, callSessionId: this.callSessionId }, 'Failed to create access request for denied voice caller');
-          }
+          this.sendTextToken('This number is not authorized to use this assistant.', true);
+
+          this.connectionState = 'disconnecting';
+
+          updateCallSession(this.callSessionId, {
+            status: 'failed',
+            endedAt: Date.now(),
+            lastError: 'Inbound voice ACL: caller blocked',
+          });
+
+          setTimeout(() => {
+            this.endSession('Inbound voice ACL denied — blocked');
+          }, 3000);
+          return;
         }
 
-        // Deny with deterministic voice copy and end the call.
-        // Mark as disconnecting so handlePrompt ignores caller input
-        // during the delay before the session ends.
-        const denialMessage = guardianNotified
-          ? 'This number is not authorized. Your request has been forwarded to the account guardian.'
-          : 'This number is not authorized to use this assistant.';
-        this.sendTextToken(denialMessage, true);
+        // Unknown/revoked/pending callers enter the name capture + guardian
+        // approval wait flow instead of being hard-rejected.
+        log.info(
+          { callSessionId: this.callSessionId, from: msg.from, trustClass: actorTrust.trustClass },
+          'Inbound voice ACL: unknown caller — entering name capture flow',
+        );
 
-        this.connectionState = 'disconnecting';
-
-        updateCallSession(this.callSessionId, {
-          status: 'failed',
-          endedAt: Date.now(),
-          lastError: 'Inbound voice ACL: caller not authorized',
+        recordCallEvent(this.callSessionId, 'inbound_acl_name_capture_started', {
+          from: msg.from,
+          trustClass: actorTrust.trustClass,
         });
 
-        setTimeout(() => {
-          this.endSession('Inbound voice ACL denied');
-        }, 3000);
+        this.startNameCapture(assistantId, msg.from);
         return;
       }
 
@@ -1028,6 +1047,280 @@ export class RelayConnection {
   }
 
   /**
+   * Enter the name capture subflow for unknown inbound callers.
+   * Prompts the caller to provide their name so we can include it
+   * in the guardian notification.
+   */
+  private startNameCapture(assistantId: string, fromNumber: string): void {
+    this.accessRequestAssistantId = assistantId;
+    this.accessRequestFromNumber = fromNumber;
+    this.connectionState = 'awaiting_name';
+
+    this.sendTextToken(
+      "Sorry, I don't recognize this number. I'll let my guardian know you called and see if I have permission to speak with you. Can I get your name?",
+      true,
+    );
+
+    log.info(
+      { callSessionId: this.callSessionId, assistantId },
+      'Name capture started for unknown inbound caller',
+    );
+  }
+
+  /**
+   * Handle the caller's name response during the name capture subflow.
+   * Creates a canonical access request, notifies the guardian, and
+   * enters the bounded wait loop for the guardian decision.
+   */
+  private handleNameCaptureResponse(callerName: string): void {
+    if (!this.accessRequestAssistantId || !this.accessRequestFromNumber) {
+      return;
+    }
+
+    this.accessRequestCallerName = callerName;
+
+    recordCallEvent(this.callSessionId, 'inbound_acl_name_captured', {
+      from: this.accessRequestFromNumber,
+      callerName,
+    });
+
+    // Create canonical access request and notify the guardian, including
+    // the caller's spoken name and voice channel metadata.
+    try {
+      const accessResult = notifyGuardianOfAccessRequest({
+        canonicalAssistantId: this.accessRequestAssistantId,
+        sourceChannel: 'voice',
+        externalChatId: this.accessRequestFromNumber,
+        senderExternalUserId: this.accessRequestFromNumber,
+        senderName: callerName,
+      });
+
+      if (accessResult.notified) {
+        this.accessRequestId = accessResult.requestId;
+        log.info(
+          { callSessionId: this.callSessionId, requestId: accessResult.requestId, callerName },
+          'Guardian notified of voice access request with caller name',
+        );
+      } else {
+        log.warn(
+          { callSessionId: this.callSessionId },
+          'Failed to notify guardian of voice access request — no sender ID',
+        );
+      }
+    } catch (err) {
+      log.error({ err, callSessionId: this.callSessionId }, 'Failed to create access request for voice caller');
+    }
+
+    // Enter the bounded wait loop for the guardian decision
+    this.startAccessRequestWait();
+  }
+
+  /**
+   * Start a bounded in-call wait loop polling the canonical request
+   * status until approved, denied, or timeout.
+   */
+  private startAccessRequestWait(): void {
+    this.accessRequestWaitActive = true;
+    this.connectionState = 'awaiting_guardian_decision';
+
+    const timeoutMs = getUserConsultationTimeoutMs();
+    const pollIntervalMs = 2000;
+
+    this.sendTextToken(
+      "Thank you. I've let my guardian know. Please hold while I check if I have permission to speak with you.",
+      true,
+    );
+
+    updateCallSession(this.callSessionId, { status: 'waiting_on_user' });
+
+    // Poll the canonical request status
+    this.accessRequestPollTimer = setInterval(() => {
+      if (!this.accessRequestWaitActive || !this.accessRequestId) {
+        this.clearAccessRequestWait();
+        return;
+      }
+
+      const request = getCanonicalGuardianRequest(this.accessRequestId);
+      if (!request) {
+        return;
+      }
+
+      if (request.status === 'approved') {
+        this.handleAccessRequestApproved();
+      } else if (request.status === 'denied') {
+        this.handleAccessRequestDenied();
+      }
+      // 'pending' continues polling; 'expired'/'cancelled' handled by timeout
+    }, pollIntervalMs);
+
+    // Timeout: give up waiting for the guardian
+    this.accessRequestTimeoutTimer = setTimeout(() => {
+      if (!this.accessRequestWaitActive) return;
+
+      log.info(
+        { callSessionId: this.callSessionId, requestId: this.accessRequestId },
+        'Access request in-call wait timed out',
+      );
+
+      this.handleAccessRequestTimeout();
+    }, timeoutMs);
+
+    log.info(
+      { callSessionId: this.callSessionId, requestId: this.accessRequestId, timeoutMs },
+      'Access request in-call wait started',
+    );
+  }
+
+  /**
+   * Clean up access request wait state (timers, flags).
+   */
+  private clearAccessRequestWait(): void {
+    this.accessRequestWaitActive = false;
+    if (this.accessRequestPollTimer) {
+      clearInterval(this.accessRequestPollTimer);
+      this.accessRequestPollTimer = null;
+    }
+    if (this.accessRequestTimeoutTimer) {
+      clearTimeout(this.accessRequestTimeoutTimer);
+      this.accessRequestTimeoutTimer = null;
+    }
+  }
+
+  /**
+   * Handle an approved access request: activate the caller as a trusted
+   * contact, update runtime context, and continue with normal call flow.
+   */
+  private handleAccessRequestApproved(): void {
+    this.clearAccessRequestWait();
+    this.connectionState = 'connected';
+
+    const assistantId = this.accessRequestAssistantId!;
+    const fromNumber = this.accessRequestFromNumber!;
+    const callerName = this.accessRequestCallerName;
+
+    recordCallEvent(this.callSessionId, 'inbound_acl_access_approved', {
+      from: fromNumber,
+      callerName,
+      requestId: this.accessRequestId,
+    });
+
+    // Activate the caller as a trusted contact via the existing upsert path
+    try {
+      upsertMember({
+        assistantId,
+        sourceChannel: 'voice',
+        externalUserId: fromNumber,
+        externalChatId: fromNumber,
+        displayName: callerName ?? undefined,
+        status: 'active',
+        policy: 'allow',
+      });
+    } catch (err) {
+      log.error({ err, callSessionId: this.callSessionId }, 'Failed to activate voice caller as trusted contact');
+    }
+
+    // Re-resolve actor trust now that the member is active
+    const updatedTrust = resolveActorTrust({
+      assistantId,
+      sourceChannel: 'voice',
+      externalChatId: fromNumber,
+      senderExternalUserId: fromNumber,
+    });
+
+    if (this.controller) {
+      this.controller.setGuardianContext(
+        toGuardianRuntimeContextFromTrust(updatedTrust, fromNumber),
+      );
+    }
+
+    updateCallSession(this.callSessionId, { status: 'in_progress' });
+
+    log.info(
+      { callSessionId: this.callSessionId, from: fromNumber },
+      'Access request approved — caller activated and continuing call',
+    );
+
+    // Use handleUserInstruction to deliver the approval-aware greeting
+    // through the normal session pipeline.
+    const guardianName = 'my guardian';
+    if (this.controller) {
+      this.controller.handleUserInstruction(
+        `Great, ${guardianName} approved! Now how can I help you?`,
+      ).catch((err) => {
+        log.error({ err, callSessionId: this.callSessionId }, 'Failed to deliver approval greeting');
+      });
+    }
+  }
+
+  /**
+   * Handle a denied access request: deliver deterministic copy and hang up.
+   */
+  private handleAccessRequestDenied(): void {
+    this.clearAccessRequestWait();
+
+    recordCallEvent(this.callSessionId, 'inbound_acl_access_denied', {
+      from: this.accessRequestFromNumber,
+      requestId: this.accessRequestId,
+    });
+
+    this.sendTextToken(
+      "Sorry, my guardian says I'm not allowed to speak with you. Goodbye.",
+      true,
+    );
+
+    this.connectionState = 'disconnecting';
+
+    updateCallSession(this.callSessionId, {
+      status: 'failed',
+      endedAt: Date.now(),
+      lastError: 'Inbound voice ACL: guardian denied access request',
+    });
+
+    log.info(
+      { callSessionId: this.callSessionId },
+      'Access request denied — ending call',
+    );
+
+    setTimeout(() => {
+      this.endSession('Access request denied');
+    }, 3000);
+  }
+
+  /**
+   * Handle an access request timeout: deliver deterministic copy and hang up.
+   */
+  private handleAccessRequestTimeout(): void {
+    this.clearAccessRequestWait();
+
+    recordCallEvent(this.callSessionId, 'inbound_acl_access_timeout', {
+      from: this.accessRequestFromNumber,
+      requestId: this.accessRequestId,
+    });
+
+    this.sendTextToken(
+      "Sorry, I can't get ahold of my guardian right now. I'll let them know you called.",
+      true,
+    );
+
+    this.connectionState = 'disconnecting';
+
+    updateCallSession(this.callSessionId, {
+      status: 'failed',
+      endedAt: Date.now(),
+      lastError: 'Inbound voice ACL: guardian approval wait timed out',
+    });
+
+    log.info(
+      { callSessionId: this.callSessionId },
+      'Access request timed out — ending call',
+    );
+
+    setTimeout(() => {
+      this.endSession('Access request timed out');
+    }, 3000);
+  }
+
+  /**
    * Validate an entered invite code against active voice invites for the
    * caller. On success, create/activate the ingress member and transition
    * to the normal call flow. On failure, allow retries up to max attempts.
@@ -1119,6 +1412,26 @@ export class RelayConnection {
 
     if (!msg.last) {
       // Partial transcript, wait for final
+      return;
+    }
+
+    // During name capture, the caller's response is their name.
+    if (this.connectionState === 'awaiting_name') {
+      const callerName = msg.voicePrompt.trim();
+      log.info(
+        { callSessionId: this.callSessionId, callerName },
+        'Name captured from unknown inbound caller',
+      );
+      this.handleNameCaptureResponse(callerName);
+      return;
+    }
+
+    // During guardian decision wait, ignore caller speech — they are on hold.
+    if (this.connectionState === 'awaiting_guardian_decision') {
+      log.debug(
+        { callSessionId: this.callSessionId },
+        'Ignoring voice prompt during guardian decision wait',
+      );
       return;
     }
 
@@ -1249,6 +1562,11 @@ export class RelayConnection {
 
   private handleDtmf(msg: RelayDtmfMessage): void {
     if (this.connectionState === 'disconnecting') {
+      return;
+    }
+
+    // Ignore DTMF during name capture and guardian decision wait
+    if (this.connectionState === 'awaiting_name' || this.connectionState === 'awaiting_guardian_decision') {
       return;
     }
 

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -194,6 +194,9 @@ export class RelayConnection {
   private accessRequestTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
   private accessRequestCallerName: string | null = null;
 
+  // Name capture timeout (unknown inbound callers)
+  private nameCaptureTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
+
   constructor(ws: ServerWebSocket<RelayWebSocketData>, callSessionId: string) {
     this.ws = ws;
     this.callSessionId = callSessionId;
@@ -324,6 +327,10 @@ export class RelayConnection {
     if (this.accessRequestTimeoutTimer) {
       clearTimeout(this.accessRequestTimeoutTimer);
       this.accessRequestTimeoutTimer = null;
+    }
+    if (this.nameCaptureTimeoutTimer) {
+      clearTimeout(this.nameCaptureTimeoutTimer);
+      this.nameCaptureTimeoutTimer = null;
     }
     this.accessRequestWaitActive = false;
     this.abortController.abort();
@@ -1061,8 +1068,17 @@ export class RelayConnection {
       true,
     );
 
+    // Start a timeout so silent callers don't keep the call open indefinitely.
+    // Uses a 30-second window — enough time to speak a name but short enough
+    // to avoid wasting resources on callers who never respond.
+    const NAME_CAPTURE_TIMEOUT_MS = 30_000;
+    this.nameCaptureTimeoutTimer = setTimeout(() => {
+      if (this.connectionState !== 'awaiting_name') return;
+      this.handleNameCaptureTimeout();
+    }, NAME_CAPTURE_TIMEOUT_MS);
+
     log.info(
-      { callSessionId: this.callSessionId, assistantId },
+      { callSessionId: this.callSessionId, assistantId, timeoutMs: NAME_CAPTURE_TIMEOUT_MS },
       'Name capture started for unknown inbound caller',
     );
   }
@@ -1075,6 +1091,12 @@ export class RelayConnection {
   private handleNameCaptureResponse(callerName: string): void {
     if (!this.accessRequestAssistantId || !this.accessRequestFromNumber) {
       return;
+    }
+
+    // Clear the name capture timeout since the caller responded.
+    if (this.nameCaptureTimeoutTimer) {
+      clearTimeout(this.nameCaptureTimeoutTimer);
+      this.nameCaptureTimeoutTimer = null;
     }
 
     this.accessRequestCallerName = callerName;
@@ -1329,6 +1351,43 @@ export class RelayConnection {
 
     setTimeout(() => {
       this.endSession('Access request timed out');
+    }, 3000);
+  }
+
+  /**
+   * Handle a name capture timeout: the caller never provided their name
+   * within the allotted window. Deliver deterministic copy and hang up.
+   */
+  private handleNameCaptureTimeout(): void {
+    if (this.nameCaptureTimeoutTimer) {
+      clearTimeout(this.nameCaptureTimeoutTimer);
+      this.nameCaptureTimeoutTimer = null;
+    }
+
+    recordCallEvent(this.callSessionId, 'inbound_acl_name_capture_timeout', {
+      from: this.accessRequestFromNumber,
+    });
+
+    this.sendTextToken(
+      "Sorry, I didn't catch your name. Please try calling back. Goodbye.",
+      true,
+    );
+
+    this.connectionState = 'disconnecting';
+
+    updateCallSession(this.callSessionId, {
+      status: 'failed',
+      endedAt: Date.now(),
+      lastError: 'Inbound voice ACL: name capture timed out',
+    });
+
+    log.info(
+      { callSessionId: this.callSessionId },
+      'Name capture timed out — ending call',
+    );
+
+    setTimeout(() => {
+      this.endSession('Name capture timed out');
     }, 3000);
   }
 

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -1111,6 +1111,18 @@ export class RelayConnection {
       log.error({ err, callSessionId: this.callSessionId }, 'Failed to create access request for voice caller');
     }
 
+    // If the access request was not successfully created (notifyGuardianOfAccessRequest
+    // threw or returned notified: false), fail closed rather than leaving the caller
+    // stuck on hold with no guardian poll target.
+    if (!this.accessRequestId) {
+      log.warn(
+        { callSessionId: this.callSessionId },
+        'Access request ID is null after notification attempt — failing closed',
+      );
+      this.handleAccessRequestTimeout();
+      return;
+    }
+
     // Enter the bounded wait loop for the guardian decision
     this.startAccessRequestWait();
   }

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -57,7 +57,17 @@ const TEMPLATES: Record<string, CopyTemplate> = {
   'ingress.access_request': (payload) => {
     const requester = str(payload.senderIdentifier, 'Someone');
     const requestCode = nonEmpty(typeof payload.requestCode === 'string' ? payload.requestCode : undefined);
-    const lines: string[] = [`${requester} is requesting access to the assistant.`];
+    const sourceChannel = typeof payload.sourceChannel === 'string' ? payload.sourceChannel : undefined;
+    const callerName = nonEmpty(typeof payload.senderName === 'string' ? payload.senderName : undefined);
+    const lines: string[] = [];
+
+    // Voice-originated access requests include caller name context
+    if (sourceChannel === 'voice' && callerName) {
+      lines.push(`${callerName} (${requester}) is calling and requesting access to the assistant.`);
+    } else {
+      lines.push(`${requester} is requesting access to the assistant.`);
+    }
+
     if (requestCode) {
       const code = requestCode.toUpperCase();
       lines.push(`Reply "${code} approve" to grant access or "${code} reject" to deny.`);

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -63,7 +63,7 @@ const TEMPLATES: Record<string, CopyTemplate> = {
 
     // Voice-originated access requests include caller name context
     if (sourceChannel === 'voice' && callerName) {
-      lines.push(`${callerName} (${requester}) is calling and requesting access to the assistant.`);
+      lines.push(`${callerName} (${str(payload.senderExternalUserId, requester)}) is calling and requesting access to the assistant.`);
     } else {
       lines.push(`${requester} is requesting access to the assistant.`);
     }

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -105,14 +105,22 @@ export function notifyGuardianOfAccessRequest(
     }
   }
 
+  // The conversationId is assistant-scoped so the dedupe query below only
+  // matches requests for the same assistant. Without this, a pending request
+  // from assistant A could be returned for assistant B, allowing the caller
+  // to piggyback on A's guardian approval.
+  const conversationId = `access-req-${canonicalAssistantId}-${sourceChannel}-${senderExternalUserId}`;
+
   // Deduplicate: skip creation if there is already a pending canonical request
-  // for the same requester on this channel. Still return notified: true with
-  // the existing request ID so callers know the guardian was already notified.
+  // for the same requester on this channel *and* assistant. Still return
+  // notified: true with the existing request ID so callers know the guardian
+  // was already notified.
   const existingCanonical = listCanonicalGuardianRequests({
     status: 'pending',
     requesterExternalUserId: senderExternalUserId,
     sourceChannel,
     kind: 'access_request',
+    conversationId,
   });
   if (existingCanonical.length > 0) {
     log.debug(
@@ -130,7 +138,7 @@ export function notifyGuardianOfAccessRequest(
     kind: 'access_request',
     sourceType: 'channel',
     sourceChannel,
-    conversationId: `access-req-${sourceChannel}-${senderExternalUserId}`,
+    conversationId,
     requesterExternalUserId: senderExternalUserId,
     requesterChatId: externalChatId,
     guardianExternalUserId: guardianExternalUserId ?? undefined,


### PR DESCRIPTION
## Summary

Replace the unknown-caller hard-reject in the voice relay server with a
friend-initiated in-call guardian approval flow. Unknown callers now get a
name capture prompt, a canonical access request is created for the guardian,
and the caller is held on the line with bounded polling for the guardian
decision (approve/deny/timeout).

### Changes

1. **relay-server.ts**: New connection states (`awaiting_name`, `awaiting_guardian_decision`),
   name capture flow, bounded poll loop with configurable timeout, and
   deterministic copy for all three outcomes (approved, denied, timeout).
   Blocked callers still get immediate denial.

2. **guardian-request-resolvers.ts**: Voice channel branch in the
   `access_request` resolver that directly activates the trusted contact
   via `upsertMember` without minting a verification session.

3. **copy-composer.ts**: Extended `ingress.access_request` template to
   include caller name context for voice-originated access requests.

4. **Tests**: Updated all 5 test files with coverage for name capture flow,
   guardian decision wait states, approve/deny/timeout outcomes, DTMF/voice
   ignore during new states, blocked caller bypass, and voice-specific copy.

Closes #10696
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
