### PR TITLE
docs: architecture docs, tests, and final cleanup for guardian identity system

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -22,6 +22,43 @@ This document owns assistant-runtime architecture details. The repo-level archit
 - Voice calls mirror the same prompt contract: `CallController` receives guardian context on setup and refreshes it immediately after successful voice challenge verification, so the first post-verification turn is grounded as `actor_role: guardian`.
 - Voice-specific behavior (DTMF/speech verification flow, relay state machine) remains voice-local; only actor-role resolution is shared.
 
+### Vellum Guardian Identity Model (Actor Tokens + Bootstrap)
+
+The vellum channel (macOS desktop, iOS, CLI) uses an identity-bound actor token system to authenticate guardian identity on HTTP routes. This replaces the previous implicit trust model where all local connections were assumed to be the guardian.
+
+**Identity lifecycle:**
+
+1. **Startup migration** — On daemon start, `ensureVellumGuardianBinding()` (in `guardian-vellum-migration.ts`) backfills a `channel='vellum'` guardian binding with a stable `guardianPrincipalId` (format: `vellum-principal-<uuid>`). Existing installations get a binding with `verifiedVia: 'startup-migration'`; new installs get one via bootstrap. This migration is idempotent and preserves bindings for other channels (Telegram, SMS, etc.).
+
+2. **Hatch bootstrap** — After hatch, the macOS client calls `POST /v1/integrations/guardian/vellum/bootstrap` with `{ platform, deviceId }`. The endpoint is idempotent: it ensures a vellum guardian principal exists, revokes any prior token for the same device binding, mints a new HMAC-SHA256 signed actor token, stores only the SHA-256 hash, and returns `{ guardianPrincipalId, actorToken, isNew }`. The raw token is returned once and never persisted on the server.
+
+3. **iOS pairing** — When an iOS device completes pairing, the pairing response includes an `actorToken` minted against the same vellum guardian principal. The pairing handler in `pairing-routes.ts` calls `mintPairingActorToken()` which looks up the vellum binding and mints a device-specific token.
+
+4. **IPC identity** — Local IPC connections (Unix domain socket from the macOS native app) do not send actor tokens. Instead, the daemon assigns a deterministic local actor identity via `resolveLocalIpcGuardianContext()` in `local-actor-identity.ts`. This looks up the vellum guardian binding and routes through the same `resolveGuardianContext` trust pipeline used by HTTP channel ingress. When no vellum binding exists yet (pre-bootstrap), a fallback guardian context is returned since the local macOS user is inherently the guardian of their own machine.
+
+**Actor token format:** `base64url(JSON claims) + '.' + base64url(HMAC-SHA256 signature)`. Claims include `assistantId`, `platform`, `deviceId`, `guardianPrincipalId`, `iat`, `exp` (null for non-expiring), and `jti`.
+
+**Hash-only storage:** Only the SHA-256 hex digest of the raw token is persisted in the `actor_token_records` table. Token verification recomputes the hash and looks it up in the store to check revocation status. Tokens are scoped to `(assistantId, guardianPrincipalId, hashedDeviceId)` with a one-active-per-device invariant.
+
+**Signing key management:** A 32-byte random signing key is generated on first startup and persisted at `~/.vellum/protected/actor-token-signing-key` with `chmod 0o600`. The key is loaded on subsequent startups via `loadOrCreateSigningKey()`.
+
+**Strict HTTP enforcement:** Vellum-channel HTTP routes (POST /v1/messages, POST /v1/confirm, POST /v1/guardian-actions/decision, etc.) require a valid actor token via the `X-Actor-Token` header. The middleware in `middleware/actor-token.ts` verifies the HMAC signature, checks the token is active in the store, and resolves a guardian context through the standard trust pipeline. For backward compatibility with the CLI, requests without an actor token that originate from a loopback address (no `X-Forwarded-For` header) fall back to `resolveLocalIpcGuardianContext()`. Gateway-proxied requests (which carry `X-Forwarded-For`) without an actor token are rejected.
+
+**Notification scoping:** Guardian-sensitive notifications (e.g., approval requests, access request alerts) are annotated with `targetGuardianPrincipalId` so the notification pipeline can scope delivery to the correct guardian identity across devices.
+
+**Key source files:**
+
+| File | Purpose |
+|------|---------|
+| `src/runtime/actor-token-service.ts` | HMAC-SHA256 mint/verify, signing key management, `hashToken` |
+| `src/runtime/actor-token-store.ts` | Hash-only persistence: create, find by hash/device binding, revoke |
+| `src/runtime/middleware/actor-token.ts` | HTTP middleware: `verifyHttpActorToken`, `verifyHttpActorTokenWithLocalFallback`, `isActorBoundGuardian` |
+| `src/runtime/local-actor-identity.ts` | `resolveLocalIpcGuardianContext` — deterministic IPC identity |
+| `src/runtime/guardian-vellum-migration.ts` | `ensureVellumGuardianBinding` — startup binding backfill |
+| `src/runtime/routes/guardian-bootstrap-routes.ts` | `POST /v1/integrations/guardian/vellum/bootstrap` handler |
+| `src/runtime/routes/pairing-routes.ts` | `mintPairingActorToken` — actor token in pairing response |
+| `src/memory/guardian-bindings.ts` | Guardian binding persistence (shared across all channels) |
+
 ### Channel-Agnostic Scoped Approval Grants
 
 Scoped approval grants allow a guardian's approval decision on one channel (e.g., Telegram) to authorize a tool execution on a different channel (e.g., voice). Two scope modes exist: `request_id` (bound to a specific pending request) and `tool_signature` (bound to `toolName` + canonical `inputDigest`). Grants are one-time-use, exact-match, fail-closed, and TTL-bound. Full architecture details (lifecycle flow, security invariants, key files) live in [`docs/architecture/security.md`](docs/architecture/security.md#channel-agnostic-scoped-approval-grants).

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -271,6 +271,16 @@ The channel guardian service generates verification challenge instructions with 
 - **Rebind requirement:** Creating a new guardian challenge when a binding already exists requires `rebind: true` in the IPC request. Without it, the daemon returns `already_bound`. This prevents accidental guardian replacement.
 - **Takeover prevention:** Verification is rejected when an active binding exists for a different external user. Same-user re-verification is allowed.
 
+### Vellum Guardian Identity (Actor Tokens)
+
+The vellum channel (macOS, iOS, CLI) uses HMAC-SHA256 signed actor tokens to bind guardian identity to HTTP requests. This enables identity-based authentication for the local desktop/mobile channel, paralleling how external channels (Telegram, SMS) use `externalUserId` for guardian identity.
+
+- **Bootstrap**: After hatch, the macOS client calls `POST /v1/integrations/guardian/vellum/bootstrap` with `{ platform, deviceId }`. Returns `{ guardianPrincipalId, actorToken, isNew }`. The endpoint is idempotent -- repeated calls with the same device return the same principal but mint a fresh token (revoking the previous one).
+- **iOS pairing**: The pairing response includes an `actorToken` automatically when a vellum guardian binding exists.
+- **IPC fallback**: Local IPC (Unix socket) connections resolve identity server-side via `resolveLocalIpcGuardianContext()` without requiring an actor token. CLI connections that pass bearer auth but lack an actor token also use this fallback (as long as the request is direct, not proxied through the gateway).
+- **HTTP enforcement**: Vellum HTTP routes require either an `X-Actor-Token` header or a provably-local connection (no `X-Forwarded-For` header). Gateway-proxied requests without an actor token are rejected.
+- **Startup migration**: On daemon start, `ensureVellumGuardianBinding()` backfills a vellum guardian binding for existing installations so the identity system works without requiring a manual bootstrap step.
+
 ## Guardian Verification and Ingress ACL
 
 This section documents the end-to-end flow from guardian verification through ingress membership enforcement, showing how the two systems work together to gate channel access.

--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -1,6 +1,7 @@
 /**
- * Tests for actor-token mint/verify service, hash-only storage, and
- * guardian bootstrap endpoint idempotency.
+ * Tests for actor-token mint/verify service, hash-only storage,
+ * guardian bootstrap endpoint idempotency, HTTP middleware strict
+ * enforcement, and local IPC identity fallback.
  */
 import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -49,6 +50,11 @@ import {
   revokeByTokenHash,
 } from '../runtime/actor-token-store.js';
 import { ensureVellumGuardianBinding } from '../runtime/guardian-vellum-migration.js';
+import {
+  verifyHttpActorToken,
+  verifyHttpActorTokenWithLocalFallback,
+} from '../runtime/middleware/actor-token.js';
+import { resolveLocalIpcGuardianContext } from '../runtime/local-actor-identity.js';
 
 initializeDb();
 
@@ -401,5 +407,221 @@ describe('bootstrap endpoint idempotency', () => {
     // Same principal, different tokens
     expect(body2.guardianPrincipalId).toBe(body1.guardianPrincipalId);
     expect(body2.actorToken).not.toBe(body1.actorToken);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP middleware strict enforcement
+// ---------------------------------------------------------------------------
+
+describe('HTTP actor token middleware (strict enforcement)', () => {
+  test('rejects request without X-Actor-Token header', () => {
+    const req = new Request('http://localhost/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const result = verifyHttpActorToken(req);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+      expect(result.message).toContain('Missing X-Actor-Token');
+    }
+  });
+
+  test('rejects request with invalid (tampered) token', () => {
+    const { token } = mintActorToken({
+      assistantId: 'self',
+      platform: 'macos',
+      deviceId: 'device-tamper',
+      guardianPrincipalId: 'principal-tamper',
+    });
+
+    const parts = token.split('.');
+    const tampered = parts[0] + 'XXXXXX.' + parts[1];
+
+    const req = new Request('http://localhost/v1/messages', {
+      method: 'POST',
+      headers: { 'X-Actor-Token': tampered },
+    });
+
+    const result = verifyHttpActorToken(req);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+    }
+  });
+
+  test('rejects request with revoked token', () => {
+    const principalId = ensureVellumGuardianBinding('self');
+    const { token, tokenHash } = mintActorToken({
+      assistantId: 'self',
+      platform: 'macos',
+      deviceId: 'device-revoked',
+      guardianPrincipalId: principalId,
+    });
+
+    createActorTokenRecord({
+      tokenHash,
+      assistantId: 'self',
+      guardianPrincipalId: principalId,
+      hashedDeviceId: 'hashed-device-revoked',
+      platform: 'macos',
+      issuedAt: Date.now(),
+    });
+
+    // Revoke the token
+    revokeByTokenHash(tokenHash);
+
+    const req = new Request('http://localhost/v1/messages', {
+      method: 'POST',
+      headers: { 'X-Actor-Token': token },
+    });
+
+    const result = verifyHttpActorToken(req);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+      expect(result.message).toContain('no longer active');
+    }
+  });
+
+  test('accepts request with valid active token and resolves guardian context', () => {
+    const principalId = ensureVellumGuardianBinding('self');
+    const { token, tokenHash } = mintActorToken({
+      assistantId: 'self',
+      platform: 'macos',
+      deviceId: 'device-valid',
+      guardianPrincipalId: principalId,
+    });
+
+    createActorTokenRecord({
+      tokenHash,
+      assistantId: 'self',
+      guardianPrincipalId: principalId,
+      hashedDeviceId: 'hashed-device-valid',
+      platform: 'macos',
+      issuedAt: Date.now(),
+    });
+
+    const req = new Request('http://localhost/v1/messages', {
+      method: 'POST',
+      headers: { 'X-Actor-Token': token },
+    });
+
+    const result = verifyHttpActorToken(req);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.claims.assistantId).toBe('self');
+      expect(result.claims.guardianPrincipalId).toBe(principalId);
+      expect(result.guardianContext).toBeTruthy();
+      expect(result.guardianContext.trustClass).toBe('guardian');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Local IPC fallback (verifyHttpActorTokenWithLocalFallback)
+// ---------------------------------------------------------------------------
+
+describe('HTTP actor token local fallback', () => {
+  test('falls back to local IPC identity when no actor token and no forwarding header', () => {
+    ensureVellumGuardianBinding('self');
+
+    const req = new Request('http://localhost/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const result = verifyHttpActorTokenWithLocalFallback(req);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.guardianContext.trustClass).toBe('guardian');
+      // localFallback should be true when claims are null
+      if ('localFallback' in result) {
+        expect(result.localFallback).toBe(true);
+        expect(result.claims).toBeNull();
+      }
+    }
+  });
+
+  test('rejects gateway-proxied request without actor token (X-Forwarded-For present)', () => {
+    ensureVellumGuardianBinding('self');
+
+    const req = new Request('http://localhost/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Forwarded-For': '1.2.3.4',
+      },
+    });
+
+    const result = verifyHttpActorTokenWithLocalFallback(req);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+      expect(result.message).toContain('Proxied requests require actor identity');
+    }
+  });
+
+  test('uses strict verification when actor token is present even with X-Forwarded-For', () => {
+    const principalId = ensureVellumGuardianBinding('self');
+    const { token, tokenHash } = mintActorToken({
+      assistantId: 'self',
+      platform: 'ios',
+      deviceId: 'device-proxied',
+      guardianPrincipalId: principalId,
+    });
+
+    createActorTokenRecord({
+      tokenHash,
+      assistantId: 'self',
+      guardianPrincipalId: principalId,
+      hashedDeviceId: 'hashed-device-proxied',
+      platform: 'ios',
+      issuedAt: Date.now(),
+    });
+
+    const req = new Request('http://localhost/v1/messages', {
+      method: 'POST',
+      headers: {
+        'X-Actor-Token': token,
+        'X-Forwarded-For': '1.2.3.4',
+      },
+    });
+
+    const result = verifyHttpActorTokenWithLocalFallback(req);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.claims).not.toBeNull();
+      expect(result.guardianContext.trustClass).toBe('guardian');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Local IPC identity resolution
+// ---------------------------------------------------------------------------
+
+describe('resolveLocalIpcGuardianContext', () => {
+  test('returns guardian context when vellum binding exists', () => {
+    ensureVellumGuardianBinding('self');
+
+    const ctx = resolveLocalIpcGuardianContext();
+    expect(ctx.trustClass).toBe('guardian');
+    expect(ctx.sourceChannel).toBe('vellum');
+  });
+
+  test('returns fallback guardian context when no vellum binding exists', () => {
+    // No binding created — fresh DB state
+    const ctx = resolveLocalIpcGuardianContext();
+    expect(ctx.trustClass).toBe('guardian');
+    expect(ctx.sourceChannel).toBe('vellum');
+  });
+
+  test('respects custom sourceChannel parameter', () => {
+    ensureVellumGuardianBinding('self');
+    const ctx = resolveLocalIpcGuardianContext('vellum');
+    expect(ctx.sourceChannel).toBe('vellum');
   });
 });

--- a/assistant/src/runtime/guardian-action-followup-executor.ts
+++ b/assistant/src/runtime/guardian-action-followup-executor.ts
@@ -1,7 +1,7 @@
 /**
  * Guardian action follow-up executor.
  *
- * After the conversation engine (M5) classifies the guardian's reply as
+ * After the conversation engine classifies the guardian's reply as
  * `call_back` or `message_back` and transitions the follow-up state to
  * `dispatching`, this module executes the actual action:
  *

--- a/assistant/src/runtime/middleware/actor-token.ts
+++ b/assistant/src/runtime/middleware/actor-token.ts
@@ -7,7 +7,7 @@
  *
  * Used by vellum-channel HTTP routes (POST /v1/messages, POST /v1/confirm,
  * POST /v1/guardian-actions/decision, etc.) to enforce identity-based
- * authentication after the M5 cutover.
+ * authentication.
  *
  * For backward compatibility with bearer-authenticated local clients (CLI),
  * provides fallback functions that resolve identity through the local IPC

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -4,8 +4,8 @@
  * These endpoints resolve pending confirmations, secrets, and trust rules
  * by requestId — orthogonal to message sending.
  *
- * After M5 cutover: all approval endpoints require a valid actor token
- * via the X-Actor-Token header. Guardian decisions additionally verify
+ * All approval endpoints require a valid actor token via the X-Actor-Token
+ * header (with local CLI fallback). Guardian decisions additionally verify
  * that the actor is the bound guardian.
  */
 import { getConversationByKey } from '../../memory/conversation-key-store.js';

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -4,9 +4,9 @@
  * These endpoints let desktop clients fetch pending guardian prompts and
  * submit button decisions without relying on text parsing.
  *
- * After M5 cutover: all guardian action endpoints require a valid actor
- * token via the X-Actor-Token header, and guardian decisions additionally
- * verify the actor is the bound guardian.
+ * All guardian action endpoints require a valid actor token via the
+ * X-Actor-Token header (with local CLI fallback). Guardian decisions
+ * additionally verify the actor is the bound guardian.
  */
 import {
   applyCanonicalGuardianDecision,


### PR DESCRIPTION
## Summary
- Updates `assistant/ARCHITECTURE.md` with a new "Vellum Guardian Identity Model" section documenting actor tokens, bootstrap endpoint, hatch auto-bootstrap, iOS pairing, IPC identity, strict HTTP enforcement, and notification scoping
- Updates `assistant/README.md` with guardian identity and pairing behavior overview
- Adds test coverage for HTTP middleware strict enforcement, local IPC fallback, revoked token rejection, and gateway-proxied request rejection
- Removes deprecated "M5 cutover" milestone references from comments in approval-routes.ts, guardian-action-routes.ts, actor-token.ts middleware, and guardian-action-followup-executor.ts

## Test plan
- [ ] Verify actor-token-service tests pass including new middleware and IPC fallback tests
- [ ] Confirm architecture docs accurately describe shipped behavior
- [ ] Verify no stale "M5 cutover" or "trusted-default" references remain

Part of #10758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
