### PR TITLE
feat: show QR code data on iOS pairing failed screen

### DIFF
--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -200,6 +200,29 @@ struct QRPairingSheet: View {
                     .padding(.horizontal, VSpacing.xl)
             }
 
+            if let payload = scannedPayload {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("QR Code Data")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                    Group {
+                        Text("Gateway: \(payload.gatewayURL)")
+                        Text("LAN: \(payload.localLanUrl ?? "none")")
+                        Text("Host ID: \(String(payload.hostId.prefix(12)))…")
+                        Text("Request ID: \(String(payload.pairingRequestId.prefix(8)))…")
+                    }
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(VColor.textSecondary)
+                }
+                .padding(.horizontal, VSpacing.xl)
+                .padding(.vertical, VSpacing.sm)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color(.systemGray6))
+                )
+                .padding(.horizontal, VSpacing.xl)
+            }
+
             Spacer()
 
             VStack(spacing: VSpacing.md) {

--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -18,6 +18,7 @@ struct QRPairingSheet: View {
     @State private var phase: PairingPhase = .scanning
     @State private var scannedPayload: DaemonQRPayloadV4?
     @State private var errorMessage: String?
+    @State private var failureReason: String?
     @State private var pollTimer: Timer?
     @State private var pairingTask: Task<Void, Never>?
 
@@ -202,10 +203,13 @@ struct QRPairingSheet: View {
 
             if let payload = scannedPayload {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("QR Code Data")
+                    Text("Debug Info")
                         .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
                     Group {
+                        if let reason = failureReason {
+                            Text("Reason: \(reason)")
+                        }
                         Text("Gateway: \(payload.gatewayURL)")
                         Text("LAN: \(payload.localLanUrl ?? "none")")
                         Text("Host ID: \(String(payload.hostId.prefix(12)))…")
@@ -230,6 +234,7 @@ struct QRPairingSheet: View {
                     phase = .scanning
                     scannedPayload = nil
                     errorMessage = nil
+                    failureReason = nil
                 }
                 .buttonStyle(.borderedProminent)
 
@@ -311,18 +316,21 @@ struct QRPairingSheet: View {
         }
 
         pairingTask = Task {
+            var lastFailureReason: String?
+
             // Try LAN first if available
             if let lanUrl = payload.localLanUrl,
                isAllowedLocalHttp(urlString: lanUrl, payload: payload) {
-                let result = await attemptPairingRequest(
+                let (json, reason) = await attemptPairingRequest(
                     baseURL: lanUrl,
                     jsonData: jsonData,
                     timeoutSeconds: 3
                 )
-                if let result = result {
-                    handlePairingResponse(result, payload: payload, effectiveBaseURL: lanUrl)
+                if let json = json {
+                    handlePairingResponse(json, payload: payload, effectiveBaseURL: lanUrl)
                     return
                 }
+                lastFailureReason = reason.map { "LAN: \($0)" }
                 // LAN failed — but if we were cancelled while waiting, stop here
                 // instead of falling through to the gateway path.
                 guard !Task.isCancelled else { return }
@@ -330,24 +338,29 @@ struct QRPairingSheet: View {
             }
 
             // Cloud gateway
-            let result = await attemptPairingRequest(
+            let (json, reason) = await attemptPairingRequest(
                 baseURL: payload.gatewayURL,
                 jsonData: jsonData,
                 timeoutSeconds: 15
             )
-            if let result = result {
-                handlePairingResponse(result, payload: payload, effectiveBaseURL: payload.gatewayURL)
+            if let json = json {
+                handlePairingResponse(json, payload: payload, effectiveBaseURL: payload.gatewayURL)
             } else if !Task.isCancelled {
+                let gatewayReason = reason.map { "Gateway: \($0)" }
+                let combinedReason = [lastFailureReason, gatewayReason].compactMap { $0 }.joined(separator: "\n")
                 await MainActor.run {
                     errorMessage = "Could not reach your Assistant. Make sure your Assistant is online and try again."
+                    failureReason = combinedReason.isEmpty ? nil : combinedReason
                     phase = .error
                 }
             }
         }
     }
 
-    private func attemptPairingRequest(baseURL: String, jsonData: Data, timeoutSeconds: TimeInterval) async -> [String: Any]? {
-        guard let url = URL(string: "\(baseURL)/pairing/request") else { return nil }
+    private func attemptPairingRequest(baseURL: String, jsonData: Data, timeoutSeconds: TimeInterval) async -> (json: [String: Any]?, failureReason: String?) {
+        guard let url = URL(string: "\(baseURL)/pairing/request") else {
+            return (nil, "Invalid URL: \(baseURL)/pairing/request")
+        }
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -357,14 +370,19 @@ struct QRPairingSheet: View {
 
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse,
-                  (200..<300).contains(httpResponse.statusCode),
-                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                return nil
+            guard let httpResponse = response as? HTTPURLResponse else {
+                return (nil, "Non-HTTP response from \(baseURL)")
             }
-            return json
+            guard (200..<300).contains(httpResponse.statusCode) else {
+                let body = String(data: data, encoding: .utf8) ?? ""
+                return (nil, "HTTP \(httpResponse.statusCode) from \(baseURL): \(body)")
+            }
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return (nil, "Invalid JSON response from \(baseURL)")
+            }
+            return (json, nil)
         } catch {
-            return nil
+            return (nil, "\(error.localizedDescription)")
         }
     }
 
@@ -519,7 +537,8 @@ struct QRPairingSheet: View {
                 }
             } catch {
                 await MainActor.run {
-                    errorMessage = "Couldn't connect: \(error.localizedDescription)"
+                    errorMessage = "Couldn't connect to your Assistant."
+                    failureReason = error.localizedDescription
                     phase = .error
                 }
             }


### PR DESCRIPTION
## Summary
- Displays QR code payload data (gateway URL, LAN URL, host ID, request ID) on the iOS pairing failed screen
- Shown between the "Could not reach" error message and the "Try Again" button
- Uses monospaced font in a gray rounded rectangle for readability
- Host ID and request ID are truncated for display

## Test plan
- [ ] Trigger a pairing failure on iOS and verify the QR code data section appears
- [ ] Verify gateway URL, LAN URL, host ID, and request ID are displayed correctly
- [ ] Verify layout looks correct with and without a LAN URL present

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
