### PR TITLE
fix: correct text block separator to only apply between consecutive text blocks

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -541,6 +541,11 @@ export class AnthropicProvider implements Provider {
               onEvent?.({ type: "text_delta", text: " " });
             }
             hasSeenTextBlock = true;
+          } else if (event.type === 'content_block_start') {
+            // Reset on non-text blocks so that text separated by tool_use
+            // (text -> tool_use -> text) doesn't get a spurious leading space
+            // in the second text segment.
+            hasSeenTextBlock = false;
           }
           if (event.type === 'content_block_start' && event.content_block.type === 'tool_use') {
             currentStreamingToolName = event.content_block.name;

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1123,9 +1123,6 @@ extension ChatViewModel {
                 startedAt: Date()
             )
             toolCall.buildingStatus = buildingStatus
-            // Flush any buffered text before processing the tool call so that
-            // text from before the tool call lands in the correct segment.
-            flushStreamingBuffer()
             // Add to existing assistant message or create one.
             // Cap at 100 tool calls per message to prevent unbounded memory growth;
             // overflow falls through to create a new message.


### PR DESCRIPTION
## Summary

Address review feedback from PR #10805:

- **Reset `hasSeenTextBlock` on non-text content blocks** in `anthropic/client.ts`: The flag was never reset when non-text blocks (e.g., `tool_use`) were encountered, causing text separated by tool calls (text -> tool_use -> text) to get a spurious leading space in the second text segment. Now resets on any non-text `content_block_start`.
- **Remove duplicate `flushStreamingBuffer()` call** in `ChatViewModel+MessageHandling.swift`: In the `.toolUseStart` handler, `flushStreamingBuffer()` was called at line 1094 (top of handler) and again at line 1128 (after building the `ToolCallData`). The second call was always a no-op since no text is buffered between the two calls.

Note: The `.join('\n')` changes in `shared.ts` and `provider-send-message.ts` were already corrected to use `joinWithSpacing()` in subsequent commits after PR #10805.

## Test plan

- [x] Ran `bun test src/__tests__/server-history-render.test.ts` — all 28 tests pass
- [ ] Verify streaming text blocks separated by tool_use don't get spurious spaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
