### PR TITLE
M3: trusted-contact pending-approval requester UX

### DIFF
--- a/assistant/src/__tests__/trusted-contact-approval-notifier.test.ts
+++ b/assistant/src/__tests__/trusted-contact-approval-notifier.test.ts
@@ -137,6 +137,10 @@ import type { GuardianContext } from '../runtime/guardian-context-resolver.js';
 /**
  * Simulates the core logic of the trusted-contact approval notifier.
  * This mirrors the implementation in inbound-message-handler.ts.
+ *
+ * Uses a Map<requestId, conversationId> for deduplication so that cleanup
+ * is scoped to the owning conversation — concurrent pollers for different
+ * conversations will not evict each other's entries.
  */
 async function simulateNotifierPoll(params: {
   conversationId: string;
@@ -147,9 +151,10 @@ async function simulateNotifierPoll(params: {
   replyCallbackUrl: string;
   bearerToken?: string;
   assistantId?: string;
-  notifiedRequestIds: Set<string>;
+  notifiedRequestIds: Map<string, string>;
 }): Promise<boolean> {
   const {
+    conversationId,
     guardianTrustClass,
     guardianExternalUserId,
     notifiedRequestIds,
@@ -166,11 +171,20 @@ async function simulateNotifierPoll(params: {
 
   const pending = getApprovalInfoByConversation(params.conversationId);
   const info = pending[0];
+
+  // Clean up resolved requests — only for THIS conversation's entries.
+  const currentPendingIds = new Set(pending.map(p => p.requestId));
+  for (const [rid, cid] of notifiedRequestIds) {
+    if (cid === conversationId && !currentPendingIds.has(rid)) {
+      notifiedRequestIds.delete(rid);
+    }
+  }
+
   if (!info || notifiedRequestIds.has(info.requestId)) {
     return false;
   }
 
-  notifiedRequestIds.add(info.requestId);
+  notifiedRequestIds.set(info.requestId, conversationId);
 
   // Resolve guardian name
   let guardianName: string | undefined;
@@ -238,7 +252,7 @@ describe('trusted-contact pending-approval notifier', () => {
       metadataJson: JSON.stringify({ displayName: 'Mom' }),
     };
 
-    const notified = new Set<string>();
+    const notified = new Map<string, string>();
     const sent = await simulateNotifierPoll({
       conversationId: 'conv-1',
       sourceChannel: 'telegram',
@@ -271,7 +285,7 @@ describe('trusted-contact pending-approval notifier', () => {
       metadataJson: JSON.stringify({ username: 'guardian_user' }),
     };
 
-    const notified = new Set<string>();
+    const notified = new Map<string, string>();
     await simulateNotifierPoll({
       conversationId: 'conv-1',
       sourceChannel: 'telegram',
@@ -300,7 +314,7 @@ describe('trusted-contact pending-approval notifier', () => {
       metadataJson: null,
     };
 
-    const notified = new Set<string>();
+    const notified = new Map<string, string>();
     await simulateNotifierPoll({
       conversationId: 'conv-1',
       sourceChannel: 'telegram',
@@ -325,7 +339,7 @@ describe('trusted-contact pending-approval notifier', () => {
 
     mockGuardianBinding = null;
 
-    const notified = new Set<string>();
+    const notified = new Map<string, string>();
     await simulateNotifierPoll({
       conversationId: 'conv-1',
       sourceChannel: 'telegram',
@@ -353,7 +367,7 @@ describe('trusted-contact pending-approval notifier', () => {
       metadataJson: JSON.stringify({ displayName: 'Guardian' }),
     };
 
-    const notified = new Set<string>();
+    const notified = new Map<string, string>();
     const baseParams = {
       conversationId: 'conv-1',
       sourceChannel: 'telegram' as ChannelId,
@@ -381,7 +395,7 @@ describe('trusted-contact pending-approval notifier', () => {
       metadataJson: JSON.stringify({ displayName: 'Guardian' }),
     };
 
-    const notified = new Set<string>();
+    const notified = new Map<string, string>();
     const baseParams = {
       conversationId: 'conv-1',
       sourceChannel: 'telegram' as ChannelId,
@@ -413,6 +427,71 @@ describe('trusted-contact pending-approval notifier', () => {
     expect(deliveredReplies).toHaveLength(2);
   });
 
+  test('concurrent pollers for different conversations do not evict each other', async () => {
+    mockGuardianBinding = {
+      id: 'binding-1',
+      metadataJson: JSON.stringify({ displayName: 'Guardian' }),
+    };
+
+    // Shared dedupe map simulating the module-level global
+    const notified = new Map<string, string>();
+
+    // Conversation A gets a pending approval and notifies
+    mockPendingApprovals = [{
+      requestId: 'req-convA',
+      toolName: 'bash',
+      input: {},
+      riskLevel: 'medium',
+    }];
+    const sentA = await simulateNotifierPoll({
+      conversationId: 'conv-A',
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-A',
+      guardianTrustClass: 'trusted_contact',
+      guardianExternalUserId: 'guardian-1',
+      replyCallbackUrl: 'http://localhost:3000/deliver/telegram',
+      notifiedRequestIds: notified,
+    });
+    expect(sentA).toBe(true);
+    expect(deliveredReplies).toHaveLength(1);
+
+    // Conversation B polls with no pending approvals — its cleanup must
+    // NOT evict conv-A's entry from the shared map.
+    mockPendingApprovals = [];
+    await simulateNotifierPoll({
+      conversationId: 'conv-B',
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-B',
+      guardianTrustClass: 'trusted_contact',
+      guardianExternalUserId: 'guardian-1',
+      replyCallbackUrl: 'http://localhost:3000/deliver/telegram',
+      notifiedRequestIds: notified,
+    });
+
+    // req-convA should still be in the notified map (not evicted by conv-B)
+    expect(notified.has('req-convA')).toBe(true);
+
+    // Re-poll conversation A with the same pending approval — should NOT
+    // re-send because the entry was preserved.
+    mockPendingApprovals = [{
+      requestId: 'req-convA',
+      toolName: 'bash',
+      input: {},
+      riskLevel: 'medium',
+    }];
+    const sentA2 = await simulateNotifierPoll({
+      conversationId: 'conv-A',
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-A',
+      guardianTrustClass: 'trusted_contact',
+      guardianExternalUserId: 'guardian-1',
+      replyCallbackUrl: 'http://localhost:3000/deliver/telegram',
+      notifiedRequestIds: notified,
+    });
+    expect(sentA2).toBe(false);
+    expect(deliveredReplies).toHaveLength(1); // Still just 1 — no duplicate
+  });
+
   test('does not activate for guardian actors', async () => {
     mockPendingApprovals = [{
       requestId: 'req-6',
@@ -421,7 +500,7 @@ describe('trusted-contact pending-approval notifier', () => {
       riskLevel: 'medium',
     }];
 
-    const notified = new Set<string>();
+    const notified = new Map<string, string>();
     const sent = await simulateNotifierPoll({
       conversationId: 'conv-1',
       sourceChannel: 'telegram',
@@ -444,7 +523,7 @@ describe('trusted-contact pending-approval notifier', () => {
       riskLevel: 'medium',
     }];
 
-    const notified = new Set<string>();
+    const notified = new Map<string, string>();
     const sent = await simulateNotifierPoll({
       conversationId: 'conv-1',
       sourceChannel: 'telegram',
@@ -466,7 +545,7 @@ describe('trusted-contact pending-approval notifier', () => {
       riskLevel: 'medium',
     }];
 
-    const notified = new Set<string>();
+    const notified = new Map<string, string>();
     const sent = await simulateNotifierPoll({
       conversationId: 'conv-1',
       sourceChannel: 'telegram',
@@ -494,7 +573,7 @@ describe('trusted-contact pending-approval notifier', () => {
       metadataJson: JSON.stringify({ displayName: 'Guardian' }),
     };
 
-    const notified = new Set<string>();
+    const notified = new Map<string, string>();
     const baseParams = {
       conversationId: 'conv-1',
       sourceChannel: 'telegram' as ChannelId,
@@ -522,7 +601,7 @@ describe('trusted-contact pending-approval notifier', () => {
   test('does not send when no pending approvals exist', async () => {
     mockPendingApprovals = [];
 
-    const notified = new Set<string>();
+    const notified = new Map<string, string>();
     const sent = await simulateNotifierPoll({
       conversationId: 'conv-1',
       sourceChannel: 'telegram',
@@ -553,7 +632,7 @@ describe('trusted-contact pending-approval notifier', () => {
       }),
     };
 
-    const notified = new Set<string>();
+    const notified = new Map<string, string>();
     await simulateNotifierPoll({
       conversationId: 'conv-1',
       sourceChannel: 'telegram',
@@ -581,7 +660,7 @@ describe('trusted-contact pending-approval notifier', () => {
       metadataJson: 'not-valid-json{{{',
     };
 
-    const notified = new Set<string>();
+    const notified = new Map<string, string>();
     await simulateNotifierPoll({
       conversationId: 'conv-1',
       sourceChannel: 'telegram',

--- a/assistant/src/__tests__/trusted-contact-approval-notifier.test.ts
+++ b/assistant/src/__tests__/trusted-contact-approval-notifier.test.ts
@@ -1,0 +1,599 @@
+/**
+ * Tests for the trusted-contact pending-approval requester notification.
+ *
+ * Verifies that:
+ * 1. Trusted contacts receive a one-shot "waiting for guardian approval" message
+ * 2. The message mentions the guardian by name when available
+ * 3. Messages are deduplicated by requestId (no repeated spam)
+ * 4. Guardian and unknown actors do NOT receive the notification
+ * 5. Delivery failures allow retry on next poll
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'tc-approval-notifier-test-'));
+
+// ── Platform mock ──
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  readHttpToken: () => 'test-token',
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+  normalizeAssistantId: (id: string) => id === 'self' || id === '' ? 'self' : id,
+}));
+
+// ── Logger mock ──
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  isDebug: () => false,
+  truncateForLog: (value: string) => value,
+}));
+
+// ── Notification signal mock ──
+mock.module('../notifications/emit-signal.js', () => ({
+  emitNotificationSignal: async () => ({
+    signalId: 'test-signal',
+    deduplicated: false,
+    dispatched: true,
+    reason: 'ok',
+    deliveryResults: [],
+  }),
+  registerBroadcastFn: () => {},
+}));
+
+// ── Gateway client mock ──
+// Track all deliverChannelReply calls for assertions
+const deliveredReplies: Array<{
+  url: string;
+  payload: Record<string, unknown>;
+  bearerToken?: string;
+}> = [];
+let deliverShouldFail = false;
+
+mock.module('../runtime/gateway-client.js', () => ({
+  deliverChannelReply: async (
+    url: string,
+    payload: Record<string, unknown>,
+    bearerToken?: string,
+  ) => {
+    if (deliverShouldFail) {
+      throw new Error('Delivery failed');
+    }
+    deliveredReplies.push({ url, payload, bearerToken });
+    return { ok: true };
+  },
+}));
+
+// ── Guardian binding mock ──
+let mockGuardianBinding: Record<string, unknown> | null = null;
+
+mock.module('../runtime/channel-guardian-service.js', () => ({
+  getGuardianBinding: () => mockGuardianBinding,
+  // Re-export stubs for other functions to prevent import errors
+  bindSessionIdentity: () => {},
+  createOutboundSession: () => ({}),
+  findActiveSession: () => null,
+  getGuardianBindingForChannel: () => null,
+  getPendingChallenge: () => null,
+  isGuardian: () => false,
+  resolveBootstrapToken: () => null,
+  updateSessionDelivery: () => {},
+  updateSessionStatus: () => {},
+  validateAndConsumeChallenge: () => ({ success: false, reason: 'no_challenge' }),
+}));
+
+// ── Pending interactions mock ──
+let mockPendingApprovals: Array<{
+  requestId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+  riskLevel: string;
+}> = [];
+
+mock.module('../runtime/channel-approvals.js', () => ({
+  getApprovalInfoByConversation: () => mockPendingApprovals,
+  getChannelApprovalPrompt: () => null,
+  buildApprovalUIMetadata: () => ({}),
+}));
+
+// ── Config env mock ──
+mock.module('../config/env.js', () => ({
+  getGatewayInternalBaseUrl: () => 'http://localhost:3000',
+}));
+
+// Import module under test AFTER mocks are set up
+import type { ChannelId } from '../channels/types.js';
+import type { GuardianContext } from '../runtime/guardian-context-resolver.js';
+
+// We need to test the private functions by importing the module.
+// Since startTrustedContactApprovalNotifier is not exported, we test it
+// indirectly through handleChannelInbound via processChannelMessageInBackground.
+//
+// However, to test the notifier function in isolation, we extract the
+// logic into a helper that we can call directly.
+
+// For unit testing, we replicate the core logic here to verify behavior.
+// The integration is tested by verifying deliverChannelReply calls.
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Simulates the core logic of the trusted-contact approval notifier.
+ * This mirrors the implementation in inbound-message-handler.ts.
+ */
+async function simulateNotifierPoll(params: {
+  conversationId: string;
+  sourceChannel: ChannelId;
+  externalChatId: string;
+  guardianTrustClass: GuardianContext['trustClass'];
+  guardianExternalUserId?: string;
+  replyCallbackUrl: string;
+  bearerToken?: string;
+  assistantId?: string;
+  notifiedRequestIds: Set<string>;
+}): Promise<boolean> {
+  const {
+    guardianTrustClass,
+    guardianExternalUserId,
+    notifiedRequestIds,
+  } = params;
+
+  // Gate check: only trusted contacts with guardian route
+  if (guardianTrustClass !== 'trusted_contact' || !guardianExternalUserId) {
+    return false;
+  }
+
+  const { getApprovalInfoByConversation } = await import('../runtime/channel-approvals.js');
+  const { deliverChannelReply } = await import('../runtime/gateway-client.js');
+  const { getGuardianBinding } = await import('../runtime/channel-guardian-service.js');
+
+  const pending = getApprovalInfoByConversation(params.conversationId);
+  const info = pending[0];
+  if (!info || notifiedRequestIds.has(info.requestId)) {
+    return false;
+  }
+
+  notifiedRequestIds.add(info.requestId);
+
+  // Resolve guardian name
+  let guardianName: string | undefined;
+  const binding = getGuardianBinding(params.assistantId ?? 'self', params.sourceChannel);
+  if (binding?.metadataJson) {
+    try {
+      const parsed = JSON.parse(binding.metadataJson as string) as Record<string, unknown>;
+      if (typeof parsed.displayName === 'string' && parsed.displayName.trim().length > 0) {
+        guardianName = parsed.displayName.trim();
+      } else if (typeof parsed.username === 'string' && parsed.username.trim().length > 0) {
+        guardianName = `@${parsed.username.trim()}`;
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  const waitingText = guardianName
+    ? `Waiting for ${guardianName}'s approval...`
+    : 'Waiting for your guardian\'s approval...';
+
+  try {
+    await deliverChannelReply(params.replyCallbackUrl, {
+      chatId: params.externalChatId,
+      text: waitingText,
+      assistantId: params.assistantId ?? 'self',
+    }, params.bearerToken);
+    return true;
+  } catch {
+    notifiedRequestIds.delete(info.requestId);
+    return false;
+  }
+}
+
+// ===========================================================================
+// TESTS
+// ===========================================================================
+
+describe('trusted-contact pending-approval notifier', () => {
+  beforeEach(() => {
+    deliveredReplies.length = 0;
+    deliverShouldFail = false;
+    mockPendingApprovals = [];
+    mockGuardianBinding = null;
+  });
+
+  afterAll(() => {
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      /* best effort */
+    }
+  });
+
+  test('sends waiting message to trusted contact when pending approval exists', async () => {
+    mockPendingApprovals = [{
+      requestId: 'req-1',
+      toolName: 'bash',
+      input: { command: 'ls' },
+      riskLevel: 'medium',
+    }];
+
+    mockGuardianBinding = {
+      id: 'binding-1',
+      metadataJson: JSON.stringify({ displayName: 'Mom' }),
+    };
+
+    const notified = new Set<string>();
+    const sent = await simulateNotifierPoll({
+      conversationId: 'conv-1',
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-123',
+      guardianTrustClass: 'trusted_contact',
+      guardianExternalUserId: 'guardian-1',
+      replyCallbackUrl: 'http://localhost:3000/deliver/telegram',
+      bearerToken: 'test-token',
+      assistantId: 'self',
+      notifiedRequestIds: notified,
+    });
+
+    expect(sent).toBe(true);
+    expect(deliveredReplies).toHaveLength(1);
+    expect(deliveredReplies[0].payload.text).toBe("Waiting for Mom's approval...");
+    expect(deliveredReplies[0].payload.chatId).toBe('chat-123');
+    expect(notified.has('req-1')).toBe(true);
+  });
+
+  test('uses username with @ prefix when display name is not available', async () => {
+    mockPendingApprovals = [{
+      requestId: 'req-2',
+      toolName: 'bash',
+      input: {},
+      riskLevel: 'medium',
+    }];
+
+    mockGuardianBinding = {
+      id: 'binding-1',
+      metadataJson: JSON.stringify({ username: 'guardian_user' }),
+    };
+
+    const notified = new Set<string>();
+    await simulateNotifierPoll({
+      conversationId: 'conv-1',
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-123',
+      guardianTrustClass: 'trusted_contact',
+      guardianExternalUserId: 'guardian-1',
+      replyCallbackUrl: 'http://localhost:3000/deliver/telegram',
+      notifiedRequestIds: notified,
+    });
+
+    expect(deliveredReplies).toHaveLength(1);
+    expect(deliveredReplies[0].payload.text).toBe("Waiting for @guardian_user's approval...");
+  });
+
+  test('uses generic phrasing when no guardian name is available', async () => {
+    mockPendingApprovals = [{
+      requestId: 'req-3',
+      toolName: 'bash',
+      input: {},
+      riskLevel: 'medium',
+    }];
+
+    // No binding metadata
+    mockGuardianBinding = {
+      id: 'binding-1',
+      metadataJson: null,
+    };
+
+    const notified = new Set<string>();
+    await simulateNotifierPoll({
+      conversationId: 'conv-1',
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-123',
+      guardianTrustClass: 'trusted_contact',
+      guardianExternalUserId: 'guardian-1',
+      replyCallbackUrl: 'http://localhost:3000/deliver/telegram',
+      notifiedRequestIds: notified,
+    });
+
+    expect(deliveredReplies).toHaveLength(1);
+    expect(deliveredReplies[0].payload.text).toBe("Waiting for your guardian's approval...");
+  });
+
+  test('uses generic phrasing when no guardian binding exists', async () => {
+    mockPendingApprovals = [{
+      requestId: 'req-4',
+      toolName: 'bash',
+      input: {},
+      riskLevel: 'medium',
+    }];
+
+    mockGuardianBinding = null;
+
+    const notified = new Set<string>();
+    await simulateNotifierPoll({
+      conversationId: 'conv-1',
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-123',
+      guardianTrustClass: 'trusted_contact',
+      guardianExternalUserId: 'guardian-1',
+      replyCallbackUrl: 'http://localhost:3000/deliver/telegram',
+      notifiedRequestIds: notified,
+    });
+
+    expect(deliveredReplies).toHaveLength(1);
+    expect(deliveredReplies[0].payload.text).toBe("Waiting for your guardian's approval...");
+  });
+
+  test('deduplicates by requestId — does not send twice for same request', async () => {
+    mockPendingApprovals = [{
+      requestId: 'req-5',
+      toolName: 'bash',
+      input: {},
+      riskLevel: 'medium',
+    }];
+
+    mockGuardianBinding = {
+      id: 'binding-1',
+      metadataJson: JSON.stringify({ displayName: 'Guardian' }),
+    };
+
+    const notified = new Set<string>();
+    const baseParams = {
+      conversationId: 'conv-1',
+      sourceChannel: 'telegram' as ChannelId,
+      externalChatId: 'chat-123',
+      guardianTrustClass: 'trusted_contact' as const,
+      guardianExternalUserId: 'guardian-1',
+      replyCallbackUrl: 'http://localhost:3000/deliver/telegram',
+      notifiedRequestIds: notified,
+    };
+
+    // First poll: should send
+    const sent1 = await simulateNotifierPoll(baseParams);
+    expect(sent1).toBe(true);
+    expect(deliveredReplies).toHaveLength(1);
+
+    // Second poll: same requestId, should NOT send
+    const sent2 = await simulateNotifierPoll(baseParams);
+    expect(sent2).toBe(false);
+    expect(deliveredReplies).toHaveLength(1); // Still just 1
+  });
+
+  test('sends separate messages for different requestIds', async () => {
+    mockGuardianBinding = {
+      id: 'binding-1',
+      metadataJson: JSON.stringify({ displayName: 'Guardian' }),
+    };
+
+    const notified = new Set<string>();
+    const baseParams = {
+      conversationId: 'conv-1',
+      sourceChannel: 'telegram' as ChannelId,
+      externalChatId: 'chat-123',
+      guardianTrustClass: 'trusted_contact' as const,
+      guardianExternalUserId: 'guardian-1',
+      replyCallbackUrl: 'http://localhost:3000/deliver/telegram',
+      notifiedRequestIds: notified,
+    };
+
+    // First request
+    mockPendingApprovals = [{
+      requestId: 'req-A',
+      toolName: 'bash',
+      input: {},
+      riskLevel: 'medium',
+    }];
+    await simulateNotifierPoll(baseParams);
+    expect(deliveredReplies).toHaveLength(1);
+
+    // Second request (different requestId)
+    mockPendingApprovals = [{
+      requestId: 'req-B',
+      toolName: 'read_file',
+      input: {},
+      riskLevel: 'low',
+    }];
+    await simulateNotifierPoll(baseParams);
+    expect(deliveredReplies).toHaveLength(2);
+  });
+
+  test('does not activate for guardian actors', async () => {
+    mockPendingApprovals = [{
+      requestId: 'req-6',
+      toolName: 'bash',
+      input: {},
+      riskLevel: 'medium',
+    }];
+
+    const notified = new Set<string>();
+    const sent = await simulateNotifierPoll({
+      conversationId: 'conv-1',
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-123',
+      guardianTrustClass: 'guardian',
+      guardianExternalUserId: 'guardian-1',
+      replyCallbackUrl: 'http://localhost:3000/deliver/telegram',
+      notifiedRequestIds: notified,
+    });
+
+    expect(sent).toBe(false);
+    expect(deliveredReplies).toHaveLength(0);
+  });
+
+  test('does not activate for unknown actors', async () => {
+    mockPendingApprovals = [{
+      requestId: 'req-7',
+      toolName: 'bash',
+      input: {},
+      riskLevel: 'medium',
+    }];
+
+    const notified = new Set<string>();
+    const sent = await simulateNotifierPoll({
+      conversationId: 'conv-1',
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-123',
+      guardianTrustClass: 'unknown',
+      replyCallbackUrl: 'http://localhost:3000/deliver/telegram',
+      notifiedRequestIds: notified,
+    });
+
+    expect(sent).toBe(false);
+    expect(deliveredReplies).toHaveLength(0);
+  });
+
+  test('does not activate for trusted contact without guardian identity', async () => {
+    mockPendingApprovals = [{
+      requestId: 'req-8',
+      toolName: 'bash',
+      input: {},
+      riskLevel: 'medium',
+    }];
+
+    const notified = new Set<string>();
+    const sent = await simulateNotifierPoll({
+      conversationId: 'conv-1',
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-123',
+      guardianTrustClass: 'trusted_contact',
+      guardianExternalUserId: undefined,
+      replyCallbackUrl: 'http://localhost:3000/deliver/telegram',
+      notifiedRequestIds: notified,
+    });
+
+    expect(sent).toBe(false);
+    expect(deliveredReplies).toHaveLength(0);
+  });
+
+  test('retries delivery on failure — removes requestId from notified set', async () => {
+    mockPendingApprovals = [{
+      requestId: 'req-9',
+      toolName: 'bash',
+      input: {},
+      riskLevel: 'medium',
+    }];
+
+    mockGuardianBinding = {
+      id: 'binding-1',
+      metadataJson: JSON.stringify({ displayName: 'Guardian' }),
+    };
+
+    const notified = new Set<string>();
+    const baseParams = {
+      conversationId: 'conv-1',
+      sourceChannel: 'telegram' as ChannelId,
+      externalChatId: 'chat-123',
+      guardianTrustClass: 'trusted_contact' as const,
+      guardianExternalUserId: 'guardian-1',
+      replyCallbackUrl: 'http://localhost:3000/deliver/telegram',
+      notifiedRequestIds: notified,
+    };
+
+    // First attempt: delivery fails
+    deliverShouldFail = true;
+    const sent1 = await simulateNotifierPoll(baseParams);
+    expect(sent1).toBe(false);
+    expect(notified.has('req-9')).toBe(false); // Removed for retry
+
+    // Second attempt: delivery succeeds
+    deliverShouldFail = false;
+    const sent2 = await simulateNotifierPoll(baseParams);
+    expect(sent2).toBe(true);
+    expect(deliveredReplies).toHaveLength(1);
+    expect(notified.has('req-9')).toBe(true);
+  });
+
+  test('does not send when no pending approvals exist', async () => {
+    mockPendingApprovals = [];
+
+    const notified = new Set<string>();
+    const sent = await simulateNotifierPoll({
+      conversationId: 'conv-1',
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-123',
+      guardianTrustClass: 'trusted_contact',
+      guardianExternalUserId: 'guardian-1',
+      replyCallbackUrl: 'http://localhost:3000/deliver/telegram',
+      notifiedRequestIds: notified,
+    });
+
+    expect(sent).toBe(false);
+    expect(deliveredReplies).toHaveLength(0);
+  });
+
+  test('prefers displayName over username when both are present', async () => {
+    mockPendingApprovals = [{
+      requestId: 'req-10',
+      toolName: 'bash',
+      input: {},
+      riskLevel: 'medium',
+    }];
+
+    mockGuardianBinding = {
+      id: 'binding-1',
+      metadataJson: JSON.stringify({
+        displayName: 'Sarah',
+        username: 'sarah_bot',
+      }),
+    };
+
+    const notified = new Set<string>();
+    await simulateNotifierPoll({
+      conversationId: 'conv-1',
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-123',
+      guardianTrustClass: 'trusted_contact',
+      guardianExternalUserId: 'guardian-1',
+      replyCallbackUrl: 'http://localhost:3000/deliver/telegram',
+      notifiedRequestIds: notified,
+    });
+
+    expect(deliveredReplies).toHaveLength(1);
+    expect(deliveredReplies[0].payload.text).toBe("Waiting for Sarah's approval...");
+  });
+
+  test('handles malformed metadataJson gracefully', async () => {
+    mockPendingApprovals = [{
+      requestId: 'req-11',
+      toolName: 'bash',
+      input: {},
+      riskLevel: 'medium',
+    }];
+
+    mockGuardianBinding = {
+      id: 'binding-1',
+      metadataJson: 'not-valid-json{{{',
+    };
+
+    const notified = new Set<string>();
+    await simulateNotifierPoll({
+      conversationId: 'conv-1',
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-123',
+      guardianTrustClass: 'trusted_contact',
+      guardianExternalUserId: 'guardian-1',
+      replyCallbackUrl: 'http://localhost:3000/deliver/telegram',
+      notifiedRequestIds: notified,
+    });
+
+    expect(deliveredReplies).toHaveLength(1);
+    // Falls back to generic phrasing
+    expect(deliveredReplies[0].payload.text).toBe("Waiting for your guardian's approval...");
+  });
+});

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1346,11 +1346,12 @@ interface BackgroundProcessingParams {
 const TELEGRAM_TYPING_INTERVAL_MS = 4_000;
 const PENDING_APPROVAL_POLL_INTERVAL_MS = 300;
 
-// Module-level set tracking which approval requestIds have already been
-// notified to trusted contacts. Since requestIds are globally unique, a flat
-// set suffices. Entries are cleaned up when the notifier detects the request
-// has been resolved (no longer pending).
-const globalNotifiedApprovalRequestIds = new Set<string>();
+// Module-level map tracking which approval requestIds have already been
+// notified to trusted contacts. Maps requestId -> conversationId so that
+// cleanup can be scoped to the owning conversation's poller, preventing
+// concurrent pollers from different conversations from evicting each
+// other's entries.
+const globalNotifiedApprovalRequestIds = new Map<string, string>();
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -1549,19 +1550,20 @@ function startTrustedContactApprovalNotifier(params: {
         const pending = getApprovalInfoByConversation(conversationId);
         const info = pending[0];
 
-        // Clean up resolved requests from the module-level dedupe set.
-        // Pending request IDs that were previously notified but are no longer
-        // in the pending list have been resolved — remove them so they don't
-        // accumulate indefinitely.
+        // Clean up resolved requests from the module-level dedupe map.
+        // Only remove entries that belong to THIS conversation — other
+        // conversations' pollers own their own entries. Without this
+        // scoping, concurrent pollers would evict each other's request
+        // IDs and cause duplicate notifications.
         const currentPendingIds = new Set(pending.map(p => p.requestId));
-        for (const rid of globalNotifiedApprovalRequestIds) {
-          if (!currentPendingIds.has(rid)) {
+        for (const [rid, cid] of globalNotifiedApprovalRequestIds) {
+          if (cid === conversationId && !currentPendingIds.has(rid)) {
             globalNotifiedApprovalRequestIds.delete(rid);
           }
         }
 
         if (info && !globalNotifiedApprovalRequestIds.has(info.requestId)) {
-          globalNotifiedApprovalRequestIds.add(info.requestId);
+          globalNotifiedApprovalRequestIds.set(info.requestId, conversationId);
           const guardianName = resolveGuardianDisplayName(
             assistantId ?? 'self',
             sourceChannel,

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1593,6 +1593,14 @@ function startTrustedContactApprovalNotifier(params: {
   void poll();
   return () => {
     active = false;
+
+    // Evict all dedupe entries owned by this conversation so the
+    // module-level map doesn't grow unboundedly after the poller stops.
+    for (const [rid, cid] of globalNotifiedApprovalRequestIds) {
+      if (cid === conversationId) {
+        globalNotifiedApprovalRequestIds.delete(rid);
+      }
+    }
   };
 }
 

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1346,6 +1346,12 @@ interface BackgroundProcessingParams {
 const TELEGRAM_TYPING_INTERVAL_MS = 4_000;
 const PENDING_APPROVAL_POLL_INTERVAL_MS = 300;
 
+// Module-level set tracking which approval requestIds have already been
+// notified to trusted contacts. Since requestIds are globally unique, a flat
+// set suffices. Entries are cleaned up when the notifier detects the request
+// has been resolved (no longer pending).
+const globalNotifiedApprovalRequestIds = new Set<string>();
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -1536,15 +1542,26 @@ function startTrustedContactApprovalNotifier(params: {
   }
 
   let active = true;
-  const notifiedRequestIds = new Set<string>();
 
   const poll = async (): Promise<void> => {
     while (active) {
       try {
         const pending = getApprovalInfoByConversation(conversationId);
         const info = pending[0];
-        if (info && !notifiedRequestIds.has(info.requestId)) {
-          notifiedRequestIds.add(info.requestId);
+
+        // Clean up resolved requests from the module-level dedupe set.
+        // Pending request IDs that were previously notified but are no longer
+        // in the pending list have been resolved — remove them so they don't
+        // accumulate indefinitely.
+        const currentPendingIds = new Set(pending.map(p => p.requestId));
+        for (const rid of globalNotifiedApprovalRequestIds) {
+          if (!currentPendingIds.has(rid)) {
+            globalNotifiedApprovalRequestIds.delete(rid);
+          }
+        }
+
+        if (info && !globalNotifiedApprovalRequestIds.has(info.requestId)) {
+          globalNotifiedApprovalRequestIds.add(info.requestId);
           const guardianName = resolveGuardianDisplayName(
             assistantId ?? 'self',
             sourceChannel,
@@ -1561,7 +1578,7 @@ function startTrustedContactApprovalNotifier(params: {
           } catch (err) {
             log.warn({ err, conversationId }, 'Failed to deliver trusted-contact pending-approval notification');
             // Remove from notified set so delivery is retried on next poll
-            notifiedRequestIds.delete(info.requestId);
+            globalNotifiedApprovalRequestIds.delete(info.requestId);
           }
         }
       } catch (err) {

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1477,6 +1477,106 @@ function startPendingApprovalPromptWatcher(params: {
   };
 }
 
+/**
+ * Resolve a human-readable guardian name from the guardian binding metadata.
+ * Returns the display name, username (prefixed with @), or undefined if
+ * no name is available.
+ */
+function resolveGuardianDisplayName(
+  assistantId: string,
+  sourceChannel: ChannelId,
+): string | undefined {
+  const binding = getGuardianBinding(assistantId, sourceChannel);
+  if (!binding?.metadataJson) return undefined;
+  try {
+    const parsed = JSON.parse(binding.metadataJson) as Record<string, unknown>;
+    if (typeof parsed.displayName === 'string' && parsed.displayName.trim().length > 0) {
+      return parsed.displayName.trim();
+    }
+    if (typeof parsed.username === 'string' && parsed.username.trim().length > 0) {
+      return `@${parsed.username.trim()}`;
+    }
+  } catch {
+    // ignore malformed metadata
+  }
+  return undefined;
+}
+
+/**
+ * Start a poller that sends a one-shot "waiting for guardian approval" message
+ * to the trusted contact when a confirmation_request enters guardian approval
+ * wait. Deduplicates by requestId so each request only produces one message.
+ *
+ * Only activates for trusted-contact actors with a resolvable guardian route.
+ */
+function startTrustedContactApprovalNotifier(params: {
+  conversationId: string;
+  sourceChannel: ChannelId;
+  externalChatId: string;
+  guardianTrustClass: GuardianContext['trustClass'];
+  guardianExternalUserId?: string;
+  replyCallbackUrl: string;
+  bearerToken?: string;
+  assistantId?: string;
+}): () => void {
+  const {
+    conversationId,
+    sourceChannel,
+    externalChatId,
+    guardianTrustClass,
+    guardianExternalUserId,
+    replyCallbackUrl,
+    bearerToken,
+    assistantId,
+  } = params;
+
+  // Only notify trusted contacts who have a resolvable guardian route.
+  if (guardianTrustClass !== 'trusted_contact' || !guardianExternalUserId) {
+    return () => {};
+  }
+
+  let active = true;
+  const notifiedRequestIds = new Set<string>();
+
+  const poll = async (): Promise<void> => {
+    while (active) {
+      try {
+        const pending = getApprovalInfoByConversation(conversationId);
+        const info = pending[0];
+        if (info && !notifiedRequestIds.has(info.requestId)) {
+          notifiedRequestIds.add(info.requestId);
+          const guardianName = resolveGuardianDisplayName(
+            assistantId ?? 'self',
+            sourceChannel,
+          );
+          const waitingText = guardianName
+            ? `Waiting for ${guardianName}'s approval...`
+            : 'Waiting for your guardian\'s approval...';
+          try {
+            await deliverChannelReply(replyCallbackUrl, {
+              chatId: externalChatId,
+              text: waitingText,
+              assistantId: assistantId ?? 'self',
+            }, bearerToken);
+          } catch (err) {
+            log.warn({ err, conversationId }, 'Failed to deliver trusted-contact pending-approval notification');
+            // Remove from notified set so delivery is retried on next poll
+            notifiedRequestIds.delete(info.requestId);
+          }
+        }
+      } catch (err) {
+        log.warn({ err, conversationId }, 'Trusted-contact approval notifier poll failed');
+      }
+      await delay(PENDING_APPROVAL_POLL_INTERVAL_MS);
+    }
+  };
+
+  void poll();
+  return () => {
+    active = false;
+  };
+}
+
 function processChannelMessageInBackground(params: BackgroundProcessingParams): void {
   const {
     processMessage,
@@ -1517,6 +1617,18 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
         bearerToken,
         assistantId,
         approvalCopyGenerator,
+      })
+      : undefined;
+    const stopTcApprovalNotifier = replyCallbackUrl
+      ? startTrustedContactApprovalNotifier({
+        conversationId,
+        sourceChannel,
+        externalChatId,
+        guardianTrustClass: guardianCtx.trustClass,
+        guardianExternalUserId: guardianCtx.guardianExternalUserId,
+        replyCallbackUrl,
+        bearerToken,
+        assistantId,
       })
       : undefined;
 
@@ -1564,6 +1676,7 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
     } finally {
       stopTypingHeartbeat?.();
       stopApprovalWatcher?.();
+      stopTcApprovalNotifier?.();
     }
   })();
 }


### PR DESCRIPTION
Closes #10724. Part of #10719.

Sends a one-shot message to trusted contacts when their request enters guardian approval wait, mentioning the guardian by name when known. Deduplicates by request ID to prevent repeated messages during poll loops.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
