### PR TITLE
fix: Keyboard shortcuts — individual pill per key token

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -270,17 +270,21 @@ struct SettingsAppearanceTab: View {
     }
 
     private func shortcutKeyPill(_ text: String) -> some View {
-        Text(text)
-            .font(VFont.mono)
-            .foregroundColor(VColor.textSecondary)
-            .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, VSpacing.xs)
-            .background(VColor.surface)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .stroke(VColor.surfaceBorder, lineWidth: 1)
-            )
+        HStack(spacing: VSpacing.xs) {
+            ForEach(text.components(separatedBy: " "), id: \.self) { token in
+                Text(token)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.textSecondary)
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.vertical, VSpacing.xs)
+                    .background(VColor.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.xl)
+                            .stroke(VColor.surfaceBorder, lineWidth: 1)
+                    )
+            }
+        }
     }
 
     private func stopRecording() {
@@ -304,17 +308,21 @@ private struct ShortcutRow: View {
                 .font(VFont.body)
                 .foregroundColor(VColor.textSecondary)
             Spacer()
-            Text(shortcut)
-                .font(VFont.mono)
-                .foregroundColor(VColor.textSecondary)
-                .padding(.horizontal, VSpacing.sm)
-                .padding(.vertical, VSpacing.xs)
-                .background(VColor.surface)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(VColor.surfaceBorder, lineWidth: 1)
-                )
+            HStack(spacing: VSpacing.xs) {
+                ForEach(shortcut.components(separatedBy: " "), id: \.self) { token in
+                    Text(token)
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textSecondary)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(VColor.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.xl)
+                                .stroke(VColor.surfaceBorder, lineWidth: 1)
+                        )
+                }
+            }
         }
         .padding(.vertical, VSpacing.md)
     }


### PR DESCRIPTION
## Summary
- Refactored shortcutKeyPill() to render each key symbol as its own individual rounded pill
- Updated ShortcutRow to use the same per-token pill pattern
- Changed corner radius from VRadius.md to VRadius.xl for more pill-like appearance matching design

Closes #10870

🤖 Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
