### PR TITLE
fix: reset AppLoadingView state when switching apps

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -206,6 +206,10 @@ extension MainWindowView {
                         windowState.closeDynamicPanel()
                     }
                 )
+                .id({
+                    if case .app(let id) = windowState.selection { return id }
+                    return nil
+                }() as String?)
             }
         case .appEditing:
             // VSplitView: ChatView (left) + workspace (right)


### PR DESCRIPTION
## Summary

- **Bug**: When user opens app A and it times out (showing error state), then navigates to app B, `AppLoadingView` retains `timedOut = true` from app A because SwiftUI's `@State` is tied to structural identity — the view is reused rather than recreated.
- **Fix**: Add `.id(appId)` modifier to `AppLoadingView` so SwiftUI treats each app as a distinct view instance, resetting all `@State` (including `timedOut`) when the selected app changes. This follows the same pattern already used for `SubagentDetailPanel` with `.id(subagentId)` in the same file.

## Test plan

- [ ] Open an app that will fail to load (e.g., a nonexistent or slow app) and wait for the timeout error state
- [ ] Navigate to a different app — verify it shows a fresh loading spinner instead of the stale error state
- [ ] Verify the timeout still works correctly for each individual app (wait 8 seconds)
- [ ] Verify the Retry button still works within a single app's error state
- [ ] Verify the Close button still dismisses the loading view

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
