### PR TITLE
fix: normalize dynamic_page fields in ui_show to prevent blank surfaces

### DIFF
--- a/assistant/src/__tests__/session-surfaces-task-progress.test.ts
+++ b/assistant/src/__tests__/session-surfaces-task-progress.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import type {
   CardSurfaceData,
+  DynamicPageSurfaceData,
   ServerMessage,
   SurfaceData,
   SurfaceType,
@@ -94,6 +95,48 @@ describe('task_progress surface compatibility', () => {
     expect(card.title).toBe('Ordering from DoorDash');
     expect(card.body).toBe('');
     expect((card.templateData as Record<string, unknown>).status).toBe('in_progress');
+  });
+
+  test('ui_show normalizes top-level dynamic_page fields into data', async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const result = await surfaceProxyResolver(ctx, 'ui_show', {
+      surface_type: 'dynamic_page',
+      title: 'My Slides',
+      html: '<h1>Hello</h1>',
+      preview: { title: 'Slides', subtitle: '3 slides about Apple' },
+    });
+
+    expect(result.isError).toBe(false);
+
+    const showMessage = sent.find((msg): msg is UiSurfaceShow => msg.type === 'ui_surface_show');
+    expect(showMessage).toBeDefined();
+    if (!showMessage || showMessage.surfaceType !== 'dynamic_page') return;
+
+    const page = showMessage.data as DynamicPageSurfaceData;
+    expect(page.html).toBe('<h1>Hello</h1>');
+    expect(page.preview).toEqual({ title: 'Slides', subtitle: '3 slides about Apple' });
+  });
+
+  test('ui_show dynamic_page uses data.html when properly nested', async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const result = await surfaceProxyResolver(ctx, 'ui_show', {
+      surface_type: 'dynamic_page',
+      title: 'My Slides',
+      data: { html: '<h1>Nested</h1>' },
+    });
+
+    expect(result.isError).toBe(false);
+
+    const showMessage = sent.find((msg): msg is UiSurfaceShow => msg.type === 'ui_surface_show');
+    expect(showMessage).toBeDefined();
+    if (!showMessage || showMessage.surfaceType !== 'dynamic_page') return;
+
+    const page = showMessage.data as DynamicPageSurfaceData;
+    expect(page.html).toBe('<h1>Nested</h1>');
   });
 
   test('ui_update normalizes top-level task_progress fields into templateData', async () => {

--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -25,6 +25,32 @@ const log = getLogger('session-surfaces');
 const MAX_UNDO_DEPTH = 10;
 const TASK_PROGRESS_TEMPLATE_FIELDS = ['title', 'status', 'steps'] as const;
 
+/**
+ * Migrate dynamic_page fields from the top-level tool input into `data`.
+ *
+ * The LLM sometimes sends `html`, `width`, `height`, or `preview` at the
+ * top level instead of nested inside `data`. Without this normalization the
+ * surface opens blank because `rawData` is `{}`.
+ */
+function normalizeDynamicPageShowData(input: Record<string, unknown>, rawData: Record<string, unknown>): DynamicPageSurfaceData {
+  const normalized: Record<string, unknown> = { ...rawData };
+
+  if (typeof normalized.html !== 'string' && typeof input.html === 'string') {
+    normalized.html = input.html;
+  }
+  if (normalized.width == null && input.width != null) {
+    normalized.width = input.width;
+  }
+  if (normalized.height == null && input.height != null) {
+    normalized.height = input.height;
+  }
+  if (!isPlainObject(normalized.preview) && isPlainObject(input.preview)) {
+    normalized.preview = input.preview;
+  }
+
+  return normalized as unknown as DynamicPageSurfaceData;
+}
+
 function normalizeCardShowData(input: Record<string, unknown>, rawData: Record<string, unknown>): CardSurfaceData {
   const normalized: Record<string, unknown> = { ...rawData };
 
@@ -592,7 +618,9 @@ export async function surfaceProxyResolver(
     const rawData = isPlainObject(input.data) ? input.data : {};
     const data = (surfaceType === 'card'
       ? normalizeCardShowData(input, rawData)
-      : rawData) as SurfaceData;
+      : surfaceType === 'dynamic_page'
+        ? normalizeDynamicPageShowData(input, rawData)
+        : rawData) as SurfaceData;
     const actions = input.actions as Array<{ id: string; label: string; style?: string }> | undefined;
     // Interactive surfaces default to awaiting user action.
     const hasActions = Array.isArray(actions) && actions.length > 0;


### PR DESCRIPTION
## Summary
- Add `normalizeDynamicPageShowData()` to migrate `html`, `width`, `height`, and `preview` from top-level tool input into the `data` object when the LLM omits the `data` wrapper — same pattern as existing `normalizeCardShowData()` for cards
- Add tests for both dynamic_page normalization paths (top-level fields and properly nested)
- Fixes blank `dynamic_page` surfaces when the LLM calls `ui_show` without wrapping fields in `data`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
