### PR TITLE
fix: add --help flag to `vellum ssh`

### DIFF
--- a/cli/src/commands/ssh.ts
+++ b/cli/src/commands/ssh.ts
@@ -33,6 +33,17 @@ function extractHostFromUrl(url: string): string {
 }
 
 export async function ssh(): Promise<void> {
+  const args = process.argv.slice(3);
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log("Usage: vellum ssh [<name>]");
+    console.log("");
+    console.log("SSH into a remote assistant instance.");
+    console.log("");
+    console.log("Arguments:");
+    console.log("  <name>    Name of the assistant to connect to (defaults to latest)");
+    process.exit(0);
+  }
+
   const name = process.argv[3];
   const entry = name ? findAssistantByName(name) : loadLatestAssistant();
 


### PR DESCRIPTION
## Summary
- Adds `--help` / `-h` flag support to the `vellum ssh` CLI command
- When invoked with `--help` or `-h`, prints usage information and exits cleanly
- The help check runs at the very start of the `ssh()` function, before any assistant lookup logic

## Test plan
- [ ] Run `vellum ssh --help` and verify it prints the usage message and exits with code 0
- [ ] Run `vellum ssh -h` and verify same behavior
- [ ] Run `vellum ssh` without the flag and verify existing behavior is unchanged
- [ ] Run `vellum ssh <name> --help` and verify it still shows help (flag anywhere in args)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
