### PR TITLE
fix: install script shell profile, symlink, and QR code warnings

### DIFF
--- a/cli/src/adapters/install.sh
+++ b/cli/src/adapters/install.sh
@@ -94,12 +94,10 @@ configure_shell_profile() {
     if [[ "$shell_name" == */zsh ]]; then
         profiles+=("$HOME/.zshrc")
     elif [[ "$shell_name" == */bash ]]; then
-        # On macOS, login shells read .bash_profile; on Linux, .bashrc
-        if [ -f "$HOME/.bash_profile" ]; then
-            profiles+=("$HOME/.bash_profile")
-        else
-            profiles+=("$HOME/.bashrc")
-        fi
+        # Write to both .bashrc (non-login shells, e.g. new terminal on Linux)
+        # and .bash_profile (login shells, e.g. macOS Terminal.app)
+        profiles+=("$HOME/.bashrc")
+        [ -f "$HOME/.bash_profile" ] && profiles+=("$HOME/.bash_profile")
     else
         # Unknown shell — try both
         profiles+=("$HOME/.bashrc")
@@ -118,31 +116,32 @@ configure_shell_profile() {
 # Create a symlink so `vellum` is available without ~/.bun/bin in PATH.
 # Tries /usr/local/bin first (works on most systems), falls back to
 # ~/.local/bin (user-writable, no sudo needed).
+# This is best-effort — failure must not abort the install script.
 symlink_vellum() {
     local vellum_bin="$HOME/.bun/bin/vellum"
     if [ ! -f "$vellum_bin" ]; then
-        return
+        return 0
     fi
 
     # Skip if vellum is already resolvable outside of ~/.bun/bin
     local resolved
     resolved=$(command -v vellum 2>/dev/null || true)
     if [ -n "$resolved" ] && [ "$resolved" != "$vellum_bin" ]; then
-        return
+        return 0
     fi
 
     # Try /usr/local/bin (may need sudo on some systems)
     if [ -d "/usr/local/bin" ] && [ -w "/usr/local/bin" ]; then
-        ln -sf "$vellum_bin" /usr/local/bin/vellum 2>/dev/null && {
+        if ln -sf "$vellum_bin" /usr/local/bin/vellum 2>/dev/null; then
             success "Symlinked /usr/local/bin/vellum → $vellum_bin"
-            return
-        }
+            return 0
+        fi
     fi
 
     # Fallback: ~/.local/bin
     local local_bin="$HOME/.local/bin"
-    mkdir -p "$local_bin"
-    ln -sf "$vellum_bin" "$local_bin/vellum" 2>/dev/null && {
+    mkdir -p "$local_bin" 2>/dev/null || true
+    if ln -sf "$vellum_bin" "$local_bin/vellum" 2>/dev/null; then
         success "Symlinked $local_bin/vellum → $vellum_bin"
         # Ensure ~/.local/bin is in PATH in shell profile
         for profile in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile"; do
@@ -150,8 +149,10 @@ symlink_vellum() {
                 printf '\nexport PATH="%s:$PATH"\n' "$local_bin" >> "$profile"
             fi
         done
-        return
-    }
+        return 0
+    fi
+
+    return 0
 }
 
 install_vellum() {
@@ -181,6 +182,12 @@ main() {
     configure_shell_profile
     install_vellum
     symlink_vellum
+
+    # Source the shell profile so vellum hatch runs with the correct PATH
+    # in this session (the profile changes only take effect in new shells
+    # otherwise).
+    export BUN_INSTALL="$HOME/.bun"
+    export PATH="$BUN_INSTALL/bin:$PATH"
 
     info "Running vellum hatch..."
     printf "\n"

--- a/cli/src/adapters/install.sh
+++ b/cli/src/adapters/install.sh
@@ -79,6 +79,81 @@ ensure_bun() {
     success "bun installed ($(bun --version))"
 }
 
+# Ensure ~/.bun/bin is in the user's shell profile so bun and vellum are
+# available in new terminal sessions. The bun installer sometimes skips
+# this (e.g. when stdin is piped via curl | bash).
+configure_shell_profile() {
+    local bun_line='export BUN_INSTALL="$HOME/.bun"'
+    local path_line='export PATH="$BUN_INSTALL/bin:$PATH"'
+    local snippet
+    snippet=$(printf '\n# bun\n%s\n%s\n' "$bun_line" "$path_line")
+
+    local profiles=()
+    local shell_name="${SHELL:-}"
+
+    if [[ "$shell_name" == */zsh ]]; then
+        profiles+=("$HOME/.zshrc")
+    elif [[ "$shell_name" == */bash ]]; then
+        # On macOS, login shells read .bash_profile; on Linux, .bashrc
+        if [ -f "$HOME/.bash_profile" ]; then
+            profiles+=("$HOME/.bash_profile")
+        else
+            profiles+=("$HOME/.bashrc")
+        fi
+    else
+        # Unknown shell — try both
+        profiles+=("$HOME/.bashrc")
+        [ -f "$HOME/.zshrc" ] && profiles+=("$HOME/.zshrc")
+    fi
+
+    for profile in "${profiles[@]}"; do
+        if [ -f "$profile" ] && grep -q 'BUN_INSTALL' "$profile" 2>/dev/null; then
+            continue
+        fi
+        printf '%s\n' "$snippet" >> "$profile"
+        success "Added bun to PATH in $profile"
+    done
+}
+
+# Create a symlink so `vellum` is available without ~/.bun/bin in PATH.
+# Tries /usr/local/bin first (works on most systems), falls back to
+# ~/.local/bin (user-writable, no sudo needed).
+symlink_vellum() {
+    local vellum_bin="$HOME/.bun/bin/vellum"
+    if [ ! -f "$vellum_bin" ]; then
+        return
+    fi
+
+    # Skip if vellum is already resolvable outside of ~/.bun/bin
+    local resolved
+    resolved=$(command -v vellum 2>/dev/null || true)
+    if [ -n "$resolved" ] && [ "$resolved" != "$vellum_bin" ]; then
+        return
+    fi
+
+    # Try /usr/local/bin (may need sudo on some systems)
+    if [ -d "/usr/local/bin" ] && [ -w "/usr/local/bin" ]; then
+        ln -sf "$vellum_bin" /usr/local/bin/vellum 2>/dev/null && {
+            success "Symlinked /usr/local/bin/vellum → $vellum_bin"
+            return
+        }
+    fi
+
+    # Fallback: ~/.local/bin
+    local local_bin="$HOME/.local/bin"
+    mkdir -p "$local_bin"
+    ln -sf "$vellum_bin" "$local_bin/vellum" 2>/dev/null && {
+        success "Symlinked $local_bin/vellum → $vellum_bin"
+        # Ensure ~/.local/bin is in PATH in shell profile
+        for profile in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile"; do
+            if [ -f "$profile" ] && ! grep -q "$local_bin" "$profile" 2>/dev/null; then
+                printf '\nexport PATH="%s:$PATH"\n' "$local_bin" >> "$profile"
+            fi
+        done
+        return
+    }
+}
+
 install_vellum() {
     if command -v vellum >/dev/null 2>&1; then
         info "Updating vellum to latest..."
@@ -103,7 +178,9 @@ main() {
 
     ensure_git
     ensure_bun
+    configure_shell_profile
     install_vellum
+    symlink_vellum
 
     info "Running vellum hatch..."
     printf "\n"

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -498,6 +498,7 @@ async function displayPairingQRCode(runtimeUrl: string, bearerToken: string | un
     });
 
     if (!registerRes.ok) {
+      console.log("⚠ Could not register pairing request (daemon may still be initializing). Run `vellum pair` to try again.\n");
       return;
     }
 
@@ -523,6 +524,7 @@ async function displayPairingQRCode(runtimeUrl: string, bearerToken: string | un
     console.log("Run `vellum pair` to generate a new one.\n");
   } catch {
     // Non-fatal — pairing is optional
+    console.log("⚠ Could not generate pairing QR code. Run `vellum pair` to try again.\n");
   }
 }
 

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -498,7 +498,7 @@ async function displayPairingQRCode(runtimeUrl: string, bearerToken: string | un
     });
 
     if (!registerRes.ok) {
-      console.log("⚠ Could not register pairing request (daemon may still be initializing). Run `vellum pair` to try again.\n");
+      console.warn("⚠ Could not register pairing request (daemon may still be initializing). Run `vellum pair` to try again.\n");
       return;
     }
 
@@ -524,7 +524,7 @@ async function displayPairingQRCode(runtimeUrl: string, bearerToken: string | un
     console.log("Run `vellum pair` to generate a new one.\n");
   } catch {
     // Non-fatal — pairing is optional
-    console.log("⚠ Could not generate pairing QR code. Run `vellum pair` to try again.\n");
+    console.warn("⚠ Could not generate pairing QR code. Run `vellum pair` to try again.\n");
   }
 }
 

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -498,7 +498,8 @@ async function displayPairingQRCode(runtimeUrl: string, bearerToken: string | un
     });
 
     if (!registerRes.ok) {
-      console.warn("⚠ Could not register pairing request (daemon may still be initializing). Run `vellum pair` to try again.\n");
+      const body = await registerRes.text().catch(() => "");
+      console.warn(`⚠ Could not register pairing request: ${registerRes.status} ${registerRes.statusText}${body ? ` — ${body}` : ""}. Run \`vellum pair\` to try again.\n`);
       return;
     }
 
@@ -522,9 +523,10 @@ async function displayPairingQRCode(runtimeUrl: string, bearerToken: string | un
     console.log(qrString);
     console.log("This pairing request expires in 5 minutes.");
     console.log("Run `vellum pair` to generate a new one.\n");
-  } catch {
+  } catch (err) {
     // Non-fatal — pairing is optional
-    console.warn("⚠ Could not generate pairing QR code. Run `vellum pair` to try again.\n");
+    const reason = err instanceof Error ? err.message : String(err);
+    console.warn(`⚠ Could not generate pairing QR code: ${reason}. Run \`vellum pair\` to try again.\n`);
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes several issues discovered when running `install.sh` from the v0.4.1 release:

- **Shell profile not configured**: `~/.bun/bin` wasn't added to `~/.zshrc` or `~/.bashrc`, so `bun` and `vellum` weren't available in new terminal sessions. The bun installer sometimes skips profile setup when stdin is piped (`curl | bash`). Added `configure_shell_profile()` to explicitly ensure the entries exist.
- **No symlink for vellum**: After `bun install -g vellum`, the binary lives at `~/.bun/bin/vellum` which isn't in PATH until the shell profile is sourced. Added `symlink_vellum()` to create `/usr/local/bin/vellum` (or `~/.local/bin/vellum` fallback) so it works immediately.
- **`~/.bun/bin/vellum --version` → `No such file or directory`**: The shebang `#!/usr/bin/env bun` couldn't find bun because PATH wasn't configured. Fixed by the shell profile setup above.
- **No QR code and no error**: `displayPairingQRCode` silently returned when pairing registration failed. Now prints a warning suggesting `vellum pair` to retry.

## Test plan
- [ ] Run `bash install.sh` on a clean macOS machine — verify bun/vellum PATH entries added to `~/.zshrc`
- [ ] Verify `vellum --version` works in a new terminal session after install
- [ ] Verify symlink created at `/usr/local/bin/vellum` or `~/.local/bin/vellum`
- [ ] Verify QR code failure shows warning message instead of silent return

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
