### PR TITLE
fix: Account Settings Login/LogOut buttons — large size

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -166,7 +166,7 @@ struct SettingsAccountTab: View {
                         .font(VFont.body)
                         .foregroundColor(VColor.textSecondary)
                     Spacer()
-                    VButton(label: "Log Out", style: .danger) {
+                    VButton(label: "Log Out", style: .danger, size: .large) {
                         Task { await authManager.logout() }
                     }
                 }
@@ -181,7 +181,8 @@ struct SettingsAccountTab: View {
                     Spacer()
                     VButton(
                         label: authManager.isSubmitting ? "Signing in..." : "Log In",
-                        style: .primary
+                        style: .primary,
+                        size: .large
                     ) {
                         Task { await authManager.startWorkOSLogin() }
                     }


### PR DESCRIPTION
Makes the Log In and Log Out buttons use size: .large in SettingsAccountTab for proper visual weight in the settings panel. Part of #10820.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
