### PR TITLE
fix: wait for gateway health before pairing QR code

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -557,8 +557,35 @@ export async function startGateway(assistantId?: string): Promise<string> {
     writeFileSync(join(vellumDir, "gateway.pid"), String(gateway.pid), "utf-8");
   }
 
+  const gatewayUrl = publicUrl || `http://localhost:${GATEWAY_PORT}`;
+
+  // Wait for the gateway to be responsive before returning. Without this,
+  // callers (e.g. displayPairingQRCode) may try to connect before the HTTP
+  // server is listening and get connection-refused errors.
+  const start = Date.now();
+  const timeoutMs = 30000;
+  let ready = false;
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(`http://localhost:${GATEWAY_PORT}/healthz`, {
+        signal: AbortSignal.timeout(2000),
+      });
+      if (res.ok) {
+        ready = true;
+        break;
+      }
+    } catch {
+      // Gateway not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+
+  if (!ready) {
+    console.warn("⚠ Gateway started but health check did not respond within 30s");
+  }
+
   console.log("✅ Gateway started\n");
-  return publicUrl || `http://localhost:${GATEWAY_PORT}`;
+  return gatewayUrl;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes "Could not generate pairing QR code: Unable to connect" error during `vellum hatch` on mac mini
- Root cause: `startGateway()` spawns the gateway process and returns immediately, but `displayPairingQRCode()` then tries to POST to `/v1/pairing/register` before the HTTP server is listening
- Fix: poll the gateway `/healthz` endpoint (up to 30s, 250ms intervals) before returning from `startGateway()`, matching how `startLocalDaemon()` waits for the socket file

## Test plan

- [ ] Verify on mac mini: `curl ... | bash` completes with QR code displayed
- [ ] Verify `vellum pair` also works after hatch
- [ ] Verify existing desktop app hatch flow unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
