### PR TITLE
fix: add --help flag to `vellum ps`

### DIFF
--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -409,6 +409,17 @@ async function listAllAssistants(): Promise<void> {
 // ── Entry point ─────────────────────────────────────────────────
 
 export async function ps(): Promise<void> {
+  const args = process.argv.slice(3);
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log("Usage: vellum ps [<name>]");
+    console.log("");
+    console.log("List all assistants, or show processes for a specific assistant.");
+    console.log("");
+    console.log("Arguments:");
+    console.log("  <name>    Show processes for the named assistant");
+    process.exit(0);
+  }
+
   const assistantId = process.argv[3];
 
   if (!assistantId) {


### PR DESCRIPTION
## Summary
- Add `--help` / `-h` flag support to the `vellum ps` CLI command
- When invoked with `--help` or `-h`, prints usage information and exits cleanly
- The help text documents the optional `<name>` argument for showing processes of a specific assistant

## Test plan
- [ ] Run `vellum ps --help` and verify it prints usage information and exits with code 0
- [ ] Run `vellum ps -h` and verify identical behavior
- [ ] Run `vellum ps` without flags and verify existing behavior is unchanged
- [ ] Run `vellum ps <name>` and verify existing behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
