### PR TITLE
fix: add channelDeliveryContext to M5 integration test approval calls

### DIFF
--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -758,6 +758,12 @@ describe('(f) timeout/stale flow: stale guardian decision after inline wait time
       requestId: pending[0].id,
       action: 'approve_once',
       actorContext: guardianActor(),
+      channelDeliveryContext: {
+        replyCallbackUrl: 'http://localhost:3000/reply',
+        guardianChatId: 'guardian-chat-1',
+        assistantId: 'self',
+        bearerToken: 'test-token',
+      },
     });
     expect(approvalResult.applied).toBe(true);
 
@@ -802,6 +808,12 @@ describe('(f) timeout/stale flow: stale guardian decision after inline wait time
       requestId: req.id,
       action: 'approve_once',
       actorContext: guardianActor(),
+      channelDeliveryContext: {
+        replyCallbackUrl: 'http://localhost:3000/reply',
+        guardianChatId: 'guardian-chat-1',
+        assistantId: 'self',
+        bearerToken: 'test-token',
+      },
     });
     expect(approvalResult.applied).toBe(true);
 
@@ -839,6 +851,12 @@ describe('(f) timeout/stale flow: stale guardian decision after inline wait time
       requestId: req.id,
       action: 'approve_once',
       actorContext: guardianActor(),
+      channelDeliveryContext: {
+        replyCallbackUrl: 'http://localhost:3000/reply',
+        guardianChatId: 'guardian-chat-1',
+        assistantId: 'self',
+        bearerToken: 'test-token',
+      },
     });
     expect(approvalResult.applied).toBe(true);
 


### PR DESCRIPTION
Adds missing channelDeliveryContext to applyCanonicalGuardianDecision calls in timeout/stale flow tests so retry notification assertions actually exercise the delivery path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
