### PR TITLE
fix: store title in surfaceState for ephemeral surface reopening

### DIFF
--- a/assistant/src/__tests__/session-surfaces-task-progress.test.ts
+++ b/assistant/src/__tests__/session-surfaces-task-progress.test.ts
@@ -26,7 +26,7 @@ function makeContext(
     sendToClient: (msg) => sent.push(msg),
     pendingSurfaceActions: new Map<string, { surfaceType: SurfaceType }>(),
     lastSurfaceAction: new Map<string, { actionId: string; data?: Record<string, unknown> }>(),
-    surfaceState: new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>(),
+    surfaceState: new Map<string, { surfaceType: SurfaceType; data: SurfaceData; title?: string }>(),
     surfaceUndoStacks: new Map<string, string[]>(),
     currentTurnSurfaces: [],
     isProcessing: () => false,

--- a/assistant/src/__tests__/session-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/session-tool-setup-app-refresh.test.ts
@@ -62,7 +62,7 @@ function makeCtx(overrides: Partial<ToolSetupContext> = {}): ToolSetupContext {
     sendToClient: mock(() => {}),
     pendingSurfaceActions: new Map(),
     lastSurfaceAction: new Map(),
-    surfaceState: new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>(),
+    surfaceState: new Map<string, { surfaceType: SurfaceType; data: SurfaceData; title?: string }>(),
     surfaceUndoStacks: new Map(),
     currentTurnSurfaces: [],
     isProcessing: () => false,

--- a/assistant/src/__tests__/session-tool-setup-memory-scope.test.ts
+++ b/assistant/src/__tests__/session-tool-setup-memory-scope.test.ts
@@ -49,7 +49,7 @@ function makeCtx(overrides: Partial<ToolSetupContext> = {}): ToolSetupContext {
     sendToClient: mock(() => {}),
     pendingSurfaceActions: new Map(),
     lastSurfaceAction: new Map(),
-    surfaceState: new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>(),
+    surfaceState: new Map<string, { surfaceType: SurfaceType; data: SurfaceData; title?: string }>(),
     surfaceUndoStacks: new Map(),
     currentTurnSurfaces: [],
     isProcessing: () => false,

--- a/assistant/src/__tests__/session-tool-setup-side-effect-flag.test.ts
+++ b/assistant/src/__tests__/session-tool-setup-side-effect-flag.test.ts
@@ -49,7 +49,7 @@ function makeCtx(overrides: Partial<ToolSetupContext> = {}): ToolSetupContext {
     sendToClient: mock(() => {}),
     pendingSurfaceActions: new Map(),
     lastSurfaceAction: new Map(),
-    surfaceState: new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>(),
+    surfaceState: new Map<string, { surfaceType: SurfaceType; data: SurfaceData; title?: string }>(),
     surfaceUndoStacks: new Map(),
     currentTurnSurfaces: [],
     isProcessing: () => false,

--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -79,7 +79,7 @@ export class ComputerUseSession {
   private pendingSurfaceActions = new Map<string, {
     resolve: (result: ToolExecutionResult) => void;
   }>();
-  private surfaceState = new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>();
+  private surfaceState = new Map<string, { surfaceType: SurfaceType; data: SurfaceData; title?: string }>();
   private terminalNotified = false;
   private prompter: PermissionPrompter | null = null;
 
@@ -337,7 +337,7 @@ export class ComputerUseSession {
         const awaitAction = (input.await_action as boolean) ?? isInteractive;
 
         // Track surface state for ui_update merging
-        this.surfaceState.set(surfaceId, { surfaceType, data });
+        this.surfaceState.set(surfaceId, { surfaceType, data, title });
 
         this.sendToClient({
           type: 'ui_surface_show',

--- a/assistant/src/daemon/handlers/apps.ts
+++ b/assistant/src/daemon/handlers/apps.ts
@@ -104,14 +104,13 @@ export function handleAppOpenRequest(msg: { appId: string }, socket: net.Socket,
     for (const session of ctx.sessions.values()) {
       const cached = session.surfaceState.get(appId);
       if (cached && cached.surfaceType === 'dynamic_page') {
-        const data = cached.data as { preview?: { title?: string } };
         const newSurfaceId = `app-open-${uuid()}`;
         ctx.send(socket, {
           type: 'ui_surface_show',
           sessionId: 'app-panel',
           surfaceId: newSurfaceId,
           surfaceType: 'dynamic_page',
-          title: data.preview?.title,
+          title: cached.title ?? (cached.data as { preview?: { title?: string } }).preview?.title,
           data: cached.data,
           display: 'panel',
         } as UiSurfaceShow);

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -96,7 +96,7 @@ export interface AgentLoopSessionContext {
 
   currentActiveSurfaceId?: string;
   currentPage?: string;
-  readonly surfaceState: Map<string, { surfaceType: SurfaceType; data: SurfaceData }>;
+  readonly surfaceState: Map<string, { surfaceType: SurfaceType; data: SurfaceData; title?: string }>;
   pendingSurfaceActions: Map<string, { surfaceType: SurfaceType }>;
   currentTurnSurfaces: Array<{ surfaceId: string; surfaceType: SurfaceType; title?: string; data: SurfaceData; actions?: Array<{ id: string; label: string; style?: string }>; display?: string }>;
 

--- a/assistant/src/daemon/session-lifecycle.ts
+++ b/assistant/src/daemon/session-lifecycle.ts
@@ -78,7 +78,7 @@ export interface AbortContext {
   prompter: PermissionPrompter;
   secretPrompter: SecretPrompter;
   pendingSurfaceActions: Map<string, { surfaceType: SurfaceType }>;
-  surfaceState: Map<string, { surfaceType: SurfaceType; data: SurfaceData }>;
+  surfaceState: Map<string, { surfaceType: SurfaceType; data: SurfaceData; title?: string }>;
   readonly queue: MessageQueue;
 }
 

--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -131,7 +131,7 @@ export interface SurfaceSessionContext {
   sendToClient(msg: ServerMessage): void;
   pendingSurfaceActions: Map<string, { surfaceType: SurfaceType }>;
   lastSurfaceAction: Map<string, { actionId: string; data?: Record<string, unknown> }>;
-  surfaceState: Map<string, { surfaceType: SurfaceType; data: SurfaceData }>;
+  surfaceState: Map<string, { surfaceType: SurfaceType; data: SurfaceData; title?: string }>;
   surfaceUndoStacks: Map<string, string[]>;
   currentTurnSurfaces: Array<{
     surfaceId: string;
@@ -632,7 +632,7 @@ export async function surfaceProxyResolver(
     const awaitAction = (input.await_action as boolean) ?? isInteractive;
 
     // Track surface state for ui_update merging
-    ctx.surfaceState.set(surfaceId, { surfaceType, data });
+    ctx.surfaceState.set(surfaceId, { surfaceType, data, title });
 
     const display = (input.display as string) === 'panel' ? 'panel' : 'inline';
 
@@ -782,6 +782,7 @@ export async function surfaceProxyResolver(
     ctx.surfaceState.set(surfaceId, {
       surfaceType: 'dynamic_page',
       data: surfaceData,
+      title: app.name,
     });
 
     ctx.sendToClient({

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -146,7 +146,7 @@ export class Session {
   /** @internal */ commandIntent?: { type: string; payload?: string; languageCode?: string };
   /** @internal */ pendingSurfaceActions = new Map<string, { surfaceType: SurfaceType }>();
   /** @internal */ lastSurfaceAction = new Map<string, { actionId: string; data?: Record<string, unknown> }>();
-  /** @internal */ surfaceState = new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>();
+  /** @internal */ surfaceState = new Map<string, { surfaceType: SurfaceType; data: SurfaceData; title?: string }>();
   /** @internal */ surfaceUndoStacks = new Map<string, string[]>();
   /** @internal */ withSurface = createSurfaceMutex();
   /** @internal */ currentTurnSurfaces: Array<{ surfaceId: string; surfaceType: SurfaceType; title?: string; data: SurfaceData; actions?: Array<{ id: string; label: string; style?: string }>; display?: string }> = [];


### PR DESCRIPTION
## Summary
- Extend the `surfaceState` map to also store the `title` when a surface is created via `ui_show`, so that reopened ephemeral surfaces retain their original title
- Update `apps.ts` to use `cached.title` as the primary title source with `preview?.title` as fallback
- Update all type definitions and test files for consistency

Addresses review feedback from PR #10806.

## Test plan
- [ ] Verify ephemeral surfaces retain their title when reopened via `app_open_request`
- [ ] Verify persistent app surfaces still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
