### PR TITLE
fix: resolve web-tree-sitter.wasm in global bun installs

### DIFF
--- a/assistant/src/tools/terminal/parser.ts
+++ b/assistant/src/tools/terminal/parser.ts
@@ -132,6 +132,16 @@ function findWasmPath(pkg: string, file: string): string {
     return execDirPath;
   }
 
+  // Use module resolution to find the package. This handles hoisted
+  // dependencies (e.g. global bun installs where web-tree-sitter is at the
+  // top-level node_modules rather than nested under @vellumai/assistant).
+  try {
+    const resolved = require.resolve(`${pkg}/package.json`);
+    const pkgDir = dirname(resolved);
+    const resolvedPath = join(pkgDir, file);
+    if (existsSync(resolvedPath)) return resolvedPath;
+  } catch { /* fall through to manual resolution */ }
+
   const sourcePath = join(dir, '..', '..', '..', 'node_modules', pkg, file);
 
   if (existsSync(sourcePath)) return sourcePath;

--- a/assistant/src/tools/terminal/parser.ts
+++ b/assistant/src/tools/terminal/parser.ts
@@ -140,7 +140,9 @@ function findWasmPath(pkg: string, file: string): string {
     const pkgDir = dirname(resolved);
     const resolvedPath = join(pkgDir, file);
     if (existsSync(resolvedPath)) return resolvedPath;
-  } catch { /* fall through to manual resolution */ }
+  } catch (err) {
+    log.warn({ err, pkg, file }, 'require.resolve failed for WASM package, falling back to manual resolution');
+  }
 
   const sourcePath = join(dir, '..', '..', '..', 'node_modules', pkg, file);
 


### PR DESCRIPTION
## Summary

- Fixes `ENOENT: no such file or directory` for `web-tree-sitter.wasm` when Vellum is installed globally via `bun install -g vellum@latest` (e.g. on mac mini via install.sh)
- Root cause: bun hoists `web-tree-sitter` to the top-level `node_modules/` in global installs, but `findWasmPath()` only looked for it nested under `@vellumai/assistant/node_modules/`
- Fix: use `require.resolve()` as the primary resolution strategy for non-compiled-binary environments, letting the module system find the package regardless of hoisting layout

## Test plan

- [x] All 116 parser tests pass
- [ ] Verify on mac mini: `curl ... | bash` install flow completes without WASM errors
- [ ] Verify macOS .app bundle still works (compiled binary path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
