### PR TITLE
fix: preactivate app-builder skill so onboarding can create Home Base

### DIFF
--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -295,7 +295,7 @@ export function createProxyApprovalCallback(
  * history or explicit preactivation. Without this, their tools are
  * unavailable in fresh sessions until `skill_load` is called.
  */
-const DEFAULT_PREACTIVATED_SKILL_IDS = ['tasks', 'notifications'];
+const DEFAULT_PREACTIVATED_SKILL_IDS = ['tasks', 'notifications', 'app-builder'];
 
 /**
  * Subset of Session state that the resolveTools callback reads at each


### PR DESCRIPTION
## Summary

- Add `app-builder` to `DEFAULT_PREACTIVATED_SKILL_IDS` so its tools (`app_create`, `app_open`, etc.) are available from the start of every session
- Without this, the BOOTSTRAP.md onboarding flow fails when trying to call `app_create` to build the Home Base dashboard, causing the assistant to fall back to plain markdown bullets ("Hitting a snag building your dashboard")

## Root Cause

The `app-builder` bundled skill provides `app_create` and other app tools, but it wasn't preactivated — meaning its tools only become available after an explicit `skill_load` call. The onboarding flow (`BOOTSTRAP.md`) tells the assistant to use `app_create` directly without loading the skill first, so the tool doesn't exist and the call fails.

## Test plan

- [x] Type-check passes (`bunx tsc --noEmit`)
- [ ] Run onboarding flow on a fresh workspace — Home Base dashboard should render instead of falling back to markdown
- [ ] Verify app tools (`app_create`, `app_file_edit`, etc.) are available immediately in new sessions without calling `skill_load`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
