### PR TITLE
Fix guardian-question vs approval request handling in voice guardian flows

### DIFF
--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -423,6 +423,7 @@ describe('guardian-dispatch', () => {
     expect(payload.activeGuardianRequestCount).toBe(1);
     expect(payload.callSessionId).toBe(session.id);
     expect(payload.requestKind).toBe('pending_question');
+    expect(payload.pendingQuestionId).toBeUndefined();
   });
 
   test('repeated guardian questions in the same call each create per-request delivery rows even when sharing a conversation', async () => {

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -428,7 +428,7 @@ describe('guardian-dispatch', () => {
     expect(payload.activeGuardianRequestCount).toBe(1);
     expect(payload.callSessionId).toBe(session.id);
     expect(payload.requestKind).toBe('pending_question');
-    expect(payload.toolName).toBeNull();
+    expect(payload.toolName).toBeUndefined();
     expect(payload.pendingQuestionId).toBeUndefined();
   });
 

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -367,6 +367,11 @@ describe('guardian-dispatch', () => {
     expect(request).toBeDefined();
     expect(request!.tool_name).toBe('send_email');
     expect(request!.input_digest).toBe('abc123def456');
+
+    const signalParams = emitCalls[0] as Record<string, unknown>;
+    const payload = signalParams.contextPayload as Record<string, unknown>;
+    expect(payload.requestKind).toBe('pending_question');
+    expect(payload.toolName).toBe('send_email');
   });
 
   test('omitting toolName and inputDigest stores null for informational ASK_GUARDIAN dispatches', async () => {
@@ -423,6 +428,7 @@ describe('guardian-dispatch', () => {
     expect(payload.activeGuardianRequestCount).toBe(1);
     expect(payload.callSessionId).toBe(session.id);
     expect(payload.requestKind).toBe('pending_question');
+    expect(payload.toolName).toBeNull();
     expect(payload.pendingQuestionId).toBeUndefined();
   });
 

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -422,6 +422,7 @@ describe('guardian-dispatch', () => {
     // The request was just created so there is 1 pending request for this session
     expect(payload.activeGuardianRequestCount).toBe(1);
     expect(payload.callSessionId).toBe(session.id);
+    expect(payload.requestKind).toBe('pending_question');
   });
 
   test('repeated guardian questions in the same call each create per-request delivery rows even when sharing a conversation', async () => {

--- a/assistant/src/__tests__/guardian-question-mode.test.ts
+++ b/assistant/src/__tests__/guardian-question-mode.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  parseGuardianQuestionPayload,
+  resolveGuardianQuestionInstructionMode,
+} from '../notifications/guardian-question-mode.js';
+
+describe('guardian-question-mode', () => {
+  test('parses pending_question payload as discriminated union', () => {
+    const parsed = parseGuardianQuestionPayload({
+      requestKind: 'pending_question',
+      requestId: 'req-1',
+      requestCode: 'A1B2C3',
+      questionText: 'What time works?',
+      callSessionId: 'call-1',
+      activeGuardianRequestCount: 2,
+    });
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.requestKind).toBe('pending_question');
+    if (!parsed || parsed.requestKind !== 'pending_question') return;
+    expect(parsed.callSessionId).toBe('call-1');
+    expect(parsed.activeGuardianRequestCount).toBe(2);
+  });
+
+  test('parses tool_grant_request payload and requires toolName', () => {
+    const parsed = parseGuardianQuestionPayload({
+      requestKind: 'tool_grant_request',
+      requestId: 'req-2',
+      requestCode: 'D4E5F6',
+      questionText: 'Allow host bash?',
+      toolName: 'host_bash',
+    });
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.requestKind).toBe('tool_grant_request');
+    if (!parsed || parsed.requestKind !== 'tool_grant_request') return;
+    expect(parsed.toolName).toBe('host_bash');
+  });
+
+  test('rejects invalid pending_question payload missing required fields', () => {
+    const parsed = parseGuardianQuestionPayload({
+      requestKind: 'pending_question',
+      requestId: 'req-3',
+      requestCode: 'AAA111',
+      questionText: 'Missing call session and count',
+    });
+    expect(parsed).toBeNull();
+  });
+
+  test('resolve mode uses discriminant for valid typed payloads', () => {
+    const resolved = resolveGuardianQuestionInstructionMode({
+      requestKind: 'pending_question',
+      requestId: 'req-1',
+      requestCode: 'A1B2C3',
+      questionText: 'What time works?',
+      callSessionId: 'call-1',
+      activeGuardianRequestCount: 2,
+    });
+
+    expect(resolved.mode).toBe('answer');
+    expect(resolved.requestKind).toBe('pending_question');
+    expect(resolved.legacyFallbackUsed).toBe(false);
+  });
+
+  test('resolve mode uses legacy fallback when requestKind is missing', () => {
+    const resolved = resolveGuardianQuestionInstructionMode({
+      requestCode: 'A1B2C3',
+      questionText: 'Allow host bash?',
+      toolName: 'host_bash',
+    });
+
+    expect(resolved.mode).toBe('approval');
+    expect(resolved.requestKind).toBeNull();
+    expect(resolved.legacyFallbackUsed).toBe(true);
+  });
+});
+

--- a/assistant/src/__tests__/guardian-question-mode.test.ts
+++ b/assistant/src/__tests__/guardian-question-mode.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 
 import {
+  buildGuardianRequestCodeInstruction,
+  hasGuardianRequestCodeInstruction,
   parseGuardianQuestionPayload,
+  resolveGuardianInstructionModeFromFields,
   resolveGuardianQuestionInstructionMode,
 } from '../notifications/guardian-question-mode.js';
 
@@ -36,6 +39,23 @@ describe('guardian-question-mode', () => {
     expect(parsed?.requestKind).toBe('tool_grant_request');
     if (!parsed || parsed.requestKind !== 'tool_grant_request') return;
     expect(parsed.toolName).toBe('host_bash');
+  });
+
+  test('parses pending_question payload with optional toolName metadata', () => {
+    const parsed = parseGuardianQuestionPayload({
+      requestKind: 'pending_question',
+      requestId: 'req-voice-tool-1',
+      requestCode: 'AA11BB',
+      questionText: 'Allow send_email?',
+      callSessionId: 'call-voice-1',
+      activeGuardianRequestCount: 1,
+      toolName: 'send_email',
+    });
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.requestKind).toBe('pending_question');
+    if (!parsed || parsed.requestKind !== 'pending_question') return;
+    expect(parsed.toolName).toBe('send_email');
   });
 
   test('rejects invalid pending_question payload missing required fields', () => {
@@ -74,5 +94,34 @@ describe('guardian-question-mode', () => {
     expect(resolved.requestKind).toBeNull();
     expect(resolved.legacyFallbackUsed).toBe(true);
   });
-});
 
+  test('resolve mode treats pending_question with toolName as approval-mode', () => {
+    const resolved = resolveGuardianQuestionInstructionMode({
+      requestKind: 'pending_question',
+      requestId: 'req-voice-tool-2',
+      requestCode: 'CC22DD',
+      questionText: 'Allow send_email?',
+      callSessionId: 'call-voice-2',
+      activeGuardianRequestCount: 1,
+      toolName: 'send_email',
+    });
+
+    expect(resolved.mode).toBe('approval');
+    expect(resolved.requestKind).toBe('pending_question');
+    expect(resolved.legacyFallbackUsed).toBe(false);
+  });
+
+  test('resolveGuardianInstructionModeFromFields returns null for unknown request kind', () => {
+    const resolved = resolveGuardianInstructionModeFromFields('unknown_kind', 'send_email');
+    expect(resolved).toBeNull();
+  });
+
+  test('answer-mode instruction detection rejects approval phrasing', () => {
+    const code = 'A1B2C3';
+    const wrongInstruction = buildGuardianRequestCodeInstruction(code, 'approval');
+    const correctInstruction = buildGuardianRequestCodeInstruction(code, 'answer');
+
+    expect(hasGuardianRequestCodeInstruction(wrongInstruction, code, 'answer')).toBe(false);
+    expect(hasGuardianRequestCodeInstruction(correctInstruction, code, 'answer')).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/guardian-question-mode.test.ts
+++ b/assistant/src/__tests__/guardian-question-mode.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, test } from 'bun:test';
 
 import {
+  buildGuardianCodeOnlyClarification,
+  buildGuardianDisambiguationExample,
+  buildGuardianDisambiguationLabel,
+  buildGuardianInvalidActionReply,
+  buildGuardianReplyDirective,
   buildGuardianRequestCodeInstruction,
   hasGuardianRequestCodeInstruction,
+  resolveGuardianInstructionModeForRequest,
   parseGuardianQuestionPayload,
   resolveGuardianInstructionModeFromFields,
   resolveGuardianQuestionInstructionMode,
@@ -123,5 +129,63 @@ describe('guardian-question-mode', () => {
 
     expect(hasGuardianRequestCodeInstruction(wrongInstruction, code, 'answer')).toBe(false);
     expect(hasGuardianRequestCodeInstruction(correctInstruction, code, 'answer')).toBe(true);
+  });
+
+  test('buildGuardianReplyDirective uses mode-specific wording', () => {
+    expect(buildGuardianReplyDirective('A1B2C3', 'approval')).toBe('Reply "A1B2C3 approve" or "A1B2C3 reject".');
+    expect(buildGuardianReplyDirective('A1B2C3', 'answer')).toBe('Reply "A1B2C3 <your answer>".');
+  });
+
+  test('resolveGuardianInstructionModeForRequest handles tool-backed pending_question as approval', () => {
+    expect(
+      resolveGuardianInstructionModeForRequest({
+        kind: 'pending_question',
+        toolName: 'send_email',
+      }),
+    ).toBe('approval');
+    expect(
+      resolveGuardianInstructionModeForRequest({
+        kind: 'pending_question',
+        toolName: null,
+      }),
+    ).toBe('answer');
+  });
+
+  test('centralized guardian response copy builders produce mode-specific copy', () => {
+    expect(buildGuardianInvalidActionReply('approval', 'A1B2C3')).toContain('approve');
+    expect(buildGuardianInvalidActionReply('answer', 'A1B2C3')).toContain('<your answer>');
+
+    expect(
+      buildGuardianCodeOnlyClarification('approval', {
+        requestCode: 'A1B2C3',
+        questionText: 'Allow send_email to bob@example.com?',
+        toolName: 'send_email',
+      }),
+    ).toContain('I found request A1B2C3 for send_email.');
+    expect(
+      buildGuardianCodeOnlyClarification('answer', {
+        requestCode: 'A1B2C3',
+        questionText: 'What time works best?',
+      }),
+    ).toContain('I found question A1B2C3.');
+
+    expect(
+      buildGuardianDisambiguationLabel('approval', {
+        questionText: 'Allow send_email to bob@example.com?',
+        toolName: 'send_email',
+      }),
+    ).toBe('send_email');
+    expect(
+      buildGuardianDisambiguationLabel('answer', {
+        questionText: 'What time works best?',
+      }),
+    ).toBe('What time works best?');
+
+    expect(buildGuardianDisambiguationExample('approval', 'A1B2C3')).toBe(
+      'For approvals: reply "A1B2C3 approve" or "A1B2C3 reject".',
+    );
+    expect(buildGuardianDisambiguationExample('answer', 'A1B2C3')).toBe(
+      'For questions: reply "A1B2C3 <your answer>".',
+    );
   });
 });

--- a/assistant/src/__tests__/guardian-question-mode.test.ts
+++ b/assistant/src/__tests__/guardian-question-mode.test.ts
@@ -12,6 +12,7 @@ import {
   parseGuardianQuestionPayload,
   resolveGuardianInstructionModeFromFields,
   resolveGuardianQuestionInstructionMode,
+  stripConflictingGuardianRequestInstructions,
 } from '../notifications/guardian-question-mode.js';
 
 describe('guardian-question-mode', () => {
@@ -187,5 +188,13 @@ describe('guardian-question-mode', () => {
     expect(buildGuardianDisambiguationExample('answer', 'A1B2C3')).toBe(
       'For questions: reply "A1B2C3 <your answer>".',
     );
+  });
+
+  test('stripConflictingGuardianRequestInstructions removes opposite-mode instructions', () => {
+    const approvalText = 'Reference code: A1B2C3. Reply "A1B2C3 approve" or "A1B2C3 reject".';
+    const answerText = 'Reference code: A1B2C3. Reply "A1B2C3 <your answer>".';
+
+    expect(stripConflictingGuardianRequestInstructions(approvalText, 'A1B2C3', 'answer')).toBe('');
+    expect(stripConflictingGuardianRequestInstructions(answerText, 'A1B2C3', 'approval')).toBe('');
   });
 });

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -506,6 +506,38 @@ describe('routing invariant: code-only messages return clarification', () => {
     expect(unchanged!.status).toBe('pending');
   });
 
+  test('code-only tool-backed pending_question asks for approve/reject decision', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'pending_question',
+      sourceType: 'voice',
+      sourceChannel: 'voice',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      callSessionId: 'call-2',
+      pendingQuestionId: 'pq-2',
+      requestCode: 'B2C3D4',
+      questionText: 'Allow send_email to bob@example.com?',
+      toolName: 'send_email',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await routeGuardianReply(replyCtx({
+      messageText: 'B2C3D4',
+      conversationId: 'conv-1',
+    }));
+
+    expect(result.consumed).toBe(true);
+    expect(result.type).toBe('code_only_clarification');
+    expect(result.decisionApplied).toBe(false);
+    expect(result.replyText).toContain('B2C3D4');
+    expect(result.replyText).toContain('approve');
+    expect(result.replyText).toContain('reject');
+    expect(result.replyText).not.toContain('<your answer>');
+
+    const unchanged = getCanonicalGuardianRequest(req.id);
+    expect(unchanged!.status).toBe('pending');
+  });
+
   test('code with decision text does apply the decision', async () => {
     const req = createCanonicalGuardianRequest({
       kind: 'tool_approval',
@@ -730,6 +762,51 @@ describe('routing invariant: disambiguation stays fail-closed', () => {
     // Disambiguation reply should list request codes
     expect(result.replyText).toContain('AAA111');
     expect(result.replyText).toContain('BBB222');
+  });
+
+  test('disambiguation treats tool-backed pending_question as approval request', async () => {
+    const answerRequest = createCanonicalGuardianRequest({
+      kind: 'pending_question',
+      sourceType: 'voice',
+      sourceChannel: 'voice',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      callSessionId: 'call-answer',
+      pendingQuestionId: 'pq-answer',
+      requestCode: 'ABC123',
+      questionText: 'What time works best?',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const approvalRequest = createCanonicalGuardianRequest({
+      kind: 'pending_question',
+      sourceType: 'voice',
+      sourceChannel: 'voice',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      callSessionId: 'call-approval',
+      pendingQuestionId: 'pq-approval',
+      requestCode: 'DEF456',
+      questionText: 'Allow send_email to bob@example.com?',
+      toolName: 'send_email',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await routeGuardianReply(replyCtx({
+      messageText: 'approve',
+      conversationId: 'conv-guardian-thread',
+      pendingRequestIds: [answerRequest.id, approvalRequest.id],
+      approvalConversationGenerator: undefined,
+    }));
+
+    expect(result.consumed).toBe(true);
+    expect(result.type).toBe('disambiguation_needed');
+    expect(result.decisionApplied).toBe(false);
+    expect(result.replyText).toContain('ABC123');
+    expect(result.replyText).toContain('DEF456');
+    expect(result.replyText).toContain('send_email');
+    expect(result.replyText).toContain('For questions: reply "ABC123 <your answer>".');
+    expect(result.replyText).toContain('For approvals: reply "DEF456 approve" or "DEF456 reject".');
   });
 
   test('single pending request does not need disambiguation', async () => {

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -475,6 +475,37 @@ describe('routing invariant: code-only messages return clarification', () => {
     expect(unchanged!.status).toBe('pending');
   });
 
+  test('code-only pending_question asks for free-text answer (not approve/reject)', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'pending_question',
+      sourceType: 'voice',
+      sourceChannel: 'voice',
+      conversationId: 'conv-1',
+      guardianExternalUserId: 'guardian-1',
+      callSessionId: 'call-1',
+      pendingQuestionId: 'pq-1',
+      requestCode: 'A2B3C4',
+      questionText: 'What time works best?',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await routeGuardianReply(replyCtx({
+      messageText: 'A2B3C4',
+      conversationId: 'conv-1',
+    }));
+
+    expect(result.consumed).toBe(true);
+    expect(result.type).toBe('code_only_clarification');
+    expect(result.decisionApplied).toBe(false);
+    expect(result.replyText).toContain('A2B3C4');
+    expect(result.replyText).toContain('<your answer>');
+    expect(result.replyText).not.toContain('approve');
+    expect(result.replyText).not.toContain('reject');
+
+    const unchanged = getCanonicalGuardianRequest(req.id);
+    expect(unchanged!.status).toBe('pending');
+  });
+
   test('code with decision text does apply the decision', async () => {
     const req = createCanonicalGuardianRequest({
       kind: 'tool_approval',

--- a/assistant/src/__tests__/notification-decision-fallback.test.ts
+++ b/assistant/src/__tests__/notification-decision-fallback.test.ts
@@ -154,6 +154,44 @@ describe('notification decision fallback copy', () => {
     expect(decision.renderedCopy.vellum?.body).toContain('"A1B2C3 <your answer>"');
   });
 
+  test('enforcement appends answer instructions when LLM copy incorrectly uses approve/reject wording', async () => {
+    configuredProvider = {
+      sendMessage: async () => ({ content: [] }),
+    };
+    extractedToolUse = {
+      name: 'record_notification_decision',
+      input: {
+        shouldNotify: true,
+        selectedChannels: ['vellum'],
+        reasoningSummary: 'LLM decision',
+        renderedCopy: {
+          vellum: {
+            title: 'Guardian Question',
+            body: 'Reference code: A1B2C3. Reply "A1B2C3 approve" or "A1B2C3 reject".',
+          },
+        },
+        dedupeKey: 'guardian-question-wrong-instructions-test',
+        confidence: 0.9,
+      },
+    };
+
+    const signal = makeSignal({
+      contextPayload: {
+        requestId: 'req-pending-approve-phrasing',
+        questionText: 'What is the gate code?',
+        requestCode: 'A1B2C3',
+        requestKind: 'pending_question',
+        callSessionId: 'call-1',
+        activeGuardianRequestCount: 1,
+      },
+    });
+
+    const decision = await evaluateSignal(signal, ['vellum'] as NotificationChannel[]);
+
+    expect(decision.fallbackUsed).toBe(false);
+    expect(decision.renderedCopy.vellum?.body).toContain('"A1B2C3 <your answer>"');
+  });
+
   test('enforcement appends explicit approve/reject instructions for tool-approval guardian questions', async () => {
     configuredProvider = {
       sendMessage: async () => ({ content: [] }),

--- a/assistant/src/__tests__/notification-decision-fallback.test.ts
+++ b/assistant/src/__tests__/notification-decision-fallback.test.ts
@@ -96,7 +96,7 @@ describe('notification decision fallback copy', () => {
     expect(decision.renderedCopy.vellum?.body).not.toContain('Action required: guardian.question');
   });
 
-  test('enforces request-code instructions for guardian.question when requestCode exists', async () => {
+  test('enforces free-text answer instructions for guardian.question when requestCode exists', async () => {
     const signal = makeSignal({
       contextPayload: {
         questionText: 'What is the gate code?',
@@ -107,11 +107,12 @@ describe('notification decision fallback copy', () => {
 
     expect(decision.fallbackUsed).toBe(true);
     expect(decision.renderedCopy.vellum?.body).toContain('A1B2C3');
-    expect(decision.renderedCopy.vellum?.body).toContain('approve');
-    expect(decision.renderedCopy.vellum?.body).toContain('reject');
+    expect(decision.renderedCopy.vellum?.body).toContain('<your answer>');
+    expect(decision.renderedCopy.vellum?.body).not.toContain('approve');
+    expect(decision.renderedCopy.vellum?.body).not.toContain('reject');
   });
 
-  test('enforcement appends explicit approve/reject instructions when LLM copy only mentions request code', async () => {
+  test('enforcement appends free-text answer instructions when LLM copy only mentions request code', async () => {
     configuredProvider = {
       sendMessage: async () => ({ content: [] }),
     };
@@ -136,6 +137,41 @@ describe('notification decision fallback copy', () => {
       contextPayload: {
         questionText: 'What is the gate code?',
         requestCode: 'A1B2C3',
+      },
+    });
+
+    const decision = await evaluateSignal(signal, ['vellum'] as NotificationChannel[]);
+
+    expect(decision.fallbackUsed).toBe(false);
+    expect(decision.renderedCopy.vellum?.body).toContain('"A1B2C3 <your answer>"');
+  });
+
+  test('enforcement appends explicit approve/reject instructions for tool-approval guardian questions', async () => {
+    configuredProvider = {
+      sendMessage: async () => ({ content: [] }),
+    };
+    extractedToolUse = {
+      name: 'record_notification_decision',
+      input: {
+        shouldNotify: true,
+        selectedChannels: ['vellum'],
+        reasoningSummary: 'LLM decision',
+        renderedCopy: {
+          vellum: {
+            title: 'Guardian Question',
+            body: 'Use reference code A1B2C3 for this request.',
+          },
+        },
+        dedupeKey: 'guardian-question-tool-approval-test',
+        confidence: 0.9,
+      },
+    };
+
+    const signal = makeSignal({
+      contextPayload: {
+        questionText: 'Allow running host_bash?',
+        requestCode: 'A1B2C3',
+        toolName: 'host_bash',
       },
     });
 

--- a/assistant/src/__tests__/notification-decision-fallback.test.ts
+++ b/assistant/src/__tests__/notification-decision-fallback.test.ts
@@ -99,9 +99,12 @@ describe('notification decision fallback copy', () => {
   test('enforces free-text answer instructions for guardian.question when requestCode exists', async () => {
     const signal = makeSignal({
       contextPayload: {
+        requestId: 'req-pending-1',
         questionText: 'What is the gate code?',
         requestCode: 'A1B2C3',
         requestKind: 'pending_question',
+        callSessionId: 'call-1',
+        activeGuardianRequestCount: 1,
       },
     });
     const decision = await evaluateSignal(signal, ['vellum'] as NotificationChannel[]);
@@ -136,9 +139,12 @@ describe('notification decision fallback copy', () => {
 
     const signal = makeSignal({
       contextPayload: {
+        requestId: 'req-pending-1',
         questionText: 'What is the gate code?',
         requestCode: 'A1B2C3',
         requestKind: 'pending_question',
+        callSessionId: 'call-1',
+        activeGuardianRequestCount: 1,
       },
     });
 
@@ -171,9 +177,11 @@ describe('notification decision fallback copy', () => {
 
     const signal = makeSignal({
       contextPayload: {
+        requestId: 'req-grant-1',
         questionText: 'Allow running host_bash?',
         requestCode: 'A1B2C3',
         requestKind: 'tool_grant_request',
+        toolName: 'host_bash',
       },
     });
 

--- a/assistant/src/__tests__/notification-decision-fallback.test.ts
+++ b/assistant/src/__tests__/notification-decision-fallback.test.ts
@@ -152,6 +152,8 @@ describe('notification decision fallback copy', () => {
 
     expect(decision.fallbackUsed).toBe(false);
     expect(decision.renderedCopy.vellum?.body).toContain('"A1B2C3 <your answer>"');
+    expect(decision.renderedCopy.vellum?.body).not.toContain('"A1B2C3 approve"');
+    expect(decision.renderedCopy.vellum?.body).not.toContain('"A1B2C3 reject"');
   });
 
   test('enforcement appends answer instructions when LLM copy incorrectly uses approve/reject wording', async () => {
@@ -228,5 +230,44 @@ describe('notification decision fallback copy', () => {
     expect(decision.fallbackUsed).toBe(false);
     expect(decision.renderedCopy.vellum?.body).toContain('"A1B2C3 approve"');
     expect(decision.renderedCopy.vellum?.body).toContain('"A1B2C3 reject"');
+  });
+
+  test('approval-mode enforcement removes conflicting answer-mode phrasing', async () => {
+    configuredProvider = {
+      sendMessage: async () => ({ content: [] }),
+    };
+    extractedToolUse = {
+      name: 'record_notification_decision',
+      input: {
+        shouldNotify: true,
+        selectedChannels: ['vellum'],
+        reasoningSummary: 'LLM decision',
+        renderedCopy: {
+          vellum: {
+            title: 'Guardian Question',
+            body: 'Reference code: A1B2C3. Reply "A1B2C3 <your answer>".',
+          },
+        },
+        dedupeKey: 'guardian-question-approval-removes-answer-test',
+        confidence: 0.9,
+      },
+    };
+
+    const signal = makeSignal({
+      contextPayload: {
+        requestId: 'req-grant-2',
+        questionText: 'Allow running host_bash?',
+        requestCode: 'A1B2C3',
+        requestKind: 'tool_grant_request',
+        toolName: 'host_bash',
+      },
+    });
+
+    const decision = await evaluateSignal(signal, ['vellum'] as NotificationChannel[]);
+
+    expect(decision.fallbackUsed).toBe(false);
+    expect(decision.renderedCopy.vellum?.body).toContain('"A1B2C3 approve"');
+    expect(decision.renderedCopy.vellum?.body).toContain('"A1B2C3 reject"');
+    expect(decision.renderedCopy.vellum?.body).not.toContain('<your answer>');
   });
 });

--- a/assistant/src/__tests__/notification-decision-fallback.test.ts
+++ b/assistant/src/__tests__/notification-decision-fallback.test.ts
@@ -101,6 +101,7 @@ describe('notification decision fallback copy', () => {
       contextPayload: {
         questionText: 'What is the gate code?',
         requestCode: 'A1B2C3',
+        requestKind: 'pending_question',
       },
     });
     const decision = await evaluateSignal(signal, ['vellum'] as NotificationChannel[]);
@@ -137,6 +138,7 @@ describe('notification decision fallback copy', () => {
       contextPayload: {
         questionText: 'What is the gate code?',
         requestCode: 'A1B2C3',
+        requestKind: 'pending_question',
       },
     });
 
@@ -171,7 +173,7 @@ describe('notification decision fallback copy', () => {
       contextPayload: {
         questionText: 'Allow running host_bash?',
         requestCode: 'A1B2C3',
-        toolName: 'host_bash',
+        requestKind: 'tool_grant_request',
       },
     });
 

--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -59,9 +59,12 @@ describe('notification decision strategy', () => {
       const signal = makeSignal({
         sourceEventName: 'guardian.question',
         contextPayload: {
+          requestId: 'req-pending-1',
           questionText: 'What is the gate code?',
           requestCode: 'A1B2C3',
           requestKind: 'pending_question',
+          callSessionId: 'call-1',
+          activeGuardianRequestCount: 1,
         },
       });
 
@@ -78,9 +81,11 @@ describe('notification decision strategy', () => {
       const signal = makeSignal({
         sourceEventName: 'guardian.question',
         contextPayload: {
+          requestId: 'req-grant-1',
           questionText: 'Allow running host_bash?',
           requestCode: 'D4E5F6',
           requestKind: 'tool_grant_request',
+          toolName: 'host_bash',
         },
       });
 

--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -55,7 +55,7 @@ describe('notification decision strategy', () => {
       expect(copy.vellum!.body).toContain('What is the gate code?');
     });
 
-    test('guardian.question template includes request-code instructions when present', () => {
+    test('guardian.question template includes free-text answer instructions when requestCode is present', () => {
       const signal = makeSignal({
         sourceEventName: 'guardian.question',
         contextPayload: {
@@ -67,9 +67,27 @@ describe('notification decision strategy', () => {
       const copy = composeFallbackCopy(signal, channels);
       expect(copy.vellum).toBeDefined();
       expect(copy.vellum!.body).toContain('A1B2C3');
+      expect(copy.vellum!.body).toContain('<your answer>');
+      expect(copy.vellum!.body).not.toContain('approve');
+      expect(copy.vellum!.body).not.toContain('reject');
+      expect(copy.telegram!.deliveryText).toContain('A1B2C3');
+    });
+
+    test('guardian.question template uses approve/reject instructions when toolName is present', () => {
+      const signal = makeSignal({
+        sourceEventName: 'guardian.question',
+        contextPayload: {
+          questionText: 'Allow running host_bash?',
+          requestCode: 'D4E5F6',
+          toolName: 'host_bash',
+        },
+      });
+
+      const copy = composeFallbackCopy(signal, channels);
+      expect(copy.vellum).toBeDefined();
+      expect(copy.vellum!.body).toContain('D4E5F6');
       expect(copy.vellum!.body).toContain('approve');
       expect(copy.vellum!.body).toContain('reject');
-      expect(copy.telegram!.deliveryText).toContain('A1B2C3');
     });
 
     test('reminder.fired template uses message from payload', () => {

--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -61,6 +61,7 @@ describe('notification decision strategy', () => {
         contextPayload: {
           questionText: 'What is the gate code?',
           requestCode: 'A1B2C3',
+          requestKind: 'pending_question',
         },
       });
 
@@ -73,13 +74,13 @@ describe('notification decision strategy', () => {
       expect(copy.telegram!.deliveryText).toContain('A1B2C3');
     });
 
-    test('guardian.question template uses approve/reject instructions when toolName is present', () => {
+    test('guardian.question template uses approve/reject instructions for approval-kind request', () => {
       const signal = makeSignal({
         sourceEventName: 'guardian.question',
         contextPayload: {
           questionText: 'Allow running host_bash?',
           requestCode: 'D4E5F6',
-          toolName: 'host_bash',
+          requestKind: 'tool_grant_request',
         },
       });
 

--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -96,6 +96,28 @@ describe('notification decision strategy', () => {
       expect(copy.vellum!.body).toContain('reject');
     });
 
+    test('guardian.question template uses approve/reject for tool-backed pending_question payloads', () => {
+      const signal = makeSignal({
+        sourceEventName: 'guardian.question',
+        contextPayload: {
+          requestId: 'req-voice-tool-1',
+          questionText: 'Allow send_email to bob@example.com?',
+          requestCode: 'A1B2C3',
+          requestKind: 'pending_question',
+          callSessionId: 'call-1',
+          activeGuardianRequestCount: 1,
+          toolName: 'send_email',
+        },
+      });
+
+      const copy = composeFallbackCopy(signal, channels);
+      expect(copy.vellum).toBeDefined();
+      expect(copy.vellum!.body).toContain('A1B2C3');
+      expect(copy.vellum!.body).toContain('approve');
+      expect(copy.vellum!.body).toContain('reject');
+      expect(copy.vellum!.body).not.toContain('<your answer>');
+    });
+
     test('reminder.fired template uses message from payload', () => {
       const signal = makeSignal({
         sourceEventName: 'reminder.fired',

--- a/assistant/src/__tests__/notification-guardian-path.test.ts
+++ b/assistant/src/__tests__/notification-guardian-path.test.ts
@@ -182,7 +182,7 @@ describe('ASK_GUARDIAN canonical notification path', () => {
     expect(payload.questionText).toBe('What is the gate code?');
     expect(payload.callSessionId).toBe(session.id);
     expect(payload.requestKind).toBe('pending_question');
-    expect(payload.toolName).toBeNull();
+    expect(payload.toolName).toBeUndefined();
     expect(payload.pendingQuestionId).toBeUndefined();
     expect(payload.requestId).toBeDefined();
     expect(payload.requestCode).toBeDefined();

--- a/assistant/src/__tests__/notification-guardian-path.test.ts
+++ b/assistant/src/__tests__/notification-guardian-path.test.ts
@@ -182,6 +182,7 @@ describe('ASK_GUARDIAN canonical notification path', () => {
     expect(payload.questionText).toBe('What is the gate code?');
     expect(payload.callSessionId).toBe(session.id);
     expect(payload.requestKind).toBe('pending_question');
+    expect(payload.toolName).toBeNull();
     expect(payload.pendingQuestionId).toBeUndefined();
     expect(payload.requestId).toBeDefined();
     expect(payload.requestCode).toBeDefined();

--- a/assistant/src/__tests__/notification-guardian-path.test.ts
+++ b/assistant/src/__tests__/notification-guardian-path.test.ts
@@ -181,6 +181,7 @@ describe('ASK_GUARDIAN canonical notification path', () => {
     const payload = signalParams.contextPayload as Record<string, unknown>;
     expect(payload.questionText).toBe('What is the gate code?');
     expect(payload.callSessionId).toBe(session.id);
+    expect(payload.requestKind).toBe('pending_question');
     expect(payload.requestId).toBeDefined();
     expect(payload.requestCode).toBeDefined();
   });

--- a/assistant/src/__tests__/notification-guardian-path.test.ts
+++ b/assistant/src/__tests__/notification-guardian-path.test.ts
@@ -182,6 +182,7 @@ describe('ASK_GUARDIAN canonical notification path', () => {
     expect(payload.questionText).toBe('What is the gate code?');
     expect(payload.callSessionId).toBe(session.id);
     expect(payload.requestKind).toBe('pending_question');
+    expect(payload.pendingQuestionId).toBeUndefined();
     expect(payload.requestId).toBeDefined();
     expect(payload.requestCode).toBeDefined();
   });

--- a/assistant/src/__tests__/tool-grant-request-escalation.test.ts
+++ b/assistant/src/__tests__/tool-grant-request-escalation.test.ts
@@ -225,6 +225,8 @@ describe('ToolApprovalHandler / grant-miss escalation', () => {
     // Notification signal should have been emitted
     expect(emittedSignals.length).toBe(1);
     expect(emittedSignals[0].sourceEventName).toBe('guardian.question');
+    const payload = emittedSignals[0].contextPayload as Record<string, unknown>;
+    expect(payload.requestKind).toBe('tool_grant_request');
   });
 
   test('non-guardian grant-miss response includes request code', async () => {

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -163,6 +163,7 @@ async function dispatchGuardianQuestionInner(params: GuardianDispatchParams): Pr
       },
       contextPayload: {
         requestId: request.id,
+        requestKind: request.kind,
         requestCode: request.requestCode,
         callSessionId,
         questionText: pendingQuestion.questionText,

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -166,6 +166,7 @@ async function dispatchGuardianQuestionInner(params: GuardianDispatchParams): Pr
         requestKind: request.kind,
         requestCode: request.requestCode,
         callSessionId,
+        toolName: toolName ?? null,
         questionText: pendingQuestion.questionText,
         activeGuardianRequestCount,
       },

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -167,7 +167,6 @@ async function dispatchGuardianQuestionInner(params: GuardianDispatchParams): Pr
         requestCode: request.requestCode,
         callSessionId,
         questionText: pendingQuestion.questionText,
-        pendingQuestionId: pendingQuestion.id,
         activeGuardianRequestCount,
       },
       conversationAffinityHint,

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -149,6 +149,7 @@ async function dispatchGuardianQuestionInner(params: GuardianDispatchParams): Pr
     // Route through the canonical notification pipeline. The paired vellum
     // conversation from this pipeline is the canonical guardian thread.
     let vellumDeliveryId: string | null = null;
+    const requestCode = request.requestCode ?? request.id.slice(0, 6).toUpperCase();
     const signalResult = await emitNotificationSignal({
       sourceEventName: 'guardian.question',
       sourceChannel: 'voice',
@@ -163,10 +164,10 @@ async function dispatchGuardianQuestionInner(params: GuardianDispatchParams): Pr
       },
       contextPayload: {
         requestId: request.id,
-        requestKind: request.kind,
-        requestCode: request.requestCode,
+        requestKind: 'pending_question',
+        requestCode,
         callSessionId,
-        toolName: toolName ?? null,
+        toolName,
         questionText: pendingQuestion.questionText,
         activeGuardianRequestCount,
       },

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -19,6 +19,10 @@ function str(value: unknown, fallback: string): string {
   return fallback;
 }
 
+function hasToolApprovalContext(payload: Record<string, unknown>): boolean {
+  return nonEmpty(typeof payload.toolName === 'string' ? payload.toolName : undefined) !== undefined;
+}
+
 export function nonEmpty(value: string | undefined): string | undefined {
   if (typeof value !== 'string') return undefined;
   const trimmed = value.trim();
@@ -48,9 +52,12 @@ const TEMPLATES: Record<string, CopyTemplate> = {
     }
 
     const normalizedCode = requestCode.toUpperCase();
+    const instruction = hasToolApprovalContext(payload)
+      ? `Reference code: ${normalizedCode}. Reply "${normalizedCode} approve" or "${normalizedCode} reject".`
+      : `Reference code: ${normalizedCode}. Reply "${normalizedCode} <your answer>".`;
     return {
       title: 'Guardian Question',
-      body: `${question}\n\nReference code: ${normalizedCode}. Reply "${normalizedCode} approve" or "${normalizedCode} reject".`,
+      body: `${question}\n\n${instruction}`,
     };
   },
 

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -10,6 +10,7 @@
  */
 
 import type { NotificationSignal } from './signal.js';
+import { resolveGuardianQuestionInstructionMode } from './guardian-question-mode.js';
 import type { NotificationChannel, RenderedChannelCopy } from './types.js';
 
 type CopyTemplate = (payload: Record<string, unknown>) => RenderedChannelCopy;
@@ -17,10 +18,6 @@ type CopyTemplate = (payload: Record<string, unknown>) => RenderedChannelCopy;
 function str(value: unknown, fallback: string): string {
   if (typeof value === 'string' && value.length > 0) return value;
   return fallback;
-}
-
-function hasToolApprovalContext(payload: Record<string, unknown>): boolean {
-  return nonEmpty(typeof payload.toolName === 'string' ? payload.toolName : undefined) !== undefined;
 }
 
 export function nonEmpty(value: string | undefined): string | undefined {
@@ -52,7 +49,8 @@ const TEMPLATES: Record<string, CopyTemplate> = {
     }
 
     const normalizedCode = requestCode.toUpperCase();
-    const instruction = hasToolApprovalContext(payload)
+    const instructionMode = resolveGuardianQuestionInstructionMode(payload);
+    const instruction = instructionMode === 'approval'
       ? `Reference code: ${normalizedCode}. Reply "${normalizedCode} approve" or "${normalizedCode} reject".`
       : `Reference code: ${normalizedCode}. Reply "${normalizedCode} <your answer>".`;
     return {

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -10,7 +10,10 @@
  */
 
 import type { NotificationSignal } from './signal.js';
-import { resolveGuardianQuestionInstructionMode } from './guardian-question-mode.js';
+import {
+  buildGuardianRequestCodeInstruction,
+  resolveGuardianQuestionInstructionMode,
+} from './guardian-question-mode.js';
 import type { NotificationChannel, RenderedChannelCopy } from './types.js';
 
 type CopyTemplate = (payload: Record<string, unknown>) => RenderedChannelCopy;
@@ -50,9 +53,7 @@ const TEMPLATES: Record<string, CopyTemplate> = {
 
     const normalizedCode = requestCode.toUpperCase();
     const modeResolution = resolveGuardianQuestionInstructionMode(payload);
-    const instruction = modeResolution.mode === 'approval'
-      ? `Reference code: ${normalizedCode}. Reply "${normalizedCode} approve" or "${normalizedCode} reject".`
-      : `Reference code: ${normalizedCode}. Reply "${normalizedCode} <your answer>".`;
+    const instruction = buildGuardianRequestCodeInstruction(normalizedCode, modeResolution.mode);
     return {
       title: 'Guardian Question',
       body: `${question}\n\n${instruction}`,

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -49,8 +49,8 @@ const TEMPLATES: Record<string, CopyTemplate> = {
     }
 
     const normalizedCode = requestCode.toUpperCase();
-    const instructionMode = resolveGuardianQuestionInstructionMode(payload);
-    const instruction = instructionMode === 'approval'
+    const modeResolution = resolveGuardianQuestionInstructionMode(payload);
+    const instruction = modeResolution.mode === 'approval'
       ? `Reference code: ${normalizedCode}. Reply "${normalizedCode} approve" or "${normalizedCode} reject".`
       : `Reference code: ${normalizedCode}. Reply "${normalizedCode} <your answer>".`;
     return {

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -17,6 +17,7 @@ import { createTimeout, extractToolUse, getConfiguredProvider, userMessage } fro
 import type { ModelIntent } from '../providers/types.js';
 import { getLogger } from '../util/logger.js';
 import { composeFallbackCopy } from './copy-composer.js';
+import { resolveGuardianQuestionInstructionMode } from './guardian-question-mode.js';
 import { createDecision } from './decisions-store.js';
 import { getPreferenceSummary } from './preference-summary.js';
 import type { NotificationSignal, RoutingIntent } from './signal.js';
@@ -451,13 +452,7 @@ function enforceGuardianRequestCode(
   if (typeof rawCode !== 'string' || rawCode.trim().length === 0) return decision;
 
   const requestCode = rawCode.trim().toUpperCase();
-  const mode: 'approval' | 'answer' = (() => {
-    const rawToolName = signal.contextPayload.toolName;
-    if (typeof rawToolName === 'string' && rawToolName.trim().length > 0) {
-      return 'approval';
-    }
-    return 'answer';
-  })();
+  const mode = resolveGuardianQuestionInstructionMode(signal.contextPayload);
   const nextCopy: Partial<Record<NotificationChannel, RenderedChannelCopy>> = {
     ...decision.renderedCopy,
   };

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -409,12 +409,18 @@ export function validateThreadActions(
 function ensureGuardianRequestCodeInCopy(
   copy: RenderedChannelCopy,
   requestCode: string,
+  mode: 'approval' | 'answer',
 ): RenderedChannelCopy {
-  const instruction = `Reference code: ${requestCode}. Reply "${requestCode} approve" or "${requestCode} reject".`;
+  const instruction = mode === 'approval'
+    ? `Reference code: ${requestCode}. Reply "${requestCode} approve" or "${requestCode} reject".`
+    : `Reference code: ${requestCode}. Reply "${requestCode} <your answer>".`;
   const hasParserCompatibleInstructions = (text: string | undefined): boolean => {
     if (typeof text !== 'string') return false;
     const upper = text.toUpperCase();
-    return upper.includes(`${requestCode} APPROVE`) && upper.includes(`${requestCode} REJECT`);
+    if (mode === 'approval') {
+      return upper.includes(`${requestCode} APPROVE`) && upper.includes(`${requestCode} REJECT`);
+    }
+    return upper.includes(`REFERENCE CODE: ${requestCode}`) && upper.includes(`"${requestCode} `);
   };
 
   const ensureText = (text: string | undefined): string => {
@@ -445,6 +451,13 @@ function enforceGuardianRequestCode(
   if (typeof rawCode !== 'string' || rawCode.trim().length === 0) return decision;
 
   const requestCode = rawCode.trim().toUpperCase();
+  const mode: 'approval' | 'answer' = (() => {
+    const rawToolName = signal.contextPayload.toolName;
+    if (typeof rawToolName === 'string' && rawToolName.trim().length > 0) {
+      return 'approval';
+    }
+    return 'answer';
+  })();
   const nextCopy: Partial<Record<NotificationChannel, RenderedChannelCopy>> = {
     ...decision.renderedCopy,
   };
@@ -452,7 +465,7 @@ function enforceGuardianRequestCode(
   for (const channel of Object.keys(nextCopy) as NotificationChannel[]) {
     const copy = nextCopy[channel];
     if (!copy) continue;
-    nextCopy[channel] = ensureGuardianRequestCodeInCopy(copy, requestCode);
+    nextCopy[channel] = ensureGuardianRequestCodeInCopy(copy, requestCode, mode);
   }
 
   return {

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -452,7 +452,16 @@ function enforceGuardianRequestCode(
   if (typeof rawCode !== 'string' || rawCode.trim().length === 0) return decision;
 
   const requestCode = rawCode.trim().toUpperCase();
-  const mode = resolveGuardianQuestionInstructionMode(signal.contextPayload);
+  const modeResolution = resolveGuardianQuestionInstructionMode(signal.contextPayload);
+  if (modeResolution.legacyFallbackUsed) {
+    log.warn(
+      {
+        signalId: signal.signalId,
+        requestKind: modeResolution.requestKind,
+      },
+      'guardian.question payload missing/invalid typed fields; using legacy instruction-mode fallback',
+    );
+  }
   const nextCopy: Partial<Record<NotificationChannel, RenderedChannelCopy>> = {
     ...decision.renderedCopy,
   };
@@ -460,7 +469,7 @@ function enforceGuardianRequestCode(
   for (const channel of Object.keys(nextCopy) as NotificationChannel[]) {
     const copy = nextCopy[channel];
     if (!copy) continue;
-    nextCopy[channel] = ensureGuardianRequestCodeInCopy(copy, requestCode, mode);
+    nextCopy[channel] = ensureGuardianRequestCodeInCopy(copy, requestCode, modeResolution.mode);
   }
 
   return {

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -21,6 +21,7 @@ import {
   buildGuardianRequestCodeInstruction,
   hasGuardianRequestCodeInstruction,
   resolveGuardianQuestionInstructionMode,
+  stripConflictingGuardianRequestInstructions,
 } from './guardian-question-mode.js';
 import { createDecision } from './decisions-store.js';
 import { getPreferenceSummary } from './preference-summary.js';
@@ -420,8 +421,9 @@ function ensureGuardianRequestCodeInCopy(
 
   const ensureText = (text: string | undefined): string => {
     const base = typeof text === 'string' ? text.trim() : '';
-    if (hasGuardianRequestCodeInstruction(base, requestCode, mode)) return base;
-    return base.length > 0 ? `${base}\n\n${instruction}` : instruction;
+    const sanitized = stripConflictingGuardianRequestInstructions(base, requestCode, mode);
+    if (hasGuardianRequestCodeInstruction(sanitized, requestCode, mode)) return sanitized;
+    return sanitized.length > 0 ? `${sanitized}\n\n${instruction}` : instruction;
   };
 
   return {

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -17,7 +17,11 @@ import { createTimeout, extractToolUse, getConfiguredProvider, userMessage } fro
 import type { ModelIntent } from '../providers/types.js';
 import { getLogger } from '../util/logger.js';
 import { composeFallbackCopy } from './copy-composer.js';
-import { resolveGuardianQuestionInstructionMode } from './guardian-question-mode.js';
+import {
+  buildGuardianRequestCodeInstruction,
+  hasGuardianRequestCodeInstruction,
+  resolveGuardianQuestionInstructionMode,
+} from './guardian-question-mode.js';
 import { createDecision } from './decisions-store.js';
 import { getPreferenceSummary } from './preference-summary.js';
 import type { NotificationSignal, RoutingIntent } from './signal.js';
@@ -412,21 +416,11 @@ function ensureGuardianRequestCodeInCopy(
   requestCode: string,
   mode: 'approval' | 'answer',
 ): RenderedChannelCopy {
-  const instruction = mode === 'approval'
-    ? `Reference code: ${requestCode}. Reply "${requestCode} approve" or "${requestCode} reject".`
-    : `Reference code: ${requestCode}. Reply "${requestCode} <your answer>".`;
-  const hasParserCompatibleInstructions = (text: string | undefined): boolean => {
-    if (typeof text !== 'string') return false;
-    const upper = text.toUpperCase();
-    if (mode === 'approval') {
-      return upper.includes(`${requestCode} APPROVE`) && upper.includes(`${requestCode} REJECT`);
-    }
-    return upper.includes(`REFERENCE CODE: ${requestCode}`) && upper.includes(`"${requestCode} `);
-  };
+  const instruction = buildGuardianRequestCodeInstruction(requestCode, mode);
 
   const ensureText = (text: string | undefined): string => {
     const base = typeof text === 'string' ? text.trim() : '';
-    if (hasParserCompatibleInstructions(base)) return base;
+    if (hasGuardianRequestCodeInstruction(base, requestCode, mode)) return base;
     return base.length > 0 ? `${base}\n\n${instruction}` : instruction;
   };
 

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -24,7 +24,12 @@ import { updateDecision } from './decisions-store.js';
 import { type DeterministicCheckContext, runDeterministicChecks } from './deterministic-checks.js';
 import { createEvent, updateEventDedupeKey } from './events-store.js';
 import { dispatchDecision } from './runtime-dispatch.js';
-import type { AttentionHints, NotificationSignal, RoutingIntent } from './signal.js';
+import type {
+  AttentionHints,
+  NotificationContextPayload,
+  NotificationSignal,
+  RoutingIntent,
+} from './signal.js';
 import type { NotificationChannel, NotificationDeliveryResult } from './types.js';
 
 const log = getLogger('emit-signal');
@@ -117,9 +122,9 @@ function getConnectedChannels(assistantId: string): NotificationChannel[] {
 
 // ── Public API ─────────────────────────────────────────────────────────
 
-export interface EmitSignalParams {
+export interface EmitSignalParams<TEventName extends string = string> {
   /** Free-form event name, e.g. 'reminder.fired', 'schedule.complete'. */
-  sourceEventName: string;
+  sourceEventName: TEventName;
   /** Source channel that produced the event. */
   sourceChannel: string;
   /** Session or conversation ID from the source context. */
@@ -129,7 +134,7 @@ export interface EmitSignalParams {
   /** Attention hints for the decision engine. */
   attentionHints: AttentionHints;
   /** Arbitrary context payload passed to the decision engine. */
-  contextPayload?: Record<string, unknown>;
+  contextPayload?: NotificationContextPayload<TEventName>;
   /** Routing intent from the source (e.g. reminder). Controls post-decision channel enforcement. */
   routingIntent?: RoutingIntent;
   /** Free-form hints from the source for the decision engine. */
@@ -169,18 +174,20 @@ export interface EmitSignalResult {
  * Fire-and-forget safe by default: errors are caught and logged unless
  * `throwOnError` is enabled by the caller.
  */
-export async function emitNotificationSignal(params: EmitSignalParams): Promise<EmitSignalResult> {
+export async function emitNotificationSignal<TEventName extends string>(
+  params: EmitSignalParams<TEventName>,
+): Promise<EmitSignalResult> {
   const signalId = uuid();
   const assistantId = params.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
 
-  const signal: NotificationSignal = {
+  const signal: NotificationSignal<TEventName> = {
     signalId,
     assistantId,
     createdAt: Date.now(),
     sourceChannel: params.sourceChannel,
     sourceSessionId: params.sourceSessionId,
     sourceEventName: params.sourceEventName,
-    contextPayload: params.contextPayload ?? {},
+    contextPayload: (params.contextPayload ?? {}) as NotificationContextPayload<TEventName>,
     attentionHints: params.attentionHints,
     routingIntent: params.routingIntent,
     routingHints: params.routingHints,

--- a/assistant/src/notifications/guardian-question-mode.ts
+++ b/assistant/src/notifications/guardian-question-mode.ts
@@ -16,6 +16,27 @@ export const GUARDIAN_QUESTION_REQUEST_KINDS = {
 export type GuardianQuestionRequestKind = keyof typeof GUARDIAN_QUESTION_REQUEST_KINDS;
 export type GuardianQuestionInstructionMode = 'approval' | 'answer';
 
+interface GuardianRequestKindModeConfig {
+  defaultMode: GuardianQuestionInstructionMode;
+  modeWhenToolNamePresent?: GuardianQuestionInstructionMode;
+}
+
+const REQUEST_KIND_MODE_CONFIG: Record<GuardianQuestionRequestKind, GuardianRequestKindModeConfig> = {
+  pending_question: {
+    defaultMode: 'answer',
+    modeWhenToolNamePresent: 'approval',
+  },
+  tool_approval: {
+    defaultMode: 'approval',
+  },
+  tool_grant_request: {
+    defaultMode: 'approval',
+  },
+  access_request: {
+    defaultMode: 'approval',
+  },
+};
+
 interface GuardianQuestionPayloadBase {
   requestKind: GuardianQuestionRequestKind;
   requestId: string;
@@ -27,6 +48,11 @@ export interface PendingQuestionGuardianPayload extends GuardianQuestionPayloadB
   requestKind: 'pending_question';
   callSessionId: string;
   activeGuardianRequestCount: number;
+  /**
+   * Voice tool-approval requests are persisted as pending_question with tool
+   * metadata so they still route through pending-question resolution.
+   */
+  toolName?: string;
 }
 
 export interface ToolApprovalGuardianPayload extends GuardianQuestionPayloadBase {
@@ -107,14 +133,21 @@ export function parseGuardianQuestionPayload(
       const activeGuardianRequestCount = typeof payload.activeGuardianRequestCount === 'number'
         ? payload.activeGuardianRequestCount
         : null;
+      const toolName = nonEmptyString(payload.toolName);
       if (!callSessionId || activeGuardianRequestCount === null || Number.isNaN(activeGuardianRequestCount)) {
         return null;
       }
-      return {
+      const pendingQuestionPayload: PendingQuestionGuardianPayload = {
         requestKind,
         ...base,
         callSessionId,
         activeGuardianRequestCount,
+      };
+      if (toolName) {
+        pendingQuestionPayload.toolName = toolName;
+      }
+      return {
+        ...pendingQuestionPayload,
       };
     }
     case 'tool_approval':
@@ -137,17 +170,67 @@ export function parseGuardianQuestionPayload(
   }
 }
 
-function modeForKind(requestKind: GuardianQuestionRequestKind): GuardianQuestionInstructionMode {
-  switch (requestKind) {
-    case 'pending_question':
-      return 'answer';
-    case 'tool_approval':
-    case 'tool_grant_request':
-    case 'access_request':
-      return 'approval';
+export function resolveGuardianInstructionModeForRequestKind(
+  requestKind: GuardianQuestionRequestKind,
+  toolName?: string | null,
+): GuardianQuestionInstructionMode {
+  const config = REQUEST_KIND_MODE_CONFIG[requestKind];
+  const normalizedToolName = nonEmptyString(toolName);
+  if (normalizedToolName && config.modeWhenToolNamePresent) {
+    return config.modeWhenToolNamePresent;
+  }
+
+  return config.defaultMode;
+}
+
+export function resolveGuardianInstructionModeFromFields(
+  requestKindValue: unknown,
+  toolNameValue: unknown,
+): { requestKind: GuardianQuestionRequestKind; mode: GuardianQuestionInstructionMode } | null {
+  const requestKind = parseGuardianQuestionRequestKind({ requestKind: requestKindValue });
+  if (!requestKind) return null;
+
+  return {
+    requestKind,
+    mode: resolveGuardianInstructionModeForRequestKind(requestKind, nonEmptyString(toolNameValue)),
+  };
+}
+
+export function buildGuardianRequestCodeInstruction(
+  requestCode: string,
+  mode: GuardianQuestionInstructionMode,
+): string {
+  switch (mode) {
+    case 'approval':
+      return `Reference code: ${requestCode}. Reply "${requestCode} approve" or "${requestCode} reject".`;
+    case 'answer':
+      return `Reference code: ${requestCode}. Reply "${requestCode} <your answer>".`;
     default: {
-      // Exhaustive guard for future request kinds
-      const _never: never = requestKind;
+      const _never: never = mode;
+      return _never;
+    }
+  }
+}
+
+export function hasGuardianRequestCodeInstruction(
+  text: string | undefined,
+  requestCode: string,
+  mode: GuardianQuestionInstructionMode,
+): boolean {
+  if (typeof text !== 'string') return false;
+  const upper = text.toUpperCase();
+  const normalizedCode = requestCode.toUpperCase();
+
+  switch (mode) {
+    case 'approval':
+      return upper.includes(`${normalizedCode} APPROVE`) && upper.includes(`${normalizedCode} REJECT`);
+    case 'answer': {
+      const hasAnswerInstruction = upper.includes(`${normalizedCode} <YOUR ANSWER>`);
+      const hasApprovalInstruction = upper.includes(`${normalizedCode} APPROVE`) || upper.includes(`${normalizedCode} REJECT`);
+      return hasAnswerInstruction && !hasApprovalInstruction;
+    }
+    default: {
+      const _never: never = mode;
       return _never;
     }
   }
@@ -164,17 +247,30 @@ export function resolveGuardianQuestionInstructionMode(
 ): GuardianQuestionModeResolution {
   const parsed = parseGuardianQuestionPayload(payload);
   if (parsed) {
+    const parsedToolName = 'toolName' in parsed ? parsed.toolName : null;
     return {
-      mode: modeForKind(parsed.requestKind),
+      mode: resolveGuardianInstructionModeForRequestKind(parsed.requestKind, parsedToolName),
       requestKind: parsed.requestKind,
       legacyFallbackUsed: false,
+    };
+  }
+
+  const requestKindResolution = resolveGuardianInstructionModeFromFields(
+    payload.requestKind,
+    payload.toolName,
+  );
+  if (requestKindResolution) {
+    return {
+      mode: requestKindResolution.mode,
+      requestKind: requestKindResolution.requestKind,
+      legacyFallbackUsed: true,
     };
   }
 
   const toolName = nonEmptyString(payload.toolName);
   return {
     mode: toolName ? 'approval' : 'answer',
-    requestKind: parseGuardianQuestionRequestKind(payload),
+    requestKind: null,
     legacyFallbackUsed: true,
   };
 }

--- a/assistant/src/notifications/guardian-question-mode.ts
+++ b/assistant/src/notifications/guardian-question-mode.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared request-kind and instruction-mode resolver for guardian.question signals.
+ *
+ * Explicit request kinds provide a stable contract between producers and
+ * notification rendering logic, avoiding implicit inference from incidental
+ * fields like `toolName`.
+ */
+
+export const GUARDIAN_QUESTION_REQUEST_KINDS = {
+  pending_question: 'pending_question',
+  tool_approval: 'tool_approval',
+  tool_grant_request: 'tool_grant_request',
+  access_request: 'access_request',
+} as const;
+
+export type GuardianQuestionRequestKind = keyof typeof GUARDIAN_QUESTION_REQUEST_KINDS;
+export type GuardianQuestionInstructionMode = 'approval' | 'answer';
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function parseGuardianQuestionRequestKind(
+  payload: Record<string, unknown>,
+): GuardianQuestionRequestKind | null {
+  const raw = nonEmptyString(payload.requestKind);
+  if (!raw) return null;
+
+  switch (raw) {
+    case 'pending_question':
+    case 'tool_approval':
+    case 'tool_grant_request':
+    case 'access_request':
+      return raw;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Resolve guardian reply instruction mode from request kind.
+ *
+ * Backward compatibility: if requestKind is missing/unknown, fall back to
+ * toolName presence so previously persisted payloads keep working.
+ */
+export function resolveGuardianQuestionInstructionMode(
+  payload: Record<string, unknown>,
+): GuardianQuestionInstructionMode {
+  const requestKind = parseGuardianQuestionRequestKind(payload);
+  if (requestKind === 'pending_question') return 'answer';
+  if (requestKind === 'tool_approval' || requestKind === 'tool_grant_request' || requestKind === 'access_request') {
+    return 'approval';
+  }
+
+  const toolName = nonEmptyString(payload.toolName);
+  return toolName ? 'approval' : 'answer';
+}
+

--- a/assistant/src/notifications/guardian-question-mode.ts
+++ b/assistant/src/notifications/guardian-question-mode.ts
@@ -346,6 +346,39 @@ export function hasGuardianRequestCodeInstruction(
   }
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function normalizeInstructionText(value: string): string {
+  return value
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+export function stripConflictingGuardianRequestInstructions(
+  text: string,
+  requestCode: string,
+  mode: GuardianQuestionInstructionMode,
+): string {
+  const escapedCode = escapeRegExp(requestCode);
+  const approvalInstructionPattern = new RegExp(
+    `(?:Reference\\s+code:\\s*${escapedCode}\\.?\\s*)?Reply\\s+"${escapedCode}\\s+approve"\\s+or\\s+"${escapedCode}\\s+reject"\\.?`,
+    'ig',
+  );
+  const answerInstructionPattern = new RegExp(
+    `(?:Reference\\s+code:\\s*${escapedCode}\\.?\\s*)?Reply\\s+"${escapedCode}\\s+<your\\s+answer>"\\.?`,
+    'ig',
+  );
+
+  const next = mode === 'answer'
+    ? text.replace(approvalInstructionPattern, '')
+    : text.replace(answerInstructionPattern, '');
+
+  return normalizeInstructionText(next);
+}
+
 /**
  * Resolve guardian reply instruction mode from request kind.
  *

--- a/assistant/src/notifications/guardian-question-mode.ts
+++ b/assistant/src/notifications/guardian-question-mode.ts
@@ -38,13 +38,62 @@ const REQUEST_KIND_MODE_CONFIG: Record<GuardianQuestionRequestKind, GuardianRequ
 };
 
 interface GuardianQuestionPayloadBase {
-  requestKind: GuardianQuestionRequestKind;
   requestId: string;
   requestCode: string;
   questionText: string;
 }
 
-export interface PendingQuestionGuardianPayload extends GuardianQuestionPayloadBase {
+interface GuardianQuestionPayloadBaseWithDiscriminator extends GuardianQuestionPayloadBase {
+  requestKind: GuardianQuestionRequestKind;
+  [key: string]: unknown;
+}
+
+export interface GuardianRequestModeInput {
+  kind: unknown;
+  toolName?: unknown;
+}
+
+export interface GuardianRequestTextInput {
+  requestCode: string;
+  questionText?: string | null;
+  toolName?: string | null;
+}
+
+type GuardianDisambiguationCategory = 'questions' | 'approvals';
+
+interface GuardianModeTextConfig {
+  invalidActionWithCode: (requestCode: string) => string;
+  invalidActionWithoutCode: string;
+  buildCodeOnlyHeader: (request: GuardianRequestTextInput) => string;
+  buildCodeOnlyDetailLine: (request: GuardianRequestTextInput) => string | null;
+  buildDisambiguationLabel: (request: Pick<GuardianRequestTextInput, 'questionText' | 'toolName'>) => string;
+  disambiguationCategory: GuardianDisambiguationCategory;
+}
+
+const MODE_TEXT_CONFIG: Record<GuardianQuestionInstructionMode, GuardianModeTextConfig> = {
+  answer: {
+    invalidActionWithCode: (requestCode) =>
+      `I found request ${requestCode}, but I still need your answer. Reply "${requestCode} <your answer>".`,
+    invalidActionWithoutCode:
+      "I couldn't determine your answer. Reply with the request code followed by your answer (e.g., \"ABC123 3pm works\").",
+    buildCodeOnlyHeader: (request) => `I found question ${request.requestCode}.`,
+    buildCodeOnlyDetailLine: (request) => request.questionText ? `Question: ${request.questionText}` : null,
+    buildDisambiguationLabel: (request) => request.questionText ?? 'question',
+    disambiguationCategory: 'questions',
+  },
+  approval: {
+    invalidActionWithCode: (requestCode) =>
+      `I found request ${requestCode}, but I need to know your decision. Reply "${requestCode} approve" or "${requestCode} reject".`,
+    invalidActionWithoutCode:
+      "I couldn't determine your intended action. Reply with the request code followed by 'approve' or 'reject' (e.g., \"ABC123 approve\").",
+    buildCodeOnlyHeader: (request) => `I found request ${request.requestCode} for ${request.toolName ?? 'an action'}.`,
+    buildCodeOnlyDetailLine: (request) => request.questionText ? `Details: ${request.questionText}` : null,
+    buildDisambiguationLabel: (request) => request.toolName ?? request.questionText ?? 'action',
+    disambiguationCategory: 'approvals',
+  },
+};
+
+export interface PendingQuestionGuardianPayload extends GuardianQuestionPayloadBaseWithDiscriminator {
   requestKind: 'pending_question';
   callSessionId: string;
   activeGuardianRequestCount: number;
@@ -55,17 +104,17 @@ export interface PendingQuestionGuardianPayload extends GuardianQuestionPayloadB
   toolName?: string;
 }
 
-export interface ToolApprovalGuardianPayload extends GuardianQuestionPayloadBase {
+export interface ToolApprovalGuardianPayload extends GuardianQuestionPayloadBaseWithDiscriminator {
   requestKind: 'tool_approval';
   toolName: string;
 }
 
-export interface ToolGrantGuardianPayload extends GuardianQuestionPayloadBase {
+export interface ToolGrantGuardianPayload extends GuardianQuestionPayloadBaseWithDiscriminator {
   requestKind: 'tool_grant_request';
   toolName: string;
 }
 
-export interface AccessRequestGuardianPayload extends GuardianQuestionPayloadBase {
+export interface AccessRequestGuardianPayload extends GuardianQuestionPayloadBaseWithDiscriminator {
   requestKind: 'access_request';
 }
 
@@ -104,7 +153,7 @@ export function parseGuardianQuestionRequestKind(
   }
 }
 
-function parseBasePayload(payload: Record<string, unknown>): Omit<GuardianQuestionPayloadBase, 'requestKind'> | null {
+function parseBasePayload(payload: Record<string, unknown>): GuardianQuestionPayloadBase | null {
   const requestId = nonEmptyString(payload.requestId);
   const requestCode = nonEmptyString(payload.requestCode);
   const questionText = nonEmptyString(payload.questionText);
@@ -196,20 +245,81 @@ export function resolveGuardianInstructionModeFromFields(
   };
 }
 
-export function buildGuardianRequestCodeInstruction(
+export function resolveGuardianInstructionModeForRequest(
+  request?: GuardianRequestModeInput | null,
+): GuardianQuestionInstructionMode {
+  if (!request) return 'approval';
+  const modeResolution = resolveGuardianInstructionModeFromFields(request.kind, request.toolName);
+  if (!modeResolution) return 'approval';
+  return modeResolution.mode;
+}
+
+function getModeTextConfig(mode: GuardianQuestionInstructionMode): GuardianModeTextConfig {
+  return MODE_TEXT_CONFIG[mode];
+}
+
+export function buildGuardianReplyDirective(
   requestCode: string,
   mode: GuardianQuestionInstructionMode,
 ): string {
   switch (mode) {
     case 'approval':
-      return `Reference code: ${requestCode}. Reply "${requestCode} approve" or "${requestCode} reject".`;
+      return `Reply "${requestCode} approve" or "${requestCode} reject".`;
     case 'answer':
-      return `Reference code: ${requestCode}. Reply "${requestCode} <your answer>".`;
+      return `Reply "${requestCode} <your answer>".`;
     default: {
       const _never: never = mode;
       return _never;
     }
   }
+}
+
+export function buildGuardianRequestCodeInstruction(
+  requestCode: string,
+  mode: GuardianQuestionInstructionMode,
+): string {
+  return `Reference code: ${requestCode}. ${buildGuardianReplyDirective(requestCode, mode)}`;
+}
+
+export function buildGuardianInvalidActionReply(
+  mode: GuardianQuestionInstructionMode,
+  requestCode?: string,
+): string {
+  const config = getModeTextConfig(mode);
+  if (requestCode) return config.invalidActionWithCode(requestCode);
+  return config.invalidActionWithoutCode;
+}
+
+export function buildGuardianCodeOnlyClarification(
+  mode: GuardianQuestionInstructionMode,
+  request: GuardianRequestTextInput,
+): string {
+  const config = getModeTextConfig(mode);
+  const lines = [
+    config.buildCodeOnlyHeader(request),
+  ];
+  const detailLine = config.buildCodeOnlyDetailLine(request);
+  if (detailLine) {
+    lines.push(detailLine);
+  }
+  lines.push(buildGuardianReplyDirective(request.requestCode, mode));
+  return lines.join('\n');
+}
+
+export function buildGuardianDisambiguationLabel(
+  mode: GuardianQuestionInstructionMode,
+  request: Pick<GuardianRequestTextInput, 'questionText' | 'toolName'>,
+): string {
+  return getModeTextConfig(mode).buildDisambiguationLabel(request);
+}
+
+export function buildGuardianDisambiguationExample(
+  mode: GuardianQuestionInstructionMode,
+  requestCode: string,
+): string {
+  const category = getModeTextConfig(mode).disambiguationCategory;
+  const replyDirective = buildGuardianReplyDirective(requestCode, mode);
+  return `For ${category}: ${replyDirective.replace(/^Reply/, 'reply')}`;
 }
 
 export function hasGuardianRequestCodeInstruction(
@@ -247,7 +357,7 @@ export function resolveGuardianQuestionInstructionMode(
 ): GuardianQuestionModeResolution {
   const parsed = parseGuardianQuestionPayload(payload);
   if (parsed) {
-    const parsedToolName = 'toolName' in parsed ? parsed.toolName : null;
+    const parsedToolName = nonEmptyString('toolName' in parsed ? parsed.toolName : null);
     return {
       mode: resolveGuardianInstructionModeForRequestKind(parsed.requestKind, parsedToolName),
       requestKind: parsed.requestKind,

--- a/assistant/src/notifications/guardian-question-mode.ts
+++ b/assistant/src/notifications/guardian-question-mode.ts
@@ -16,6 +16,45 @@ export const GUARDIAN_QUESTION_REQUEST_KINDS = {
 export type GuardianQuestionRequestKind = keyof typeof GUARDIAN_QUESTION_REQUEST_KINDS;
 export type GuardianQuestionInstructionMode = 'approval' | 'answer';
 
+interface GuardianQuestionPayloadBase {
+  requestKind: GuardianQuestionRequestKind;
+  requestId: string;
+  requestCode: string;
+  questionText: string;
+}
+
+export interface PendingQuestionGuardianPayload extends GuardianQuestionPayloadBase {
+  requestKind: 'pending_question';
+  callSessionId: string;
+  activeGuardianRequestCount: number;
+}
+
+export interface ToolApprovalGuardianPayload extends GuardianQuestionPayloadBase {
+  requestKind: 'tool_approval';
+  toolName: string;
+}
+
+export interface ToolGrantGuardianPayload extends GuardianQuestionPayloadBase {
+  requestKind: 'tool_grant_request';
+  toolName: string;
+}
+
+export interface AccessRequestGuardianPayload extends GuardianQuestionPayloadBase {
+  requestKind: 'access_request';
+}
+
+export type GuardianQuestionPayload =
+  | PendingQuestionGuardianPayload
+  | ToolApprovalGuardianPayload
+  | ToolGrantGuardianPayload
+  | AccessRequestGuardianPayload;
+
+export interface GuardianQuestionModeResolution {
+  mode: GuardianQuestionInstructionMode;
+  requestKind: GuardianQuestionRequestKind | null;
+  legacyFallbackUsed: boolean;
+}
+
 function nonEmptyString(value: unknown): string | null {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();
@@ -39,6 +78,81 @@ export function parseGuardianQuestionRequestKind(
   }
 }
 
+function parseBasePayload(payload: Record<string, unknown>): Omit<GuardianQuestionPayloadBase, 'requestKind'> | null {
+  const requestId = nonEmptyString(payload.requestId);
+  const requestCode = nonEmptyString(payload.requestCode);
+  const questionText = nonEmptyString(payload.questionText);
+  if (!requestId || !requestCode || !questionText) return null;
+  return { requestId, requestCode, questionText };
+}
+
+/**
+ * Parse a guardian.question context payload into a strict discriminated union.
+ *
+ * Returns null when required fields for the declared requestKind are missing,
+ * or when requestKind is absent/unknown.
+ */
+export function parseGuardianQuestionPayload(
+  payload: Record<string, unknown>,
+): GuardianQuestionPayload | null {
+  const requestKind = parseGuardianQuestionRequestKind(payload);
+  if (!requestKind) return null;
+
+  const base = parseBasePayload(payload);
+  if (!base) return null;
+
+  switch (requestKind) {
+    case 'pending_question': {
+      const callSessionId = nonEmptyString(payload.callSessionId);
+      const activeGuardianRequestCount = typeof payload.activeGuardianRequestCount === 'number'
+        ? payload.activeGuardianRequestCount
+        : null;
+      if (!callSessionId || activeGuardianRequestCount === null || Number.isNaN(activeGuardianRequestCount)) {
+        return null;
+      }
+      return {
+        requestKind,
+        ...base,
+        callSessionId,
+        activeGuardianRequestCount,
+      };
+    }
+    case 'tool_approval':
+    case 'tool_grant_request': {
+      const toolName = nonEmptyString(payload.toolName);
+      if (!toolName) return null;
+      return {
+        requestKind,
+        ...base,
+        toolName,
+      };
+    }
+    case 'access_request':
+      return {
+        requestKind,
+        ...base,
+      };
+    default:
+      return null;
+  }
+}
+
+function modeForKind(requestKind: GuardianQuestionRequestKind): GuardianQuestionInstructionMode {
+  switch (requestKind) {
+    case 'pending_question':
+      return 'answer';
+    case 'tool_approval':
+    case 'tool_grant_request':
+    case 'access_request':
+      return 'approval';
+    default: {
+      // Exhaustive guard for future request kinds
+      const _never: never = requestKind;
+      return _never;
+    }
+  }
+}
+
 /**
  * Resolve guardian reply instruction mode from request kind.
  *
@@ -47,14 +161,20 @@ export function parseGuardianQuestionRequestKind(
  */
 export function resolveGuardianQuestionInstructionMode(
   payload: Record<string, unknown>,
-): GuardianQuestionInstructionMode {
-  const requestKind = parseGuardianQuestionRequestKind(payload);
-  if (requestKind === 'pending_question') return 'answer';
-  if (requestKind === 'tool_approval' || requestKind === 'tool_grant_request' || requestKind === 'access_request') {
-    return 'approval';
+): GuardianQuestionModeResolution {
+  const parsed = parseGuardianQuestionPayload(payload);
+  if (parsed) {
+    return {
+      mode: modeForKind(parsed.requestKind),
+      requestKind: parsed.requestKind,
+      legacyFallbackUsed: false,
+    };
   }
 
   const toolName = nonEmptyString(payload.toolName);
-  return toolName ? 'approval' : 'answer';
+  return {
+    mode: toolName ? 'approval' : 'answer',
+    requestKind: parseGuardianQuestionRequestKind(payload),
+    legacyFallbackUsed: true,
+  };
 }
-

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -4,6 +4,8 @@
  * decision engine route contextually.
  */
 
+import type { GuardianQuestionPayload } from './guardian-question-mode.js';
+
 export interface AttentionHints {
   requiresAction: boolean;
   urgency: 'low' | 'medium' | 'high';
@@ -14,14 +16,23 @@ export interface AttentionHints {
 
 export type RoutingIntent = 'single_channel' | 'multi_channel' | 'all_channels';
 
-export interface NotificationSignal {
+export interface NotificationEventContextPayloadMap {
+  'guardian.question': GuardianQuestionPayload;
+}
+
+export type NotificationContextPayload<TEventName extends string = string> =
+  TEventName extends keyof NotificationEventContextPayloadMap
+    ? NotificationEventContextPayloadMap[TEventName]
+    : Record<string, unknown>;
+
+export interface NotificationSignal<TEventName extends string = string> {
   signalId: string;
   assistantId: string;
   createdAt: number; // epoch ms
   sourceChannel: string; // free-form: 'vellum', 'telegram', 'voice', 'scheduler', etc.
   sourceSessionId: string;
-  sourceEventName: string; // free-form: 'reminder_fired', 'schedule_complete', 'guardian_question', etc.
-  contextPayload: Record<string, unknown>;
+  sourceEventName: TEventName; // free-form: 'reminder_fired', 'schedule_complete', 'guardian_question', etc.
+  contextPayload: NotificationContextPayload<TEventName>;
   attentionHints: AttentionHints;
   /** Routing intent from the source (e.g. reminder). Controls post-decision channel enforcement. */
   routingIntent?: RoutingIntent;

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -28,6 +28,11 @@ import {
   getCanonicalGuardianRequestByCode,
   listCanonicalGuardianRequests,
 } from '../memory/canonical-guardian-store.js';
+import {
+  buildGuardianRequestCodeInstruction,
+  resolveGuardianInstructionModeFromFields,
+  type GuardianQuestionInstructionMode,
+} from '../notifications/guardian-question-mode.js';
 import { getLogger } from '../util/logger.js';
 import { runApprovalConversationTurn } from './approval-conversation-turn.js';
 import type { ApprovalAction } from './channel-approval-types.js';
@@ -570,13 +575,15 @@ async function applyDecision(
     return notConsumed();
   }
 
+  const request = getCanonicalGuardianRequest(requestId);
+
   return {
     decisionApplied: false,
     consumed: true,
     type: 'canonical_decision_stale',
     requestId,
     canonicalResult,
-    replyText: failureReplyText(canonicalResult.reason),
+    replyText: failureReplyText(canonicalResult.reason, request?.requestCode, request ?? undefined),
   };
 }
 
@@ -643,8 +650,17 @@ function inferActionFromText(text: string): ApprovalAction {
   return 'approve_once';
 }
 
-function isPendingQuestionRequest(request?: CanonicalGuardianRequest | null): boolean {
-  return request?.kind === 'pending_question';
+function resolveRequestInstructionMode(
+  request?: Pick<CanonicalGuardianRequest, 'kind' | 'toolName'> | null,
+): GuardianQuestionInstructionMode {
+  if (!request) return 'approval';
+  const modeResolution = resolveGuardianInstructionModeFromFields(request.kind, request.toolName);
+  if (!modeResolution) return 'approval';
+  return modeResolution.mode;
+}
+
+function isAnswerModeRequest(request?: Pick<CanonicalGuardianRequest, 'kind' | 'toolName'> | null): boolean {
+  return resolveRequestInstructionMode(request) === 'answer';
 }
 
 // ---------------------------------------------------------------------------
@@ -669,18 +685,33 @@ function failureReplyText(
       return 'This request has expired.';
     case 'identity_mismatch':
       return "You don't have permission to decide on this request.";
-    case 'invalid_action':
-      if (isPendingQuestionRequest(request)) {
-        return requestCode
-          ? `I found request ${requestCode}, but I still need your answer. Reply "${requestCode} <your answer>".`
-          : "I couldn't determine your answer. Reply with the request code followed by your answer (e.g., \"ABC123 3pm works\").";
+    case 'invalid_action': {
+      const mode = resolveRequestInstructionMode(request);
+      switch (mode) {
+        case 'answer':
+          return requestCode
+            ? `I found request ${requestCode}, but I still need your answer. Reply "${requestCode} <your answer>".`
+            : "I couldn't determine your answer. Reply with the request code followed by your answer (e.g., \"ABC123 3pm works\").";
+        case 'approval':
+          return requestCode
+            ? `I found request ${requestCode}, but I need to know your decision. Reply "${requestCode} approve" or "${requestCode} reject".`
+            : "I couldn't determine your intended action. Reply with the request code followed by 'approve' or 'reject' (e.g., \"ABC123 approve\").";
+        default: {
+          const _never: never = mode;
+          return _never;
+        }
       }
-      return requestCode
-        ? `I found request ${requestCode}, but I need to know your decision. Reply "${requestCode} approve" or "${requestCode} reject".`
-        : "I couldn't determine your intended action. Reply with the request code followed by 'approve' or 'reject' (e.g., \"ABC123 approve\").";
+    }
     default:
       return "I couldn't process that request. Please try again.";
   }
+}
+
+function instructionTail(mode: GuardianQuestionInstructionMode, requestCode: string): string {
+  const instruction = buildGuardianRequestCodeInstruction(requestCode, mode);
+  const prefix = `Reference code: ${requestCode}. `;
+  if (!instruction.startsWith(prefix)) return instruction;
+  return instruction.slice(prefix.length);
 }
 
 // ---------------------------------------------------------------------------
@@ -694,14 +725,15 @@ function failureReplyText(
  */
 function composeCodeOnlyClarification(request: CanonicalGuardianRequest): string {
   const code = request.requestCode ?? 'unknown';
-  if (isPendingQuestionRequest(request)) {
+  const mode = resolveRequestInstructionMode(request);
+  if (mode === 'answer') {
     const lines: string[] = [
       `I found question ${code}.`,
     ];
     if (request.questionText) {
       lines.push(`Question: ${request.questionText}`);
     }
-    lines.push(`Reply "${code} <your answer>" to send your answer.`);
+    lines.push(instructionTail(mode, code));
     return lines.join('\n');
   }
 
@@ -712,7 +744,7 @@ function composeCodeOnlyClarification(request: CanonicalGuardianRequest): string
   if (request.questionText) {
     lines.push(`Details: ${request.questionText}`);
   }
-  lines.push(`Reply "${code} approve" to approve or "${code} reject" to reject.`);
+  lines.push(instructionTail(mode, code));
   return lines.join('\n');
 }
 
@@ -730,6 +762,10 @@ function composeDisambiguationReply(
   engineReplyText?: string,
 ): string {
   const lines: string[] = [];
+  const requestsWithMode = pendingRequests.map((request) => ({
+    request,
+    mode: resolveRequestInstructionMode(request),
+  }));
 
   if (engineReplyText) {
     lines.push(engineReplyText);
@@ -738,23 +774,23 @@ function composeDisambiguationReply(
 
   lines.push(`You have ${pendingRequests.length} pending requests. Please specify which one:`);
 
-  for (const req of pendingRequests) {
-    const toolLabel = isPendingQuestionRequest(req)
-      ? (req.questionText ?? 'question')
-      : (req.toolName ?? 'action');
-    const code = req.requestCode ?? req.id.slice(0, 6).toUpperCase();
+  for (const { request, mode } of requestsWithMode) {
+    const toolLabel = mode === 'answer'
+      ? (request.questionText ?? 'question')
+      : (request.toolName ?? request.questionText ?? 'action');
+    const code = request.requestCode ?? request.id.slice(0, 6).toUpperCase();
     lines.push(`  - ${code}: ${toolLabel}`);
   }
 
-  const questionRequest = pendingRequests.find((req) => isPendingQuestionRequest(req));
-  const decisionRequest = pendingRequests.find((req) => !isPendingQuestionRequest(req));
+  const questionRequest = requestsWithMode.find(({ mode }) => mode === 'answer');
+  const decisionRequest = requestsWithMode.find(({ mode }) => mode === 'approval');
   lines.push('');
   if (questionRequest) {
-    const exampleCode = questionRequest.requestCode ?? questionRequest.id.slice(0, 6).toUpperCase();
+    const exampleCode = questionRequest.request.requestCode ?? questionRequest.request.id.slice(0, 6).toUpperCase();
     lines.push(`For questions: reply "${exampleCode} <your answer>".`);
   }
   if (decisionRequest) {
-    const exampleCode = decisionRequest.requestCode ?? decisionRequest.id.slice(0, 6).toUpperCase();
+    const exampleCode = decisionRequest.request.requestCode ?? decisionRequest.request.id.slice(0, 6).toUpperCase();
     lines.push(`For approvals: reply "${exampleCode} approve" or "${exampleCode} reject".`);
   }
 

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -29,9 +29,11 @@ import {
   listCanonicalGuardianRequests,
 } from '../memory/canonical-guardian-store.js';
 import {
-  buildGuardianRequestCodeInstruction,
-  resolveGuardianInstructionModeFromFields,
-  type GuardianQuestionInstructionMode,
+  buildGuardianCodeOnlyClarification,
+  buildGuardianDisambiguationExample,
+  buildGuardianDisambiguationLabel,
+  buildGuardianInvalidActionReply,
+  resolveGuardianInstructionModeForRequest,
 } from '../notifications/guardian-question-mode.js';
 import { getLogger } from '../util/logger.js';
 import { runApprovalConversationTurn } from './approval-conversation-turn.js';
@@ -652,15 +654,8 @@ function inferActionFromText(text: string): ApprovalAction {
 
 function resolveRequestInstructionMode(
   request?: Pick<CanonicalGuardianRequest, 'kind' | 'toolName'> | null,
-): GuardianQuestionInstructionMode {
-  if (!request) return 'approval';
-  const modeResolution = resolveGuardianInstructionModeFromFields(request.kind, request.toolName);
-  if (!modeResolution) return 'approval';
-  return modeResolution.mode;
-}
-
-function isAnswerModeRequest(request?: Pick<CanonicalGuardianRequest, 'kind' | 'toolName'> | null): boolean {
-  return resolveRequestInstructionMode(request) === 'answer';
+): 'approval' | 'answer' {
+  return resolveGuardianInstructionModeForRequest(request);
 }
 
 // ---------------------------------------------------------------------------
@@ -685,33 +680,11 @@ function failureReplyText(
       return 'This request has expired.';
     case 'identity_mismatch':
       return "You don't have permission to decide on this request.";
-    case 'invalid_action': {
-      const mode = resolveRequestInstructionMode(request);
-      switch (mode) {
-        case 'answer':
-          return requestCode
-            ? `I found request ${requestCode}, but I still need your answer. Reply "${requestCode} <your answer>".`
-            : "I couldn't determine your answer. Reply with the request code followed by your answer (e.g., \"ABC123 3pm works\").";
-        case 'approval':
-          return requestCode
-            ? `I found request ${requestCode}, but I need to know your decision. Reply "${requestCode} approve" or "${requestCode} reject".`
-            : "I couldn't determine your intended action. Reply with the request code followed by 'approve' or 'reject' (e.g., \"ABC123 approve\").";
-        default: {
-          const _never: never = mode;
-          return _never;
-        }
-      }
-    }
+    case 'invalid_action':
+      return buildGuardianInvalidActionReply(resolveRequestInstructionMode(request), requestCode ?? undefined);
     default:
       return "I couldn't process that request. Please try again.";
   }
-}
-
-function instructionTail(mode: GuardianQuestionInstructionMode, requestCode: string): string {
-  const instruction = buildGuardianRequestCodeInstruction(requestCode, mode);
-  const prefix = `Reference code: ${requestCode}. `;
-  if (!instruction.startsWith(prefix)) return instruction;
-  return instruction.slice(prefix.length);
 }
 
 // ---------------------------------------------------------------------------
@@ -726,26 +699,11 @@ function instructionTail(mode: GuardianQuestionInstructionMode, requestCode: str
 function composeCodeOnlyClarification(request: CanonicalGuardianRequest): string {
   const code = request.requestCode ?? 'unknown';
   const mode = resolveRequestInstructionMode(request);
-  if (mode === 'answer') {
-    const lines: string[] = [
-      `I found question ${code}.`,
-    ];
-    if (request.questionText) {
-      lines.push(`Question: ${request.questionText}`);
-    }
-    lines.push(instructionTail(mode, code));
-    return lines.join('\n');
-  }
-
-  const toolLabel = request.toolName ?? 'an action';
-  const lines: string[] = [
-    `I found request ${code} for ${toolLabel}.`,
-  ];
-  if (request.questionText) {
-    lines.push(`Details: ${request.questionText}`);
-  }
-  lines.push(instructionTail(mode, code));
-  return lines.join('\n');
+  return buildGuardianCodeOnlyClarification(mode, {
+    requestCode: code,
+    questionText: request.questionText,
+    toolName: request.toolName,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -775,9 +733,10 @@ function composeDisambiguationReply(
   lines.push(`You have ${pendingRequests.length} pending requests. Please specify which one:`);
 
   for (const { request, mode } of requestsWithMode) {
-    const toolLabel = mode === 'answer'
-      ? (request.questionText ?? 'question')
-      : (request.toolName ?? request.questionText ?? 'action');
+    const toolLabel = buildGuardianDisambiguationLabel(mode, {
+      questionText: request.questionText,
+      toolName: request.toolName,
+    });
     const code = request.requestCode ?? request.id.slice(0, 6).toUpperCase();
     lines.push(`  - ${code}: ${toolLabel}`);
   }
@@ -787,11 +746,11 @@ function composeDisambiguationReply(
   lines.push('');
   if (questionRequest) {
     const exampleCode = questionRequest.request.requestCode ?? questionRequest.request.id.slice(0, 6).toUpperCase();
-    lines.push(`For questions: reply "${exampleCode} <your answer>".`);
+    lines.push(buildGuardianDisambiguationExample(questionRequest.mode, exampleCode));
   }
   if (decisionRequest) {
     const exampleCode = decisionRequest.request.requestCode ?? decisionRequest.request.id.slice(0, 6).toUpperCase();
-    lines.push(`For approvals: reply "${exampleCode} approve" or "${exampleCode} reject".`);
+    lines.push(buildGuardianDisambiguationExample(decisionRequest.mode, exampleCode));
   }
 
   return lines.join('\n');

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -280,7 +280,7 @@ export async function routeGuardianReply(
           consumed: true,
           type: 'canonical_decision_stale',
           requestId: request.id,
-          replyText: failureReplyText('already_resolved', request.requestCode),
+          replyText: failureReplyText('already_resolved', request.requestCode, request),
         };
       }
 
@@ -643,6 +643,10 @@ function inferActionFromText(text: string): ApprovalAction {
   return 'approve_once';
 }
 
+function isPendingQuestionRequest(request?: CanonicalGuardianRequest | null): boolean {
+  return request?.kind === 'pending_question';
+}
+
 // ---------------------------------------------------------------------------
 // Failure reason reply text
 // ---------------------------------------------------------------------------
@@ -653,7 +657,11 @@ type CanonicalFailureReason = 'already_resolved' | 'identity_mismatch' | 'invali
  * Map a canonical decision failure reason to a distinct, actionable reply
  * so the guardian understands exactly what happened and what to do next.
  */
-function failureReplyText(reason: CanonicalFailureReason, requestCode?: string | null): string {
+function failureReplyText(
+  reason: CanonicalFailureReason,
+  requestCode?: string | null,
+  request?: CanonicalGuardianRequest,
+): string {
   switch (reason) {
     case 'already_resolved':
       return 'This request has already been resolved.';
@@ -662,6 +670,11 @@ function failureReplyText(reason: CanonicalFailureReason, requestCode?: string |
     case 'identity_mismatch':
       return "You don't have permission to decide on this request.";
     case 'invalid_action':
+      if (isPendingQuestionRequest(request)) {
+        return requestCode
+          ? `I found request ${requestCode}, but I still need your answer. Reply "${requestCode} <your answer>".`
+          : "I couldn't determine your answer. Reply with the request code followed by your answer (e.g., \"ABC123 3pm works\").";
+      }
       return requestCode
         ? `I found request ${requestCode}, but I need to know your decision. Reply "${requestCode} approve" or "${requestCode} reject".`
         : "I couldn't determine your intended action. Reply with the request code followed by 'approve' or 'reject' (e.g., \"ABC123 approve\").";
@@ -681,6 +694,17 @@ function failureReplyText(reason: CanonicalFailureReason, requestCode?: string |
  */
 function composeCodeOnlyClarification(request: CanonicalGuardianRequest): string {
   const code = request.requestCode ?? 'unknown';
+  if (isPendingQuestionRequest(request)) {
+    const lines: string[] = [
+      `I found question ${code}.`,
+    ];
+    if (request.questionText) {
+      lines.push(`Question: ${request.questionText}`);
+    }
+    lines.push(`Reply "${code} <your answer>" to send your answer.`);
+    return lines.join('\n');
+  }
+
   const toolLabel = request.toolName ?? 'an action';
   const lines: string[] = [
     `I found request ${code} for ${toolLabel}.`,
@@ -715,15 +739,24 @@ function composeDisambiguationReply(
   lines.push(`You have ${pendingRequests.length} pending requests. Please specify which one:`);
 
   for (const req of pendingRequests) {
-    const toolLabel = req.toolName ?? 'action';
+    const toolLabel = isPendingQuestionRequest(req)
+      ? (req.questionText ?? 'question')
+      : (req.toolName ?? 'action');
     const code = req.requestCode ?? req.id.slice(0, 6).toUpperCase();
     lines.push(`  - ${code}: ${toolLabel}`);
   }
 
-  // Include a concrete example using the first request's code
-  const exampleCode = pendingRequests[0].requestCode ?? pendingRequests[0].id.slice(0, 6).toUpperCase();
+  const questionRequest = pendingRequests.find((req) => isPendingQuestionRequest(req));
+  const decisionRequest = pendingRequests.find((req) => !isPendingQuestionRequest(req));
   lines.push('');
-  lines.push(`Reply "${exampleCode} approve" to approve a specific request.`);
+  if (questionRequest) {
+    const exampleCode = questionRequest.requestCode ?? questionRequest.id.slice(0, 6).toUpperCase();
+    lines.push(`For questions: reply "${exampleCode} <your answer>".`);
+  }
+  if (decisionRequest) {
+    const exampleCode = decisionRequest.requestCode ?? decisionRequest.id.slice(0, 6).toUpperCase();
+    lines.push(`For approvals: reply "${exampleCode} approve" or "${exampleCode} reject".`);
+  }
 
   return lines.join('\n');
 }

--- a/assistant/src/runtime/tool-grant-request-helper.ts
+++ b/assistant/src/runtime/tool-grant-request-helper.ts
@@ -128,6 +128,7 @@ export function createOrReuseToolGrantRequest(
     questionText,
     expiresAt: new Date(Date.now() + GUARDIAN_APPROVAL_TTL_MS).toISOString(),
   });
+  const requestCode = canonicalRequest.requestCode ?? canonicalRequest.id.slice(0, 6).toUpperCase();
 
   // Emit notification so guardian is alerted. Uses 'guardian.question' as
   // sourceEventName so that existing request-code guidance in the notification
@@ -145,8 +146,8 @@ export function createOrReuseToolGrantRequest(
     },
     contextPayload: {
       requestId: canonicalRequest.id,
-      requestKind: canonicalRequest.kind,
-      requestCode: canonicalRequest.requestCode,
+      requestKind: 'tool_grant_request',
+      requestCode,
       sourceChannel,
       requesterExternalUserId,
       requesterChatId: requesterChatId ?? null,

--- a/assistant/src/runtime/tool-grant-request-helper.ts
+++ b/assistant/src/runtime/tool-grant-request-helper.ts
@@ -145,6 +145,7 @@ export function createOrReuseToolGrantRequest(
     },
     contextPayload: {
       requestId: canonicalRequest.id,
+      requestKind: canonicalRequest.kind,
       requestCode: canonicalRequest.requestCode,
       sourceChannel,
       requesterExternalUserId,


### PR DESCRIPTION
## Summary
This fixes misclassification/misleading UX between informational guardian questions and tool-approval requests in voice-originated guardian flows.

The reported case (`B60097`) was stored as a canonical `pending_question` with `tool_name = NULL`, but guardian-facing copy/instructions still used `approve/reject` language. That made a question-answer flow look like an approval flow.

## Changes
- Make guardian request-code instructions mode-aware in notifications:
  - `toolName` present => approval instructions (`approve` / `reject`)
  - no `toolName` => answer instructions (`<code> <your answer>`)
- Apply the same mode-aware enforcement to LLM-produced notification copy.
- Update guardian reply router clarification/disambiguation text for `pending_question` requests to request free-text answers instead of approval phrasing.
- Add regression coverage for both modes and pending-question code-only clarification behavior.

## Files
- `assistant/src/notifications/copy-composer.ts`
- `assistant/src/notifications/decision-engine.ts`
- `assistant/src/runtime/guardian-reply-router.ts`
- `assistant/src/__tests__/notification-decision-strategy.test.ts`
- `assistant/src/__tests__/notification-decision-fallback.test.ts`
- `assistant/src/__tests__/guardian-routing-invariants.test.ts`

## Validation
- `cd assistant && bun test src/__tests__/notification-decision-strategy.test.ts src/__tests__/notification-decision-fallback.test.ts src/__tests__/guardian-routing-invariants.test.ts`
- `cd assistant && bunx tsc --noEmit`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
