### PR TITLE
feat: add Slack notifications to main CI workflows

### DIFF
--- a/.github/config/github_slack_mapping.yaml
+++ b/.github/config/github_slack_mapping.yaml
@@ -1,0 +1,28 @@
+github_to_slack_all_notifications:
+  noanflaherty: U04C2QS2404
+  asharma53: U04BTP01B2S
+  AnitaKirkovska: U060M1MUT7F
+  ashleeradka: U06LGSYA9JP
+  awlevin: U07CLDQ4TB3
+  NgoHarrison: U07M5C935Q8
+  vincent0426: U08CJM4D56D
+  TirmanSidhu: U08ASQYPTB6
+  emmiekehoe: U08Q1QHGKTM
+  alex-nork: U095KUZ3L20
+  tkheyfets: U09AWSU8XM1
+  Jasonnnz: U09DVL1JN3V
+
+github_to_slack_failure_notifications: # neutral good
+  siddseethepalli: U04C0B3038A
+  dvargas92495: U05D5EGNNMS
+  clopen-set: U08QQU27M0W
+  m-abboud: U06CMAEKH4L
+  Shaarson: U08EREL8F18
+
+github_to_slack_success_notifications: # chaotic evil
+
+github_to_slack_cancelled_notifications: # chaotic neutral
+  dvargas92495: U05D5EGNNMS
+  clopen-set: U08QQU27M0W
+  m-abboud: U06CMAEKH4L
+  Shaarson: U08EREL8F18

--- a/.github/config/slack.yaml
+++ b/.github/config/slack.yaml
@@ -1,0 +1,28 @@
+username: Build Alerts
+
+pretext: >-
+  {{icon jobStatus}} {{jobName}} {{jobStatus}}
+  {{#if (and env.SHOULD_TAG (eq env.SHOULD_TAG 'true'))}}by <@{{ env.SLACK_USER_ID }}>{{else}}by {{ env.SLACK_USER_ID }}{{/if}}
+  <{{repositoryUrl}}|{{repositoryName}}>
+
+text: |
+  *<{{workflowRunUrl}}|{{workflow}}>*
+
+fallback: |-
+  [{{repositoryName}}] {{jobName}} - {{jobStatus}}
+
+footer: >-
+  <{{repositoryUrl}}|{{repositoryName}}> {{workflow}} #{{runNumber}}
+
+colors:
+  success: "#5DADE2"
+  failure: "#884EA0"
+  cancelled: "#A569BD"
+  default: "#7D3C98"
+
+icons:
+  success: ":white_check_mark:"
+  failure: ":kimk-cryingggggggg:"
+  cancelled: ":meow_meltshoe:"
+  skipped: ":dw_arthur_side_eye:"
+  default: ":interrobang:"

--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -80,3 +80,65 @@ jobs:
           fi
 
           echo "Consecutive failures on main: $CONSECUTIVE"
+
+  notify:
+    name: Slack Notification
+    needs: [checks]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get Slack ID
+        id: slack-id
+        run: |
+          GITHUB_USER="${{ github.actor }}"
+
+          if [[ "${{ needs.checks.result }}" == "failure" ]]; then
+            STATUS="failure"
+          elif [[ "${{ needs.checks.result }}" == "cancelled" ]]; then
+            STATUS="cancelled"
+          elif [[ "${{ needs.checks.result }}" == "skipped" ]]; then
+            STATUS="skipped"
+          else
+            STATUS="success"
+          fi
+
+          SLACK_ID=$(yq ".github_to_slack_all_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+
+          if [ "$SLACK_ID" = "null" ]; then
+            case $STATUS in
+              failure)
+                SLACK_ID=$(yq ".github_to_slack_failure_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+                ;;
+              success)
+                SLACK_ID=$(yq ".github_to_slack_success_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+                ;;
+              cancelled)
+                SLACK_ID=$(yq ".github_to_slack_cancelled_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+                ;;
+            esac
+          fi
+
+          if [ "$SLACK_ID" = "null" ]; then
+            SLACK_ID="$GITHUB_USER"
+          fi
+
+          if [ "$SLACK_ID" = "$GITHUB_USER" ]; then
+            echo "should_tag=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_tag=true" >> $GITHUB_OUTPUT
+          fi
+          echo "id=$SLACK_ID" >> $GITHUB_OUTPUT
+          echo "status=$STATUS" >> $GITHUB_OUTPUT
+
+      - uses: act10ns/slack@v2
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_USER_ID: ${{ steps.slack-id.outputs.id }}
+          SHOULD_TAG: ${{ steps.slack-id.outputs.should_tag }}
+        with:
+          status: ${{ steps.slack-id.outputs.status }}
+          channel: "#build-alerts"
+          config: .github/config/slack.yaml

--- a/.github/workflows/ci-main-cli.yaml
+++ b/.github/workflows/ci-main-cli.yaml
@@ -70,3 +70,65 @@ jobs:
           fi
 
           echo "Consecutive failures on main: $CONSECUTIVE"
+
+  notify:
+    name: Slack Notification
+    needs: [checks]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get Slack ID
+        id: slack-id
+        run: |
+          GITHUB_USER="${{ github.actor }}"
+
+          if [[ "${{ needs.checks.result }}" == "failure" ]]; then
+            STATUS="failure"
+          elif [[ "${{ needs.checks.result }}" == "cancelled" ]]; then
+            STATUS="cancelled"
+          elif [[ "${{ needs.checks.result }}" == "skipped" ]]; then
+            STATUS="skipped"
+          else
+            STATUS="success"
+          fi
+
+          SLACK_ID=$(yq ".github_to_slack_all_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+
+          if [ "$SLACK_ID" = "null" ]; then
+            case $STATUS in
+              failure)
+                SLACK_ID=$(yq ".github_to_slack_failure_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+                ;;
+              success)
+                SLACK_ID=$(yq ".github_to_slack_success_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+                ;;
+              cancelled)
+                SLACK_ID=$(yq ".github_to_slack_cancelled_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+                ;;
+            esac
+          fi
+
+          if [ "$SLACK_ID" = "null" ]; then
+            SLACK_ID="$GITHUB_USER"
+          fi
+
+          if [ "$SLACK_ID" = "$GITHUB_USER" ]; then
+            echo "should_tag=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_tag=true" >> $GITHUB_OUTPUT
+          fi
+          echo "id=$SLACK_ID" >> $GITHUB_OUTPUT
+          echo "status=$STATUS" >> $GITHUB_OUTPUT
+
+      - uses: act10ns/slack@v2
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_USER_ID: ${{ steps.slack-id.outputs.id }}
+          SHOULD_TAG: ${{ steps.slack-id.outputs.should_tag }}
+        with:
+          status: ${{ steps.slack-id.outputs.status }}
+          channel: "#build-alerts"
+          config: .github/config/slack.yaml

--- a/.github/workflows/ci-main-gateway.yaml
+++ b/.github/workflows/ci-main-gateway.yaml
@@ -71,3 +71,65 @@ jobs:
           fi
 
           echo "Consecutive failures on main: $CONSECUTIVE"
+
+  notify:
+    name: Slack Notification
+    needs: [checks]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get Slack ID
+        id: slack-id
+        run: |
+          GITHUB_USER="${{ github.actor }}"
+
+          if [[ "${{ needs.checks.result }}" == "failure" ]]; then
+            STATUS="failure"
+          elif [[ "${{ needs.checks.result }}" == "cancelled" ]]; then
+            STATUS="cancelled"
+          elif [[ "${{ needs.checks.result }}" == "skipped" ]]; then
+            STATUS="skipped"
+          else
+            STATUS="success"
+          fi
+
+          SLACK_ID=$(yq ".github_to_slack_all_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+
+          if [ "$SLACK_ID" = "null" ]; then
+            case $STATUS in
+              failure)
+                SLACK_ID=$(yq ".github_to_slack_failure_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+                ;;
+              success)
+                SLACK_ID=$(yq ".github_to_slack_success_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+                ;;
+              cancelled)
+                SLACK_ID=$(yq ".github_to_slack_cancelled_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+                ;;
+            esac
+          fi
+
+          if [ "$SLACK_ID" = "null" ]; then
+            SLACK_ID="$GITHUB_USER"
+          fi
+
+          if [ "$SLACK_ID" = "$GITHUB_USER" ]; then
+            echo "should_tag=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_tag=true" >> $GITHUB_OUTPUT
+          fi
+          echo "id=$SLACK_ID" >> $GITHUB_OUTPUT
+          echo "status=$STATUS" >> $GITHUB_OUTPUT
+
+      - uses: act10ns/slack@v2
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_USER_ID: ${{ steps.slack-id.outputs.id }}
+          SHOULD_TAG: ${{ steps.slack-id.outputs.should_tag }}
+        with:
+          status: ${{ steps.slack-id.outputs.status }}
+          channel: "#build-alerts"
+          config: .github/config/slack.yaml

--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -150,3 +150,65 @@ jobs:
       - name: Run tests
         working-directory: clients/macos
         run: ./build.sh test
+
+  notify:
+    name: Slack Notification
+    needs: [build, test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get Slack ID
+        id: slack-id
+        run: |
+          GITHUB_USER="${{ github.actor }}"
+
+          if [[ "${{ needs.build.result }}" == "failure" || "${{ needs.test.result }}" == "failure" ]]; then
+            STATUS="failure"
+          elif [[ "${{ needs.build.result }}" == "cancelled" || "${{ needs.test.result }}" == "cancelled" ]]; then
+            STATUS="cancelled"
+          elif [[ "${{ needs.build.result }}" == "skipped" || "${{ needs.test.result }}" == "skipped" ]]; then
+            STATUS="skipped"
+          else
+            STATUS="success"
+          fi
+
+          SLACK_ID=$(yq ".github_to_slack_all_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+
+          if [ "$SLACK_ID" = "null" ]; then
+            case $STATUS in
+              failure)
+                SLACK_ID=$(yq ".github_to_slack_failure_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+                ;;
+              success)
+                SLACK_ID=$(yq ".github_to_slack_success_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+                ;;
+              cancelled)
+                SLACK_ID=$(yq ".github_to_slack_cancelled_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+                ;;
+            esac
+          fi
+
+          if [ "$SLACK_ID" = "null" ]; then
+            SLACK_ID="$GITHUB_USER"
+          fi
+
+          if [ "$SLACK_ID" = "$GITHUB_USER" ]; then
+            echo "should_tag=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_tag=true" >> $GITHUB_OUTPUT
+          fi
+          echo "id=$SLACK_ID" >> $GITHUB_OUTPUT
+          echo "status=$STATUS" >> $GITHUB_OUTPUT
+
+      - uses: act10ns/slack@v2
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_USER_ID: ${{ steps.slack-id.outputs.id }}
+          SHOULD_TAG: ${{ steps.slack-id.outputs.should_tag }}
+        with:
+          status: ${{ steps.slack-id.outputs.status }}
+          channel: "#build-alerts"
+          config: .github/config/slack.yaml


### PR DESCRIPTION
## Summary
- Add Slack notification job to all 4 main CI workflows (assistant, cli, gateway, macOS) using the same `act10ns/slack@v2` pattern as the vellum repo
- Add `.github/config/slack.yaml` (message template) and `.github/config/github_slack_mapping.yaml` (GitHub-to-Slack user ID mappings) mirroring the vellum repo config
- Notifications post to `#build-alerts` with status-aware user tagging (all/failure/success/cancelled notification groups)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
