### PR TITLE
fix: remove embed-worker from vellum ps process list

### DIFF
--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -226,7 +226,6 @@ async function getLocalProcesses(entry: AssistantEntry): Promise<TableRow[]> {
     { name: "daemon", pgrepName: "vellum-daemon", port: RUNTIME_HTTP_PORT, pidFile: join(vellumDir, "vellum.pid") },
     { name: "qdrant", pgrepName: "qdrant", port: QDRANT_PORT, pidFile: join(vellumDir, "workspace", "data", "qdrant", "qdrant.pid") },
     { name: "gateway", pgrepName: "vellum-gateway", port: GATEWAY_PORT, pidFile: join(vellumDir, "gateway.pid") },
-    { name: "embed-worker", pgrepName: "embed-worker", port: 0, pidFile: join(vellumDir, "embed-worker.pid") },
   ];
 
   const results = await Promise.all(specs.map(detectProcess));


### PR DESCRIPTION
## Summary
- Removes `embed-worker` from the `vellum ps` process list since it's a lazy-started subprocess of the daemon, not a standalone service
- Previously showed a misleading yellow "not running / not detected" status even when everything was working correctly
- The embed-worker only spawns on-demand when the first embedding request arrives via `LocalEmbeddingBackend`

## Test plan
- [ ] Run `vellum ps <name>` and verify only daemon, qdrant, and gateway are listed
- [ ] Verify embeddings still work correctly (embed-worker still spawns on demand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
