### PR TITLE
fix: restore Vercel handler in onDisappear during credential polling

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -21,6 +21,8 @@ final class SharingState {
     var pendingPublish: (html: String, title: String?, appId: String?)?
     /// Timer for polling credential availability during setup flow.
     var credentialPollTimer: Timer?
+    /// Stashed handler so onDisappear can restore it when polling is active.
+    var previousVercelHandler: ((VercelApiConfigResponseMessage) -> Void)?
 }
 
 /// Sidebar interaction state -- hover, rename, expand/collapse lists, drawer.
@@ -198,7 +200,8 @@ struct MainWindowView: View {
         // after polling ends. Without this, the poll closure permanently
         // overwrites SettingsStore's onVercelApiConfigResponse and hasVercelKey
         // is never updated again.
-        let previousHandler = daemonClient.onVercelApiConfigResponse
+        sharing.previousVercelHandler = daemonClient.onVercelApiConfigResponse
+        let previousHandler = sharing.previousVercelHandler
 
         sharing.credentialPollTimer = Timer.scheduledTimer(withTimeInterval: 3, repeats: true) { [self] timer in
             Task { @MainActor in
@@ -208,6 +211,7 @@ struct MainWindowView: View {
                     sharing.credentialPollTimer = nil
                     sharing.pendingPublish = nil
                     daemonClient.onVercelApiConfigResponse = previousHandler
+                    sharing.previousVercelHandler = nil
                     return
                 }
 
@@ -222,6 +226,7 @@ struct MainWindowView: View {
                         sharing.credentialPollTimer = nil
                         sharing.pendingPublish = nil
                         daemonClient.onVercelApiConfigResponse = previousHandler
+                        sharing.previousVercelHandler = nil
                         // Auto-retry publish with saved params
                         publishPage(html: pending.html, title: pending.title, appId: pending.appId)
                     }
@@ -623,6 +628,10 @@ struct MainWindowView: View {
             sharing.credentialPollTimer?.invalidate()
             sharing.credentialPollTimer = nil
             sharing.pendingPublish = nil
+            if let handler = sharing.previousVercelHandler {
+                daemonClient.onVercelApiConfigResponse = handler
+                sharing.previousVercelHandler = nil
+            }
             daemonClient.stopSSE()
         }
         .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in


### PR DESCRIPTION
## Summary
- Store `previousVercelHandler` on `SharingState` so `onDisappear` can restore `daemonClient.onVercelApiConfigResponse` when credential polling is active
- Previously, the handler was only a local variable inside `startCredentialPollForPublish()`, so `onDisappear` couldn't restore it — leaving a stale polling closure attached
- Clear `previousVercelHandler` on all existing restore paths (timeout, credential found) for consistency

Addresses Devin review feedback on #10784.

## Test plan
- [ ] Trigger credential polling (publish without Vercel key configured), then close the main window before polling completes — verify SettingsStore continues to receive Vercel config updates
- [ ] Let polling complete normally (timeout or credential found) — verify handler is restored and `previousVercelHandler` is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
