### PR TITLE
Inline connection status indicators next to URL fields

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ConnectionStatusRow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ConnectionStatusRow.swift
@@ -8,39 +8,31 @@ struct ConnectionStatusInfo {
     let icon: String
 }
 
-/// A reusable row that displays a labelled connection status with an animated
-/// refresh button. Used for Platform, Gateway, and Tunnel status indicators.
-struct ConnectionStatusRow: View {
-    let label: String
+// MARK: - Inline Connection Status
+
+/// A compact status indicator (icon + text + refresh) designed to sit inline
+/// next to a URL field. No label column — just the status badge and refresh.
+struct InlineConnectionStatus: View {
     let status: ConnectionStatusInfo
     var isRefreshing: Bool = false
     var lastChecked: Date? = nil
+    var accessibilityLabel: String = "connection"
     var onRefresh: (() -> Void)? = nil
-
-    /// Label font — defaults to `VFont.bodyMedium` to match Gateway/Tunnel.
-    var labelFont: Font = VFont.bodyMedium
-
-    /// Fixed width for the label column so icons line up across rows.
-    var labelWidth: CGFloat = 60
 
     @State private var spinning: Bool = false
 
     var body: some View {
         let isSpinning = isRefreshing || spinning
 
-        HStack(spacing: VSpacing.sm) {
-            Text(label)
-                .font(labelFont)
-                .foregroundColor(VColor.textSecondary)
-                .frame(width: labelWidth, alignment: .leading)
-
+        HStack(spacing: VSpacing.xs) {
             Image(systemName: status.icon)
                 .foregroundColor(status.color)
-                .font(.system(size: 12))
+                .font(.system(size: 11))
 
             Text(status.label)
-                .font(VFont.body)
+                .font(VFont.caption)
                 .foregroundColor(status.color)
+                .lineLimit(1)
 
             if let onRefresh {
                 let tooltipText: String = {
@@ -61,15 +53,13 @@ struct ConnectionStatusRow: View {
                     SpinningRefreshIcon(isSpinning: isSpinning)
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Refresh \(label) status")
+                .accessibilityLabel("Refresh \(accessibilityLabel) status")
                 .help(tooltipText)
             }
-
-            Spacer()
         }
+        .fixedSize()
     }
 
-    /// Returns a human-readable relative time string (e.g. "just now", "2 minutes ago").
     private func relativeTimeString(from date: Date) -> String {
         let seconds = Int(-date.timeIntervalSinceNow)
         if seconds < 5 { return "just now" }

--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -87,44 +87,39 @@ struct GatewaySettingsCard: View {
                 .buttonStyle(.plain)
                 .accessibilityLabel("Copy gateway address")
                 .help("Copy address")
+
+                InlineConnectionStatus(
+                    status: gatewayStatusInfo,
+                    isRefreshing: store.isCheckingGateway,
+                    lastChecked: store.gatewayLastChecked,
+                    accessibilityLabel: "gateway"
+                ) {
+                    Task { await store.testGatewayOnly() }
+                }
             }
 
             Text("Point your tunnel (ngrok, Cloudflare, etc.) to this address.")
                 .font(VFont.caption)
                 .foregroundColor(VColor.textSecondary)
 
-            // Gateway connection status (checks local daemon)
-            ConnectionStatusRow(
-                label: "Gateway",
-                status: gatewayStatusInfo,
-                isRefreshing: store.isCheckingGateway,
-                lastChecked: store.gatewayLastChecked
-            ) {
-                Task { await store.testGatewayOnly() }
-            }
-
-            Divider()
-                .background(VColor.surfaceBorder)
-
             // Gateway URL field
-            HStack(spacing: VSpacing.xs) {
-                Text("Gateway URL")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textSecondary)
-            }
+            Text("Gateway URL")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
 
-            VInlineActionField(text: $gatewayUrlText, placeholder: "https://your-tunnel.example.com", allowEmpty: true, isFocused: $isGatewayUrlFocused) {
-                store.saveIngressPublicBaseUrl(gatewayUrlText)
-            }
+            HStack(spacing: VSpacing.sm) {
+                VInlineActionField(text: $gatewayUrlText, placeholder: "https://your-tunnel.example.com", allowEmpty: true, isFocused: $isGatewayUrlFocused) {
+                    store.saveIngressPublicBaseUrl(gatewayUrlText)
+                }
 
-            // Tunnel connection status (checks public URL)
-            ConnectionStatusRow(
-                label: "Tunnel",
-                status: tunnelStatusInfo,
-                isRefreshing: store.isCheckingTunnel,
-                lastChecked: store.tunnelLastChecked
-            ) {
-                Task { await store.testTunnelOnly() }
+                InlineConnectionStatus(
+                    status: tunnelStatusInfo,
+                    isRefreshing: store.isCheckingTunnel,
+                    lastChecked: store.tunnelLastChecked,
+                    accessibilityLabel: "tunnel"
+                ) {
+                    Task { await store.testTunnelOnly() }
+                }
             }
 
             // Diagnostic message when gateway is up but tunnel is down

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -117,20 +117,33 @@ struct SettingsAccountTab: View {
                     .font(VFont.caption)
                     .foregroundColor(VColor.textSecondary)
 
-                VInlineActionField(text: $platformUrlText, placeholder: "https://platform.vellum.ai", isFocused: $isPlatformUrlFocused) {
-                    store.savePlatformBaseUrl(platformUrlText)
-                    Task { await store.checkVellumPlatform() }
-                }
-            }
+                HStack(spacing: VSpacing.sm) {
+                    VInlineActionField(text: $platformUrlText, placeholder: "https://platform.vellum.ai", isFocused: $isPlatformUrlFocused) {
+                        store.savePlatformBaseUrl(platformUrlText)
+                        Task { await store.checkVellumPlatform() }
+                    }
 
-            // Platform connection status
-            ConnectionStatusRow(
-                label: "Platform",
-                status: platformStatusInfo,
-                isRefreshing: store.isCheckingVellumPlatform,
-                lastChecked: store.platformLastChecked
-            ) {
-                Task { await store.checkVellumPlatform() }
+                    InlineConnectionStatus(
+                        status: platformStatusInfo,
+                        isRefreshing: store.isCheckingVellumPlatform,
+                        lastChecked: store.platformLastChecked,
+                        accessibilityLabel: "platform"
+                    ) {
+                        Task { await store.checkVellumPlatform() }
+                    }
+                }
+            } else {
+                HStack(spacing: VSpacing.sm) {
+                    InlineConnectionStatus(
+                        status: platformStatusInfo,
+                        isRefreshing: store.isCheckingVellumPlatform,
+                        lastChecked: store.platformLastChecked,
+                        accessibilityLabel: "platform"
+                    ) {
+                        Task { await store.checkVellumPlatform() }
+                    }
+                    Spacer()
+                }
             }
 
             Divider().background(VColor.surfaceBorder)


### PR DESCRIPTION
## Summary
- Replaced `ConnectionStatusRow` with a compact `InlineConnectionStatus` view (icon + text + refresh) that sits inline next to each URL field
- Removed the subtitle labels (Platform, Gateway, Tunnel) and the divider between gateway/tunnel sections
- Deleted the now-unused `ConnectionStatusRow` struct

## Original prompt
Lets simplify this UI by moving each of the three status indicators (Could not connect, Running, Reachable) and their refresh buttons to the right of the text url field. We can remove the subtitle text of Platform, Gateway, Tunnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
