### PR TITLE
feat: backend brain graph API endpoint

### DIFF
--- a/assistant/src/home-base/prebuilt/brain-graph.html
+++ b/assistant/src/home-base/prebuilt/brain-graph.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Brain Graph</title>
+</head>
+<body>
+  <h1>🧠 Brain Graph</h1>
+  <p>Loading...</p>
+</body>
+</html>

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -126,6 +126,7 @@ import {
   handleGuardianActionDecision,
   handleGuardianActionsPending,
 } from './routes/guardian-action-routes.js';
+import { handleGetBrainGraph, handleServeBrainGraphUI } from './routes/brain-graph-routes.js';
 import { handleGetIdentity,handleHealth } from './routes/identity-routes.js';
 import {
   handleBlockMember,
@@ -826,6 +827,8 @@ export class RuntimeHttpServer {
       }
 
       if (endpoint === 'identity' && req.method === 'GET') return handleGetIdentity();
+      if (endpoint === 'brain-graph' && req.method === 'GET') return handleGetBrainGraph();
+      if (endpoint === 'brain-graph-ui' && req.method === 'GET') return handleServeBrainGraphUI();
       if (endpoint === 'events' && req.method === 'GET') return handleSubscribeAssistantEvents(req, url);
 
       // Internal OAuth callback endpoint (gateway -> runtime)

--- a/assistant/src/runtime/routes/brain-graph-routes.ts
+++ b/assistant/src/runtime/routes/brain-graph-routes.ts
@@ -1,0 +1,165 @@
+/**
+ * Route handlers for the brain graph visualization endpoint.
+ *
+ * Queries the memory database to return a knowledge graph shaped for brain-lobe
+ * visualization, with entities mapped to brain regions based on their type.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { count } from 'drizzle-orm';
+
+import { getDb } from '../../memory/db.js';
+import { memoryEntities, memoryEntityRelations, memoryItems } from '../../memory/schema.js';
+import { resolveBundledDir } from '../../util/bundled-asset.js';
+
+function getLobeRegion(entityType: string): string {
+  switch (entityType) {
+    case 'person':
+    case 'organization':
+      return 'right-social';
+    case 'project':
+    case 'company':
+      return 'left-planning';
+    case 'tool':
+      return 'left-technical';
+    case 'concept':
+      return 'right-creative';
+    case 'location':
+      return 'right-spatial';
+    default:
+      return 'center';
+  }
+}
+
+function getEntityColor(entityType: string): string {
+  switch (entityType) {
+    case 'person':
+      return '#22c55e';
+    case 'project':
+      return '#f97316';
+    case 'tool':
+      return '#06b6d4';
+    case 'company':
+      return '#a855f7';
+    case 'organization':
+      return '#a855f7';
+    case 'concept':
+      return '#eab308';
+    case 'location':
+      return '#14b8a6';
+    default:
+      return '#94a3b8';
+  }
+}
+
+function getMemoryKindColor(kind: string): string {
+  switch (kind) {
+    case 'profile':
+      return '#8b5cf6';
+    case 'preference':
+      return '#3b82f6';
+    case 'constraint':
+      return '#ef4444';
+    case 'instruction':
+      return '#f59e0b';
+    case 'style':
+      return '#ec4899';
+    default:
+      return '#94a3b8';
+  }
+}
+
+export function handleGetBrainGraph(): Response {
+  try {
+    const db = getDb();
+
+    const entityRows = db
+      .select({
+        id: memoryEntities.id,
+        name: memoryEntities.name,
+        type: memoryEntities.type,
+        mentionCount: memoryEntities.mentionCount,
+        firstSeenAt: memoryEntities.firstSeenAt,
+        lastSeenAt: memoryEntities.lastSeenAt,
+      })
+      .from(memoryEntities)
+      .all();
+
+    const relationRows = db
+      .select({
+        sourceEntityId: memoryEntityRelations.sourceEntityId,
+        targetEntityId: memoryEntityRelations.targetEntityId,
+        relation: memoryEntityRelations.relation,
+      })
+      .from(memoryEntityRelations)
+      .all();
+
+    const kindCountRows = db
+      .select({
+        kind: memoryItems.kind,
+        count: count(),
+      })
+      .from(memoryItems)
+      .groupBy(memoryItems.kind)
+      .all();
+
+    const entities = entityRows.map((entity) => ({
+      id: entity.id,
+      name: entity.name,
+      type: entity.type,
+      lobeRegion: getLobeRegion(entity.type),
+      color: getEntityColor(entity.type),
+      mentionCount: entity.mentionCount,
+      firstSeenAt: entity.firstSeenAt,
+      lastSeenAt: entity.lastSeenAt,
+    }));
+
+    const relations = relationRows.map((rel) => ({
+      sourceId: rel.sourceEntityId,
+      targetId: rel.targetEntityId,
+      relation: rel.relation,
+    }));
+
+    const memorySummary = kindCountRows.map((row) => ({
+      kind: row.kind,
+      count: row.count,
+      color: getMemoryKindColor(row.kind),
+    }));
+
+    const totalKnowledgeCount = memorySummary.reduce((sum, entry) => sum + entry.count, 0);
+
+    return Response.json({
+      entities,
+      relations,
+      memorySummary,
+      totalKnowledgeCount,
+      generatedAt: new Date().toISOString(),
+    });
+  } catch (err) {
+    return Response.json(
+      { error: 'Failed to generate brain graph', detail: err instanceof Error ? err.message : String(err) },
+      { status: 500 },
+    );
+  }
+}
+
+export function handleServeBrainGraphUI(): Response {
+  try {
+    const prebuiltDir = resolveBundledDir(
+      import.meta.dirname ?? __dirname,
+      '../../home-base/prebuilt',
+      'prebuilt',
+    );
+    const html = readFileSync(join(prebuiltDir, 'brain-graph.html'), 'utf-8');
+    return new Response(html, {
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
+  } catch (err) {
+    return Response.json(
+      { error: 'Brain graph UI not available', detail: err instanceof Error ? err.message : String(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/gateway/src/http/routes/brain-graph-proxy.ts
+++ b/gateway/src/http/routes/brain-graph-proxy.ts
@@ -1,0 +1,80 @@
+/**
+ * Gateway proxy endpoints for the brain graph knowledge-graph visualizer.
+ *
+ * Exposes GET /v1/brain-graph and GET /v1/brain-graph-ui through the gateway
+ * even when the broad runtime proxy is disabled.
+ */
+
+import type { GatewayConfig } from "../../config.js";
+import { fetchImpl } from "../../fetch.js";
+import { getLogger } from "../../logger.js";
+import { GATEWAY_ORIGIN_HEADER } from "../../runtime/client.js";
+import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
+
+const log = getLogger("brain-graph-proxy");
+
+export function createBrainGraphProxyHandler(config: GatewayConfig) {
+  async function proxyTo(req: Request, upstream: string): Promise<Response> {
+    const start = performance.now();
+
+    const reqHeaders = stripHopByHop(new Headers(req.headers));
+    reqHeaders.delete("host");
+    reqHeaders.delete("authorization");
+
+    if (config.runtimeBearerToken) {
+      reqHeaders.set("authorization", `Bearer ${config.runtimeBearerToken}`);
+    }
+    if (config.runtimeGatewayOriginSecret) {
+      reqHeaders.set(GATEWAY_ORIGIN_HEADER, config.runtimeGatewayOriginSecret);
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(new DOMException("The operation was aborted due to timeout", "TimeoutError"));
+    }, config.runtimeTimeoutMs);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(upstream, {
+        method: "GET",
+        headers: reqHeaders,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const duration = Math.round(performance.now() - start);
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        log.error({ duration, upstream }, "Brain graph proxy upstream timed out");
+        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+      }
+      log.error({ err, duration, upstream }, "Brain graph proxy upstream connection failed");
+      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    }
+
+    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const duration = Math.round(performance.now() - start);
+
+    if (response.status >= 400) {
+      const body = await response.text();
+      log.warn(
+        { status: response.status, duration, upstream },
+        "Brain graph proxy upstream error",
+      );
+      return new Response(body, { status: response.status, headers: resHeaders });
+    }
+
+    log.info({ status: response.status, duration, upstream }, "Brain graph proxy completed");
+    return new Response(response.body, { status: response.status, headers: resHeaders });
+  }
+
+  async function handleBrainGraph(req: Request): Promise<Response> {
+    return proxyTo(req, `${config.assistantRuntimeBaseUrl}/v1/brain-graph`);
+  }
+
+  async function handleBrainGraphUI(req: Request): Promise<Response> {
+    return proxyTo(req, `${config.assistantRuntimeBaseUrl}/v1/brain-graph-ui`);
+  }
+
+  return { handleBrainGraph, handleBrainGraphUI };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -34,6 +34,7 @@ import { createTelegramControlPlaneProxyHandler } from "./http/routes/telegram-c
 import { createIngressControlPlaneProxyHandler } from "./http/routes/ingress-control-plane-proxy.js";
 import { matchIngressControlPlaneRoute } from "./http/routes/ingress-control-plane-route-match.js";
 import { createRuntimeHealthProxyHandler } from "./http/routes/runtime-health-proxy.js";
+import { createBrainGraphProxyHandler } from "./http/routes/brain-graph-proxy.js";
 import { validateBearerToken } from "./http/auth/bearer.js";
 import { getLogger, initLogger } from "./logger.js";
 import { CircuitBreakerOpenError } from "./runtime/client.js";
@@ -205,6 +206,7 @@ function main() {
   const telegramControlPlaneProxy = createTelegramControlPlaneProxyHandler(config);
   const ingressControlPlaneProxy = createIngressControlPlaneProxyHandler(config);
   const runtimeHealthProxy = createRuntimeHealthProxyHandler(config);
+  const brainGraphProxy = createBrainGraphProxyHandler(config);
   const handleFeatureFlagsGet = createFeatureFlagsGetHandler();
   const handleFeatureFlagsPatch = createFeatureFlagsPatchHandler();
 
@@ -445,6 +447,18 @@ function main() {
         const authError = requireRuntimeBearerAuth();
         if (authError) return authError;
         return runtimeHealthProxy.handleRuntimeHealth(tracedReq);
+      }
+
+      // ── Brain graph proxy ──
+      if (url.pathname === "/v1/brain-graph" && req.method === "GET") {
+        const authError = requireRuntimeBearerAuth();
+        if (authError) return authError;
+        return brainGraphProxy.handleBrainGraph(tracedReq);
+      }
+      if (url.pathname === "/v1/brain-graph-ui" && req.method === "GET") {
+        const authError = requireRuntimeBearerAuth();
+        if (authError) return authError;
+        return brainGraphProxy.handleBrainGraphUI(tracedReq);
       }
 
       // ── Telegram integration control-plane proxy ──


### PR DESCRIPTION
Adds GET /v1/brain-graph endpoint that queries memory entities, relations, and items from the database and returns them with brain lobe region assignments and color categorization. Also adds GET /v1/brain-graph-ui placeholder page. Closes #10814.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
