### PR TITLE
ci: add workflow_dispatch trigger to CI Main iOS Build

### DIFF
--- a/.github/workflows/ci-main-ios.yaml
+++ b/.github/workflows/ci-main-ios.yaml
@@ -1,6 +1,7 @@
 name: CI Main iOS Build
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to the CI Main iOS Build workflow so it can be triggered manually from the GitHub Actions UI

## Original prompt
Add a workflow dispatch trigger to CI Main iOS Build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
