### PR TITLE
fix: clear stale assistantPhoneNumbers entries on number assignment

### DIFF
--- a/assistant/src/daemon/handlers/config-twilio.ts
+++ b/assistant/src/daemon/handlers/config-twilio.ts
@@ -291,6 +291,22 @@ export async function handleTwilioConfig(
       const sms = (raw?.sms ?? {}) as Record<string, unknown>;
       sms.phoneNumber = msg.phoneNumber;
 
+      // Clear any legacy assistantPhoneNumbers entries that reference a
+      // different number than the one being assigned. The gateway prefers
+      // mapped numbers over the global phoneNumber, so stale entries would
+      // cause outbound sends to use an outdated number.
+      const mappings = sms.assistantPhoneNumbers as Record<string, string> | undefined;
+      if (mappings && typeof mappings === 'object') {
+        for (const [key, value] of Object.entries(mappings)) {
+          if (value !== msg.phoneNumber) {
+            delete mappings[key];
+          }
+        }
+        if (Object.keys(mappings).length === 0) {
+          delete sms.assistantPhoneNumbers;
+        }
+      }
+
       const wasSuppressed = ctx.suppressConfigReload;
       ctx.setSuppressConfigReload(true);
       try {


### PR DESCRIPTION
## Summary

- Addresses Codex P1 feedback on #10812 (unresolved review thread at line 292)
- When assigning a phone number via `assign_number`, also removes any legacy `sms.assistantPhoneNumbers` entries that reference a different number than the one being assigned
- The gateway prefers mapped numbers over the global `phoneNumber` (`config.assistantPhoneNumbers?.[assistantId] ?? config.twilioPhoneNumber`), so stale entries would cause outbound SMS sends to use an outdated or released number

## Test plan

- [ ] Verify that `assign_number` with a new phone number prunes stale `assistantPhoneNumbers` entries from the config
- [ ] Verify that entries matching the newly assigned number are preserved
- [ ] Verify that the `assistantPhoneNumbers` key is deleted entirely when no entries remain after pruning
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10838" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
