### PR TITLE
fix: Advanced Settings — feature flag toggle rows, label+caption left, toggle right

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
@@ -151,6 +151,7 @@ struct SettingsAdvancedDevTab: View {
                     }
                 }
             ))
+            .accessibilityLabel(flag.displayName)
         }
     }
 
@@ -191,6 +192,7 @@ struct SettingsAdvancedDevTab: View {
                                 MacOSClientFeatureFlagManager.shared.setOverride(entry.key, enabled: newValue)
                             }
                         ))
+                        .accessibilityLabel(entry.label)
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
@@ -105,7 +105,41 @@ struct SettingsAdvancedDevTab: View {
     }
 
     private func assistantFlagRow(flag: DaemonClient.AssistantFeatureFlag) -> some View {
-        HStack {
+        let flagBinding = Binding<Bool>(
+            get: {
+                assistantFlags.first(where: { $0.key == flag.key })?.enabled ?? flag.enabled
+            },
+            set: { newValue in
+                // Optimistically update local state
+                if let index = assistantFlags.firstIndex(where: { $0.key == flag.key }) {
+                    assistantFlags[index] = DaemonClient.AssistantFeatureFlag(
+                        key: flag.key,
+                        enabled: newValue,
+                        defaultEnabled: flag.defaultEnabled,
+                        description: flag.description,
+                        label: flag.label
+                    )
+                }
+                // Persist via gateway API
+                Task {
+                    do {
+                        try await daemonClient?.setFeatureFlag(key: flag.key, enabled: newValue)
+                    } catch {
+                        // Revert on failure
+                        if let index = assistantFlags.firstIndex(where: { $0.key == flag.key }) {
+                            assistantFlags[index] = DaemonClient.AssistantFeatureFlag(
+                                key: flag.key,
+                                enabled: !newValue,
+                                defaultEnabled: flag.defaultEnabled,
+                                description: flag.description,
+                                label: flag.label
+                            )
+                        }
+                    }
+                }
+            }
+        )
+        return HStack {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 Text(flag.displayName)
                     .font(VFont.body)
@@ -117,42 +151,38 @@ struct SettingsAdvancedDevTab: View {
                 }
             }
             Spacer()
-            VToggle(isOn: Binding(
-                get: {
-                    assistantFlags.first(where: { $0.key == flag.key })?.enabled ?? flag.enabled
-                },
-                set: { newValue in
-                    // Optimistically update local state
-                    if let index = assistantFlags.firstIndex(where: { $0.key == flag.key }) {
-                        assistantFlags[index] = DaemonClient.AssistantFeatureFlag(
-                            key: flag.key,
-                            enabled: newValue,
-                            defaultEnabled: flag.defaultEnabled,
-                            description: flag.description,
-                            label: flag.label
-                        )
-                    }
-                    // Persist via gateway API
-                    Task {
-                        do {
-                            try await daemonClient?.setFeatureFlag(key: flag.key, enabled: newValue)
-                        } catch {
-                            // Revert on failure
-                            if let index = assistantFlags.firstIndex(where: { $0.key == flag.key }) {
-                                assistantFlags[index] = DaemonClient.AssistantFeatureFlag(
-                                    key: flag.key,
-                                    enabled: !newValue,
-                                    defaultEnabled: flag.defaultEnabled,
-                                    description: flag.description,
-                                    label: flag.label
-                                )
-                            }
-                        }
-                    }
-                }
-            ))
-            .accessibilityLabel(flag.displayName)
+            VToggle(isOn: flagBinding)
+                .accessibilityLabel(flag.displayName)
         }
+        .contentShape(Rectangle())
+        .onTapGesture { flagBinding.wrappedValue.toggle() }
+    }
+
+    private func macOSFlagRow(index: Int, entry: MacOSFeatureFlagState) -> some View {
+        let flagBinding = Binding<Bool>(
+            get: { macOSFlagStates[index].enabled },
+            set: { newValue in
+                macOSFlagStates[index].enabled = newValue
+                MacOSClientFeatureFlagManager.shared.setOverride(entry.key, enabled: newValue)
+            }
+        )
+        return HStack {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text(entry.label)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                if !entry.description.isEmpty {
+                    Text(entry.description)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
+            Spacer()
+            VToggle(isOn: flagBinding)
+                .accessibilityLabel(entry.label)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { flagBinding.wrappedValue.toggle() }
     }
 
     // MARK: - macOS Feature Flags
@@ -173,27 +203,7 @@ struct SettingsAdvancedDevTab: View {
                     .foregroundColor(VColor.textMuted)
             } else {
                 ForEach(Array(macOSFlagStates.enumerated()), id: \.element.id) { index, entry in
-                    HStack {
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text(entry.label)
-                                .font(VFont.body)
-                                .foregroundColor(VColor.textSecondary)
-                            if !entry.description.isEmpty {
-                                Text(entry.description)
-                                    .font(VFont.caption)
-                                    .foregroundColor(VColor.textMuted)
-                            }
-                        }
-                        Spacer()
-                        VToggle(isOn: Binding(
-                            get: { macOSFlagStates[index].enabled },
-                            set: { newValue in
-                                macOSFlagStates[index].enabled = newValue
-                                MacOSClientFeatureFlagManager.shared.setOverride(entry.key, enabled: newValue)
-                            }
-                        ))
-                        .accessibilityLabel(entry.label)
-                    }
+                    macOSFlagRow(index: index, entry: entry)
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
@@ -155,7 +155,7 @@ struct SettingsAdvancedDevTab: View {
                 .accessibilityLabel(flag.displayName)
         }
         .contentShape(Rectangle())
-        .onTapGesture { flagBinding.wrappedValue.toggle() }
+        .onTapGesture { withAnimation { flagBinding.wrappedValue.toggle() } }
     }
 
     private func macOSFlagRow(index: Int, entry: MacOSFeatureFlagState) -> some View {
@@ -182,7 +182,7 @@ struct SettingsAdvancedDevTab: View {
                 .accessibilityLabel(entry.label)
         }
         .contentShape(Rectangle())
-        .onTapGesture { flagBinding.wrappedValue.toggle() }
+        .onTapGesture { withAnimation { flagBinding.wrappedValue.toggle() } }
     }
 
     // MARK: - macOS Feature Flags

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
@@ -105,7 +105,18 @@ struct SettingsAdvancedDevTab: View {
     }
 
     private func assistantFlagRow(flag: DaemonClient.AssistantFeatureFlag) -> some View {
-        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+        HStack {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text(flag.displayName)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                if let description = flag.description, !description.isEmpty {
+                    Text(description)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
+            Spacer()
             VToggle(isOn: Binding(
                 get: {
                     assistantFlags.first(where: { $0.key == flag.key })?.enabled ?? flag.enabled
@@ -139,15 +150,7 @@ struct SettingsAdvancedDevTab: View {
                         }
                     }
                 }
-            ), label: flag.displayName)
-            .font(VFont.body)
-            .foregroundColor(VColor.textSecondary)
-
-            if let description = flag.description, !description.isEmpty {
-                Text(description)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
-            }
+            ))
         }
     }
 
@@ -169,22 +172,25 @@ struct SettingsAdvancedDevTab: View {
                     .foregroundColor(VColor.textMuted)
             } else {
                 ForEach(Array(macOSFlagStates.enumerated()), id: \.element.id) { index, entry in
-                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    HStack {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text(entry.label)
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textSecondary)
+                            if !entry.description.isEmpty {
+                                Text(entry.description)
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.textMuted)
+                            }
+                        }
+                        Spacer()
                         VToggle(isOn: Binding(
                             get: { macOSFlagStates[index].enabled },
                             set: { newValue in
                                 macOSFlagStates[index].enabled = newValue
                                 MacOSClientFeatureFlagManager.shared.setOverride(entry.key, enabled: newValue)
                             }
-                        ), label: entry.label)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textSecondary)
-
-                        if !entry.description.isEmpty {
-                            Text(entry.description)
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textMuted)
-                        }
+                        ))
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Restructured assistantFlagRow and macOS flag rows in SettingsAdvancedDevTab to match the Privacy Settings Diagnostics layout
- Label and description (caption) now on the left in a VStack, VToggle on the right — consistent with the privacy settings toggle pattern

Closes #10854

🤖 Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
