### PR TITLE
M4: inline wait-and-resume for trusted-contact grant-gated tools

### DIFF
--- a/assistant/src/__tests__/tool-grant-request-escalation.test.ts
+++ b/assistant/src/__tests__/tool-grant-request-escalation.test.ts
@@ -5,6 +5,7 @@
  * 2. tool_grant_request resolver registration and behavior
  * 3. Canonical decision primitive grant minting for tool_grant_request kind
  * 4. End-to-end: deny -> approve -> consume grant flow
+ * 5. Inline wait-and-resume for trusted-contact grant-gated tools
  */
 
 import { mkdtempSync, rmSync } from 'node:fs';
@@ -115,8 +116,11 @@ import {
 import { getDb, initializeDb, resetDb } from '../memory/db.js';
 import { scopedApprovalGrants } from '../memory/schema.js';
 import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
-import { ToolApprovalHandler } from '../tools/tool-approval-handler.js';
+import { ToolApprovalHandler, waitForInlineGrant } from '../tools/tool-approval-handler.js';
 import type { ToolContext, ToolLifecycleEvent } from '../tools/types.js';
+
+/** Short wait config for tests — avoids blocking test suite on the 60s default. */
+const TEST_INLINE_WAIT_CONFIG = { maxWaitMs: 100, intervalMs: 20 };
 
 initializeDb();
 
@@ -189,7 +193,7 @@ describe('tool_grant_request resolver registration', () => {
 // ---------------------------------------------------------------------------
 
 describe('ToolApprovalHandler / grant-miss escalation', () => {
-  const handler = new ToolApprovalHandler();
+  const handler = new ToolApprovalHandler({ inlineGrantWait: TEST_INLINE_WAIT_CONFIG });
   const events: ToolLifecycleEvent[] = [];
   const emitLifecycleEvent = (event: ToolLifecycleEvent) => { events.push(event); };
 
@@ -227,7 +231,7 @@ describe('ToolApprovalHandler / grant-miss escalation', () => {
     expect(emittedSignals[0].sourceEventName).toBe('guardian.question');
   });
 
-  test('non-guardian grant-miss response includes request code', async () => {
+  test('non-guardian grant-miss response includes request code after timeout', async () => {
     const toolName = 'bash';
     const input = { command: 'deploy' };
 
@@ -238,9 +242,10 @@ describe('ToolApprovalHandler / grant-miss escalation', () => {
 
     expect(result.allowed).toBe(false);
     if (result.allowed) return;
-    expect(result.result.content).toContain('request has been sent to the guardian');
+    // After inline wait times out, the message should include the request code
+    // and indicate the guardian did not approve in time.
+    expect(result.result.content).toContain('guardian approval was not received in time');
     expect(result.result.content).toContain('request code:');
-    expect(result.result.content).toContain('Please retry after the guardian approves');
   });
 
   test('non-guardian duplicate grant-miss deduplicates the request', async () => {
@@ -249,7 +254,7 @@ describe('ToolApprovalHandler / grant-miss escalation', () => {
 
     const context = makeContext({ guardianTrustClass: 'trusted_contact' });
 
-    // First invocation creates the request
+    // First invocation creates the request (and waits, then times out)
     await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
@@ -263,14 +268,15 @@ describe('ToolApprovalHandler / grant-miss escalation', () => {
     // Reset notification tracking
     emittedSignals.length = 0;
 
-    // Second invocation with same tool+input deduplicates
+    // Second invocation with same tool+input deduplicates (reuses the request, waits, times out)
     const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
 
     expect(result.allowed).toBe(false);
     if (result.allowed) return;
-    expect(result.result.content).toContain('already pending');
+    // Both calls get the timeout message since inline wait now runs for deduped requests too
+    expect(result.result.content).toContain('guardian approval was not received in time');
 
     // Still only one canonical request
     const requests = listCanonicalGuardianRequests({
@@ -434,7 +440,8 @@ describe('applyCanonicalGuardianDecision / tool_grant_request', () => {
 // ---------------------------------------------------------------------------
 
 describe('end-to-end: tool grant escalation -> approval -> consume', () => {
-  const handler = new ToolApprovalHandler();
+  // Use a wider wait window so the delayed guardian approval arrives in time
+  const handler = new ToolApprovalHandler({ inlineGrantWait: { maxWaitMs: 2_000, intervalMs: 20 } });
   const events: ToolLifecycleEvent[] = [];
   const emitLifecycleEvent = (event: ToolLifecycleEvent) => { events.push(event); };
 
@@ -444,54 +451,348 @@ describe('end-to-end: tool grant escalation -> approval -> consume', () => {
     emittedSignals.length = 0;
   });
 
-  test('first invocation denied + request created; guardian approves; second invocation succeeds; replay denied', async () => {
+  test('inline wait: guardian approves during wait -> tool proceeds inline', async () => {
     const toolName = 'bash';
     const input = { command: 'echo secret' };
     const _inputDigest = computeToolApprovalDigest(toolName, input);
 
     const context = makeContext({ guardianTrustClass: 'trusted_contact' });
 
-    // Step 1: First invocation is denied, but a tool_grant_request is created
-    const firstResult = await handler.checkPreExecutionGates(
+    // Schedule guardian approval after 100ms — within the 2s wait window.
+    // The approval happens asynchronously while checkPreExecutionGates is
+    // polling for the grant.
+    const approvalPromise = (async () => {
+      await new Promise((r) => setTimeout(r, 100));
+      const pendingRequests = listCanonicalGuardianRequests({
+        kind: 'tool_grant_request',
+        status: 'pending',
+        toolName: 'bash',
+      });
+      if (pendingRequests.length === 0) return;
+      await applyCanonicalGuardianDecision({
+        requestId: pendingRequests[0].id,
+        action: 'approve_once',
+        actorContext: guardianActor(),
+      });
+    })();
+
+    const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
-    expect(firstResult.allowed).toBe(false);
 
-    // Verify the canonical request was created
+    await approvalPromise;
+
+    // The tool invocation should have succeeded inline
+    expect(result.allowed).toBe(true);
+    if (!result.allowed) return;
+    expect(result.grantConsumed).toBe(true);
+
+    // Replay is denied (one-time grant semantics)
+    const replayResult = await handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+    expect(replayResult.allowed).toBe(false);
+  });
+
+  test('pre-existing grant from prior approval is consumed immediately (no wait)', async () => {
+    const toolName = 'bash';
+    const input = { command: 'echo secret' };
+    const _inputDigest = computeToolApprovalDigest(toolName, input);
+
+    const context = makeContext({ guardianTrustClass: 'trusted_contact' });
+
+    // Step 1: First invocation times out (short wait, no approval)
+    const shortHandler = new ToolApprovalHandler({ inlineGrantWait: TEST_INLINE_WAIT_CONFIG });
+    await shortHandler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+
+    // Verify request was created
     const pendingRequests = listCanonicalGuardianRequests({
       kind: 'tool_grant_request',
       status: 'pending',
       toolName: 'bash',
     });
     expect(pendingRequests.length).toBe(1);
-    const canonicalRequestId = pendingRequests[0].id;
 
-    // Step 2: Guardian approves the canonical request -> grant is minted
+    // Step 2: Guardian approves the request (mints a grant)
     const approvalResult = await applyCanonicalGuardianDecision({
-      requestId: canonicalRequestId,
+      requestId: pendingRequests[0].id,
       action: 'approve_once',
       actorContext: guardianActor(),
     });
     expect(approvalResult.applied).toBe(true);
-    if (!approvalResult.applied) return;
-    expect(approvalResult.grantMinted).toBe(true);
 
-    // Verify request is now approved
-    const resolvedRequest = getCanonicalGuardianRequest(canonicalRequestId);
-    expect(resolvedRequest!.status).toBe('approved');
-
-    // Step 3: Second identical invocation consumes the grant and succeeds
+    // Step 3: Second invocation finds the pre-existing grant immediately
+    const start = Date.now();
     const secondResult = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
+    const elapsed = Date.now() - start;
+
     expect(secondResult.allowed).toBe(true);
     if (!secondResult.allowed) return;
     expect(secondResult.grantConsumed).toBe(true);
+    // Should be nearly instant since the grant already exists
+    expect(elapsed).toBeLessThan(500);
+  });
+});
 
-    // Step 4: Replay is denied (one-time grant semantics)
-    const replayResult = await handler.checkPreExecutionGates(
+// ---------------------------------------------------------------------------
+// 5. Inline wait-and-resume for trusted-contact grant-gated tools
+// ---------------------------------------------------------------------------
+
+describe('inline wait-and-resume', () => {
+  const events: ToolLifecycleEvent[] = [];
+  const emitLifecycleEvent = (event: ToolLifecycleEvent) => { events.push(event); };
+
+  beforeEach(() => {
+    resetTables();
+    events.length = 0;
+    emittedSignals.length = 0;
+    deliveredReplies.length = 0;
+  });
+
+  test('waitForInlineGrant returns granted when grant appears during wait', async () => {
+    // Create a canonical request manually
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_grant_request',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      conversationId: 'conv-1',
+      requesterExternalUserId: 'requester-1',
+      guardianExternalUserId: 'guardian-1',
+      toolName: 'bash',
+      inputDigest: 'sha256:waitgrant',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    // Schedule approval after 50ms
+    setTimeout(async () => {
+      await applyCanonicalGuardianDecision({
+        requestId: req.id,
+        action: 'approve_once',
+        actorContext: guardianActor(),
+      });
+    }, 50);
+
+    const result = await waitForInlineGrant(
+      req.id,
+      {
+        toolName: 'bash',
+        inputDigest: 'sha256:waitgrant',
+        consumingRequestId: 'consume-1',
+        assistantId: 'self',
+      },
+      { maxWaitMs: 2_000, intervalMs: 20 },
+    );
+
+    expect(result.outcome).toBe('granted');
+    if (result.outcome === 'granted') {
+      expect(result.grant.id).toBeDefined();
+    }
+  });
+
+  test('waitForInlineGrant returns denied when guardian rejects during wait', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_grant_request',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      conversationId: 'conv-1',
+      requesterExternalUserId: 'requester-1',
+      guardianExternalUserId: 'guardian-1',
+      toolName: 'bash',
+      inputDigest: 'sha256:denywait',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    // Schedule rejection after 50ms
+    setTimeout(async () => {
+      await applyCanonicalGuardianDecision({
+        requestId: req.id,
+        action: 'reject',
+        actorContext: guardianActor(),
+      });
+    }, 50);
+
+    const result = await waitForInlineGrant(
+      req.id,
+      {
+        toolName: 'bash',
+        inputDigest: 'sha256:denywait',
+        consumingRequestId: 'consume-1',
+        assistantId: 'self',
+      },
+      { maxWaitMs: 2_000, intervalMs: 20 },
+    );
+
+    expect(result.outcome).toBe('denied');
+    if (result.outcome === 'denied') {
+      expect(result.requestId).toBe(req.id);
+    }
+  });
+
+  test('waitForInlineGrant returns timeout when no decision arrives', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_grant_request',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      conversationId: 'conv-1',
+      requesterExternalUserId: 'requester-1',
+      guardianExternalUserId: 'guardian-1',
+      toolName: 'bash',
+      inputDigest: 'sha256:timeoutwait',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const start = Date.now();
+    const result = await waitForInlineGrant(
+      req.id,
+      {
+        toolName: 'bash',
+        inputDigest: 'sha256:timeoutwait',
+        consumingRequestId: 'consume-1',
+        assistantId: 'self',
+      },
+      { maxWaitMs: 100, intervalMs: 20 },
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.outcome).toBe('timeout');
+    if (result.outcome === 'timeout') {
+      expect(result.requestId).toBe(req.id);
+    }
+    expect(elapsed).toBeGreaterThanOrEqual(80);
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  test('waitForInlineGrant returns aborted when signal fires during wait', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'tool_grant_request',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      conversationId: 'conv-1',
+      requesterExternalUserId: 'requester-1',
+      guardianExternalUserId: 'guardian-1',
+      toolName: 'bash',
+      inputDigest: 'sha256:abortwait',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 50);
+
+    const start = Date.now();
+    const result = await waitForInlineGrant(
+      req.id,
+      {
+        toolName: 'bash',
+        inputDigest: 'sha256:abortwait',
+        consumingRequestId: 'consume-1',
+        assistantId: 'self',
+      },
+      { maxWaitMs: 5_000, intervalMs: 20, signal: controller.signal },
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.outcome).toBe('aborted');
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  test('inline wait: guardian rejects -> handler returns explicit denial', async () => {
+    const handler = new ToolApprovalHandler({ inlineGrantWait: { maxWaitMs: 2_000, intervalMs: 20 } });
+
+    const toolName = 'bash';
+    const input = { command: 'rm -rf /' };
+    const context = makeContext({ guardianTrustClass: 'trusted_contact' });
+
+    // Schedule rejection after 100ms
+    const rejectionPromise = (async () => {
+      await new Promise((r) => setTimeout(r, 100));
+      const pending = listCanonicalGuardianRequests({
+        kind: 'tool_grant_request',
+        status: 'pending',
+        toolName: 'bash',
+      });
+      if (pending.length === 0) return;
+      await applyCanonicalGuardianDecision({
+        requestId: pending[0].id,
+        action: 'reject',
+        actorContext: guardianActor(),
+      });
+    })();
+
+    const start = Date.now();
+    const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );
-    expect(replayResult.allowed).toBe(false);
+    const elapsed = Date.now() - start;
+
+    await rejectionPromise;
+
+    expect(result.allowed).toBe(false);
+    if (result.allowed) return;
+    expect(result.result.content).toContain('guardian rejected the request');
+    // Should exit well before the 2s timeout
+    expect(elapsed).toBeLessThan(1_000);
+  });
+
+  test('inline wait: abort signal cancels cleanly during wait', async () => {
+    const handler = new ToolApprovalHandler({ inlineGrantWait: { maxWaitMs: 5_000, intervalMs: 20 } });
+
+    const toolName = 'bash';
+    const input = { command: 'do something' };
+    const controller = new AbortController();
+    const context = makeContext({
+      guardianTrustClass: 'trusted_contact',
+      signal: controller.signal,
+    });
+
+    // Abort after 100ms
+    setTimeout(() => controller.abort(), 100);
+
+    const start = Date.now();
+    const result = await handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.allowed).toBe(false);
+    if (result.allowed) return;
+    expect(result.result.content).toBe('Cancelled');
+    expect(result.result.isError).toBe(true);
+    expect(elapsed).toBeLessThan(1_000);
+  });
+
+  test('unknown/unverified actors do NOT get inline wait behavior', async () => {
+    const handler = new ToolApprovalHandler({ inlineGrantWait: { maxWaitMs: 2_000, intervalMs: 20 } });
+
+    const toolName = 'bash';
+    const input = { command: 'ls' };
+    const context = makeContext({
+      guardianTrustClass: 'unknown',
+      executionChannel: 'telegram',
+      requesterExternalUserId: 'unknown-user',
+    });
+
+    const start = Date.now();
+    const result = await handler.checkPreExecutionGates(
+      toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.allowed).toBe(false);
+    if (result.allowed) return;
+    // Unknown actors get the generic fail-closed message, not the wait behavior
+    expect(result.result.content).toContain('verified channel identity');
+    // Should be near-instant, no waiting
+    expect(elapsed).toBeLessThan(200);
+
+    // No canonical request created
+    const requests = listCanonicalGuardianRequests({
+      kind: 'tool_grant_request',
+      status: 'pending',
+    });
+    expect(requests.length).toBe(0);
   });
 });

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -545,13 +545,23 @@ const toolGrantRequestResolver: GuardianRequestResolver = {
     // Staleness guard: the inline_wait_active marker is persisted in DB and
     // can outlive the actual waiter if the daemon crashes or restarts during
     // the wait. To avoid permanently suppressing the retry notification, we
-    // treat the marker as stale if the request's updatedAt is older than the
-    // maximum wait budget plus a 30s buffer.
+    // treat the marker as stale if the encoded start timestamp is older than
+    // the maximum wait budget plus a 30s buffer.
     const INLINE_WAIT_STALENESS_BUFFER_MS = 30_000;
     const freshRequest = getCanonicalGuardianRequest(request.id);
-    let inlineWaitActive = freshRequest?.followupState === 'inline_wait_active';
+    const followupState = freshRequest?.followupState ?? '';
+    let inlineWaitActive = followupState.startsWith('inline_wait_active');
     if (inlineWaitActive && freshRequest) {
-      const markerAgeMs = Date.now() - new Date(freshRequest.updatedAt).getTime();
+      // The followupState encodes the wall-clock epoch when the inline wait
+      // started (e.g. 'inline_wait_active:1700000000000'). We use this
+      // instead of updatedAt because resolveCanonicalGuardianRequest sets
+      // updatedAt = now during CAS resolution, making updatedAt always fresh
+      // by the time this resolver runs.
+      const colonIdx = followupState.indexOf(':');
+      const waitStartMs = colonIdx !== -1 ? Number(followupState.slice(colonIdx + 1)) : NaN;
+      const markerAgeMs = Number.isFinite(waitStartMs)
+        ? Date.now() - waitStartMs
+        : Infinity; // Treat unparseable timestamps as stale for safety.
       const stalenessThresholdMs = TC_GRANT_WAIT_MAX_MS + INLINE_WAIT_STALENESS_BUFFER_MS;
       if (markerAgeMs > stalenessThresholdMs) {
         log.warn(
@@ -561,7 +571,7 @@ const toolGrantRequestResolver: GuardianRequestResolver = {
             toolName: request.toolName,
             markerAgeMs,
             stalenessThresholdMs,
-            updatedAt: freshRequest.updatedAt,
+            waitStartMs,
           },
           'inline_wait_active marker is stale (daemon likely crashed during wait) — sending retry notification',
         );

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -12,7 +12,7 @@
  */
 
 import { answerCall } from '../calls/call-domain.js';
-import type { CanonicalGuardianRequest } from '../memory/canonical-guardian-store.js';
+import { getCanonicalGuardianRequest, type CanonicalGuardianRequest } from '../memory/canonical-guardian-store.js';
 import { upsertMember } from '../memory/ingress-member-store.js';
 import { emitNotificationSignal } from '../notifications/emit-signal.js';
 import { addRule } from '../permissions/trust-store.js';
@@ -534,7 +534,26 @@ const toolGrantRequestResolver: GuardianRequestResolver = {
       'Tool grant request resolver: approved (grant minting deferred to canonical primitive)',
     );
 
-    if (channelDeliveryContext && requesterChatId) {
+    // Re-read the canonical request to check whether an inline grant waiter
+    // has already claimed this request. When followupState is
+    // 'inline_wait_active', the requester's original tool call is blocking
+    // on the grant and will resume automatically — sending a "please retry"
+    // notification would be stale and confusing (and could cause duplicate
+    // attempts or one-time-grant denials).
+    const freshRequest = getCanonicalGuardianRequest(request.id);
+    const inlineWaitActive = freshRequest?.followupState === 'inline_wait_active';
+
+    if (inlineWaitActive) {
+      log.info(
+        {
+          event: 'resolver_tool_grant_request_skip_retry_notification',
+          requestId: request.id,
+          toolName: request.toolName,
+          followupState: freshRequest?.followupState,
+        },
+        'Skipping requester retry notification — inline grant wait is active and will resume the original invocation',
+      );
+    } else if (channelDeliveryContext && requesterChatId) {
       try {
         await deliverChannelReply(channelDeliveryContext.replyCallbackUrl, {
           chatId: requesterChatId,

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -22,6 +22,7 @@ import { createOutboundSession } from '../runtime/channel-guardian-service.js';
 import { deliverChannelReply } from '../runtime/gateway-client.js';
 import * as pendingInteractions from '../runtime/pending-interactions.js';
 import { getTool } from '../tools/registry.js';
+import { TC_GRANT_WAIT_MAX_MS } from '../tools/tool-approval-handler.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('guardian-request-resolvers');
@@ -540,8 +541,33 @@ const toolGrantRequestResolver: GuardianRequestResolver = {
     // on the grant and will resume automatically — sending a "please retry"
     // notification would be stale and confusing (and could cause duplicate
     // attempts or one-time-grant denials).
+    //
+    // Staleness guard: the inline_wait_active marker is persisted in DB and
+    // can outlive the actual waiter if the daemon crashes or restarts during
+    // the wait. To avoid permanently suppressing the retry notification, we
+    // treat the marker as stale if the request's updatedAt is older than the
+    // maximum wait budget plus a 30s buffer.
+    const INLINE_WAIT_STALENESS_BUFFER_MS = 30_000;
     const freshRequest = getCanonicalGuardianRequest(request.id);
-    const inlineWaitActive = freshRequest?.followupState === 'inline_wait_active';
+    let inlineWaitActive = freshRequest?.followupState === 'inline_wait_active';
+    if (inlineWaitActive && freshRequest) {
+      const markerAgeMs = Date.now() - new Date(freshRequest.updatedAt).getTime();
+      const stalenessThresholdMs = TC_GRANT_WAIT_MAX_MS + INLINE_WAIT_STALENESS_BUFFER_MS;
+      if (markerAgeMs > stalenessThresholdMs) {
+        log.warn(
+          {
+            event: 'resolver_tool_grant_request_stale_inline_wait',
+            requestId: request.id,
+            toolName: request.toolName,
+            markerAgeMs,
+            stalenessThresholdMs,
+            updatedAt: freshRequest.updatedAt,
+          },
+          'inline_wait_active marker is stale (daemon likely crashed during wait) — sending retry notification',
+        );
+        inlineWaitActive = false;
+      }
+    }
 
     if (inlineWaitActive) {
       log.info(

--- a/assistant/src/memory/canonical-guardian-store.ts
+++ b/assistant/src/memory/canonical-guardian-store.ts
@@ -292,7 +292,7 @@ export interface UpdateCanonicalGuardianRequestParams {
   status?: CanonicalRequestStatus;
   answerText?: string;
   decidedByExternalUserId?: string;
-  followupState?: string;
+  followupState?: string | null;
   expiresAt?: string;
 }
 

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -1,5 +1,5 @@
 import { consumeGrantForInvocation } from '../approvals/approval-primitive.js';
-import { getCanonicalGuardianRequest } from '../memory/canonical-guardian-store.js';
+import { getCanonicalGuardianRequest, updateCanonicalGuardianRequest } from '../memory/canonical-guardian-store.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { createOrReuseToolGrantRequest } from '../runtime/tool-grant-request-helper.js';
 import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
@@ -420,6 +420,14 @@ export class ToolApprovalHandler {
         // If escalation failed (no binding, missing identity), fall through
         // to the generic denial path.
         if ('created' in escalation || 'deduped' in escalation) {
+          // Stamp the canonical request so the approval resolver knows an
+          // inline consumer is waiting. Without this, the resolver would
+          // send a stale "please retry" notification even though the
+          // original invocation is about to resume inline.
+          updateCanonicalGuardianRequest(escalation.requestId, {
+            followupState: 'inline_wait_active',
+          });
+
           const waitResult = await waitForInlineGrant(
             escalation.requestId,
             deferredConsumeParams!,
@@ -444,6 +452,11 @@ export class ToolApprovalHandler {
           }
 
           if (waitResult.outcome === 'aborted') {
+            // Clear the inline-wait stamp so a later guardian approval
+            // (if the request is still pending) will send the retry notification.
+            updateCanonicalGuardianRequest(escalation.requestId, {
+              followupState: null,
+            });
             const durationMs = Date.now() - startTime;
             emitLifecycleEvent({
               type: 'error',
@@ -463,6 +476,13 @@ export class ToolApprovalHandler {
             });
             return { allowed: false, result: { content: 'Cancelled', isError: true } };
           }
+
+          // Clear the inline-wait stamp so a later guardian approval
+          // (if the request is still pending after timeout) will send
+          // the retry notification as expected.
+          updateCanonicalGuardianRequest(escalation.requestId, {
+            followupState: null,
+          });
 
           const codeSuffix = escalation.requestCode
             ? ` (request code: ${escalation.requestCode})`

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -1,4 +1,5 @@
 import { consumeGrantForInvocation } from '../approvals/approval-primitive.js';
+import { getCanonicalGuardianRequest } from '../memory/canonical-guardian-store.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { createOrReuseToolGrantRequest } from '../runtime/tool-grant-request-helper.js';
 import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
@@ -10,6 +11,112 @@ import { isSideEffectTool } from './side-effects.js';
 import type { ExecutionTarget, Tool, ToolContext, ToolExecutionResult, ToolLifecycleEvent } from './types.js';
 
 const log = getLogger('tool-approval-handler');
+
+/** Default polling interval for inline grant wait (ms). */
+export const TC_GRANT_WAIT_INTERVAL_MS = 500;
+/** Default maximum wait time for inline grant wait (ms). */
+export const TC_GRANT_WAIT_MAX_MS = 60_000;
+
+/**
+ * Inline wait result for trusted-contact grant polling.
+ * - `granted`: a grant was minted and consumed within the wait window.
+ * - `denied`: the guardian explicitly rejected the request.
+ * - `timeout`: the wait budget expired without a decision.
+ * - `aborted`: the session was cancelled during the wait.
+ * - `escalation_failed`: the grant request could not be created.
+ */
+export type InlineGrantWaitOutcome =
+  | { outcome: 'granted'; grant: { id: string } }
+  | { outcome: 'denied'; requestId: string }
+  | { outcome: 'timeout'; requestId: string }
+  | { outcome: 'aborted' }
+  | { outcome: 'escalation_failed'; reason: string };
+
+/**
+ * Wait bounded for a guardian to approve a tool grant request and for the
+ * resulting grant to become consumable. Polls both the canonical request
+ * status (to detect early rejection) and the grant store (to detect approval
+ * and atomically consume the grant).
+ *
+ * Only called for trusted_contact actors with valid guardian bindings.
+ */
+export async function waitForInlineGrant(
+  escalationRequestId: string,
+  consumeParams: Parameters<typeof consumeGrantForInvocation>[0],
+  options?: { maxWaitMs?: number; intervalMs?: number; signal?: AbortSignal },
+): Promise<InlineGrantWaitOutcome> {
+  const maxWait = options?.maxWaitMs ?? TC_GRANT_WAIT_MAX_MS;
+  const interval = options?.intervalMs ?? TC_GRANT_WAIT_INTERVAL_MS;
+  const signal = options?.signal;
+  const deadline = Date.now() + maxWait;
+
+  log.info(
+    {
+      event: 'tc_inline_grant_wait_start',
+      escalationRequestId,
+      toolName: consumeParams.toolName,
+      maxWaitMs: maxWait,
+      intervalMs: interval,
+    },
+    'Starting inline wait for guardian grant decision',
+  );
+
+  while (Date.now() < deadline) {
+    if (signal?.aborted) {
+      return { outcome: 'aborted' };
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, interval));
+
+    if (signal?.aborted) {
+      return { outcome: 'aborted' };
+    }
+
+    // Check if the canonical request was rejected — exit early without
+    // waiting for the full timeout.
+    const request = getCanonicalGuardianRequest(escalationRequestId);
+    if (request && request.status === 'denied') {
+      log.info(
+        {
+          event: 'tc_inline_grant_wait_denied',
+          escalationRequestId,
+          toolName: consumeParams.toolName,
+          elapsedMs: maxWait - (deadline - Date.now()),
+        },
+        'Guardian denied tool grant request during inline wait',
+      );
+      return { outcome: 'denied', requestId: escalationRequestId };
+    }
+
+    // Try to consume the grant — if the guardian approved, the canonical
+    // decision primitive will have minted a scoped grant by now.
+    const grantResult = await consumeGrantForInvocation(consumeParams, { maxWaitMs: 0 });
+    if (grantResult.ok) {
+      log.info(
+        {
+          event: 'tc_inline_grant_wait_granted',
+          escalationRequestId,
+          toolName: consumeParams.toolName,
+          grantId: grantResult.grant.id,
+          elapsedMs: maxWait - (deadline - Date.now()),
+        },
+        'Grant found during inline wait — tool execution proceeding',
+      );
+      return { outcome: 'granted', grant: { id: grantResult.grant.id } };
+    }
+  }
+
+  log.info(
+    {
+      event: 'tc_inline_grant_wait_timeout',
+      escalationRequestId,
+      toolName: consumeParams.toolName,
+      maxWaitMs: maxWait,
+    },
+    'Inline grant wait timed out — no guardian decision within budget',
+  );
+  return { outcome: 'timeout', requestId: escalationRequestId };
+}
 
 function isUntrustedGuardianTrustClass(role: ToolContext['guardianTrustClass']): boolean {
   return role === 'trusted_contact' || role === 'unknown';
@@ -40,12 +147,26 @@ export type PreExecutionGateResult =
   | { allowed: true; tool: Tool; grantConsumed?: boolean }
   | { allowed: false; result: ToolExecutionResult };
 
+/** Configuration for the inline grant wait behavior. */
+export interface InlineGrantWaitConfig {
+  /** Maximum time to wait for guardian approval (ms). Defaults to TC_GRANT_WAIT_MAX_MS. */
+  maxWaitMs?: number;
+  /** Polling interval during the wait (ms). Defaults to TC_GRANT_WAIT_INTERVAL_MS. */
+  intervalMs?: number;
+}
+
 /**
  * Handles pre-execution approval gates: abort checks, guardian policy,
  * allowed-tool-set gating, and task-run preflight checks.
  * These run before the interactive permission prompt flow.
  */
 export class ToolApprovalHandler {
+  private inlineGrantWaitConfig: InlineGrantWaitConfig;
+
+  constructor(config?: { inlineGrantWait?: InlineGrantWaitConfig }) {
+    this.inlineGrantWaitConfig = config?.inlineGrantWait ?? {};
+  }
+
   /**
    * Evaluate all pre-execution approval gates for a tool invocation.
    * Returns the resolved Tool if all gates pass, or an early-return
@@ -267,12 +388,15 @@ export class ToolApprovalHandler {
         return { allowed: false, result: { content: 'Cancelled', isError: true } };
       }
 
-      // No matching grant or race condition — deny.
+      // No matching grant or race condition — deny or wait inline.
       //
-      // For verified non-guardian actors with sufficient context, escalate to
-      // the guardian by creating a canonical tool_grant_request. Unverified
-      // actors remain fail-closed with no escalation.
-      let escalationMessage: string | undefined;
+      // For verified non-guardian actors (trusted_contact) with sufficient
+      // context, escalate to the guardian by creating a canonical
+      // tool_grant_request. Then wait bounded for the grant to become
+      // available — this lets the tool call succeed inline after guardian
+      // approval without the requester having to retry manually.
+      //
+      // Unverified actors remain fail-closed with no escalation or wait.
       if (
         context.guardianTrustClass === 'trusted_contact'
         && context.assistantId
@@ -292,24 +416,100 @@ export class ToolApprovalHandler {
           questionText: `Trusted contact is requesting permission to use "${name}"`,
         });
 
-        if ('created' in escalation) {
+        // Only wait inline if the escalation succeeded (created or deduped).
+        // If escalation failed (no binding, missing identity), fall through
+        // to the generic denial path.
+        if ('created' in escalation || 'deduped' in escalation) {
+          const waitResult = await waitForInlineGrant(
+            escalation.requestId,
+            deferredConsumeParams!,
+            {
+              maxWaitMs: this.inlineGrantWaitConfig.maxWaitMs,
+              intervalMs: this.inlineGrantWaitConfig.intervalMs,
+              signal: context.signal,
+            },
+          );
+
+          if (waitResult.outcome === 'granted') {
+            log.info({
+              toolName: name,
+              sessionId: context.sessionId,
+              conversationId: context.conversationId,
+              trustClass: context.guardianTrustClass,
+              executionTarget,
+              grantId: waitResult.grant.id,
+              escalationRequestId: escalation.requestId,
+            }, 'Inline grant wait succeeded — allowing trusted contact tool invocation');
+            return { allowed: true, tool, grantConsumed: true };
+          }
+
+          if (waitResult.outcome === 'aborted') {
+            const durationMs = Date.now() - startTime;
+            emitLifecycleEvent({
+              type: 'error',
+              toolName: name,
+              executionTarget,
+              input,
+              workingDir: context.workingDir,
+              sessionId: context.sessionId,
+              conversationId: context.conversationId,
+              requestId: context.requestId,
+              riskLevel,
+              decision: 'error',
+              durationMs,
+              errorMessage: 'Cancelled',
+              isExpected: true,
+              errorCategory: 'tool_failure',
+            });
+            return { allowed: false, result: { content: 'Cancelled', isError: true } };
+          }
+
           const codeSuffix = escalation.requestCode
             ? ` (request code: ${escalation.requestCode})`
             : '';
-          escalationMessage = `Permission denied for "${name}": this action requires guardian approval. `
-            + `A request has been sent to the guardian${codeSuffix}. `
-            + `Please retry after the guardian approves.`;
-        } else if ('deduped' in escalation) {
-          const codeSuffix = escalation.requestCode
-            ? ` (request code: ${escalation.requestCode})`
-            : '';
-          escalationMessage = `Permission denied for "${name}": guardian approval is already pending${codeSuffix}. `
-            + `Please retry after the guardian approves.`;
+
+          let escalationMessage: string;
+          if (waitResult.outcome === 'denied') {
+            escalationMessage = `Permission denied for "${name}": the guardian rejected the request${codeSuffix}.`;
+          } else {
+            // timeout
+            escalationMessage = `Permission denied for "${name}": guardian approval was not received in time${codeSuffix}. `
+              + `Please retry after the guardian approves.`;
+          }
+
+          log.warn({
+            toolName: name,
+            sessionId: context.sessionId,
+            conversationId: context.conversationId,
+            trustClass: context.guardianTrustClass,
+            executionTarget,
+            reason: 'guardian_approval_required',
+            grantMissReason: grantResult.reason,
+            waitOutcome: waitResult.outcome,
+            escalationRequestId: escalation.requestId,
+          }, 'Inline grant wait ended without approval — denying trusted contact tool invocation');
+          const durationMs = Date.now() - startTime;
+          emitLifecycleEvent({
+            type: 'permission_denied',
+            toolName: name,
+            executionTarget,
+            input,
+            workingDir: context.workingDir,
+            sessionId: context.sessionId,
+            conversationId: context.conversationId,
+            requestId: context.requestId,
+            riskLevel,
+            decision: 'deny',
+            reason: escalationMessage,
+            durationMs,
+          });
+          return { allowed: false, result: { content: escalationMessage, isError: true } };
         }
-        // If escalation.failed, fall through to generic denial message.
+        // escalation.failed — fall through to generic denial.
       }
 
-      const reason = escalationMessage ?? guardianApprovalDeniedMessage(context.guardianTrustClass, name);
+      // Unknown/unverified actors or escalation failures — generic denial.
+      const reason = guardianApprovalDeniedMessage(context.guardianTrustClass, name);
       log.warn({
         toolName: name,
         sessionId: context.sessionId,
@@ -318,7 +518,7 @@ export class ToolApprovalHandler {
         executionTarget,
         reason: 'guardian_approval_required',
         grantMissReason: grantResult.reason,
-        escalated: !!escalationMessage,
+        escalated: false,
       }, 'Guardian approval gate blocked untrusted actor tool invocation (no matching grant)');
       const durationMs = Date.now() - startTime;
       emitLifecycleEvent({

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -425,7 +425,7 @@ export class ToolApprovalHandler {
           // send a stale "please retry" notification even though the
           // original invocation is about to resume inline.
           updateCanonicalGuardianRequest(escalation.requestId, {
-            followupState: 'inline_wait_active',
+            followupState: 'inline_wait_active:' + Date.now(),
           });
 
           const waitResult = await waitForInlineGrant(


### PR DESCRIPTION
Closes #10725. Part of #10719.

When a trusted contact with a guardian binding tries a host/side-effect tool without a grant, the system now creates a tool_grant_request and waits bounded for guardian approval. If the grant arrives within the wait window, tool execution continues inline. Timeout/reject paths return explicit outcomes. Unknown/unverified actors remain fail-closed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
