### PR TITLE
fix: add --help flag to `vellum hatch`

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -157,7 +157,22 @@ function parseArgs(): HatchArgs {
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
-    if (arg === "-d") {
+    if (arg === "--help" || arg === "-h") {
+      console.log("Usage: vellum hatch [species] [options]");
+      console.log("");
+      console.log("Create a new assistant instance.");
+      console.log("");
+      console.log("Species:");
+      console.log("  vellum       Default assistant (default)");
+      console.log("  openclaw     OpenClaw adapter");
+      console.log("");
+      console.log("Options:");
+      console.log("  -d                        Run in detached mode");
+      console.log("  --name <name>             Custom instance name");
+      console.log("  --remote <host>           Remote host (local, gcp, aws, custom)");
+      console.log("  --daemon-only             Start daemon only, skip gateway");
+      process.exit(0);
+    } else if (arg === "-d") {
       detached = true;
     } else if (arg === "--daemon-only") {
       daemonOnly = true;


### PR DESCRIPTION
## Summary
- Adds `--help` / `-h` flag support to the `vellum hatch` CLI command
- Prints usage information including available species and options, then exits

## Test plan
- [ ] Run `vellum hatch --help` and verify usage output is printed
- [ ] Run `vellum hatch -h` and verify same usage output
- [ ] Run `vellum hatch` without `--help` and verify normal behavior is unchanged
- [ ] Run `vellum hatch --help` with other flags and verify help takes precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
