### PR TITLE
feat: browser-automated Vercel token setup on publish

### DIFF
--- a/assistant/src/config/bundled-skills/vercel-token-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/vercel-token-setup/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: "Vercel Token Setup"
+description: "Set up a Vercel API token for publishing apps using browser automation"
+includes: ["browser"]
+metadata: {"vellum": {"emoji": "▲"}}
+---
+
+You are helping your user set up a Vercel API token so they can publish apps to the web.
+
+## Client Check
+
+Determine whether the user has browser automation available (macOS desktop app) or is on a non-interactive channel (Telegram, SMS, etc.).
+
+- **macOS desktop app**: Follow the **Automated Setup** path below.
+- **Telegram or other channel** (no browser automation): Follow the **Manual Setup for Channels** path below.
+
+---
+
+# Path A: Manual Setup for Channels (Telegram, SMS, etc.)
+
+When the user is on Telegram or any non-macOS client, walk them through a text-based setup. No browser automation is used — the user follows links and performs each action manually.
+
+### Channel Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Vercel API Token**
+>
+> Since I can't automate the browser from here, I'll walk you through each step with direct links. You'll need:
+> 1. A Vercel account (free tier works)
+> 2. About 2 minutes
+>
+> Ready to start?
+
+If the user declines, acknowledge and stop.
+
+### Channel Step 2: Create the Token
+
+Tell the user:
+
+> **Step 1: Create an API token**
+>
+> Open this link to go to your Vercel tokens page:
+> https://vercel.com/account/tokens
+>
+> 1. Click **"Create"** (or **"Create Token"**)
+> 2. Set the token name to **"Vellum Assistant"**
+> 3. Select scope: **"Full Account"**
+> 4. Set expiration to the longest option available (or **"No Expiration"** if offered)
+> 5. Click **"Create Token"**
+>
+> A token value will appear — **copy it now**, as it's only shown once.
+
+### Channel Step 3: Store the Token
+
+Tell the user:
+
+> **Step 2: Send me the token**
+>
+> Please paste the token value into the secure prompt below.
+
+Present the secure prompt:
+
+```
+credential_store prompt:
+  service: "vercel"
+  field: "api_token"
+  label: "Vercel API Token"
+  description: "Paste the API token you just created on vercel.com"
+  placeholder: "Enter your Vercel API token"
+```
+
+Wait for the user to complete the prompt. Once received, store it:
+
+```
+credential_store store:
+  service: "vercel"
+  field: "api_token"
+  value: "<the token the user provided>"
+  allowedTools: ["publish_page", "unpublish_page"]
+  allowedDomains: ["api.vercel.com"]
+```
+
+### Channel Step 4: Done!
+
+> **Vercel is connected!** You can now publish apps to the web. Try clicking Publish on any app you've built.
+
+---
+
+# Path B: Automated Setup (macOS Desktop App)
+
+You will automate Vercel token creation via the browser while the user watches. The user's only manual action is signing in to Vercel (if needed) and one copy-paste for the token value.
+
+## Browser Interaction Principles
+
+Vercel's UI may change over time. Do NOT memorize or depend on specific element IDs, CSS selectors, or DOM structures. Instead:
+
+1. **Screenshot first, act second.** Before every interaction, take a `browser_screenshot` to see the current visual state. Use `browser_snapshot` to find interactive elements.
+2. **Adapt to what you see.** If a button's label or position differs from what you expect, use the screenshot to find the correct element.
+3. **Verify after every action.** After clicking, typing, or navigating, take a new screenshot to confirm the action succeeded.
+4. **Never assume DOM structure.** Use the snapshot to identify what's on the page and interact accordingly.
+5. **When stuck, screenshot and describe.** If you cannot find an expected element after 2 attempts, take a screenshot, describe what you see to the user, and ask for guidance.
+
+## Anti-Loop Guardrails
+
+Each step has a **retry budget of 3 attempts**. An attempt is one try at the step's primary action (e.g., clicking a button, filling a form). If a step fails after 3 attempts:
+
+1. **Stop trying.** Do not continue retrying the same approach.
+2. **Fall back to manual.** Tell the user what you were trying to do and ask them to complete that step manually in the browser. Give them the direct URL and clear text instructions.
+3. **Resume automation** at the next step once the user confirms the manual step is done.
+
+If **two or more steps** require manual fallback, abandon the automated flow entirely and switch to giving the user the remaining steps as clear text instructions with links.
+
+## Things That Do Not Work — Do Not Attempt
+
+These actions are technically impossible in the browser automation environment:
+
+- **Downloading files.** `browser_click` on a Download button does not save files to disk.
+- **Reading the token value from a screenshot.** The token IS visible in the creation dialog, but you MUST NOT attempt to read it from a screenshot — it is too easy to misread characters, and the value must be exact. Always use the `credential_store prompt` approach to let the user copy-paste it accurately.
+- **Clipboard operations.** You cannot copy/paste via browser automation.
+
+## Step 1: Single Upfront Confirmation
+
+Tell the user:
+
+> **Setting up your Vercel API token so we can publish your app...**
+>
+> Here's what will happen:
+> 1. **A browser opens** to your Vercel account settings
+> 2. **You sign in** (if not already signed in)
+> 3. **I create the token** — you just watch
+> 4. **One quick copy-paste** — I'll ask you to copy the token value into a secure prompt
+>
+> Takes about a minute. Ready?
+
+If the user declines, acknowledge and stop. No further confirmations are needed after this point.
+
+## Step 2: Open Vercel and Sign In
+
+**Goal:** The user is signed in and the Vercel tokens page is loaded.
+
+Navigate to `https://vercel.com/account/tokens`.
+
+Take a screenshot and snapshot to check the page state:
+- **Sign-in page:** Tell the user: "Please sign in to your Vercel account in the browser." Then auto-detect sign-in completion by polling screenshots every 5-10 seconds. Check if the current URL has moved away from the login/sign-in page to the tokens page. Do NOT ask the user to "let me know when you're done" — detect it automatically. Once sign-in is detected, tell the user: "Signed in! Creating your API token now..."
+- **Already signed in:** Tell the user: "Already signed in — creating your API token now..." and continue immediately.
+
+**Verify:** URL contains `vercel.com/account/tokens` and no sign-in overlay is visible.
+
+## Step 3: Create Token
+
+**Goal:** A new API token named "Vellum Assistant" is created.
+
+Take a screenshot and snapshot. Find and click the button to create a new token (typically labeled "Create" or "Create Token").
+
+On the creation form:
+- Token name: **"Vellum Assistant"**
+- Scope: Select **"Full Account"** (or the broadest scope available)
+- Expiration: Select the longest option available, or **"No Expiration"** if offered
+- Click create/submit
+
+**Verify:** Take a screenshot. A dialog or section should now display the newly created token value.
+
+## Step 4: Capture Token via Secure Prompt
+
+**Goal:** The token value is securely captured and stored.
+
+### CRITICAL — Token Capture Protocol
+
+After token creation, Vercel shows the token value **once**. You MUST follow this exact sequence — **no improvisation**:
+
+1. Tell the user: "Your token has been created! Please copy the token value shown on screen and paste it into the secure prompt below."
+2. **IMMEDIATELY** present a `credential_store prompt` for the token. This is your ONLY next action.
+3. Wait for the user to paste the token.
+
+**Absolute prohibitions during this step:**
+- Do NOT try to read the token value from the screenshot. It must come from the user via secure prompt to ensure accuracy.
+- Do NOT navigate away from the page until the user has pasted the token.
+- Do NOT click any download or copy buttons.
+
+Present the secure prompt:
+
+```
+credential_store prompt:
+  service: "vercel"
+  field: "api_token"
+  label: "Vercel API Token"
+  description: "Copy the token value shown on the Vercel page and paste it here."
+  placeholder: "Enter your Vercel API token"
+```
+
+Wait for the user to complete the prompt. Once received, store it:
+
+```
+credential_store store:
+  service: "vercel"
+  field: "api_token"
+  value: "<the token the user provided>"
+  allowedTools: ["publish_page", "unpublish_page"]
+  allowedDomains: ["api.vercel.com"]
+```
+
+**Verify:** `credential_store list` shows `api_token` for `vercel`.
+
+## Step 5: Done!
+
+"**Vercel is connected!** Your API token is set up and ready to go. You can now publish apps to the web."
+
+## Error Handling
+
+- **Page load failures:** Retry navigation once. If it still fails, tell the user and ask them to check their internet connection.
+- **Element not found:** Take a fresh screenshot to re-assess. The Vercel UI may have changed. Describe what you see and try alternative approaches. If stuck after 2 attempts, ask the user for guidance.
+- **Token already exists with same name:** This is fine — Vercel allows multiple tokens with the same name. Proceed with creation.
+- **Any unexpected state:** Take a `browser_screenshot`, describe what you see, and ask the user for guidance.

--- a/assistant/src/daemon/handlers/publish.ts
+++ b/assistant/src/daemon/handlers/publish.ts
@@ -4,15 +4,13 @@ import * as net from 'node:net';
 import { v4 as uuid } from 'uuid';
 
 import { createPublishedPage, getPublishedPageByDeploymentId, getPublishedPageByHash, markDeleted, updatePublishedPage } from '../../memory/published-pages-store.js';
-import { setSecureKey } from '../../security/secure-keys.js';
 import { deleteVercelDeployment,deployHtmlToVercel } from '../../services/vercel-deploy.js';
 import { credentialBroker } from '../../tools/credentials/broker.js';
-import { getCredentialMetadata, upsertCredentialMetadata } from '../../tools/credentials/metadata-store.js';
 import type {
   PublishPageRequest,
   UnpublishPageRequest,
 } from '../ipc-protocol.js';
-import { defineHandlers, type HandlerContext,log, requestSecretStandalone } from './shared.js';
+import { defineHandlers, type HandlerContext,log } from './shared.js';
 
 export async function handlePublishPage(
   msg: PublishPageRequest,
@@ -67,50 +65,17 @@ export async function handlePublishPage(
       execute: publishExecute,
     });
 
-    // If no credential found, prompt the user and retry
+    // If no credential found, return a structured error so the client can
+    // trigger the assistant-driven token setup flow instead of blocking on
+    // a vault dialog.
     if (!useResult.success && useResult.reason?.includes('No credential found')) {
-      const allowedTools = ['publish_page', 'unpublish_page'];
-      const secretResult = await requestSecretStandalone(socket, ctx, {
-        service: 'vercel',
-        field: 'api_token',
-        label: 'Vercel API Token',
-        description: 'Required to publish site apps to the web. Create a token at vercel.com/account/tokens.',
-        placeholder: 'Enter your Vercel API token',
-        purpose: 'Publish site apps to the web',
-        allowedTools,
-        allowedDomains: ['api.vercel.com'],
+      ctx.send(socket, {
+        type: 'publish_page_response',
+        success: false,
+        error: 'Vercel API token not configured',
+        errorCode: 'credentials_missing',
       });
-
-      if (!secretResult.value) {
-        ctx.send(socket, {
-          type: 'publish_page_response',
-          success: false,
-          error: 'Cancelled',
-        });
-        return;
-      }
-
-      if (secretResult.delivery === 'transient_send') {
-        // One-time send: inject for single use without persisting to keychain.
-        // Metadata must exist for broker policy checks.
-        if (!getCredentialMetadata('vercel', 'api_token')) {
-          upsertCredentialMetadata('vercel', 'api_token', { allowedTools });
-        }
-        credentialBroker.injectTransient('vercel', 'api_token', secretResult.value);
-      } else {
-        // Default: persist to keychain
-        const storageKey = `credential:vercel:api_token`;
-        setSecureKey(storageKey, secretResult.value);
-        upsertCredentialMetadata('vercel', 'api_token', { allowedTools });
-      }
-
-      // Retry with the newly stored credential
-      useResult = await credentialBroker.serverUse({
-        service: 'vercel',
-        field: 'api_token',
-        toolName: 'publish_page',
-        execute: publishExecute,
-      });
+      return;
     }
 
     if (useResult.success && useResult.result) {

--- a/assistant/src/daemon/ipc-contract/apps.ts
+++ b/assistant/src/daemon/ipc-contract/apps.ts
@@ -342,6 +342,7 @@ export interface PublishPageResponse {
   publicUrl?: string;
   deploymentId?: string;
   error?: string;
+  errorCode?: string;
 }
 
 export interface UnpublishPageResponse {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -17,6 +17,10 @@ final class SharingState {
     var publishedUrl: String?
     var publishError: String?
     var workspaceEditorContentHeight: CGFloat = 20
+    /// Saved publish params for auto-retry after credential setup completes.
+    var pendingPublish: (html: String, title: String?, appId: String?)?
+    /// Timer for polling credential availability during setup flow.
+    var credentialPollTimer: Timer?
 }
 
 /// Sidebar interaction state -- hover, rename, expand/collapse lists, drawer.
@@ -148,12 +152,21 @@ struct MainWindowView: View {
         sharing.publishError = nil
 
         Task { @MainActor in
-            daemonClient.onPublishPageResponse = { response in
+            daemonClient.onPublishPageResponse = { [self] response in
                 sharing.isPublishing = false
                 if response.success, let url = response.publicUrl {
                     sharing.publishedUrl = url
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(url, forType: .string)
+                } else if response.errorCode == "credentials_missing" {
+                    // Save pending publish for auto-retry after credential setup
+                    sharing.pendingPublish = (html: html, title: title, appId: appId)
+                    // Inject message into active session to trigger assistant-driven setup
+                    if let viewModel = threadManager.activeViewModel {
+                        viewModel.inputText = "I want to publish my app but I don't have a Vercel API token set up yet. Can you help me create one and then publish my app?"
+                        viewModel.sendMessage()
+                    }
+                    startCredentialPollForPublish()
                 } else if let error = response.error, error != "Cancelled" {
                     sharing.publishError = error
                     // Auto-dismiss error after 5 seconds
@@ -169,6 +182,43 @@ struct MainWindowView: View {
                 try daemonClient.sendPublishPage(html: html, title: title, appId: appId)
             } catch {
                 sharing.isPublishing = false
+            }
+        }
+    }
+
+    /// Polls the daemon for Vercel credential availability every 3 seconds.
+    /// When the credential appears, auto-retries the pending publish.
+    /// Times out after 5 minutes.
+    private func startCredentialPollForPublish() {
+        sharing.credentialPollTimer?.invalidate()
+        let startTime = Date()
+        let timeout: TimeInterval = 300 // 5 minutes
+
+        sharing.credentialPollTimer = Timer.scheduledTimer(withTimeInterval: 3, repeats: true) { [self] timer in
+            Task { @MainActor in
+                // Timeout check
+                if Date().timeIntervalSince(startTime) > timeout {
+                    timer.invalidate()
+                    sharing.credentialPollTimer = nil
+                    sharing.pendingPublish = nil
+                    return
+                }
+
+                // Poll for credential
+                daemonClient.onVercelApiConfigResponse = { [self] response in
+                    if response.success && response.hasToken, let pending = sharing.pendingPublish {
+                        timer.invalidate()
+                        sharing.credentialPollTimer = nil
+                        sharing.pendingPublish = nil
+                        // Auto-retry publish with saved params
+                        publishPage(html: pending.html, title: pending.title, appId: pending.appId)
+                    }
+                }
+                do {
+                    try daemonClient.sendVercelApiConfig(action: "get")
+                } catch {
+                    // Polling failure is non-fatal; will retry on next tick
+                }
             }
         }
     }

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -3375,13 +3375,15 @@ public struct IPCPublishPageResponse: Codable, Sendable {
     public let publicUrl: String?
     public let deploymentId: String?
     public let error: String?
+    public let errorCode: String?
 
-    public init(type: String, success: Bool, publicUrl: String? = nil, deploymentId: String? = nil, error: String? = nil) {
+    public init(type: String, success: Bool, publicUrl: String? = nil, deploymentId: String? = nil, error: String? = nil, errorCode: String? = nil) {
         self.type = type
         self.success = success
         self.publicUrl = publicUrl
         self.deploymentId = deploymentId
         self.error = error
+        self.errorCode = errorCode
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `vercel-token-setup` bundled skill with browser automation (macOS) and manual text-based (channels) paths for creating Vercel API tokens
- Replace blocking vault dialog in publish handler with `credentials_missing` error code for non-blocking fast return
- Client detects missing credentials, injects setup message into active session, polls for credential availability, and auto-retries publish

## Original prompt

Implement browser-automated Vercel token setup on publish: when credentials are missing, the assistant automatically helps the user set up a Vercel API token using browser automation, then completes the publish in one seamless flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
