### PR TITLE
fix: cancel previous timer on rapid copy clicks in PublishedButton

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -988,15 +988,17 @@ private struct PublishedButton: View {
     @Binding var copied: Bool
 
     @State private var isHovered = false
+    @State private var resetTimer: DispatchWorkItem?
 
     var body: some View {
         Button {
+            resetTimer?.cancel()
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(url, forType: .string)
             copied = true
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                copied = false
-            }
+            let timer = DispatchWorkItem { copied = false }
+            resetTimer = timer
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: timer)
         } label: {
             HStack(spacing: VSpacing.xs) {
                 Image(systemName: "checkmark")


### PR DESCRIPTION
Addresses Devin review feedback on #10771. Uses DispatchWorkItem pattern (matching ChatBubble.swift) to cancel the previous reset timer before scheduling a new one, preventing premature copied-state reset on rapid clicks.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
