### PR TITLE
fix: add --help flag to `vellum wake`

### DIFF
--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -7,6 +7,14 @@ import { isProcessAlive } from "../lib/process";
 import { startLocalDaemon, startGateway } from "../lib/local";
 
 export async function wake(): Promise<void> {
+  const args = process.argv.slice(3);
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log("Usage: vellum wake");
+    console.log("");
+    console.log("Start the daemon and gateway processes.");
+    process.exit(0);
+  }
+
   const assistants = loadAllAssistants();
   const hasLocal = assistants.some((a) => a.cloud === "local");
   if (!hasLocal) {


### PR DESCRIPTION
## Summary
- Add `--help` / `-h` flag support to the `vellum wake` CLI command
- When invoked with `--help` or `-h`, prints usage information and exits before loading assistants or starting any processes

## Test plan
- [ ] Run `vellum wake --help` and verify it prints usage info and exits cleanly
- [ ] Run `vellum wake -h` and verify same behavior
- [ ] Run `vellum wake` without the flag and verify normal behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
