### PR TITLE
M1: Runtime actor-token + bootstrap API + migration primitives

### DIFF
--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Tests for actor-token mint/verify service, hash-only storage, and
+ * guardian bootstrap endpoint idempotency.
+ */
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = realpathSync(mkdtempSync(join(tmpdir(), 'actor-token-test-')));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  getDbPath: () => join(testDir, 'test.db'),
+  normalizeAssistantId: (id: string) => id === 'self' ? 'self' : id,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { initializeDb, resetDb } from '../memory/db.js';
+import {
+  createBinding,
+  getActiveBinding,
+} from '../memory/guardian-bindings.js';
+import {
+  hashToken,
+  initSigningKey,
+  mintActorToken,
+  verifyActorToken,
+} from '../runtime/actor-token-service.js';
+import {
+  createActorTokenRecord,
+  findActiveByDeviceBinding,
+  findActiveByTokenHash,
+  revokeByDeviceBinding,
+  revokeByTokenHash,
+} from '../runtime/actor-token-store.js';
+import { ensureVellumGuardianBinding } from '../runtime/guardian-vellum-migration.js';
+
+initializeDb();
+
+beforeEach(() => {
+  // Reset the signing key to a deterministic value for reproducibility
+  initSigningKey(Buffer.from('test-signing-key-32-bytes-long!!'));
+  // Clear DB state between tests
+  resetDb();
+  initializeDb();
+});
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true, force: true }); } catch {}
+});
+
+// ---------------------------------------------------------------------------
+// Actor token mint/verify
+// ---------------------------------------------------------------------------
+
+describe('actor-token mint/verify', () => {
+  test('mint returns token, hash, and claims', () => {
+    const result = mintActorToken({
+      assistantId: 'self',
+      platform: 'macos',
+      deviceId: 'device-123',
+      guardianPrincipalId: 'principal-abc',
+    });
+
+    expect(result.token).toBeTruthy();
+    expect(result.tokenHash).toBeTruthy();
+    expect(result.claims.assistantId).toBe('self');
+    expect(result.claims.platform).toBe('macos');
+    expect(result.claims.deviceId).toBe('device-123');
+    expect(result.claims.guardianPrincipalId).toBe('principal-abc');
+    expect(result.claims.iat).toBeGreaterThan(0);
+    expect(result.claims.exp).toBeNull();
+    expect(result.claims.jti).toBeTruthy();
+  });
+
+  test('verify succeeds for valid token', () => {
+    const { token } = mintActorToken({
+      assistantId: 'self',
+      platform: 'ios',
+      deviceId: 'device-456',
+      guardianPrincipalId: 'principal-def',
+    });
+
+    const result = verifyActorToken(token);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.claims.assistantId).toBe('self');
+      expect(result.claims.platform).toBe('ios');
+    }
+  });
+
+  test('verify fails for tampered token', () => {
+    const { token } = mintActorToken({
+      assistantId: 'self',
+      platform: 'macos',
+      deviceId: 'device-789',
+      guardianPrincipalId: 'principal-ghi',
+    });
+
+    // Tamper with the payload
+    const parts = token.split('.');
+    const tampered = parts[0] + 'X' + '.' + parts[1];
+    const result = verifyActorToken(tampered);
+    expect(result.ok).toBe(false);
+  });
+
+  test('verify fails for malformed token', () => {
+    const result = verifyActorToken('not-a-valid-token');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('malformed_token');
+    }
+  });
+
+  test('verify fails for expired token', () => {
+    const { token } = mintActorToken({
+      assistantId: 'self',
+      platform: 'macos',
+      deviceId: 'device-exp',
+      guardianPrincipalId: 'principal-exp',
+      ttlMs: -1000, // Already expired
+    });
+
+    const result = verifyActorToken(token);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('token_expired');
+    }
+  });
+
+  test('hashToken produces consistent SHA-256 hex', () => {
+    const hash1 = hashToken('test-token');
+    const hash2 = hashToken('test-token');
+    expect(hash1).toBe(hash2);
+    expect(hash1.length).toBe(64); // SHA-256 hex = 64 chars
+  });
+
+  test('different tokens produce different hashes', () => {
+    const { token: t1 } = mintActorToken({
+      assistantId: 'self',
+      platform: 'macos',
+      deviceId: 'dev1',
+      guardianPrincipalId: 'p1',
+    });
+    const { token: t2 } = mintActorToken({
+      assistantId: 'self',
+      platform: 'macos',
+      deviceId: 'dev2',
+      guardianPrincipalId: 'p2',
+    });
+    expect(hashToken(t1)).not.toBe(hashToken(t2));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hash-only storage
+// ---------------------------------------------------------------------------
+
+describe('actor-token store (hash-only)', () => {
+  test('createActorTokenRecord stores hash, never raw token', () => {
+    const { tokenHash } = mintActorToken({
+      assistantId: 'self',
+      platform: 'macos',
+      deviceId: 'dev-store',
+      guardianPrincipalId: 'principal-store',
+    });
+
+    const record = createActorTokenRecord({
+      tokenHash,
+      assistantId: 'self',
+      guardianPrincipalId: 'principal-store',
+      hashedDeviceId: 'hashed-dev-store',
+      platform: 'macos',
+      issuedAt: Date.now(),
+    });
+
+    expect(record.tokenHash).toBe(tokenHash);
+    expect(record.status).toBe('active');
+    // Verify the record can be found by hash
+    const found = findActiveByTokenHash(tokenHash);
+    expect(found).not.toBeNull();
+    expect(found!.tokenHash).toBe(tokenHash);
+  });
+
+  test('findActiveByDeviceBinding returns matching record', () => {
+    const { tokenHash } = mintActorToken({
+      assistantId: 'self',
+      platform: 'ios',
+      deviceId: 'dev-bind',
+      guardianPrincipalId: 'principal-bind',
+    });
+
+    createActorTokenRecord({
+      tokenHash,
+      assistantId: 'self',
+      guardianPrincipalId: 'principal-bind',
+      hashedDeviceId: 'hashed-dev-bind',
+      platform: 'ios',
+      issuedAt: Date.now(),
+    });
+
+    const found = findActiveByDeviceBinding('self', 'principal-bind', 'hashed-dev-bind');
+    expect(found).not.toBeNull();
+    expect(found!.platform).toBe('ios');
+  });
+
+  test('revokeByDeviceBinding marks tokens as revoked', () => {
+    const { tokenHash } = mintActorToken({
+      assistantId: 'self',
+      platform: 'macos',
+      deviceId: 'dev-revoke',
+      guardianPrincipalId: 'principal-revoke',
+    });
+
+    createActorTokenRecord({
+      tokenHash,
+      assistantId: 'self',
+      guardianPrincipalId: 'principal-revoke',
+      hashedDeviceId: 'hashed-dev-revoke',
+      platform: 'macos',
+      issuedAt: Date.now(),
+    });
+
+    const count = revokeByDeviceBinding('self', 'principal-revoke', 'hashed-dev-revoke');
+    expect(count).toBe(1);
+
+    // Should no longer be found as active
+    const found = findActiveByTokenHash(tokenHash);
+    expect(found).toBeNull();
+  });
+
+  test('revokeByTokenHash revokes a single token', () => {
+    const { tokenHash } = mintActorToken({
+      assistantId: 'self',
+      platform: 'macos',
+      deviceId: 'dev-single',
+      guardianPrincipalId: 'principal-single',
+    });
+
+    createActorTokenRecord({
+      tokenHash,
+      assistantId: 'self',
+      guardianPrincipalId: 'principal-single',
+      hashedDeviceId: 'hashed-dev-single',
+      platform: 'macos',
+      issuedAt: Date.now(),
+    });
+
+    expect(revokeByTokenHash(tokenHash)).toBe(true);
+    expect(findActiveByTokenHash(tokenHash)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guardian vellum migration
+// ---------------------------------------------------------------------------
+
+describe('guardian vellum migration', () => {
+  test('ensureVellumGuardianBinding creates binding when missing', () => {
+    const principalId = ensureVellumGuardianBinding('self');
+    expect(principalId).toMatch(/^vellum-principal-/);
+
+    const binding = getActiveBinding('self', 'vellum');
+    expect(binding).not.toBeNull();
+    expect(binding!.guardianExternalUserId).toBe(principalId);
+    expect(binding!.verifiedVia).toBe('startup-migration');
+  });
+
+  test('ensureVellumGuardianBinding is idempotent', () => {
+    const first = ensureVellumGuardianBinding('self');
+    const second = ensureVellumGuardianBinding('self');
+    expect(first).toBe(second);
+  });
+
+  test('ensureVellumGuardianBinding preserves existing bindings for other channels', () => {
+    // Create a telegram binding
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'tg-user-123',
+      guardianDeliveryChatId: 'tg-chat-456',
+      verifiedVia: 'challenge',
+    });
+
+    // Now backfill vellum
+    ensureVellumGuardianBinding('self');
+
+    // Telegram binding should still exist
+    const tgBinding = getActiveBinding('self', 'telegram');
+    expect(tgBinding).not.toBeNull();
+    expect(tgBinding!.guardianExternalUserId).toBe('tg-user-123');
+
+    // Vellum binding should also exist
+    const vBinding = getActiveBinding('self', 'vellum');
+    expect(vBinding).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bootstrap idempotency (via route handler)
+// ---------------------------------------------------------------------------
+
+describe('bootstrap endpoint idempotency', () => {
+  test('calling bootstrap twice returns same guardianPrincipalId', async () => {
+    // We test the logic used by the bootstrap route handler directly
+    // rather than spinning up a full HTTP server.
+    const { handleGuardianBootstrap } = await import('../runtime/routes/guardian-bootstrap-routes.js');
+
+    const req1 = new Request('http://localhost/v1/integrations/guardian/vellum/bootstrap', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ platform: 'macos', deviceId: 'test-device-1' }),
+    });
+
+    const res1 = await handleGuardianBootstrap(req1);
+    expect(res1.status).toBe(200);
+    const body1 = await res1.json() as Record<string, unknown>;
+    expect(body1.guardianPrincipalId).toBeTruthy();
+    expect(body1.actorToken).toBeTruthy();
+    expect(body1.isNew).toBe(true);
+
+    // Second call with same device
+    const req2 = new Request('http://localhost/v1/integrations/guardian/vellum/bootstrap', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ platform: 'macos', deviceId: 'test-device-1' }),
+    });
+
+    const res2 = await handleGuardianBootstrap(req2);
+    expect(res2.status).toBe(200);
+    const body2 = await res2.json() as Record<string, unknown>;
+    expect(body2.guardianPrincipalId).toBe(body1.guardianPrincipalId);
+    expect(body2.actorToken).toBeTruthy();
+    // New token minted (previous revoked), but same principal
+    expect(body2.actorToken).not.toBe(body1.actorToken);
+    expect(body2.isNew).toBe(false);
+  });
+
+  test('bootstrap rejects missing fields', async () => {
+    const { handleGuardianBootstrap } = await import('../runtime/routes/guardian-bootstrap-routes.js');
+
+    const req = new Request('http://localhost/v1/integrations/guardian/vellum/bootstrap', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ platform: 'macos' }),
+    });
+
+    const res = await handleGuardianBootstrap(req);
+    expect(res.status).toBe(400);
+  });
+
+  test('bootstrap rejects invalid platform', async () => {
+    const { handleGuardianBootstrap } = await import('../runtime/routes/guardian-bootstrap-routes.js');
+
+    const req = new Request('http://localhost/v1/integrations/guardian/vellum/bootstrap', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ platform: 'android', deviceId: 'test-device' }),
+    });
+
+    const res = await handleGuardianBootstrap(req);
+    expect(res.status).toBe(400);
+  });
+
+  test('bootstrap with different devices returns same principal but different tokens', async () => {
+    const { handleGuardianBootstrap } = await import('../runtime/routes/guardian-bootstrap-routes.js');
+
+    const req1 = new Request('http://localhost/v1/integrations/guardian/vellum/bootstrap', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ platform: 'macos', deviceId: 'device-A' }),
+    });
+
+    const res1 = await handleGuardianBootstrap(req1);
+    const body1 = await res1.json() as Record<string, unknown>;
+
+    const req2 = new Request('http://localhost/v1/integrations/guardian/vellum/bootstrap', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ platform: 'ios', deviceId: 'device-B' }),
+    });
+
+    const res2 = await handleGuardianBootstrap(req2);
+    const body2 = await res2.json() as Record<string, unknown>;
+
+    // Same principal, different tokens
+    expect(body2.guardianPrincipalId).toBe(body1.guardianPrincipalId);
+    expect(body2.actorToken).not.toBe(body1.actorToken);
+  });
+});

--- a/assistant/src/daemon/handlers/pairing.ts
+++ b/assistant/src/daemon/handlers/pairing.ts
@@ -11,6 +11,7 @@ import type {
   PairingApprovalResponse,
 } from '../ipc-protocol.js';
 import type { PairingStore } from '../pairing-store.js';
+import { cleanupPairingState } from '../../runtime/routes/pairing-routes.js';
 import { defineHandlers, type HandlerContext,log } from './shared.js';
 
 /** Module-level reference set by the daemon server at startup. */
@@ -46,6 +47,7 @@ function handlePairingApprovalResponse(
 
   if (msg.decision === 'deny') {
     pairingStoreRef.deny(msg.pairingRequestId);
+    cleanupPairingState(msg.pairingRequestId);
     log.info({ pairingRequestId: msg.pairingRequestId }, 'Pairing request denied');
     return;
   }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -35,6 +35,7 @@ import { rotateToolInvocations } from '../memory/tool-usage-store.js';
 import { migrateToDataLayout } from '../migrations/data-layout.js';
 import { migrateToWorkspaceLayout } from '../migrations/workspace-layout.js';
 import { emitNotificationSignal, registerBroadcastFn } from '../notifications/emit-signal.js';
+import { initSigningKey, loadOrCreateSigningKey } from '../runtime/actor-token-service.js';
 import { assistantEventHub } from '../runtime/assistant-event-hub.js';
 import { RuntimeHttpServer } from '../runtime/http-server.js';
 import { startScheduler } from '../schedule/scheduler.js';
@@ -130,6 +131,11 @@ export async function runDaemon(): Promise<void> {
     writeFileSync(httpTokenPath, bearerToken, { mode: 0o600 });
     chmodSync(httpTokenPath, 0o600);
     log.info('Daemon startup: bearer token written');
+
+    // Load (or generate + persist) the actor-token signing key so tokens
+    // survive daemon restarts. Must happen after ensureDataDir() creates
+    // the protected directory.
+    initSigningKey(loadOrCreateSigningKey());
 
     log.info('Daemon startup: migrations complete');
 

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -38,6 +38,7 @@ import { emitNotificationSignal, registerBroadcastFn } from '../notifications/em
 import { assistantEventHub } from '../runtime/assistant-event-hub.js';
 import { RuntimeHttpServer } from '../runtime/http-server.js';
 import { startScheduler } from '../schedule/scheduler.js';
+import { ensureVellumGuardianBinding } from '../runtime/guardian-vellum-migration.js';
 import { getLogger, initLogger } from '../util/logger.js';
 import {
   ensureDataDir,
@@ -145,6 +146,13 @@ export async function runDaemon(): Promise<void> {
     }
     initializeDb();
     log.info('Daemon startup: DB initialized');
+
+    // Backfill vellum guardian binding for existing installations
+    try {
+      ensureVellumGuardianBinding('self');
+    } catch (err) {
+      log.warn({ err }, 'Vellum guardian binding backfill failed — continuing startup');
+    }
 
     try {
       syncUpdateBulletinOnStartup();

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -1,6 +1,7 @@
 import { getDb } from './db-connection.js';
 import {
   addCoreColumns,
+  createActorTokenRecordsTable,
   createAssistantInboxTables,
   createCallSessionsTables,
   createCanonicalGuardianTables,
@@ -164,6 +165,9 @@ export function initializeDb(): void {
 
   // 26. Voice invite columns on assistant_ingress_invites
   migrateVoiceInviteColumns(database);
+
+  // 27. Actor token records (hash-only actor token persistence)
+  createActorTokenRecordsTable(database);
 
   validateMigrationState(database);
 }

--- a/assistant/src/memory/migrations/038-actor-token-records.ts
+++ b/assistant/src/memory/migrations/038-actor-token-records.ts
@@ -1,0 +1,39 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Create the actor_token_records table for hash-only actor token persistence.
+ *
+ * Stores the SHA-256 hash of each actor token alongside metadata for
+ * verification and revocation. The raw token plaintext is never stored.
+ */
+export function createActorTokenRecordsTable(database: DrizzleDb): void {
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS actor_token_records (
+      id TEXT PRIMARY KEY,
+      token_hash TEXT NOT NULL,
+      assistant_id TEXT NOT NULL,
+      guardian_principal_id TEXT NOT NULL,
+      hashed_device_id TEXT NOT NULL,
+      platform TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'active',
+      issued_at INTEGER NOT NULL,
+      expires_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  // Unique active token per device binding
+  database.run(
+    /*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_actor_tokens_active_device
+      ON actor_token_records(assistant_id, guardian_principal_id, hashed_device_id)
+      WHERE status = 'active'`,
+  );
+
+  // Token hash lookup for verification
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_actor_tokens_hash
+      ON actor_token_records(token_hash)
+      WHERE status = 'active'`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -39,6 +39,7 @@ export { migrateGuardianActionToolMetadata } from './034-guardian-action-tool-me
 export { migrateGuardianActionSupersession } from './035-guardian-action-supersession.js';
 export { migrateNormalizePhoneIdentities } from './036-normalize-phone-identities.js';
 export { migrateVoiceInviteColumns } from './037-voice-invite-columns.js';
+export { createActorTokenRecordsTable } from './038-actor-token-records.js';
 export { createCoreTables } from './100-core-tables.js';
 export { createWatchersAndLogsTables } from './101-watchers-and-logs.js';
 export { addCoreColumns } from './102-alter-table-columns.js';

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -1138,6 +1138,22 @@ export const conversationAssistantAttentionState = sqliteTable('conversation_ass
   index('idx_conv_attn_state_assistant_last_seen').on(table.assistantId, table.lastSeenAssistantMessageAt),
 ]);
 
+// ── Actor Token Records ──────────────────────────────────────────────
+
+export const actorTokenRecords = sqliteTable('actor_token_records', {
+  id: text('id').primaryKey(),
+  tokenHash: text('token_hash').notNull(),
+  assistantId: text('assistant_id').notNull(),
+  guardianPrincipalId: text('guardian_principal_id').notNull(),
+  hashedDeviceId: text('hashed_device_id').notNull(),
+  platform: text('platform').notNull(),
+  status: text('status').notNull().default('active'),
+  issuedAt: integer('issued_at').notNull(),
+  expiresAt: integer('expires_at'),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+});
+
 // ── Scoped Approval Grants ──────────────────────────────────────────
 
 export const scopedApprovalGrants = sqliteTable('scoped_approval_grants', {

--- a/assistant/src/runtime/actor-token-service.ts
+++ b/assistant/src/runtime/actor-token-service.ts
@@ -9,8 +9,11 @@
  */
 
 import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 
 import { getLogger } from '../util/logger.js';
+import { getRootDir } from '../util/platform.js';
 
 const log = getLogger('actor-token-service');
 
@@ -55,20 +58,61 @@ export type VerifyResult =
 let signingKey: Buffer | null = null;
 
 /**
- * Initialize (or reinitialize) the signing key. In production this is
- * derived once at startup from a persisted secret; tests can inject a
- * deterministic key.
+ * Path to the persisted signing key file.
+ * Stored in the protected directory alongside other sensitive material.
  */
-export function initSigningKey(key?: Buffer): void {
-  signingKey = key ?? randomBytes(32);
+function getSigningKeyPath(): string {
+  return join(getRootDir(), 'protected', 'actor-token-signing-key');
+}
+
+/**
+ * Load a signing key from disk or generate and persist a new one.
+ * Uses the same atomic-write + chmod 0o600 pattern as approved-devices-store.ts.
+ */
+export function loadOrCreateSigningKey(): Buffer {
+  const keyPath = getSigningKeyPath();
+
+  // Try to load existing key
+  if (existsSync(keyPath)) {
+    try {
+      const raw = readFileSync(keyPath);
+      if (raw.length === 32) {
+        log.info('Actor-token signing key loaded from disk');
+        return raw;
+      }
+      log.warn('Signing key file has unexpected length, regenerating');
+    } catch (err) {
+      log.warn({ err }, 'Failed to read signing key file, regenerating');
+    }
+  }
+
+  // Generate and persist a new key
+  const newKey = randomBytes(32);
+  const dir = dirname(keyPath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const tmpPath = keyPath + '.tmp.' + process.pid;
+  writeFileSync(tmpPath, newKey, { mode: 0o600 });
+  renameSync(tmpPath, keyPath);
+  chmodSync(keyPath, 0o600);
+
+  log.info('Actor-token signing key generated and persisted');
+  return newKey;
+}
+
+/**
+ * Initialize (or reinitialize) the signing key. Called at daemon startup
+ * with a key loaded from disk via loadOrCreateSigningKey(), or by tests
+ * with a deterministic key.
+ */
+export function initSigningKey(key: Buffer): void {
+  signingKey = key;
 }
 
 function getSigningKey(): Buffer {
   if (!signingKey) {
-    // Lazy init on first use — ensures the daemon can mint tokens even
-    // if initSigningKey() was not called during startup.
-    signingKey = randomBytes(32);
-    log.info('Actor-token signing key lazily initialized');
+    throw new Error('Actor-token signing key not initialized — call initSigningKey() during startup');
   }
   return signingKey;
 }

--- a/assistant/src/runtime/actor-token-service.ts
+++ b/assistant/src/runtime/actor-token-service.ts
@@ -1,0 +1,185 @@
+/**
+ * Actor-token mint/verify service.
+ *
+ * Mints HMAC-signed actor tokens bound to (assistantId, guardianPrincipalId,
+ * deviceId, platform). Only the SHA-256 hash of the token is persisted —
+ * the raw plaintext is returned to the caller once and never stored.
+ *
+ * Token format: base64url(JSON claims) + '.' + base64url(HMAC-SHA256 signature)
+ */
+
+import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('actor-token-service');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ActorTokenClaims {
+  /** The assistant this token is scoped to. */
+  assistantId: string;
+  /** Platform: 'macos' | 'ios' */
+  platform: string;
+  /** Opaque device identifier (hashed for storage). */
+  deviceId: string;
+  /** The guardian principal this token is bound to. */
+  guardianPrincipalId: string;
+  /** Token issuance timestamp (epoch ms). */
+  iat: number;
+  /** Token expiration timestamp (epoch ms). Null means non-expiring. */
+  exp: number | null;
+  /** Random jti (JWT ID) for uniqueness. */
+  jti: string;
+}
+
+export interface MintResult {
+  /** The raw actor token string — returned once, never persisted. */
+  token: string;
+  /** SHA-256 hex hash of the token (for storage/lookup). */
+  tokenHash: string;
+  /** The decoded claims. */
+  claims: ActorTokenClaims;
+}
+
+export type VerifyResult =
+  | { ok: true; claims: ActorTokenClaims }
+  | { ok: false; reason: string };
+
+// ---------------------------------------------------------------------------
+// Signing key management
+// ---------------------------------------------------------------------------
+
+let signingKey: Buffer | null = null;
+
+/**
+ * Initialize (or reinitialize) the signing key. In production this is
+ * derived once at startup from a persisted secret; tests can inject a
+ * deterministic key.
+ */
+export function initSigningKey(key?: Buffer): void {
+  signingKey = key ?? randomBytes(32);
+}
+
+function getSigningKey(): Buffer {
+  if (!signingKey) {
+    // Lazy init on first use — ensures the daemon can mint tokens even
+    // if initSigningKey() was not called during startup.
+    signingKey = randomBytes(32);
+    log.info('Actor-token signing key lazily initialized');
+  }
+  return signingKey;
+}
+
+// ---------------------------------------------------------------------------
+// Base64url helpers
+// ---------------------------------------------------------------------------
+
+function base64urlEncode(data: Buffer | string): string {
+  const buf = typeof data === 'string' ? Buffer.from(data, 'utf-8') : data;
+  return buf.toString('base64url');
+}
+
+function base64urlDecode(str: string): Buffer {
+  return Buffer.from(str, 'base64url');
+}
+
+// ---------------------------------------------------------------------------
+// Hashing
+// ---------------------------------------------------------------------------
+
+/** SHA-256 hex digest of a raw token string. */
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// Mint
+// ---------------------------------------------------------------------------
+
+/**
+ * Mint a new actor token.
+ *
+ * @param params Token claims (assistantId, platform, deviceId, guardianPrincipalId).
+ * @param ttlMs  Optional TTL in milliseconds. Null/undefined means non-expiring.
+ * @returns The raw token, its hash, and the embedded claims.
+ */
+export function mintActorToken(params: {
+  assistantId: string;
+  platform: string;
+  deviceId: string;
+  guardianPrincipalId: string;
+  ttlMs?: number | null;
+}): MintResult {
+  const now = Date.now();
+  const claims: ActorTokenClaims = {
+    assistantId: params.assistantId,
+    platform: params.platform,
+    deviceId: params.deviceId,
+    guardianPrincipalId: params.guardianPrincipalId,
+    iat: now,
+    exp: params.ttlMs != null ? now + params.ttlMs : null,
+    jti: randomBytes(16).toString('hex'),
+  };
+
+  const payload = base64urlEncode(JSON.stringify(claims));
+  const sig = createHmac('sha256', getSigningKey())
+    .update(payload)
+    .digest();
+  const token = payload + '.' + base64urlEncode(sig);
+  const tokenHash = hashToken(token);
+
+  return { token, tokenHash, claims };
+}
+
+// ---------------------------------------------------------------------------
+// Verify
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify an actor token's structural integrity and signature.
+ *
+ * Does NOT check revocation — callers must additionally verify the
+ * token hash exists in the actor-token store with status='active'.
+ */
+export function verifyActorToken(token: string): VerifyResult {
+  const dotIndex = token.indexOf('.');
+  if (dotIndex < 0) {
+    return { ok: false, reason: 'malformed_token' };
+  }
+
+  const payload = token.slice(0, dotIndex);
+  const sigPart = token.slice(dotIndex + 1);
+
+  // Recompute HMAC
+  const expectedSig = createHmac('sha256', getSigningKey())
+    .update(payload)
+    .digest();
+  const actualSig = base64urlDecode(sigPart);
+
+  if (expectedSig.length !== actualSig.length) {
+    return { ok: false, reason: 'invalid_signature' };
+  }
+
+  // Constant-time comparison
+  if (!timingSafeEqual(expectedSig, actualSig)) {
+    return { ok: false, reason: 'invalid_signature' };
+  }
+
+  let claims: ActorTokenClaims;
+  try {
+    const decoded = base64urlDecode(payload).toString('utf-8');
+    claims = JSON.parse(decoded) as ActorTokenClaims;
+  } catch {
+    return { ok: false, reason: 'malformed_claims' };
+  }
+
+  // Expiration check
+  if (claims.exp != null && Date.now() > claims.exp) {
+    return { ok: false, reason: 'token_expired' };
+  }
+
+  return { ok: true, claims };
+}

--- a/assistant/src/runtime/actor-token-store.ts
+++ b/assistant/src/runtime/actor-token-store.ts
@@ -1,0 +1,193 @@
+/**
+ * Hash-only actor token persistence.
+ *
+ * Stores only the SHA-256 hash of each actor token alongside metadata
+ * (assistantId, guardianPrincipalId, deviceId hash, platform, status).
+ * The raw token plaintext is never stored.
+ *
+ * Uses the assistant SQLite database via drizzle-orm.
+ */
+
+import { and, eq } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+
+import { getDb } from '../memory/db.js';
+import { actorTokenRecords } from '../memory/schema.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('actor-token-store');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ActorTokenStatus = 'active' | 'revoked';
+
+export interface ActorTokenRecord {
+  id: string;
+  tokenHash: string;
+  assistantId: string;
+  guardianPrincipalId: string;
+  hashedDeviceId: string;
+  platform: string;
+  status: ActorTokenStatus;
+  issuedAt: number;
+  expiresAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Store a new actor token record (hash-only).
+ */
+export function createActorTokenRecord(params: {
+  tokenHash: string;
+  assistantId: string;
+  guardianPrincipalId: string;
+  hashedDeviceId: string;
+  platform: string;
+  issuedAt: number;
+  expiresAt?: number | null;
+}): ActorTokenRecord {
+  const db = getDb();
+  const now = Date.now();
+  const id = uuid();
+
+  const row = {
+    id,
+    tokenHash: params.tokenHash,
+    assistantId: params.assistantId,
+    guardianPrincipalId: params.guardianPrincipalId,
+    hashedDeviceId: params.hashedDeviceId,
+    platform: params.platform,
+    status: 'active' as const,
+    issuedAt: params.issuedAt,
+    expiresAt: params.expiresAt ?? null,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  db.insert(actorTokenRecords).values(row).run();
+  log.info({ id, assistantId: params.assistantId, platform: params.platform }, 'Actor token record created');
+
+  return row;
+}
+
+/**
+ * Look up an active actor token record by its hash.
+ */
+export function findActiveByTokenHash(tokenHash: string): ActorTokenRecord | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(actorTokenRecords)
+    .where(
+      and(
+        eq(actorTokenRecords.tokenHash, tokenHash),
+        eq(actorTokenRecords.status, 'active'),
+      ),
+    )
+    .get();
+
+  return row ? rowToRecord(row) : null;
+}
+
+/**
+ * Find an active token for a specific (assistantId, guardianPrincipalId, deviceId).
+ * Used for idempotent bootstrap — if an active token already exists for this
+ * device binding, we can revoke-and-remint or return the existing record.
+ */
+export function findActiveByDeviceBinding(
+  assistantId: string,
+  guardianPrincipalId: string,
+  hashedDeviceId: string,
+): ActorTokenRecord | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(actorTokenRecords)
+    .where(
+      and(
+        eq(actorTokenRecords.assistantId, assistantId),
+        eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),
+        eq(actorTokenRecords.hashedDeviceId, hashedDeviceId),
+        eq(actorTokenRecords.status, 'active'),
+      ),
+    )
+    .get();
+
+  return row ? rowToRecord(row) : null;
+}
+
+/**
+ * Revoke all active tokens for a given device binding.
+ * Called before minting a new token to ensure one-active-per-device.
+ */
+export function revokeByDeviceBinding(
+  assistantId: string,
+  guardianPrincipalId: string,
+  hashedDeviceId: string,
+): number {
+  const db = getDb();
+  const now = Date.now();
+
+  const result = db
+    .update(actorTokenRecords)
+    .set({ status: 'revoked', updatedAt: now })
+    .where(
+      and(
+        eq(actorTokenRecords.assistantId, assistantId),
+        eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),
+        eq(actorTokenRecords.hashedDeviceId, hashedDeviceId),
+        eq(actorTokenRecords.status, 'active'),
+      ),
+    )
+    .run();
+
+  return result.changes;
+}
+
+/**
+ * Revoke a single token by its hash.
+ */
+export function revokeByTokenHash(tokenHash: string): boolean {
+  const db = getDb();
+  const now = Date.now();
+
+  const result = db
+    .update(actorTokenRecords)
+    .set({ status: 'revoked', updatedAt: now })
+    .where(
+      and(
+        eq(actorTokenRecords.tokenHash, tokenHash),
+        eq(actorTokenRecords.status, 'active'),
+      ),
+    )
+    .run();
+
+  return result.changes > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function rowToRecord(row: typeof actorTokenRecords.$inferSelect): ActorTokenRecord {
+  return {
+    id: row.id,
+    tokenHash: row.tokenHash,
+    assistantId: row.assistantId,
+    guardianPrincipalId: row.guardianPrincipalId,
+    hashedDeviceId: row.hashedDeviceId,
+    platform: row.platform,
+    status: row.status as ActorTokenStatus,
+    issuedAt: row.issuedAt,
+    expiresAt: row.expiresAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/assistant/src/runtime/guardian-vellum-migration.ts
+++ b/assistant/src/runtime/guardian-vellum-migration.ts
@@ -1,0 +1,56 @@
+/**
+ * Startup migration: backfill channel='vellum' guardian binding.
+ *
+ * On runtime start, ensures that a guardian binding exists for the
+ * 'vellum' channel with a guardianPrincipalId. This is required for
+ * the identity-bound hatch bootstrap flow.
+ *
+ * - If a vellum binding already exists, no-op.
+ * - If no vellum binding exists, creates one with a fresh principal.
+ * - Preserves existing guardian bindings for other channels unchanged.
+ */
+
+import { v4 as uuid } from 'uuid';
+
+import {
+  createBinding,
+  getActiveBinding,
+} from '../memory/guardian-bindings.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('guardian-vellum-migration');
+
+/**
+ * Ensure a vellum guardian binding exists for the given assistant.
+ * Called during daemon startup to backfill existing installations.
+ *
+ * Returns the guardianPrincipalId (existing or newly created).
+ */
+export function ensureVellumGuardianBinding(assistantId: string = 'self'): string {
+  const existing = getActiveBinding(assistantId, 'vellum');
+  if (existing) {
+    log.debug(
+      { assistantId, guardianPrincipalId: existing.guardianExternalUserId },
+      'Vellum guardian binding already exists',
+    );
+    return existing.guardianExternalUserId;
+  }
+
+  const guardianPrincipalId = `vellum-principal-${uuid()}`;
+
+  createBinding({
+    assistantId,
+    channel: 'vellum',
+    guardianExternalUserId: guardianPrincipalId,
+    guardianDeliveryChatId: 'local',
+    verifiedVia: 'startup-migration',
+    metadataJson: JSON.stringify({ migratedAt: Date.now() }),
+  });
+
+  log.info(
+    { assistantId, guardianPrincipalId },
+    'Backfilled vellum guardian binding on startup',
+  );
+
+  return guardianPrincipalId;
+}

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -137,6 +137,7 @@ import {
   handleRevokeMember,
   handleUpsertMember,
 } from './routes/ingress-routes.js';
+import { handleGuardianBootstrap } from './routes/guardian-bootstrap-routes.js';
 import {
   handleCancelOutbound,
   handleClearSlackChannelConfig,
@@ -767,6 +768,9 @@ export class RuntimeHttpServer {
       if (endpoint === 'integrations/guardian/outbound/start' && req.method === 'POST') return await handleStartOutbound(req);
       if (endpoint === 'integrations/guardian/outbound/resend' && req.method === 'POST') return await handleResendOutbound(req);
       if (endpoint === 'integrations/guardian/outbound/cancel' && req.method === 'POST') return await handleCancelOutbound(req);
+
+      // Guardian vellum channel bootstrap
+      if (endpoint === 'integrations/guardian/vellum/bootstrap' && req.method === 'POST') return await handleGuardianBootstrap(req);
 
       if (endpoint === 'attachments' && req.method === 'POST') return await handleUploadAttachment(req);
       if (endpoint === 'attachments' && req.method === 'DELETE') return await handleDeleteAttachment(req);

--- a/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
+++ b/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
@@ -1,0 +1,126 @@
+/**
+ * POST /v1/integrations/guardian/vellum/bootstrap
+ *
+ * Idempotent bootstrap endpoint for the vellum guardian channel.
+ * Creates or confirms a guardianPrincipalId and channel='vellum'
+ * guardian binding, then mints and returns an actor token bound
+ * to (assistantId, guardianPrincipalId, deviceId).
+ *
+ * Only the hashed token is persisted.
+ */
+
+import { createHash } from 'node:crypto';
+import { v4 as uuid } from 'uuid';
+
+import {
+  createBinding,
+  getActiveBinding,
+} from '../../memory/guardian-bindings.js';
+import { getLogger } from '../../util/logger.js';
+import { normalizeAssistantId } from '../../util/platform.js';
+import { mintActorToken } from '../actor-token-service.js';
+import {
+  createActorTokenRecord,
+  revokeByDeviceBinding,
+} from '../actor-token-store.js';
+import { httpError } from '../http-errors.js';
+
+const log = getLogger('guardian-bootstrap');
+
+/** Hash a device ID for storage (same pattern as approved-devices-store). */
+function hashDeviceId(deviceId: string): string {
+  return createHash('sha256').update(deviceId).digest('hex');
+}
+
+/**
+ * Ensure a guardianPrincipalId exists for the vellum channel.
+ * If a binding already exists, returns the existing guardianExternalUserId
+ * as the principal. Otherwise creates a new binding with a fresh principal.
+ */
+function ensureGuardianPrincipal(assistantId: string): {
+  guardianPrincipalId: string;
+  isNew: boolean;
+} {
+  const existing = getActiveBinding(assistantId, 'vellum');
+  if (existing) {
+    return { guardianPrincipalId: existing.guardianExternalUserId, isNew: false };
+  }
+
+  // Mint a new principal ID for the vellum channel
+  const guardianPrincipalId = `vellum-principal-${uuid()}`;
+
+  createBinding({
+    assistantId,
+    channel: 'vellum',
+    guardianExternalUserId: guardianPrincipalId,
+    guardianDeliveryChatId: 'local',
+    verifiedVia: 'bootstrap',
+    metadataJson: JSON.stringify({ bootstrapedAt: Date.now() }),
+  });
+
+  log.info({ assistantId, guardianPrincipalId }, 'Created vellum guardian principal via bootstrap');
+  return { guardianPrincipalId, isNew: true };
+}
+
+/**
+ * Handle POST /v1/integrations/guardian/vellum/bootstrap
+ *
+ * Body: { platform: 'macos' | 'ios', deviceId: string }
+ * Returns: { guardianPrincipalId, actorToken, isNew }
+ */
+export async function handleGuardianBootstrap(req: Request): Promise<Response> {
+  try {
+    const body = await req.json() as Record<string, unknown>;
+    const platform = typeof body.platform === 'string' ? body.platform.trim() : '';
+    const deviceId = typeof body.deviceId === 'string' ? body.deviceId.trim() : '';
+
+    if (!platform || !deviceId) {
+      return httpError('BAD_REQUEST', 'Missing required fields: platform, deviceId', 400);
+    }
+
+    if (platform !== 'macos' && platform !== 'ios') {
+      return httpError('BAD_REQUEST', 'Invalid platform. Expected "macos" or "ios".', 400);
+    }
+
+    const assistantId = normalizeAssistantId('self');
+    const { guardianPrincipalId, isNew } = ensureGuardianPrincipal(assistantId);
+    const hashedDeviceId = hashDeviceId(deviceId);
+
+    // Revoke any existing active tokens for this device binding
+    // so we maintain one-active-token-per-device
+    revokeByDeviceBinding(assistantId, guardianPrincipalId, hashedDeviceId);
+
+    // Mint a new actor token
+    const { token, tokenHash, claims } = mintActorToken({
+      assistantId,
+      platform,
+      deviceId,
+      guardianPrincipalId,
+    });
+
+    // Store only the hash
+    createActorTokenRecord({
+      tokenHash,
+      assistantId,
+      guardianPrincipalId,
+      hashedDeviceId,
+      platform,
+      issuedAt: claims.iat,
+      expiresAt: claims.exp,
+    });
+
+    log.info(
+      { assistantId, platform, guardianPrincipalId, isNew },
+      'Guardian bootstrap completed',
+    );
+
+    return Response.json({
+      guardianPrincipalId,
+      actorToken: token,
+      isNew,
+    });
+  } catch (err) {
+    log.error({ err }, 'Guardian bootstrap failed');
+    return httpError('INTERNAL_ERROR', 'Internal server error', 500);
+  }
+}

--- a/assistant/src/runtime/routes/pairing-routes.ts
+++ b/assistant/src/runtime/routes/pairing-routes.ts
@@ -9,10 +9,66 @@ import {
 } from '../../daemon/approved-devices-store.js';
 import type { ServerMessage } from '../../daemon/ipc-contract.js';
 import { PairingStore } from '../../daemon/pairing-store.js';
+import { getActiveBinding } from '../../memory/guardian-bindings.js';
 import { getLogger } from '../../util/logger.js';
+import { normalizeAssistantId } from '../../util/platform.js';
+import { mintActorToken } from '../actor-token-service.js';
+import {
+  createActorTokenRecord,
+  revokeByDeviceBinding,
+} from '../actor-token-store.js';
 import { httpError } from '../http-errors.js';
 
 const log = getLogger('runtime-http');
+
+/**
+ * Mint an actor token for a paired device if a vellum guardian principal exists.
+ * Returns the raw actor token string, or null if no vellum binding exists.
+ */
+function mintPairingActorToken(deviceId: string, platform: string): string | null {
+  try {
+    const assistantId = normalizeAssistantId('self');
+    const binding = getActiveBinding(assistantId, 'vellum');
+    if (!binding) return null;
+
+    const guardianPrincipalId = binding.guardianExternalUserId;
+    const hashedDeviceId = hashDeviceId(deviceId);
+
+    // Revoke previous tokens for this device
+    revokeByDeviceBinding(assistantId, guardianPrincipalId, hashedDeviceId);
+
+    const { token, tokenHash, claims } = mintActorToken({
+      assistantId,
+      platform,
+      deviceId,
+      guardianPrincipalId,
+    });
+
+    createActorTokenRecord({
+      tokenHash,
+      assistantId,
+      guardianPrincipalId,
+      hashedDeviceId,
+      platform,
+      issuedAt: claims.iat,
+      expiresAt: claims.exp,
+    });
+
+    log.info({ assistantId, platform }, 'Minted actor token during pairing');
+    return token;
+  } catch (err) {
+    log.warn({ err }, 'Failed to mint actor token during pairing — continuing without it');
+    return null;
+  }
+}
+
+/**
+ * Transient in-memory map of pairingRequestId -> actorToken.
+ * Actor tokens are minted when the pairing request is created (we have the
+ * raw deviceId), and retrieved when the status is polled as approved.
+ * Never persisted to disk — cleared when entries expire.
+ */
+const pendingActorTokens = new Map<string, string>();
 
 export interface PairingHandlerContext {
   pairingStore: PairingStore;
@@ -90,13 +146,22 @@ export async function handlePairingRequest(req: Request, ctx: PairingHandlerCont
       refreshDevice(hashedDeviceId, deviceName);
       ctx.pairingStore.approve(pairingRequestId, ctx.bearerToken);
       log.info({ pairingRequestId, hashedDeviceId }, 'Auto-approved allowlisted device');
+      const actorToken = mintPairingActorToken(deviceId, 'ios');
       return Response.json({
         status: 'approved',
         bearerToken: ctx.bearerToken,
         gatewayUrl: entry.gatewayUrl,
         localLanUrl: entry.localLanUrl,
         ...(ctx.featureFlagToken ? { featureFlagToken: ctx.featureFlagToken } : {}),
+        ...(actorToken ? { actorToken } : {}),
       });
+    }
+
+    // Pre-mint actor token while we still have the raw deviceId.
+    // Store in transient memory only — never on disk.
+    const pendingActorToken = mintPairingActorToken(deviceId, 'ios');
+    if (pendingActorToken) {
+      pendingActorTokens.set(pairingRequestId, pendingActorToken);
     }
 
     // Send IPC to macOS to show approval prompt
@@ -139,12 +204,19 @@ export function handlePairingStatus(url: URL, ctx: PairingHandlerContext): Respo
   }
 
   if (entry.status === 'approved') {
+    // Retrieve the pre-minted actor token from transient memory.
+    // Cleared after retrieval to avoid leaking the token on repeated polls.
+    const actorToken = pendingActorTokens.get(id);
+    if (actorToken) {
+      pendingActorTokens.delete(id);
+    }
     return Response.json({
       status: 'approved',
       bearerToken: entry.bearerToken,
       gatewayUrl: entry.gatewayUrl,
       localLanUrl: entry.localLanUrl,
       ...(ctx.featureFlagToken ? { featureFlagToken: ctx.featureFlagToken } : {}),
+      ...(actorToken ? { actorToken } : {}),
     });
   }
 

--- a/assistant/src/runtime/routes/pairing-routes.ts
+++ b/assistant/src/runtime/routes/pairing-routes.ts
@@ -63,11 +63,14 @@ function mintPairingActorToken(deviceId: string, platform: string): string | nul
 }
 
 /**
- * Transient in-memory map of pairingRequestId -> raw deviceId.
+ * Transient in-memory map of pairingRequestId -> { deviceId, createdAt }.
  * Stored when a pairing request is initiated (we have the raw deviceId)
  * so the token can be minted later when the pairing is actually approved.
+ * Entries include a timestamp so stale entries can be swept if the
+ * corresponding pairing expires without an explicit deny.
  */
-const pendingDeviceIds = new Map<string, string>();
+const PENDING_DEVICE_ID_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const pendingDeviceIds = new Map<string, { deviceId: string; createdAt: number }>();
 
 /**
  * Transient in-memory map of pairingRequestId -> { actorToken, approvedAt }.
@@ -88,6 +91,21 @@ function sweepApprovedTokens(): void {
   for (const [id, entry] of approvedActorTokens) {
     if (now - entry.approvedAt > TOKEN_RETRIEVAL_TTL_MS) {
       approvedActorTokens.delete(id);
+    }
+  }
+}
+
+/**
+ * Sweep stale entries from the pending device IDs map.
+ * Entries older than PENDING_DEVICE_ID_TTL_MS are removed to prevent
+ * unbounded accumulation of raw device identifiers when pairings expire
+ * without an explicit deny.
+ */
+function sweepPendingDeviceIds(): void {
+  const now = Date.now();
+  for (const [id, entry] of pendingDeviceIds) {
+    if (now - entry.createdAt > PENDING_DEVICE_ID_TTL_MS) {
+      pendingDeviceIds.delete(id);
     }
   }
 }
@@ -191,7 +209,7 @@ export async function handlePairingRequest(req: Request, ctx: PairingHandlerCont
     // Store the raw deviceId transiently so we can mint the actor token
     // later when the pairing is actually approved (avoids revoking existing
     // tokens and creating DB records for unapproved devices).
-    pendingDeviceIds.set(pairingRequestId, deviceId);
+    pendingDeviceIds.set(pairingRequestId, { deviceId, createdAt: Date.now() });
 
     // Send IPC to macOS to show approval prompt
     if (ctx.pairingBroadcast) {
@@ -229,24 +247,29 @@ export function handlePairingStatus(url: URL, ctx: PairingHandlerContext): Respo
 
   const entry = ctx.pairingStore.get(id);
   if (!entry) {
+    // Pairing expired or was swept — clean up any lingering pending device ID
+    pendingDeviceIds.delete(id);
     return httpError('NOT_FOUND', 'Not found', 404);
   }
 
   if (entry.status === 'approved') {
-    // Sweep expired token entries on each poll
+    // Sweep expired entries on each poll
     sweepApprovedTokens();
+    sweepPendingDeviceIds();
 
     // Mint the actor token on first approved poll if we still have the
     // raw deviceId from the pairing request. Once minted, the token is
     // cached in approvedActorTokens with a TTL so subsequent polls can
     // still retrieve it if the first response was dropped.
+    // The pending deviceId is only removed after a successful mint so
+    // transient failures allow retries on subsequent polls.
     let tokenEntry = approvedActorTokens.get(id);
     if (!tokenEntry) {
-      const rawDeviceId = pendingDeviceIds.get(id);
-      if (rawDeviceId) {
-        pendingDeviceIds.delete(id);
-        const actorToken = mintPairingActorToken(rawDeviceId, 'ios');
+      const pending = pendingDeviceIds.get(id);
+      if (pending) {
+        const actorToken = mintPairingActorToken(pending.deviceId, 'ios');
         if (actorToken) {
+          pendingDeviceIds.delete(id);
           tokenEntry = { actorToken, approvedAt: Date.now() };
           approvedActorTokens.set(id, tokenEntry);
         }

--- a/assistant/src/runtime/routes/pairing-routes.ts
+++ b/assistant/src/runtime/routes/pairing-routes.ts
@@ -63,12 +63,43 @@ function mintPairingActorToken(deviceId: string, platform: string): string | nul
 }
 
 /**
- * Transient in-memory map of pairingRequestId -> actorToken.
- * Actor tokens are minted when the pairing request is created (we have the
- * raw deviceId), and retrieved when the status is polled as approved.
- * Never persisted to disk — cleared when entries expire.
+ * Transient in-memory map of pairingRequestId -> raw deviceId.
+ * Stored when a pairing request is initiated (we have the raw deviceId)
+ * so the token can be minted later when the pairing is actually approved.
  */
-const pendingActorTokens = new Map<string, string>();
+const pendingDeviceIds = new Map<string, string>();
+
+/**
+ * Transient in-memory map of pairingRequestId -> { actorToken, approvedAt }.
+ * Populated when a pairing is approved and the actor token is minted.
+ * Entries are kept for TOKEN_RETRIEVAL_TTL_MS after approval so that
+ * subsequent polls can still retrieve the token if the first response
+ * was dropped or timed out.
+ */
+const TOKEN_RETRIEVAL_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const approvedActorTokens = new Map<string, { actorToken: string; approvedAt: number }>();
+
+/**
+ * Sweep stale entries from the approved actor tokens map.
+ * Called lazily on each status poll.
+ */
+function sweepApprovedTokens(): void {
+  const now = Date.now();
+  for (const [id, entry] of approvedActorTokens) {
+    if (now - entry.approvedAt > TOKEN_RETRIEVAL_TTL_MS) {
+      approvedActorTokens.delete(id);
+    }
+  }
+}
+
+/**
+ * Clean up all transient pairing state for a given request.
+ * Called when pairing is denied or otherwise finalized.
+ */
+export function cleanupPairingState(pairingRequestId: string): void {
+  pendingDeviceIds.delete(pairingRequestId);
+  approvedActorTokens.delete(pairingRequestId);
+}
 
 export interface PairingHandlerContext {
   pairingStore: PairingStore;
@@ -157,12 +188,10 @@ export async function handlePairingRequest(req: Request, ctx: PairingHandlerCont
       });
     }
 
-    // Pre-mint actor token while we still have the raw deviceId.
-    // Store in transient memory only — never on disk.
-    const pendingActorToken = mintPairingActorToken(deviceId, 'ios');
-    if (pendingActorToken) {
-      pendingActorTokens.set(pairingRequestId, pendingActorToken);
-    }
+    // Store the raw deviceId transiently so we can mint the actor token
+    // later when the pairing is actually approved (avoids revoking existing
+    // tokens and creating DB records for unapproved devices).
+    pendingDeviceIds.set(pairingRequestId, deviceId);
 
     // Send IPC to macOS to show approval prompt
     if (ctx.pairingBroadcast) {
@@ -204,19 +233,33 @@ export function handlePairingStatus(url: URL, ctx: PairingHandlerContext): Respo
   }
 
   if (entry.status === 'approved') {
-    // Retrieve the pre-minted actor token from transient memory.
-    // Cleared after retrieval to avoid leaking the token on repeated polls.
-    const actorToken = pendingActorTokens.get(id);
-    if (actorToken) {
-      pendingActorTokens.delete(id);
+    // Sweep expired token entries on each poll
+    sweepApprovedTokens();
+
+    // Mint the actor token on first approved poll if we still have the
+    // raw deviceId from the pairing request. Once minted, the token is
+    // cached in approvedActorTokens with a TTL so subsequent polls can
+    // still retrieve it if the first response was dropped.
+    let tokenEntry = approvedActorTokens.get(id);
+    if (!tokenEntry) {
+      const rawDeviceId = pendingDeviceIds.get(id);
+      if (rawDeviceId) {
+        pendingDeviceIds.delete(id);
+        const actorToken = mintPairingActorToken(rawDeviceId, 'ios');
+        if (actorToken) {
+          tokenEntry = { actorToken, approvedAt: Date.now() };
+          approvedActorTokens.set(id, tokenEntry);
+        }
+      }
     }
+
     return Response.json({
       status: 'approved',
       bearerToken: entry.bearerToken,
       gatewayUrl: entry.gatewayUrl,
       localLanUrl: entry.localLanUrl,
       ...(ctx.featureFlagToken ? { featureFlagToken: ctx.featureFlagToken } : {}),
-      ...(actorToken ? { actorToken } : {}),
+      ...(tokenEntry ? { actorToken: tokenEntry.actorToken } : {}),
     });
   }
 


### PR DESCRIPTION
Part of #10751. Adds actor-token mint/verify service with hash-only storage, POST /v1/integrations/guardian/vellum/bootstrap endpoint, startup migration for existing assistants, and pairing extension to return actor tokens. Closes #10752.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
