### PR TITLE
fix: validate app_create inputs to prevent writeFileSync crashes

### DIFF
--- a/assistant/src/memory/app-store.ts
+++ b/assistant/src/memory/app-store.ts
@@ -147,6 +147,9 @@ function savePages(appId: string, pages: Record<string, string>): void {
   mkdirSync(pagesDir, { recursive: true });
   for (const [filename, content] of Object.entries(pages)) {
     validatePageFilename(filename);
+    if (typeof content !== 'string') {
+      throw new Error(`Page content for "${filename}" must be a string, got ${typeof content}`);
+    }
     writeFileSync(join(pagesDir, filename), content, 'utf-8');
   }
 }
@@ -194,6 +197,9 @@ export function createApp(params: {
   // Write htmlDefinition to {appId}/index.html on disk
   const appDir = join(dir, app.id);
   mkdirSync(appDir, { recursive: true });
+  if (typeof params.htmlDefinition !== 'string') {
+    throw new Error(`htmlDefinition must be a string, got ${typeof params.htmlDefinition}`);
+  }
   writeFileSync(join(appDir, 'index.html'), params.htmlDefinition, 'utf-8');
 
   // Write preview to companion file to keep the JSON small

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -102,6 +102,21 @@ export async function executeAppCreate(
   const preview = input.preview;
   const appType = input.type === 'site' ? 'site' as const : 'app' as const;
 
+  // Validate required fields — LLM input is not type-checked at runtime
+  if (typeof name !== 'string' || name.trim() === '') {
+    return { content: JSON.stringify({ error: 'name is required and must be a non-empty string' }), isError: true };
+  }
+  if (typeof htmlDefinition !== 'string') {
+    return { content: JSON.stringify({ error: 'html is required and must be a string containing the HTML definition' }), isError: true };
+  }
+  if (pages) {
+    for (const [filename, content] of Object.entries(pages)) {
+      if (typeof content !== 'string') {
+        return { content: JSON.stringify({ error: `pages["${filename}"] must be a string, got ${typeof content}` }), isError: true };
+      }
+    }
+  }
+
   const app = store.createApp({ name, description, schemaJson, htmlDefinition, pages, appType });
 
   if (input.set_as_home_base) {


### PR DESCRIPTION
## Summary
- Adds runtime input validation in `executeAppCreate` for `name`, `html`, and `pages` values — returns a clear error result so the LLM can retry instead of crashing
- Adds defensive type checks in `app-store.ts` (`createApp` and `savePages`) before `writeFileSync` calls as defense-in-depth

Fixes the `"The 'data' argument must be of type string or an instance of Buffer, TypedArray, or DataView"` crash when the LLM sends non-string values for required fields.

## Test plan
- [x] `bun test src/__tests__/app-executors.test.ts` — 35 tests pass
- [x] `bun test src/__tests__/app-builder-tool-scripts.test.ts src/__tests__/app-open-proxy.test.ts` — 26 tests pass
- [x] `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
