### PR TITLE
fix: dev watch opt-in, strip markdown from titles, fix grid padding

### DIFF
--- a/assistant/src/cli/core-commands.ts
+++ b/assistant/src/cli/core-commands.ts
@@ -107,8 +107,9 @@ export function registerDaemonCommand(program: Command): void {
 export function registerDevCommand(program: Command): void {
   program
     .command('dev')
-    .description('Run the daemon in dev mode with auto-restart on file changes')
-    .action(async () => {
+    .description('Run the daemon in dev mode')
+    .option('--watch', 'Auto-restart on source file changes (disruptive during Claude Code sessions)')
+    .action(async (opts: { watch?: boolean }) => {
       let status = await getDaemonStatus();
       if (status.running) {
         log.info('Stopping existing daemon...');
@@ -161,10 +162,12 @@ export function registerDevCommand(program: Command): void {
 
       const mainPath = `${import.meta.dirname}/../daemon/main.ts`;
 
-      log.info('Starting daemon in dev mode (Ctrl+C to stop)');
+      const useWatch = opts.watch === true;
+      log.info(`Starting daemon in dev mode${useWatch ? ' with file watching' : ''} (Ctrl+C to stop)`);
 
       const repoRoot = join(import.meta.dirname, '..', '..', '..');
-      const child = spawn('bun', ['--watch', 'run', mainPath], {
+      const args = useWatch ? ['--watch', 'run', mainPath] : ['run', mainPath];
+      const child = spawn('bun', args, {
         stdio: 'inherit',
         env: {
           ...process.env,

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -286,7 +286,7 @@ function buildTitlePrompt(
   assistantResponse?: string,
 ): string {
   const parts: string[] = [
-    'Generate a very short title for this conversation. Rules: at most 5 words, at most 40 characters, no quotes.',
+    'Generate a very short title for this conversation. Rules: at most 5 words, at most 40 characters, no quotes, no markdown formatting.',
   ];
 
   if (context) {
@@ -313,10 +313,24 @@ function buildTitlePrompt(
 
 function normalizeTitle(raw: string): string {
   let title = raw.trim().replace(/^["']|["']$/g, '');
+  title = stripMarkdown(title);
   const words = title.split(/\s+/);
   if (words.length > 5) title = words.slice(0, 5).join(' ');
   if (title.length > 40) title = title.slice(0, 40).trimEnd();
   return title;
+}
+
+/** Strip common markdown formatting so titles render as plain text. */
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/\*\*(.+?)\*\*/g, '$1')   // **bold**
+    .replace(/__(.+?)__/g, '$1')        // __bold__
+    .replace(/\*(.+?)\*/g, '$1')        // *italic*
+    .replace(/_(.+?)_/g, '$1')          // _italic_
+    .replace(/~~(.+?)~~/g, '$1')        // ~~strikethrough~~
+    .replace(/`(.+?)`/g, '$1')          // `code`
+    .replace(/\[(.+?)\]\(.+?\)/g, '$1') // [link](url)
+    .replace(/^#{1,6}\s+/gm, '');       // # headings
 }
 
 function deriveFallbackTitle(context?: TitleContext): string | null {
@@ -328,7 +342,7 @@ function deriveFallbackTitle(context?: TitleContext): string | null {
 
 function buildRegenerationPrompt(recentMessages: MessageRow[]): string {
   const parts: string[] = [
-    'Generate a very short title for this conversation based on the recent messages below. Rules: at most 5 words, at most 40 characters, no quotes.',
+    'Generate a very short title for this conversation based on the recent messages below. Rules: at most 5 words, at most 40 characters, no quotes, no markdown formatting.',
     '',
     'Recent messages:',
   ];

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -71,7 +71,6 @@ struct AppsGridView: View {
                 .font(VFont.caption)
                 .foregroundColor(VColor.textMuted)
                 .tracking(1.2)
-                .padding(.leading, VSpacing.xs)
 
             LazyVGrid(columns: columns, spacing: VSpacing.xl) {
                 ForEach(filteredPinnedApps) { app in
@@ -87,7 +86,6 @@ struct AppsGridView: View {
                 .font(VFont.caption)
                 .foregroundColor(VColor.textMuted)
                 .tracking(1.2)
-                .padding(.leading, VSpacing.xs)
 
             LazyVGrid(columns: columns, spacing: VSpacing.xl) {
                 ForEach(apps) { app in
@@ -103,7 +101,6 @@ struct AppsGridView: View {
                 .font(VFont.caption)
                 .foregroundColor(VColor.textMuted)
                 .tracking(1.2)
-                .padding(.leading, VSpacing.xs)
 
             let visibleRecent = Array(filteredRecentApps.prefix(recentVisibleCount))
 
@@ -159,9 +156,8 @@ struct AppsGridView: View {
                     .foregroundColor(VColor.textSecondary)
                     .lineLimit(1)
                     .truncationMode(.tail)
-                    .frame(maxWidth: .infinity)
-                    .multilineTextAlignment(.center)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .buttonStyle(.plain)
         .scaleEffect(isHovered ? 1.05 : 1.0)


### PR DESCRIPTION
## Summary
- Make `--watch` flag opt-in for `vellum dev` to avoid disruptive restarts during Claude Code sessions
- Strip markdown formatting from conversation titles and instruct LLM not to use markdown in titles
- Remove extra left padding on section headers in the apps grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
