### PR TITLE
fix: enforce assistant-id boundary conformance across daemon control-plane

### DIFF
--- a/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
+++ b/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
@@ -287,4 +287,127 @@ describe('assistant ID boundary', () => {
   // all daemon storage keyed by DAEMON_INTERNAL_ASSISTANT_ID uses the fixed
   // internal value rather than externally-provided IDs).
   // -------------------------------------------------------------------------
+
+  // -------------------------------------------------------------------------
+  // Rule (e): No assistantId on daemon control-plane request/param types
+  //
+  // Daemon IPC contracts and guardian outbound param interfaces must not
+  // accept an assistantId field -- the daemon always uses
+  // DAEMON_INTERNAL_ASSISTANT_ID internally. Accepting assistantId on these
+  // surfaces invites callers to pass external IDs into daemon scoping.
+  // -------------------------------------------------------------------------
+
+  test('IPC contract types do not contain assistantId for Twilio/readiness/guardian requests', () => {
+    const ipcContractPath = join(import.meta.dir, '..', 'daemon', 'ipc-contract', 'integrations.ts');
+    const content = readFileSync(ipcContractPath, 'utf-8');
+
+    // Extract the interface blocks for the three request types and verify
+    // none of them declare an assistantId property.
+    const requestTypeNames = [
+      'TwilioConfigRequest',
+      'ChannelReadinessRequest',
+      'GuardianVerificationRequest',
+    ];
+
+    for (const typeName of requestTypeNames) {
+      // Find the interface/type block — match from the type name to the next
+      // closing brace at the same indentation level. We use a simple heuristic:
+      // find the line declaring the type, then scan forward to the closing '}'.
+      const typeIndex = content.indexOf(typeName);
+      expect(typeIndex, `Expected to find ${typeName} in IPC contract`).toBeGreaterThan(-1);
+
+      // Extract from the type declaration to the next '}' line
+      const blockStart = content.indexOf('{', typeIndex);
+      if (blockStart === -1) continue;
+      let braceDepth = 0;
+      let blockEnd = blockStart;
+      for (let i = blockStart; i < content.length; i++) {
+        if (content[i] === '{') braceDepth++;
+        if (content[i] === '}') braceDepth--;
+        if (braceDepth === 0) {
+          blockEnd = i + 1;
+          break;
+        }
+      }
+      const block = content.slice(blockStart, blockEnd);
+
+      // The block should not contain an assistantId property declaration
+      // (matches "assistantId?" or "assistantId:" on a non-comment line)
+      const lines = block.split('\n');
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) continue;
+        expect(
+          /\bassistantId\s*[?:]/.test(trimmed),
+          `${typeName} must not declare an assistantId property. Found: "${trimmed}"`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  test('guardian outbound param interfaces do not contain assistantId', () => {
+    const actionsPath = join(import.meta.dir, '..', 'runtime', 'guardian-outbound-actions.ts');
+    const content = readFileSync(actionsPath, 'utf-8');
+
+    const interfaceNames = [
+      'StartOutboundParams',
+      'ResendOutboundParams',
+      'CancelOutboundParams',
+    ];
+
+    for (const name of interfaceNames) {
+      const idx = content.indexOf(name);
+      expect(idx, `Expected to find ${name} in guardian-outbound-actions.ts`).toBeGreaterThan(-1);
+
+      const blockStart = content.indexOf('{', idx);
+      if (blockStart === -1) continue;
+      let braceDepth = 0;
+      let blockEnd = blockStart;
+      for (let i = blockStart; i < content.length; i++) {
+        if (content[i] === '{') braceDepth++;
+        if (content[i] === '}') braceDepth--;
+        if (braceDepth === 0) {
+          blockEnd = i + 1;
+          break;
+        }
+      }
+      const block = content.slice(blockStart, blockEnd);
+
+      const lines = block.split('\n');
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) continue;
+        expect(
+          /\bassistantId\s*[?:]/.test(trimmed),
+          `${name} must not declare an assistantId property. Found: "${trimmed}"`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  test('channel readiness service does not accept assistantId parameter', () => {
+    const servicePath = join(import.meta.dir, '..', 'runtime', 'channel-readiness-service.ts');
+    const content = readFileSync(servicePath, 'utf-8');
+
+    // getReadiness and invalidateChannel signatures must not include assistantId
+    const signaturePatterns = [
+      /getReadiness\([^)]*assistantId/,
+      /invalidateChannel\([^)]*assistantId/,
+    ];
+    for (const pattern of signaturePatterns) {
+      expect(
+        pattern.test(content),
+        `Channel readiness service must not accept assistantId parameter (matched: ${pattern})`,
+      ).toBe(false);
+    }
+
+    // ChannelProbeContext must not have assistantId
+    const probeContextMatch = content.match(/interface\s+ChannelProbeContext\s*\{([^}]*)\}/);
+    if (probeContextMatch) {
+      expect(
+        probeContextMatch[1],
+        'ChannelProbeContext must not contain assistantId',
+      ).not.toContain('assistantId');
+    }
+  });
 });

--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -302,24 +302,18 @@ describe('ChannelReadinessService', () => {
     expect(snapshot.reasons).toEqual([]);
   });
 
-  test('remote cache is scoped per assistantId', async () => {
-    const remoteCalls: Record<string, number> = {};
-    const probe: ChannelProbe = {
-      channel: 'sms',
-      runLocalChecks: () => [{ name: 'local', passed: true, message: 'ok' }],
-      async runRemoteChecks(context) {
-        const key = context?.assistantId ?? '__default__';
-        remoteCalls[key] = (remoteCalls[key] ?? 0) + 1;
-        return [{ name: 'remote', passed: true, message: `ok-${key}` }];
-      },
-    };
+  test('remote cache uses fixed internal scope (no per-assistantId scoping)', async () => {
+    const probe = makeProbe(
+      'sms',
+      [{ name: 'local', passed: true, message: 'ok' }],
+      [{ name: 'remote', passed: true, message: 'ok' }],
+    );
     service.registerProbe(probe);
 
-    await service.getReadiness('sms', true, 'ast-alpha');
-    await service.getReadiness('sms', true, 'ast-beta');
-    await service.getReadiness('sms', true, 'ast-alpha');
+    // All calls share the same cache key since there is no assistantId dimension
+    await service.getReadiness('sms', true);
+    await service.getReadiness('sms', true);
 
-    expect(remoteCalls['ast-alpha']).toBe(1);
-    expect(remoteCalls['ast-beta']).toBe(1);
+    expect(probe.remoteCallCount).toBe(1);
   });
 });

--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -268,7 +268,7 @@ describe('startOutbound', () => {
 
 describe('resendOutbound', () => {
   test('returns no_active_session when no session exists', () => {
-    const result = resendOutbound({ channel: 'sms', assistantId: 'no-such-assistant' });
+    const result = resendOutbound({ channel: 'sms' });
     expect(result.success).toBe(false);
     expect(result.error).toBe('no_active_session');
   });
@@ -339,7 +339,7 @@ describe('resendOutbound', () => {
 
 describe('cancelOutbound', () => {
   test('returns no_active_session when no session exists', () => {
-    const result = cancelOutbound({ channel: 'sms', assistantId: 'no-such-assistant-cancel' });
+    const result = cancelOutbound({ channel: 'sms' });
     expect(result.success).toBe(false);
     expect(result.error).toBe('no_active_session');
   });
@@ -397,7 +397,7 @@ describe('HTTP route: handleResendOutbound', () => {
   });
 
   test('returns 400 for no_active_session', async () => {
-    const req = jsonRequest({ channel: 'sms', assistantId: 'resend-no-session' });
+    const req = jsonRequest({ channel: 'sms' });
     const resp = await handleResendOutbound(req);
     expect(resp.status).toBe(400);
     const body = await resp.json() as { error?: string };
@@ -439,7 +439,7 @@ describe('HTTP route: handleCancelOutbound', () => {
   });
 
   test('returns 400 for no_active_session', async () => {
-    const req = jsonRequest({ channel: 'sms', assistantId: 'cancel-no-session' });
+    const req = jsonRequest({ channel: 'sms' });
     const resp = await handleCancelOutbound(req);
     expect(resp.status).toBe(400);
     const body = await resp.json() as { error?: string };

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -101,8 +101,7 @@ export type CallerIdentityResult =
  * - Otherwise, always use `assistant_number` (implicit default).
  *
  * For `assistant_number`: uses the Twilio phone number from
- *   `getTwilioConfig(assistantId)` so multi-assistant mappings are honored.
- *   No eligibility check is performed — this is a fast path.
+ *   `getTwilioConfig()`. No eligibility check is performed — this is a fast path.
  * For `user_number`: uses `config.calls.callerIdentity.userNumber` or the
  *   secure key `credential:twilio:user_phone_number`, then validates that the
  *   number is usable as an outbound caller ID via the Twilio API.
@@ -133,8 +132,8 @@ export async function resolveCallerIdentity(
   }
 
   if (mode === 'assistant_number') {
-    const twilioConfig = getTwilioConfig(assistantId);
-    log.info({ mode, source, fromNumber: twilioConfig.phoneNumber, assistantId }, 'Resolved caller identity');
+    const twilioConfig = getTwilioConfig();
+    log.info({ mode, source, fromNumber: twilioConfig.phoneNumber }, 'Resolved caller identity');
     return { ok: true, mode, fromNumber: twilioConfig.phoneNumber, source };
   }
 

--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -15,26 +15,15 @@ export interface TwilioConfig {
   wssBaseUrl: string;
 }
 
-function resolveTwilioPhoneNumber(assistantId: string | undefined, config: ReturnType<typeof loadConfig>): string {
-  if (assistantId) {
-    const assistantPhone = config.sms?.assistantPhoneNumbers?.[assistantId];
-    if (assistantPhone) {
-      return assistantPhone;
-    }
-  }
-
-  // Global fallback order:
-  // 1. TWILIO_PHONE_NUMBER env var (explicit override)
-  // 2. config file sms.phoneNumber (primary storage)
-  // 3. credential:twilio:phone_number secure key (backward-compat fallback)
+function resolveTwilioPhoneNumber(config: ReturnType<typeof loadConfig>): string {
   return getTwilioPhoneNumberEnv() || config.sms?.phoneNumber || getSecureKey('credential:twilio:phone_number') || '';
 }
 
-export function getTwilioConfig(assistantId?: string): TwilioConfig {
+export function getTwilioConfig(): TwilioConfig {
   const accountSid = getSecureKey('credential:twilio:account_sid');
   const authToken = getSecureKey('credential:twilio:auth_token');
   const config = loadConfig();
-  const phoneNumber = resolveTwilioPhoneNumber(assistantId, config);
+  const phoneNumber = resolveTwilioPhoneNumber(config);
   const webhookBaseUrl = getPublicBaseUrl(config);
 
   // Always use the centralized relay URL derived from the public ingress base URL.

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -252,7 +252,7 @@ function buildVoiceWebhookTwiml(
     });
   }
 
-  const twilioConfig = getTwilioConfig(assistantId);
+  const twilioConfig = getTwilioConfig();
   let relayUrl: string;
   try {
     relayUrl = getTwilioRelayUrl(loadConfig());

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -60,7 +60,6 @@ export function getReadinessService(): ChannelReadinessService {
 
 export function createGuardianChallenge(
   channel?: ChannelId,
-  assistantId?: string,
   rebind?: boolean,
   sessionId?: string,
 ): GuardianVerificationResult {
@@ -89,7 +88,6 @@ export function createGuardianChallenge(
 
 export function getGuardianStatus(
   channel?: ChannelId,
-  _assistantId?: string,
 ): GuardianVerificationResult {
   const resolvedAssistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const resolvedChannel = channel ?? 'telegram';
@@ -166,10 +164,10 @@ export function handleGuardianVerification(
 
   try {
     if (msg.action === 'create_challenge') {
-      const result = createGuardianChallenge(channel, assistantId, msg.rebind, msg.sessionId);
+      const result = createGuardianChallenge(channel, msg.rebind, msg.sessionId);
       ctx.send(socket, { type: 'guardian_verification_response', ...result });
     } else if (msg.action === 'status') {
-      const result = getGuardianStatus(channel, assistantId);
+      const result = getGuardianStatus(channel);
       ctx.send(socket, { type: 'guardian_verification_response', ...result });
     } else if (msg.action === 'revoke') {
       // Capture binding before revoking so we can revoke the guardian's
@@ -198,13 +196,13 @@ export function handleGuardianVerification(
         channel,
       });
     } else if (msg.action === 'start_outbound') {
-      const result = startOutbound({ channel, assistantId, destination: msg.destination, rebind: msg.rebind, originConversationId: msg.originConversationId });
+      const result = startOutbound({ channel, destination: msg.destination, rebind: msg.rebind, originConversationId: msg.originConversationId });
       ctx.send(socket, { type: 'guardian_verification_response', ...result });
     } else if (msg.action === 'resend_outbound') {
-      const result = resendOutbound({ channel, assistantId, originConversationId: msg.originConversationId });
+      const result = resendOutbound({ channel, originConversationId: msg.originConversationId });
       ctx.send(socket, { type: 'guardian_verification_response', ...result });
     } else if (msg.action === 'cancel_outbound') {
-      const result = cancelOutbound({ channel, assistantId });
+      const result = cancelOutbound({ channel });
       ctx.send(socket, { type: 'guardian_verification_response', ...result });
     } else {
       ctx.send(socket, {
@@ -241,13 +239,13 @@ export async function handleChannelReadiness(
 
     if (msg.action === 'refresh') {
       if (msg.channel) {
-        service.invalidateChannel(msg.channel, msg.assistantId);
+        service.invalidateChannel(msg.channel);
       } else {
         service.invalidateAll();
       }
     }
 
-    const snapshots = await service.getReadiness(msg.channel, msg.includeRemote, msg.assistantId);
+    const snapshots = await service.getReadiness(msg.channel, msg.includeRemote);
 
     ctx.send(socket, {
       type: 'channel_readiness_response',

--- a/assistant/src/daemon/handlers/config-twilio.ts
+++ b/assistant/src/daemon/handlers/config-twilio.ts
@@ -91,15 +91,7 @@ export async function handleTwilioConfig(
       const hasCredentials = hasTwilioCredentials();
       const raw = loadRawConfig();
       const sms = (raw?.sms ?? {}) as Record<string, unknown>;
-      // When assistantId is provided, look up in assistantPhoneNumbers first,
-      // fall back to the legacy phoneNumber field
-      let phoneNumber: string;
-      if (msg.assistantId) {
-        const mapping = (sms.assistantPhoneNumbers as Record<string, string> | undefined) ?? {};
-        phoneNumber = mapping[msg.assistantId] ?? (sms.phoneNumber as string) ?? '';
-      } else {
-        phoneNumber = (sms.phoneNumber as string) ?? '';
-      }
+      const phoneNumber = (sms.phoneNumber as string) ?? '';
       ctx.send(socket, {
         type: 'twilio_config_response',
         success: true,
@@ -242,22 +234,7 @@ export async function handleTwilioConfig(
 
       const raw = loadRawConfig();
       const sms = (raw?.sms ?? {}) as Record<string, unknown>;
-      // When assistantId is provided, only set the legacy global phoneNumber
-      // if it's not already set — this prevents multi-assistant assignments
-      // from clobbering each other's outbound SMS number.
-      if (msg.assistantId) {
-        if (!sms.phoneNumber) {
-          sms.phoneNumber = purchased.phoneNumber;
-        }
-      } else {
-        sms.phoneNumber = purchased.phoneNumber;
-      }
-      // When assistantId is provided, also persist into the per-assistant mapping
-      if (msg.assistantId) {
-        const mapping = (sms.assistantPhoneNumbers as Record<string, string> | undefined) ?? {};
-        mapping[msg.assistantId] = purchased.phoneNumber;
-        sms.assistantPhoneNumbers = mapping;
-      }
+      sms.phoneNumber = purchased.phoneNumber;
 
       const wasSuppressed = ctx.suppressConfigReload;
       ctx.setSuppressConfigReload(true);
@@ -312,22 +289,7 @@ export async function handleTwilioConfig(
       // Also persist in assistant config (non-secret) for the UI
       const raw = loadRawConfig();
       const sms = (raw?.sms ?? {}) as Record<string, unknown>;
-      // When assistantId is provided, only set the legacy global phoneNumber
-      // if it's not already set — this prevents multi-assistant assignments
-      // from clobbering each other's outbound SMS number.
-      if (msg.assistantId) {
-        if (!sms.phoneNumber) {
-          sms.phoneNumber = msg.phoneNumber;
-        }
-      } else {
-        sms.phoneNumber = msg.phoneNumber;
-      }
-      // When assistantId is provided, also persist into the per-assistant mapping
-      if (msg.assistantId) {
-        const mapping = (sms.assistantPhoneNumbers as Record<string, string> | undefined) ?? {};
-        mapping[msg.assistantId] = msg.phoneNumber;
-        sms.assistantPhoneNumbers = mapping;
-      }
+      sms.phoneNumber = msg.phoneNumber;
 
       const wasSuppressed = ctx.suppressConfigReload;
       ctx.setSuppressConfigReload(true);
@@ -394,13 +356,7 @@ export async function handleTwilioConfig(
 
       const raw = loadRawConfig();
       const sms = (raw?.sms ?? {}) as Record<string, unknown>;
-      let phoneNumber: string;
-      if (msg.assistantId) {
-        const mapping = (sms.assistantPhoneNumbers as Record<string, string> | undefined) ?? {};
-        phoneNumber = mapping[msg.assistantId] ?? (sms.phoneNumber as string) ?? '';
-      } else {
-        phoneNumber = (sms.phoneNumber as string) ?? '';
-      }
+      const phoneNumber = (sms.phoneNumber as string) ?? '';
 
       if (!phoneNumber) {
         ctx.send(socket, {
@@ -717,9 +673,6 @@ export async function handleTwilioConfig(
       let phoneNumber: string;
       if (msg.phoneNumber) {
         phoneNumber = msg.phoneNumber;
-      } else if (msg.assistantId) {
-        const mapping = (sms.assistantPhoneNumbers as Record<string, string> | undefined) ?? {};
-        phoneNumber = mapping[msg.assistantId] ?? (sms.phoneNumber as string) ?? '';
       } else {
         phoneNumber = (sms.phoneNumber as string) ?? '';
       }
@@ -742,17 +695,6 @@ export async function handleTwilioConfig(
       // Clear the number from config and secure key store
       if (sms.phoneNumber === phoneNumber) {
         delete sms.phoneNumber;
-      }
-      const assistantPhoneNumbers = sms.assistantPhoneNumbers as Record<string, string> | undefined;
-      if (assistantPhoneNumbers) {
-        for (const [id, num] of Object.entries(assistantPhoneNumbers)) {
-          if (num === phoneNumber) {
-            delete assistantPhoneNumbers[id];
-          }
-        }
-        if (Object.keys(assistantPhoneNumbers).length === 0) {
-          delete sms.assistantPhoneNumbers;
-        }
       }
 
       const wasSuppressed = ctx.suppressConfigReload;
@@ -802,18 +744,9 @@ export async function handleTwilioConfig(
 
       const raw = loadRawConfig();
       const smsSection = (raw?.sms ?? {}) as Record<string, unknown>;
-      let from = '';
-      // When assistantId is provided, check assistant-scoped phone mapping first
-      if (msg.assistantId) {
-        const mapping = (smsSection.assistantPhoneNumbers as Record<string, string> | undefined) ?? {};
-        from = mapping[msg.assistantId] ?? '';
-      }
-      // Fall back to global phone number
-      if (!from) {
-        from = (smsSection.phoneNumber as string | undefined)
-          || getSecureKey('credential:twilio:phone_number')
-          || '';
-      }
+      const from = (smsSection.phoneNumber as string | undefined)
+        || getSecureKey('credential:twilio:phone_number')
+        || '';
       if (!from) {
         ctx.send(socket, {
           type: 'twilio_config_response',
@@ -838,7 +771,7 @@ export async function handleTwilioConfig(
           'Content-Type': 'application/json',
           ...(bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {}),
         },
-        body: JSON.stringify({ to, text, ...(msg.assistantId ? { assistantId: msg.assistantId } : {}) }),
+        body: JSON.stringify({ to, text }),
         signal: AbortSignal.timeout(30_000),
       });
 
@@ -910,7 +843,7 @@ export async function handleTwilioConfig(
       const readinessIssues: string[] = [];
       try {
         const readinessService = getReadinessService();
-        const snapshots = await readinessService.getReadiness('sms', false, msg.assistantId);
+        const snapshots = await readinessService.getReadiness('sms', false);
         const snapshot = snapshots[0];
         if (snapshot) {
           readinessReady = snapshot.ready;
@@ -932,14 +865,7 @@ export async function handleTwilioConfig(
         try {
           const raw = loadRawConfig();
           const smsSection = (raw?.sms ?? {}) as Record<string, unknown>;
-          let phoneNumber = '';
-          if (msg.assistantId) {
-            const mapping = (smsSection.assistantPhoneNumbers as Record<string, string> | undefined) ?? {};
-            phoneNumber = mapping[msg.assistantId] ?? '';
-          }
-          if (!phoneNumber) {
-            phoneNumber = (smsSection.phoneNumber as string | undefined) || getSecureKey('credential:twilio:phone_number') || '';
-          }
+          const phoneNumber = (smsSection.phoneNumber as string | undefined) || getSecureKey('credential:twilio:phone_number') || '';
           if (phoneNumber) {
             const accountSid = getSecureKey('credential:twilio:account_sid')!;
             const authToken = getSecureKey('credential:twilio:auth_token')!;

--- a/assistant/src/daemon/handlers/config-twilio.ts
+++ b/assistant/src/daemon/handlers/config-twilio.ts
@@ -697,6 +697,20 @@ export async function handleTwilioConfig(
         delete sms.phoneNumber;
       }
 
+      // Prune any legacy assistant-mapped phone entries that reference
+      // the released number so the gateway does not attempt to send from it.
+      const mappings = sms.assistantPhoneNumbers as Record<string, string> | undefined;
+      if (mappings && typeof mappings === 'object') {
+        for (const [key, value] of Object.entries(mappings)) {
+          if (value === phoneNumber) {
+            delete mappings[key];
+          }
+        }
+        if (Object.keys(mappings).length === 0) {
+          delete sms.assistantPhoneNumbers;
+        }
+      }
+
       const wasSuppressed = ctx.suppressConfigReload;
       ctx.setSuppressConfigReload(true);
       try {

--- a/assistant/src/daemon/ipc-contract/integrations.ts
+++ b/assistant/src/daemon/ipc-contract/integrations.ts
@@ -55,7 +55,6 @@ export interface TwilioConfigRequest {
   phoneNumber?: string;       // Only for action: 'assign_number' or 'sms_send_test'
   areaCode?: string;          // Only for action: 'provision_number'
   country?: string;           // Only for action: 'provision_number' (ISO 3166-1 alpha-2, default 'US')
-  assistantId?: string;       // Scope number assignment/lookup to a specific assistant
   verificationSid?: string;   // Only for update/delete verification actions
   verificationParams?: {
     tollfreePhoneNumberSid?: string;
@@ -78,8 +77,6 @@ export interface ChannelReadinessRequest {
   type: 'channel_readiness';
   action: 'get' | 'refresh';
   channel?: ChannelId;
-  /** @deprecated Ignored — daemon always uses internal scope (DAEMON_INTERNAL_ASSISTANT_ID). */
-  assistantId?: string;
   includeRemote?: boolean;
 }
 
@@ -88,8 +85,6 @@ export interface GuardianVerificationRequest {
   action: 'create_challenge' | 'status' | 'revoke' | 'start_outbound' | 'resend_outbound' | 'cancel_outbound';
   channel?: ChannelId;  // Defaults to 'telegram'
   sessionId?: string;
-  /** @deprecated Ignored — daemon always uses internal scope (DAEMON_INTERNAL_ASSISTANT_ID). */
-  assistantId?: string;
   rebind?: boolean;  // When true, allows creating a challenge even if a binding already exists
   /** E.164 phone number for SMS/voice, Telegram handle/chat-id. Used by outbound actions. */
   destination?: string;

--- a/assistant/src/messaging/providers/sms/adapter.ts
+++ b/assistant/src/messaging/providers/sms/adapter.ts
@@ -56,22 +56,8 @@ function hasTwilioCredentials(): boolean {
   );
 }
 
-/**
- * Resolve the configured SMS phone number.
- * Priority: assistant-scoped phone number > TWILIO_PHONE_NUMBER env > config sms.phoneNumber > secure key fallback.
- */
-function getPhoneNumber(assistantId?: string): string | undefined {
-  // Check assistant-scoped phone number first
-  if (assistantId) {
-    try {
-      const config = loadConfig();
-      const assistantPhone = config.sms?.assistantPhoneNumbers?.[assistantId];
-      if (assistantPhone) return assistantPhone;
-    } catch {
-      // Config may not be available yet during early startup
-    }
-  }
-
+/** Resolve the configured SMS phone number. */
+function getPhoneNumber(): string | undefined {
   const fromEnv = getTwilioPhoneNumberEnv();
   if (fromEnv) return fromEnv;
 
@@ -83,15 +69,6 @@ function getPhoneNumber(assistantId?: string): string | undefined {
   }
 
   return getSecureKey('credential:twilio:phone_number') || undefined;
-}
-
-function hasAnyAssistantPhoneNumber(): boolean {
-  try {
-    const config = loadConfig();
-    return Object.keys(config.sms?.assistantPhoneNumbers ?? {}).length > 0;
-  } catch {
-    return false;
-  }
 }
 
 export const smsMessagingProvider: MessagingProvider = {
@@ -106,7 +83,7 @@ export const smsMessagingProvider: MessagingProvider = {
    * the `from` for outbound messages.
    */
   isConnected(): boolean {
-    return hasTwilioCredentials() && (!!getPhoneNumber() || hasAnyAssistantPhoneNumber());
+    return hasTwilioCredentials() && !!getPhoneNumber();
   },
 
   async testConnection(_token: string): Promise<ConnectionInfo> {
@@ -120,7 +97,7 @@ export const smsMessagingProvider: MessagingProvider = {
     }
 
     const phoneNumber = getPhoneNumber();
-    if (!phoneNumber && !hasAnyAssistantPhoneNumber()) {
+    if (!phoneNumber) {
       return {
         connected: false,
         user: 'unknown',
@@ -133,12 +110,11 @@ export const smsMessagingProvider: MessagingProvider = {
 
     return {
       connected: true,
-      user: phoneNumber ?? 'assistant-scoped numbers configured',
+      user: phoneNumber,
       platform: 'sms',
       metadata: {
         accountSid: accountSid.slice(0, 6) + '...',
-        ...(phoneNumber ? { phoneNumber } : {}),
-        hasAssistantScopedPhoneNumbers: hasAnyAssistantPhoneNumber(),
+        phoneNumber,
       },
     };
   },
@@ -154,20 +130,13 @@ export const smsMessagingProvider: MessagingProvider = {
     // exists for the next inbound SMS from this number.
     try {
       const sourceChannel = 'sms';
-      const conversationKey = assistantId && assistantId !== 'self'
-        ? `asst:${assistantId}:${sourceChannel}:${conversationId}`
-        : `${sourceChannel}:${conversationId}`;
+      const conversationKey = `${sourceChannel}:${conversationId}`;
       const { conversationId: internalId } = getOrCreateConversation(conversationKey);
-      // external_conversation_bindings is assistant-agnostic (unique by
-      // sourceChannel + externalChatId). Restrict proactive writes to self so
-      // multi-assistant sends cannot clobber each other's binding metadata.
-      if (!assistantId || assistantId === 'self') {
-        externalConversationStore.upsertOutboundBinding({
-          conversationId: internalId,
-          sourceChannel,
-          externalChatId: conversationId,
-        });
-      }
+      externalConversationStore.upsertOutboundBinding({
+        conversationId: internalId,
+        sourceChannel,
+        externalChatId: conversationId,
+      });
     } catch {
       // Best-effort — don't fail the send if binding upsert fails
     }

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -31,41 +31,15 @@ function hasIngressConfigured(): boolean {
   }
 }
 
-function getAssistantMappedPhoneNumber(
-  smsConfig: Record<string, unknown>,
-  assistantId?: string,
-): string | undefined {
-  if (!assistantId) return undefined;
-  const mapping = (smsConfig.assistantPhoneNumbers as Record<string, string> | undefined) ?? {};
-  return mapping[assistantId];
-}
-
-function hasAnyAssistantMappedPhoneNumber(smsConfig: Record<string, unknown>): boolean {
-  const mapping = (smsConfig.assistantPhoneNumbers as Record<string, string> | undefined) ?? {};
-  return Object.keys(mapping).length > 0;
-}
-
-function hasAnyAssistantMappedPhoneNumberSafe(): boolean {
-  try {
-    const raw = loadRawConfig();
-    const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
-    return hasAnyAssistantMappedPhoneNumber(smsConfig);
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Resolve SMS from-number with canonical precedence:
- * assistant mapping -> env override -> config sms.phoneNumber -> secure key fallback.
+ * env override -> config sms.phoneNumber -> secure key fallback.
  */
-function resolveSmsPhoneNumber(assistantId?: string): string {
+function resolveSmsPhoneNumber(): string {
   try {
     const raw = loadRawConfig();
     const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
-    const mapped = getAssistantMappedPhoneNumber(smsConfig, assistantId);
-    return mapped
-      || getTwilioPhoneNumberEnv()
+    return getTwilioPhoneNumberEnv()
       || (smsConfig.phoneNumber as string)
       || getSecureKey('credential:twilio:phone_number')
       || '';
@@ -78,7 +52,7 @@ function resolveSmsPhoneNumber(assistantId?: string): string {
 
 const smsProbe: ChannelProbe = {
   channel: 'sms',
-  runLocalChecks(context?: ChannelProbeContext): ReadinessCheckResult[] {
+  runLocalChecks(): ReadinessCheckResult[] {
     const results: ReadinessCheckResult[] = [];
 
     const hasCreds = hasTwilioCredentials();
@@ -90,18 +64,14 @@ const smsProbe: ChannelProbe = {
         : 'Twilio Account SID and Auth Token are not configured',
     });
 
-    const resolvedNumber = resolveSmsPhoneNumber(context?.assistantId);
-    const hasPhone = !!resolvedNumber || (!context?.assistantId && hasAnyAssistantMappedPhoneNumberSafe());
+    const resolvedNumber = resolveSmsPhoneNumber();
+    const hasPhone = !!resolvedNumber;
     results.push({
       name: 'phone_number',
       passed: hasPhone,
       message: hasPhone
-        ? (context?.assistantId && !resolvedNumber
-          ? `Assistant ${context.assistantId} has no direct mapping, but SMS phone numbers are assigned`
-          : 'Phone number is assigned')
-        : (context?.assistantId
-          ? `No phone number assigned for assistant ${context.assistantId}`
-          : 'No phone number assigned'),
+        ? 'Phone number is assigned'
+        : 'No phone number assigned',
     });
 
     const hasIngress = hasIngressConfigured();
@@ -115,14 +85,14 @@ const smsProbe: ChannelProbe = {
 
     return results;
   },
-  async runRemoteChecks(context?: ChannelProbeContext): Promise<ReadinessCheckResult[]> {
+  async runRemoteChecks(): Promise<ReadinessCheckResult[]> {
     if (!hasTwilioCredentials()) return [];
 
     const accountSid = getSecureKey('credential:twilio:account_sid');
     const authToken = getSecureKey('credential:twilio:auth_token');
     if (!accountSid || !authToken) return [];
 
-    const phoneNumber = resolveSmsPhoneNumber(context?.assistantId);
+    const phoneNumber = resolveSmsPhoneNumber();
     if (!phoneNumber) return [];
 
     // Only toll-free numbers need verification checks
@@ -170,18 +140,16 @@ const smsProbe: ChannelProbe = {
 
 /**
  * Resolve voice from-number with the same precedence as SMS:
- * assistant mapping -> env override -> config sms.phoneNumber -> secure key fallback.
+ * env override -> config sms.phoneNumber -> secure key fallback.
  *
  * Voice and SMS share the same Twilio phone number infrastructure, so the
  * resolution logic is identical to resolveSmsPhoneNumber.
  */
-function resolveVoicePhoneNumber(assistantId?: string): string {
+function resolveVoicePhoneNumber(): string {
   try {
     const raw = loadRawConfig();
     const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
-    const mapped = getAssistantMappedPhoneNumber(smsConfig, assistantId);
-    return mapped
-      || getTwilioPhoneNumberEnv()
+    return getTwilioPhoneNumberEnv()
       || (smsConfig.phoneNumber as string)
       || getSecureKey('credential:twilio:phone_number')
       || '';
@@ -194,7 +162,7 @@ function resolveVoicePhoneNumber(assistantId?: string): string {
 
 const voiceProbe: ChannelProbe = {
   channel: 'voice',
-  runLocalChecks(context?: ChannelProbeContext): ReadinessCheckResult[] {
+  runLocalChecks(): ReadinessCheckResult[] {
     const results: ReadinessCheckResult[] = [];
 
     const hasCreds = hasTwilioCredentials();
@@ -206,18 +174,14 @@ const voiceProbe: ChannelProbe = {
         : 'Twilio Account SID and Auth Token are not configured',
     });
 
-    const resolvedNumber = resolveVoicePhoneNumber(context?.assistantId);
-    const hasPhone = !!resolvedNumber || (!context?.assistantId && hasAnyAssistantMappedPhoneNumberSafe());
+    const resolvedNumber = resolveVoicePhoneNumber();
+    const hasPhone = !!resolvedNumber;
     results.push({
       name: 'phone_number',
       passed: hasPhone,
       message: hasPhone
-        ? (context?.assistantId && !resolvedNumber
-          ? `Assistant ${context.assistantId} has no direct mapping, but phone numbers are assigned`
-          : 'Phone number is assigned for voice calls')
-        : (context?.assistantId
-          ? `No phone number assigned for assistant ${context.assistantId}`
-          : 'No phone number assigned for voice calls'),
+        ? 'Phone number is assigned for voice calls'
+        : 'No phone number assigned for voice calls',
     });
 
     const hasIngress = hasIngressConfigured();
@@ -290,7 +254,6 @@ export class ChannelReadinessService {
   async getReadiness(
     channel?: ChannelId,
     includeRemote?: boolean,
-    assistantId?: string,
   ): Promise<ChannelReadinessSnapshot[]> {
     const channels = channel
       ? [channel]
@@ -304,14 +267,14 @@ export class ChannelReadinessService {
         continue;
       }
 
-      const probeContext: ChannelProbeContext = { assistantId };
+      const probeContext: ChannelProbeContext = {};
       const localChecks = probe.runLocalChecks(probeContext);
       let remoteChecks: ReadinessCheckResult[] | undefined;
       let remoteChecksFreshlyFetched = false;
       let remoteChecksAffectReadiness = false;
       let stale = false;
 
-      const cacheKey = this.snapshotCacheKey(ch, assistantId);
+      const cacheKey = this.snapshotCacheKey(ch);
       const cached = this.snapshots.get(cacheKey);
       const now = Date.now();
 
@@ -372,11 +335,7 @@ export class ChannelReadinessService {
   }
 
   /** Clear cached snapshot for a specific channel, forcing re-evaluation on next call. */
-  invalidateChannel(channel: ChannelId, assistantId?: string): void {
-    if (assistantId) {
-      this.snapshots.delete(this.snapshotCacheKey(channel, assistantId));
-      return;
-    }
+  invalidateChannel(channel: ChannelId): void {
     const prefix = `${channel}::`;
     for (const key of this.snapshots.keys()) {
       if (key.startsWith(prefix)) {
@@ -401,8 +360,8 @@ export class ChannelReadinessService {
     };
   }
 
-  private snapshotCacheKey(channel: ChannelId, assistantId?: string): string {
-    return `${channel}::${assistantId ?? '__default__'}`;
+  private snapshotCacheKey(channel: ChannelId): string {
+    return `${channel}::__default__`;
   }
 }
 

--- a/assistant/src/runtime/channel-readiness-types.ts
+++ b/assistant/src/runtime/channel-readiness-types.ts
@@ -22,10 +22,8 @@ export interface ChannelReadinessSnapshot {
   remoteChecks?: ReadinessCheckResult[];
 }
 
-/** Optional probe context for assistant-scoped readiness checks. */
-export interface ChannelProbeContext {
-  assistantId?: string;
-}
+/** Optional probe context for readiness checks. */
+export interface ChannelProbeContext {}
 
 /** Probe interface that channels implement to provide readiness checks. */
 export interface ChannelProbe {

--- a/assistant/src/runtime/guardian-outbound-actions.ts
+++ b/assistant/src/runtime/guardian-outbound-actions.ts
@@ -94,7 +94,6 @@ function getTelegramBotUsername(): string | undefined {
 
 export interface StartOutboundParams {
   channel: ChannelId;
-  assistantId?: string;
   destination?: string;
   rebind?: boolean;
   /** Origin conversation ID so completion/failure pointers can route back. */
@@ -103,14 +102,12 @@ export interface StartOutboundParams {
 
 export interface ResendOutboundParams {
   channel: ChannelId;
-  assistantId?: string;
   /** Origin conversation ID so completion/failure pointers can route back on resend. */
   originConversationId?: string;
 }
 
 export interface CancelOutboundParams {
   channel: ChannelId;
-  assistantId?: string;
 }
 
 /**

--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -144,16 +144,15 @@ export function handleClearSlackChannelConfig(): Response {
 /**
  * POST /v1/integrations/guardian/challenge
  *
- * Body: { channel?: ChannelId; assistantId?: string; rebind?: boolean; sessionId?: string }
+ * Body: { channel?: ChannelId; rebind?: boolean; sessionId?: string }
  */
 export async function handleCreateGuardianChallenge(req: Request): Promise<Response> {
   const body = (await req.json()) as {
     channel?: ChannelId;
-    assistantId?: string;
     rebind?: boolean;
     sessionId?: string;
   };
-  const result = createGuardianChallenge(body.channel, body.assistantId, body.rebind, body.sessionId);
+  const result = createGuardianChallenge(body.channel, body.rebind, body.sessionId);
   const status = result.success ? 200 : 400;
   return Response.json(result, { status });
 }
@@ -161,12 +160,11 @@ export async function handleCreateGuardianChallenge(req: Request): Promise<Respo
 /**
  * GET /v1/integrations/guardian/status
  *
- * Query params: channel?, assistantId?
+ * Query params: channel?
  */
 export function handleGetGuardianStatus(url: URL): Response {
   const channel = (url.searchParams.get('channel') as ChannelId | null) ?? undefined;
-  const assistantId = url.searchParams.get('assistantId') ?? undefined;
-  const result = getGuardianStatus(channel, assistantId);
+  const result = getGuardianStatus(channel);
   return Response.json(result);
 }
 
@@ -177,13 +175,12 @@ export function handleGetGuardianStatus(url: URL): Response {
 /**
  * POST /v1/integrations/guardian/outbound/start
  *
- * Body: { channel: ChannelId; destination?: string; assistantId?: string; rebind?: boolean; originConversationId?: string }
+ * Body: { channel: ChannelId; destination?: string; rebind?: boolean; originConversationId?: string }
  */
 export async function handleStartOutbound(req: Request): Promise<Response> {
   const body = (await req.json()) as {
     channel?: ChannelId;
     destination?: string;
-    assistantId?: string;
     rebind?: boolean;
     originConversationId?: string;
   };
@@ -209,7 +206,6 @@ export async function handleStartOutbound(req: Request): Promise<Response> {
   const result = startOutbound({
     channel: body.channel,
     destination: body.destination,
-    assistantId: body.assistantId,
     rebind: body.rebind,
     originConversationId: body.originConversationId,
   });
@@ -225,12 +221,11 @@ export async function handleStartOutbound(req: Request): Promise<Response> {
 /**
  * POST /v1/integrations/guardian/outbound/resend
  *
- * Body: { channel: ChannelId; assistantId?: string; originConversationId?: string }
+ * Body: { channel: ChannelId; originConversationId?: string }
  */
 export async function handleResendOutbound(req: Request): Promise<Response> {
   const body = (await req.json()) as {
     channel?: ChannelId;
-    assistantId?: string;
     originConversationId?: string;
   };
   if (!body.channel) {
@@ -238,7 +233,6 @@ export async function handleResendOutbound(req: Request): Promise<Response> {
   }
   const result = resendOutbound({
     channel: body.channel,
-    assistantId: body.assistantId,
     originConversationId: body.originConversationId,
   });
   const status = result.success ? 200 : (result.error === 'rate_limited' ? 429 : 400);
@@ -248,19 +242,17 @@ export async function handleResendOutbound(req: Request): Promise<Response> {
 /**
  * POST /v1/integrations/guardian/outbound/cancel
  *
- * Body: { channel: ChannelId; assistantId?: string }
+ * Body: { channel: ChannelId }
  */
 export async function handleCancelOutbound(req: Request): Promise<Response> {
   const body = (await req.json()) as {
     channel?: ChannelId;
-    assistantId?: string;
   };
   if (!body.channel) {
     return httpError('BAD_REQUEST', 'The "channel" field is required.', 400);
   }
   const result = cancelOutbound({
     channel: body.channel,
-    assistantId: body.assistantId,
   });
   const status = result.success ? 200 : 400;
   return Response.json(result, { status });

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -296,7 +296,7 @@ The guardian system adds a cryptographic trust layer for channel-based interacti
 
 #### Canonical Assistant ID Scoping
 
-All channel ingress paths canonicalize the `assistantId` via `normalizeAssistantId()` (from `util/platform.ts`) before any DB operations. The system uses `"self"` as the canonical single-tenant identifier, but callers may pass the real assistant name (e.g., `"vellum-true-eel"`) or `"self"` depending on context. `normalizeAssistantId()` maps any known lockfile assistant ID to `"self"`, ensuring consistent DB key usage regardless of how the caller identifies the assistant. This canonicalization runs at every ingress boundary: the guardian IPC handler (`config-channels.ts`), the guardian context resolver, the relay server, and the inbound message handler.
+The daemon uses the fixed constant `DAEMON_INTERNAL_ASSISTANT_ID` (`"self"`) from `runtime/assistant-scope.ts` for all assistant-scoped storage keys. Public/external assistant IDs are a gateway/platform concern and never leak into daemon scoping logic. The `normalizeAssistantId()` function in `util/platform.ts` exists solely for the gateway layer to canonicalize inbound requests before proxying -- daemon and runtime code must not call it or accept an `assistantId` parameter for scoping.
 
 #### Guardian Verify Code Parsing
 

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1102,13 +1102,6 @@ export function buildSchema(): Record<string, unknown> {
               schema: { type: "string", enum: ["sms", "voice", "telegram"] },
               description: "Optional guardian channel filter.",
             },
-            {
-              name: "assistantId",
-              in: "query",
-              required: false,
-              schema: { type: "string" },
-              description: "Optional assistant identifier override.",
-            },
           ],
           responses: {
             "200": { description: "Guardian status returned" },


### PR DESCRIPTION
## Summary
- Remove `assistantId` from all daemon control-plane request types (`TwilioConfigRequest`, `ChannelReadinessRequest`, `GuardianVerificationRequest`) and guardian outbound param interfaces (`StartOutboundParams`, `ResendOutboundParams`, `CancelOutboundParams`)
- Remove daemon-side assistant-scoped Twilio behavior: delete `msg.assistantId` branches, `sms.assistantPhoneNumbers` reads/writes, and assistant-mapped phone number resolution from `config-twilio`, `twilio-config`, SMS adapter, and channel readiness service
- Remove `assistantId` from guardian HTTP endpoints (challenge, status, outbound start/resend/cancel) in integration routes and gateway schema; update architecture docs to reflect daemon uses fixed internal scope (`self`) with no external assistant ID parameterization
- Add guard tests preventing reintroduction of daemon-side `assistantId` on Twilio/readiness/guardian request types

The daemon control-plane no longer accepts `assistantId` for Twilio/readiness/guardian verification. The gateway remains assistant-id aware at ingress/routing boundaries. No data migration performed by design.

## Original prompt
assistant-id-boundary-conformance-single-pr-2026-02-28.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
