### PR TITLE
fix: add --help flag to `vellum sleep`

### DIFF
--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -5,6 +5,14 @@ import { loadAllAssistants } from "../lib/assistant-config";
 import { stopProcessByPidFile } from "../lib/process";
 
 export async function sleep(): Promise<void> {
+  const args = process.argv.slice(3);
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log("Usage: vellum sleep");
+    console.log("");
+    console.log("Stop the daemon and gateway processes.");
+    process.exit(0);
+  }
+
   const assistants = loadAllAssistants();
   const hasLocal = assistants.some((a) => a.cloud === "local");
   if (!hasLocal) {


### PR DESCRIPTION
## Summary
- Add `--help` / `-h` flag support to the `vellum sleep` CLI command
- When invoked with `--help` or `-h`, prints usage information and exits before performing any other work

## Test plan
- [ ] Run `vellum sleep --help` and verify it prints the usage message and exits cleanly
- [ ] Run `vellum sleep -h` and verify the same behavior
- [ ] Run `vellum sleep` without the flag and verify normal behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
