### PR TITLE
fix: drop removed assistantId param from Twilio and Guardian IPC callers

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1063,7 +1063,7 @@ public final class SettingsStore: ObservableObject {
                 twilioPhoneRefreshPending = false
                 return
             }
-            try daemonClient.sendTwilioConfig(action: "get", assistantId: twilioAssistantScope)
+            try daemonClient.sendTwilioConfig(action: "get")
         } catch {
             twilioSaveInProgress = false
             twilioPhoneRefreshPending = false
@@ -1086,8 +1086,7 @@ public final class SettingsStore: ObservableObject {
             try daemonClient.sendTwilioConfig(
                 action: "set_credentials",
                 accountSid: trimmedSid,
-                authToken: trimmedToken,
-                assistantId: twilioAssistantScope
+                authToken: trimmedToken
             )
         } catch {
             twilioSaveInProgress = false
@@ -1104,7 +1103,7 @@ public final class SettingsStore: ObservableObject {
                 twilioSaveInProgress = false
                 return
             }
-            try daemonClient.sendTwilioConfig(action: "clear_credentials", assistantId: twilioAssistantScope)
+            try daemonClient.sendTwilioConfig(action: "clear_credentials")
         } catch {
             twilioSaveInProgress = false
             twilioError = "Failed to clear Twilio credentials: \(error.localizedDescription)"
@@ -1126,8 +1125,7 @@ public final class SettingsStore: ObservableObject {
             }
             try daemonClient.sendTwilioConfig(
                 action: "assign_number",
-                phoneNumber: trimmed,
-                assistantId: twilioAssistantScope
+                phoneNumber: trimmed
             )
         } catch {
             twilioSaveInProgress = false
@@ -1152,8 +1150,7 @@ public final class SettingsStore: ObservableObject {
             try daemonClient.sendTwilioConfig(
                 action: "provision_number",
                 areaCode: (trimmedAreaCode?.isEmpty == false) ? trimmedAreaCode : nil,
-                country: (trimmedCountry?.isEmpty == false) ? trimmedCountry?.uppercased() : nil,
-                assistantId: twilioAssistantScope
+                country: (trimmedCountry?.isEmpty == false) ? trimmedCountry?.uppercased() : nil
             )
         } catch {
             twilioSaveInProgress = false
@@ -1172,7 +1169,7 @@ public final class SettingsStore: ObservableObject {
                 twilioNumbersRefreshPending = false
                 return
             }
-            try daemonClient.sendTwilioConfig(action: "list_numbers", assistantId: twilioAssistantScope)
+            try daemonClient.sendTwilioConfig(action: "list_numbers")
         } catch {
             twilioListInProgress = false
             twilioNumbersRefreshPending = false
@@ -1184,7 +1181,7 @@ public final class SettingsStore: ObservableObject {
 
     func refreshChannelGuardianStatus(channel: String) {
         do {
-            try daemonClient?.sendGuardianVerification(action: "status", channel: channel, assistantId: guardianAssistantScope)
+            try daemonClient?.sendGuardianVerification(action: "status", channel: channel)
         } catch {
             log.error("Failed to refresh \(channel) guardian status: \(error)")
         }
@@ -1234,7 +1231,6 @@ public final class SettingsStore: ObservableObject {
             try daemonClient.sendGuardianVerification(
                 action: "create_challenge",
                 channel: channel,
-                assistantId: guardianAssistantScope,
                 rebind: rebind ? true : nil
             )
         } catch {
@@ -1274,7 +1270,7 @@ public final class SettingsStore: ObservableObject {
         }
         // Invalidate the pending challenge token on the backend so it can't be used after cancellation
         do {
-            try daemonClient?.sendGuardianVerification(action: "revoke", channel: channel, assistantId: guardianAssistantScope)
+            try daemonClient?.sendGuardianVerification(action: "revoke", channel: channel)
         } catch {
             log.error("Failed to revoke \(channel) guardian challenge on cancel: \(error)")
         }
@@ -1296,7 +1292,7 @@ public final class SettingsStore: ObservableObject {
             break
         }
         do {
-            try daemonClient?.sendGuardianVerification(action: "revoke", channel: channel, assistantId: guardianAssistantScope)
+            try daemonClient?.sendGuardianVerification(action: "revoke", channel: channel)
         } catch {
             log.error("Failed to revoke \(channel) guardian: \(error)")
         }
@@ -1417,7 +1413,6 @@ public final class SettingsStore: ObservableObject {
             try daemonClient.sendGuardianVerification(
                 action: "start_outbound",
                 channel: channel,
-                assistantId: guardianAssistantScope,
                 destination: destination
             )
         } catch {
@@ -1442,8 +1437,7 @@ public final class SettingsStore: ObservableObject {
         do {
             try daemonClient?.sendGuardianVerification(
                 action: "resend_outbound",
-                channel: channel,
-                assistantId: guardianAssistantScope
+                channel: channel
             )
         } catch {
             log.error("Failed to resend outbound \(channel) guardian verification: \(error)")
@@ -1466,8 +1460,7 @@ public final class SettingsStore: ObservableObject {
         do {
             try daemonClient?.sendGuardianVerification(
                 action: "cancel_outbound",
-                channel: channel,
-                assistantId: guardianAssistantScope
+                channel: channel
             )
         } catch {
             log.error("Failed to cancel outbound \(channel) guardian verification: \(error)")

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1136,17 +1136,17 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         action: String,
         channel: String? = nil,
         sessionId: String? = nil,
-        assistantId: String? = nil,
         rebind: Bool? = nil,
-        destination: String? = nil
+        destination: String? = nil,
+        originConversationId: String? = nil
     ) throws {
         try send(GuardianVerificationRequestMessage(
             action: action,
             channel: channel,
             sessionId: sessionId,
-            assistantId: assistantId,
             rebind: rebind,
-            destination: destination
+            destination: destination,
+            originConversationId: originConversationId
         ))
     }
 
@@ -1162,8 +1162,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         authToken: String? = nil,
         phoneNumber: String? = nil,
         areaCode: String? = nil,
-        country: String? = nil,
-        assistantId: String? = nil
+        country: String? = nil
     ) throws {
         try send(TwilioConfigRequestMessage(
             action: action,
@@ -1171,8 +1170,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             authToken: authToken,
             phoneNumber: phoneNumber,
             areaCode: areaCode,
-            country: country,
-            assistantId: assistantId
+            country: country
         ))
     }
 

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2004,8 +2004,7 @@ extension IPCTwilioConfigRequest {
         authToken: String? = nil,
         phoneNumber: String? = nil,
         areaCode: String? = nil,
-        country: String? = nil,
-        assistantId: String? = nil
+        country: String? = nil
     ) {
         self.init(
             type: "twilio_config",
@@ -2014,8 +2013,7 @@ extension IPCTwilioConfigRequest {
             authToken: authToken,
             phoneNumber: phoneNumber,
             areaCode: areaCode,
-            country: country,
-            assistantId: assistantId
+            country: country
         )
     }
 }
@@ -2041,18 +2039,18 @@ extension IPCGuardianVerificationRequest {
         action: String,
         channel: String? = nil,
         sessionId: String? = nil,
-        assistantId: String? = nil,
         rebind: Bool? = nil,
-        destination: String? = nil
+        destination: String? = nil,
+        originConversationId: String? = nil
     ) {
         self.init(
             type: "guardian_verification",
             action: action,
             channel: channel,
             sessionId: sessionId,
-            assistantId: assistantId,
             rebind: rebind,
-            destination: destination
+            destination: destination,
+            originConversationId: originConversationId
         )
     }
 }


### PR DESCRIPTION
## Summary
- `IPCTwilioConfigRequest` and `IPCGuardianVerificationRequest` dropped the `assistantId` field in a recent IPC contract update
- Updates `IPCMessages.swift` and `DaemonClient.swift` convenience inits to match the generated types
- Removes `assistantId` argument from all `sendTwilioConfig` and `sendGuardianVerification` callers in `SettingsStore.swift`
- Restores build on main (was failing with "extra argument 'assistantId' in call")

## Test plan
- [ ] `./build.sh` succeeds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
