### PR TITLE
fix: remove app-builder from default preactivated skills

### DIFF
--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -295,7 +295,7 @@ export function createProxyApprovalCallback(
  * history or explicit preactivation. Without this, their tools are
  * unavailable in fresh sessions until `skill_load` is called.
  */
-const DEFAULT_PREACTIVATED_SKILL_IDS = ['tasks', 'notifications', 'app-builder'];
+const DEFAULT_PREACTIVATED_SKILL_IDS = ['tasks', 'notifications'];
 
 /**
  * Subset of Session state that the resolveTools callback reads at each


### PR DESCRIPTION
## Summary
- Removes `app-builder` from `DEFAULT_PREACTIVATED_SKILL_IDS` in `session-tool-setup.ts`
- The app-builder skill exposes side-effectful app/file mutation tools in all conversations by default, even when not needed
- It should remain opt-in, activated only via conversation history or explicit configuration

Addresses feedback from Devin review on PR #10715.

## Test plan
- [ ] Verify app-builder tools are not projected in fresh sessions without explicit activation
- [ ] Verify app-builder tools still activate when loaded via skill_load or conversation history

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
