### PR TITLE
fix: clear followupState on successful inline grant consumption

### DIFF
--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -300,6 +300,12 @@ describe('(a) target flow: trusted-contact inline guardian approval end-to-end',
     if (!result.allowed) return;
     expect(result.grantConsumed).toBe(true);
 
+    // followupState should be cleared after a successful inline grant
+    const resolved = listCanonicalGuardianRequests({ kind: 'tool_grant_request' });
+    expect(resolved.length).toBe(1);
+    const freshReq = getCanonicalGuardianRequest(resolved[0].id);
+    expect(freshReq?.followupState).toBeNull();
+
     // A guardian.question notification should have been emitted
     const questionSignals = emittedSignals.filter((s) => s.sourceEventName === 'guardian.question');
     expect(questionSignals.length).toBeGreaterThan(0);

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -439,6 +439,10 @@ export class ToolApprovalHandler {
           );
 
           if (waitResult.outcome === 'granted') {
+            // Clear the inline-wait stamp now that the grant has been consumed.
+            updateCanonicalGuardianRequest(escalation.requestId, {
+              followupState: null,
+            });
             log.info({
               toolName: name,
               sessionId: context.sessionId,


### PR DESCRIPTION
## Summary
- Clear `followupState` to `null` on the `granted` path in `checkPreExecutionGates`, matching the behavior of the `aborted` and `timeout`/`denied` paths
- Add test assertion verifying `followupState` is cleared after a successful inline grant

## Original prompt
address feedback in https://github.com/vellum-ai/vellum-assistant/pull/10803#discussion_r2868004084

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
