### PR TITLE
fix: kill stale build.sh watchers on new run

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -742,6 +742,15 @@ echo "Built: $APP_DIR"
 # 7. Run if requested
 if [ "$CMD" = "run" ]; then
     echo "Launching..."
+    # Kill any previous build.sh watcher processes so they don't linger
+    # after their terminal is closed and trigger surprise rebuilds.
+    my_pid=$$
+    for pid in $(pgrep -f "build\.sh run" 2>/dev/null || true); do
+        if [ "$pid" != "$my_pid" ]; then
+            kill "$pid" 2>/dev/null || true
+        fi
+    done
+
     # Kill existing instance if running (SIGTERM for clean shutdown)
     if pgrep -x "$BUNDLE_DISPLAY_NAME" > /dev/null; then
         pkill -x "$BUNDLE_DISPLAY_NAME" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Kill any orphaned `build.sh run` watcher processes when starting a new `./build.sh run`
- Prevents surprise app rebuilds/relaunches triggered by stale watchers detecting file changes (e.g. from `git pull`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
