### PR TITLE
feat: add iOS build to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -828,6 +828,40 @@ jobs:
         run: bun run test
         working-directory: gateway
 
+  build-ios:
+    needs: bump-and-tag
+    runs-on: macos-14
+    timeout-minutes: 15
+    continue-on-error: true
+    outputs:
+      actual_result: ${{ steps.report.outputs.status }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: "v${{ needs.bump-and-tag.outputs.version }}"
+
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Clear stale SPM artifact cache
+        run: rm -rf ~/Library/Caches/org.swift.swiftpm/artifacts
+
+      - name: Build for simulator
+        working-directory: clients/ios
+        run: ./build.sh
+
+      - name: Run iOS tests
+        working-directory: clients/ios
+        run: ./build.sh test
+
+      - name: Report actual result
+        id: report
+        if: always()
+        run: echo "status=${{ job.status }}" >> "$GITHUB_OUTPUT"
+
   ci-playwright:
     needs: [bump-and-tag, build-macos]
     runs-on: macos-14
@@ -930,7 +964,7 @@ jobs:
 
   notify:
     if: always() && !cancelled()
-    needs: [bump-and-tag, publish-npm, publish-meta, build-macos, push-assistant-image, push-gateway-image, release, update-platform, ci-assistant, ci-cli, ci-gateway, ci-playwright]
+    needs: [bump-and-tag, publish-npm, publish-meta, build-macos, build-ios, push-assistant-image, push-gateway-image, release, update-platform, ci-assistant, ci-cli, ci-gateway, ci-playwright]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true
@@ -984,6 +1018,7 @@ jobs:
           G=$(ci_icon "${{ needs.ci-gateway.result }}")
           P=$(ci_icon "${{ needs.ci-playwright.result }}")
           D=$(ci_icon "${{ needs.build-macos.result }}")
+          I=$(ci_icon "${{ needs.build-ios.outputs.actual_result }}")
           AI=$(ci_icon "${{ needs.push-assistant-image.result }}")
           GI=$(ci_icon "${{ needs.push-gateway-image.result }}")
 
@@ -993,7 +1028,7 @@ jobs:
             PLAYWRIGHT_LINE=" (<${RUN_URL}#artifacts|view report>)"
           fi
 
-          CI_LINE=$(printf '*CI Checks:*\n• %s assistant\n• %s cli\n• %s gateway\n• %s playwright%s\n• %s desktop\n• %s assistant-docker\n• %s gateway-docker' "$A" "$C" "$G" "$P" "$PLAYWRIGHT_LINE" "$D" "$AI" "$GI")
+          CI_LINE=$(printf '*CI Checks:*\n• %s assistant\n• %s cli\n• %s gateway\n• %s playwright%s\n• %s desktop\n• %s ios\n• %s assistant-docker\n• %s gateway-docker' "$A" "$C" "$G" "$P" "$PLAYWRIGHT_LINE" "$D" "$I" "$AI" "$GI")
           META_LINE=$(printf '*Version:* `%s`\n*Triggered by:* %s' "$VERSION" "${{ github.actor }}")
 
           # Fetch release notes from GitHub release


### PR DESCRIPTION
## Summary
- Adds a `build-ios` job to the release workflow that builds the iOS app for simulator and runs tests
- Uses `continue-on-error: true` so iOS failures don't block the release or the `release` job
- Reports actual iOS build status in the Slack notification via `outputs.actual_result` (same pattern as `ci-assistant`)
- Includes the SPM artifact cache clear step from #10781

## Test plan
- [ ] Trigger a release and verify the iOS build job runs in parallel with other jobs
- [ ] Verify the Slack notification includes the iOS status line
- [ ] Verify that if iOS fails, the release still succeeds and Slack shows the failure icon for iOS only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
