### PR TITLE
fix: wire IPC pending confirmations into NL approval routing

### DIFF
--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -328,6 +328,12 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
     // session-scoped interaction should be resolved.
     expect(resolveMock).toHaveBeenCalledTimes(1);
     expect(resolveMock).toHaveBeenCalledWith('req-live');
+    expect(resolveCanonicalGuardianRequestMock).toHaveBeenCalledTimes(1);
+    expect(resolveCanonicalGuardianRequestMock).toHaveBeenCalledWith(
+      'req-live',
+      'pending',
+      { status: 'denied' },
+    );
   });
 
   test('registers IPC confirmation events for NL approval routing', async () => {

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -12,6 +12,10 @@ const routeGuardianReplyMock = mock(async () => ({
   decisionApplied: false,
   type: 'not_consumed' as const,
 })) as any;
+const createCanonicalGuardianRequestMock = mock(() => ({
+  id: 'canonical-id',
+}));
+const generateCanonicalRequestCodeMock = mock(() => 'ABC123');
 const listPendingByDestinationMock = mock(() => [] as Array<{ id: string; kind?: string }>);
 const listCanonicalMock = mock(() => [] as Array<{ id: string }>);
 const getByConversationMock = mock(
@@ -21,6 +25,7 @@ const getByConversationMock = mock(
     session?: unknown;
   }>,
 );
+const registerMock = mock(() => {});
 const resolveMock = mock(() => undefined as unknown);
 const addMessageMock = mock(async () => ({ id: 'persisted-message-id' }));
 const getConfigMock = mock(() => ({
@@ -33,11 +38,14 @@ mock.module('../runtime/guardian-reply-router.js', () => ({
 }));
 
 mock.module('../memory/canonical-guardian-store.js', () => ({
+  createCanonicalGuardianRequest: createCanonicalGuardianRequestMock,
+  generateCanonicalRequestCode: generateCanonicalRequestCodeMock,
   listPendingCanonicalGuardianRequestsByDestinationConversation: listPendingByDestinationMock,
   listCanonicalGuardianRequests: listCanonicalMock,
 }));
 
 mock.module('../runtime/pending-interactions.js', () => ({
+  register: registerMock,
   getByConversation: getByConversationMock,
   resolve: resolveMock,
 }));
@@ -151,8 +159,11 @@ function makeSession(overrides: Partial<TestSession> = {}): TestSession {
 describe('handleUserMessage pending-confirmation reply interception', () => {
   beforeEach(() => {
     routeGuardianReplyMock.mockClear();
+    createCanonicalGuardianRequestMock.mockClear();
+    generateCanonicalRequestCodeMock.mockClear();
     listPendingByDestinationMock.mockClear();
     listCanonicalMock.mockClear();
+    registerMock.mockClear();
     getByConversationMock.mockClear();
     resolveMock.mockClear();
     addMessageMock.mockClear();
@@ -314,5 +325,58 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
     // session-scoped interaction should be resolved.
     expect(resolveMock).toHaveBeenCalledTimes(1);
     expect(resolveMock).toHaveBeenCalledWith('req-live');
+  });
+
+  test('registers IPC confirmation events for NL approval routing', async () => {
+    const session = makeSession({
+      hasAnyPendingConfirmation: () => false,
+      enqueueMessage: mock(() => ({ queued: false, requestId: 'direct-id' })),
+      processMessage: async (_content, _attachments, onEvent) => {
+        (onEvent as (msg: ServerMessage) => void)({
+          type: 'confirmation_request',
+          requestId: 'req-confirm-1',
+          toolName: 'call_start',
+          input: { phone_number: '+18084436762' },
+          riskLevel: 'high',
+          executionTarget: 'host',
+          allowlistOptions: [],
+          scopeOptions: [],
+          persistentDecisionsAllowed: false,
+        } as ServerMessage);
+        return 'msg-id';
+      },
+    });
+    const { ctx, sent } = createContext(session);
+
+    await handleUserMessage(makeMessage('please call now'), {} as net.Socket, ctx);
+
+    expect(registerMock).toHaveBeenCalledTimes(1);
+    expect(registerMock).toHaveBeenCalledWith(
+      'req-confirm-1',
+      expect.objectContaining({
+        conversationId: 'conv-1',
+        kind: 'confirmation',
+        session,
+        confirmationDetails: expect.objectContaining({
+          toolName: 'call_start',
+          riskLevel: 'high',
+          executionTarget: 'host',
+        }),
+      }),
+    );
+    expect(createCanonicalGuardianRequestMock).toHaveBeenCalledTimes(1);
+    expect(createCanonicalGuardianRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'req-confirm-1',
+        kind: 'tool_approval',
+        sourceType: 'desktop',
+        sourceChannel: 'vellum',
+        conversationId: 'conv-1',
+        toolName: 'call_start',
+        status: 'pending',
+        requestCode: 'ABC123',
+      }),
+    );
+    expect(sent.some((event) => event.type === 'confirmation_request')).toBe(true);
   });
 });

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -3,7 +3,7 @@ import * as net from 'node:net';
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
 import type { HandlerContext } from '../daemon/handlers.js';
-import type { UserMessage } from '../daemon/ipc-contract.js';
+import type { ConfirmationResponse, UserMessage } from '../daemon/ipc-contract.js';
 import type { ServerMessage } from '../daemon/ipc-protocol.js';
 import { DebouncerMap } from '../util/debounce.js';
 
@@ -18,6 +18,7 @@ const createCanonicalGuardianRequestMock = mock(() => ({
 const generateCanonicalRequestCodeMock = mock(() => 'ABC123');
 const listPendingByDestinationMock = mock(() => [] as Array<{ id: string; kind?: string }>);
 const listCanonicalMock = mock(() => [] as Array<{ id: string }>);
+const resolveCanonicalGuardianRequestMock = mock(() => null as { id: string } | null);
 const getByConversationMock = mock(
   () => [] as Array<{
     requestId: string;
@@ -42,6 +43,7 @@ mock.module('../memory/canonical-guardian-store.js', () => ({
   generateCanonicalRequestCode: generateCanonicalRequestCodeMock,
   listPendingCanonicalGuardianRequestsByDestinationConversation: listPendingByDestinationMock,
   listCanonicalGuardianRequests: listCanonicalMock,
+  resolveCanonicalGuardianRequest: resolveCanonicalGuardianRequestMock,
 }));
 
 mock.module('../runtime/pending-interactions.js', () => ({
@@ -80,7 +82,7 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
-import { handleUserMessage } from '../daemon/handlers/sessions.js';
+import { handleConfirmationResponse, handleUserMessage } from '../daemon/handlers/sessions.js';
 
 interface TestSession {
   messages: Array<{ role: string; content: unknown[] }>;
@@ -163,6 +165,7 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
     generateCanonicalRequestCodeMock.mockClear();
     listPendingByDestinationMock.mockClear();
     listCanonicalMock.mockClear();
+    resolveCanonicalGuardianRequestMock.mockClear();
     registerMock.mockClear();
     getByConversationMock.mockClear();
     resolveMock.mockClear();
@@ -378,5 +381,69 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
       }),
     );
     expect(sent.some((event) => event.type === 'confirmation_request')).toBe(true);
+  });
+
+  test('syncs canonical status to approved for IPC allow decisions', () => {
+    const session = {
+      hasPendingConfirmation: (requestId: string) => requestId === 'req-confirm-allow',
+      handleConfirmationResponse: mock(() => {}),
+    };
+    const { ctx } = createContext(makeSession());
+    ctx.sessions.set('conv-1', session as any);
+
+    const msg: ConfirmationResponse = {
+      type: 'confirmation_response',
+      requestId: 'req-confirm-allow',
+      decision: 'always_allow',
+    };
+
+    handleConfirmationResponse(msg, {} as net.Socket, ctx);
+
+    expect((session.handleConfirmationResponse as any).mock.calls.length).toBe(1);
+    expect((session.handleConfirmationResponse as any).mock.calls[0]).toEqual([
+      'req-confirm-allow',
+      'always_allow',
+      undefined,
+      undefined,
+    ]);
+    expect(resolveCanonicalGuardianRequestMock).toHaveBeenCalledWith(
+      'req-confirm-allow',
+      'pending',
+      { status: 'approved' },
+    );
+    expect(resolveMock).toHaveBeenCalledWith('req-confirm-allow');
+  });
+
+  test('syncs canonical status to denied for IPC deny decisions in CU sessions', () => {
+    const cuSession = {
+      hasPendingConfirmation: (requestId: string) => requestId === 'req-confirm-deny',
+      handleConfirmationResponse: mock(() => {}),
+    };
+    const { ctx } = createContext(makeSession({
+      hasPendingConfirmation: () => false,
+    }));
+    ctx.cuSessions.set('cu-1', cuSession as any);
+
+    const msg: ConfirmationResponse = {
+      type: 'confirmation_response',
+      requestId: 'req-confirm-deny',
+      decision: 'always_deny',
+    };
+
+    handleConfirmationResponse(msg, {} as net.Socket, ctx);
+
+    expect((cuSession.handleConfirmationResponse as any).mock.calls.length).toBe(1);
+    expect((cuSession.handleConfirmationResponse as any).mock.calls[0]).toEqual([
+      'req-confirm-deny',
+      'always_deny',
+      undefined,
+      undefined,
+    ]);
+    expect(resolveCanonicalGuardianRequestMock).toHaveBeenCalledWith(
+      'req-confirm-deny',
+      'pending',
+      { status: 'denied' },
+    );
+    expect(resolveMock).toHaveBeenCalledWith('req-confirm-deny');
   });
 });

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -55,6 +55,7 @@ import { getDb, initializeDb, resetDb } from '../memory/db.js';
 import type { AssistantEvent } from '../runtime/assistant-event.js';
 import { AssistantEventHub } from '../runtime/assistant-event-hub.js';
 import { RuntimeHttpServer } from '../runtime/http-server.js';
+import type { ApprovalConversationGenerator } from '../runtime/http-types.js';
 import * as pendingInteractions from '../runtime/pending-interactions.js';
 
 initializeDb();
@@ -215,11 +216,15 @@ describe('POST /v1/messages — queue-if-busy and hub publishing', () => {
     try { rmSync(testDir, { recursive: true, force: true }); } catch { /* best effort */ }
   });
 
-  async function startServer(sessionFactory: () => Session): Promise<void> {
+  async function startServer(
+    sessionFactory: () => Session,
+    options?: { approvalConversationGenerator?: ApprovalConversationGenerator },
+  ): Promise<void> {
     port = 19000 + Math.floor(Math.random() * 1000);
     server = new RuntimeHttpServer({
       port,
       bearerToken: TEST_TOKEN,
+      approvalConversationGenerator: options?.approvalConversationGenerator,
       sendMessageDeps: {
         getOrCreateSession: async () => sessionFactory(),
         assistantEventHub: eventHub,
@@ -331,6 +336,67 @@ describe('POST /v1/messages — queue-if-busy and hub publishing', () => {
       body: JSON.stringify({
         conversationKey,
         content: 'yes',
+        sourceChannel: 'vellum',
+        interface: 'macos',
+      }),
+    });
+    const body = await res.json() as { accepted: boolean; messageId?: string; queued?: boolean };
+
+    expect(res.status).toBe(202);
+    expect(body.accepted).toBe(true);
+    expect(body.messageId).toBeDefined();
+    expect(body.queued).toBeUndefined();
+    expect(handleConfirmationResponseMock).toHaveBeenCalledTimes(1);
+    expect(denyAllPendingConfirmationsMock).toHaveBeenCalledTimes(0);
+    expect(enqueueMessageMock).toHaveBeenCalledTimes(0);
+    expect(runAgentLoopMock).toHaveBeenCalledTimes(0);
+
+    await stopServer();
+  });
+
+  test('consumes natural-language approval text when approval conversation generator is configured', async () => {
+    const conversationKey = 'conv-inline-nl';
+    const { conversationId } = getOrCreateConversation(conversationKey);
+    const requestId = 'req-inline-nl';
+    const {
+      session,
+      runAgentLoopMock,
+      enqueueMessageMock,
+      denyAllPendingConfirmationsMock,
+      handleConfirmationResponseMock,
+    } = makePendingApprovalSession(requestId, false);
+
+    pendingInteractions.register(requestId, {
+      session,
+      conversationId,
+      kind: 'confirmation',
+    });
+    createCanonicalGuardianRequest({
+      id: requestId,
+      kind: 'tool_approval',
+      sourceType: 'desktop',
+      sourceChannel: 'vellum',
+      conversationId,
+      toolName: 'call_start',
+      status: 'pending',
+      requestCode: 'C0FFEE',
+      expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    });
+
+    const approvalConversationGenerator: ApprovalConversationGenerator = async (context) => ({
+      disposition: 'approve_once',
+      replyText: 'Approved.',
+      targetRequestId: context.pendingApprovals[0]?.requestId,
+    });
+
+    await startServer(() => session, { approvalConversationGenerator });
+
+    const res = await fetch(messagesUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({
+        conversationKey,
+        content: "sure let's do that",
         sourceChannel: 'vellum',
         interface: 'macos',
       }),

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -7,6 +7,8 @@ import { type InterfaceId,isChannelId, parseChannelId, parseInterfaceId } from '
 import { getConfig } from '../../config/loader.js';
 import { getAttachmentsForMessage, getFilePathForAttachment, setAttachmentThumbnail } from '../../memory/attachments-store.js';
 import {
+  createCanonicalGuardianRequest,
+  generateCanonicalRequestCode,
   listCanonicalGuardianRequests,
   listPendingCanonicalGuardianRequestsByDestinationConversation,
 } from '../../memory/canonical-guardian-store.js';
@@ -49,6 +51,7 @@ import { resolveRecordingIntent } from '../recording-intent.js';
 import { classifyRecordingIntentFallback, containsRecordingKeywords } from '../recording-intent-fallback.js';
 import { buildSessionErrorMessage,classifySessionError } from '../session-error.js';
 import { resolveChannelCapabilities } from '../session-runtime-assembly.js';
+import type { Session } from '../session.js';
 import { generateVideoThumbnail } from '../video-thumbnail.js';
 import { handleRecordingPause, handleRecordingRestart, handleRecordingResume, handleRecordingStart, handleRecordingStop } from './recording.js';
 import {
@@ -65,6 +68,68 @@ import {
 } from './shared.js';
 
 const desktopApprovalConversationGenerator = createApprovalConversationGenerator();
+
+function makeIpcEventSender(params: {
+  ctx: HandlerContext;
+  socket: net.Socket;
+  session: Session;
+  conversationId: string;
+  sourceChannel: string;
+}): (event: ServerMessage) => void {
+  const {
+    ctx,
+    socket,
+    session,
+    conversationId,
+    sourceChannel,
+  } = params;
+
+  return (event: ServerMessage) => {
+    if (event.type === 'confirmation_request') {
+      pendingInteractions.register(event.requestId, {
+        session,
+        conversationId,
+        kind: 'confirmation',
+        confirmationDetails: {
+          toolName: event.toolName,
+          input: event.input,
+          riskLevel: event.riskLevel,
+          executionTarget: event.executionTarget,
+          allowlistOptions: event.allowlistOptions,
+          scopeOptions: event.scopeOptions,
+          persistentDecisionsAllowed: event.persistentDecisionsAllowed,
+        },
+      });
+
+      try {
+        createCanonicalGuardianRequest({
+          id: event.requestId,
+          kind: 'tool_approval',
+          sourceType: 'desktop',
+          sourceChannel,
+          conversationId,
+          toolName: event.toolName,
+          status: 'pending',
+          requestCode: generateCanonicalRequestCode(),
+          expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+        });
+      } catch (err) {
+        log.debug(
+          { err, requestId: event.requestId, conversationId },
+          'Failed to create canonical request from IPC confirmation event',
+        );
+      }
+    } else if (event.type === 'secret_request') {
+      pendingInteractions.register(event.requestId, {
+        session,
+        conversationId,
+        kind: 'secret',
+      });
+    }
+
+    ctx.send(socket, event);
+  };
+}
 
 export async function handleUserMessage(
   msg: UserMessage,
@@ -83,8 +148,14 @@ export async function handleUserMessage(
       wireEscalationHandler(session, socket, ctx);
     }
 
-    const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
     const ipcChannel = parseChannelId(msg.channel) ?? 'vellum';
+    const sendEvent = makeIpcEventSender({
+      ctx,
+      socket,
+      session,
+      conversationId: msg.sessionId,
+      sourceChannel: ipcChannel,
+    });
     const ipcInterface = parseInterfaceId(msg.interface);
     if (!ipcInterface) {
       ctx.send(socket, {
@@ -638,6 +709,7 @@ export function handleConfirmationResponse(
         msg.selectedPattern,
         msg.selectedScope,
       );
+      pendingInteractions.resolve(msg.requestId);
       return;
     }
   }
@@ -651,6 +723,7 @@ export function handleConfirmationResponse(
         msg.selectedPattern,
         msg.selectedScope,
       );
+      pendingInteractions.resolve(msg.requestId);
       return;
     }
   }
@@ -670,6 +743,7 @@ export function handleSecretResponse(
     clearTimeout(standalone.timer);
     pendingStandaloneSecrets.delete(msg.requestId);
     standalone.resolve({ value: msg.value ?? null, delivery: msg.delivery ?? 'store' });
+    pendingInteractions.resolve(msg.requestId);
     return;
   }
 
@@ -680,6 +754,7 @@ export function handleSecretResponse(
     if (session.hasPendingSecret(msg.requestId)) {
       ctx.touchSession(sessionId);
       session.handleSecretResponse(msg.requestId, msg.value, msg.delivery);
+      pendingInteractions.resolve(msg.requestId);
       return;
     }
   }
@@ -801,9 +876,15 @@ export async function handleSessionCreate(
     }
 
     ctx.socketToSession.set(socket, conversation.id);
-    const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
     const requestId = uuid();
     const transportChannel = parseChannelId(msg.transport?.channelId) ?? 'vellum';
+    const sendEvent = makeIpcEventSender({
+      ctx,
+      socket,
+      session,
+      conversationId: conversation.id,
+      sourceChannel: transportChannel,
+    });
     session.setTurnChannelContext({
       userMessageChannel: transportChannel,
       assistantMessageChannel: transportChannel,
@@ -1136,7 +1217,16 @@ export async function handleRegenerate(
   }
   ctx.touchSession(msg.sessionId);
 
-  const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
+  const regenerateChannel = parseChannelId(
+    session.getTurnChannelContext()?.assistantMessageChannel,
+  ) ?? 'vellum';
+  const sendEvent = makeIpcEventSender({
+    ctx,
+    socket,
+    session,
+    conversationId: msg.sessionId,
+    sourceChannel: regenerateChannel,
+  });
   const requestId = uuid();
   session.traceEmitter.emit('request_received', 'Regenerate requested', {
     requestId,

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -688,6 +688,7 @@ export async function handleUserMessage(
       // stale request IDs are not reused as routing candidates.
       for (const interaction of pendingInteractions.getByConversation(msg.sessionId)) {
         if (interaction.session === session && interaction.kind === 'confirmation') {
+          syncCanonicalStatusFromIpcConfirmationDecision(interaction.requestId, 'deny');
           pendingInteractions.resolve(interaction.requestId);
         }
       }

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -11,6 +11,7 @@ import {
   generateCanonicalRequestCode,
   listCanonicalGuardianRequests,
   listPendingCanonicalGuardianRequestsByDestinationConversation,
+  resolveCanonicalGuardianRequest,
 } from '../../memory/canonical-guardian-store.js';
 import { getAttentionStateByConversationIds } from '../../memory/conversation-attention-store.js';
 import * as conversationStore from '../../memory/conversation-store.js';
@@ -68,6 +69,24 @@ import {
 } from './shared.js';
 
 const desktopApprovalConversationGenerator = createApprovalConversationGenerator();
+
+function syncCanonicalStatusFromIpcConfirmationDecision(
+  requestId: string,
+  decision: ConfirmationResponse['decision'],
+): void {
+  const targetStatus = decision === 'deny' || decision === 'always_deny'
+    ? 'denied' as const
+    : 'approved' as const;
+
+  try {
+    resolveCanonicalGuardianRequest(requestId, 'pending', { status: targetStatus });
+  } catch (err) {
+    log.debug(
+      { err, requestId, targetStatus },
+      'Failed to resolve canonical request from IPC confirmation response',
+    );
+  }
+}
 
 function makeIpcEventSender(params: {
   ctx: HandlerContext;
@@ -709,6 +728,7 @@ export function handleConfirmationResponse(
         msg.selectedPattern,
         msg.selectedScope,
       );
+      syncCanonicalStatusFromIpcConfirmationDecision(msg.requestId, msg.decision);
       pendingInteractions.resolve(msg.requestId);
       return;
     }
@@ -723,6 +743,7 @@ export function handleConfirmationResponse(
         msg.selectedPattern,
         msg.selectedScope,
       );
+      syncCanonicalStatusFromIpcConfirmationDecision(msg.requestId, msg.decision);
       pendingInteractions.resolve(msg.requestId);
       return;
     }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -714,6 +714,7 @@ export class RuntimeHttpServer {
           processMessage: this.processMessage,
           persistAndProcessMessage: this.persistAndProcessMessage,
           sendMessageDeps: this.sendMessageDeps,
+          approvalConversationGenerator: this.approvalConversationGenerator,
         });
       }
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -27,6 +27,7 @@ import { buildAssistantEvent } from '../assistant-event.js';
 import { routeGuardianReply } from '../guardian-reply-router.js';
 import { httpError } from '../http-errors.js';
 import type {
+  ApprovalConversationGenerator,
   MessageProcessor,
   NonBlockingMessageProcessor,
   RuntimeAttachmentMetadata,
@@ -87,6 +88,7 @@ async function tryConsumeInlineApprovalReply(params: {
   }>;
   session: import('../../daemon/session.js').Session;
   onEvent: (msg: ServerMessage) => void;
+  approvalConversationGenerator?: ApprovalConversationGenerator;
 }): Promise<{ consumed: boolean; messageId?: string }> {
   const {
     conversationId,
@@ -96,6 +98,7 @@ async function tryConsumeInlineApprovalReply(params: {
     attachments,
     session,
     onEvent,
+    approvalConversationGenerator,
   } = params;
   const trimmedContent = content.trim();
 
@@ -125,6 +128,7 @@ async function tryConsumeInlineApprovalReply(params: {
     },
     conversationId,
     pendingRequestIds,
+    approvalConversationGenerator,
   });
 
   if (!routerResult.consumed || routerResult.type === 'nl_keep_pending') {
@@ -377,6 +381,7 @@ export async function handleSendMessage(
     processMessage?: MessageProcessor;
     persistAndProcessMessage?: NonBlockingMessageProcessor;
     sendMessageDeps?: SendMessageDeps;
+    approvalConversationGenerator?: ApprovalConversationGenerator;
   },
 ): Promise<Response> {
   const body = await req.json() as {
@@ -455,10 +460,11 @@ export async function handleSendMessage(
         sourceChannel,
         sourceInterface,
         content: content ?? '',
-        attachments,
-        session,
-        onEvent,
-      });
+      attachments,
+      session,
+      onEvent,
+      approvalConversationGenerator: deps.approvalConversationGenerator,
+    });
       if (inlineReplyResult.consumed) {
         return Response.json(
           { accepted: true, ...(inlineReplyResult.messageId ? { messageId: inlineReplyResult.messageId } : {}) },


### PR DESCRIPTION
## Root Cause
Natural-language approval replies in mac chat were still failing on the IPC/socket path because `confirmation_request` events were sent to the client but never registered in server-side `pendingInteractions` or canonical guardian requests. When the user replied with text (e.g. "approve"), inline routing had no live request IDs to target and fell back to auto-deny + normal message handling.

## What changed
- Added a shared IPC event sender wrapper in `assistant/src/daemon/handlers/sessions.ts` that, for every IPC `confirmation_request`/`secret_request`:
  - registers the pending interaction in `pendingInteractions`
  - creates a canonical `tool_approval` request for confirmation events
  - then forwards the event to the socket
- Wired that wrapper into all relevant IPC paths:
  - `handleUserMessage`
  - `handleSessionCreate` initial message path
  - `handleRegenerate`
- Kept pending interaction tracker aligned on direct IPC responses by resolving tracker entries in:
  - `handleConfirmationResponse`
  - `handleSecretResponse`
- Extended HTTP `/v1/messages` inline-approval consumption to pass through the configured approval conversation generator, enabling true natural-language decision text (not only deterministic phrases).

## Tests
- `bun test src/__tests__/handlers-user-message-approval-consumption.test.ts`
- `bun test src/__tests__/send-endpoint-busy.test.ts`
- `bun test src/__tests__/conversation-routes.test.ts`
- `bun test src/__tests__/handle-user-message-secret-resume.test.ts`
- `bun test src/__tests__/recording-intent-handler.test.ts`
- `bun test src/__tests__/daemon-server-session-init.test.ts`
- `bunx tsc --noEmit`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
