### PR TITLE
feat: iOS pairing actor-token plumbing + startup bootstrap

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -76,6 +76,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     let clientProvider: ClientProvider
     let authManager = AuthManager()
     let ambientAgentManager = AmbientAgentManager()
+    /// Background task that retries actor-token bootstrap until success.
+    private var actorTokenBootstrapTask: Task<Void, Never>?
 
     override init() {
         self.clientProvider = ClientProvider(client: DaemonClient(config: .fromUserDefaults()))
@@ -90,10 +92,14 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // the new approval flow. Runs once; the flag persists across future launches.
         migrateToPairingV4IfNeeded()
 
-
         // Initial connect is handled by SceneDelegate.sceneWillEnterForeground, which fires
         // during launch and on every background→foreground transition. Calling connect() here
         // too would race with the scene's connect() since isConnected is false while in-flight.
+
+        // Ensure an actor token is present. Newly paired devices receive it
+        // via the pairing response; existing devices that paired before
+        // actor-token support was added will bootstrap here on startup.
+        ensureActorTokenBootstrap()
 
         // Register for push notifications
         UNUserNotificationCenter.current().requestAuthorization(
@@ -190,6 +196,64 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         log.info("v4 pairing migration complete — legacy pairing state cleared")
     }
 
+
+    // MARK: - Actor Token Bootstrap
+
+    /// Ensures an actor token is present. If missing, waits for the daemon
+    /// to become reachable and calls the bootstrap endpoint with exponential
+    /// backoff. Runs entirely in the background and never blocks the UI.
+    private func ensureActorTokenBootstrap() {
+        actorTokenBootstrapTask?.cancel()
+
+        actorTokenBootstrapTask = Task { [weak self] in
+            guard let self else { return }
+
+            // Already have a token — nothing to do.
+            if ActorTokenManager.hasToken { return }
+
+            let deviceId = getOrCreateDeviceId()
+            var delay: UInt64 = 2_000_000_000 // 2 seconds initial
+            let maxDelay: UInt64 = 60_000_000_000 // 60 seconds cap
+
+            while !Task.isCancelled {
+                // Wait for the daemon to be connected before attempting.
+                guard self.clientProvider.client.isConnected else {
+                    try? await Task.sleep(nanoseconds: delay)
+                    continue
+                }
+
+                guard let daemon = self.clientProvider.client as? DaemonClient else {
+                    return
+                }
+
+                let success = await daemon.bootstrapActorToken(
+                    platform: "ios",
+                    deviceId: deviceId
+                )
+
+                if success {
+                    log.info("Actor token bootstrap succeeded")
+                    return
+                }
+
+                // Exponential backoff with jitter
+                let jitter = UInt64.random(in: 0...(delay / 4))
+                try? await Task.sleep(nanoseconds: delay + jitter)
+                delay = min(delay * 2, maxDelay)
+            }
+        }
+    }
+
+    /// Get or create a stable device ID stored in the Keychain.
+    /// Shared with QRPairingSheet so both paths use the same identity.
+    private func getOrCreateDeviceId() -> String {
+        if let existing = APIKeyManager.shared.getAPIKey(provider: "pairing-device-id"), !existing.isEmpty {
+            return existing
+        }
+        let newId = UUID().uuidString
+        _ = APIKeyManager.shared.setAPIKey(newId, provider: "pairing-device-id")
+        return newId
+    }
 
     func application(
         _ application: UIApplication,

--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -202,7 +202,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     /// Ensures an actor token is present. If missing, waits for the daemon
     /// to become reachable and calls the bootstrap endpoint with exponential
     /// backoff. Runs entirely in the background and never blocks the UI.
-    private func ensureActorTokenBootstrap() {
+    func ensureActorTokenBootstrap() {
         actorTokenBootstrapTask?.cancel()
 
         actorTokenBootstrapTask = Task { [weak self] in
@@ -213,9 +213,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
             // If no pairing config exists (fresh install or logged-out state),
             // bail out immediately. Without a gateway URL the daemon connection
-            // will never succeed, so looping would just drain battery. The
-            // bootstrap will be re-triggered after a successful QR pairing via
-            // the clientProvider rebuild path.
+            // will never succeed, so looping would just drain battery.
+            // QRPairingSheet re-triggers this method after a successful pairing
+            // when no actor token was included in the pairing response.
             let gatewayURL = UserDefaults.standard.string(forKey: UserDefaultsKeys.gatewayBaseURL)
             guard let gatewayURL, !gatewayURL.isEmpty else {
                 log.info("Actor token bootstrap skipped — no pairing config present")

--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -211,14 +211,28 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             // Already have a token — nothing to do.
             if ActorTokenManager.hasToken { return }
 
+            // If no pairing config exists (fresh install or logged-out state),
+            // bail out immediately. Without a gateway URL the daemon connection
+            // will never succeed, so looping would just drain battery. The
+            // bootstrap will be re-triggered after a successful QR pairing via
+            // the clientProvider rebuild path.
+            let gatewayURL = UserDefaults.standard.string(forKey: UserDefaultsKeys.gatewayBaseURL)
+            guard let gatewayURL, !gatewayURL.isEmpty else {
+                log.info("Actor token bootstrap skipped — no pairing config present")
+                return
+            }
+
             let deviceId = getOrCreateDeviceId()
             var delay: UInt64 = 2_000_000_000 // 2 seconds initial
             let maxDelay: UInt64 = 60_000_000_000 // 60 seconds cap
+            let connectionMaxDelay: UInt64 = 300_000_000_000 // 5 minutes cap for waiting on connection
+            var connectionDelay: UInt64 = 2_000_000_000
 
             while !Task.isCancelled {
                 // Wait for the daemon to be connected before attempting.
                 guard self.clientProvider.client.isConnected else {
-                    try? await Task.sleep(nanoseconds: delay)
+                    try? await Task.sleep(nanoseconds: connectionDelay)
+                    connectionDelay = min(connectionDelay * 2, connectionMaxDelay)
                     continue
                 }
 

--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -525,8 +525,12 @@ struct QRPairingSheet: View {
 
         // Persist the actor token received during pairing so subsequent HTTP
         // requests include the X-Actor-Token header immediately.
+        // When re-pairing to an assistant that omits the token, clear the
+        // previous value so the old credential is never sent to the new gateway.
         if let actorToken = actorToken, !actorToken.isEmpty {
             ActorTokenManager.setToken(actorToken)
+        } else {
+            ActorTokenManager.deleteToken()
         }
 
         // Generate conversation key if missing

--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -543,6 +543,17 @@ struct QRPairingSheet: View {
         phase = .connecting
         clientProvider.rebuildClient()
 
+        // If the pairing response did not include an actor token, re-trigger
+        // the bootstrap loop so the device obtains one from the daemon now
+        // that a valid gateway URL is configured. Without this, a fresh
+        // install that pairs in-session would lack an actor token until the
+        // next app restart.
+        if !ActorTokenManager.hasToken {
+            if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+                appDelegate.ensureActorTokenBootstrap()
+            }
+        }
+
         Task {
             do {
                 try await clientProvider.client.connect()

--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -403,12 +403,14 @@ struct QRPairingSheet: View {
             }
             let localLanUrl = response["localLanUrl"] as? String
             let featureFlagToken = response["featureFlagToken"] as? String
+            let actorToken = response["actorToken"] as? String
             savePairingConfig(
                 bearerToken: bearerToken,
                 gatewayUrl: gatewayUrl,
                 hostId: payload.hostId,
                 localLanUrl: localLanUrl,
-                featureFlagToken: featureFlagToken
+                featureFlagToken: featureFlagToken,
+                actorToken: actorToken
             )
             connectToMac()
 
@@ -477,12 +479,14 @@ struct QRPairingSheet: View {
                     }
                     let localLanUrl = json["localLanUrl"] as? String
                     let featureFlagToken = json["featureFlagToken"] as? String
+                    let actorToken = json["actorToken"] as? String
                     savePairingConfig(
                         bearerToken: bearerToken,
                         gatewayUrl: gatewayUrl,
                         hostId: payload.hostId,
                         localLanUrl: localLanUrl,
-                        featureFlagToken: featureFlagToken
+                        featureFlagToken: featureFlagToken,
+                        actorToken: actorToken
                     )
                     connectToMac()
 
@@ -507,7 +511,7 @@ struct QRPairingSheet: View {
 
     // MARK: - Config Persistence
 
-    private func savePairingConfig(bearerToken: String, gatewayUrl: String, hostId: String, localLanUrl: String?, featureFlagToken: String? = nil) {
+    private func savePairingConfig(bearerToken: String, gatewayUrl: String, hostId: String, localLanUrl: String?, featureFlagToken: String? = nil, actorToken: String? = nil) {
         UserDefaults.standard.set(gatewayUrl, forKey: UserDefaultsKeys.gatewayBaseURL)
         _ = APIKeyManager.shared.setAPIKey(bearerToken, provider: "runtime-bearer-token")
         if !hostId.isEmpty {
@@ -518,6 +522,12 @@ struct QRPairingSheet: View {
         }
         // Don't delete on absence — the server may not send featureFlagToken yet,
         // so a missing field shouldn't wipe a previously stored token.
+
+        // Persist the actor token received during pairing so subsequent HTTP
+        // requests include the X-Actor-Token header immediately.
+        if let actorToken = actorToken, !actorToken.isEmpty {
+            ActorTokenManager.setToken(actorToken)
+        }
 
         // Generate conversation key if missing
         if UserDefaults.standard.string(forKey: UserDefaultsKeys.conversationKey)?.isEmpty != false {


### PR DESCRIPTION
## Summary
- Extends iOS QR pairing flow to parse and store `actorToken` from pairing response via `ActorTokenManager`
- Adds startup bootstrap in iOS `AppDelegate` with exponential backoff retry for existing paired devices missing actor tokens
- Follows the same pattern as macOS `AppDelegate.ensureActorTokenBootstrap()`

## Test plan
- [ ] Newly paired iOS devices receive actor token directly via QR pairing response
- [ ] Existing paired iOS beta devices auto-bootstrap actor token on startup
- [ ] `X-Actor-Token` header is sent on all iOS HTTP requests (already handled by shared HTTPDaemonClient)
- [ ] Pairing flow still works end-to-end without regressions

Part of #10754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
