### PR TITLE
fix: unused assistantId lint errors in telegram/whatsapp deliver routes

### DIFF
--- a/gateway/src/http/routes/telegram-deliver.ts
+++ b/gateway/src/http/routes/telegram-deliver.ts
@@ -43,7 +43,7 @@ export function createTelegramDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "Invalid JSON" }, { status: 400 });
     }
 
-    const { chatId, text, assistantId, attachments, approval, chatAction } = body;
+    const { chatId, text, assistantId: _assistantId, attachments, approval, chatAction } = body;
 
     if (!chatId || typeof chatId !== "string") {
       return Response.json({ error: "chatId is required" }, { status: 400 });

--- a/gateway/src/http/routes/whatsapp-deliver.ts
+++ b/gateway/src/http/routes/whatsapp-deliver.ts
@@ -60,7 +60,7 @@ export function createWhatsAppDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "to is required" }, { status: 400 });
     }
 
-    const { text, assistantId, attachments, approval } = body;
+    const { text, assistantId: _assistantId, attachments, approval } = body;
 
     if (text !== undefined && typeof text !== "string") {
       return Response.json({ error: "text must be a string" }, { status: 400 });


### PR DESCRIPTION
## Summary
- Prefixed unused `assistantId` destructured variables with `_` in `telegram-deliver.ts` and `whatsapp-deliver.ts` to fix `@typescript-eslint/no-unused-vars` lint errors

## Original prompt
fix this CI failure: https://github.com/vellum-ai/vellum-assistant/actions/runs/22531666042/job/65271878387

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
