### PR TITLE
M2: bridge trusted-contact confirmation_request to guardian.question notifications

### DIFF
--- a/assistant/src/__tests__/confirmation-request-guardian-bridge.test.ts
+++ b/assistant/src/__tests__/confirmation-request-guardian-bridge.test.ts
@@ -366,4 +366,45 @@ describe('bridgeConfirmationRequestToGuardian', () => {
     const payload = emittedSignals[0].contextPayload as Record<string, unknown>;
     expect(payload.requesterChatId).toBeNull();
   });
+
+  test('skips when binding guardian identity does not match canonical request guardian', () => {
+    // Create a canonical request where guardianExternalUserId differs from the
+    // binding's guardianExternalUserId ('guardian-1' in the mock).
+    const canonicalRequest = makeCanonicalRequest({
+      guardianExternalUserId: 'old-guardian-who-was-rebound',
+    });
+    const guardianContext = makeTrustedContactContext();
+
+    const result = bridgeConfirmationRequestToGuardian({
+      canonicalRequest,
+      guardianContext,
+      conversationId: 'conv-1',
+      toolName: 'bash',
+    });
+
+    expect('skipped' in result && result.skipped).toBe(true);
+    if ('skipped' in result) {
+      expect(result.reason).toBe('binding_identity_mismatch');
+    }
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test('does not skip when canonical request guardian identity is null', () => {
+    // When guardianExternalUserId is null on the canonical request (e.g. desktop
+    // flow), the identity check should be skipped and the bridge should proceed.
+    const canonicalRequest = makeCanonicalRequest({
+      guardianExternalUserId: null,
+    });
+    const guardianContext = makeTrustedContactContext();
+
+    const result = bridgeConfirmationRequestToGuardian({
+      canonicalRequest,
+      guardianContext,
+      conversationId: 'conv-1',
+      toolName: 'bash',
+    });
+
+    expect('bridged' in result && result.bridged).toBe(true);
+    expect(emittedSignals).toHaveLength(1);
+  });
 });

--- a/assistant/src/__tests__/confirmation-request-guardian-bridge.test.ts
+++ b/assistant/src/__tests__/confirmation-request-guardian-bridge.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Tests for the confirmation-request -> guardian.question notification bridge.
+ *
+ * Verifies that:
+ * 1. Trusted-contact confirmation_requests emit guardian.question notifications
+ * 2. Canonical delivery rows are persisted for guardian destinations
+ * 3. Guardian and unknown actor sessions are correctly skipped
+ * 4. Missing guardian binding causes a skip
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'confirmation-bridge-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  isDebug: () => false,
+  truncateForLog: (value: string) => value,
+}));
+
+// Mock notification emission — capture calls without running the full pipeline
+const emittedSignals: Array<Record<string, unknown>> = [];
+const mockOnThreadCreatedCallbacks: Array<(info: { conversationId: string; title: string; sourceEventName: string }) => void> = [];
+mock.module('../notifications/emit-signal.js', () => ({
+  emitNotificationSignal: async (params: Record<string, unknown>) => {
+    emittedSignals.push(params);
+    // Capture onThreadCreated callback so tests can invoke it
+    if (typeof params.onThreadCreated === 'function') {
+      mockOnThreadCreatedCallbacks.push(params.onThreadCreated as (info: { conversationId: string; title: string; sourceEventName: string }) => void);
+    }
+    return {
+      signalId: 'test-signal',
+      deduplicated: false,
+      dispatched: true,
+      reason: 'ok',
+      deliveryResults: [
+        { channel: 'telegram', destination: 'guardian-chat-1', success: true },
+      ],
+    };
+  },
+  registerBroadcastFn: () => {},
+}));
+
+// Mock channel guardian service — provide a guardian binding for 'self' + 'telegram'
+mock.module('../runtime/channel-guardian-service.js', () => ({
+  getGuardianBinding: (assistantId: string, channel: string) => {
+    if (assistantId === 'self' && channel === 'telegram') {
+      return {
+        id: 'binding-1',
+        assistantId: 'self',
+        channel: 'telegram',
+        guardianExternalUserId: 'guardian-1',
+        guardianDeliveryChatId: 'guardian-chat-1',
+        status: 'active',
+      };
+    }
+    return null;
+  },
+}));
+
+import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
+import {
+  createCanonicalGuardianRequest,
+  generateCanonicalRequestCode,
+  listCanonicalGuardianDeliveries,
+} from '../memory/canonical-guardian-store.js';
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { bridgeConfirmationRequestToGuardian } from '../runtime/confirmation-request-guardian-bridge.js';
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run('DELETE FROM canonical_guardian_deliveries');
+  db.run('DELETE FROM canonical_guardian_requests');
+}
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCanonicalRequest(overrides: Record<string, unknown> = {}) {
+  return createCanonicalGuardianRequest({
+    id: `req-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    kind: 'tool_approval',
+    sourceType: 'channel',
+    sourceChannel: 'telegram',
+    conversationId: 'conv-1',
+    requesterExternalUserId: 'requester-1',
+    guardianExternalUserId: 'guardian-1',
+    toolName: 'bash',
+    status: 'pending',
+    requestCode: generateCanonicalRequestCode(),
+    expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    ...overrides,
+  });
+}
+
+function makeTrustedContactContext(overrides: Partial<GuardianRuntimeContext> = {}): GuardianRuntimeContext {
+  return {
+    sourceChannel: 'telegram',
+    trustClass: 'trusted_contact',
+    guardianExternalUserId: 'guardian-1',
+    guardianChatId: 'guardian-chat-1',
+    requesterExternalUserId: 'requester-1',
+    requesterChatId: 'requester-chat-1',
+    requesterIdentifier: '@requester',
+    ...overrides,
+  };
+}
+
+// ===========================================================================
+// TESTS
+// ===========================================================================
+
+describe('bridgeConfirmationRequestToGuardian', () => {
+  beforeEach(() => {
+    resetTables();
+    emittedSignals.length = 0;
+    mockOnThreadCreatedCallbacks.length = 0;
+  });
+
+  test('emits guardian.question for trusted-contact sessions', () => {
+    const canonicalRequest = makeCanonicalRequest();
+    const guardianContext = makeTrustedContactContext();
+
+    const result = bridgeConfirmationRequestToGuardian({
+      canonicalRequest,
+      guardianContext,
+      conversationId: 'conv-1',
+      toolName: 'bash',
+    });
+
+    expect('bridged' in result && result.bridged).toBe(true);
+    expect(emittedSignals).toHaveLength(1);
+    expect(emittedSignals[0].sourceEventName).toBe('guardian.question');
+    expect(emittedSignals[0].sourceChannel).toBe('telegram');
+    expect(emittedSignals[0].sourceSessionId).toBe('conv-1');
+
+    const payload = emittedSignals[0].contextPayload as Record<string, unknown>;
+    expect(payload.requestId).toBe(canonicalRequest.id);
+    expect(payload.requestCode).toBe(canonicalRequest.requestCode);
+    expect(payload.toolName).toBe('bash');
+    expect(payload.requesterExternalUserId).toBe('requester-1');
+    expect(payload.requesterIdentifier).toBe('@requester');
+  });
+
+  test('skips guardian actor sessions (self-approve)', () => {
+    const canonicalRequest = makeCanonicalRequest();
+    const guardianContext: GuardianRuntimeContext = {
+      sourceChannel: 'telegram',
+      trustClass: 'guardian',
+      guardianExternalUserId: 'guardian-1',
+    };
+
+    const result = bridgeConfirmationRequestToGuardian({
+      canonicalRequest,
+      guardianContext,
+      conversationId: 'conv-1',
+      toolName: 'bash',
+    });
+
+    expect('skipped' in result && result.skipped).toBe(true);
+    if ('skipped' in result) {
+      expect(result.reason).toBe('not_trusted_contact');
+    }
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test('skips unknown actor sessions', () => {
+    const canonicalRequest = makeCanonicalRequest();
+    const guardianContext: GuardianRuntimeContext = {
+      sourceChannel: 'telegram',
+      trustClass: 'unknown',
+    };
+
+    const result = bridgeConfirmationRequestToGuardian({
+      canonicalRequest,
+      guardianContext,
+      conversationId: 'conv-1',
+      toolName: 'bash',
+    });
+
+    expect('skipped' in result && result.skipped).toBe(true);
+    if ('skipped' in result) {
+      expect(result.reason).toBe('not_trusted_contact');
+    }
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test('skips when guardian identity is missing', () => {
+    const canonicalRequest = makeCanonicalRequest();
+    const guardianContext = makeTrustedContactContext({
+      guardianExternalUserId: undefined,
+    });
+
+    const result = bridgeConfirmationRequestToGuardian({
+      canonicalRequest,
+      guardianContext,
+      conversationId: 'conv-1',
+      toolName: 'bash',
+    });
+
+    expect('skipped' in result && result.skipped).toBe(true);
+    if ('skipped' in result) {
+      expect(result.reason).toBe('missing_guardian_identity');
+    }
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test('skips when no guardian binding exists for channel', () => {
+    const canonicalRequest = makeCanonicalRequest({ sourceChannel: 'sms' });
+    const guardianContext = makeTrustedContactContext({
+      sourceChannel: 'sms',
+    });
+
+    const result = bridgeConfirmationRequestToGuardian({
+      canonicalRequest,
+      guardianContext,
+      conversationId: 'conv-1',
+      toolName: 'bash',
+    });
+
+    expect('skipped' in result && result.skipped).toBe(true);
+    if ('skipped' in result) {
+      expect(result.reason).toBe('no_guardian_binding');
+    }
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test('sets correct attention hints for urgency', () => {
+    const canonicalRequest = makeCanonicalRequest();
+    const guardianContext = makeTrustedContactContext();
+
+    bridgeConfirmationRequestToGuardian({
+      canonicalRequest,
+      guardianContext,
+      conversationId: 'conv-1',
+      toolName: 'bash',
+    });
+
+    const hints = emittedSignals[0].attentionHints as Record<string, unknown>;
+    expect(hints.requiresAction).toBe(true);
+    expect(hints.urgency).toBe('high');
+    expect(hints.isAsyncBackground).toBe(false);
+    expect(hints.visibleInSourceNow).toBe(false);
+  });
+
+  test('uses dedupe key scoped to canonical request ID', () => {
+    const canonicalRequest = makeCanonicalRequest();
+    const guardianContext = makeTrustedContactContext();
+
+    bridgeConfirmationRequestToGuardian({
+      canonicalRequest,
+      guardianContext,
+      conversationId: 'conv-1',
+      toolName: 'bash',
+    });
+
+    expect(emittedSignals[0].dedupeKey).toBe(`tc-confirmation-request:${canonicalRequest.id}`);
+  });
+
+  test('creates vellum delivery row via onThreadCreated callback', () => {
+    const canonicalRequest = makeCanonicalRequest();
+    const guardianContext = makeTrustedContactContext();
+
+    bridgeConfirmationRequestToGuardian({
+      canonicalRequest,
+      guardianContext,
+      conversationId: 'conv-1',
+      toolName: 'bash',
+    });
+
+    expect(mockOnThreadCreatedCallbacks).toHaveLength(1);
+
+    // Simulate the broadcaster invoking onThreadCreated
+    mockOnThreadCreatedCallbacks[0]({
+      conversationId: 'guardian-thread-1',
+      title: 'Guardian question',
+      sourceEventName: 'guardian.question',
+    });
+
+    const deliveries = listCanonicalGuardianDeliveries(canonicalRequest.id);
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].destinationChannel).toBe('vellum');
+    expect(deliveries[0].destinationConversationId).toBe('guardian-thread-1');
+  });
+
+  test('uses custom assistantId when provided', () => {
+    const canonicalRequest = makeCanonicalRequest();
+    const guardianContext = makeTrustedContactContext();
+
+    bridgeConfirmationRequestToGuardian({
+      canonicalRequest,
+      guardianContext,
+      conversationId: 'conv-1',
+      toolName: 'bash',
+      assistantId: 'custom-assistant',
+    });
+
+    // The mock only returns a binding for 'self', so 'custom-assistant'
+    // should fail with no_guardian_binding.
+    // Actually let's verify the signal uses the right assistantId.
+    // Since mock only has binding for 'self', this will skip.
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test('passes assistantId to notification signal', () => {
+    const canonicalRequest = makeCanonicalRequest();
+    const guardianContext = makeTrustedContactContext();
+
+    // Use default assistantId 'self' which has a binding
+    bridgeConfirmationRequestToGuardian({
+      canonicalRequest,
+      guardianContext,
+      conversationId: 'conv-1',
+      toolName: 'bash',
+    });
+
+    expect(emittedSignals[0].assistantId).toBe('self');
+  });
+
+  test('includes requesterChatId as null when not provided', () => {
+    const canonicalRequest = makeCanonicalRequest();
+    const guardianContext = makeTrustedContactContext({
+      requesterChatId: undefined,
+    });
+
+    bridgeConfirmationRequestToGuardian({
+      canonicalRequest,
+      guardianContext,
+      conversationId: 'conv-1',
+      toolName: 'bash',
+    });
+
+    const payload = emittedSignals[0].contextPayload as Record<string, unknown>;
+    expect(payload.requesterChatId).toBeNull();
+  });
+});

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -157,6 +157,7 @@ function makePendingInteractionRegistrar(
           guardianContext,
           conversationId,
           toolName: msg.toolName,
+          assistantId: session.assistantId ?? 'self',
         });
       }
     } else if (msg.type === 'secret_request') {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -18,6 +18,7 @@ import * as conversationStore from '../memory/conversation-store.js';
 import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import { RateLimitProvider } from '../providers/ratelimit.js';
 import { getFailoverProvider, initializeProviders } from '../providers/registry.js';
+import { bridgeConfirmationRequestToGuardian } from '../runtime/confirmation-request-guardian-bridge.js';
 import * as pendingInteractions from '../runtime/pending-interactions.js';
 import { checkIngressForSecrets } from '../security/secret-ingress.js';
 import { getSubagentManager } from '../subagent/index.js';
@@ -133,7 +134,7 @@ function makePendingInteractionRegistrar(
       // via applyCanonicalGuardianDecision.
       const guardianContext = session.guardianContext;
       const sourceChannel = guardianContext?.sourceChannel ?? 'vellum';
-      createCanonicalGuardianRequest({
+      const canonicalRequest = createCanonicalGuardianRequest({
         id: msg.requestId,
         kind: 'tool_approval',
         sourceType: resolveCanonicalRequestSourceType(sourceChannel),
@@ -147,6 +148,17 @@ function makePendingInteractionRegistrar(
         requestCode: generateCanonicalRequestCode(),
         expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
       });
+
+      // For trusted-contact sessions, bridge to guardian.question so the
+      // guardian gets notified and can approve via callback/request-code.
+      if (guardianContext) {
+        bridgeConfirmationRequestToGuardian({
+          canonicalRequest,
+          guardianContext,
+          conversationId,
+          toolName: msg.toolName,
+        });
+      }
     } else if (msg.type === 'secret_request') {
       pendingInteractions.register(msg.requestId, {
         session,

--- a/assistant/src/runtime/confirmation-request-guardian-bridge.ts
+++ b/assistant/src/runtime/confirmation-request-guardian-bridge.ts
@@ -42,7 +42,7 @@ export interface BridgeConfirmationRequestParams {
 
 export type BridgeConfirmationRequestResult =
   | { bridged: true; signalId: string }
-  | { skipped: true; reason: 'not_trusted_contact' | 'no_guardian_binding' | 'missing_guardian_identity' };
+  | { skipped: true; reason: 'not_trusted_contact' | 'no_guardian_binding' | 'missing_guardian_identity' | 'binding_identity_mismatch' };
 
 // ---------------------------------------------------------------------------
 // Helper
@@ -90,6 +90,27 @@ export function bridgeConfirmationRequestToGuardian(
       'No guardian binding for confirmation request bridge',
     );
     return { skipped: true, reason: 'no_guardian_binding' };
+  }
+
+  // Validate that the binding's guardian identity matches the canonical request's
+  // guardian identity. A mismatch can occur if a guardian rebind happens between
+  // message ingress and confirmation emission — sending the notification to the
+  // new binding would leak requester/tool metadata to the wrong recipient.
+  if (
+    canonicalRequest.guardianExternalUserId &&
+    binding.guardianExternalUserId !== canonicalRequest.guardianExternalUserId
+  ) {
+    log.warn(
+      {
+        sourceChannel,
+        assistantId,
+        bindingGuardianId: binding.guardianExternalUserId,
+        expectedGuardianId: canonicalRequest.guardianExternalUserId,
+        requestId: canonicalRequest.id,
+      },
+      'Guardian binding identity does not match canonical request guardian — skipping notification to prevent misrouting',
+    );
+    return { skipped: true, reason: 'binding_identity_mismatch' };
   }
 
   const senderLabel = guardianContext.requesterIdentifier

--- a/assistant/src/runtime/confirmation-request-guardian-bridge.ts
+++ b/assistant/src/runtime/confirmation-request-guardian-bridge.ts
@@ -141,6 +141,8 @@ export function bridgeConfirmationRequestToGuardian(
         destinationChatId: result.destination.length > 0 ? result.destination : undefined,
       });
     }
+  }).catch((err) => {
+    log.warn({ err, requestId: canonicalRequest.id }, 'Failed to record channel deliveries for guardian bridge');
   });
 
   log.info(

--- a/assistant/src/runtime/confirmation-request-guardian-bridge.ts
+++ b/assistant/src/runtime/confirmation-request-guardian-bridge.ts
@@ -1,0 +1,162 @@
+/**
+ * Bridge trusted-contact confirmation_request events to guardian.question notifications.
+ *
+ * When a trusted-contact channel session creates a confirmation_request (tool approval),
+ * this helper emits a guardian.question notification signal and persists canonical
+ * delivery rows to guardian destinations (Telegram/SMS/Vellum), enabling the guardian
+ * to approve via callback/request-code path.
+ *
+ * Modeled after the tool-grant-request-helper pattern. Designed to be called from
+ * both the daemon event registrar (server.ts) and the HTTP hub publisher
+ * (conversation-routes.ts) — the two paths that create confirmation_request
+ * canonical records.
+ */
+
+import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
+import {
+  createCanonicalGuardianDelivery,
+  type CanonicalGuardianRequest,
+} from '../memory/canonical-guardian-store.js';
+import { emitNotificationSignal } from '../notifications/emit-signal.js';
+import { getLogger } from '../util/logger.js';
+import { getGuardianBinding } from './channel-guardian-service.js';
+
+const log = getLogger('confirmation-request-guardian-bridge');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface BridgeConfirmationRequestParams {
+  /** The canonical guardian request already persisted for this confirmation_request. */
+  canonicalRequest: CanonicalGuardianRequest;
+  /** Guardian runtime context from the session. */
+  guardianContext: GuardianRuntimeContext;
+  /** Conversation ID where the confirmation_request was emitted. */
+  conversationId: string;
+  /** Tool name from the confirmation_request. */
+  toolName: string;
+  /** Logical assistant ID (defaults to 'self'). */
+  assistantId?: string;
+}
+
+export type BridgeConfirmationRequestResult =
+  | { bridged: true; signalId: string }
+  | { skipped: true; reason: 'not_trusted_contact' | 'no_guardian_binding' | 'missing_guardian_identity' };
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Bridge a trusted-contact confirmation_request to a guardian.question notification.
+ *
+ * Only emits when the session belongs to a trusted-contact actor with a
+ * resolvable guardian binding. Guardian and unknown actors are skipped — guardians
+ * self-approve, and unknown actors are already fail-closed by the routing layer.
+ *
+ * Fire-and-forget safe: notification emission errors are logged but not propagated.
+ */
+export function bridgeConfirmationRequestToGuardian(
+  params: BridgeConfirmationRequestParams,
+): BridgeConfirmationRequestResult {
+  const {
+    canonicalRequest,
+    guardianContext,
+    conversationId,
+    toolName,
+    assistantId = 'self',
+  } = params;
+
+  // Only bridge for trusted-contact sessions. Guardians self-approve and
+  // unknown actors are fail-closed by the routing layer.
+  if (guardianContext.trustClass !== 'trusted_contact') {
+    return { skipped: true, reason: 'not_trusted_contact' };
+  }
+
+  if (!guardianContext.guardianExternalUserId) {
+    log.debug(
+      { conversationId, sourceChannel: guardianContext.sourceChannel },
+      'Skipping guardian bridge: no guardian identity on trusted-contact context',
+    );
+    return { skipped: true, reason: 'missing_guardian_identity' };
+  }
+
+  const sourceChannel = guardianContext.sourceChannel;
+  const binding = getGuardianBinding(assistantId, sourceChannel);
+  if (!binding) {
+    log.debug(
+      { sourceChannel, assistantId },
+      'No guardian binding for confirmation request bridge',
+    );
+    return { skipped: true, reason: 'no_guardian_binding' };
+  }
+
+  const senderLabel = guardianContext.requesterIdentifier
+    || guardianContext.requesterExternalUserId
+    || 'unknown';
+
+  const questionText = `Tool approval request: ${toolName}`;
+
+  // Emit guardian.question notification so the guardian is alerted.
+  const signalPromise = emitNotificationSignal({
+    sourceEventName: 'guardian.question',
+    sourceChannel,
+    sourceSessionId: conversationId,
+    assistantId,
+    attentionHints: {
+      requiresAction: true,
+      urgency: 'high',
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
+    contextPayload: {
+      requestId: canonicalRequest.id,
+      requestCode: canonicalRequest.requestCode,
+      sourceChannel,
+      requesterExternalUserId: guardianContext.requesterExternalUserId,
+      requesterChatId: guardianContext.requesterChatId ?? null,
+      requesterIdentifier: senderLabel,
+      toolName,
+      questionText,
+    },
+    dedupeKey: `tc-confirmation-request:${canonicalRequest.id}`,
+    onThreadCreated: (info) => {
+      createCanonicalGuardianDelivery({
+        requestId: canonicalRequest.id,
+        destinationChannel: 'vellum',
+        destinationConversationId: info.conversationId,
+      });
+    },
+  });
+
+  // Record channel deliveries from the notification pipeline (fire-and-forget).
+  void signalPromise.then((signalResult) => {
+    for (const result of signalResult.deliveryResults) {
+      if (result.channel === 'vellum') continue; // handled in onThreadCreated
+      if (result.channel !== 'telegram' && result.channel !== 'sms') continue;
+      createCanonicalGuardianDelivery({
+        requestId: canonicalRequest.id,
+        destinationChannel: result.channel,
+        destinationChatId: result.destination.length > 0 ? result.destination : undefined,
+      });
+    }
+  });
+
+  log.info(
+    {
+      sourceChannel,
+      requesterExternalUserId: guardianContext.requesterExternalUserId,
+      toolName,
+      requestId: canonicalRequest.id,
+      requestCode: canonicalRequest.requestCode,
+    },
+    'Guardian notified of trusted-contact confirmation request',
+  );
+
+  // Return the signal ID synchronously from the promise-producing call.
+  // The actual signal ID is not available until the promise resolves, but
+  // callers only need to know it was bridged — the ID is for diagnostics.
+  // We use the canonical request ID as a stable correlation key.
+  return { bridged: true, signalId: canonicalRequest.id };
+}

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -15,6 +15,7 @@ import {
   listCanonicalGuardianRequests,
   listPendingCanonicalGuardianRequestsByDestinationConversation,
 } from '../../memory/canonical-guardian-store.js';
+import { bridgeConfirmationRequestToGuardian } from '../confirmation-request-guardian-bridge.js';
 import {
   getConversationByKey,
   getOrCreateConversation,
@@ -335,7 +336,7 @@ function makeHubPublisher(
       // via applyCanonicalGuardianDecision.
       const guardianContext = session.guardianContext;
       const sourceChannel = guardianContext?.sourceChannel ?? 'vellum';
-      createCanonicalGuardianRequest({
+      const canonicalRequest = createCanonicalGuardianRequest({
         id: msg.requestId,
         kind: 'tool_approval',
         sourceType: resolveCanonicalRequestSourceType(sourceChannel),
@@ -349,6 +350,17 @@ function makeHubPublisher(
         requestCode: generateCanonicalRequestCode(),
         expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
       });
+
+      // For trusted-contact sessions, bridge to guardian.question so the
+      // guardian gets notified and can approve via callback/request-code.
+      if (guardianContext) {
+        bridgeConfirmationRequestToGuardian({
+          canonicalRequest,
+          guardianContext,
+          conversationId,
+          toolName: msg.toolName,
+        });
+      }
     } else if (msg.type === 'secret_request') {
       pendingInteractions.register(msg.requestId, {
         session,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -359,6 +359,7 @@ function makeHubPublisher(
           guardianContext,
           conversationId,
           toolName: msg.toolName,
+          assistantId: session.assistantId ?? 'self',
         });
       }
     } else if (msg.type === 'secret_request') {


### PR DESCRIPTION
Closes #10723. Part of #10719.

When a trusted-contact channel session creates a confirmation_request (tool approval), emits a guardian.question notification and persists canonical delivery rows to guardian destinations. Extracts a reusable helper to avoid duplicated logic. Guardian can now approve trusted-contact prompt requests via callback/request-code path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
