### PR TITLE
docs: update README slash-command docs for /update hatchedAt behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ Most commands are shared from the [`claude-skills`](https://github.com/vellum-ai
 | `/safe-check-review [file]` | Check the active plan PR for review feedback from codex/devin/humans. Addresses requested changes, waits if reviews are pending. |
 | `/resume-plan [file]` | Merge the current plan PR, implement the next one, create it, and stop again. Repeats until the plan is complete. The PR body includes the full plan content for traceability. |
 
-| `/update` | Pull latest from main, restart the backend daemon, verify gateway health (fail fast on startup failure), rebuild/launch the macOS app, and print a startup summary. |
+| `/update` | Pull latest from main, restart the backend daemon, verify gateway health (fail fast on startup failure), rebuild/launch the macOS app, and print a startup summary. The default assistant is resolved from the lockfile by selecting the most recently hatched assistant (`hatchedAt` descending). |
 
 
 ## Linear Ticket Hygiene

--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ Multiple plans can run in parallel — just specify the plan name to disambiguat
 |---------|---------|
 | `/plan-html <topic\|plan-name>` | Create or refresh a rollout plan in `.private/plans/` with both markdown and a polished, review-friendly HTML view (including per-PR file lists). |
 | `/release [version]` | Cut a release: pull main, determine/create version tag, generate release notes, publish GitHub Release, and verify CI trigger. |
-| `/update` | Pull latest from `main`, restart daemon, relaunch a single source gateway with ingress + Twilio auth env plus resilient routing defaults (`GATEWAY_UNMAPPED_POLICY` / `GATEWAY_DEFAULT_ASSISTANT_ID`) injected from local config/credentials, verify gateway health (fail fast on startup failure or duplicate gateway processes), then launch app pinned to local `gateway/`. Prints a startup summary with daemon/gateway health, Twilio env presence, and routing config. |
+| `/update` | Pull latest from `main`, restart daemon, relaunch a single source gateway with ingress + Twilio auth env plus resilient routing defaults (`GATEWAY_UNMAPPED_POLICY` / `GATEWAY_DEFAULT_ASSISTANT_ID`) injected from local config/credentials, verify gateway health (fail fast on startup failure or duplicate gateway processes), then launch app pinned to local `gateway/`. The default assistant is resolved from the lockfile by selecting the most recently hatched assistant (`hatchedAt` descending), matching the CLI `loadLatestAssistant()` behavior. Prints a startup summary with daemon/gateway health, Twilio env presence, and routing config. |
 
 
 ### Review


### PR DESCRIPTION
## Summary
- Updates the README Slash Commands section to document that `/update` now selects the most recently hatched assistant by default (sorted by `hatchedAt` descending), matching the CLI `loadLatestAssistant()` behavior.
- Also updates the AGENTS.md Slash Commands TLDR table with the same information.

## Test plan
- [x] Verify README.md `/update` description includes hatchedAt selection behavior
- [x] Verify AGENTS.md `/update` description includes hatchedAt selection behavior

Addresses Codex feedback on #10664.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
