### PR TITLE
feat: improve email declutter flow — button fix, enriched output, provider-agnostic tools

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -1,6 +1,6 @@
 # Update — Pull Latest and Restart Vellum
 
-Pull the latest changes from main, restart the backend daemon, rebuild/launch the macOS app, and start the source gateway.
+Pull the latest changes from main, rebuild/launch the macOS app (which manages its own daemon and gateway lifecycle).
 
 ## Steps
 
@@ -9,7 +9,7 @@ Pull the latest changes from main, restart the backend daemon, rebuild/launch th
    export PATH="$HOME/.bun/bin:$PATH"
    ```
 
-1. Kill app, daemon, and **all** gateway processes. There must only ever be one gateway running, and it must always be started from source:
+1. Kill app, daemon, and **all** gateway processes. The macOS app manages its own daemon and gateway — kill everything so it starts clean:
    ```bash
    pkill -x "Vellum" || true
    pkill -x "vellum-assistant" || true
@@ -17,6 +17,7 @@ Pull the latest changes from main, restart the backend daemon, rebuild/launch th
    pkill -f "dev:proxy" || true
    pkill -f "gateway/src/index" || true
    lsof -ti :7830 | xargs kill -9 2>/dev/null || true
+   lsof -ti :7821 | xargs kill -9 2>/dev/null || true
    ```
 
 2. Switch to main and pull latest:
@@ -31,135 +32,7 @@ Pull the latest changes from main, restart the backend daemon, rebuild/launch th
    cd gateway && bun install && cd ..
    ```
 
-4. Start the daemon fresh with runtime HTTP enabled (required for gateway/Twilio/OAuth ingress):
-   ```bash
-   cd assistant && bun run daemon:restart:http && cd ..
-   ```
-
-5. Resolve gateway env and start the source gateway. These MUST run in the same shell so variables persist:
-   ```bash
-   INGRESS_PUBLIC_BASE_URL="$(
-     python3 - <<'PY'
-import json, os
-cfg_path = os.path.expanduser("~/.vellum/workspace/config.json")
-try:
-    with open(cfg_path, "r", encoding="utf-8") as f:
-        cfg = json.load(f)
-    ingress = (cfg.get("ingress") or {}).get("publicBaseUrl") or ""
-    print(str(ingress).strip())
-except Exception:
-    print("")
-PY
-   )"
-   TWILIO_AUTH_TOKEN="${TWILIO_AUTH_TOKEN:-$(
-     cd assistant
-     bun -e 'import { getSecureKey } from "./src/security/secure-keys.js"; process.stdout.write(getSecureKey("credential:twilio:auth_token") ?? "")'
-     cd ..
-   )}"
-   TWILIO_ACCOUNT_SID="${TWILIO_ACCOUNT_SID:-$(
-     cd assistant
-     bun -e 'import { getSecureKey } from "./src/security/secure-keys.js"; process.stdout.write(getSecureKey("credential:twilio:account_sid") ?? "")'
-     cd ..
-   )}"
-   TWILIO_PHONE_NUMBER="${TWILIO_PHONE_NUMBER:-$(
-     cd assistant
-     bun -e 'import { getSecureKey } from "./src/security/secure-keys.js"; process.stdout.write(getSecureKey("credential:twilio:phone_number") ?? "")'
-     cd ..
-   )}"
-
-   # Resolve default assistant ID from lockfile (sort by hatchedAt descending
-   # to match CLI loadLatestAssistant() behavior — most recently hatched wins).
-   GATEWAY_DEFAULT_ASSISTANT_ID="${GATEWAY_DEFAULT_ASSISTANT_ID:-$(
-     python3 - <<'PY'
-import json, os
-lock_path = os.path.expanduser("~/.vellum.lock.json")
-try:
-    with open(lock_path, "r", encoding="utf-8") as f:
-        data = json.load(f)
-    assistants = [a for a in (data.get("assistants") or []) if isinstance(a, dict) and (a.get("assistantId") or "").strip()]
-    assistants.sort(key=lambda a: a.get("hatchedAt") or "", reverse=True)
-    if assistants:
-        print(assistants[0]["assistantId"].strip())
-except Exception:
-    pass
-PY
-   )}"
-
-   # Always default to "default" routing policy (matches CLI startGateway() behavior).
-   GATEWAY_UNMAPPED_POLICY="${GATEWAY_UNMAPPED_POLICY:-default}"
-
-   if [ "$GATEWAY_UNMAPPED_POLICY" = "default" ] && [ -z "$GATEWAY_DEFAULT_ASSISTANT_ID" ]; then
-     echo "WARNING: GATEWAY_UNMAPPED_POLICY=default but no GATEWAY_DEFAULT_ASSISTANT_ID is set. Falling back to reject."
-     GATEWAY_UNMAPPED_POLICY="reject"
-   fi
-
-   [ -z "$INGRESS_PUBLIC_BASE_URL" ] && echo "WARNING: INGRESS_PUBLIC_BASE_URL is empty (Twilio signature validation may fail)."
-   [ -z "$TWILIO_AUTH_TOKEN" ] && echo "WARNING: TWILIO_AUTH_TOKEN is empty (Twilio webhooks will be rejected)."
-   [ -z "$TWILIO_ACCOUNT_SID" ] && echo "WARNING: TWILIO_ACCOUNT_SID is empty (SMS delivery will fail)."
-   [ -z "$TWILIO_PHONE_NUMBER" ] && echo "WARNING: TWILIO_PHONE_NUMBER is empty (SMS delivery will fail)."
-   echo "Gateway routing: $GATEWAY_UNMAPPED_POLICY${GATEWAY_DEFAULT_ASSISTANT_ID:+ -> $GATEWAY_DEFAULT_ASSISTANT_ID}"
-
-   # Start the source gateway (must be in the same shell block so env vars are available)
-   cd gateway
-   mkdir -p "${HOME}/.vellum"
-   nohup env \
-     GATEWAY_RUNTIME_PROXY_ENABLED=true \
-     GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH=false \
-     INGRESS_PUBLIC_BASE_URL="$INGRESS_PUBLIC_BASE_URL" \
-     TWILIO_AUTH_TOKEN="$TWILIO_AUTH_TOKEN" \
-     TWILIO_ACCOUNT_SID="$TWILIO_ACCOUNT_SID" \
-     TWILIO_PHONE_NUMBER="$TWILIO_PHONE_NUMBER" \
-     GATEWAY_UNMAPPED_POLICY="$GATEWAY_UNMAPPED_POLICY" \
-     GATEWAY_DEFAULT_ASSISTANT_ID="$GATEWAY_DEFAULT_ASSISTANT_ID" \
-     bun run dev:proxy \
-     > "${HOME}/.vellum/gateway-dev.log" 2>&1 &
-   cd ..
-   ```
-
-6. Poll gateway health with retries (fail fast before building the macOS app):
-   ```bash
-   # Poll gateway health with retries
-   GATEWAY_HEALTHY=false
-   for i in 1 2 3 4 5 6 7 8 9 10; do
-     sleep 1
-     if curl -sS --max-time 2 http://127.0.0.1:7830/healthz >/dev/null 2>&1; then
-       GATEWAY_HEALTHY=true
-       break
-     fi
-   done
-
-   if [ "$GATEWAY_HEALTHY" != "true" ]; then
-     echo ""
-     echo "ERROR: Gateway failed to start or is not healthy after 10 seconds."
-     echo "Recent gateway logs:"
-     cat "${HOME}/.vellum/gateway-dev.log" 2>/dev/null || echo "(no log file found)"
-     echo ""
-     echo "Troubleshooting:"
-     echo "  1. Check if port 7830 is in use: lsof -i :7830"
-     echo "  2. Review full gateway log: cat ~/.vellum/gateway-dev.log"
-     echo "  3. Try restarting: pkill -f 'gateway/src/index' && /update"
-     echo ""
-     echo "Stopping — please fix the issue before continuing."
-     exit 1
-   fi
-
-   GATEWAY_PIDS=$(pgrep -f "gateway/src/index" 2>/dev/null | wc -l | tr -d ' ')
-   if [ "$GATEWAY_PIDS" -gt 1 ]; then
-     echo ""
-     echo "ERROR: Multiple gateway processes detected ($GATEWAY_PIDS)."
-     echo "PIDs:"
-     pgrep -f "gateway/src/index" || true
-     echo "Recent gateway logs:"
-     tail -n 80 "${HOME}/.vellum/gateway-dev.log" 2>/dev/null || echo "(no log file found)"
-     echo ""
-     echo "Kill extras and retry:"
-     echo "  pkill -f 'gateway/src/index' && /update"
-     echo ""
-     exit 1
-   fi
-   ```
-
-7. Build the macOS app from source synchronously (wait for build to complete before launching to avoid opening a stale build), then launch with file-watching in the background:
+4. Build the macOS app from source synchronously (wait for build to complete before launching to avoid opening a stale build), then launch with file-watching in the background:
    ```bash
    REPO_ROOT="$(pwd)"
    cd clients/macos && VELLUM_GATEWAY_DIR="$REPO_ROOT/gateway" ./build.sh
@@ -170,21 +43,15 @@ PY
    cd clients/macos && VELLUM_GATEWAY_DIR="$REPO_ROOT/gateway" ./build.sh run &
    ```
 
-8. Print startup summary (re-read values from gateway log since shell vars don't persist across steps):
+5. Wait for the app to launch and settle, then print startup summary:
    ```bash
+   sleep 5
    echo ""
    echo "=== Startup Summary ==="
-   DAEMON_STATUS=$(curl -sS --max-time 2 http://127.0.0.1:7821/healthz 2>&1 || echo "UNHEALTHY")
-   GATEWAY_STATUS=$(curl -sS --max-time 2 http://127.0.0.1:7830/healthz 2>&1 || echo "UNHEALTHY")
+   DAEMON_STATUS=$(curl -sS --max-time 2 http://127.0.0.1:7821/healthz 2>&1 || echo "NOT YET RUNNING (app will start daemon on first launch/hatch)")
+   GATEWAY_STATUS=$(curl -sS --max-time 2 http://127.0.0.1:7830/healthz 2>&1 || echo "NOT YET RUNNING (app will start gateway on first launch/hatch)")
    echo "  Daemon:   $DAEMON_STATUS"
    echo "  Gateway:  $GATEWAY_STATUS"
-   # Extract routing config from gateway startup log
-   GATEWAY_POLICY=$(grep -o 'unmappedPolicy: "[^"]*"' ~/.vellum/gateway-dev.log 2>/dev/null | tail -1)
-   GATEWAY_HAS_DEFAULT=$(grep -o 'hasDefaultAssistant: [a-z]*' ~/.vellum/gateway-dev.log 2>/dev/null | tail -1)
-   GATEWAY_POLICY="${GATEWAY_POLICY:-unknown}"
-   GATEWAY_HAS_DEFAULT="${GATEWAY_HAS_DEFAULT:-unknown}"
-   echo "  Gateway routing: $GATEWAY_POLICY, $GATEWAY_HAS_DEFAULT"
-   echo "  Gateway log: ~/.vellum/gateway-dev.log"
    echo "======================="
    echo ""
    ```
@@ -192,5 +59,5 @@ PY
 Report:
 
 1. What was pulled (new commits).
-2. The startup summary block output (daemon health, gateway health, env presence, routing config).
-3. The gateway log path: `~/.vellum/gateway-dev.log`.
+2. The startup summary block output (daemon health, gateway health).
+3. Note: the macOS app manages its own daemon and gateway. On first launch, the app will hatch and start them automatically.

--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ Multiple plans can run in parallel — just specify the plan name to disambiguat
 |---------|---------|
 | `/plan-html <topic\|plan-name>` | Create or refresh a rollout plan in `.private/plans/` with both markdown and a polished, review-friendly HTML view (including per-PR file lists). |
 | `/release [version]` | Cut a release: pull main, determine/create version tag, generate release notes, publish GitHub Release, and verify CI trigger. |
-| `/update` | Pull latest from `main`, restart daemon, relaunch a single source gateway with ingress + Twilio auth env plus resilient routing defaults (`GATEWAY_UNMAPPED_POLICY` / `GATEWAY_DEFAULT_ASSISTANT_ID`) injected from local config/credentials, verify gateway health (fail fast on startup failure or duplicate gateway processes), then launch app pinned to local `gateway/`. The default assistant is resolved from the lockfile by selecting the most recently hatched assistant (`hatchedAt` descending), matching the CLI `loadLatestAssistant()` behavior. Prints a startup summary with daemon/gateway health, Twilio env presence, and routing config. |
+| `/update` | Pull latest from `main`, kill stale processes, rebuild and launch the macOS app. The app manages its own daemon and gateway lifecycle (hatching on first launch). Prints a startup summary. |
 
 
 ### Review

--- a/assistant/src/config/bundled-skills/messaging/TOOLS.json
+++ b/assistant/src/config/bundled-skills/messaging/TOOLS.json
@@ -1018,6 +1018,64 @@
       "execution_target": "host"
     },
     {
+      "name": "messaging_sender_digest",
+      "description": "Scan connected email platform and group messages by sender to identify high-volume senders (e.g. newsletters). Works with any email provider that supports sender digest. Returns top senders sorted by message count with metadata for bulk cleanup.",
+      "category": "messaging",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "platform": {
+            "type": "string",
+            "description": "Platform (e.g. \"gmail\"). Auto-detected if only one is connected."
+          },
+          "query": {
+            "type": "string",
+            "description": "Search query (default 'category:promotions newer_than:90d')"
+          },
+          "max_messages": {
+            "type": "number",
+            "description": "Maximum messages to scan (default 500, cap 2000)"
+          },
+          "max_senders": {
+            "type": "number",
+            "description": "Maximum senders to return (default 30)"
+          }
+        }
+      },
+      "executor": "tools/messaging-sender-digest.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "messaging_archive_by_sender",
+      "description": "Archive all messages matching a search query on the connected email platform. Paginates through all results and archives in bulk. Works with any email provider that supports archive by query. Include a confidence score (0-1).",
+      "category": "messaging",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "platform": {
+            "type": "string",
+            "description": "Platform (e.g. \"gmail\"). Auto-detected if only one is connected."
+          },
+          "query": {
+            "type": "string",
+            "description": "Search query (e.g. \"from:marketing@example.com category:promotions newer_than:90d\")"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          }
+        },
+        "required": [
+          "query",
+          "confidence"
+        ]
+      },
+      "executor": "tools/messaging-archive-by-sender.ts",
+      "execution_target": "host"
+    },
+    {
       "name": "gmail_outreach_scan",
       "description": "Scan Gmail for cold outreach emails (sales, recruiting, marketing) using LLM classification. Returns top outreach senders with suggested cleanup actions. Read-only \u2014 use gmail_batch_archive and gmail_filters for cleanup.",
       "category": "messaging",

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
@@ -161,7 +161,12 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         sample_subjects: s.sampleSubjects,
       }));
 
-      return ok(JSON.stringify({ senders: result, total_scanned: allMessageIds.length }));
+      return ok(JSON.stringify({
+        senders: result,
+        total_scanned: allMessageIds.length,
+        query_used: query,
+        note: `message_count reflects emails found per sender within the ${allMessageIds.length} messages scanned. The archive tool may find additional messages beyond this sample.`,
+      }));
     });
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-archive-by-sender.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-archive-by-sender.ts
@@ -1,0 +1,35 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { err, ok, resolveProvider, withProviderToken } from './shared.js';
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const platform = input.platform as string | undefined;
+  const query = input.query as string;
+
+  if (!query) {
+    return err('query is required.');
+  }
+
+  try {
+    const provider = resolveProvider(platform);
+
+    if (!provider.archiveByQuery) {
+      return err(`The ${provider.displayName} provider does not support archive by query.`);
+    }
+
+    return withProviderToken(provider, async (token) => {
+      const result = await provider.archiveByQuery!(token, query);
+
+      if (result.archived === 0) {
+        return ok('No messages matched the query. Nothing archived.');
+      }
+
+      const summary = `Archived ${result.archived} message(s) matching query: ${query}`;
+      if (result.truncated) {
+        return ok(`${summary}\n\nNote: this operation was capped at 5000 messages. Additional messages matching the query may remain in the inbox. Run the command again to archive more.`);
+      }
+      return ok(summary);
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-sender-digest.ts
@@ -1,0 +1,51 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { err, ok, resolveProvider, withProviderToken } from './shared.js';
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const platform = input.platform as string | undefined;
+  const query = (input.query as string) ?? 'category:promotions newer_than:90d';
+  const maxMessages = input.max_messages as number | undefined;
+  const maxSenders = input.max_senders as number | undefined;
+
+  try {
+    const provider = resolveProvider(platform);
+
+    if (!provider.senderDigest) {
+      return err(`The ${provider.displayName} provider does not support sender digest scanning.`);
+    }
+
+    return withProviderToken(provider, async (token) => {
+      const result = await provider.senderDigest!(token, query, { maxMessages, maxSenders });
+
+      if (result.senders.length === 0) {
+        return ok(JSON.stringify({
+          senders: [],
+          total_scanned: 0,
+          message: 'No emails found matching the query. Try broadening the search (e.g. remove category filter or extend date range).',
+        }));
+      }
+
+      // Map to snake_case output format for LLM consumption
+      const senders = result.senders.map((s) => ({
+        id: s.id,
+        display_name: s.displayName,
+        email: s.email,
+        message_count: s.messageCount,
+        has_unsubscribe: s.hasUnsubscribe,
+        newest_message_id: s.newestMessageId,
+        search_query: s.searchQuery,
+        message_ids: s.messageIds,
+        has_more: s.hasMore,
+      }));
+
+      return ok(JSON.stringify({
+        senders,
+        total_scanned: result.totalScanned,
+        query_used: result.queryUsed,
+        note: `message_count reflects emails found per sender within the ${result.totalScanned} messages scanned. The archive tool may find additional messages beyond this sample.`,
+      }));
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/messaging/provider-types.ts
+++ b/assistant/src/messaging/provider-types.ts
@@ -81,3 +81,27 @@ export interface SendOptions {
   /** Optional assistant scope for multi-assistant channels. */
   assistantId?: string;
 }
+
+/** Result from a sender digest scan — groups messages by sender for bulk cleanup. */
+export interface SenderDigestEntry {
+  id: string;
+  displayName: string;
+  email: string;
+  messageCount: number;
+  hasUnsubscribe: boolean;
+  newestMessageId: string;
+  searchQuery: string;
+  messageIds: string[];
+  hasMore: boolean;
+}
+
+export interface SenderDigestResult {
+  senders: SenderDigestEntry[];
+  totalScanned: number;
+  queryUsed: string;
+}
+
+export interface ArchiveResult {
+  archived: number;
+  truncated?: boolean;
+}

--- a/assistant/src/messaging/provider.ts
+++ b/assistant/src/messaging/provider.ts
@@ -6,6 +6,7 @@
  */
 
 import type {
+  ArchiveResult,
   ConnectionInfo,
   Conversation,
   HistoryOptions,
@@ -13,6 +14,7 @@ import type {
   Message,
   SearchOptions,
   SearchResult,
+  SenderDigestResult,
   SendOptions,
   SendResult,
 } from './provider-types.js';
@@ -37,6 +39,11 @@ export interface MessagingProvider {
 
   getThreadReplies?(token: string, conversationId: string, threadId: string, options?: HistoryOptions): Promise<Message[]>;
   markRead?(token: string, conversationId: string, messageId?: string): Promise<void>;
+
+  /** Scan messages and group by sender for bulk cleanup (e.g. newsletter decluttering). */
+  senderDigest?(token: string, query: string, options?: { maxMessages?: number; maxSenders?: number }): Promise<SenderDigestResult>;
+  /** Archive messages matching a search query. */
+  archiveByQuery?(token: string, query: string): Promise<ArchiveResult>;
 
   /**
    * Override the default credential check used by getConnectedProviders().

--- a/assistant/src/messaging/providers/gmail/adapter.ts
+++ b/assistant/src/messaging/providers/gmail/adapter.ts
@@ -7,6 +7,7 @@
 
 import type { MessagingProvider } from '../../provider.js';
 import type {
+  ArchiveResult,
   ConnectionInfo,
   Conversation,
   HistoryOptions,
@@ -14,6 +15,8 @@ import type {
   Message,
   SearchOptions,
   SearchResult,
+  SenderDigestEntry,
+  SenderDigestResult,
   SendOptions,
   SendResult,
 } from '../../provider-types.js';
@@ -190,5 +193,129 @@ export const gmailMessagingProvider: MessagingProvider = {
   async markRead(token: string, _conversationId: string, messageId?: string): Promise<void> {
     if (!messageId) return;
     await gmail.modifyMessage(token, messageId, { removeLabelIds: ['UNREAD'] });
+  },
+
+  async senderDigest(token: string, query: string, options?: { maxMessages?: number; maxSenders?: number }): Promise<SenderDigestResult> {
+    const maxMessages = Math.min(options?.maxMessages ?? 500, 2000);
+    const maxSenders = options?.maxSenders ?? 30;
+    const maxIdsPerSender = 1000;
+
+    const allMessageIds: string[] = [];
+    let pageToken: string | undefined;
+
+    while (allMessageIds.length < maxMessages) {
+      const pageSize = Math.min(100, maxMessages - allMessageIds.length);
+      const listResp = await gmail.listMessages(token, query, pageSize, pageToken);
+      const ids = (listResp.messages ?? []).map((m) => m.id);
+      if (ids.length === 0) break;
+      allMessageIds.push(...ids);
+      pageToken = listResp.nextPageToken ?? undefined;
+      if (!pageToken) break;
+    }
+
+    if (allMessageIds.length === 0) {
+      return { senders: [], totalScanned: 0, queryUsed: query };
+    }
+
+    const messages = await gmail.batchGetMessages(token, allMessageIds, 'metadata', [
+      'From', 'List-Unsubscribe',
+    ]);
+
+    const senderMap = new Map<string, {
+      displayName: string; email: string; messageCount: number;
+      hasUnsubscribe: boolean; newestMessageId: string;
+      newestUnsubscribableMessageId: string | null; newestUnsubscribableEpoch: number;
+      messageIds: string[]; hasMore: boolean;
+    }>();
+
+    for (const msg of messages) {
+      const headers = msg.payload?.headers ?? [];
+      const fromHeader = headers.find((h) => h.name.toLowerCase() === 'from')?.value ?? '';
+      const listUnsub = headers.find((h) => h.name.toLowerCase() === 'list-unsubscribe')?.value;
+
+      const match = fromHeader.match(/^(.+?)\s*<([^>]+)>$/);
+      const email = match ? match[2].toLowerCase() : fromHeader.trim().toLowerCase();
+      const displayName = match ? match[1].replace(/^["']|["']$/g, '').trim() : '';
+      if (!email) continue;
+
+      let agg = senderMap.get(email);
+      if (!agg) {
+        agg = {
+          displayName, email, messageCount: 0, hasUnsubscribe: false,
+          newestMessageId: msg.id, newestUnsubscribableMessageId: null,
+          newestUnsubscribableEpoch: 0, messageIds: [], hasMore: false,
+        };
+        senderMap.set(email, agg);
+      }
+
+      agg.messageCount++;
+      if (listUnsub) agg.hasUnsubscribe = true;
+      if (!agg.displayName && displayName) agg.displayName = displayName;
+
+      if (agg.messageIds.length < maxIdsPerSender) {
+        agg.messageIds.push(msg.id);
+      } else {
+        agg.hasMore = true;
+      }
+
+      const msgEpoch = msg.internalDate ? Number(msg.internalDate) : 0;
+      if (listUnsub && msgEpoch >= agg.newestUnsubscribableEpoch) {
+        agg.newestUnsubscribableMessageId = msg.id;
+        agg.newestUnsubscribableEpoch = msgEpoch;
+      }
+    }
+
+    const sorted = [...senderMap.values()]
+      .sort((a, b) => b.messageCount - a.messageCount)
+      .slice(0, maxSenders);
+
+    const senders: SenderDigestEntry[] = sorted.map((s) => ({
+      id: Buffer.from(s.email).toString('base64url'),
+      displayName: s.displayName || s.email.split('@')[0],
+      email: s.email,
+      messageCount: s.messageCount,
+      hasUnsubscribe: s.hasUnsubscribe,
+      newestMessageId: (s.hasUnsubscribe && s.newestUnsubscribableMessageId)
+        ? s.newestUnsubscribableMessageId
+        : s.newestMessageId,
+      searchQuery: `from:${s.email} ${query}`,
+      messageIds: s.messageIds,
+      hasMore: s.hasMore,
+    }));
+
+    return { senders, totalScanned: allMessageIds.length, queryUsed: query };
+  },
+
+  async archiveByQuery(token: string, query: string): Promise<ArchiveResult> {
+    const maxMessages = 5000;
+    const batchModifyLimit = 1000;
+
+    const allMessageIds: string[] = [];
+    let pageToken: string | undefined;
+    let truncated = false;
+
+    while (allMessageIds.length < maxMessages) {
+      const listResp = await gmail.listMessages(token, query, Math.min(500, maxMessages - allMessageIds.length), pageToken);
+      const ids = (listResp.messages ?? []).map((m) => m.id);
+      if (ids.length === 0) break;
+      allMessageIds.push(...ids);
+      pageToken = listResp.nextPageToken ?? undefined;
+      if (!pageToken) break;
+    }
+
+    if (allMessageIds.length >= maxMessages && pageToken) {
+      truncated = true;
+    }
+
+    if (allMessageIds.length === 0) {
+      return { archived: 0 };
+    }
+
+    for (let i = 0; i < allMessageIds.length; i += batchModifyLimit) {
+      const chunk = allMessageIds.slice(i, i + batchModifyLimit);
+      await gmail.batchModifyMessages(token, chunk, { removeLabelIds: ['INBOX'] });
+    }
+
+    return { archived: allMessageIds.length, truncated };
   },
 };

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -124,8 +124,11 @@ public struct InlineSurfaceRouter: View {
         .frame(maxWidth: isDynamicPreview || isDocumentPreview ? 350 : 540, alignment: .leading)
         }
         }
-        .onChange(of: surface) { _, _ in
-            clickedActionLabel = nil
+        .onChange(of: surface) { oldSurface, newSurface in
+            if newSurface.completionState != nil { return }
+            if oldSurface.data != newSurface.data || oldSurface.actions != newSurface.actions {
+                clickedActionLabel = nil
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- **InlineSurfaceRouter.swift**: Fixed button clicked state flicker by guarding `.onChange(of: surface)` to skip resets on completionState transitions
- **gmail-sender-digest.ts**: Added `query_used` and `note` fields to output so LLM always has count semantics
- **Provider abstraction**: Extended `MessagingProvider` with optional `senderDigest()` and `archiveByQuery()` methods, implemented in Gmail adapter, created `messaging_sender_digest` and `messaging_archive_by_sender` generic tools
- **TOOLS.json**: Registered both new provider-agnostic tools
- **update.md + README**: Simplified /update — macOS app manages its own daemon and gateway lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
