### PR TITLE
fix: read ChannelProbeContext from types file in boundary guard test

### DIFF
--- a/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
+++ b/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
@@ -401,8 +401,12 @@ describe('assistant ID boundary', () => {
       ).toBe(false);
     }
 
-    // ChannelProbeContext must not have assistantId
-    const probeContextMatch = content.match(/interface\s+ChannelProbeContext\s*\{([^}]*)\}/);
+    // ChannelProbeContext must not have assistantId.
+    // The interface is declared in channel-readiness-types.ts, not the service file.
+    const typesPath = join(import.meta.dir, '..', 'runtime', 'channel-readiness-types.ts');
+    const typesContent = readFileSync(typesPath, 'utf-8');
+    const probeContextMatch = typesContent.match(/interface\s+ChannelProbeContext\s*\{([^}]*)\}/);
+    expect(probeContextMatch, 'Expected to find ChannelProbeContext interface in channel-readiness-types.ts').not.toBeNull();
     if (probeContextMatch) {
       expect(
         probeContextMatch[1],


### PR DESCRIPTION
## Summary
- Fixes the `ChannelProbeContext` guard test in `assistant-id-boundary-guard.test.ts` to read from `channel-readiness-types.ts` (where the interface is defined) instead of `channel-readiness-service.ts`
- Previously the regex match silently returned `null` and the assertion was skipped, leaving the boundary check unenforced
- Adds an explicit `expect(...).not.toBeNull()` to fail if the interface is not found, preventing silent skips in the future

## Original prompt
address the latent feedback on https://github.com/vellum-ai/vellum-assistant/pull/10812

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
