### PR TITLE
fix: handle ephemeral surface reopening in app_open_request

### DIFF
--- a/assistant/src/daemon/handlers/apps.ts
+++ b/assistant/src/daemon/handlers/apps.ts
@@ -77,28 +77,55 @@ export function handleAppDataRequest(
 }
 
 export function handleAppOpenRequest(msg: { appId: string }, socket: net.Socket, ctx: HandlerContext): void {
-  const appId = msg.appId;
-  if (!appId) {
-    ctx.send(socket, { type: 'error', message: 'app_open_request requires appId' });
-    return;
-  }
+  try {
+    const appId = msg.appId;
+    if (!appId) {
+      ctx.send(socket, { type: 'error', message: 'app_open_request requires appId' });
+      return;
+    }
 
-  const app = getApp(appId);
-  if (!app) {
+    const app = getApp(appId);
+    if (app) {
+      const surfaceId = `app-open-${uuid()}`;
+      ctx.send(socket, {
+        type: 'ui_surface_show',
+        sessionId: 'app-panel',
+        surfaceId,
+        surfaceType: 'dynamic_page',
+        title: app.name,
+        data: { html: app.htmlDefinition, appId: app.id, appType: app.appType },
+        display: 'panel',
+      } as UiSurfaceShow);
+      return;
+    }
+
+    // Fallback: the ID might be a surfaceId from an ephemeral ui_show surface
+    // (not a persistent app). Search active sessions for cached surface data.
+    for (const session of ctx.sessions.values()) {
+      const cached = session.surfaceState.get(appId);
+      if (cached && cached.surfaceType === 'dynamic_page') {
+        const data = cached.data as { preview?: { title?: string } };
+        const newSurfaceId = `app-open-${uuid()}`;
+        ctx.send(socket, {
+          type: 'ui_surface_show',
+          sessionId: 'app-panel',
+          surfaceId: newSurfaceId,
+          surfaceType: 'dynamic_page',
+          title: data.preview?.title,
+          data: cached.data,
+          display: 'panel',
+        } as UiSurfaceShow);
+        return;
+      }
+    }
+
+    log.warn({ appId }, 'App not found in store or session surfaces');
     ctx.send(socket, { type: 'error', message: `App not found: ${appId}` });
-    return;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err, appId: msg.appId }, 'Failed to handle app open request');
+    ctx.send(socket, { type: 'error', message: `Failed to open app: ${message}` });
   }
-
-  const surfaceId = `app-open-${uuid()}`;
-  ctx.send(socket, {
-    type: 'ui_surface_show',
-    sessionId: 'app-panel',
-    surfaceId,
-    surfaceType: 'dynamic_page',
-    title: app.name,
-    data: { html: app.htmlDefinition, appId: app.id, appType: app.appType },
-    display: 'panel',
-  } as UiSurfaceShow);
 }
 
 export function handleAppUpdatePreview(msg: AppUpdatePreviewRequest, socket: net.Socket, ctx: HandlerContext): void {


### PR DESCRIPTION
## Summary
- When a slideshow/app is created via `ui_show` (ephemeral) instead of `app_create` (persistent), clicking the reopen arrow button failed with "Failed to load app" timeout
- Added fallback in `handleAppOpenRequest` to search active session `surfaceState` maps when the app store lookup fails, allowing ephemeral surfaces to be reopened
- Added try-catch error handling for consistency with all other handlers in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
