### PR TITLE
fix: add --help flag to `vellum recover`

### DIFF
--- a/cli/src/commands/recover.ts
+++ b/cli/src/commands/recover.ts
@@ -9,6 +9,17 @@ import { getArchivePath, getMetadataPath } from "../lib/retire-archive";
 import { exec } from "../lib/step-runner";
 
 export async function recover(): Promise<void> {
+  const args = process.argv.slice(3);
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log("Usage: vellum recover <name>");
+    console.log("");
+    console.log("Restore a previously retired local assistant from its archive.");
+    console.log("");
+    console.log("Arguments:");
+    console.log("  <name>    Name of the retired assistant to recover");
+    process.exit(0);
+  }
+
   const name = process.argv[3];
   if (!name) {
     console.error("Usage: vellum recover <name>");


### PR DESCRIPTION
## Summary
- Add `--help` / `-h` flag support to the `vellum recover` CLI command
- When invoked with `--help` or `-h`, the command prints usage information and exits cleanly instead of proceeding with recovery logic

## Test plan
- [ ] Run `vellum recover --help` and verify it prints usage info and exits with code 0
- [ ] Run `vellum recover -h` and verify the same behavior
- [ ] Run `vellum recover <name>` and verify normal recovery behavior is unchanged
- [ ] Run `vellum recover` with no arguments and verify the existing error message is still shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
