### PR TITLE
fix: preserve SettingsStore callback during credential polling

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -194,6 +194,12 @@ struct MainWindowView: View {
         let startTime = Date()
         let timeout: TimeInterval = 300 // 5 minutes
 
+        // Preserve SettingsStore's handler so it continues receiving updates
+        // after polling ends. Without this, the poll closure permanently
+        // overwrites SettingsStore's onVercelApiConfigResponse and hasVercelKey
+        // is never updated again.
+        let previousHandler = daemonClient.onVercelApiConfigResponse
+
         sharing.credentialPollTimer = Timer.scheduledTimer(withTimeInterval: 3, repeats: true) { [self] timer in
             Task { @MainActor in
                 // Timeout check
@@ -201,15 +207,21 @@ struct MainWindowView: View {
                     timer.invalidate()
                     sharing.credentialPollTimer = nil
                     sharing.pendingPublish = nil
+                    daemonClient.onVercelApiConfigResponse = previousHandler
                     return
                 }
 
                 // Poll for credential
                 daemonClient.onVercelApiConfigResponse = { [self] response in
+                    // Forward to the previous handler (e.g. SettingsStore) so it
+                    // stays in sync with credential state during polling.
+                    previousHandler?(response)
+
                     if response.success && response.hasToken, let pending = sharing.pendingPublish {
                         timer.invalidate()
                         sharing.credentialPollTimer = nil
                         sharing.pendingPublish = nil
+                        daemonClient.onVercelApiConfigResponse = previousHandler
                         // Auto-retry publish with saved params
                         publishPage(html: pending.html, title: pending.title, appId: pending.appId)
                     }
@@ -608,6 +620,9 @@ struct MainWindowView: View {
         }
         .onDisappear {
             copyThread.cancel()
+            sharing.credentialPollTimer?.invalidate()
+            sharing.credentialPollTimer = nil
+            sharing.pendingPublish = nil
             daemonClient.stopSSE()
         }
         .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -206,6 +206,10 @@ extension MainWindowView {
                         windowState.closeDynamicPanel()
                     }
                 )
+                .id({
+                    if case .app(let id) = windowState.selection { return id }
+                    return nil
+                }() as String?)
             }
         case .appEditing:
             // VSplitView: ChatView (left) + workspace (right)


### PR DESCRIPTION
## Summary

- **Callback preservation**: The Vercel credential polling timer in `startCredentialPollForPublish()` was overwriting `daemonClient.onVercelApiConfigResponse` with a new closure every 3 seconds. This permanently broke SettingsStore's handler (set at init time), meaning `hasVercelKey` would never update again after polling ended. The fix saves the previous handler before polling starts, forwards responses to it during polling, and restores it when polling completes (either on credential found or timeout).
- **Timer cleanup on disappear**: The `credentialPollTimer` was not invalidated in the `onDisappear` handler, so if the view disappeared while polling was active, the timer would keep firing for up to 5 minutes. Added cleanup to invalidate the timer and clear the pending publish state.

## Test plan

- [ ] Trigger a publish without Vercel credentials configured to start the credential polling flow
- [ ] While polling is active, open Settings and verify `hasVercelKey` still updates when checking Vercel config
- [ ] Complete the credential setup and verify auto-retry publish works
- [ ] Let the 5-minute timeout expire and verify SettingsStore's handler is restored
- [ ] Close the main window while polling is active and verify no timer leak (no continued polling after disappear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
