### PR TITLE
fix: add --help flag to `vellum pair`

### DIFF
--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -72,6 +72,14 @@ async function pollForApproval(
 
 export async function pair(): Promise<void> {
   const args = process.argv.slice(3);
+
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log("Usage: vellum pair <path-to-qrcode.png>");
+    console.log("");
+    console.log("Pair with a remote assistant by scanning the QR code PNG generated during setup.");
+    process.exit(0);
+  }
+
   const qrCodePath = args[0] || process.env.VELLUM_CUSTOM_QR_CODE_PATH;
 
   if (!qrCodePath) {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -31,8 +31,8 @@ const commands = {
   email,
   hatch,
   login,
-  pair,
   logout,
+  pair,
   ps,
   recover,
   retire,
@@ -90,9 +90,9 @@ async function main() {
     console.log("  contacts Manage the contact graph");
     console.log("  email    Email operations (status, create inbox)");
     console.log("  hatch    Create a new assistant instance");
-    console.log("  pair     Pair with a remote assistant via QR code");
     console.log("  login    Log in to the Vellum platform");
     console.log("  logout   Log out of the Vellum platform");
+    console.log("  pair     Pair with a remote assistant via QR code");
     console.log("  ps       List assistants (or processes for a specific assistant)");
     console.log("  recover  Restore a previously retired local assistant");
     console.log("  retire   Delete an assistant instance");


### PR DESCRIPTION
## Summary
- The `vellum pair` command previously had no `--help` / `-h` flag support. Users had to run the command without arguments to see usage info, which would exit with status code 1 (error).
- Added early `--help` / `-h` argument detection that prints usage information and exits cleanly with status code 0.

## Test plan
- [ ] Run `vellum pair --help` and verify it prints usage info and exits with code 0
- [ ] Run `vellum pair -h` and verify it prints usage info and exits with code 0
- [ ] Run `vellum pair` (no args) and verify existing error behavior is unchanged (exits with code 1)
- [ ] Run `vellum pair <valid-qr.png>` and verify normal pairing flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
