### PR TITLE
fix: clear name capture timeout on transport close

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -346,6 +346,10 @@ export class RelayConnection {
   handleTransportClosed(code?: number, reason?: string): void {
     // Clean up access request wait state on disconnect to stop polling
     this.clearAccessRequestWait();
+    if (this.nameCaptureTimeoutTimer) {
+      clearTimeout(this.nameCaptureTimeoutTimer);
+      this.nameCaptureTimeoutTimer = null;
+    }
 
     const session = getCallSession(this.callSessionId);
     if (!session) return;


### PR DESCRIPTION
## Summary
Clear the `nameCaptureTimeoutTimer` in `handleTransportClosed` to prevent a leaked timer from overwriting a finalized session status.

**Bug:** When an unknown caller hangs up during the name capture phase, `handleTransportClosed` finalizes the session as `completed` but does not clear the 30s name capture timeout. The leaked timer fires later and overwrites the status to `failed` with a misleading error, corrupting call analytics and audit trails.

**Fix:** Add `nameCaptureTimeoutTimer` cleanup alongside the existing `clearAccessRequestWait()` call in `handleTransportClosed`.

Addresses https://github.com/vellum-ai/vellum-assistant/pull/10720#discussion_r2867895455
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
