### PR TITLE
fix: unify Not configured style across channel cards, drop Bot/Credentials label prefix

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -83,10 +83,11 @@ struct SettingsAppearanceTab: View {
             .vCard(background: VColor.surfaceSubtle)
 
             // KEYBOARD SHORTCUTS section
-            VStack(alignment: .leading, spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: 0) {
                 Text("Keyboard Shortcuts")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
+                    .padding(.bottom, VSpacing.md)
 
                 // Open Vellum (configurable)
                 HStack {
@@ -94,34 +95,28 @@ struct SettingsAppearanceTab: View {
                         .font(VFont.body)
                         .foregroundColor(VColor.textSecondary)
                     Spacer()
-                    Text(ShortcutHelper.displayString(for: store.globalHotkeyShortcut))
-                        .font(VFont.mono)
-                        .foregroundColor(VColor.textPrimary)
-                        .padding(.horizontal, VSpacing.sm)
-                        .padding(.vertical, VSpacing.xs)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.sm)
-                                .stroke(VColor.surfaceBorder, lineWidth: 1)
-                        )
+                    shortcutKeyPill(ShortcutHelper.displayString(for: store.globalHotkeyShortcut))
 
                     if isRecordingGlobalHotkey {
-                        VButton(label: "Press shortcut...", style: .tertiary) {
+                        VButton(label: "Press shortcut...", style: .outlined, size: .large) {
                             stopRecording()
                         }
                     } else {
-                        VButton(label: "Record", style: .tertiary) {
+                        VButton(label: "Record", style: .outlined, size: .large) {
                             startRecording()
                         }
                     }
                 }
+                .padding(.vertical, VSpacing.md)
 
                 if let shortcutConflictWarning {
                     Text(shortcutConflictWarning)
                         .font(VFont.caption)
                         .foregroundColor(VColor.warning)
+                        .padding(.bottom, VSpacing.xs)
                 }
+
+                Divider().background(VColor.surfaceBorder)
 
                 // Quick Input (configurable)
                 HStack {
@@ -129,28 +124,22 @@ struct SettingsAppearanceTab: View {
                         .font(VFont.body)
                         .foregroundColor(VColor.textSecondary)
                     Spacer()
-                    Text(ShortcutHelper.displayString(for: store.quickInputHotkeyShortcut))
-                        .font(VFont.mono)
-                        .foregroundColor(VColor.textPrimary)
-                        .padding(.horizontal, VSpacing.sm)
-                        .padding(.vertical, VSpacing.xs)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.sm)
-                                .stroke(VColor.surfaceBorder, lineWidth: 1)
-                        )
+                    shortcutKeyPill(ShortcutHelper.displayString(for: store.quickInputHotkeyShortcut))
 
                     if isRecordingQuickInputHotkey {
-                        VButton(label: "Press shortcut...", style: .tertiary) {
+                        VButton(label: "Press shortcut...", style: .outlined, size: .large) {
                             stopRecording()
                         }
                     } else {
-                        VButton(label: "Record", style: .tertiary) {
+                        VButton(label: "Record", style: .outlined, size: .large) {
                             startRecordingQuickInput()
                         }
                     }
                 }
+                .padding(.vertical, VSpacing.md)
+
+                Divider().background(VColor.surfaceBorder)
+
                 ShortcutRow(label: "Start voice input", shortcut: "Hold Fn")
             }
             .padding(VSpacing.lg)
@@ -280,6 +269,20 @@ struct SettingsAppearanceTab: View {
         }
     }
 
+    private func shortcutKeyPill(_ text: String) -> some View {
+        Text(text)
+            .font(VFont.mono)
+            .foregroundColor(VColor.textSecondary)
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+            .background(VColor.surface)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+            )
+    }
+
     private func stopRecording() {
         isRecordingGlobalHotkey = false
         isRecordingQuickInputHotkey = false
@@ -303,16 +306,17 @@ private struct ShortcutRow: View {
             Spacer()
             Text(shortcut)
                 .font(VFont.mono)
-                .foregroundColor(VColor.textPrimary)
+                .foregroundColor(VColor.textSecondary)
                 .padding(.horizontal, VSpacing.sm)
                 .padding(.vertical, VSpacing.xs)
                 .background(VColor.surface)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
                 .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.sm)
+                    RoundedRectangle(cornerRadius: VRadius.md)
                         .stroke(VColor.surfaceBorder, lineWidth: 1)
                 )
         }
+        .padding(.vertical, VSpacing.md)
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -958,31 +958,33 @@ struct SettingsChannelsTab: View {
         valueURL: URL? = nil,
         action: RowAction? = nil
     ) -> some View {
-        HStack(spacing: VSpacing.sm) {
-            Text(label)
-                .font(VFont.caption)
-                .foregroundColor(VColor.textSecondary)
-                .frame(width: labelColumnWidth, alignment: .leading)
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack(spacing: VSpacing.sm) {
+                Text(label)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+                    .frame(width: labelColumnWidth, alignment: .leading)
 
-            Image(systemName: icon)
-                .foregroundColor(iconColor)
-                .font(.system(size: 12))
+                Image(systemName: icon)
+                    .foregroundColor(iconColor)
+                    .font(.system(size: 12))
 
-            if let url = valueURL {
-                Link(value, destination: url)
-                    .font(valueFont)
-                    .lineLimit(1)
-                    .onHover { hovering in
-                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                    }
-            } else {
-                Text(value)
-                    .font(valueFont)
-                    .foregroundColor(valueColor)
-                    .lineLimit(1)
+                if let url = valueURL {
+                    Link(value, destination: url)
+                        .font(valueFont)
+                        .lineLimit(1)
+                        .onHover { hovering in
+                            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                        }
+                } else {
+                    Text(value)
+                        .font(valueFont)
+                        .foregroundColor(valueColor)
+                        .lineLimit(1)
+                }
+
+                Spacer()
             }
-
-            Spacer()
 
             if let action {
                 VButton(label: action.label, style: action.style, size: .large, action: action.action)
@@ -1139,39 +1141,41 @@ struct SettingsChannelsTab: View {
 
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             if verified {
-                HStack(spacing: VSpacing.sm) {
-                    guardianLabel
-                    VStack(alignment: .leading, spacing: 2) {
-                        if let telegramProfileURL {
-                            Link(primaryIdentity ?? "Verified", destination: telegramProfileURL)
-                                .font(VFont.body)
-                                .lineLimit(1)
-                                .onHover { hovering in
-                                    if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                                }
-                        } else {
-                            Text(primaryIdentity ?? "Verified")
-                                .font(VFont.body)
-                                .foregroundColor(VColor.textSecondary)
-                                .lineLimit(1)
-                        }
-                        if let secondaryIdentity {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    HStack(spacing: VSpacing.sm) {
+                        guardianLabel
+                        VStack(alignment: .leading, spacing: 2) {
                             if let telegramProfileURL {
-                                Link(secondaryIdentity, destination: telegramProfileURL)
-                                    .font(VFont.caption)
+                                Link(primaryIdentity ?? "Verified", destination: telegramProfileURL)
+                                    .font(VFont.body)
                                     .lineLimit(1)
                                     .onHover { hovering in
                                         if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
                                     }
                             } else {
-                                Text(secondaryIdentity)
-                                    .font(VFont.caption)
-                                    .foregroundColor(VColor.textMuted)
+                                Text(primaryIdentity ?? "Verified")
+                                    .font(VFont.body)
+                                    .foregroundColor(VColor.textSecondary)
                                     .lineLimit(1)
                             }
+                            if let secondaryIdentity {
+                                if let telegramProfileURL {
+                                    Link(secondaryIdentity, destination: telegramProfileURL)
+                                        .font(VFont.caption)
+                                        .lineLimit(1)
+                                        .onHover { hovering in
+                                            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                                        }
+                                } else {
+                                    Text(secondaryIdentity)
+                                        .font(VFont.caption)
+                                        .foregroundColor(VColor.textMuted)
+                                        .lineLimit(1)
+                                }
+                            }
                         }
+                        Spacer()
                     }
-                    Spacer()
                     VButton(label: "Revoke", style: .secondary, size: .large) {
                         store.revokeChannelGuardian(channel: channel)
                     }
@@ -1201,7 +1205,7 @@ struct SettingsChannelsTab: View {
             }
 
             if let error {
-                HStack(spacing: VSpacing.sm) {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text(error)
                         .font(VFont.caption)
                         .foregroundColor(VColor.error)
@@ -1296,9 +1300,6 @@ struct SettingsChannelsTab: View {
                     .font(VFont.body)
                     .foregroundColor(VColor.warning)
                 Spacer()
-                VButton(label: "Cancel", style: .secondary, size: .large) {
-                    store.cancelOutboundGuardian(channel: channel)
-                }
             }
 
             VStack(alignment: .leading, spacing: VSpacing.xs) {
@@ -1421,6 +1422,10 @@ struct SettingsChannelsTab: View {
                 }
             }
             .padding(.leading, labelColumnWidth + VSpacing.sm)
+
+            VButton(label: "Cancel", style: .secondary, size: .large) {
+                store.cancelOutboundGuardian(channel: channel)
+            }
         }
         .onAppear { startCountdownTimer() }
         .onDisappear { stopCountdownTimer() }
@@ -1506,9 +1511,6 @@ struct SettingsChannelsTab: View {
                     .font(VFont.body)
                     .foregroundColor(VColor.warning)
                 Spacer()
-                VButton(label: "Cancel", style: .secondary, size: .large) {
-                    store.cancelGuardianChallenge(channel: channel)
-                }
             }
 
             if let command {
@@ -1575,6 +1577,10 @@ struct SettingsChannelsTab: View {
                     )
                     .textSelection(.enabled)
                     .padding(.leading, labelColumnWidth + VSpacing.sm)
+            }
+
+            VButton(label: "Cancel", style: .secondary, size: .large) {
+                store.cancelGuardianChallenge(channel: channel)
             }
         }
     }
@@ -1691,23 +1697,25 @@ struct SettingsChannelsTab: View {
                     .foregroundColor(VColor.warning)
             }
         } else if !hasToken {
-            HStack(spacing: VSpacing.sm) {
-                mobilePairingLabel
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .foregroundColor(VColor.warning)
-                    .font(.system(size: 12))
-                Text("Bearer token required")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.warning)
-                Spacer()
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                HStack(spacing: VSpacing.sm) {
+                    mobilePairingLabel
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(VColor.warning)
+                        .font(.system(size: 12))
+                    Text("Bearer token required")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.warning)
+                }
                 VButton(label: "Generate Token", style: .secondary, size: .large) {
                     regenerateHttpToken()
                 }
             }
         } else {
-            HStack(spacing: VSpacing.sm) {
-                mobilePairingLabel
-                Spacer()
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                HStack(spacing: VSpacing.sm) {
+                    mobilePairingLabel
+                }
                 VButton(label: "Pair Device", leftIcon: "qrcode", style: .primary, size: .large) {
                     showingPairingQR = true
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -291,16 +291,19 @@ struct SettingsChannelsTab: View {
             } else if telegramSetupExpanded {
                 telegramCredentialEntry
             } else {
-                channelStatusRow(
-                    label: "Bot",
-                    icon: "exclamationmark.triangle",
-                    iconColor: VColor.warning,
-                    value: "Not configured",
-                    valueColor: VColor.textMuted,
-                    action: .init(label: "Set Up", style: .secondary) {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    HStack(spacing: VSpacing.sm) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .foregroundColor(VColor.warning)
+                            .font(.system(size: 12))
+                        Text("Not configured")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    VButton(label: "Set Up", style: .secondary, size: .large) {
                         telegramSetupExpanded = true
                     }
-                )
+                }
             }
 
             if let error = store.telegramError {
@@ -461,16 +464,19 @@ struct SettingsChannelsTab: View {
             } else if slackChannelSetupExpanded {
                 slackChannelCredentialEntry
             } else {
-                channelStatusRow(
-                    label: "Bot",
-                    icon: "exclamationmark.triangle",
-                    iconColor: VColor.warning,
-                    value: "Not configured",
-                    valueColor: VColor.textMuted,
-                    action: .init(label: "Set Up", style: .secondary) {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    HStack(spacing: VSpacing.sm) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .foregroundColor(VColor.warning)
+                            .font(.system(size: 12))
+                        Text("Not configured")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    VButton(label: "Set Up", style: .secondary, size: .large) {
                         slackChannelSetupExpanded = true
                     }
-                )
+                }
             }
 
             if let error = store.slackChannelError {
@@ -568,16 +574,19 @@ struct SettingsChannelsTab: View {
             } else if twilioSetupExpanded {
                 twilioCredentialEntry
             } else {
-                channelStatusRow(
-                    label: "Credentials",
-                    icon: "exclamationmark.triangle",
-                    iconColor: VColor.warning,
-                    value: "Not configured",
-                    valueColor: VColor.textMuted,
-                    action: .init(label: "Set Up", style: .secondary) {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    HStack(spacing: VSpacing.sm) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .foregroundColor(VColor.warning)
+                            .font(.system(size: 12))
+                        Text("Not configured")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    VButton(label: "Set Up", style: .secondary, size: .large) {
                         twilioSetupExpanded = true
                     }
-                )
+                }
             }
 
             // Phone number row (only when credentials exist)
@@ -653,16 +662,19 @@ struct SettingsChannelsTab: View {
             } else if voiceSetupExpanded {
                 voiceCredentialEntry
             } else {
-                channelStatusRow(
-                    label: "Credentials",
-                    icon: "exclamationmark.triangle",
-                    iconColor: VColor.warning,
-                    value: "Not configured",
-                    valueColor: VColor.textMuted,
-                    action: .init(label: "Set Up", style: .secondary) {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    HStack(spacing: VSpacing.sm) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .foregroundColor(VColor.warning)
+                            .font(.system(size: 12))
+                        Text("Not configured")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    VButton(label: "Set Up", style: .secondary, size: .large) {
                         voiceSetupExpanded = true
                     }
-                )
+                }
             }
 
             // Phone number row (only when credentials exist)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -282,7 +282,7 @@ struct SettingsChannelsTab: View {
                     iconColor: VColor.success,
                     value: store.telegramBotUsername.map { "@\($0)" } ?? "Configured",
                     valueURL: store.telegramBotUsername.flatMap { URL(string: "https://web.telegram.org/k/#@\($0)") },
-                    action: .init(label: "Clear", style: .danger, disabled: store.telegramSaveInProgress) {
+                    action: .init(label: "Clear", style: .secondary, disabled: store.telegramSaveInProgress) {
                         store.clearTelegramCredentials()
                         telegramBotTokenText = ""
                         telegramSetupExpanded = false
@@ -364,7 +364,7 @@ struct SettingsChannelsTab: View {
                             }
                         }
                         Spacer()
-                        VButton(label: "Revoke", style: .danger) {
+                        VButton(label: "Revoke", style: .secondary, size: .large) {
                             store.revokeTelegramApprovedMember(memberId: member.id)
                         }
                         .disabled(store.telegramRevokingMemberIds.contains(member.id))
@@ -389,7 +389,7 @@ struct SettingsChannelsTab: View {
                     .font(VFont.caption)
                     .foregroundColor(VColor.textSecondary)
                 Spacer()
-                VButton(label: "Cancel", style: .tertiary) {
+                VButton(label: "Cancel", style: .secondary, size: .large) {
                     telegramSetupExpanded = false
                     telegramBotTokenText = ""
                 }
@@ -413,7 +413,7 @@ struct SettingsChannelsTab: View {
                         .foregroundColor(VColor.textSecondary)
                 }
             } else {
-                VButton(label: "Save", style: .primary) {
+                VButton(label: "Save", style: .secondary, size: .large) {
                     store.saveTelegramToken(botToken: telegramBotTokenText)
                     telegramBotTokenText = ""
                     telegramSetupExpanded = false
@@ -451,7 +451,7 @@ struct SettingsChannelsTab: View {
                         }
                         return parts.isEmpty ? "Configured" : parts.joined(separator: " — ")
                     }(),
-                    action: .init(label: "Clear", style: .danger, disabled: store.slackChannelSaveInProgress) {
+                    action: .init(label: "Clear", style: .secondary, disabled: store.slackChannelSaveInProgress) {
                         store.clearSlackChannelConfig()
                         slackChannelBotTokenInput = ""
                         slackChannelAppTokenInput = ""
@@ -494,7 +494,7 @@ struct SettingsChannelsTab: View {
                     .font(VFont.caption)
                     .foregroundColor(VColor.textSecondary)
                 Spacer()
-                VButton(label: "Cancel", style: .tertiary) {
+                VButton(label: "Cancel", style: .secondary, size: .large) {
                     slackChannelSetupExpanded = false
                     slackChannelBotTokenInput = ""
                     slackChannelAppTokenInput = ""
@@ -524,7 +524,7 @@ struct SettingsChannelsTab: View {
                         .foregroundColor(VColor.textSecondary)
                 }
             } else {
-                VButton(label: "Save", style: .primary) {
+                VButton(label: "Save", style: .secondary, size: .large) {
                     store.saveSlackChannelConfig(
                         botToken: slackChannelBotTokenInput,
                         appToken: slackChannelAppTokenInput
@@ -561,7 +561,7 @@ struct SettingsChannelsTab: View {
                     icon: "checkmark.circle.fill",
                     iconColor: VColor.success,
                     value: "Configured",
-                    action: .init(label: "Clear", style: .danger, disabled: store.twilioSaveInProgress) {
+                    action: .init(label: "Clear", style: .secondary, disabled: store.twilioSaveInProgress) {
                         store.clearTwilioCredentials()
                     }
                 )
@@ -646,7 +646,7 @@ struct SettingsChannelsTab: View {
                     icon: "checkmark.circle.fill",
                     iconColor: VColor.success,
                     value: "Configured",
-                    action: .init(label: "Clear", style: .danger, disabled: store.twilioSaveInProgress) {
+                    action: .init(label: "Clear", style: .secondary, disabled: store.twilioSaveInProgress) {
                         store.clearTwilioCredentials()
                     }
                 )
@@ -721,7 +721,7 @@ struct SettingsChannelsTab: View {
                     .font(VFont.caption)
                     .foregroundColor(VColor.textSecondary)
                 Spacer()
-                VButton(label: "Cancel", style: .tertiary) {
+                VButton(label: "Cancel", style: .secondary, size: .large) {
                     twilioSetupExpanded = false
                     twilioAccountSidText = ""
                     twilioAuthTokenText = ""
@@ -747,7 +747,7 @@ struct SettingsChannelsTab: View {
                         .foregroundColor(VColor.textSecondary)
                 }
             } else {
-                VButton(label: "Save Credentials", style: .primary) {
+                VButton(label: "Save Credentials", style: .secondary, size: .large) {
                     store.saveTwilioCredentials(
                         accountSid: twilioAccountSidText,
                         authToken: twilioAuthTokenText
@@ -773,7 +773,7 @@ struct SettingsChannelsTab: View {
                     .font(VFont.caption)
                     .foregroundColor(VColor.textSecondary)
                 Spacer()
-                VButton(label: "Cancel", style: .tertiary) {
+                VButton(label: "Cancel", style: .secondary, size: .large) {
                     twilioNumberPickerExpanded = false
                 }
             }
@@ -813,7 +813,7 @@ struct SettingsChannelsTab: View {
                                     .foregroundColor(VColor.textSecondary)
                             }
                         } else {
-                            VButton(label: "Use", style: .secondary) {
+                            VButton(label: "Use", style: .secondary, size: .large) {
                                 store.assignTwilioNumber(phoneNumber: number.phoneNumber)
                                 twilioNumberPickerExpanded = false
                             }
@@ -834,7 +834,7 @@ struct SettingsChannelsTab: View {
                     .font(VFont.caption)
                     .foregroundColor(VColor.textSecondary)
                 Spacer()
-                VButton(label: "Cancel", style: .tertiary) {
+                VButton(label: "Cancel", style: .secondary, size: .large) {
                     voiceSetupExpanded = false
                     voiceAccountSidText = ""
                     voiceAuthTokenText = ""
@@ -860,7 +860,7 @@ struct SettingsChannelsTab: View {
                         .foregroundColor(VColor.textSecondary)
                 }
             } else {
-                VButton(label: "Save Credentials", style: .primary) {
+                VButton(label: "Save Credentials", style: .secondary, size: .large) {
                     store.saveTwilioCredentials(
                         accountSid: voiceAccountSidText,
                         authToken: voiceAuthTokenText
@@ -886,7 +886,7 @@ struct SettingsChannelsTab: View {
                     .font(VFont.caption)
                     .foregroundColor(VColor.textSecondary)
                 Spacer()
-                VButton(label: "Cancel", style: .tertiary) {
+                VButton(label: "Cancel", style: .secondary, size: .large) {
                     voiceNumberPickerExpanded = false
                 }
             }
@@ -926,7 +926,7 @@ struct SettingsChannelsTab: View {
                                     .foregroundColor(VColor.textSecondary)
                             }
                         } else {
-                            VButton(label: "Use", style: .secondary) {
+                            VButton(label: "Use", style: .secondary, size: .large) {
                                 store.assignTwilioNumber(phoneNumber: number.phoneNumber)
                                 voiceNumberPickerExpanded = false
                             }
@@ -985,7 +985,7 @@ struct SettingsChannelsTab: View {
             Spacer()
 
             if let action {
-                VButton(label: action.label, style: action.style, action: action.action)
+                VButton(label: action.label, style: action.style, size: .large, action: action.action)
                     .disabled(action.disabled)
             }
         }
@@ -1172,7 +1172,7 @@ struct SettingsChannelsTab: View {
                         }
                     }
                     Spacer()
-                    VButton(label: "Revoke", style: .danger) {
+                    VButton(label: "Revoke", style: .secondary, size: .large) {
                         store.revokeChannelGuardian(channel: channel)
                     }
                 }
@@ -1206,7 +1206,7 @@ struct SettingsChannelsTab: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.error)
                     if alreadyBound {
-                        VButton(label: "Replace", style: .secondary) {
+                        VButton(label: "Replace", style: .secondary, size: .large) {
                             store.startChannelGuardianVerification(channel: channel, rebind: true)
                         }
                     }
@@ -1296,7 +1296,7 @@ struct SettingsChannelsTab: View {
                     .font(VFont.body)
                     .foregroundColor(VColor.warning)
                 Spacer()
-                VButton(label: "Cancel", style: .tertiary) {
+                VButton(label: "Cancel", style: .secondary, size: .large) {
                     store.cancelOutboundGuardian(channel: channel)
                 }
             }
@@ -1389,7 +1389,7 @@ struct SettingsChannelsTab: View {
                         return "Resend in \(remaining)s"
                     }()
 
-                    VButton(label: resendCooldownText ?? "Resend", style: .secondary) {
+                    VButton(label: resendCooldownText ?? "Resend", style: .secondary, size: .large) {
                         store.resendOutboundGuardian(channel: channel)
                     }
                     .disabled(!canResend)
@@ -1506,7 +1506,7 @@ struct SettingsChannelsTab: View {
                     .font(VFont.body)
                     .foregroundColor(VColor.warning)
                 Spacer()
-                VButton(label: "Cancel", style: .tertiary) {
+                VButton(label: "Cancel", style: .secondary, size: .large) {
                     store.cancelGuardianChallenge(channel: channel)
                 }
             }
@@ -1618,7 +1618,7 @@ struct SettingsChannelsTab: View {
                         icon: "iphone",
                         iconColor: VColor.success,
                         value: device.deviceName,
-                        action: .init(label: "Remove", style: .danger) {
+                        action: .init(label: "Remove", style: .secondary) {
                             store.removeApprovedDevice(hashedDeviceId: device.hashedDeviceId)
                         }
                     )
@@ -1700,7 +1700,7 @@ struct SettingsChannelsTab: View {
                     .font(VFont.body)
                     .foregroundColor(VColor.warning)
                 Spacer()
-                VButton(label: "Generate Token", style: .secondary) {
+                VButton(label: "Generate Token", style: .secondary, size: .large) {
                     regenerateHttpToken()
                 }
             }
@@ -1708,7 +1708,7 @@ struct SettingsChannelsTab: View {
             HStack(spacing: VSpacing.sm) {
                 mobilePairingLabel
                 Spacer()
-                VButton(label: "Pair Device", leftIcon: "qrcode", style: .primary) {
+                VButton(label: "Pair Device", leftIcon: "qrcode", style: .primary, size: .large) {
                     showingPairingQR = true
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Settings/ShortcutHelper.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ShortcutHelper.swift
@@ -9,7 +9,7 @@ enum ShortcutHelper {
     /// display string like "Command Shift Space".
     static func displayString(for shortcut: String) -> String {
         let parts = shortcut.lowercased().split(separator: "+").map(String.init)
-        return parts.map { displayToken($0) }.joined()
+        return parts.map { displayToken($0) }.joined(separator: " ")
     }
 
     /// Parses a shortcut string into modifier flags and a key string suitable


### PR DESCRIPTION
## Summary
- Replaced all four "Not configured" `channelStatusRow` calls (Telegram, Slack, SMS, Voice) with inline layouts matching the Email card style: warning triangle icon + caption text, no label prefix
- Removed "Bot" and "Credentials" label prefixes from not-configured states
- "Set Up" button remains below the status line (consistent with M2 button placement)

Closes #10842

🤖 Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
