### PR TITLE
fix: Account Settings Hatch button — large size

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -462,7 +462,7 @@ struct SettingsAccountTab: View {
                             .foregroundColor(VColor.textMuted)
                     }
                     Spacer()
-                    VButton(label: "Hatch...", style: .primary) {
+                    VButton(label: "Hatch...", style: .primary, size: .large) {
                         AppDelegate.shared?.replayOnboarding()
                         onClose()
                     }


### PR DESCRIPTION
Makes the Hatch button use size: .large in SettingsAccountTab for proper visual weight in the settings panel. Part of #10821.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
