### PR TITLE
fix: Voice Settings — replace Picker with VDropdown for conversation timeout

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -388,6 +388,7 @@ struct VoiceSettingsView: View {
                 selection: $wakeWordTimeoutSeconds,
                 options: timeoutOptions
             )
+            .frame(width: 160)
             .accessibilityLabel("Conversation timeout duration")
         }
         .padding(VSpacing.lg)


### PR DESCRIPTION
## Summary
- Replaced native Picker with VDropdown in the conversation timeout section of Voice Settings for visual consistency with the design system

Closes #10857

🤖 Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
