### PR TITLE
feat: guardian notifications scoped to vellum guardian identities/devices

### DIFF
--- a/assistant/src/daemon/ipc-contract/notifications.ts
+++ b/assistant/src/daemon/ipc-contract/notifications.ts
@@ -8,6 +8,12 @@ export interface NotificationIntent {
   body: string;
   /** Optional deep-link metadata so the client can navigate to the relevant context. */
   deepLinkMetadata?: Record<string, unknown>;
+  /**
+   * When set, this notification is guardian-sensitive and should only be
+   * displayed by clients whose guardian identity matches this principal ID.
+   * Clients not bound to this guardian should ignore the notification.
+   */
+  targetGuardianPrincipalId?: string;
 }
 
 /** Server push — broadcast when a notification creates a new vellum conversation thread. */
@@ -16,6 +22,11 @@ export interface NotificationThreadCreated {
   conversationId: string;
   title: string;
   sourceEventName: string;
+  /**
+   * When set, this thread was created for a guardian-sensitive notification
+   * and should only be surfaced by clients bound to this guardian identity.
+   */
+  targetGuardianPrincipalId?: string;
 }
 
 /** Client ack sent after UNUserNotificationCenter.add() completes (or fails). */

--- a/assistant/src/notifications/adapters/macos.ts
+++ b/assistant/src/notifications/adapters/macos.ts
@@ -5,6 +5,12 @@
  * The adapter broadcasts a `notification_intent` message that the Vellum
  * client can use to display a native notification (e.g. NSUserNotification
  * or UNUserNotificationCenter).
+ *
+ * Guardian-sensitive notifications (approval requests, escalation alerts)
+ * are annotated with `targetGuardianPrincipalId` so that only clients
+ * bound to the guardian identity display them. Non-guardian clients
+ * should ignore notifications with a `targetGuardianPrincipalId` that
+ * does not match their own identity.
  */
 
 import type { ServerMessage } from '../../daemon/ipc-contract.js';
@@ -21,6 +27,24 @@ const log = getLogger('notif-adapter-vellum');
 
 export type BroadcastFn = (msg: ServerMessage) => void;
 
+/**
+ * Event name prefixes that carry guardian-sensitive content (approval
+ * requests, escalation alerts, access requests). Notifications for
+ * these events are scoped to bound guardian devices via
+ * `targetGuardianPrincipalId`.
+ */
+const GUARDIAN_SENSITIVE_EVENT_PREFIXES = [
+  'guardian.question',
+  'ingress.escalation',
+  'ingress.access_request',
+] as const;
+
+export function isGuardianSensitiveEvent(sourceEventName: string): boolean {
+  return GUARDIAN_SENSITIVE_EVENT_PREFIXES.some(
+    (prefix) => sourceEventName === prefix || sourceEventName.startsWith(prefix + '.'),
+  );
+}
+
 export class VellumAdapter implements ChannelAdapter {
   readonly channel: NotificationChannel = 'vellum';
 
@@ -30,8 +54,22 @@ export class VellumAdapter implements ChannelAdapter {
     this.broadcast = broadcast;
   }
 
-  async send(payload: ChannelDeliveryPayload, _destination: ChannelDestination): Promise<DeliveryResult> {
+  async send(payload: ChannelDeliveryPayload, destination: ChannelDestination): Promise<DeliveryResult> {
     try {
+      // For guardian-sensitive events, annotate the outbound message with
+      // the target guardian identity so clients can filter. The
+      // guardianPrincipalId comes from the vellum binding resolved by
+      // the destination resolver.
+      const guardianPrincipalId =
+        typeof destination.metadata?.guardianPrincipalId === 'string'
+          ? destination.metadata.guardianPrincipalId
+          : undefined;
+
+      const targetGuardianPrincipalId =
+        guardianPrincipalId && isGuardianSensitiveEvent(payload.sourceEventName)
+          ? guardianPrincipalId
+          : undefined;
+
       this.broadcast({
         type: 'notification_intent',
         deliveryId: payload.deliveryId,
@@ -39,10 +77,15 @@ export class VellumAdapter implements ChannelAdapter {
         title: payload.copy.title,
         body: payload.copy.body,
         deepLinkMetadata: payload.deepLinkTarget,
+        targetGuardianPrincipalId,
       } as ServerMessage);
 
       log.info(
-        { sourceEventName: payload.sourceEventName, title: payload.copy.title },
+        {
+          sourceEventName: payload.sourceEventName,
+          title: payload.copy.title,
+          guardianScoped: targetGuardianPrincipalId != null,
+        },
         'Vellum notification intent broadcast',
       );
 

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -12,6 +12,7 @@
 import { v4 as uuid } from 'uuid';
 
 import { getLogger } from '../util/logger.js';
+import { isGuardianSensitiveEvent } from './adapters/macos.js';
 import { pairDeliveryWithConversation } from './conversation-pairing.js';
 import { composeFallbackCopy } from './copy-composer.js';
 import { createDelivery, findDeliveryByDecisionAndChannel, updateDeliveryStatus } from './deliveries-store.js';
@@ -34,6 +35,8 @@ export interface ThreadCreatedInfo {
   conversationId: string;
   title: string;
   sourceEventName: string;
+  /** Present when the thread is for a guardian-sensitive notification. */
+  targetGuardianPrincipalId?: string;
 }
 export type OnThreadCreatedFn = (info: ThreadCreatedInfo) => void;
 export interface BroadcastDecisionOptions {
@@ -163,6 +166,18 @@ export class NotificationBroadcaster {
       if (channel === 'vellum' && pairing.conversationId) {
         deepLinkTarget = { ...deepLinkTarget, conversationId: pairing.conversationId };
 
+        // Resolve guardian scoping for thread-created events so clients
+        // can filter guardian-sensitive threads the same way they filter
+        // guardian-sensitive notification intents.
+        const guardianPrincipalId =
+          typeof destination.metadata?.guardianPrincipalId === 'string'
+            ? destination.metadata.guardianPrincipalId
+            : undefined;
+        const targetGuardianPrincipalId =
+          guardianPrincipalId && isGuardianSensitiveEvent(signal.sourceEventName)
+            ? guardianPrincipalId
+            : undefined;
+
         const threadTitle =
           copy.threadTitle ??
           copy.title ??
@@ -171,6 +186,7 @@ export class NotificationBroadcaster {
           conversationId: pairing.conversationId,
           title: threadTitle,
           sourceEventName: signal.sourceEventName,
+          targetGuardianPrincipalId,
         };
 
         // The per-dispatch onThreadCreated callback fires whenever a vellum

--- a/assistant/src/notifications/destination-resolver.ts
+++ b/assistant/src/notifications/destination-resolver.ts
@@ -2,7 +2,10 @@
  * Resolves per-channel destination endpoints for notification delivery.
  *
  * - Vellum: no external endpoint needed — delivery goes through the IPC
- *   broadcast mechanism to connected desktop/mobile clients.
+ *   broadcast mechanism to connected desktop/mobile clients. The
+ *   guardianPrincipalId from the vellum binding is included in metadata
+ *   so downstream adapters can scope guardian-sensitive notifications to
+ *   bound guardian devices only.
  * - Binding-based channels (telegram, sms): require a chat/delivery ID
  *   sourced from the guardian binding for the assistant.
  */
@@ -35,7 +38,18 @@ export function resolveDestinations(
     switch (channel as NotificationChannel) {
       case 'vellum': {
         // Vellum delivery is local IPC — no external endpoint required.
-        result.set('vellum', { channel: 'vellum' });
+        // Include the guardianPrincipalId from the vellum binding so the
+        // adapter can annotate guardian-sensitive notifications for scoped
+        // delivery to bound guardian devices.
+        const vellumBinding = getActiveBinding(assistantId, 'vellum');
+        const metadata: Record<string, unknown> = {};
+        if (vellumBinding) {
+          metadata.guardianPrincipalId = vellumBinding.guardianExternalUserId;
+        }
+        result.set('vellum', {
+          channel: 'vellum',
+          metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+        });
         break;
       }
       case 'telegram':

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -72,9 +72,10 @@ function getBroadcaster(): NotificationBroadcaster {
           conversationId: info.conversationId,
           title: info.title,
           sourceEventName: info.sourceEventName,
+          targetGuardianPrincipalId: info.targetGuardianPrincipalId,
         });
         log.info(
-          { conversationId: info.conversationId },
+          { conversationId: info.conversationId, guardianScoped: info.targetGuardianPrincipalId != null },
           'Emitted notification_thread_created push event',
         );
       });

--- a/assistant/src/runtime/actor-token-store.ts
+++ b/assistant/src/runtime/actor-token-store.ts
@@ -152,6 +152,31 @@ export function revokeByDeviceBinding(
 }
 
 /**
+ * Find all active actor token records for a given (assistantId, guardianPrincipalId).
+ * Used for multi-device guardian fanout — returns all bound devices (macOS, iOS, etc.)
+ * so notification targeting can reach every device for the same guardian identity.
+ */
+export function findActiveByGuardianPrincipalId(
+  assistantId: string,
+  guardianPrincipalId: string,
+): ActorTokenRecord[] {
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(actorTokenRecords)
+    .where(
+      and(
+        eq(actorTokenRecords.assistantId, assistantId),
+        eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),
+        eq(actorTokenRecords.status, 'active'),
+      ),
+    )
+    .all();
+
+  return rows.map(rowToRecord);
+}
+
+/**
  * Revoke a single token by its hash.
  */
 export function revokeByTokenHash(tokenHash: string): boolean {

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -319,6 +319,19 @@ extension AppDelegate {
     }
 
     func deliverNotificationIntent(_ msg: NotificationIntentMessage) {
+        // Guardian scoping: skip notifications targeted at a different guardian.
+        if let target = msg.targetGuardianPrincipalId {
+            let localId = ActorTokenManager.getGuardianPrincipalId()
+            if localId == nil || localId != target {
+                log.info("Skipping notification_intent for guardian \(target) — local guardian is \(localId ?? "nil")")
+                // Ack so the delivery audit trail stays consistent
+                if let deliveryId = msg.deliveryId {
+                    sendNotificationIntentResult(deliveryId: deliveryId, success: true, errorMessage: nil, errorCode: nil)
+                }
+                return
+            }
+        }
+
         let nowMs = Date().timeIntervalSince1970 * 1000
         pruneFallbackMarkers(nowMs: nowMs)
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -286,6 +286,16 @@ extension AppDelegate {
     /// app is active. All notification types get a fallback native alert when
     /// backgrounded to guarantee delivery if the notification_intent IPC is late.
     func handleNotificationThreadCreated(_ msg: IPCNotificationThreadCreated) {
+        // Guardian scoping: skip thread creation for notifications targeted at
+        // a different guardian identity.
+        if let target = msg.targetGuardianPrincipalId {
+            let localId = ActorTokenManager.getGuardianPrincipalId()
+            if localId == nil || localId != target {
+                log.info("Skipping notification_thread_created for guardian \(target) — local guardian is \(localId ?? "nil")")
+                return
+            }
+        }
+
         ensureMainWindowExists()
         mainWindow?.threadManager.createNotificationThread(
             conversationId: msg.conversationId,

--- a/clients/shared/App/Auth/ActorTokenManager.swift
+++ b/clients/shared/App/Auth/ActorTokenManager.swift
@@ -8,6 +8,7 @@ import Foundation
 /// Follows the same Keychain persistence pattern as SessionTokenManager.
 public enum ActorTokenManager {
     private static let provider = "actor-token"
+    private static let guardianPrincipalIdProvider = "actor-token-guardian-principal-id"
 
     public static func getToken() -> String? {
         APIKeyManager.shared.getAPIKey(provider: provider)
@@ -19,10 +20,54 @@ public enum ActorTokenManager {
 
     public static func deleteToken() {
         _ = APIKeyManager.shared.deleteAPIKey(provider: provider)
+        _ = APIKeyManager.shared.deleteAPIKey(provider: guardianPrincipalIdProvider)
     }
 
     /// Whether an actor token is currently stored.
     public static var hasToken: Bool {
         getToken() != nil
+    }
+
+    // MARK: - Guardian Principal ID
+
+    /// Store the guardian principal ID alongside the actor token.
+    public static func setGuardianPrincipalId(_ id: String) {
+        _ = APIKeyManager.shared.setAPIKey(id, provider: guardianPrincipalIdProvider)
+    }
+
+    /// Retrieve the guardian principal ID. First checks the explicitly stored
+    /// value, then falls back to decoding the actor token's JWT payload.
+    public static func getGuardianPrincipalId() -> String? {
+        if let stored = APIKeyManager.shared.getAPIKey(provider: guardianPrincipalIdProvider) {
+            return stored
+        }
+        // Fallback: decode the actor token JWT payload (base64url-encoded JSON
+        // claims in the first segment before the '.' separator).
+        guard let token = getToken() else { return nil }
+        return Self.extractGuardianPrincipalIdFromToken(token)
+    }
+
+    /// Decode the base64url-encoded JWT payload from an actor token and
+    /// extract the `guardianPrincipalId` claim.
+    static func extractGuardianPrincipalIdFromToken(_ token: String) -> String? {
+        let parts = token.split(separator: ".", maxSplits: 2)
+        guard let payloadSegment = parts.first else { return nil }
+
+        // base64url -> base64
+        var base64 = String(payloadSegment)
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        // Pad to multiple of 4
+        let remainder = base64.count % 4
+        if remainder != 0 {
+            base64.append(contentsOf: String(repeating: "=", count: 4 - remainder))
+        }
+
+        guard let data = Data(base64Encoded: base64),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let principalId = json["guardianPrincipalId"] as? String else {
+            return nil
+        }
+        return principalId
     }
 }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1827,6 +1827,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
             let decoded = try JSONDecoder().decode(GuardianBootstrapResponse.self, from: data)
             ActorTokenManager.setToken(decoded.actorToken)
+            ActorTokenManager.setGuardianPrincipalId(decoded.guardianPrincipalId)
             log.info("Actor token bootstrap succeeded (isNew=\(decoded.isNew))")
             return true
         } catch {

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -3130,14 +3130,18 @@ public struct IPCNotificationIntent: Codable, Sendable {
     public let body: String
     /// Optional deep-link metadata so the client can navigate to the relevant context.
     public let deepLinkMetadata: [String: AnyCodable]?
+    /// When set, this notification is guardian-sensitive and should only be
+    /// displayed by clients whose guardian identity matches this principal ID.
+    public let targetGuardianPrincipalId: String?
 
-    public init(type: String, deliveryId: String? = nil, sourceEventName: String, title: String, body: String, deepLinkMetadata: [String: AnyCodable]? = nil) {
+    public init(type: String, deliveryId: String? = nil, sourceEventName: String, title: String, body: String, deepLinkMetadata: [String: AnyCodable]? = nil, targetGuardianPrincipalId: String? = nil) {
         self.type = type
         self.deliveryId = deliveryId
         self.sourceEventName = sourceEventName
         self.title = title
         self.body = body
         self.deepLinkMetadata = deepLinkMetadata
+        self.targetGuardianPrincipalId = targetGuardianPrincipalId
     }
 }
 
@@ -3164,12 +3168,16 @@ public struct IPCNotificationThreadCreated: Codable, Sendable {
     public let conversationId: String
     public let title: String
     public let sourceEventName: String
+    /// When set, this thread was created for a guardian-sensitive notification
+    /// and should only be surfaced by clients bound to this guardian identity.
+    public let targetGuardianPrincipalId: String?
 
-    public init(type: String, conversationId: String, title: String, sourceEventName: String) {
+    public init(type: String, conversationId: String, title: String, sourceEventName: String, targetGuardianPrincipalId: String? = nil) {
         self.type = type
         self.conversationId = conversationId
         self.title = title
         self.sourceEventName = sourceEventName
+        self.targetGuardianPrincipalId = targetGuardianPrincipalId
     }
 }
 


### PR DESCRIPTION
Scopes guardian-sensitive notifications to only bound guardian devices. Resolves target recipients by guardianPrincipalId + active actor token records. Preserves multi-device fanout for macOS + iOS. Part of #10757.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
