### PR TITLE
fix: persist removed-app tombstones so daemon sync respects user removals

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
@@ -24,6 +24,9 @@ final class AppListManager: ObservableObject {
 
     @Published var apps: [AppItem] = []
 
+    /// IDs of apps the user explicitly removed. Prevents daemon sync from re-adding them.
+    private var removedAppIds: Set<String> = []
+
     private let fileURL: URL
 
     /// Only pinned apps, sorted by pinnedOrder ascending.
@@ -54,6 +57,9 @@ final class AppListManager: ObservableObject {
     }
 
     func recordAppOpen(id: String, name: String, icon: String? = nil, previewBase64: String? = nil, appType: String? = nil) {
+        // Clear tombstone so an explicitly re-opened app reappears in the sidebar
+        removedAppIds.remove(id)
+
         if let index = apps.firstIndex(where: { $0.id == id }) {
             // Don't reshuffle apps that are already visible in the collapsed top-5 sidebar.
             let top5Ids = Set(displayApps.prefix(5).map(\.id))
@@ -120,7 +126,8 @@ final class AppListManager: ObservableObject {
         let existingIds = Set(apps.map(\.id))
         var didAdd = false
         for daemonApp in daemonApps {
-            guard !existingIds.contains(daemonApp.id) else { continue }
+            guard !existingIds.contains(daemonApp.id),
+                  !removedAppIds.contains(daemonApp.id) else { continue }
             let generated = VAppIconGenerator.generate(from: daemonApp.name, type: daemonApp.appType)
             var item = AppItem(
                 id: daemonApp.id,
@@ -151,6 +158,7 @@ final class AppListManager: ObservableObject {
 
     func removeApp(id: String) {
         apps.removeAll { $0.id == id }
+        removedAppIds.insert(id)
         save()
     }
 
@@ -189,12 +197,19 @@ final class AppListManager: ObservableObject {
 
     // MARK: - Persistence
 
+    /// On-disk container wrapping both the app list and the removal tombstone set.
+    private struct PersistedData: Codable {
+        var apps: [AppItem]
+        var removedAppIds: Set<String>?
+    }
+
     private func save() {
         do {
             let encoder = JSONEncoder()
             encoder.dateEncodingStrategy = .iso8601
             encoder.outputFormatting = .prettyPrinted
-            let data = try encoder.encode(apps)
+            let container = PersistedData(apps: apps, removedAppIds: removedAppIds)
+            let data = try encoder.encode(container)
             try data.write(to: fileURL, options: .atomic)
         } catch {
             log.error("Failed to save app list: \(error.localizedDescription)")
@@ -206,7 +221,15 @@ final class AppListManager: ObservableObject {
         do {
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
-            apps = try decoder.decode([AppItem].self, from: data)
+
+            // Try the new container format first, fall back to the legacy bare-array format
+            if let container = try? decoder.decode(PersistedData.self, from: data) {
+                apps = container.apps
+                removedAppIds = container.removedAppIds ?? []
+            } else {
+                apps = try decoder.decode([AppItem].self, from: data)
+                removedAppIds = []
+            }
             log.info("Loaded \(self.apps.count) app list entries")
 
             // Migrate existing apps that don't have icons assigned yet


### PR DESCRIPTION
## Summary
- Adds a persisted `removedAppIds` tombstone set to `AppListManager` that tracks IDs of apps the user explicitly removed from the sidebar
- `syncFromDaemon` now skips apps whose ID is in the tombstone set, preventing removed recents from reappearing on daemon sync/refresh/reconnect
- `removeApp` adds the removed app's ID to the tombstone set
- `recordAppOpen` clears the tombstone for re-opened apps, so explicitly opening an app brings it back to the sidebar
- Persistence uses a backward-compatible `PersistedData` container struct; existing `app-list.json` files (bare arrays) are transparently migrated on first load

Addresses review feedback from PR #10815.

## Test plan
- [ ] Remove an app from recents via context menu
- [ ] Trigger daemon sync (e.g., restart, reconnect) and verify the removed app does not reappear
- [ ] Open a previously removed app and verify it reappears in the sidebar
- [ ] Verify existing app-list.json files are loaded correctly (backward compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
