### PR TITLE
fix: prevent macOS git shim popup during daemon operations

### DIFF
--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -16,6 +16,11 @@ const log = getLogger('workspace-git');
  * Strips all GIT_* env vars (e.g. GIT_DIR, GIT_WORK_TREE) that CI runners
  * or parent processes may set, then adds GIT_CEILING_DIRECTORIES to prevent
  * walking up to a parent repo.
+ *
+ * On macOS, augments PATH with common binary directories so the real git
+ * binary is found even when the daemon is launched from a .app bundle with
+ * a minimal PATH. Without this, the macOS /usr/bin/git shim triggers an
+ * "Install Command Line Developer Tools" popup on every git invocation.
  */
 function cleanGitEnv(workspaceDir: string): Record<string, string> {
   const env: Record<string, string> = {};
@@ -25,6 +30,20 @@ function cleanGitEnv(workspaceDir: string): Record<string, string> {
     }
   }
   env.GIT_CEILING_DIRECTORIES = workspaceDir;
+
+  const home = process.env.HOME ?? '';
+  const extraDirs = [
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+    `${home}/.local/bin`,
+  ];
+  const currentPath = env.PATH ?? '';
+  const pathDirs = currentPath.split(':');
+  const missing = extraDirs.filter(d => !pathDirs.includes(d));
+  if (missing.length > 0) {
+    env.PATH = [...missing, currentPath].filter(Boolean).join(':');
+  }
+
   return env;
 }
 

--- a/cli/src/adapters/install.sh
+++ b/cli/src/adapters/install.sh
@@ -41,6 +41,10 @@ ensure_git() {
         exit 1
     fi
 
+    # Clear bash's command hash so it finds the newly installed git binary
+    # instead of the cached path to the macOS /usr/bin/git shim.
+    hash -r 2>/dev/null || true
+
     if ! git --version >/dev/null 2>&1; then
         error "git installation failed. Please install manually."
         exit 1

--- a/cli/src/adapters/install.sh
+++ b/cli/src/adapters/install.sh
@@ -14,13 +14,23 @@ success() { printf "${GREEN}${BOLD}==>${RESET} ${BOLD}%s${RESET}\n" "$1"; }
 error() { printf "${RED}error:${RESET} %s\n" "$1" >&2; }
 
 ensure_git() {
-    if command -v git >/dev/null 2>&1; then
+    # On macOS, /usr/bin/git is a shim that triggers an "Install Command Line
+    # Developer Tools" popup instead of running git. Check that git actually
+    # works, not just that the binary exists.
+    if command -v git >/dev/null 2>&1 && git --version >/dev/null 2>&1; then
         success "git already installed ($(git --version))"
         return
     fi
 
     info "Installing git..."
-    if command -v apt-get >/dev/null 2>&1; then
+    if [ "$(uname -s)" = "Darwin" ]; then
+        if command -v brew >/dev/null 2>&1; then
+            brew install git
+        else
+            error "git is required. Install Homebrew (https://brew.sh) then run: brew install git"
+            exit 1
+        fi
+    elif command -v apt-get >/dev/null 2>&1; then
         sudo apt-get update -qq && sudo apt-get install -y -qq git
     elif command -v yum >/dev/null 2>&1; then
         sudo yum install -y git
@@ -31,7 +41,7 @@ ensure_git() {
         exit 1
     fi
 
-    if ! command -v git >/dev/null 2>&1; then
+    if ! git --version >/dev/null 2>&1; then
         error "git installation failed. Please install manually."
         exit 1
     fi


### PR DESCRIPTION
## Summary
- On Mac mini, every message sent via `vellum client` triggers a macOS "git requires command line developer tools" popup
- **Root cause 1:** `cleanGitEnv()` in `git-service.ts` passes the daemon's inherited PATH as-is. When launched from Vellum.app, the PATH is minimal and only includes `/usr/bin/git` (Apple's shim that triggers the popup). Now augments PATH with `/opt/homebrew/bin`, `/usr/local/bin`, and `~/.local/bin` so the real Homebrew-installed git is found first.
- **Root cause 2:** `ensure_git()` in `install.sh` uses `command -v git` which passes on macOS because the shim exists at `/usr/bin/git`. Now verifies git actually works with `git --version` and adds macOS/Homebrew support to the installer.

## Test plan
- [ ] On a Mac mini with git installed via Homebrew, verify `vellum client` no longer triggers the Xcode CLI tools popup
- [ ] On a fresh Mac mini without git, verify the install script detects the shim and installs git via Homebrew
- [ ] On Linux, verify the install script still works with apt-get/yum/apk

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
