### PR TITLE
feat: show disconnected empty state on iOS Chats tab

### DIFF
--- a/clients/ios/Views/ContentView.swift
+++ b/clients/ios/Views/ContentView.swift
@@ -235,7 +235,8 @@ struct ContentView: View {
                     Label("Home", systemImage: "house")
                 }
 
-            ThreadListView(store: threadStore)
+            ChatsTabView(store: threadStore, onConnectTapped: navigateToConnectSettings)
+                .environmentObject(clientProvider)
                 .id(ObjectIdentifier(clientProvider.client as AnyObject))
                 .tag(Tab.chats)
                 .tabItem {

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -3,6 +3,59 @@ import SwiftUI
 import UIKit
 import VellumAssistantShared
 
+// MARK: - Tab Entry Point
+
+/// The tab-level Chats entry point. Switches between connected and disconnected
+/// states so ThreadListView only mounts when a live DaemonClient is available.
+struct ChatsTabView: View {
+    @EnvironmentObject var clientProvider: ClientProvider
+    @ObservedObject var store: IOSThreadStore
+    var onConnectTapped: (() -> Void)?
+
+    var body: some View {
+        if clientProvider.isConnected {
+            ThreadListView(store: store)
+        } else {
+            ChatsDisconnectedView(onConnectTapped: onConnectTapped)
+        }
+    }
+}
+
+// MARK: - Disconnected State
+
+struct ChatsDisconnectedView: View {
+    var onConnectTapped: (() -> Void)?
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: VSpacing.lg) {
+                Image(systemName: "message")
+                    .font(.system(size: 48))
+                    .foregroundColor(VColor.textMuted)
+                    .accessibilityHidden(true)
+                Text("Chats Require Connection")
+                    .font(VFont.title)
+                    .foregroundColor(VColor.textPrimary)
+                Text("Connect to your Assistant to start a conversation.")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, VSpacing.xl)
+                if onConnectTapped != nil {
+                    Button {
+                        onConnectTapped?()
+                    } label: {
+                        Text("Go to Settings")
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .navigationTitle("Chats")
+        }
+    }
+}
+
 // MARK: - ThreadListView
 
 struct ThreadListView: View {


### PR DESCRIPTION
## Summary
- Adds a `ChatsTabView` wrapper that checks `clientProvider.isConnected` before mounting `ThreadListView`
- When disconnected, shows a "Chats Require Connection" empty state with a "Go to Settings" button, matching the existing pattern used by Tasks, Home, and Identity tabs
- Fixes infinite loading spinner when navigating to Chats without a connected assistant

## Test plan
- [ ] Open the app without connecting to an assistant, navigate to Chats tab — verify "Chats Require Connection" screen appears
- [ ] Tap "Go to Settings" — verify it navigates to Settings tab
- [ ] Connect to an assistant, return to Chats tab — verify normal thread list appears
- [ ] Disconnect and verify the empty state reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
