### PR TITLE
feat: IPC identity plumbing (deterministic local actor identity)

### DIFF
--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -13,7 +13,6 @@ import {
 import { addMessage, getMessages } from '../../memory/conversation-store.js';
 import { getBindingByConversation } from '../../memory/external-conversation-store.js';
 import { deliverChannelReply } from '../../runtime/gateway-client.js';
-import { resolveLocalIpcGuardianContext } from '../../runtime/local-actor-identity.js';
 import {
   blockIngressMember,
   createIngressInvite,
@@ -306,11 +305,15 @@ async function executeApprove(
     }
   }
   session.setAssistantId(assistantId);
-  // Resolve local actor identity through the unified trust pipeline.
-  // The guardian approved this escalation, so the resolved context tags
-  // the message as guardian provenance (avoiding unknown-provenance
-  // memory gating).
-  session.setGuardianContext(resolveLocalIpcGuardianContext(sourceChannel ?? 'vellum'));
+  // The guardian already approved this escalation via the inbox, so we
+  // directly set guardian trust. Going through resolveLocalIpcGuardianContext
+  // would look up the vellum binding's guardian ID and compare it against
+  // a different channel's binding (e.g. telegram/sms), misclassifying the
+  // actor as 'unknown'.
+  session.setGuardianContext({
+    sourceChannel: sourceChannel ?? 'vellum',
+    trustClass: 'guardian',
+  });
   session.setCommandIntent(null);
 
   // Process the message through the agent loop (no IPC event callback

--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -13,6 +13,7 @@ import {
 import { addMessage, getMessages } from '../../memory/conversation-store.js';
 import { getBindingByConversation } from '../../memory/external-conversation-store.js';
 import { deliverChannelReply } from '../../runtime/gateway-client.js';
+import { resolveLocalIpcGuardianContext } from '../../runtime/local-actor-identity.js';
 import {
   blockIngressMember,
   createIngressInvite,
@@ -305,9 +306,11 @@ async function executeApprove(
     }
   }
   session.setAssistantId(assistantId);
-  // The guardian approved this escalation, so tag as guardian trust to avoid
-  // unknown-provenance memory gating.
-  session.setGuardianContext({ trustClass: 'guardian', sourceChannel: sourceChannel ?? 'vellum' });
+  // Resolve local actor identity through the unified trust pipeline.
+  // The guardian approved this escalation, so the resolved context tags
+  // the message as guardian provenance (avoiding unknown-provenance
+  // memory gating).
+  session.setGuardianContext(resolveLocalIpcGuardianContext(sourceChannel ?? 'vellum'));
   session.setCommandIntent(null);
 
   // Process the message through the agent loop (no IPC event callback

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -4,6 +4,7 @@ import { v4 as uuid } from 'uuid';
 
 import { createAssistantMessage, createUserMessage } from '../../agent/message-types.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../../runtime/assistant-scope.js';
+import { resolveLocalIpcGuardianContext } from '../../runtime/local-actor-identity.js';
 import { type InterfaceId,isChannelId, parseChannelId, parseInterfaceId } from '../../channels/types.js';
 import { getConfig } from '../../config/loader.js';
 import { getAttachmentsForMessage, getFilePathForAttachment, setAttachmentThumbnail } from '../../memory/attachments-store.js';
@@ -273,9 +274,11 @@ export async function handleUserMessage(
         assistantMessageInterface: ipcInterface,
       });
       session.setAssistantId(DAEMON_INTERNAL_ASSISTANT_ID);
-      // IPC/desktop user IS the guardian — default to guardian trust so
-      // messages are not tagged as unknown provenance.
-      session.setGuardianContext({ trustClass: 'guardian', sourceChannel: ipcChannel });
+      // Resolve local IPC actor identity through the same trust pipeline
+      // used by HTTP channel ingress. The vellum guardian binding provides
+      // the guardianPrincipalId, and resolveGuardianContext classifies the
+      // local user as 'guardian' via binding match.
+      session.setGuardianContext(resolveLocalIpcGuardianContext(ipcChannel));
       session.setCommandIntent(null);
       // Fire-and-forget: don't block the IPC handler so the connection can
       // continue receiving messages (e.g. cancel, confirmations, or

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -1,0 +1,72 @@
+/**
+ * Deterministic local actor identity for IPC connections.
+ *
+ * IPC (Unix domain socket) connections come from the local macOS native app.
+ * No actor token is sent over the socket; instead, the daemon assigns a
+ * deterministic local actor identity server-side by looking up the vellum
+ * channel guardian binding.
+ *
+ * This routes IPC connections through the same `resolveGuardianContext`
+ * pathway used by HTTP channel ingress, producing equivalent
+ * guardian-context behavior for the vellum channel.
+ */
+
+import type { ChannelId } from '../channels/types.js';
+import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
+import { getActiveBinding } from '../memory/guardian-bindings.js';
+import { getLogger } from '../util/logger.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
+import {
+  resolveGuardianContext,
+  toGuardianRuntimeContext,
+} from './guardian-context-resolver.js';
+
+const log = getLogger('local-actor-identity');
+
+/**
+ * Resolve the guardian runtime context for a local IPC connection.
+ *
+ * Looks up the vellum guardian binding to obtain the `guardianPrincipalId`,
+ * then passes it as the sender identity through `resolveGuardianContext` --
+ * the same pathway HTTP channel routes use. This ensures IPC and HTTP
+ * produce equivalent trust classification for the vellum channel.
+ *
+ * When no vellum guardian binding exists (e.g. fresh install before
+ * bootstrap), falls back to a minimal guardian context so the local
+ * user is not incorrectly denied.
+ */
+export function resolveLocalIpcGuardianContext(
+  sourceChannel: ChannelId = 'vellum',
+): GuardianRuntimeContext {
+  const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
+  const binding = getActiveBinding(assistantId, 'vellum');
+
+  if (!binding) {
+    // No vellum binding yet (pre-bootstrap). The local user is
+    // inherently the guardian of their own machine, so produce a
+    // guardian context without a binding match. The trust resolver
+    // would classify this as 'unknown' due to no_binding, but for
+    // the local IPC case that is incorrect -- the local macOS user
+    // is always the guardian.
+    log.debug('No vellum guardian binding found; using fallback guardian context for IPC');
+    return {
+      sourceChannel,
+      trustClass: 'guardian',
+    };
+  }
+
+  const guardianPrincipalId = binding.guardianExternalUserId;
+
+  // Route through the shared trust resolution pipeline. The sender
+  // identity is the guardianPrincipalId from the vellum binding, so
+  // resolveGuardianContext will match it against the binding and
+  // classify the actor as 'guardian'.
+  const guardianCtx = resolveGuardianContext({
+    assistantId,
+    sourceChannel,
+    externalChatId: 'local',
+    senderExternalUserId: guardianPrincipalId,
+  });
+
+  return toGuardianRuntimeContext(sourceChannel, guardianCtx);
+}

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -57,16 +57,20 @@ export function resolveLocalIpcGuardianContext(
 
   const guardianPrincipalId = binding.guardianExternalUserId;
 
-  // Route through the shared trust resolution pipeline. The sender
-  // identity is the guardianPrincipalId from the vellum binding, so
-  // resolveGuardianContext will match it against the binding and
-  // classify the actor as 'guardian'.
+  // Route through the shared trust resolution pipeline using 'vellum'
+  // as the channel for binding lookup. The guardianPrincipalId comes
+  // from the vellum binding, so the binding lookup must also target
+  // 'vellum' — otherwise resolveActorTrust would look up a different
+  // channel's binding (e.g. telegram/sms) and the IDs wouldn't match,
+  // causing a 'unknown' trust classification.
   const guardianCtx = resolveGuardianContext({
     assistantId,
-    sourceChannel,
+    sourceChannel: 'vellum',
     externalChatId: 'local',
     senderExternalUserId: guardianPrincipalId,
   });
 
+  // Overlay the caller's actual sourceChannel onto the resolved context
+  // so downstream consumers see the correct channel provenance.
   return toGuardianRuntimeContext(sourceChannel, guardianCtx);
 }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -27,6 +27,7 @@ import { buildAssistantEvent } from '../assistant-event.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import { routeGuardianReply } from '../guardian-reply-router.js';
 import { httpError } from '../http-errors.js';
+import { resolveLocalIpcGuardianContext } from '../local-actor-identity.js';
 import type {
   ApprovalConversationGenerator,
   MessageProcessor,
@@ -443,9 +444,11 @@ export async function handleSendMessage(
   if (deps.sendMessageDeps) {
     const smDeps = deps.sendMessageDeps;
     const session = await smDeps.getOrCreateSession(mapping.conversationId);
-    // HTTP API is a trusted local ingress (same as IPC) — set guardian context
-    // so that memory extraction is not silently disabled by unverified provenance.
-    session.setGuardianContext({ trustClass: 'guardian', sourceChannel: sourceChannel ?? 'http' });
+    // Resolve local actor identity through the unified trust pipeline.
+    // HTTP API is a trusted local ingress (same as IPC) — the resolved
+    // context tags the message as guardian provenance so memory extraction
+    // is not silently disabled by unverified provenance.
+    session.setGuardianContext(resolveLocalIpcGuardianContext(sourceChannel ?? 'vellum'));
     const onEvent = makeHubPublisher(smDeps, mapping.conversationId, session);
 
     const attachments = hasAttachments


### PR DESCRIPTION
Assigns deterministic local actor identity for IPC connections, routes through same guardian-context resolution as HTTP, and removes hardcoded trustClass guardian defaults in session init. Part of #10755.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
