### PR TITLE
feat: polished code block & inline code styling

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -326,7 +326,7 @@ struct ChatBubble: View {
                             secondaryTextColor: isUser ? VColor.userBubbleTextSecondary : VColor.textSecondary,
                             mutedTextColor: isUser ? VColor.userBubbleTextSecondary : VColor.textMuted,
                             tintColor: isUser ? VColor.userBubbleText : VColor.accent,
-                            codeBackgroundColor: isUser ? VColor.userBubbleText.opacity(0.1) : VColor.backgroundSubtle,
+                            codeBackgroundColor: isUser ? VColor.userBubbleText.opacity(0.1) : VColor.codeBackground,
                             hrColor: isUser ? VColor.userBubbleText.opacity(0.3) : VColor.surfaceBorder
                         )
                     } else {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -53,8 +53,24 @@ extension ChatBubble {
         let options = AttributedString.MarkdownParsingOptions(
             interpretedSyntax: .inlineOnlyPreservingWhitespace
         )
-        let result = (try? AttributedString(markdown: text, options: options))
+        var result = (try? AttributedString(markdown: text, options: options))
             ?? AttributedString(text)
+        var inlineCodeRanges: [Range<AttributedString.Index>] = []
+        for run in result.runs {
+            if let intent = run.inlinePresentationIntent, intent.contains(.code) {
+                inlineCodeRanges.append(run.range)
+            }
+        }
+        for range in inlineCodeRanges.reversed() {
+            result[range].foregroundColor = VColor.codeText
+            result[range].backgroundColor = VColor.codeBackground
+            var trailing = AttributedString("\u{2009}")
+            trailing.backgroundColor = VColor.codeBackground
+            result.insert(trailing, at: range.upperBound)
+            var leading = AttributedString("\u{2009}")
+            leading.backgroundColor = VColor.codeBackground
+            result.insert(leading, at: range.lowerBound)
+        }
         if isStreaming {
             lastStreamingInlineMarkdown = (text, result)
             return result
@@ -142,6 +158,24 @@ extension ChatBubble {
         )
         var parsed = (try? AttributedString(markdown: trimmed, options: options))
             ?? AttributedString(trimmed)
+
+        // Apply background, red text, and padding to inline code spans
+        var markdownCodeRanges: [Range<AttributedString.Index>] = []
+        for run in parsed.runs {
+            if let intent = run.inlinePresentationIntent, intent.contains(.code) {
+                markdownCodeRanges.append(run.range)
+            }
+        }
+        for range in markdownCodeRanges.reversed() {
+            parsed[range].foregroundColor = VColor.codeText
+            parsed[range].backgroundColor = VColor.codeBackground
+            var trailing = AttributedString("\u{2009}")
+            trailing.backgroundColor = VColor.codeBackground
+            parsed.insert(trailing, at: range.upperBound)
+            var leading = AttributedString("\u{2009}")
+            leading.backgroundColor = VColor.codeBackground
+            parsed.insert(leading, at: range.lowerBound)
+        }
 
         // Highlight slash command token (e.g. /model) in blue
         if let slashMatch = trimmed.range(of: #"^/\w+"#, options: .regularExpression) {

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -13,7 +13,7 @@ struct MarkdownSegmentView: View {
     var secondaryTextColor: Color = VColor.textSecondary
     var mutedTextColor: Color = VColor.textMuted
     var tintColor: Color = VColor.accent
-    var codeBackgroundColor: Color = VColor.backgroundSubtle
+    var codeBackgroundColor: Color = VColor.codeBackground
     var hrColor: Color = VColor.surfaceBorder
 
     @Environment(\.conversationZoomScale) private var zoomScale
@@ -287,6 +287,24 @@ struct MarkdownSegmentView: View {
             default:
                 break
             }
+        }
+
+        // Apply background, red text, and padding to inline code spans
+        var codeRanges: [Range<AttributedString.Index>] = []
+        for run in result.runs {
+            if let intent = run.inlinePresentationIntent, intent.contains(.code) {
+                codeRanges.append(run.range)
+            }
+        }
+        for range in codeRanges.reversed() {
+            result[range].foregroundColor = VColor.codeText
+            result[range].backgroundColor = VColor.codeBackground
+            var trailing = AttributedString("\u{2009}")
+            trailing.backgroundColor = VColor.codeBackground
+            result.insert(trailing, at: range.upperBound)
+            var leading = AttributedString("\u{2009}")
+            leading.backgroundColor = VColor.codeBackground
+            result.insert(leading, at: range.lowerBound)
         }
 
         return result

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -198,6 +198,8 @@ public enum VColor {
     public static let warning = adaptiveColor(light: Amber._700, dark: Amber._600)
 
     // Chat
+    public static let codeBackground = adaptiveColor(light: Moss._200, dark: Moss._700)
+    public static let codeText = adaptiveColor(light: Color(hex: 0xDC2626), dark: Color(hex: 0xF87171))
     public static let userBubble = adaptiveColor(light: Moss._200, dark: Moss._950)
     public static let userBubbleText = adaptiveColor(light: Stone._900, dark: Moss._50)
     public static let userBubbleTextSecondary = adaptiveColor(light: Stone._600, dark: Moss._50.opacity(0.8))

--- a/clients/shared/Features/Chat/MarkdownRenderer.swift
+++ b/clients/shared/Features/Chat/MarkdownRenderer.swift
@@ -46,7 +46,7 @@ private struct CodeBlockView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .textSelection(.enabled)
         }
-        .background(VColor.backgroundSubtle)
+        .background(VColor.codeBackground)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
     }
 
@@ -293,8 +293,25 @@ public struct MarkdownRenderer: View {
         let options = AttributedString.MarkdownParsingOptions(
             interpretedSyntax: .inlineOnlyPreservingWhitespace
         )
-        return (try? AttributedString(markdown: text, options: options))
+        var result = (try? AttributedString(markdown: text, options: options))
             ?? AttributedString(text)
+        var codeRanges: [Range<AttributedString.Index>] = []
+        for run in result.runs {
+            if let intent = run.inlinePresentationIntent, intent.contains(.code) {
+                codeRanges.append(run.range)
+            }
+        }
+        for range in codeRanges.reversed() {
+            result[range].foregroundColor = VColor.codeText
+            result[range].backgroundColor = VColor.codeBackground
+            var trailing = AttributedString("\u{2009}")
+            trailing.backgroundColor = VColor.codeBackground
+            result.insert(trailing, at: range.upperBound)
+            var leading = AttributedString("\u{2009}")
+            leading.backgroundColor = VColor.codeBackground
+            result.insert(leading, at: range.lowerBound)
+        }
+        return result
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `VColor.codeBackground` and `VColor.codeText` semantic tokens for code styling
- Fenced code blocks now use a dedicated background color with clear contrast against the chat background (light: Moss._200, dark: Moss._700)
- Inline code spans get background highlight, red text color, and thin-space padding for visual breathing room

## Test plan

- [ ] Build the macOS app and verify it compiles
- [ ] Send a message that triggers code blocks and inline code in the response
- [ ] Verify in light mode: code blocks are visibly darker than chat background
- [ ] Verify in dark mode: code blocks are visibly lighter than chat background
- [ ] Verify inline `code` text has red color, background highlight, and padding
- [ ] Verify user bubble code blocks still use their existing `userBubbleText.opacity(0.1)` style

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
