### PR TITLE
fix: sync pre-existing apps into Things sidebar

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -648,6 +648,14 @@ extension AppDelegate {
                 guard !Task.isCancelled else { return }
                 if case .appsListResponse(let response) = message {
                     self.cachedApps = response.apps
+                    // Sync daemon apps into the sidebar list so pre-existing apps appear
+                    let daemonItems = response.apps.map {
+                        AppListManager.AppItem_Daemon(
+                            id: $0.id, name: $0.name, icon: $0.icon,
+                            appType: $0.appType, createdAt: $0.createdAt
+                        )
+                    }
+                    self.mainWindow?.appListManager.syncFromDaemon(daemonItems)
                     return
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
@@ -114,6 +114,41 @@ final class AppListManager: ObservableObject {
         save()
     }
 
+    /// Sync apps from the daemon's authoritative list into the local sidebar list.
+    /// Adds any apps that don't already exist locally, using their daemon createdAt timestamp.
+    func syncFromDaemon(_ daemonApps: [AppItem_Daemon]) {
+        let existingIds = Set(apps.map(\.id))
+        var didAdd = false
+        for daemonApp in daemonApps {
+            guard !existingIds.contains(daemonApp.id) else { continue }
+            let generated = VAppIconGenerator.generate(from: daemonApp.name, type: daemonApp.appType)
+            var item = AppItem(
+                id: daemonApp.id,
+                name: daemonApp.name,
+                icon: daemonApp.icon,
+                appType: daemonApp.appType,
+                lastOpenedAt: Date(timeIntervalSince1970: TimeInterval(daemonApp.createdAt) / 1000.0)
+            )
+            item.sfSymbol = generated.sfSymbol
+            item.iconBackground = generated.colors
+            apps.append(item)
+            didAdd = true
+        }
+        if didAdd {
+            save()
+            log.info("Synced \(self.apps.count - existingIds.count) new apps from daemon")
+        }
+    }
+
+    /// Lightweight wrapper for the daemon's app representation, used by syncFromDaemon.
+    struct AppItem_Daemon {
+        let id: String
+        let name: String
+        let icon: String?
+        let appType: String?
+        let createdAt: Int
+    }
+
     func removeApp(id: String) {
         apps.removeAll { $0.id == id }
         save()


### PR DESCRIPTION
## Summary
- Pre-existing apps weren't showing up in the "Things" sidebar because the client's local app list (`app-list.json`) was only populated via explicit `recordAppOpen()` calls
- Added `syncFromDaemon()` to `AppListManager` that adds missing apps using their daemon `createdAt` timestamps
- Called from `refreshAppsCache()` after the daemon app list is fetched, covering both startup sync and new app creation

## Original prompt
I have a lot of apps that were recently built but they're not showing up in the Things section of the sidenav. Only Home Base appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
