### PR TITLE
fix: allow archiving the last conversation in sidebar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -885,7 +885,7 @@ struct MainWindowView: View {
                 .buttonStyle(.plain)
                 .padding(.trailing, VSpacing.xs)
                 .accessibilityLabel("Confirm archive \(thread.title)")
-            } else if isHovered && threadManager.visibleThreads.count > 1 {
+            } else if isHovered {
                 Button {
                     sidebar.threadPendingDeletion = thread.id
                 } label: {
@@ -923,12 +923,10 @@ struct MainWindowView: View {
                     Label("Rename", systemImage: "pencil")
                 }
             }
-            if threadManager.visibleThreads.count > 1 {
-                Button {
-                    threadManager.archiveThread(id: thread.id)
-                } label: {
-                    Label("Archive", systemImage: "archivebox")
-                }
+            Button {
+                threadManager.archiveThread(id: thread.id)
+            } label: {
+                Label("Archive", systemImage: "archivebox")
             }
         }
         .onHover { hovering in


### PR DESCRIPTION
## Summary

- Remove `visibleThreads.count > 1` guard that prevented archiving when only one conversation exists in the sidebar
- The hover archive button and context menu archive option are now always available
- `archiveThread()` already handles this case by calling `createThread()` when no visible threads remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
