### PR TITLE
fix: resolve lint errors (import sorting, prefer-const, unused var)

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -143,12 +143,12 @@ import { addMessage, getMessages } from '../memory/conversation-store.js';
 import { getDb, initializeDb, resetDb } from '../memory/db.js';
 import { createInvite } from '../memory/ingress-invite-store.js';
 import { upsertMember } from '../memory/ingress-member-store.js';
-import { generateVoiceCode, hashVoiceCode } from '../util/voice-code.js';
 import { conversations } from '../memory/schema.js';
 import {
   createOutboundSession,
   getGuardianBinding,
 } from '../runtime/channel-guardian-service.js';
+import { generateVoiceCode, hashVoiceCode } from '../util/voice-code.js';
 
 initializeDb();
 

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -35,6 +35,7 @@ import {
   type GuardianApprovalRequest,
   updateApprovalDecision,
 } from '../memory/channel-guardian-store.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import type {
   ApprovalAction,
   ApprovalDecisionResult,
@@ -45,7 +46,6 @@ import {
   type PendingApprovalInfo,
 } from '../runtime/channel-approvals.js';
 import type { ApplyGuardianDecisionResult } from '../runtime/guardian-decision-types.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
 import { getLogger } from '../util/logger.js';
 import { mintGrantFromDecision } from './approval-primitive.js';

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -18,9 +18,9 @@ import {
   listCanonicalGuardianDeliveries,
 } from '../memory/canonical-guardian-store.js';
 import { revokeScopedApprovalGrantsForContext } from '../memory/scoped-approval-grants.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
 import { getLogger } from '../util/logger.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { readHttpToken } from '../util/platform.js';
 import { getMaxCallDurationMs, getUserConsultationTimeoutMs, SILENCE_TIMEOUT_MS } from './call-constants.js';
 import { persistCallCompletionMessage } from './call-conversation-messages.js';

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -21,6 +21,7 @@ import {
   resolveActorTrust,
   toGuardianRuntimeContextFromTrust,
 } from '../runtime/actor-trust-resolver.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import {
   getPendingChallenge,
   validateAndConsumeChallenge,
@@ -32,7 +33,6 @@ import {
 import { redeemVoiceInviteCode } from '../runtime/ingress-service.js';
 import { parseJsonSafe } from '../util/json.js';
 import { getLogger } from '../util/logger.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { getAccessRequestPollIntervalMs, getTtsPlaybackDelayMs, getUserConsultationTimeoutMs } from './call-constants.js';
 import { CallController } from './call-controller.js';
 import { persistCallCompletionMessage } from './call-conversation-messages.js';

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -3,6 +3,7 @@ import * as net from 'node:net';
 import type { ChannelId } from '../../channels/types.js';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
 import { findMember, revokeMember } from '../../memory/ingress-member-store.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../../runtime/assistant-scope.js';
 import {
   createVerificationChallenge,
   findActiveSession,
@@ -17,7 +18,6 @@ import {
   resendOutbound,
   startOutbound,
 } from '../../runtime/guardian-outbound-actions.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from '../../runtime/assistant-scope.js';
 import type {
   ChannelReadinessRequest,
   GuardianVerificationRequest,
@@ -89,7 +89,7 @@ export function createGuardianChallenge(
 
 export function getGuardianStatus(
   channel?: ChannelId,
-  assistantId?: string,
+  _assistantId?: string,
 ): GuardianVerificationResult {
   const resolvedAssistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const resolvedChannel = channel ?? 'telegram';

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -1,8 +1,8 @@
 import * as net from 'node:net';
 
 import { type Confidence, recordConversationSeenSignal, type SignalType } from '../../memory/conversation-attention-store.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from '../../runtime/assistant-scope.js';
 import { updateDeliveryClientOutcome } from '../../notifications/deliveries-store.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../../runtime/assistant-scope.js';
 import type { ClientMessage } from '../ipc-protocol.js';
 import { handleRideShotgunStart, handleRideShotgunStop } from '../ride-shotgun-handler.js';
 import { handleWatchObservation } from '../watch-handler.js';

--- a/assistant/src/daemon/handlers/publish.ts
+++ b/assistant/src/daemon/handlers/publish.ts
@@ -58,7 +58,7 @@ export async function handlePublishPage(
       return { url: result.url, deploymentId: result.deploymentId };
     };
 
-    let useResult = await credentialBroker.serverUse({
+    const useResult = await credentialBroker.serverUse({
       service: 'vercel',
       field: 'api_token',
       toolName: 'publish_page',

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -3,7 +3,6 @@ import * as net from 'node:net';
 import { v4 as uuid } from 'uuid';
 
 import { createAssistantMessage, createUserMessage } from '../../agent/message-types.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from '../../runtime/assistant-scope.js';
 import { type InterfaceId,isChannelId, parseChannelId, parseInterfaceId } from '../../channels/types.js';
 import { getConfig } from '../../config/loader.js';
 import { getAttachmentsForMessage, getFilePathForAttachment, setAttachmentThumbnail } from '../../memory/attachments-store.js';
@@ -18,6 +17,7 @@ import { getAttentionStateByConversationIds } from '../../memory/conversation-at
 import * as conversationStore from '../../memory/conversation-store.js';
 import { GENERATING_TITLE, queueGenerateConversationTitle, UNTITLED_FALLBACK } from '../../memory/conversation-title-service.js';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../../runtime/assistant-scope.js';
 import { routeGuardianReply } from '../../runtime/guardian-reply-router.js';
 import * as pendingInteractions from '../../runtime/pending-interactions.js';
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -10,7 +10,6 @@
 import { v4 as uuid } from 'uuid';
 
 import type { AgentEvent,AgentLoop, CheckpointDecision } from '../agent/loop.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { createAssistantMessage } from '../agent/message-types.js';
 import type { ChannelId, InterfaceId, TurnChannelContext, TurnInterfaceContext } from '../channels/types.js';
 import { getConfig } from '../config/loader.js';
@@ -27,6 +26,7 @@ import type { PermissionPrompter } from '../permissions/prompter.js';
 import type { ContentBlock,Message } from '../providers/types.js';
 import type { Provider } from '../providers/types.js';
 import { resolveActorTrust } from '../runtime/actor-trust-resolver.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import type { UsageActor } from '../usage/actors.js';
 import { getLogger } from '../util/logger.js';
 import { truncate } from '../util/truncate.js';

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -12,8 +12,8 @@
 import { v4 as uuid } from 'uuid';
 
 import { getDeliverableChannels } from '../channels/config.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { getActiveBinding } from '../memory/channel-guardian-store.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { getLogger } from '../util/logger.js';
 import { type BroadcastFn, VellumAdapter } from './adapters/macos.js';
 import { SmsAdapter } from './adapters/sms.js';

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -39,8 +39,8 @@ import * as externalConversationStore from '../memory/external-conversation-stor
 import { consumeCallback, consumeCallbackError } from '../security/oauth-callback-registry.js';
 import { getLogger } from '../util/logger.js';
 import { buildAssistantEvent } from './assistant-event.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
 import { assistantEventHub } from './assistant-event-hub.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
 import { sweepFailedEvents } from './channel-retry-sweep.js';
 import { httpError } from './http-errors.js';
 // Middleware

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -8,12 +8,12 @@
  */
 
 import type { ChannelId } from '../channels/types.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
 import { getSqlite } from '../memory/db.js';
 import { findActiveVoiceInvites,findByTokenHash, hashToken, markInviteExpired, recordInviteUse, redeemInvite as storeRedeemInvite } from '../memory/ingress-invite-store.js';
 import { findMember, upsertMember } from '../memory/ingress-member-store.js';
 import { canonicalizeInboundIdentity } from '../util/canonicalize-identity.js';
 import { hashVoiceCode } from '../util/voice-code.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
 
 // ---------------------------------------------------------------------------
 // Outcome type

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -27,8 +27,8 @@ import { canonicalizeInboundIdentity } from '../../util/canonicalize-identity.js
 import { IngressBlockedError } from '../../util/errors.js';
 import { getLogger } from '../../util/logger.js';
 import { readHttpToken } from '../../util/platform.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import { notifyGuardianOfAccessRequest } from '../access-request-helper.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import {
   buildApprovalUIMetadata,
   getApprovalInfoByConversation,


### PR DESCRIPTION
## Summary
- Fixed 12 `simple-import-sort/imports` errors across multiple files via eslint autofix
- Fixed `prefer-const` error in `publish.ts` (`let useResult` → `const useResult`)
- Fixed `no-unused-vars` error in `config-channels.ts` (renamed `assistantId` → `_assistantId`)

## Test plan
- [x] `bun run lint` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
