### PR TITLE
fix: add --help flag to `vellum login`

### DIFF
--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -7,6 +7,17 @@ import {
 
 export async function login(): Promise<void> {
   const args = process.argv.slice(3);
+
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log("Usage: vellum login --token <session-token>");
+    console.log("");
+    console.log("Log in to the Vellum platform.");
+    console.log("");
+    console.log("Options:");
+    console.log("  --token <token>    Session token from the Vellum platform");
+    process.exit(0);
+  }
+
   let token: string | null = null;
 
   for (let i = 0; i < args.length; i++) {


### PR DESCRIPTION
## Summary
- Add `--help` / `-h` flag support to the `vellum login` CLI command
- When invoked with `--help` or `-h`, prints usage information and exits with code 0 instead of proceeding with the login flow

## Test plan
- [ ] Run `vellum login --help` and verify it prints the usage message and exits cleanly
- [ ] Run `vellum login -h` and verify the same behavior
- [ ] Run `vellum login --token <token>` and verify normal login flow still works
- [ ] Run `vellum login` with no args and verify the existing error message still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
