### PR TITLE
M1: trusted-contact approval routing foundation (no dead-end interactivity)

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -2873,3 +2873,118 @@ describe('NL approval routing via destination-scoped canonical requests', () => 
     expect(unchanged!.status).toBe('pending');
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Trusted-contact self-approval guard (pre-row)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('trusted-contact self-approval blocked before guardian approval row exists', () => {
+  beforeEach(() => {
+    // Create a guardian binding so the requester resolves as trusted_contact
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-tc-selfapproval',
+      guardianDeliveryChatId: 'guardian-tc-selfapproval-chat',
+    });
+  });
+
+  test('trusted contact cannot self-approve via conversational engine when no guardian approval row exists', async () => {
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // Create the requester conversation (different user than guardian)
+    const initReq = makeInboundRequest({
+      content: 'init',
+      externalChatId: 'tc-selfapproval-chat',
+      senderExternalUserId: 'tc-selfapproval-user',
+    });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token');
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    // Register a pending interaction — but do NOT create a guardian approval
+    // row in channelGuardianApprovalRequests. This simulates the window
+    // between the pending confirmation being created (isInteractive=true)
+    // and the guardian approval prompt being delivered.
+    const sessionMock = registerPendingInteraction('req-tc-selfapproval-1', conversationId!, 'shell');
+
+    deliverSpy.mockClear();
+
+    // The conversational engine would normally classify "yes" as approve_once,
+    // but the guard should intercept before the engine runs.
+    const mockConversationGenerator = mock(async (_ctx: unknown) => ({
+      disposition: 'approve_once' as const,
+      replyText: 'Approved!',
+    }));
+
+    // Trusted contact sends "yes" to try to self-approve
+    const req = makeInboundRequest({
+      content: 'yes',
+      externalChatId: 'tc-selfapproval-chat',
+      senderExternalUserId: 'tc-selfapproval-user',
+    });
+    const res = await handleChannelInbound(
+      req, noopProcessMessage, 'token', 'self', undefined,
+      undefined, mockConversationGenerator,
+    );
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    // Should be blocked with assistant_turn (pending guardian notice),
+    // NOT decision_applied
+    expect(body.approval).toBe('assistant_turn');
+    // The session should NOT have been resolved
+    expect(sessionMock).not.toHaveBeenCalled();
+
+    // The pending interaction should still be registered (not consumed)
+    const stillPending = pendingInteractions.get('req-tc-selfapproval-1');
+    expect(stillPending).toBeDefined();
+
+    deliverSpy.mockRestore();
+  });
+
+  test('trusted contact cannot self-approve via legacy parser when no guardian approval row exists', async () => {
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const initReq = makeInboundRequest({
+      content: 'init',
+      externalChatId: 'tc-selfapproval-chat',
+      senderExternalUserId: 'tc-selfapproval-user',
+    });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token');
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    // Register pending interaction without guardian approval row
+    const sessionMock = registerPendingInteraction('req-tc-selfapproval-2', conversationId!, 'shell');
+
+    deliverSpy.mockClear();
+
+    // No conversational engine — falls through to legacy parser path.
+    // "approve" would normally be parsed as an approval decision.
+    const req = makeInboundRequest({
+      content: 'approve',
+      externalChatId: 'tc-selfapproval-chat',
+      senderExternalUserId: 'tc-selfapproval-user',
+    });
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token');
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    // Should be blocked, not decision_applied
+    expect(body.approval).toBe('assistant_turn');
+    expect(sessionMock).not.toHaveBeenCalled();
+
+    // Pending interaction should still exist
+    const stillPending = pendingInteractions.get('req-tc-selfapproval-2');
+    expect(stillPending).toBeDefined();
+
+    deliverSpy.mockRestore();
+  });
+});

--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -2665,8 +2665,10 @@ describe('background channel processing approval prompts', () => {
     deliverPromptSpy.mockRestore();
   });
 
-  test('non-guardian channel turns are not interactive to prevent self-approval', async () => {
-    // Set up a guardian binding for a DIFFERENT user so the sender is non-guardian
+  test('trusted-contact channel turns with resolvable guardian route are interactive', async () => {
+    // Set up a guardian binding for a DIFFERENT user so the sender is a
+    // trusted contact (not the guardian). The guardian route is resolvable
+    // because the binding exists — approval notifications can be delivered.
     createBinding({
       assistantId: 'self',
       channel: 'telegram',
@@ -2701,7 +2703,9 @@ describe('background channel processing approval prompts', () => {
     await new Promise((resolve) => setTimeout(resolve, 300));
 
     expect(processCalls.length).toBeGreaterThan(0);
-    expect(processCalls[0].options?.isInteractive).toBe(false);
+    // Trusted contacts with a resolvable guardian route should be interactive
+    // so approval prompts can be routed to the guardian for decision.
+    expect(processCalls[0].options?.isInteractive).toBe(true);
   });
 
   test('unverified channel turns never broadcast approval prompts', async () => {

--- a/assistant/src/__tests__/guardian-routing-state.test.ts
+++ b/assistant/src/__tests__/guardian-routing-state.test.ts
@@ -1,0 +1,544 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+
+// ---------------------------------------------------------------------------
+// Test isolation: in-memory SQLite via temp directory
+// ---------------------------------------------------------------------------
+
+const testDir = mkdtempSync(join(tmpdir(), 'guardian-routing-state-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+// Mock security check to always pass
+mock.module('../security/secret-ingress.js', () => ({
+  checkIngressForSecrets: () => ({ blocked: false }),
+}));
+
+// Mock ingress member store with a configurable member lookup.
+// By default returns an active member so ACL passes.
+let mockFindMember: (() => unknown) | null = null;
+mock.module('../memory/ingress-member-store.js', () => ({
+  findMember: (...args: unknown[]) => {
+    if (mockFindMember) return mockFindMember();
+    return {
+      id: 'member-test-default',
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'telegram-user-default',
+      externalChatId: null,
+      displayName: null,
+      username: null,
+      status: 'active',
+      policy: 'allow',
+      inviteId: null,
+      createdBySessionId: null,
+      revokedReason: null,
+      blockedReason: null,
+      lastSeenAt: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+  },
+  updateLastSeen: () => {},
+  upsertMember: () => {},
+}));
+
+import {
+  type GuardianContext,
+  resolveRoutingState,
+  resolveRoutingStateFromRuntime,
+  type RoutingState,
+} from '../runtime/guardian-context-resolver.js';
+import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
+import { createBinding } from '../memory/channel-guardian-store.js';
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { channelInboundEvents, messages } from '../memory/schema.js';
+import { sweepFailedEvents } from '../runtime/channel-retry-sweep.js';
+import { handleChannelInbound } from '../runtime/routes/channel-routes.js';
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+function resetTables(): void {
+  const db = getDb();
+  db.run('DELETE FROM channel_inbound_events');
+  db.run('DELETE FROM channel_guardian_bindings');
+  db.run('DELETE FROM channel_guardian_approval_requests');
+  db.run('DELETE FROM canonical_guardian_requests');
+  db.run('DELETE FROM conversation_keys');
+  db.run('DELETE FROM messages');
+  db.run('DELETE FROM conversations');
+  db.run('DELETE FROM ingress_members');
+  db.run('DELETE FROM external_conversation_bindings');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Unit tests: resolveRoutingState
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('resolveRoutingState', () => {
+  test('guardian actors are always interactive and route-resolvable', () => {
+    const ctx: GuardianContext = {
+      trustClass: 'guardian',
+      guardianExternalUserId: 'guardian-123',
+      guardianChatId: 'chat-123',
+    };
+    const state = resolveRoutingState(ctx);
+    expect(state).toEqual({
+      canBeInteractive: true,
+      guardianRouteResolvable: true,
+      promptWaitingAllowed: true,
+    });
+  });
+
+  test('guardian actors are interactive even without guardianExternalUserId', () => {
+    // Edge case: guardian is chatting in their own chat, no separate binding needed
+    const ctx: GuardianContext = {
+      trustClass: 'guardian',
+    };
+    const state = resolveRoutingState(ctx);
+    expect(state.canBeInteractive).toBe(true);
+    expect(state.promptWaitingAllowed).toBe(true);
+  });
+
+  test('trusted contact with resolvable guardian route is interactive', () => {
+    const ctx: GuardianContext = {
+      trustClass: 'trusted_contact',
+      guardianExternalUserId: 'guardian-456',
+      guardianChatId: 'guardian-chat-456',
+    };
+    const state = resolveRoutingState(ctx);
+    expect(state).toEqual({
+      canBeInteractive: true,
+      guardianRouteResolvable: true,
+      promptWaitingAllowed: true,
+    });
+  });
+
+  test('trusted contact without guardian route is NOT interactive (fail-fast)', () => {
+    const ctx: GuardianContext = {
+      trustClass: 'trusted_contact',
+      // No guardianExternalUserId — no guardian binding for this channel
+    };
+    const state = resolveRoutingState(ctx);
+    expect(state).toEqual({
+      canBeInteractive: true,
+      guardianRouteResolvable: false,
+      promptWaitingAllowed: false,
+    });
+  });
+
+  test('unknown actors are never interactive regardless of guardian route', () => {
+    const withRoute: GuardianContext = {
+      trustClass: 'unknown',
+      guardianExternalUserId: 'guardian-789',
+    };
+    const withoutRoute: GuardianContext = {
+      trustClass: 'unknown',
+    };
+
+    expect(resolveRoutingState(withRoute).promptWaitingAllowed).toBe(false);
+    expect(resolveRoutingState(withRoute).canBeInteractive).toBe(false);
+    expect(resolveRoutingState(withoutRoute).promptWaitingAllowed).toBe(false);
+  });
+});
+
+describe('resolveRoutingStateFromRuntime', () => {
+  test('produces same result as resolveRoutingState for guardian runtime context', () => {
+    const runtimeCtx = {
+      sourceChannel: 'telegram' as const,
+      trustClass: 'trusted_contact' as const,
+      guardianExternalUserId: 'guardian-rt-1',
+    };
+    const state = resolveRoutingStateFromRuntime(runtimeCtx);
+    expect(state.promptWaitingAllowed).toBe(true);
+    expect(state.guardianRouteResolvable).toBe(true);
+  });
+
+  test('trusted contact runtime context without guardian binding is not interactive', () => {
+    const runtimeCtx = {
+      sourceChannel: 'telegram' as const,
+      trustClass: 'trusted_contact' as const,
+      // No guardianExternalUserId
+    };
+    const state = resolveRoutingStateFromRuntime(runtimeCtx);
+    expect(state.promptWaitingAllowed).toBe(false);
+    expect(state.guardianRouteResolvable).toBe(false);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Integration tests: inbound message handler interactivity
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('inbound-message-handler trusted-contact interactivity', () => {
+  beforeEach(() => {
+    resetTables();
+    mockFindMember = null;
+  });
+
+  function makeInboundRequest(overrides: Record<string, unknown> = {}): Request {
+    return new Request('http://localhost/channels/inbound', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Gateway-Origin': 'test-token',
+      },
+      body: JSON.stringify({
+        sourceChannel: 'telegram',
+        interface: 'telegram',
+        externalChatId: 'chat-123',
+        externalMessageId: `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        content: 'hello',
+        senderExternalUserId: 'telegram-user-default',
+        replyCallbackUrl: 'https://gateway.test/deliver/telegram',
+        ...overrides,
+      }),
+    });
+  }
+
+  const noopProcessMessage = mock(async (
+    conversationId: string,
+    _content: string,
+    _attachmentIds?: string[],
+    _options?: Record<string, unknown>,
+  ) => {
+    const messageId = `msg-${Date.now()}`;
+    const db = getDb();
+    db.insert(messages).values({
+      id: messageId,
+      conversationId,
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'hello' }]),
+      createdAt: Date.now(),
+    }).run();
+    return { messageId };
+  });
+
+  test('trusted contact with guardian binding gets interactive turn', async () => {
+    // Create guardian binding so the trusted contact has a resolvable route
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-user-for-tc',
+      guardianDeliveryChatId: 'guardian-chat-for-tc',
+    });
+
+    const processCalls: Array<{ options?: Record<string, unknown> }> = [];
+    const processMessage = mock(async (
+      conversationId: string,
+      _content: string,
+      _attachmentIds?: string[],
+      options?: Record<string, unknown>,
+    ) => {
+      processCalls.push({ options });
+      const messageId = `msg-tc-interactive-${Date.now()}`;
+      const db = getDb();
+      db.insert(messages).values({
+        id: messageId,
+        conversationId,
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'hello' }]),
+        createdAt: Date.now(),
+      }).run();
+      return { messageId };
+    });
+
+    const req = makeInboundRequest({
+      externalMessageId: `msg-tc-interactive-${Date.now()}`,
+    });
+
+    const res = await handleChannelInbound(req, processMessage as any, 'test-token');
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+
+    // Wait for background processing
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(processCalls.length).toBeGreaterThan(0);
+    expect(processCalls[0].options?.isInteractive).toBe(true);
+  });
+
+  test('trusted contact WITHOUT guardian binding gets non-interactive turn (fail-fast)', async () => {
+    // No guardian binding created — trusted contact has no guardian route
+    // but findMember still returns an active member (trusted_contact trust class)
+
+    const processCalls: Array<{ options?: Record<string, unknown> }> = [];
+    const processMessage = mock(async (
+      conversationId: string,
+      _content: string,
+      _attachmentIds?: string[],
+      options?: Record<string, unknown>,
+    ) => {
+      processCalls.push({ options });
+      const messageId = `msg-tc-noroute-${Date.now()}`;
+      const db = getDb();
+      db.insert(messages).values({
+        id: messageId,
+        conversationId,
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'hello' }]),
+        createdAt: Date.now(),
+      }).run();
+      return { messageId };
+    });
+
+    const req = makeInboundRequest({
+      externalMessageId: `msg-tc-noroute-${Date.now()}`,
+    });
+
+    const res = await handleChannelInbound(req, processMessage as any, 'test-token');
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(processCalls.length).toBeGreaterThan(0);
+    // Trusted contact without a guardian binding should NOT be interactive
+    // to prevent dead-end 300s prompt waits
+    expect(processCalls[0].options?.isInteractive).toBe(false);
+  });
+
+  test('guardian actors remain interactive regardless', async () => {
+    // Guardian binding matches the sender
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'telegram-user-default',
+      guardianDeliveryChatId: 'chat-123',
+    });
+
+    const processCalls: Array<{ options?: Record<string, unknown> }> = [];
+    const processMessage = mock(async (
+      conversationId: string,
+      _content: string,
+      _attachmentIds?: string[],
+      options?: Record<string, unknown>,
+    ) => {
+      processCalls.push({ options });
+      const messageId = `msg-guardian-${Date.now()}`;
+      const db = getDb();
+      db.insert(messages).values({
+        id: messageId,
+        conversationId,
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'hello' }]),
+        createdAt: Date.now(),
+      }).run();
+      return { messageId };
+    });
+
+    const req = makeInboundRequest({
+      externalMessageId: `msg-guardian-${Date.now()}`,
+    });
+
+    const res = await handleChannelInbound(req, processMessage as any, 'test-token');
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(processCalls.length).toBeGreaterThan(0);
+    expect(processCalls[0].options?.isInteractive).toBe(true);
+  });
+
+  test('unknown actors remain non-interactive', async () => {
+    // No guardian binding, no member record => unknown trust class
+    mockFindMember = () => null;
+
+    const processCalls: Array<{ options?: Record<string, unknown> }> = [];
+    const processMessage = mock(async (
+      conversationId: string,
+      _content: string,
+      _attachmentIds?: string[],
+      options?: Record<string, unknown>,
+    ) => {
+      processCalls.push({ options });
+      const messageId = `msg-unknown-${Date.now()}`;
+      const db = getDb();
+      db.insert(messages).values({
+        id: messageId,
+        conversationId,
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'hello' }]),
+        createdAt: Date.now(),
+      }).run();
+      return { messageId };
+    });
+
+    const req = makeInboundRequest({
+      externalMessageId: `msg-unknown-${Date.now()}`,
+      // No senderExternalUserId => unknown trust class
+      senderExternalUserId: undefined,
+    });
+
+    const res = await handleChannelInbound(req, processMessage as any, 'test-token');
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(processCalls.length).toBeGreaterThan(0);
+    expect(processCalls[0].options?.isInteractive).toBe(false);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Integration tests: channel-retry-sweep routing state
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('channel-retry-sweep routing state', () => {
+  beforeEach(() => {
+    resetTables();
+    mockFindMember = null;
+  });
+
+  function seedFailedEvent(trustClass: 'guardian' | 'trusted_contact' | 'unknown', guardianExternalUserId?: string): string {
+    const inbound = channelDeliveryStore.recordInbound('telegram', `chat-${trustClass}`, `msg-${trustClass}-${Date.now()}`);
+    channelDeliveryStore.storePayload(inbound.eventId, {
+      content: 'retry me',
+      sourceChannel: 'telegram',
+      interface: 'telegram',
+      guardianCtx: {
+        trustClass,
+        sourceChannel: 'telegram',
+        requesterExternalUserId: 'test-user',
+        requesterChatId: `chat-${trustClass}`,
+        ...(guardianExternalUserId ? { guardianExternalUserId } : {}),
+      },
+    });
+
+    const db = getDb();
+    db.update(channelInboundEvents)
+      .set({
+        processingStatus: 'failed',
+        processingAttempts: 1,
+        retryAfter: Date.now() - 1,
+      })
+      .where(eq(channelInboundEvents.id, inbound.eventId))
+      .run();
+
+    return inbound.eventId;
+  }
+
+  test('trusted_contact with guardian binding replays as interactive', async () => {
+    const eventId = seedFailedEvent('trusted_contact', 'guardian-for-sweep');
+    let capturedOptions: { isInteractive?: boolean } | undefined;
+
+    await sweepFailedEvents(
+      async (conversationId, _content, _attachmentIds, options) => {
+        capturedOptions = options as { isInteractive?: boolean };
+        const messageId = `message-tc-sweep-${Date.now()}`;
+        const db = getDb();
+        db.insert(messages).values({
+          id: messageId,
+          conversationId,
+          role: 'user',
+          content: JSON.stringify([{ type: 'text', text: 'retry me' }]),
+          createdAt: Date.now(),
+        }).run();
+        return { messageId };
+      },
+      undefined,
+    );
+
+    expect(capturedOptions?.isInteractive).toBe(true);
+  });
+
+  test('trusted_contact without guardian binding replays as non-interactive', async () => {
+    const eventId = seedFailedEvent('trusted_contact');
+    let capturedOptions: { isInteractive?: boolean } | undefined;
+
+    await sweepFailedEvents(
+      async (conversationId, _content, _attachmentIds, options) => {
+        capturedOptions = options as { isInteractive?: boolean };
+        const messageId = `message-tc-no-binding-${Date.now()}`;
+        const db = getDb();
+        db.insert(messages).values({
+          id: messageId,
+          conversationId,
+          role: 'user',
+          content: JSON.stringify([{ type: 'text', text: 'retry me' }]),
+          createdAt: Date.now(),
+        }).run();
+        return { messageId };
+      },
+      undefined,
+    );
+
+    expect(capturedOptions?.isInteractive).toBe(false);
+  });
+
+  test('guardian replays as interactive', async () => {
+    const eventId = seedFailedEvent('guardian', 'guardian-self');
+    let capturedOptions: { isInteractive?: boolean } | undefined;
+
+    await sweepFailedEvents(
+      async (conversationId, _content, _attachmentIds, options) => {
+        capturedOptions = options as { isInteractive?: boolean };
+        const messageId = `message-guardian-sweep-${Date.now()}`;
+        const db = getDb();
+        db.insert(messages).values({
+          id: messageId,
+          conversationId,
+          role: 'user',
+          content: JSON.stringify([{ type: 'text', text: 'retry me' }]),
+          createdAt: Date.now(),
+        }).run();
+        return { messageId };
+      },
+      undefined,
+    );
+
+    expect(capturedOptions?.isInteractive).toBe(true);
+  });
+
+  test('unknown replays as non-interactive', async () => {
+    const eventId = seedFailedEvent('unknown');
+    let capturedOptions: { isInteractive?: boolean } | undefined;
+
+    await sweepFailedEvents(
+      async (conversationId, _content, _attachmentIds, options) => {
+        capturedOptions = options as { isInteractive?: boolean };
+        const messageId = `message-unknown-sweep-${Date.now()}`;
+        const db = getDb();
+        db.insert(messages).values({
+          id: messageId,
+          conversationId,
+          role: 'user',
+          content: JSON.stringify([{ type: 'text', text: 'retry me' }]),
+          createdAt: Date.now(),
+        }).run();
+        return { messageId };
+      },
+      undefined,
+    );
+
+    expect(capturedOptions?.isInteractive).toBe(false);
+  });
+});

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -7,6 +7,7 @@ import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.
 import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
 import { getLogger } from '../util/logger.js';
 import { deliverReplyViaCallback } from './channel-reply-delivery.js';
+import { resolveRoutingStateFromRuntime } from './guardian-context-resolver.js';
 import type { MessageProcessor } from './http-types.js';
 
 const log = getLogger('runtime-http');
@@ -129,7 +130,9 @@ export async function sweepFailedEvents(
           },
           assistantId,
           guardianContext,
-          isInteractive: guardianContext?.trustClass === 'guardian',
+          isInteractive: guardianContext
+            ? resolveRoutingStateFromRuntime(guardianContext).promptWaitingAllowed
+            : false,
         },
         sourceChannel,
         sourceInterface,

--- a/assistant/src/runtime/guardian-context-resolver.ts
+++ b/assistant/src/runtime/guardian-context-resolver.ts
@@ -62,6 +62,88 @@ export function resolveGuardianContext(input: ResolveGuardianContextInput): Guar
   };
 }
 
+// ---------------------------------------------------------------------------
+// Routing-state helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Routing state for a channel actor turn.
+ *
+ * Determines whether a turn should be treated as interactive (the caller
+ * can be kept waiting for a guardian to respond to an approval prompt) by
+ * combining trust class with guardian route resolvability.
+ *
+ * A guardian route is "resolvable" when a verified guardian binding exists
+ * for the channel — meaning there is a concrete destination to deliver
+ * approval notifications to. Without a resolvable guardian route, entering
+ * an interactive wait (up to 300s) is a dead-end: no guardian will ever
+ * see the prompt.
+ */
+export interface RoutingState {
+  /** Whether the actor's trust class alone permits interactive waits. */
+  canBeInteractive: boolean;
+  /** Whether a verified guardian destination exists for this channel. */
+  guardianRouteResolvable: boolean;
+  /**
+   * Whether the turn should actually enter an interactive prompt wait.
+   * True only when the actor can be interactive AND a guardian route is
+   * resolvable. This is the canonical decision used by processMessage.
+   */
+  promptWaitingAllowed: boolean;
+}
+
+/**
+ * Compute the routing state for a channel actor turn.
+ *
+ * Guardian actors are always interactive (they self-approve).
+ * Trusted contacts are only interactive when a guardian binding exists
+ * to receive approval notifications. Unknown actors are never interactive.
+ */
+export function resolveRoutingState(ctx: GuardianContext): RoutingState {
+  const isGuardian = ctx.trustClass === 'guardian';
+  const isTrustedContact = ctx.trustClass === 'trusted_contact';
+
+  // Guardians self-approve — they are always interactive and route-resolvable.
+  if (isGuardian) {
+    return {
+      canBeInteractive: true,
+      guardianRouteResolvable: true,
+      promptWaitingAllowed: true,
+    };
+  }
+
+  // Trusted contacts can be interactive only if a guardian destination
+  // exists. The guardian binding populates guardianExternalUserId during
+  // trust resolution; its presence means there is a verified guardian
+  // to route approval notifications to.
+  const guardianRouteResolvable = !!ctx.guardianExternalUserId;
+  if (isTrustedContact) {
+    return {
+      canBeInteractive: true,
+      guardianRouteResolvable,
+      promptWaitingAllowed: guardianRouteResolvable,
+    };
+  }
+
+  // Unknown actors are never interactive.
+  return {
+    canBeInteractive: false,
+    guardianRouteResolvable: !!ctx.guardianExternalUserId,
+    promptWaitingAllowed: false,
+  };
+}
+
+/**
+ * Convenience: compute routing state from a GuardianRuntimeContext
+ * (the shape persisted in stored payloads and used by the retry sweep).
+ */
+export function resolveRoutingStateFromRuntime(ctx: GuardianRuntimeContext): RoutingState {
+  return resolveRoutingState({
+    trustClass: ctx.trustClass,
+    guardianExternalUserId: ctx.guardianExternalUserId,
+  });
+}
+
 export function toGuardianRuntimeContext(sourceChannel: ChannelId, ctx: GuardianContext): GuardianRuntimeContext {
   return {
     sourceChannel,

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -741,6 +741,35 @@ export async function handleApprovalInterception(
         }
         return { handled: true, type: 'decision_applied' };
       }
+
+      // Guard: trusted contacts with a guardian binding must not self-approve
+      // even when no guardian approval row exists yet. The guardian approval
+      // row is created asynchronously when the approval prompt is delivered
+      // to the guardian. In the window between the pending confirmation being
+      // created (isInteractive=true) and the guardian approval row being
+      // persisted, the trusted contact could otherwise fall through to the
+      // standard conversational engine / legacy parser and resolve their own
+      // pending request via handleChannelDecision.
+      if (guardianCtx.trustClass === 'trusted_contact' && guardianCtx.guardianExternalUserId) {
+        log.info(
+          { conversationId, externalChatId, guardianExternalUserId: guardianCtx.guardianExternalUserId },
+          'Blocking trusted-contact self-approval: pending confirmation exists but guardian approval row not yet created',
+        );
+        try {
+          const pendingText = await composeApprovalMessageGenerative({
+            scenario: 'request_pending_guardian',
+            channel: sourceChannel,
+          }, {}, approvalCopyGenerator);
+          await deliverChannelReply(replyCallbackUrl, {
+            chatId: externalChatId,
+            text: pendingText,
+            assistantId,
+          }, bearerToken);
+        } catch (err) {
+          log.error({ err, conversationId }, 'Failed to deliver guardian-pending notice to trusted contact (pre-row guard)');
+        }
+        return { handled: true, type: 'assistant_turn' };
+      }
     }
   }
 

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -46,7 +46,7 @@ import {
 } from '../channel-guardian-service.js';
 import { getTransport } from '../channel-invite-transport.js';
 import { deliverChannelReply } from '../gateway-client.js';
-import { resolveGuardianContext } from '../guardian-context-resolver.js';
+import { resolveGuardianContext, resolveRoutingState } from '../guardian-context-resolver.js';
 import { routeGuardianReply } from '../guardian-reply-router.js';
 import {
   composeChannelVerifyReply,
@@ -1536,7 +1536,7 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
           },
           assistantId,
           guardianContext: toGuardianRuntimeContext(sourceChannel, guardianCtx),
-          isInteractive: guardianCtx.trustClass === 'guardian',
+          isInteractive: resolveRoutingState(guardianCtx).promptWaitingAllowed,
           ...(cmdIntent ? { commandIntent: cmdIntent } : {}),
         },
         sourceChannel,


### PR DESCRIPTION
Closes #10721. Part of #10719.

Adds a canonical routing-state helper that determines whether a trusted-contact turn can be interactive based on guardian route resolvability. Prevents dead-end 300s prompt waits when no guardian destination exists to receive approval notifications. Includes fail-fast behavior for missing guardian bindings and tests for routeable vs unrouteable trusted-contact interactivity.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
