### PR TITLE
fix: restrict copy hit target to icon only on PublishedButton

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -985,54 +985,52 @@ private struct PublishedButton: View {
     let url: String
     @Binding var copied: Bool
 
-    @State private var isHovered = false
+    @State private var isCopyHovered = false
     @State private var resetTimer: DispatchWorkItem?
 
     var body: some View {
-        Button {
-            resetTimer?.cancel()
-            NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(url, forType: .string)
-            copied = true
-            let timer = DispatchWorkItem { copied = false }
-            resetTimer = timer
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: timer)
-        } label: {
-            HStack(spacing: VSpacing.xs) {
-                Image(systemName: "checkmark")
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundColor(VColor.success)
-                Text("Published")
-                    .font(VFont.caption)
-                Divider()
-                    .frame(height: 12)
-                Image(systemName: copied ? "checkmark" : "doc.on.doc")
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundColor(copied ? VColor.success : VColor.buttonSecondaryText)
-                    .animation(VAnimation.fast, value: copied)
-            }
-            .foregroundColor(VColor.buttonSecondaryText)
-            .padding(.horizontal, VSpacing.md)
-            .padding(.vertical, VSpacing.buttonV)
-            .frame(height: 24)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.lg)
-                    .fill(isHovered ? VColor.ghostHover : .clear)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.lg)
-                    .stroke(VColor.buttonSecondaryBorder, lineWidth: 1)
-            )
-            .contentShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        HStack(spacing: VSpacing.xs) {
+            Image(systemName: "checkmark")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(VColor.success)
+            Text("Published")
+                .font(VFont.caption)
+            Divider()
+                .frame(height: 12)
+            Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(copied ? VColor.success : (isCopyHovered ? VColor.textPrimary : VColor.buttonSecondaryText))
+                .animation(VAnimation.fast, value: copied)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    resetTimer?.cancel()
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(url, forType: .string)
+                    copied = true
+                    let timer = DispatchWorkItem { copied = false }
+                    resetTimer = timer
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: timer)
+                }
+                .onHover { hovering in
+                    isCopyHovered = hovering
+                    if hovering { NSCursor.pointingHand.set() }
+                    else { NSCursor.arrow.set() }
+                }
+                .accessibilityLabel(copied ? "URL copied" : "Copy published URL")
         }
-        .buttonStyle(.plain)
-        .onHover { hovering in
-            isHovered = hovering
-            if hovering { NSCursor.pointingHand.set() }
-            else { NSCursor.arrow.set() }
-        }
+        .foregroundColor(VColor.buttonSecondaryText)
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.buttonV)
+        .frame(height: 24)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(Color.clear)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.buttonSecondaryBorder, lineWidth: 1)
+        )
         .controlSize(.small)
-        .accessibilityLabel(copied ? "URL copied" : "Copy published URL")
     }
 }
 


### PR DESCRIPTION
## Summary

- Restructured `PublishedButton` so the copy-to-clipboard action only triggers when clicking the copy icon, not the entire button area
- The "Published ✓" label is now a passive display element; only the `doc.on.doc` icon has a tap gesture and pointer cursor
- Added subtle hover highlight on the copy icon for affordance

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
