### PR TITLE
fix: QR code interleaves with chat messages in terminal client

### DIFF
--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -745,6 +745,14 @@ function estimateItemHeight(item: FeedItem, terminalColumns: number): number {
   if (item.type === "help") {
     return 6;
   }
+  if (item.type === "status" || item.type === "error") {
+    const cols = Math.max(1, terminalColumns);
+    let lines = 0;
+    for (const line of item.text.split("\n")) {
+      lines += Math.max(1, Math.ceil(line.length / cols));
+    }
+    return lines;
+  }
   return 1;
 }
 


### PR DESCRIPTION
## Summary
- The QR code from `/pair` interleaves with chat messages because `estimateItemHeight` returned `1` for status items regardless of content
- The QR code is a ~30-line multi-line string added as a single status feed item, but the visible window calculation thought it was 1 line tall
- This caused the window to show too many items, and Ink's re-render interleaved the QR code with surrounding messages
- Fix: count newlines and line wrapping for status/error items, same as message items

## Test plan
- [ ] Run `vellum client`, send a message, then run `/pair` — QR code should display as a block and scroll up naturally when new messages arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
