### PR TITLE
fix: Account Settings — move Log In/Out, Hatch, Retire buttons to own bottom row

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -158,27 +158,31 @@ struct SettingsAccountTab: View {
                         .foregroundColor(VColor.textSecondary)
                 }
             } else if let user = authManager.currentUser {
-                HStack(spacing: VSpacing.sm) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(VColor.success)
-                        .font(.system(size: 14))
-                    Text(user.email ?? user.display ?? "Signed in")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textSecondary)
-                    Spacer()
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    HStack(spacing: VSpacing.sm) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(VColor.success)
+                            .font(.system(size: 14))
+                        Text(user.email ?? user.display ?? "Signed in")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                        Spacer()
+                    }
                     VButton(label: "Log Out", style: .danger, size: .large) {
                         Task { await authManager.logout() }
                     }
                 }
             } else {
-                HStack(spacing: VSpacing.sm) {
-                    Image(systemName: "xmark.circle")
-                        .foregroundColor(VColor.textMuted)
-                        .font(.system(size: 14))
-                    Text("Not signed in")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textSecondary)
-                    Spacer()
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    HStack(spacing: VSpacing.sm) {
+                        Image(systemName: "xmark.circle")
+                            .foregroundColor(VColor.textMuted)
+                            .font(.system(size: 14))
+                        Text("Not signed in")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                        Spacer()
+                    }
                     VButton(
                         label: authManager.isSubmitting ? "Signing in..." : "Log In",
                         style: .primary,
@@ -365,7 +369,7 @@ struct SettingsAccountTab: View {
                 .font(VFont.sectionTitle)
                 .foregroundColor(VColor.textPrimary)
 
-            HStack {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text("Retire this assistant")
                         .font(VFont.body)
@@ -380,7 +384,6 @@ struct SettingsAccountTab: View {
                             .foregroundColor(VColor.textMuted)
                     }
                 }
-                Spacer()
                 VButton(label: "Retire...", style: .danger, size: .large) {
                     showingRetireConfirmation = true
                 }
@@ -453,7 +456,7 @@ struct SettingsAccountTab: View {
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
 
-                HStack {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         Text("Hatch a new assistant")
                             .font(VFont.body)
@@ -462,7 +465,6 @@ struct SettingsAccountTab: View {
                             .font(VFont.caption)
                             .foregroundColor(VColor.textMuted)
                     }
-                    Spacer()
                     VButton(label: "Hatch...", style: .primary, size: .large) {
                         AppDelegate.shared?.replayOnboarding()
                         onClose()


### PR DESCRIPTION
## Summary
- Moved Log In / Log Out buttons to own dedicated bottom row in Account section
- Moved Hatch button to own dedicated bottom row in Hatch New Assistant section
- Moved Retire button to own dedicated bottom row in Retire Assistant section
- All buttons remain left-aligned, consistent with the rest of settings

Closes #10864
Closes #10865
Closes #10866

🤖 Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
