### PR TITLE
fix: allow natural-language approval interception with queued turns

### DIFF
--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -238,6 +238,28 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
     expect(requestComplete?.runStillActive).toBe(false);
   });
 
+  test('consumes decision replies even when queue depth is non-zero', async () => {
+    listPendingByDestinationMock.mockReturnValue([{ id: 'req-1', kind: 'tool_approval' }]);
+    listCanonicalMock.mockReturnValue([{ id: 'req-1' }]);
+    routeGuardianReplyMock.mockResolvedValue({
+      consumed: true,
+      decisionApplied: true,
+      type: 'canonical_decision_applied',
+      requestId: 'req-1',
+    });
+
+    const session = makeSession({
+      getQueueDepth: () => 2,
+    });
+    const { ctx } = createContext(session);
+
+    await handleUserMessage(makeMessage('approve'), {} as net.Socket, ctx);
+
+    expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
+    expect((session.denyAllPendingConfirmations as any).mock.calls.length).toBe(0);
+    expect((session.enqueueMessage as any).mock.calls.length).toBe(0);
+  });
+
   test('does not mutate in-memory history while processing', async () => {
     listPendingByDestinationMock.mockReturnValue([{ id: 'req-1', kind: 'tool_approval' }]);
     listCanonicalMock.mockReturnValue([{ id: 'req-1' }]);

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -136,13 +136,18 @@ function makeHangingSession(): Session {
   } as unknown as Session;
 }
 
-function makePendingApprovalSession(requestId: string, processing: boolean): {
+function makePendingApprovalSession(
+  requestId: string,
+  processing: boolean,
+  options?: { queueDepth?: number },
+): {
   session: Session;
   runAgentLoopMock: ReturnType<typeof mock>;
   enqueueMessageMock: ReturnType<typeof mock>;
   denyAllPendingConfirmationsMock: ReturnType<typeof mock>;
   handleConfirmationResponseMock: ReturnType<typeof mock>;
 } {
+  const queueDepth = options?.queueDepth ?? 0;
   const pending = new Set([requestId]);
   const messages: unknown[] = [];
   const runAgentLoopMock = mock(async () => {});
@@ -171,7 +176,7 @@ function makePendingApprovalSession(requestId: string, processing: boolean): {
     hasAnyPendingConfirmation: () => pending.size > 0,
     hasPendingConfirmation: (candidateRequestId: string) => pending.has(candidateRequestId),
     denyAllPendingConfirmations: denyAllPendingConfirmationsMock,
-    getQueueDepth: () => 0,
+    getQueueDepth: () => queueDepth,
     enqueueMessage: enqueueMessageMock,
     runAgentLoop: runAgentLoopMock,
     handleConfirmationResponse: handleConfirmationResponseMock,
@@ -441,6 +446,61 @@ describe('POST /v1/messages — queue-if-busy and hub publishing', () => {
       toolName: 'call_start',
       status: 'pending',
       requestCode: 'DEF456',
+      expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    });
+
+    await startServer(() => session);
+
+    const res = await fetch(messagesUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({
+        conversationKey,
+        content: 'approve',
+        sourceChannel: 'vellum',
+        interface: 'macos',
+      }),
+    });
+    const body = await res.json() as { accepted: boolean; messageId?: string; queued?: boolean };
+
+    expect(res.status).toBe(202);
+    expect(body.accepted).toBe(true);
+    expect(body.messageId).toBeDefined();
+    expect(body.queued).toBeUndefined();
+    expect(handleConfirmationResponseMock).toHaveBeenCalledTimes(1);
+    expect(denyAllPendingConfirmationsMock).toHaveBeenCalledTimes(0);
+    expect(enqueueMessageMock).toHaveBeenCalledTimes(0);
+    expect(runAgentLoopMock).toHaveBeenCalledTimes(0);
+
+    await stopServer();
+  });
+
+  test('consumes explicit approval text while busy even when queue depth is non-zero', async () => {
+    const conversationKey = 'conv-inline-busy-queued';
+    const { conversationId } = getOrCreateConversation(conversationKey);
+    const requestId = 'req-inline-busy-queued';
+    const {
+      session,
+      runAgentLoopMock,
+      enqueueMessageMock,
+      denyAllPendingConfirmationsMock,
+      handleConfirmationResponseMock,
+    } = makePendingApprovalSession(requestId, true, { queueDepth: 2 });
+
+    pendingInteractions.register(requestId, {
+      session,
+      conversationId,
+      kind: 'confirmation',
+    });
+    createCanonicalGuardianRequest({
+      id: requestId,
+      kind: 'tool_approval',
+      sourceType: 'desktop',
+      sourceChannel: 'vellum',
+      conversationId,
+      toolName: 'call_start',
+      status: 'pending',
+      requestCode: 'Q2D456',
       expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
     });
 

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -551,11 +551,13 @@ export async function handleUserMessage(
       }
     }
 
-    // If exactly one live turn is waiting on confirmation (no queued turns),
-    // try to consume this text as an inline approval decision first.
+    // If a live turn is waiting on confirmation, try to consume this text as
+    // an inline approval decision before auto-deny. We intentionally do not
+    // gate on queue depth: users often retry "approve"/"yes" while the queue
+    // is draining after a prior denial, and requiring an empty queue causes a
+    // deny/retry cascade where natural-language approvals never land.
     if (
       session.hasAnyPendingConfirmation()
-      && session.getQueueDepth() === 0
       && messageText.trim().length > 0
     ) {
       try {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -102,12 +102,12 @@ async function tryConsumeInlineApprovalReply(params: {
   } = params;
   const trimmedContent = content.trim();
 
-  // Only consume inline replies when there are no queued turns, matching
-  // the IPC path guard. With queued messages, "approve"/"no" should be
-  // processed in queue order rather than treated as a confirmation reply.
+  // Try inline approval interception whenever a pending confirmation exists.
+  // We intentionally do not block on queue depth: after an auto-deny, users
+  // often retry with "approve"/"yes" while the queue is still draining, and
+  // requiring an empty queue can create a deny/retry cascade.
   if (
     !session.hasAnyPendingConfirmation()
-    || session.getQueueDepth() > 0
     || trimmedContent.length === 0
   ) {
     return { consumed: false };


### PR DESCRIPTION
## Summary
- remove the queue-depth guard from inline approval interception in the IPC session handler so explicit approval/rejection replies are still consumed while queued turns exist
- mirror the same behavior in HTTP `/v1/messages` inline approval interception
- add regression coverage for non-zero queue depth in both IPC and HTTP approval-consumption tests

## Root cause
Inline approval interception was conditioned on `getQueueDepth() === 0`. After an auto-deny + retry cycle, queued turns can remain while a new permission prompt is active, causing `approve`/`allow`/`yes` to skip interception and fall through to auto-deny.

## Validation
- bun test src/__tests__/handlers-user-message-approval-consumption.test.ts
- bun test src/__tests__/send-endpoint-busy.test.ts
- bunx tsc --noEmit

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
