### PR TITLE
fix: word-boundary-aware underscore stripping in title markdown

### DIFF
--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -326,7 +326,7 @@ function stripMarkdown(text: string): string {
     .replace(/\*\*(.+?)\*\*/g, '$1')   // **bold**
     .replace(/__(.+?)__/g, '$1')        // __bold__
     .replace(/\*(.+?)\*/g, '$1')        // *italic*
-    .replace(/_(.+?)_/g, '$1')          // _italic_
+    .replace(/(?<!\w)_(.+?)_(?!\w)/g, '$1') // _italic_ (word-boundary-aware to preserve snake_case)
     .replace(/~~(.+?)~~/g, '$1')        // ~~strikethrough~~
     .replace(/`(.+?)`/g, '$1')          // `code`
     .replace(/\[(.+?)\]\(.+?\)/g, '$1') // [link](url)


### PR DESCRIPTION
## Summary
- Make the `_italic_` markdown stripping regex word-boundary-aware so it doesn't mangle `snake_case` words in conversation titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
