### PR TITLE
fix: regenerate IPC Swift code to match contract

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -846,14 +846,12 @@ public struct IPCChannelReadinessRequest: Codable, Sendable {
     public let type: String
     public let action: String
     public let channel: String?
-    public let assistantId: String?
     public let includeRemote: Bool?
 
-    public init(type: String, action: String, channel: String? = nil, assistantId: String? = nil, includeRemote: Bool? = nil) {
+    public init(type: String, action: String, channel: String? = nil, includeRemote: Bool? = nil) {
         self.type = type
         self.action = action
         self.channel = channel
-        self.assistantId = assistantId
         self.includeRemote = includeRemote
     }
 }
@@ -1995,19 +1993,17 @@ public struct IPCGuardianVerificationRequest: Codable, Sendable {
     public let action: String
     public let channel: String?
     public let sessionId: String?
-    public let assistantId: String?
     public let rebind: Bool?
     /// E.164 phone number for SMS/voice, Telegram handle/chat-id. Used by outbound actions.
     public let destination: String?
     /// Origin conversation ID so completion/failure pointers can route back.
     public let originConversationId: String?
 
-    public init(type: String, action: String, channel: String? = nil, sessionId: String? = nil, assistantId: String? = nil, rebind: Bool? = nil, destination: String? = nil, originConversationId: String? = nil) {
+    public init(type: String, action: String, channel: String? = nil, sessionId: String? = nil, rebind: Bool? = nil, destination: String? = nil, originConversationId: String? = nil) {
         self.type = type
         self.action = action
         self.channel = channel
         self.sessionId = sessionId
-        self.assistantId = assistantId
         self.rebind = rebind
         self.destination = destination
         self.originConversationId = originConversationId
@@ -5114,12 +5110,11 @@ public struct IPCTwilioConfigRequest: Codable, Sendable {
     public let phoneNumber: String?
     public let areaCode: String?
     public let country: String?
-    public let assistantId: String?
     public let verificationSid: String?
     public let verificationParams: IPCTwilioConfigRequestVerificationParams?
     public let text: String?
 
-    public init(type: String, action: String, accountSid: String? = nil, authToken: String? = nil, phoneNumber: String? = nil, areaCode: String? = nil, country: String? = nil, assistantId: String? = nil, verificationSid: String? = nil, verificationParams: IPCTwilioConfigRequestVerificationParams? = nil, text: String? = nil) {
+    public init(type: String, action: String, accountSid: String? = nil, authToken: String? = nil, phoneNumber: String? = nil, areaCode: String? = nil, country: String? = nil, verificationSid: String? = nil, verificationParams: IPCTwilioConfigRequestVerificationParams? = nil, text: String? = nil) {
         self.type = type
         self.action = action
         self.accountSid = accountSid
@@ -5127,7 +5122,6 @@ public struct IPCTwilioConfigRequest: Codable, Sendable {
         self.phoneNumber = phoneNumber
         self.areaCode = areaCode
         self.country = country
-        self.assistantId = assistantId
         self.verificationSid = verificationSid
         self.verificationParams = verificationParams
         self.text = text


### PR DESCRIPTION
## Summary
- Regenerated `IPCContractGenerated.swift` to match the current IPC contract
- Removed stale `assistantId` fields from `IPCChannelReadinessRequest`, `IPCGuardianVerificationRequest`, and `IPCTwilioConfigRequest`

## Original prompt
fix this CI failure: https://github.com/vellum-ai/vellum-assistant/actions/runs/22531502781/job/65271492353

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
