### PR TITLE
fix: make Slack notification step non-blocking

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -134,6 +134,7 @@ jobs:
           echo "status=$STATUS" >> $GITHUB_OUTPUT
 
       - uses: act10ns/slack@v2
+        continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_USER_ID: ${{ steps.slack-id.outputs.id }}

--- a/.github/workflows/ci-main-cli.yaml
+++ b/.github/workflows/ci-main-cli.yaml
@@ -124,6 +124,7 @@ jobs:
           echo "status=$STATUS" >> $GITHUB_OUTPUT
 
       - uses: act10ns/slack@v2
+        continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_USER_ID: ${{ steps.slack-id.outputs.id }}

--- a/.github/workflows/ci-main-gateway.yaml
+++ b/.github/workflows/ci-main-gateway.yaml
@@ -125,6 +125,7 @@ jobs:
           echo "status=$STATUS" >> $GITHUB_OUTPUT
 
       - uses: act10ns/slack@v2
+        continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_USER_ID: ${{ steps.slack-id.outputs.id }}

--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -204,6 +204,7 @@ jobs:
           echo "status=$STATUS" >> $GITHUB_OUTPUT
 
       - uses: act10ns/slack@v2
+        continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_USER_ID: ${{ steps.slack-id.outputs.id }}


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to the `act10ns/slack@v2` step in all 4 main CI workflows so transient Slack/webhook failures don't mark CI as failed

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/10739

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
