### PR TITLE
fix: prevent app_create hook from auto-opening apps

### DIFF
--- a/assistant/src/__tests__/session-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/session-tool-setup-app-refresh.test.ts
@@ -417,6 +417,27 @@ describe('session-tool-setup app refresh side effects', () => {
       });
     });
 
+    test('does not auto-open or refresh surfaces for app_create', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({
+        content: JSON.stringify({ id: 'new-app-2', name: 'Silent App' }),
+        isError: false,
+      });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, broadcastSpy,
+      );
+
+      await toolFn('app_create', { name: 'Silent App', html: '<p>hi</p>' });
+
+      // app_create should only broadcast — no surface refresh, no deployment update.
+      // These are handled by the app_create executor itself, which respects auto_open.
+      expect(refreshSpy).not.toHaveBeenCalled();
+      expect(updatePublishedSpy).not.toHaveBeenCalled();
+    });
+
     test('skips side effects when app_create result is an error', async () => {
       const ctx = makeCtx();
       const executor = makeFakeExecutor({ content: 'Error', isError: true });

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -70,11 +70,14 @@ function registerHook(toolNames: string | string[], hook: PostExecutionHook): vo
 
 // Broadcast app_files_changed when a new app is created so clients
 // (e.g. macOS "Things" sidebar) refresh their app list immediately.
-registerHook('app_create', (_name, _input, result, { ctx, broadcastToAllClients }) => {
+// Only broadcast — do not call handleAppChange, which would auto-open
+// the app and regress auto_open:false semantics. The app_create executor
+// already handles auto-open when appropriate.
+registerHook('app_create', (_name, _input, result, { broadcastToAllClients }) => {
   try {
     const parsed = JSON.parse(result.content) as { id?: string };
     if (parsed.id) {
-      handleAppChange(ctx, parsed.id, broadcastToAllClients);
+      broadcastToAllClients?.({ type: 'app_files_changed', appId: parsed.id });
     }
   } catch {
     // Result wasn't valid JSON — skip the broadcast.


### PR DESCRIPTION
## Summary

- Addresses review feedback on #10801 (from both Codex and Devin)
- The `app_create` post-execution hook was calling `handleAppChange()`, which auto-opens apps, refreshes surfaces, and triggers deployment updates — regressing `auto_open: false` semantics
- Replaced with a direct `broadcastToAllClients?.({ type: 'app_files_changed', appId })` call, matching the `app_delete` hook pattern
- Added a regression test verifying `refreshSurfacesForApp` and `updatePublishedAppDeployment` are NOT called for `app_create`

## Test plan

- [x] All 23 existing tests in `session-tool-setup-app-refresh.test.ts` pass
- [x] New test `does not auto-open or refresh surfaces for app_create` passes
- [x] TypeScript type check passes (`bunx tsc --noEmit`)
- [ ] Verify that creating an app with `auto_open: false` no longer pops open a UI surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
