### PR TITLE
feat: support image URLs in app preview icons and misc fixes

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -1332,7 +1332,25 @@ Both `ui_show` and `app_create` support a `preview` object for an inline chat pr
 }
 ```
 
-**With `app_create`:**
+**With `app_create` (image URL icon):**
+```json
+{
+  "name": "Microsoft Overview",
+  "schema_json": "{}",
+  "html": "...",
+  "preview": {
+    "title": "Microsoft",
+    "subtitle": "3 Slides",
+    "icon": "https://www.microsoft.com/favicon.ico",
+    "metrics": [
+      { "label": "Founded", "value": "1975" },
+      { "label": "Market Cap", "value": "$2.98T" }
+    ]
+  }
+}
+```
+
+**With `app_create` (emoji icon):**
 ```json
 {
   "name": "Expense Tracker",
@@ -1349,7 +1367,7 @@ Both `ui_show` and `app_create` support a `preview` object for an inline chat pr
 }
 ```
 
-Preview fields: `title` (required), `subtitle`, `description`, `icon` (emoji), `metrics` (up to 3 key-value pills). When `app_create` is called with `auto_open: true` (the default), the preview is forwarded through `app_open` automatically.
+Preview fields: `title` (required), `subtitle`, `description`, `icon`, `metrics` (up to 3 key-value pills). The `icon` field accepts an emoji or an image URL. **Prefer an image URL whenever you have a relevant one** — logos, favicons, product images, headshots, flags, album art, or any image you encountered during research. The preview card renders image URLs as a thumbnail automatically. Fall back to emoji only when there is no natural image. When `app_create` is called with `auto_open: true` (the default), the preview is forwarded through `app_open` automatically.
 
 ### 6. Handle Iteration
 

--- a/assistant/src/config/bundled-skills/app-builder/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-builder/TOOLS.json
@@ -50,7 +50,7 @@
               "title": { "type": "string", "description": "Preview card title" },
               "subtitle": { "type": "string", "description": "Optional subtitle" },
               "description": { "type": "string", "description": "Optional short description" },
-              "icon": { "type": "string", "description": "Optional emoji icon" },
+              "icon": { "type": "string", "description": "Optional icon — image URL preferred when available (logo, favicon, photo, etc.), emoji as fallback" },
               "metrics": {
                 "type": "array",
                 "description": "Optional key-value metrics",

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -338,9 +338,24 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
   let currentSegmentParts: string[] = [];
   let hasOpenSegment = false;
 
+  function joinWithSpacing(parts: string[]): string {
+    let result = parts[0] ?? '';
+    for (let i = 1; i < parts.length; i++) {
+      const prev = result[result.length - 1];
+      const next = parts[i][0];
+      // Only insert a space when neither side already has whitespace
+      if (prev && next && prev !== ' ' && prev !== '\n' && prev !== '\t' &&
+          next !== ' ' && next !== '\n' && next !== '\t') {
+        result += ' ';
+      }
+      result += parts[i];
+    }
+    return result;
+  }
+
   function finalizeSegment(): void {
     if (hasOpenSegment) {
-      textSegments[textSegments.length - 1] = currentSegmentParts.join('\n');
+      textSegments[textSegments.length - 1] = joinWithSpacing(currentSegmentParts);
       currentSegmentParts = [];
       hasOpenSegment = false;
     }
@@ -445,7 +460,7 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
 
   finalizeSegment();
 
-  const text = textParts.join('\n');
+  const text = joinWithSpacing(textParts);
   let rendered: string;
   if (attachmentParts.length === 0) {
     rendered = text;

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -531,12 +531,14 @@ export class AnthropicProvider implements Provider {
         let pendingInputJsonFlush: ReturnType<typeof setTimeout> | undefined;
 
         stream.on("streamEvent", (event) => {
-          // Insert a newline separator when a new text content block starts
+          // Insert a space separator when a new text content block starts
           // after a previous one, so consecutive text blocks don't get
           // concatenated without whitespace (e.g. "sentence.NextSentence").
+          // Uses a space instead of \n because the client's MarkdownRenderer
+          // can collapse soft line breaks (\n) within a paragraph.
           if (event.type === 'content_block_start' && event.content_block.type === 'text') {
             if (hasSeenTextBlock) {
-              onEvent?.({ type: "text_delta", text: "\n" });
+              onEvent?.({ type: "text_delta", text: " " });
             }
             hasSeenTextBlock = true;
           }

--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -107,10 +107,22 @@ export function extractText(response: ProviderResponse): string {
  * Extract all text blocks from a ProviderResponse and join them.
  */
 export function extractAllText(response: ProviderResponse): string {
-  return response.content
+  const parts = response.content
     .filter((b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text')
-    .map((b) => b.text)
-    .join('\n');
+    .map((b) => b.text);
+  // Join consecutive text blocks with a space, but skip the separator when
+  // either side already has whitespace (avoids double-spacing).
+  let result = parts[0] ?? '';
+  for (let i = 1; i < parts.length; i++) {
+    const prev = result[result.length - 1];
+    const next = parts[i][0];
+    if (prev && next && prev !== ' ' && prev !== '\n' && prev !== '\t' &&
+        next !== ' ' && next !== '\n' && next !== '\t') {
+      result += ' ';
+    }
+    result += parts[i];
+  }
+  return result;
 }
 
 /**

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -422,6 +422,27 @@ struct MainWindowView: View {
                     windowState.activeDynamicParsedSurface = nil
                 }
 
+                // Reset publish state when switching to a different app so new/different
+                // apps don't inherit the "Published" badge from a previously published app.
+                let oldAppId: String? = {
+                    switch oldSelection {
+                    case .app(let id): return id
+                    case .appEditing(let id, _): return id
+                    default: return nil
+                    }
+                }()
+                let newAppId: String? = {
+                    switch newSelection {
+                    case .app(let id): return id
+                    case .appEditing(let id, _): return id
+                    default: return nil
+                    }
+                }()
+                if oldAppId != newAppId {
+                    sharing.publishedUrl = nil
+                    sharing.publishError = nil
+                }
+
                 // Collapse the sidebar when an app opens to avoid crowding
                 if sidebarExpanded {
                     let shouldCollapse: Bool = {

--- a/clients/shared/Features/Chat/InlineWidgets/InlineDynamicPagePreview.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineDynamicPagePreview.swift
@@ -19,8 +19,27 @@ public struct InlineDynamicPagePreview: View {
                 // Icon + title row
                 HStack(spacing: VSpacing.sm) {
                     if let icon = preview.icon {
-                        Text(icon)
-                            .font(.system(size: 28))
+                        if let url = URL(string: icon), url.scheme == "https" || url.scheme == "http" {
+                            AsyncImage(url: url) { phase in
+                                switch phase {
+                                case .success(let image):
+                                    image
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                case .failure:
+                                    RoundedRectangle(cornerRadius: VRadius.sm)
+                                        .fill(VColor.surfaceSubtle)
+                                default:
+                                    RoundedRectangle(cornerRadius: VRadius.sm)
+                                        .fill(VColor.surfaceSubtle)
+                                }
+                            }
+                            .frame(width: 32, height: 32)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                        } else {
+                            Text(icon)
+                                .font(.system(size: 28))
+                        }
                     }
 
                     VStack(alignment: .leading, spacing: VSpacing.xxs) {


### PR DESCRIPTION
## Summary
- Preview card icon field now accepts image URLs (logos, favicons, photos, etc.) in addition to emoji — AsyncImage rendering with graceful fallback to a placeholder on failure
- Updated app-builder skill/tool docs to guide the LLM toward using image URLs when a relevant image is available (not constrained to company logos — any relevant image works)
- Fix text block joining to use space-aware concatenation instead of naive newline/join (prevents sentence concatenation and double-spacing)
- Reset publish state when switching between apps in the sidebar
- Use space separator instead of newline between streaming text blocks

## Test plan
- [ ] Create an app about a company (e.g. "tell me about Microsoft") — verify the preview card shows a favicon/logo image instead of emoji
- [ ] Create a generic app (e.g. "build me an expense tracker") — verify emoji icon still works
- [ ] Verify image load failure shows a subtle placeholder, not a broken state
- [ ] Verify text blocks in chat don't concatenate without spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
