### PR TITLE
fix: register prompter IPC approval events for NL interception

### DIFF
--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -100,6 +100,7 @@ interface TestSession {
   setAssistantId: (assistantId: string) => void;
   setGuardianContext: (ctx: unknown) => void;
   setCommandIntent: (intent: unknown) => void;
+  updateClient: (sendToClient: (msg: ServerMessage) => void, hasNoClient?: boolean) => void;
   processMessage: (...args: unknown[]) => Promise<string>;
 }
 
@@ -153,6 +154,7 @@ function makeSession(overrides: Partial<TestSession> = {}): TestSession {
     setAssistantId: () => {},
     setGuardianContext: () => {},
     setCommandIntent: () => {},
+    updateClient: () => {},
     processMessage: async () => 'msg-id',
     ...overrides,
   };
@@ -406,6 +408,53 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
         toolName: 'call_start',
         status: 'pending',
         requestCode: 'ABC123',
+      }),
+    );
+    expect(sent.some((event) => event.type === 'confirmation_request')).toBe(true);
+  });
+
+  test('registers IPC confirmation events emitted via session sender (prompter path)', async () => {
+    let currentSender: (msg: ServerMessage) => void = () => {};
+    const session = makeSession({
+      hasAnyPendingConfirmation: () => false,
+      enqueueMessage: mock(() => ({ queued: false, requestId: 'direct-id' })),
+      updateClient: (sendToClient: (msg: ServerMessage) => void) => {
+        currentSender = sendToClient;
+      },
+      processMessage: async () => {
+        currentSender({
+          type: 'confirmation_request',
+          requestId: 'req-prompter-1',
+          toolName: 'call_start',
+          input: { phone_number: '+18084436762' },
+          riskLevel: 'high',
+          executionTarget: 'host',
+          allowlistOptions: [],
+          scopeOptions: [],
+          persistentDecisionsAllowed: false,
+        } as ServerMessage);
+        return 'msg-id';
+      },
+    });
+    const { ctx, sent } = createContext(session);
+
+    await handleUserMessage(makeMessage('please call now'), {} as net.Socket, ctx);
+
+    expect(registerMock).toHaveBeenCalledWith(
+      'req-prompter-1',
+      expect.objectContaining({
+        conversationId: 'conv-1',
+        kind: 'confirmation',
+        session,
+      }),
+    );
+    expect(createCanonicalGuardianRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'req-prompter-1',
+        kind: 'tool_approval',
+        sourceType: 'desktop',
+        sourceChannel: 'vellum',
+        conversationId: 'conv-1',
       }),
     );
     expect(sent.some((event) => event.type === 'confirmation_request')).toBe(true);

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -176,6 +176,10 @@ export async function handleUserMessage(
       conversationId: msg.sessionId,
       sourceChannel: ipcChannel,
     });
+    // Route prompter-originated events (confirmation_request/secret_request)
+    // through the IPC wrapper so pending-interactions + canonical tracking
+    // are updated before the message is sent to the client.
+    session.updateClient(sendEvent, false);
     const ipcInterface = parseInterfaceId(msg.interface);
     if (!ipcInterface) {
       ctx.send(socket, {
@@ -910,6 +914,7 @@ export async function handleSessionCreate(
       conversationId: conversation.id,
       sourceChannel: transportChannel,
     });
+    session.updateClient(sendEvent, false);
     session.setTurnChannelContext({
       userMessageChannel: transportChannel,
       assistantMessageChannel: transportChannel,
@@ -1260,6 +1265,7 @@ export async function handleRegenerate(
     conversationId: msg.sessionId,
     sourceChannel: regenerateChannel,
   });
+  session.updateClient(sendEvent, false);
   const requestId = uuid();
   session.traceEmitter.emit('request_received', 'Regenerate requested', {
     requestId,


### PR DESCRIPTION
## Summary
- rebind IPC session sender to the wrapped `makeIpcEventSender(...)` callback in `handleUserMessage`, `handleSessionCreate` initial-message path, and `handleRegenerate`
- ensure prompter-originated `confirmation_request` / `secret_request` events flow through the same registrar path that populates `pendingInteractions` and canonical guardian requests
- add regression coverage for the prompter path by emitting `confirmation_request` via the session sender (set by `updateClient`) and asserting registration occurs

## Root Cause
Natural-language approval interception depends on pending request IDs from `pendingInteractions` and canonical guardian requests. Those stores were populated only when events passed through `makeIpcEventSender(...)`. In IPC flows, the tool prompter emits `confirmation_request` via the session sender (`updateClient`), which was still bound to the raw socket sender in some paths, bypassing registration entirely.

As a result, inline interception could see zero pending requests and fall through to auto-deny.

## Validation
- `bun test src/__tests__/handlers-user-message-approval-consumption.test.ts`
- `bun test src/__tests__/send-endpoint-busy.test.ts`
- `bunx tsc --noEmit`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
