### PR TITLE
fix: Account Settings Retire button — large size

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -380,7 +380,7 @@ struct SettingsAccountTab: View {
                     }
                 }
                 Spacer()
-                VButton(label: "Retire...", style: .danger) {
+                VButton(label: "Retire...", style: .danger, size: .large) {
                     showingRetireConfirmation = true
                 }
             }


### PR DESCRIPTION
Makes the Retire button use size: .large in SettingsAccountTab for proper visual weight in the settings panel. Part of #10822.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
