### PR TITLE
fix: skip redundant title rewrite on repeated blocked messages

### DIFF
--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -214,7 +214,7 @@ export async function runAgentLoopImpl(
       }
       // Replace loading placeholder so the thread isn't stuck as "Generating title..."
       const currentConv = conversationStore.getConversation(ctx.conversationId);
-      if (isReplaceableTitle(currentConv?.title ?? null)) {
+      if (isReplaceableTitle(currentConv?.title ?? null) && currentConv?.title !== UNTITLED_FALLBACK) {
         conversationStore.updateConversationTitle(ctx.conversationId, UNTITLED_FALLBACK);
         onEvent({ type: 'session_title_updated', sessionId: ctx.conversationId, title: UNTITLED_FALLBACK });
       }


### PR DESCRIPTION
## Summary
- Skip title rewrite in the blocked-by-hook path when the title is already `UNTITLED_FALLBACK`
- `isReplaceableTitle` returns true for "Untitled Conversation", so repeated blocks caused unnecessary `updateConversationTitle` calls and `session_title_updated` events

## Original prompt
Addresses review feedback from #10746.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
