### PR TITLE
fix: VCard border — use adaptive VColor.surfaceBorder instead of hardcoded hex

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/VCard.swift
+++ b/clients/shared/DesignSystem/Components/Display/VCard.swift
@@ -16,7 +16,7 @@ public struct VCard<Content: View>: View {
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .overlay(
                 RoundedRectangle(cornerRadius: VRadius.md)
-                    .stroke(Color(hex: 0xE8E6DA), lineWidth: 2)
+                    .stroke(VColor.surfaceBorder, lineWidth: 1)
             )
     }
 }

--- a/clients/shared/DesignSystem/Modifiers/CardModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/CardModifier.swift
@@ -15,7 +15,7 @@ public struct CardModifier: ViewModifier {
             .clipShape(RoundedRectangle(cornerRadius: radius))
             .overlay(
                 RoundedRectangle(cornerRadius: radius)
-                    .stroke(Color(hex: 0xE8E6DA), lineWidth: 2)
+                    .stroke(VColor.surfaceBorder, lineWidth: 1)
             )
     }
 }


### PR DESCRIPTION
## Summary
- VCard and `.vCard()` modifier had a hardcoded `Color(hex: 0xE8E6DA)` border — this is Moss._100, the light-mode value of `surfaceBorder`, so it appeared too bright/harsh in dark mode
- Replace with `VColor.surfaceBorder` (adaptive: Moss._100 light / Moss._600 dark) so the border matches the separator tone in both modes
- Reduce `lineWidth` from 2 → 1 to match the visual weight of other dividers

## Test plan
- [ ] VCard borders look correct in both light and dark mode
- [ ] Border matches the Settings tab separator line visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
