### PR TITLE
fix: pass through guardian notifications when local principal not yet initialized

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -320,10 +320,12 @@ extension AppDelegate {
 
     func deliverNotificationIntent(_ msg: NotificationIntentMessage) {
         // Guardian scoping: skip notifications targeted at a different guardian.
+        // When the local principal is nil (not yet bootstrapped), pass through all
+        // notifications so urgent prompts aren't silently missed during startup.
         if let target = msg.targetGuardianPrincipalId {
             let localId = ActorTokenManager.getGuardianPrincipalId()
-            if localId == nil || localId != target {
-                log.info("Skipping notification_intent for guardian \(target) — local guardian is \(localId ?? "nil")")
+            if let localId, localId != target {
+                log.info("Skipping notification_intent for guardian \(target) — local guardian is \(localId)")
                 // Ack so the delivery audit trail stays consistent
                 if let deliveryId = msg.deliveryId {
                     sendNotificationIntentResult(deliveryId: deliveryId, success: true, errorMessage: nil, errorCode: nil)

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -287,11 +287,13 @@ extension AppDelegate {
     /// backgrounded to guarantee delivery if the notification_intent IPC is late.
     func handleNotificationThreadCreated(_ msg: IPCNotificationThreadCreated) {
         // Guardian scoping: skip thread creation for notifications targeted at
-        // a different guardian identity.
+        // a different guardian identity. When the local principal is nil (not yet
+        // bootstrapped), pass through all notifications so urgent prompts aren't
+        // silently missed during startup.
         if let target = msg.targetGuardianPrincipalId {
             let localId = ActorTokenManager.getGuardianPrincipalId()
-            if localId == nil || localId != target {
-                log.info("Skipping notification_thread_created for guardian \(target) — local guardian is \(localId ?? "nil")")
+            if let localId, localId != target {
+                log.info("Skipping notification_thread_created for guardian \(target) — local guardian is \(localId)")
                 return
             }
         }


### PR DESCRIPTION
Addresses Codex P2 feedback on #10844: when ActorTokenManager.getGuardianPrincipalId() is nil (startup/bootstrap window), guardian notifications now pass through instead of being dropped. Only filters when local principal is known and doesn't match.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
