### PR TITLE
fix: Automation Settings — large size buttons, Manage to own bottom row

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAutomationTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAutomationTab.swift
@@ -18,7 +18,7 @@ struct SettingsAutomationTab: View {
                         .font(VFont.sectionTitle)
                         .foregroundColor(VColor.textPrimary)
 
-                    HStack {
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
                             Text("Manage Reminders")
                                 .font(VFont.body)
@@ -27,8 +27,7 @@ struct SettingsAutomationTab: View {
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.textMuted)
                         }
-                        Spacer()
-                        VButton(label: "Manage...", style: .tertiary) {
+                        VButton(label: "Manage...", style: .secondary, size: .large) {
                             showingReminders = true
                         }
                     }
@@ -41,7 +40,7 @@ struct SettingsAutomationTab: View {
                         .font(VFont.sectionTitle)
                         .foregroundColor(VColor.textPrimary)
 
-                    HStack {
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
                             Text("Manage Scheduled Tasks")
                                 .font(VFont.body)
@@ -50,8 +49,7 @@ struct SettingsAutomationTab: View {
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.textMuted)
                         }
-                        Spacer()
-                        VButton(label: "Manage...", style: .tertiary) {
+                        VButton(label: "Manage...", style: .secondary, size: .large) {
                             showingScheduledTasks = true
                         }
                     }
@@ -156,7 +154,7 @@ struct HeartbeatAutomationSection: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
                 } else {
-                    VButton(label: "Run Now", style: .primary) {
+                    VButton(label: "Run Now", style: .primary, size: .large) {
                         isRunning = true
                         runError = nil
                         guard let client = daemonClient else {


### PR DESCRIPTION
## Summary
- Changed Manage Reminders and Manage Scheduled Tasks buttons from .tertiary/.small to .secondary/.large, moved to own bottom row left-aligned
- Changed Run Now button to large size

Closes #10868

🤖 Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
