### PR TITLE
feat: strict cutover — remove trusted-default vellum paths + identity-required enforcement

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -714,7 +714,7 @@ export class RuntimeHttpServer {
       if (endpoint === 'confirm' && req.method === 'POST') return await handleConfirm(req);
       if (endpoint === 'secret' && req.method === 'POST') return await handleSecret(req);
       if (endpoint === 'trust-rules' && req.method === 'POST') return await handleTrustRule(req);
-      if (endpoint === 'pending-interactions' && req.method === 'GET') return handleListPendingInteractions(url);
+      if (endpoint === 'pending-interactions' && req.method === 'GET') return handleListPendingInteractions(url, req);
 
       // Guardian action endpoints — deterministic button-based decisions
       if (endpoint === 'guardian-actions/pending' && req.method === 'GET') return handleGuardianActionsPending(req);

--- a/assistant/src/runtime/middleware/actor-token.ts
+++ b/assistant/src/runtime/middleware/actor-token.ts
@@ -167,10 +167,15 @@ export type ActorTokenVerificationWithFallback =
  * Verify the actor token with fallback to local IPC identity resolution.
  *
  * When an actor token is present, the full verification pipeline runs.
- * When absent, the request has already passed bearer token auth in the
- * HTTP server layer, meaning it is from a trusted local client (e.g. CLI).
- * In that case, we fall back to `resolveLocalIpcGuardianContext()` which
- * produces the same guardian context as the IPC pathway.
+ * When absent AND the request originates from a loopback address, the
+ * request is treated as a trusted local client (e.g. CLI) and we fall
+ * back to `resolveLocalIpcGuardianContext()` which produces the same
+ * guardian context as the IPC pathway.
+ *
+ * The loopback origin check prevents gateway-proxied remote requests
+ * (which carry `X-Forwarded-For` injected by the gateway runtime proxy)
+ * from being granted local guardian identity. Only direct connections
+ * without a forwarding header qualify for the local fallback.
  *
  * This preserves backward compatibility with the CLI, which sends only
  * `Authorization: Bearer <token>` without `X-Actor-Token`.
@@ -185,10 +190,25 @@ export function verifyHttpActorTokenWithLocalFallback(
     return verifyHttpActorToken(req);
   }
 
-  // No actor token — this request passed bearer auth at the HTTP server
-  // level, so it is from a local trusted client. Resolve identity the
-  // same way as IPC connections.
-  log.debug('No actor token present on bearer-authenticated request; using local IPC identity fallback');
+  // Gate the local fallback on provably-local origin. The gateway runtime
+  // proxy always injects X-Forwarded-For with the real client IP when
+  // forwarding requests. Direct local connections (CLI, macOS app) never
+  // set this header. If X-Forwarded-For is present, the request was
+  // proxied through the gateway on behalf of a potentially remote client
+  // and must not receive local guardian identity.
+  if (req.headers.get('x-forwarded-for')) {
+    log.warn('Rejecting local identity fallback: request has X-Forwarded-For (proxied through gateway)');
+    return {
+      ok: false,
+      status: 401,
+      message: 'Missing X-Actor-Token header. Proxied requests require actor identity.',
+    };
+  }
+
+  // No actor token, no forwarding header — this is a direct local
+  // connection that passed bearer auth at the HTTP server layer.
+  // Resolve identity the same way as IPC connections.
+  log.debug('No actor token present on direct local request; using local IPC identity fallback');
   const guardianContext = resolveLocalIpcGuardianContext('vellum');
   return {
     ok: true,

--- a/assistant/src/runtime/middleware/actor-token.ts
+++ b/assistant/src/runtime/middleware/actor-token.ts
@@ -8,6 +8,10 @@
  * Used by vellum-channel HTTP routes (POST /v1/messages, POST /v1/confirm,
  * POST /v1/guardian-actions/decision, etc.) to enforce identity-based
  * authentication after the M5 cutover.
+ *
+ * For backward compatibility with bearer-authenticated local clients (CLI),
+ * provides fallback functions that resolve identity through the local IPC
+ * guardian context pathway when no actor token is present.
  */
 
 import type { ChannelId } from '../../channels/types.js';
@@ -21,6 +25,7 @@ import {
   resolveGuardianContext,
   toGuardianRuntimeContext,
 } from '../guardian-context-resolver.js';
+import { resolveLocalIpcGuardianContext } from '../local-actor-identity.js';
 
 const log = getLogger('actor-token-middleware');
 
@@ -136,4 +141,72 @@ export function isActorBoundGuardian(claims: ActorTokenClaims): boolean {
   const binding = getActiveBinding(assistantId, 'vellum');
   if (!binding) return false;
   return binding.guardianExternalUserId === claims.guardianPrincipalId;
+}
+
+// ---------------------------------------------------------------------------
+// Bearer-auth fallback variants
+// ---------------------------------------------------------------------------
+
+/**
+ * Result for the fallback verification path where the actor token is absent
+ * but the request is bearer-authenticated (local trusted client like CLI).
+ */
+export interface ActorTokenLocalFallbackResult {
+  ok: true;
+  claims: null;
+  guardianContext: GuardianRuntimeContext;
+  localFallback: true;
+}
+
+export type ActorTokenVerificationWithFallback =
+  | ActorTokenResult
+  | ActorTokenLocalFallbackResult
+  | ActorTokenError;
+
+/**
+ * Verify the actor token with fallback to local IPC identity resolution.
+ *
+ * When an actor token is present, the full verification pipeline runs.
+ * When absent, the request has already passed bearer token auth in the
+ * HTTP server layer, meaning it is from a trusted local client (e.g. CLI).
+ * In that case, we fall back to `resolveLocalIpcGuardianContext()` which
+ * produces the same guardian context as the IPC pathway.
+ *
+ * This preserves backward compatibility with the CLI, which sends only
+ * `Authorization: Bearer <token>` without `X-Actor-Token`.
+ */
+export function verifyHttpActorTokenWithLocalFallback(
+  req: Request,
+): ActorTokenVerificationWithFallback {
+  const rawToken = extractActorToken(req);
+
+  // If an actor token is present, use the strict verification pipeline.
+  if (rawToken) {
+    return verifyHttpActorToken(req);
+  }
+
+  // No actor token — this request passed bearer auth at the HTTP server
+  // level, so it is from a local trusted client. Resolve identity the
+  // same way as IPC connections.
+  log.debug('No actor token present on bearer-authenticated request; using local IPC identity fallback');
+  const guardianContext = resolveLocalIpcGuardianContext('vellum');
+  return {
+    ok: true,
+    claims: null,
+    guardianContext,
+    localFallback: true,
+  };
+}
+
+/**
+ * Check whether the local fallback identity is the bound guardian.
+ *
+ * When no actor token is present (local fallback), the local user is
+ * treated as the guardian of their own machine — equivalent to IPC.
+ * This returns true when either the resolved trust class is 'guardian'
+ * or no vellum binding exists yet (pre-bootstrap).
+ */
+export function isLocalFallbackBoundGuardian(): boolean {
+  const guardianContext = resolveLocalIpcGuardianContext('vellum');
+  return guardianContext.trustClass === 'guardian';
 }

--- a/assistant/src/runtime/middleware/actor-token.ts
+++ b/assistant/src/runtime/middleware/actor-token.ts
@@ -1,0 +1,139 @@
+/**
+ * Actor-token verification middleware for HTTP routes.
+ *
+ * Extracts the X-Actor-Token header, verifies the HMAC signature,
+ * checks that the token is active in the store, and returns the
+ * verified claims and resolved guardian runtime context.
+ *
+ * Used by vellum-channel HTTP routes (POST /v1/messages, POST /v1/confirm,
+ * POST /v1/guardian-actions/decision, etc.) to enforce identity-based
+ * authentication after the M5 cutover.
+ */
+
+import type { ChannelId } from '../../channels/types.js';
+import type { GuardianRuntimeContext } from '../../daemon/session-runtime-assembly.js';
+import { getActiveBinding } from '../../memory/guardian-bindings.js';
+import { getLogger } from '../../util/logger.js';
+import { type ActorTokenClaims, hashToken, verifyActorToken } from '../actor-token-service.js';
+import { findActiveByTokenHash } from '../actor-token-store.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
+import {
+  resolveGuardianContext,
+  toGuardianRuntimeContext,
+} from '../guardian-context-resolver.js';
+
+const log = getLogger('actor-token-middleware');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ActorTokenResult {
+  ok: true;
+  claims: ActorTokenClaims;
+  guardianContext: GuardianRuntimeContext;
+}
+
+export interface ActorTokenError {
+  ok: false;
+  status: number;
+  message: string;
+}
+
+export type ActorTokenVerification = ActorTokenResult | ActorTokenError;
+
+// ---------------------------------------------------------------------------
+// Header extraction
+// ---------------------------------------------------------------------------
+
+const ACTOR_TOKEN_HEADER = 'x-actor-token';
+
+export function extractActorToken(req: Request): string | null {
+  return req.headers.get(ACTOR_TOKEN_HEADER) || null;
+}
+
+// ---------------------------------------------------------------------------
+// Full verification pipeline
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify the X-Actor-Token header and resolve a guardian runtime context.
+ *
+ * Steps:
+ * 1. Extract the header value.
+ * 2. Verify HMAC signature and expiration.
+ * 3. Check the token hash is active in the actor-token store.
+ * 4. Resolve a guardian context through the standard trust pipeline using
+ *    the claims' guardianPrincipalId as the sender identity.
+ *
+ * Returns an ok result with claims and guardianContext, or an error with
+ * the HTTP status code and message to return.
+ */
+export function verifyHttpActorToken(req: Request): ActorTokenVerification {
+  const rawToken = extractActorToken(req);
+  if (!rawToken) {
+    return {
+      ok: false,
+      status: 401,
+      message: 'Missing X-Actor-Token header. Vellum HTTP requests require actor identity.',
+    };
+  }
+
+  // Structural + signature verification
+  const verifyResult = verifyActorToken(rawToken);
+  if (!verifyResult.ok) {
+    log.warn({ reason: verifyResult.reason }, 'Actor token verification failed');
+    return {
+      ok: false,
+      status: 401,
+      message: `Invalid actor token: ${verifyResult.reason}`,
+    };
+  }
+
+  // Check the token is active in the store (not revoked)
+  const tokenHash = hashToken(rawToken);
+  const record = findActiveByTokenHash(tokenHash);
+  if (!record) {
+    log.warn('Actor token not found in active store (possibly revoked)');
+    return {
+      ok: false,
+      status: 401,
+      message: 'Actor token is no longer active',
+    };
+  }
+
+  const { claims } = verifyResult;
+
+  // Resolve guardian context through the shared trust pipeline.
+  // The guardianPrincipalId from the token is used as the sender identity,
+  // and 'vellum' is used as the channel for binding lookup.
+  const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
+  const guardianCtx = resolveGuardianContext({
+    assistantId,
+    sourceChannel: 'vellum',
+    externalChatId: 'local',
+    senderExternalUserId: claims.guardianPrincipalId,
+  });
+
+  const guardianContext = toGuardianRuntimeContext('vellum' as ChannelId, guardianCtx);
+
+  return {
+    ok: true,
+    claims,
+    guardianContext,
+  };
+}
+
+/**
+ * Verify that the actor identity from a verified token matches the bound
+ * guardian for the vellum channel. Used for guardian-decision endpoints
+ * where only the guardian should be able to approve/reject.
+ *
+ * Returns true if the actor is the bound guardian, false otherwise.
+ */
+export function isActorBoundGuardian(claims: ActorTokenClaims): boolean {
+  const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
+  const binding = getActiveBinding(assistantId, 'vellum');
+  if (!binding) return false;
+  return binding.guardianExternalUserId === claims.guardianPrincipalId;
+}

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -3,20 +3,64 @@
  *
  * These endpoints resolve pending confirmations, secrets, and trust rules
  * by requestId — orthogonal to message sending.
+ *
+ * After M5 cutover: all approval endpoints require a valid actor token
+ * via the X-Actor-Token header. Guardian decisions additionally verify
+ * that the actor is the bound guardian.
  */
 import { getConversationByKey } from '../../memory/conversation-key-store.js';
 import { addRule } from '../../permissions/trust-store.js';
 import { getTool } from '../../tools/registry.js';
 import { getLogger } from '../../util/logger.js';
 import { httpError } from '../http-errors.js';
+import { isActorBoundGuardian, verifyHttpActorToken } from '../middleware/actor-token.js';
 import * as pendingInteractions from '../pending-interactions.js';
 
 const log = getLogger('approval-routes');
 
 /**
+ * Verify the actor token from the request. Returns an error Response
+ * if verification fails, or null if the actor is authenticated.
+ */
+function requireActorToken(req: Request): Response | null {
+  const result = verifyHttpActorToken(req);
+  if (!result.ok) {
+    return httpError(
+      result.status === 401 ? 'UNAUTHORIZED' : 'FORBIDDEN',
+      result.message,
+      result.status,
+    );
+  }
+  return null;
+}
+
+/**
+ * Verify the actor token and confirm the actor is the bound guardian.
+ * Returns an error Response if verification or guardian check fails.
+ */
+function requireBoundGuardian(req: Request): Response | null {
+  const result = verifyHttpActorToken(req);
+  if (!result.ok) {
+    return httpError(
+      result.status === 401 ? 'UNAUTHORIZED' : 'FORBIDDEN',
+      result.message,
+      result.status,
+    );
+  }
+  if (!isActorBoundGuardian(result.claims)) {
+    return httpError('FORBIDDEN', 'Actor is not the bound guardian for this channel', 403);
+  }
+  return null;
+}
+
+/**
  * POST /v1/confirm — resolve a pending confirmation by requestId.
+ * Requires a valid actor token (guardian-bound).
  */
 export async function handleConfirm(req: Request): Promise<Response> {
+  const authError = requireBoundGuardian(req);
+  if (authError) return authError;
+
   const body = await req.json() as {
     requestId?: string;
     decision?: string;
@@ -43,8 +87,12 @@ export async function handleConfirm(req: Request): Promise<Response> {
 
 /**
  * POST /v1/secret — resolve a pending secret request by requestId.
+ * Requires a valid actor token (guardian-bound).
  */
 export async function handleSecret(req: Request): Promise<Response> {
+  const authError = requireBoundGuardian(req);
+  if (authError) return authError;
+
   const body = await req.json() as {
     requestId?: string;
     value?: string;
@@ -76,6 +124,7 @@ export async function handleSecret(req: Request): Promise<Response> {
 
 /**
  * POST /v1/trust-rules — add a trust rule for a pending confirmation.
+ * Requires a valid actor token (guardian-bound).
  *
  * Does NOT resolve the confirmation itself (the client still needs to
  * POST /v1/confirm to approve/deny). Validates the pattern and scope
@@ -83,6 +132,9 @@ export async function handleSecret(req: Request): Promise<Response> {
  * confirmation_request.
  */
 export async function handleTrustRule(req: Request): Promise<Response> {
+  const authError = requireBoundGuardian(req);
+  if (authError) return authError;
+
   const body = await req.json() as {
     requestId?: string;
     pattern?: string;
@@ -155,12 +207,15 @@ export async function handleTrustRule(req: Request): Promise<Response> {
 
 /**
  * GET /v1/pending-interactions?conversationKey=...
+ * Requires a valid actor token.
  *
  * Returns pending confirmations and secrets for a conversation, allowing
  * polling-based clients (like the CLI) to discover approval requests
  * without SSE.
  */
-export function handleListPendingInteractions(url: URL): Response {
+export function handleListPendingInteractions(url: URL, req: Request): Response {
+  const authError = requireActorToken(req);
+  if (authError) return authError;
   const conversationKey = url.searchParams.get('conversationKey');
   const conversationId = url.searchParams.get('conversationId');
 

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -13,17 +13,22 @@ import { addRule } from '../../permissions/trust-store.js';
 import { getTool } from '../../tools/registry.js';
 import { getLogger } from '../../util/logger.js';
 import { httpError } from '../http-errors.js';
-import { isActorBoundGuardian, verifyHttpActorToken } from '../middleware/actor-token.js';
+import {
+  isActorBoundGuardian,
+  isLocalFallbackBoundGuardian,
+  verifyHttpActorTokenWithLocalFallback,
+} from '../middleware/actor-token.js';
 import * as pendingInteractions from '../pending-interactions.js';
 
 const log = getLogger('approval-routes');
 
 /**
- * Verify the actor token from the request. Returns an error Response
- * if verification fails, or null if the actor is authenticated.
+ * Verify the actor token from the request with local fallback.
+ * Returns an error Response if verification fails, or null if
+ * the actor is authenticated (via actor token or local identity).
  */
 function requireActorToken(req: Request): Response | null {
-  const result = verifyHttpActorToken(req);
+  const result = verifyHttpActorTokenWithLocalFallback(req);
   if (!result.ok) {
     return httpError(
       result.status === 401 ? 'UNAUTHORIZED' : 'FORBIDDEN',
@@ -36,10 +41,12 @@ function requireActorToken(req: Request): Response | null {
 
 /**
  * Verify the actor token and confirm the actor is the bound guardian.
- * Returns an error Response if verification or guardian check fails.
+ * When no actor token is present (bearer-authenticated local client),
+ * falls back to local IPC identity resolution and checks the local
+ * identity is the bound guardian.
  */
 function requireBoundGuardian(req: Request): Response | null {
-  const result = verifyHttpActorToken(req);
+  const result = verifyHttpActorTokenWithLocalFallback(req);
   if (!result.ok) {
     return httpError(
       result.status === 401 ? 'UNAUTHORIZED' : 'FORBIDDEN',
@@ -47,7 +54,12 @@ function requireBoundGuardian(req: Request): Response | null {
       result.status,
     );
   }
-  if (!isActorBoundGuardian(result.claims)) {
+  // For actor-token-authenticated requests, check the token's identity.
+  // For local fallback (bearer-auth only), check the local identity.
+  const isBoundGuardian = result.claims
+    ? isActorBoundGuardian(result.claims)
+    : isLocalFallbackBoundGuardian();
+  if (!isBoundGuardian) {
     return httpError('FORBIDDEN', 'Actor is not the bound guardian for this channel', 403);
   }
   return null;

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -28,7 +28,7 @@ import { buildAssistantEvent } from '../assistant-event.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import { routeGuardianReply } from '../guardian-reply-router.js';
 import { httpError } from '../http-errors.js';
-import { verifyHttpActorToken } from '../middleware/actor-token.js';
+import { verifyHttpActorTokenWithLocalFallback } from '../middleware/actor-token.js';
 import type {
   ApprovalConversationGenerator,
   MessageProcessor,
@@ -455,9 +455,10 @@ export async function handleSendMessage(
 
   // ── Queue-if-busy path (preferred when sendMessageDeps is wired) ────
   if (deps.sendMessageDeps) {
-    // Vellum HTTP requests require a valid actor token for identity verification.
-    // IPC connections use local-actor-identity.ts instead (no token needed).
-    const actorVerification = sourceChannel === 'vellum' ? verifyHttpActorToken(req) : null;
+    // Vellum HTTP requests prefer actor-token identity. When absent (e.g. CLI
+    // bearer-auth only), fall back to local IPC identity resolution so
+    // bearer-authenticated local clients are not rejected.
+    const actorVerification = sourceChannel === 'vellum' ? verifyHttpActorTokenWithLocalFallback(req) : null;
     if (actorVerification && !actorVerification.ok) {
       return httpError(
         actorVerification.status === 401 ? 'UNAUTHORIZED' : 'FORBIDDEN',
@@ -569,8 +570,9 @@ export async function handleSendMessage(
     return httpError('SERVICE_UNAVAILABLE', 'Message processing not configured', 503);
   }
 
-  // Require actor token for vellum channel requests on the legacy path too.
-  const legacyActorVerification = sourceChannel === 'vellum' ? verifyHttpActorToken(req) : null;
+  // Require actor token for vellum channel requests on the legacy path too,
+  // with local IPC fallback for bearer-authenticated CLI clients.
+  const legacyActorVerification = sourceChannel === 'vellum' ? verifyHttpActorTokenWithLocalFallback(req) : null;
   if (legacyActorVerification && !legacyActorVerification.ok) {
     return httpError(
       legacyActorVerification.status === 401 ? 'UNAUTHORIZED' : 'FORBIDDEN',

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -28,7 +28,7 @@ import { buildAssistantEvent } from '../assistant-event.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import { routeGuardianReply } from '../guardian-reply-router.js';
 import { httpError } from '../http-errors.js';
-import { resolveLocalIpcGuardianContext } from '../local-actor-identity.js';
+import { verifyHttpActorToken } from '../middleware/actor-token.js';
 import type {
   ApprovalConversationGenerator,
   MessageProcessor,
@@ -455,13 +455,32 @@ export async function handleSendMessage(
 
   // ── Queue-if-busy path (preferred when sendMessageDeps is wired) ────
   if (deps.sendMessageDeps) {
+    // Vellum HTTP requests require a valid actor token for identity verification.
+    // IPC connections use local-actor-identity.ts instead (no token needed).
+    const actorVerification = sourceChannel === 'vellum' ? verifyHttpActorToken(req) : null;
+    if (actorVerification && !actorVerification.ok) {
+      return httpError(
+        actorVerification.status === 401 ? 'UNAUTHORIZED' : 'FORBIDDEN',
+        actorVerification.message,
+        actorVerification.status,
+      );
+    }
+
     const smDeps = deps.sendMessageDeps;
     const session = await smDeps.getOrCreateSession(mapping.conversationId);
-    // Resolve local actor identity through the unified trust pipeline.
-    // HTTP API is a trusted local ingress (same as IPC) — the resolved
-    // context tags the message as guardian provenance so memory extraction
-    // is not silently disabled by unverified provenance.
-    session.setGuardianContext(resolveLocalIpcGuardianContext(sourceChannel ?? 'vellum'));
+    // Resolve actor identity from the verified actor token. The token's
+    // guardianPrincipalId is matched against the vellum guardian binding
+    // through the standard trust pipeline.
+    if (actorVerification?.ok) {
+      session.setGuardianContext(actorVerification.guardianContext);
+    } else {
+      // Non-vellum channels (e.g. voice) go through the channel ingress
+      // path with their own trust resolution.
+      session.setGuardianContext({
+        sourceChannel,
+        trustClass: 'unknown',
+      });
+    }
     const onEvent = makeHubPublisher(smDeps, mapping.conversationId, session);
 
     const attachments = hasAttachments
@@ -550,12 +569,26 @@ export async function handleSendMessage(
     return httpError('SERVICE_UNAVAILABLE', 'Message processing not configured', 503);
   }
 
+  // Require actor token for vellum channel requests on the legacy path too.
+  const legacyActorVerification = sourceChannel === 'vellum' ? verifyHttpActorToken(req) : null;
+  if (legacyActorVerification && !legacyActorVerification.ok) {
+    return httpError(
+      legacyActorVerification.status === 401 ? 'UNAUTHORIZED' : 'FORBIDDEN',
+      legacyActorVerification.message,
+      legacyActorVerification.status,
+    );
+  }
+
+  const guardianContext = legacyActorVerification?.ok
+    ? legacyActorVerification.guardianContext
+    : { trustClass: 'unknown' as const, sourceChannel };
+
   try {
     const result = await processor(
       mapping.conversationId,
       content ?? '',
       hasAttachments ? attachmentIds : undefined,
-      { guardianContext: { trustClass: 'guardian', sourceChannel } },
+      { guardianContext },
       sourceChannel,
       sourceInterface,
     );

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -20,7 +20,11 @@ import type { ApprovalAction } from '../channel-approval-types.js';
 import type { GuardianDecisionPrompt } from '../guardian-decision-types.js';
 import { buildDecisionActions } from '../guardian-decision-types.js';
 import { httpError } from '../http-errors.js';
-import { isActorBoundGuardian, verifyHttpActorToken } from '../middleware/actor-token.js';
+import {
+  isActorBoundGuardian,
+  isLocalFallbackBoundGuardian,
+  verifyHttpActorTokenWithLocalFallback,
+} from '../middleware/actor-token.js';
 
 // ---------------------------------------------------------------------------
 // GET /v1/guardian-actions/pending?conversationId=...
@@ -35,7 +39,7 @@ import { isActorBoundGuardian, verifyHttpActorToken } from '../middleware/actor-
  * can render structured button UIs.
  */
 export function handleGuardianActionsPending(req: Request): Response {
-  const tokenResult = verifyHttpActorToken(req);
+  const tokenResult = verifyHttpActorTokenWithLocalFallback(req);
   if (!tokenResult.ok) {
     return httpError(
       tokenResult.status === 401 ? 'UNAUTHORIZED' : 'FORBIDDEN',
@@ -68,7 +72,7 @@ export function handleGuardianActionsPending(req: Request): Response {
  * minting.
  */
 export async function handleGuardianActionDecision(req: Request): Promise<Response> {
-  const tokenResult = verifyHttpActorToken(req);
+  const tokenResult = verifyHttpActorTokenWithLocalFallback(req);
   if (!tokenResult.ok) {
     return httpError(
       tokenResult.status === 401 ? 'UNAUTHORIZED' : 'FORBIDDEN',
@@ -76,7 +80,10 @@ export async function handleGuardianActionDecision(req: Request): Promise<Respon
       tokenResult.status,
     );
   }
-  if (!isActorBoundGuardian(tokenResult.claims)) {
+  const isBoundGuardian = tokenResult.claims
+    ? isActorBoundGuardian(tokenResult.claims)
+    : isLocalFallbackBoundGuardian();
+  if (!isBoundGuardian) {
     return httpError('FORBIDDEN', 'Actor is not the bound guardian for this channel', 403);
   }
 
@@ -110,11 +117,17 @@ export async function handleGuardianActionDecision(req: Request): Promise<Respon
     }
   }
 
+  // Resolve the actor's external user ID: from the token claims if present,
+  // otherwise from the vellum guardian binding (local fallback).
+  const actorExternalUserId = tokenResult.claims
+    ? tokenResult.claims.guardianPrincipalId
+    : tokenResult.guardianContext.guardianExternalUserId;
+
   const canonicalResult = await applyCanonicalGuardianDecision({
     requestId,
     action: action as ApprovalAction,
     actorContext: {
-      externalUserId: tokenResult.claims.guardianPrincipalId,
+      externalUserId: actorExternalUserId,
       channel: 'vellum',
       isTrusted: true,
     },

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -3,6 +3,10 @@
  *
  * These endpoints let desktop clients fetch pending guardian prompts and
  * submit button decisions without relying on text parsing.
+ *
+ * After M5 cutover: all guardian action endpoints require a valid actor
+ * token via the X-Actor-Token header, and guardian decisions additionally
+ * verify the actor is the bound guardian.
  */
 import {
   applyCanonicalGuardianDecision,
@@ -16,6 +20,7 @@ import type { ApprovalAction } from '../channel-approval-types.js';
 import type { GuardianDecisionPrompt } from '../guardian-decision-types.js';
 import { buildDecisionActions } from '../guardian-decision-types.js';
 import { httpError } from '../http-errors.js';
+import { isActorBoundGuardian, verifyHttpActorToken } from '../middleware/actor-token.js';
 
 // ---------------------------------------------------------------------------
 // GET /v1/guardian-actions/pending?conversationId=...
@@ -23,12 +28,22 @@ import { httpError } from '../http-errors.js';
 
 /**
  * List pending guardian decision prompts for a conversation.
+ * Requires a valid actor token.
  *
  * Returns guardian approval requests (from the channel guardian store) that
  * are still pending, mapped to the GuardianDecisionPrompt shape so clients
  * can render structured button UIs.
  */
 export function handleGuardianActionsPending(req: Request): Response {
+  const tokenResult = verifyHttpActorToken(req);
+  if (!tokenResult.ok) {
+    return httpError(
+      tokenResult.status === 401 ? 'UNAUTHORIZED' : 'FORBIDDEN',
+      tokenResult.message,
+      tokenResult.status,
+    );
+  }
+
   const url = new URL(req.url);
   const conversationId = url.searchParams.get('conversationId');
 
@@ -46,12 +61,25 @@ export function handleGuardianActionsPending(req: Request): Response {
 
 /**
  * Submit a guardian action decision.
+ * Requires a valid actor token for a bound guardian.
  *
  * Routes all decisions through the unified canonical guardian decision
  * primitive which handles CAS resolution, resolver dispatch, and grant
  * minting.
  */
 export async function handleGuardianActionDecision(req: Request): Promise<Response> {
+  const tokenResult = verifyHttpActorToken(req);
+  if (!tokenResult.ok) {
+    return httpError(
+      tokenResult.status === 401 ? 'UNAUTHORIZED' : 'FORBIDDEN',
+      tokenResult.message,
+      tokenResult.status,
+    );
+  }
+  if (!isActorBoundGuardian(tokenResult.claims)) {
+    return httpError('FORBIDDEN', 'Actor is not the bound guardian for this channel', 403);
+  }
+
   const body = await req.json() as {
     requestId?: string;
     action?: string;
@@ -86,7 +114,7 @@ export async function handleGuardianActionDecision(req: Request): Promise<Respon
     requestId,
     action: action as ApprovalAction,
     actorContext: {
-      externalUserId: undefined,
+      externalUserId: tokenResult.claims.guardianPrincipalId,
       channel: 'vellum',
       isTrusted: true,
     },


### PR DESCRIPTION
Removes all legacy trusted-default behavior for vellum channel. HTTP routes now require valid actor tokens. Guardian decisions enforce identity-matching. Dead legacy code paths removed. Part of #10756.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
