### PR TITLE
fix: Advanced Settings — Simulate button large size

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -194,7 +194,7 @@ struct ToolPermissionTesterView: View {
     @ViewBuilder
     private var simulateButton: some View {
         HStack(spacing: VSpacing.sm) {
-            VButton(label: model.isSimulating ? "Simulating\u{2026}" : "Simulate", style: .primary) {
+            VButton(label: model.isSimulating ? "Simulating\u{2026}" : "Simulate", style: .primary, size: .large) {
                 model.simulate()
             }
             .disabled(!model.canSimulate)


### PR DESCRIPTION
## Summary
- Added `size: .large` to the Simulate button in ToolPermissionTesterView

Closes #10853

🤖 Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
