### PR TITLE
fix: add --help flag to `vellum logout` and `vellum whoami`

### DIFF
--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -43,11 +43,27 @@ export async function login(): Promise<void> {
 }
 
 export async function logout(): Promise<void> {
+  const args = process.argv.slice(3);
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log("Usage: vellum logout");
+    console.log("");
+    console.log("Log out of the Vellum platform and remove the stored session token.");
+    process.exit(0);
+  }
+
   clearPlatformToken();
   console.log("Logged out. Platform token removed.");
 }
 
 export async function whoami(): Promise<void> {
+  const args = process.argv.slice(3);
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log("Usage: vellum whoami");
+    console.log("");
+    console.log("Show the currently logged-in Vellum platform user.");
+    process.exit(0);
+  }
+
   const token = readPlatformToken();
   if (!token) {
     console.error("Not logged in. Run `vellum login --token <token>` first.");


### PR DESCRIPTION
## Summary
- Add `--help` / `-h` flag support to the `vellum logout` CLI command, printing usage information and a description of the command
- Add `--help` / `-h` flag support to the `vellum whoami` CLI command, printing usage information and a description of the command

## Test plan
- [ ] Run `vellum logout --help` and verify it prints usage info and exits with code 0
- [ ] Run `vellum logout -h` and verify it prints usage info and exits with code 0
- [ ] Run `vellum whoami --help` and verify it prints usage info and exits with code 0
- [ ] Run `vellum whoami -h` and verify it prints usage info and exits with code 0
- [ ] Run `vellum logout` without flags and verify it still logs out normally
- [ ] Run `vellum whoami` without flags and verify it still shows user info normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
