### PR TITLE
fix: add environment: dev to playwright workflow for vars access

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -21,6 +21,7 @@ jobs:
   playwright:
     name: Playwright Tests
     runs-on: macos-14
+    environment: dev
     timeout-minutes: 60
     env:
       APP_DISPLAY_NAME: Vellum


### PR DESCRIPTION
## Summary
- Add `environment: dev` to the Playwright workflow job so it can access GitHub Actions variables scoped to the `dev` environment (specifically `TWILIO_ACCOUNT_SID`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
