### PR TITLE
fix: add --help flag to `vellum retire`

### DIFF
--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -121,6 +121,20 @@ function parseSource(): string | undefined {
 }
 
 export async function retire(): Promise<void> {
+  const args = process.argv.slice(3);
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log("Usage: vellum retire <name> [--source <source>]");
+    console.log("");
+    console.log("Delete an assistant instance and archive its data.");
+    console.log("");
+    console.log("Arguments:");
+    console.log("  <name>               Name of the assistant to retire");
+    console.log("");
+    console.log("Options:");
+    console.log("  --source <source>    Source identifier for the retirement");
+    process.exit(0);
+  }
+
   const name = process.argv[3];
 
   if (!name) {


### PR DESCRIPTION
## Summary
- Add `--help` / `-h` flag support to the `vellum retire` CLI command
- When the flag is passed, prints usage information (arguments, options) and exits cleanly
- The help check runs before any argument validation, so `vellum retire --help` works without requiring a name

## Test plan
- [ ] Run `vellum retire --help` and verify it prints the usage message and exits with code 0
- [ ] Run `vellum retire -h` and verify the same behavior
- [ ] Run `vellum retire` (no args) and verify the existing error message still appears
- [ ] Run `vellum retire <name>` and verify normal retirement flow is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
