### PR TITLE
fix: add separators between text blocks to prevent sentence concatenation

### DIFF
--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -340,7 +340,7 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
 
   function finalizeSegment(): void {
     if (hasOpenSegment) {
-      textSegments[textSegments.length - 1] = currentSegmentParts.join('');
+      textSegments[textSegments.length - 1] = currentSegmentParts.join('\n');
       currentSegmentParts = [];
       hasOpenSegment = false;
     }
@@ -445,7 +445,7 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
 
   finalizeSegment();
 
-  const text = textParts.join('');
+  const text = textParts.join('\n');
   let rendered: string;
   if (attachmentParts.length === 0) {
     rendered = text;

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -512,6 +512,10 @@ export class AnthropicProvider implements Provider {
             )
           : this.client.messages.stream(params, { signal: timeoutSignal });
 
+        // Track whether we've seen a text content block so we can insert a
+        // separator between consecutive text blocks in the same response.
+        let hasSeenTextBlock = false;
+
         stream.on("text", (text) => {
           onEvent?.({ type: "text_delta", text });
         });
@@ -527,6 +531,15 @@ export class AnthropicProvider implements Provider {
         let pendingInputJsonFlush: ReturnType<typeof setTimeout> | undefined;
 
         stream.on("streamEvent", (event) => {
+          // Insert a newline separator when a new text content block starts
+          // after a previous one, so consecutive text blocks don't get
+          // concatenated without whitespace (e.g. "sentence.NextSentence").
+          if (event.type === 'content_block_start' && event.content_block.type === 'text') {
+            if (hasSeenTextBlock) {
+              onEvent?.({ type: "text_delta", text: "\n" });
+            }
+            hasSeenTextBlock = true;
+          }
           if (event.type === 'content_block_start' && event.content_block.type === 'tool_use') {
             currentStreamingToolName = event.content_block.name;
             accumulatedInputJson = '';

--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -110,7 +110,7 @@ export function extractAllText(response: ProviderResponse): string {
   return response.content
     .filter((b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text')
     .map((b) => b.text)
-    .join('');
+    .join('\n');
 }
 
 /**

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1604,7 +1604,7 @@ public struct ChatMessage: Identifiable, Equatable {
 
     /// Concatenated text from all segments. Backward-compatible computed property.
     public var text: String {
-        textSegments.joined()
+        textSegments.joined(separator: "\n")
     }
 
     public init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, guardianDecision: GuardianDecisionData? = nil, skillInvocation: SkillInvocationData? = nil, attachments: [ChatAttachment] = [], toolCalls: [ToolCallData] = [], inlineSurfaces: [InlineSurfaceData] = [], isError: Bool = false) {

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -623,7 +623,7 @@ extension ChatViewModel {
                 pendingVoiceMessage = false
                 if let existingId = currentAssistantMessageId,
                    let index = messages.firstIndex(where: { $0.id == existingId }) {
-                    let responseText = messages[index].textSegments.joined()
+                    let responseText = messages[index].textSegments.joined(separator: "\n")
                     onVoiceResponseComplete?(responseText)
                 }
             }
@@ -699,7 +699,7 @@ extension ChatViewModel {
                 // Extract a summary from the last assistant message
                 if let existingId = messages.last(where: { $0.role == .assistant })?.id,
                    let index = messages.firstIndex(where: { $0.id == existingId }) {
-                    let summary = messages[index].textSegments.joined()
+                    let summary = messages[index].textSegments.joined(separator: "\n")
                     callback(summary)
                 } else {
                     callback("Response complete")
@@ -1123,6 +1123,9 @@ extension ChatViewModel {
                 startedAt: Date()
             )
             toolCall.buildingStatus = buildingStatus
+            // Flush any buffered text before processing the tool call so that
+            // text from before the tool call lands in the correct segment.
+            flushStreamingBuffer()
             // Add to existing assistant message or create one.
             // Cap at 100 tool calls per message to prevent unbounded memory growth;
             // overflow falls through to create a new message.


### PR DESCRIPTION
## Summary
- Fixed text concatenation bug where consecutive text content blocks from LLM responses were joined without separators (e.g. "for you.Now let me build" instead of "for you.\nNow let me build")
- Backend: `renderHistoryContent` and `extractAllText` now join text parts with `\n` instead of empty string
- Streaming: Anthropic provider inserts `\n` between consecutive text content blocks; client flushes streaming buffer before tool_start to prevent segment misattribution
- Client: `ChatMessage.text` and voice/summary callbacks now join segments with `\n`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
