### PR TITLE
fix: broadcast app_files_changed on app_create and app_delete

### DIFF
--- a/assistant/src/__tests__/session-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/session-tool-setup-app-refresh.test.ts
@@ -392,6 +392,85 @@ describe('session-tool-setup app refresh side effects', () => {
     });
   });
 
+  // ── app_create side effects ─────────────────────────────────────────
+
+  describe('app_create side effects', () => {
+    test('broadcasts app_files_changed after app_create', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({
+        content: JSON.stringify({ id: 'new-app-1', name: 'My App' }),
+        isError: false,
+      });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, broadcastSpy,
+      );
+
+      await toolFn('app_create', { name: 'My App', html: '<h1>hi</h1>' });
+
+      expect(broadcastSpy).toHaveBeenCalledTimes(1);
+      expect((broadcastSpy.mock.calls as unknown[][])[0][0]).toEqual({
+        type: 'app_files_changed',
+        appId: 'new-app-1',
+      });
+    });
+
+    test('skips side effects when app_create result is an error', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: 'Error', isError: true });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, broadcastSpy,
+      );
+
+      await toolFn('app_create', { name: 'Bad', html: '' });
+
+      expect(broadcastSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── app_delete side effects ────────────────────────────────────────
+
+  describe('app_delete side effects', () => {
+    test('broadcasts app_files_changed after app_delete', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: '{}', isError: false });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, broadcastSpy,
+      );
+
+      await toolFn('app_delete', { app_id: 'del-app-1' });
+
+      expect(broadcastSpy).toHaveBeenCalledTimes(1);
+      expect((broadcastSpy.mock.calls as unknown[][])[0][0]).toEqual({
+        type: 'app_files_changed',
+        appId: 'del-app-1',
+      });
+    });
+
+    test('skips side effects when app_delete result is an error', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: 'Error', isError: true });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, broadcastSpy,
+      );
+
+      await toolFn('app_delete', { app_id: 'del-err' });
+
+      expect(broadcastSpy).not.toHaveBeenCalled();
+    });
+  });
+
   // ── Name-based hook targeting (skill-origin tools) ──────────────────
 
   describe('name-based hooks fire for skill-origin tools', () => {
@@ -437,7 +516,7 @@ describe('session-tool-setup app refresh side effects', () => {
         ctx, noopLifecycleHandler, broadcastSpy,
       );
 
-      for (const toolName of ['read_file', 'write_file', 'shell', 'app_create', 'app_list', 'app_delete']) {
+      for (const toolName of ['read_file', 'write_file', 'shell', 'app_list']) {
         refreshSpy.mockClear();
         broadcastSpy.mockClear();
         updatePublishedSpy.mockClear();

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -68,12 +68,34 @@ function registerHook(toolNames: string | string[], hook: PostExecutionHook): vo
   }
 }
 
+// Broadcast app_files_changed when a new app is created so clients
+// (e.g. macOS "Things" sidebar) refresh their app list immediately.
+registerHook('app_create', (_name, _input, result, { ctx, broadcastToAllClients }) => {
+  try {
+    const parsed = JSON.parse(result.content) as { id?: string };
+    if (parsed.id) {
+      handleAppChange(ctx, parsed.id, broadcastToAllClients);
+    }
+  } catch {
+    // Result wasn't valid JSON — skip the broadcast.
+  }
+});
+
 // Auto-refresh workspace surfaces when a persisted app is updated.
 // If no surface is currently showing the app, auto-open it.
 registerHook('app_update', (_name, input, _result, { ctx, broadcastToAllClients }) => {
   const appId = input.app_id as string | undefined;
   if (appId) {
     handleAppChange(ctx, appId, broadcastToAllClients);
+  }
+});
+
+// Broadcast app_files_changed when an app is deleted so clients remove it
+// from their cached app lists.
+registerHook('app_delete', (_name, input, _result, { broadcastToAllClients }) => {
+  const appId = input.app_id as string | undefined;
+  if (appId) {
+    broadcastToAllClients?.({ type: 'app_files_changed', appId });
   }
 });
 


### PR DESCRIPTION
## Summary

- Add `app_create` post-execution hook that parses the app ID from the result JSON and broadcasts `app_files_changed` to all connected clients
- Add `app_delete` post-execution hook that broadcasts `app_files_changed` so clients remove deleted apps from their cached lists
- Update tests: add 4 new test cases for the new hooks and remove `app_create`/`app_delete` from the "non-app tools" negative test list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
