### PR TITLE
feat: export document writer content as .md file

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 import os
 import VellumAssistantShared
 
@@ -127,6 +128,27 @@ final class DocumentManager: ObservableObject {
         initialContent = ""
         pendingInitialContent = nil
         log.info("Document closed")
+    }
+
+    func exportToFile() {
+        let content = currentContent ?? ""
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = sanitizedFilename(from: title) + ".md"
+        panel.canCreateDirectories = true
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            DispatchQueue.global(qos: .userInitiated).async {
+                try? content.write(to: url, atomically: true, encoding: .utf8)
+            }
+        }
+    }
+
+    private func sanitizedFilename(from title: String) -> String {
+        let replaced = title.replacingOccurrences(of: " ", with: "-")
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        let sanitized = replaced.unicodeScalars.filter { allowed.contains($0) }
+        let result = String(String.UnicodeScalarView(sanitized))
+        return result.isEmpty ? "document" : result
     }
 
     func save() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DocumentEditorPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DocumentEditorPanel.swift
@@ -24,8 +24,8 @@ struct DocumentEditorPanelView: View {
                 if documentManager.isSaving {
                     ProgressView().controlSize(.small).scaleEffect(0.7)
                 } else {
-                    VIconButton(label: "Save", icon: "square.and.arrow.down", isActive: false, iconOnly: true) {
-                        documentManager.save()
+                    VIconButton(label: "Export", icon: "square.and.arrow.down", isActive: false, iconOnly: true) {
+                        documentManager.exportToFile()
                     }
                 }
                 VIconButton(label: "Close", icon: "xmark", isActive: false, iconOnly: true, action: onClose)


### PR DESCRIPTION
## Summary
- Change the document writer's save button to an export button that opens an NSSavePanel for saving as `.md`
- Add `exportToFile()` method with filename sanitization (spaces → hyphens, strip invalid chars)
- Daemon persistence is unaffected — the 2-second debounced auto-save continues handling it

## Original prompt
Add .md file export to Document Writer save button — change the save button to open an NSSavePanel and write the document content as a `.md` file to disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
