### PR TITLE
fix: show loading state instead of app directory when expanding inline app card

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -192,22 +192,26 @@ extension MainWindowView {
                     .background(VColor.backgroundSubtle)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
             } else {
-                // Gallery mode fallback
-                GeneratedPanel(
-                    onClose: { sharing.showSharePicker = false; windowState.closeDynamicPanel() },
-                    isExpanded: Binding(
-                        get: { windowState.isDynamicExpanded },
-                        set: { windowState.isDynamicExpanded = $0 }
-                    ),
-                    daemonClient: daemonClient,
-                    onOpenApp: { surfaceMsg in
-                        windowState.activeDynamicSurface = surfaceMsg
-                        windowState.activeDynamicParsedSurface = Surface.from(surfaceMsg)
-                    },
-                    onRecordAppOpen: { id, name, icon, appType in
-                        appListManager.recordAppOpen(id: id, name: name, icon: icon, appType: appType)
+                // Loading state while waiting for daemon to send surface data
+                // via ui_surface_show in response to app_open_request.
+                VStack(spacing: VSpacing.md) {
+                    Spacer()
+                    ProgressView()
+                        .controlSize(.regular)
+                    Text("Loading app…")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textMuted)
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(VColor.backgroundSubtle)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                .overlay(alignment: .topTrailing) {
+                    VIconButton(label: "Close", icon: "xmark", iconOnly: true) {
+                        windowState.closeDynamicPanel()
                     }
-                )
+                    .padding(VSpacing.lg)
+                }
             }
         case .appEditing:
             // VSplitView: ChatView (left) + workspace (right)


### PR DESCRIPTION
## Summary
- When clicking the expand arrow on an inline app card in chat, the app surface data arrives asynchronously from the daemon via `ui_surface_show`
- Previously, during this loading window, the fallback showed `GeneratedPanel` (the "Dynamic" app directory listing), which was confusing and ugly
- Now shows a clean loading spinner with "Loading app…" text and a close button until the actual app surface data arrives

## Test plan
- [ ] Build an app via the app builder skill
- [ ] Click the expand arrow (↗) on the inline app card in chat
- [ ] Verify a loading spinner appears briefly instead of the app directory
- [ ] Verify the actual app loads and renders correctly once the daemon responds
- [ ] Verify the close button (X) works to dismiss the loading state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
