### PR TITLE
fix: preserve preview metadata in history for app preview cards

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -1154,7 +1154,15 @@ export function handleHistoryRequest(
           surfaceId: s.surfaceId,
           surfaceType: s.surfaceType,
           title: s.title,
-          data: {} as Record<string, unknown>,
+          data: {
+            ...(s.surfaceType === 'dynamic_page'
+              ? {
+                  ...(s.data.preview ? { preview: s.data.preview } : {}),
+                  ...(s.data.appId ? { appId: s.data.appId } : {}),
+                  ...(s.data.appType ? { appType: s.data.appType } : {}),
+                }
+              : {}),
+          } as Record<string, unknown>,
           ...(s.actions ? { actions: s.actions } : {}),
           ...(s.display ? { display: s.display } : {}),
         })))

--- a/clients/macos/vellum-assistantTests/ChatDynamicPreviewRegressionTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatDynamicPreviewRegressionTests.swift
@@ -462,6 +462,59 @@ final class ChatDynamicPreviewRegressionTests: XCTestCase {
         XCTAssertEqual(msg.inlineSurfaces[0].surfaceType, .dynamicPage)
     }
 
+    func testPopulateFromHistoryWithLightModeSurface() {
+        // Light-mode history strips html but preserves preview metadata.
+        // The surface should still parse and render as an inline preview card.
+        let surfaceData: [String: AnyCodable] = [
+            "preview": AnyCodable([
+                "title": "Slides",
+                "subtitle": "5 pages"
+            ] as [String: Any]),
+            "appId": AnyCodable("app-light-1")
+        ]
+        let historySurface = IPCHistoryResponseSurface(
+            surfaceId: "hist-light-surface",
+            surfaceType: "dynamic_page",
+            title: "Light Mode App",
+            data: surfaceData,
+            actions: nil,
+            display: nil
+        )
+        let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
+            IPCHistoryResponseMessage(
+                id: nil,
+                role: "assistant",
+                text: "Here are your slides",
+                timestamp: 6000,
+                toolCalls: nil,
+                toolCallsBeforeText: nil,
+                attachments: nil,
+                textSegments: nil,
+                contentOrder: nil,
+                surfaces: [historySurface],
+                subagentNotification: nil
+            ),
+        ]
+
+        viewModel.populateFromHistory(historyItems)
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.inlineSurfaces.count, 1,
+                       "Light-mode surface with preview should still hydrate as inline")
+        let surface = msg.inlineSurfaces[0]
+        XCTAssertEqual(surface.id, "hist-light-surface")
+        if case .dynamicPage(let dpData) = surface.data {
+            XCTAssertEqual(dpData.html, "",
+                           "html should default to empty string when stripped by light mode")
+            XCTAssertNotNil(dpData.preview, "Preview metadata should be preserved")
+            XCTAssertEqual(dpData.preview?.title, "Slides")
+            XCTAssertEqual(dpData.appId, "app-light-1")
+        } else {
+            XCTFail("Surface data should be a dynamic page")
+        }
+    }
+
     // MARK: - Surface content order tracking
 
     func testDynamicPreviewAppearsInContentOrder() {

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -910,7 +910,7 @@ public extension Surface {
     }
 
     private static func parseDynamicPageData(_ dict: [String: Any?]) -> DynamicPageSurfaceData? {
-        guard let html = dict["html"] as? String else { return nil }
+        let html = dict["html"] as? String ?? ""
         return DynamicPageSurfaceData(
             html: html,
             width: dict["width"] as? Int,


### PR DESCRIPTION
## Summary
- Include preview, appId, and appType in the history response for dynamic_page surfaces (previously stripped to empty `{}`)
- Make the `html` field optional in `parseDynamicPageData` (defaults to empty string) so history surfaces without full HTML still parse
- Add regression test verifying light-mode history surfaces with preview metadata hydrate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
