### PR TITLE
fix: simplify early title generation in agent loop

### DIFF
--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -227,19 +227,23 @@ export async function runAgentLoopImpl(
     // regeneration at turn 3 will refine the title with more context.
     // No abort signal — title generation should complete even if the user
     // cancels the response, since the user message is already persisted.
+    // Deferred via setTimeout so the main agent loop LLM call enqueues
+    // first, avoiding rate-limit slot contention on strict configs.
     if (isReplaceableTitle(conversationStore.getConversation(ctx.conversationId)?.title ?? null)) {
-      queueGenerateConversationTitle({
-        conversationId: ctx.conversationId,
-        provider: ctx.provider,
-        userMessage: options?.titleText ?? content,
-        onTitleUpdated: (title) => {
-          onEvent({
-            type: 'session_title_updated',
-            sessionId: ctx.conversationId,
-            title,
-          });
-        },
-      });
+      setTimeout(() => {
+        queueGenerateConversationTitle({
+          conversationId: ctx.conversationId,
+          provider: ctx.provider,
+          userMessage: options?.titleText ?? content,
+          onTitleUpdated: (title) => {
+            onEvent({
+              type: 'session_title_updated',
+              sessionId: ctx.conversationId,
+              title,
+            });
+          },
+        });
+      }, 0);
     }
 
     const isFirstMessage = ctx.messages.length === 1;

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -20,7 +20,7 @@ import { commitAppTurnChanges } from '../memory/app-git-service.js';
 import { getApp, listAppFiles } from '../memory/app-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { getConversationOriginChannel, getConversationOriginInterface, provenanceFromGuardianContext } from '../memory/conversation-store.js';
-import { GENERATING_TITLE, isReplaceableTitle, queueGenerateConversationTitle, queueRegenerateConversationTitle, UNTITLED_FALLBACK } from '../memory/conversation-title-service.js';
+import { isReplaceableTitle, queueGenerateConversationTitle, queueRegenerateConversationTitle, UNTITLED_FALLBACK } from '../memory/conversation-title-service.js';
 import { stripMemoryRecallMessages } from '../memory/retriever.js';
 import type { PermissionPrompter } from '../permissions/prompter.js';
 import type { ContentBlock,Message } from '../providers/types.js';
@@ -212,9 +212,9 @@ export async function runAgentLoopImpl(
         conversationStore.deleteMessageById(userMessageId);
       }
       // Replace loading placeholder so the thread isn't stuck as "Generating title..."
-      const blockedConv = conversationStore.getConversation(ctx.conversationId);
-      if (blockedConv?.title === GENERATING_TITLE) {
-        conversationStore.updateConversationTitle(ctx.conversationId, UNTITLED_FALLBACK, 1);
+      const currentConv = conversationStore.getConversation(ctx.conversationId);
+      if (isReplaceableTitle(currentConv?.title ?? null)) {
+        conversationStore.updateConversationTitle(ctx.conversationId, UNTITLED_FALLBACK);
         onEvent({ type: 'session_title_updated', sessionId: ctx.conversationId, title: UNTITLED_FALLBACK });
       }
       onEvent({ type: 'error', message: `Message blocked by hook "${preMessageResult.blockedBy}"` });
@@ -225,26 +225,21 @@ export async function runAgentLoopImpl(
     // Firing after hook gating but before the main LLM call removes the
     // delay of waiting for the full assistant response. The second-pass
     // regeneration at turn 3 will refine the title with more context.
-    // Deferred via setTimeout so the main agent loop LLM call is queued
-    // first, avoiding rate-limit slot contention. No abort signal — title
-    // generation should complete even if the user cancels the response,
-    // since the user message is already persisted.
-    const currentConvForTitle = conversationStore.getConversation(ctx.conversationId);
-    if (isReplaceableTitle(currentConvForTitle?.title ?? null)) {
-      setTimeout(() => {
-        queueGenerateConversationTitle({
-          conversationId: ctx.conversationId,
-          provider: ctx.provider,
-          userMessage: options?.titleText ?? content,
-          onTitleUpdated: (title) => {
-            onEvent({
-              type: 'session_title_updated',
-              sessionId: ctx.conversationId,
-              title,
-            });
-          },
-        });
-      }, 0);
+    // No abort signal — title generation should complete even if the user
+    // cancels the response, since the user message is already persisted.
+    if (isReplaceableTitle(conversationStore.getConversation(ctx.conversationId)?.title ?? null)) {
+      queueGenerateConversationTitle({
+        conversationId: ctx.conversationId,
+        provider: ctx.provider,
+        userMessage: options?.titleText ?? content,
+        onTitleUpdated: (title) => {
+          onEvent({
+            type: 'session_title_updated',
+            sessionId: ctx.conversationId,
+            title,
+          });
+        },
+      });
     }
 
     const isFirstMessage = ctx.messages.length === 1;


### PR DESCRIPTION
## Summary
- Use `isReplaceableTitle()` instead of direct `=== GENERATING_TITLE` comparison in the blocked-by-hook path, consistent with every other title check in the codebase
- Remove unnecessary `setTimeout(0)` wrapper — `queueGenerateConversationTitle` is already async fire-and-forget
- Drop incorrect `isAutoTitle=1` on terminal `UNTITLED_FALLBACK` in blocked path — a dead-end fallback shouldn't be marked as refineable
- Remove redundant `getConversation` call and unused `GENERATING_TITLE` import

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
