### PR TITLE
fix: keep inline-code color consistent in assistant rich-text messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -326,6 +326,7 @@ struct ChatBubble: View {
                             secondaryTextColor: isUser ? VColor.userBubbleTextSecondary : VColor.textSecondary,
                             mutedTextColor: isUser ? VColor.userBubbleTextSecondary : VColor.textMuted,
                             tintColor: isUser ? VColor.userBubbleText : VColor.accent,
+                            codeTextColor: isUser ? VColor.userBubbleText : VColor.codeText,
                             codeBackgroundColor: isUser ? VColor.userBubbleText.opacity(0.1) : VColor.codeBackground,
                             hrColor: isUser ? VColor.userBubbleText.opacity(0.3) : VColor.surfaceBorder
                         )

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -13,6 +13,7 @@ struct MarkdownSegmentView: View {
     var secondaryTextColor: Color = VColor.textSecondary
     var mutedTextColor: Color = VColor.textMuted
     var tintColor: Color = VColor.accent
+    var codeTextColor: Color = VColor.codeText
     var codeBackgroundColor: Color = VColor.codeBackground
     var hrColor: Color = VColor.surfaceBorder
 
@@ -187,6 +188,7 @@ struct MarkdownSegmentView: View {
         }
         hasher.combine(secondaryTextColor.description)
         hasher.combine(textColor.description)
+        hasher.combine(codeTextColor.description)
         hasher.combine(codeBackgroundColor.description)
         hasher.combine(zoomScale)
         let cacheKey = hasher.finalize()
@@ -197,7 +199,7 @@ struct MarkdownSegmentView: View {
             return cached.value
         }
 
-        let result = Self.buildAttributedStringUncached(from: segments, secondaryTextColor: secondaryTextColor, codeTextColor: textColor, codeBackgroundColor: codeBackgroundColor, zoomScale: zoomScale)
+        let result = Self.buildAttributedStringUncached(from: segments, secondaryTextColor: secondaryTextColor, codeTextColor: codeTextColor, codeBackgroundColor: codeBackgroundColor, zoomScale: zoomScale)
 
         // Skip caching for very long segment groups to avoid a single huge
         // entry evicting many smaller, more frequently accessed entries.


### PR DESCRIPTION
## Summary
- Adds a dedicated `codeTextColor` stored property to `MarkdownSegmentView` (defaults to `VColor.codeText`) so assistant inline code retains its distinctive styling
- Passes `codeTextColor: VColor.userBubbleText` for user bubbles, `VColor.codeText` for assistant bubbles
- Updates the cache key hasher to include `codeTextColor`

Addresses feedback from Devin review on PR #10715.

## Test plan
- [ ] Verify assistant messages with rich content (headings, lists, code blocks) render inline code in `VColor.codeText` (red)
- [ ] Verify user messages render inline code in `VColor.userBubbleText`
- [ ] Verify plain assistant messages (non-rich path) still use `VColor.codeText`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
