### PR TITLE
fix: clear stale SPM artifact cache in iOS CI

### DIFF
--- a/.github/workflows/ci-main-ios.yaml
+++ b/.github/workflows/ci-main-ios.yaml
@@ -24,6 +24,9 @@ jobs:
       - name: Install XcodeGen
         run: brew install xcodegen
 
+      - name: Clear stale SPM artifact cache
+        run: rm -rf ~/Library/Caches/org.swift.swiftpm/artifacts
+
       - name: Build for simulator
         working-directory: clients/ios
         run: ./build.sh

--- a/.github/workflows/pr-ios.yaml
+++ b/.github/workflows/pr-ios.yaml
@@ -29,6 +29,9 @@ jobs:
       - name: Install XcodeGen
         run: brew install xcodegen
 
+      - name: Clear stale SPM artifact cache
+        run: rm -rf ~/Library/Caches/org.swift.swiftpm/artifacts
+
       - name: Build for simulator
         working-directory: clients/ios
         run: ./build.sh


### PR DESCRIPTION
## Summary
- Clears `~/Library/Caches/org.swift.swiftpm/artifacts` before the iOS build step in both `ci-main-ios.yaml` and `pr-ios.yaml`
- Fixes `failed downloading Sentry-Dynamic-WithARM64e.xcframework.zip: already exists in file system` error caused by stale cached binary target artifacts on the macOS CI runner

## Test plan
- [ ] Merge and verify the next `ci-main-ios` run passes package resolution
- [ ] PR builds with `preview` label should also resolve packages cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
