### PR TITLE
fix: add stale assistantPhoneNumbers cleanup to provision_number handler

### DIFF
--- a/assistant/src/daemon/handlers/config-twilio.ts
+++ b/assistant/src/daemon/handlers/config-twilio.ts
@@ -236,6 +236,22 @@ export async function handleTwilioConfig(
       const sms = (raw?.sms ?? {}) as Record<string, unknown>;
       sms.phoneNumber = purchased.phoneNumber;
 
+      // Clear any legacy assistantPhoneNumbers entries that reference a
+      // different number than the one being assigned. The gateway prefers
+      // mapped numbers over the global phoneNumber, so stale entries would
+      // cause outbound sends to use an outdated number.
+      const mappings = sms.assistantPhoneNumbers as Record<string, string> | undefined;
+      if (mappings && typeof mappings === 'object') {
+        for (const [key, value] of Object.entries(mappings)) {
+          if (value !== purchased.phoneNumber) {
+            delete mappings[key];
+          }
+        }
+        if (Object.keys(mappings).length === 0) {
+          delete sms.assistantPhoneNumbers;
+        }
+      }
+
       const wasSuppressed = ctx.suppressConfigReload;
       ctx.setSuppressConfigReload(true);
       try {


### PR DESCRIPTION
Addresses Devin feedback on #10838. Adds the same legacy assistantPhoneNumbers cleanup logic from the assign_number handler to the provision_number handler for consistency. The gateway prefers mapped numbers, so stale entries would cause outbound SMS to use a released number.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
