### PR TITLE
fix: show 'Published' with copy button instead of 'Copied!' after publishing

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -840,6 +840,7 @@ struct DynamicWorkspaceWrapper: View {
     let onMicrophoneToggle: () -> Void
 
     @State private var showVersionHistory = false
+    @State private var publishUrlCopied = false
 
     var body: some View {
         ZStack {
@@ -933,11 +934,7 @@ struct DynamicWorkspaceWrapper: View {
                                 .controlSize(.small)
                                 .frame(height: 24)
                         } else if let url = sharing.publishedUrl {
-                            VButton(label: "Copied!", icon: "checkmark", style: .tertiary) {
-                                NSPasteboard.general.clearContents()
-                                NSPasteboard.general.setString(url, forType: .string)
-                            }
-                            .controlSize(.small)
+                            PublishedButton(url: url, copied: $publishUrlCopied)
                         } else {
                             VButton(label: "Publish", icon: "arrow.up.right", style: .tertiary) {
                                 onPublishPage(data.html, data.preview?.title, data.appId)
@@ -981,6 +978,61 @@ struct DynamicWorkspaceWrapper: View {
             }
             } // else (not showing version history)
         }
+    }
+}
+
+/// Shows "Published ✓" with an inline copy-to-clipboard button.
+/// Tapping the copy icon copies the URL and briefly shows a checkmark.
+private struct PublishedButton: View {
+    let url: String
+    @Binding var copied: Bool
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(url, forType: .string)
+            copied = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                copied = false
+            }
+        } label: {
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(VColor.success)
+                Text("Published")
+                    .font(VFont.caption)
+                Divider()
+                    .frame(height: 12)
+                Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(copied ? VColor.success : VColor.buttonSecondaryText)
+                    .animation(VAnimation.fast, value: copied)
+            }
+            .foregroundColor(VColor.buttonSecondaryText)
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.buttonV)
+            .frame(height: 24)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .fill(isHovered ? VColor.ghostHover : .clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .stroke(VColor.buttonSecondaryBorder, lineWidth: 1)
+            )
+            .contentShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            isHovered = hovering
+            if hovering { NSCursor.pointingHand.set() }
+            else { NSCursor.arrow.set() }
+        }
+        .controlSize(.small)
+        .accessibilityLabel(copied ? "URL copied" : "Copy published URL")
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace the misleading "Copied!" button that appears after publishing an app with a "Published" label (green checkmark) and an inline copy-to-clipboard button
- Clicking the copy icon copies the published URL and briefly shows a checkmark confirmation (1.5s)
- Extracted into a dedicated `PublishedButton` view with proper hover states and accessibility labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
