### PR TITLE
fix: add timeout fallback for app loading state

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -194,24 +194,18 @@ extension MainWindowView {
             } else {
                 // Loading state while waiting for daemon to send surface data
                 // via ui_surface_show in response to app_open_request.
-                VStack(spacing: VSpacing.md) {
-                    Spacer()
-                    ProgressView()
-                        .controlSize(.regular)
-                    Text("Loading app…")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textMuted)
-                    Spacer()
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(VColor.backgroundSubtle)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-                .overlay(alignment: .topTrailing) {
-                    VIconButton(label: "Close", icon: "xmark", iconOnly: true) {
+                AppLoadingView(
+                    appId: {
+                        if case .app(let id) = windowState.selection { return id }
+                        return nil
+                    }(),
+                    onRetry: { appId in
+                        try? daemonClient.sendAppOpen(appId: appId)
+                    },
+                    onClose: {
                         windowState.closeDynamicPanel()
                     }
-                    .padding(VSpacing.lg)
-                }
+                )
             }
         case .appEditing:
             // VSplitView: ChatView (left) + workspace (right)
@@ -1033,6 +1027,77 @@ private struct PublishedButton: View {
         }
         .controlSize(.small)
         .accessibilityLabel(copied ? "URL copied" : "Copy published URL")
+    }
+}
+
+// MARK: - App Loading View
+
+/// Shows a loading spinner while waiting for the daemon to send surface data,
+/// with a timeout that transitions to an error state so the user isn't stuck
+/// on an infinite spinner when the daemon fails to respond.
+private struct AppLoadingView: View {
+    let appId: String?
+    let onRetry: (String) -> Void
+    let onClose: () -> Void
+
+    private static let timeoutSeconds: UInt64 = 8
+
+    @State private var timedOut = false
+
+    var body: some View {
+        VStack(spacing: VSpacing.md) {
+            Spacer()
+            if timedOut {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.system(size: 28, weight: .light))
+                    .foregroundColor(VColor.warning)
+                Text("Failed to load app")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                Text("The app didn't respond in time. It may be unavailable or still starting up.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 280)
+                HStack(spacing: VSpacing.sm) {
+                    if let appId {
+                        VButton(label: "Retry", icon: "arrow.clockwise", style: .secondary) {
+                            timedOut = false
+                            onRetry(appId)
+                        }
+                        .controlSize(.small)
+                    }
+                    VButton(label: "Close", style: .tertiary) {
+                        onClose()
+                    }
+                    .controlSize(.small)
+                }
+                .padding(.top, VSpacing.xs)
+            } else {
+                ProgressView()
+                    .controlSize(.regular)
+                Text("Loading app\u{2026}")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textMuted)
+            }
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(VColor.backgroundSubtle)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .overlay(alignment: .topTrailing) {
+            VIconButton(label: "Close", icon: "xmark", iconOnly: true) {
+                onClose()
+            }
+            .padding(VSpacing.lg)
+        }
+        .task(id: timedOut) {
+            guard !timedOut else { return }
+            try? await Task.sleep(nanoseconds: Self.timeoutSeconds * 1_000_000_000)
+            if !Task.isCancelled {
+                timedOut = true
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Addresses Codex review feedback on #10749. Adds a timeout mechanism to the app loading state so users see a recoverable error instead of an infinite spinner when the app surface fails to arrive.

## Summary

- Extracts the app loading spinner into a dedicated `AppLoadingView` struct with built-in timeout handling
- After 8 seconds without a surface response, transitions from loading spinner to an error state with a warning icon, explanation, Retry button, and Close button
- Retry resets the timer and re-sends `app_open_request` to the daemon
- If the surface arrives before timeout, SwiftUI removes the loading view (cancelling the timer automatically)

## Test plan

- [ ] Open an app from the apps grid -- verify normal loading spinner appears briefly then the app renders
- [ ] Disconnect the daemon and open an app -- verify error state appears after ~8 seconds with Retry and Close buttons
- [ ] Click Retry -- verify spinner reappears and timer restarts
- [ ] Click Close -- verify the panel dismisses cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
