### PR TITLE
M2: Shared/macOS client actor-token plumbing + hatch auto-bootstrap

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -156,6 +156,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     private var bootstrapInterstitialWindow: NSWindow?
     /// Active task for the bootstrap retry coordinator. Cancelled on dismiss.
     private var bootstrapRetryTask: Task<Void, Never>?
+    /// Background task that retries actor-token bootstrap until success.
+    private var actorTokenBootstrapTask: Task<Void, Never>?
     /// Tracks file paths of .vellumapp bundles awaiting daemon responses (FIFO).
     /// Each call to sendOpenBundle appends a path; handleOpenBundleResponse
     /// pops the first entry so concurrent opens are correctly paired.
@@ -354,6 +356,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         setupNotifications()
         setupAutoUpdate()
         installCLISymlinkIfNeeded()
+
+        // Ensure an actor token is present. On first launch this is the
+        // initial bootstrap; on subsequent launches it retries silently
+        // if a previous attempt failed or the token was cleared.
+        ensureActorTokenBootstrap()
 
         if isFirstLaunch {
             // Enter the bootstrap state machine. The sequence is:
@@ -601,6 +608,49 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         }
     }
 
+    // MARK: - Actor Token Bootstrap
+
+    /// Ensures an actor token is present. If missing, waits for the daemon
+    /// to become reachable and calls the bootstrap endpoint with exponential
+    /// backoff. Runs entirely in the background and never blocks the UI.
+    private func ensureActorTokenBootstrap() {
+        actorTokenBootstrapTask?.cancel()
+
+        actorTokenBootstrapTask = Task { [weak self] in
+            guard let self else { return }
+
+            // Already have a token — nothing to do.
+            if ActorTokenManager.hasToken { return }
+
+            let deviceId = PairingQRCodeSheet.computeHostId()
+            var delay: UInt64 = 2_000_000_000 // 2 seconds initial
+            let maxDelay: UInt64 = 60_000_000_000 // 60 seconds cap
+
+            while !Task.isCancelled {
+                // Wait for the daemon to be connected before attempting.
+                guard self.daemonClient.isConnected else {
+                    try? await Task.sleep(nanoseconds: delay)
+                    continue
+                }
+
+                let success = await self.daemonClient.bootstrapActorToken(
+                    platform: "macos",
+                    deviceId: deviceId
+                )
+
+                if success {
+                    log.info("Actor token bootstrap succeeded")
+                    return
+                }
+
+                // Exponential backoff with jitter
+                let jitter = UInt64.random(in: 0...(delay / 4))
+                try? await Task.sleep(nanoseconds: delay + jitter)
+                delay = min(delay * 2, maxDelay)
+            }
+        }
+    }
+
     private func showAuthWindow() {
         if let existing = authWindow {
             existing.makeKeyAndOrderFront(nil)
@@ -725,6 +775,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 }
             }
 
+            actorTokenBootstrapTask?.cancel()
+            actorTokenBootstrapTask = nil
+            ActorTokenManager.deleteToken()
+
             assistantCli.stopMonitoring()
             hasSetupApp = false
             hasSetupDaemon = false
@@ -739,8 +793,15 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         UserDefaults.standard.set(assistant.assistantId, forKey: "connectedAssistantId")
         assistant.writeToWorkspaceConfig()
 
+        // Clear stale actor token for the previous assistant and re-bootstrap
+        // for the new one once the daemon connects.
+        actorTokenBootstrapTask?.cancel()
+        actorTokenBootstrapTask = nil
+        ActorTokenManager.deleteToken()
+
         hasSetupDaemon = false
         setupDaemonClient()
+        ensureActorTokenBootstrap()
     }
 
     @objc func performRetire() {
@@ -804,6 +865,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         // new onboarding flow.
         bootstrapRetryTask?.cancel()
         bootstrapRetryTask = nil
+        actorTokenBootstrapTask?.cancel()
+        actorTokenBootstrapTask = nil
+        ActorTokenManager.deleteToken()
 
         mainWindow?.close()
         mainWindow = nil

--- a/clients/shared/App/Auth/ActorTokenManager.swift
+++ b/clients/shared/App/Auth/ActorTokenManager.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Cross-platform actor-token storage using Keychain via APIKeyManager.
+/// The actor token is an HMAC-signed credential that binds an assistant,
+/// platform, device, and guardian principal. It is transmitted as
+/// `X-Actor-Token` on HTTP requests to the runtime.
+///
+/// Follows the same Keychain persistence pattern as SessionTokenManager.
+public enum ActorTokenManager {
+    private static let provider = "actor-token"
+
+    public static func getToken() -> String? {
+        APIKeyManager.shared.getAPIKey(provider: provider)
+    }
+
+    public static func setToken(_ token: String) {
+        _ = APIKeyManager.shared.setAPIKey(token, provider: provider)
+    }
+
+    public static func deleteToken() {
+        _ = APIKeyManager.shared.deleteAPIKey(provider: provider)
+    }
+
+    /// Whether an actor token is currently stored.
+    public static var hasToken: Bool {
+        getToken() != nil
+    }
+}

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1768,4 +1768,71 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
     }
 
+    // MARK: - Actor Token Bootstrap
+
+    /// Response from `POST /v1/integrations/guardian/vellum/bootstrap`.
+    public struct GuardianBootstrapResponse: Decodable {
+        public let guardianPrincipalId: String
+        public let actorToken: String
+        public let isNew: Bool
+    }
+
+    /// Calls the runtime's guardian bootstrap endpoint to obtain an actor token.
+    /// The token is bound to (assistantId, platform, deviceId) and persisted
+    /// in Keychain via `ActorTokenManager`.
+    ///
+    /// Returns `true` on success, `false` on failure.
+    public func bootstrapActorToken(platform: String, deviceId: String) async -> Bool {
+        let baseURL: String
+        let bearerToken: String?
+
+        if let httpTransport {
+            baseURL = httpTransport.baseURL
+            bearerToken = httpTransport.bearerToken
+        } else if let local = resolveLocalDaemonHTTPEndpoint() {
+            baseURL = local.baseURL
+            bearerToken = local.bearerToken
+        } else {
+            log.error("Cannot bootstrap actor token — no HTTP endpoint available")
+            return false
+        }
+
+        guard let url = URL(string: "\(baseURL)/v1/integrations/guardian/vellum/bootstrap") else {
+            log.error("Invalid bootstrap URL")
+            return false
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 15
+        if let token = bearerToken, !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let body: [String: Any] = [
+            "platform": platform,
+            "deviceId": deviceId
+        ]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+                log.error("Actor token bootstrap failed (HTTP \(statusCode))")
+                return false
+            }
+
+            let decoded = try JSONDecoder().decode(GuardianBootstrapResponse.self, from: data)
+            ActorTokenManager.setToken(decoded.actorToken)
+            log.info("Actor token bootstrap succeeded (isNew=\(decoded.isNew))")
+            return true
+        } catch {
+            log.error("Actor token bootstrap error: \(error.localizedDescription)")
+            return false
+        }
+    }
+
 }

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -892,6 +892,10 @@ final class HTTPTransport {
         if let token = bearerToken {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
+        // Attach actor token when available for identity-bound requests.
+        if let actorToken = ActorTokenManager.getToken() {
+            request.setValue(actorToken, forHTTPHeaderField: "X-Actor-Token")
+        }
     }
 
     private func setConnected(_ connected: Bool) {


### PR DESCRIPTION
Part of #10751. Adds actor-token Keychain persistence in the shared client layer, sends X-Actor-Token header on relevant HTTP requests, auto-bootstraps actor token after hatch completion, and adds startup retry loop for missing tokens. Closes #10753.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
