### PR TITLE
Fix pending confirmation bubble on valid NL decision replies

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -262,7 +262,7 @@ struct MessageListView: View {
                     }
 
                     let lastVisible = displayMessages.last
-                    let hasPendingConfirmation = lastVisible?.confirmation?.state == .pending
+                    let hasPendingConfirmation = displayMessages.contains(where: { $0.confirmation?.state == .pending })
                     let currentTurnMessages: ArraySlice<ChatMessage> = {
                         if isSending, let last = displayMessages.last, last.role == .user {
                             let lastNonUser = displayMessages.last(where: {

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -108,6 +108,58 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.errorText)
     }
 
+    func testSendMessageDoesNotPrematurelyDenyPendingConfirmationForExplicitApprovePhrase() {
+        viewModel.sessionId = "sess-1"
+        var confirmation = ToolConfirmationData(
+            requestId: "req-approve",
+            toolName: "bash",
+            input: ["command": AnyCodable("ls -la")],
+            riskLevel: "low",
+            diff: nil,
+            allowlistOptions: [],
+            scopeOptions: [],
+            executionTarget: "host",
+            persistentDecisionsAllowed: true
+        )
+        confirmation.state = .pending
+        viewModel.messages.append(ChatMessage(role: .assistant, text: "", confirmation: confirmation))
+
+        viewModel.inputText = "approve"
+        viewModel.sendMessage()
+
+        XCTAssertEqual(
+            viewModel.messages.first(where: { $0.confirmation?.requestId == "req-approve" })?.confirmation?.state,
+            .pending,
+            "Explicit natural-language approval phrases should keep pending confirmation state until daemon resolution"
+        )
+    }
+
+    func testSendMessageStillPreemptivelyDeniesPendingConfirmationForRegularFollowUpText() {
+        viewModel.sessionId = "sess-1"
+        var confirmation = ToolConfirmationData(
+            requestId: "req-follow-up",
+            toolName: "bash",
+            input: ["command": AnyCodable("ls -la")],
+            riskLevel: "low",
+            diff: nil,
+            allowlistOptions: [],
+            scopeOptions: [],
+            executionTarget: "host",
+            persistentDecisionsAllowed: true
+        )
+        confirmation.state = .pending
+        viewModel.messages.append(ChatMessage(role: .assistant, text: "", confirmation: confirmation))
+
+        viewModel.inputText = "can you explain what this command does?"
+        viewModel.sendMessage()
+
+        XCTAssertEqual(
+            viewModel.messages.first(where: { $0.confirmation?.requestId == "req-follow-up" })?.confirmation?.state,
+            .denied,
+            "Non-decision follow-up text should keep the existing optimistic auto-deny behavior"
+        )
+    }
+
     // MARK: - Session Info
 
     func testSessionInfoStoresSessionId() {

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -108,7 +108,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.errorText)
     }
 
-    func testSendMessageDoesNotPrematurelyDenyPendingConfirmationForExplicitApprovePhrase() {
+    func testSendMessageOptimisticallyApprovesSinglePendingConfirmationForExplicitApprovePhrase() {
         viewModel.sessionId = "sess-1"
         var confirmation = ToolConfirmationData(
             requestId: "req-approve",
@@ -129,8 +129,34 @@ final class ChatViewModelTests: XCTestCase {
 
         XCTAssertEqual(
             viewModel.messages.first(where: { $0.confirmation?.requestId == "req-approve" })?.confirmation?.state,
-            .pending,
-            "Explicit natural-language approval phrases should keep pending confirmation state until daemon resolution"
+            .approved,
+            "Explicit natural-language approval phrases should optimistically resolve a single pending confirmation"
+        )
+    }
+
+    func testSendMessageOptimisticallyDeniesSinglePendingConfirmationForExplicitRejectPhrase() {
+        viewModel.sessionId = "sess-1"
+        var confirmation = ToolConfirmationData(
+            requestId: "req-reject",
+            toolName: "bash",
+            input: ["command": AnyCodable("ls -la")],
+            riskLevel: "low",
+            diff: nil,
+            allowlistOptions: [],
+            scopeOptions: [],
+            executionTarget: "host",
+            persistentDecisionsAllowed: true
+        )
+        confirmation.state = .pending
+        viewModel.messages.append(ChatMessage(role: .assistant, text: "", confirmation: confirmation))
+
+        viewModel.inputText = "no"
+        viewModel.sendMessage()
+
+        XCTAssertEqual(
+            viewModel.messages.first(where: { $0.confirmation?.requestId == "req-reject" })?.confirmation?.state,
+            .denied,
+            "Explicit rejection phrases should optimistically resolve a single pending confirmation as denied"
         )
     }
 
@@ -157,6 +183,51 @@ final class ChatViewModelTests: XCTestCase {
             viewModel.messages.first(where: { $0.confirmation?.requestId == "req-follow-up" })?.confirmation?.state,
             .denied,
             "Non-decision follow-up text should keep the existing optimistic auto-deny behavior"
+        )
+    }
+
+    func testSendMessageKeepsPendingConfirmationsWhenDecisionPhraseIsAmbiguousAcrossMultipleRequests() {
+        viewModel.sessionId = "sess-1"
+        var confirmationA = ToolConfirmationData(
+            requestId: "req-a",
+            toolName: "bash",
+            input: ["command": AnyCodable("ls -la")],
+            riskLevel: "low",
+            diff: nil,
+            allowlistOptions: [],
+            scopeOptions: [],
+            executionTarget: "host",
+            persistentDecisionsAllowed: true
+        )
+        confirmationA.state = .pending
+        var confirmationB = ToolConfirmationData(
+            requestId: "req-b",
+            toolName: "bash",
+            input: ["command": AnyCodable("pwd")],
+            riskLevel: "low",
+            diff: nil,
+            allowlistOptions: [],
+            scopeOptions: [],
+            executionTarget: "host",
+            persistentDecisionsAllowed: true
+        )
+        confirmationB.state = .pending
+
+        viewModel.messages.append(ChatMessage(role: .assistant, text: "", confirmation: confirmationA))
+        viewModel.messages.append(ChatMessage(role: .assistant, text: "", confirmation: confirmationB))
+
+        viewModel.inputText = "approve"
+        viewModel.sendMessage()
+
+        XCTAssertEqual(
+            viewModel.messages.first(where: { $0.confirmation?.requestId == "req-a" })?.confirmation?.state,
+            .pending,
+            "Decision phrases should not pre-resolve when multiple pending confirmations exist"
+        )
+        XCTAssertEqual(
+            viewModel.messages.first(where: { $0.confirmation?.requestId == "req-b" })?.confirmation?.state,
+            .pending,
+            "Decision phrases should not pre-resolve when multiple pending confirmations exist"
         )
     }
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -458,8 +458,10 @@ public final class ChatViewModel: ObservableObject {
 
     /// Deterministic approval/reject phrases consumed inline by the daemon's
     /// guardian router. Keep this list in sync with guardian-reply-router.ts.
-    private static let explicitInlineConfirmationDecisionPhrases: Set<String> = [
+    private static let explicitInlineConfirmationApprovePhrases: Set<String> = [
         "approve", "approved", "approve once", "yes", "y", "allow", "go for it", "go ahead", "proceed", "do it",
+    ]
+    private static let explicitInlineConfirmationRejectPhrases: Set<String> = [
         "reject", "deny", "decline", "no", "n", "block", "cancel",
     ]
 
@@ -471,17 +473,23 @@ public final class ChatViewModel: ObservableObject {
             .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
     }
 
-    /// Returns true when the outbound user message is a plain-text approval/reject
-    /// reply intended to answer an inline confirmation prompt.
-    private static func isLikelyInlineConfirmationDecisionMessage(
+    /// Infer a deterministic inline confirmation decision from outbound user text.
+    /// Returns nil when the text is not an explicit decision phrase.
+    private static func inferInlineConfirmationDecision(
         rawText: String,
         hasAttachments: Bool,
         hasSkillInvocation: Bool
-    ) -> Bool {
-        guard !hasAttachments, !hasSkillInvocation else { return false }
+    ) -> String? {
+        guard !hasAttachments, !hasSkillInvocation else { return nil }
         let normalized = normalizeDecisionPhrase(rawText)
-        guard !normalized.isEmpty else { return false }
-        return explicitInlineConfirmationDecisionPhrases.contains(normalized)
+        guard !normalized.isEmpty else { return nil }
+        if explicitInlineConfirmationApprovePhrases.contains(normalized) {
+            return "allow"
+        }
+        if explicitInlineConfirmationRejectPhrases.contains(normalized) {
+            return "deny"
+        }
+        return nil
     }
 
     /// Number of messages currently revealed at the top of the conversation.
@@ -932,14 +940,26 @@ public final class ChatViewModel: ObservableObject {
         guard !text.isEmpty || hasAttachments || hasSkillInvocation else { return }
 
         // For ordinary follow-up messages, pessimistically mark pending prompts as denied
-        // to match daemon auto-deny behavior. Skip this for explicit approval/reject text
-        // because those replies are consumed inline by the daemon and should not flash a
-        // premature denied state in the UI.
-        if !Self.isLikelyInlineConfirmationDecisionMessage(
+        // to match daemon auto-deny behavior.
+        //
+        // For deterministic approval/reject text replies:
+        // - if there is exactly one pending confirmation, optimistically resolve it in
+        //   the UI immediately so the decision bubble does not linger after the user reply
+        // - otherwise leave pending confirmations unchanged (message may be routed as a
+        //   normal chat turn or require disambiguation server-side)
+        if let inlineDecision = Self.inferInlineConfirmationDecision(
             rawText: rawText,
             hasAttachments: hasAttachments,
             hasSkillInvocation: hasSkillInvocation
         ) {
+            let pendingConfirmationIndices = messages.indices.filter {
+                messages[$0].confirmation?.state == .pending
+            }
+            if pendingConfirmationIndices.count == 1 {
+                let idx = pendingConfirmationIndices[0]
+                messages[idx].confirmation?.state = inlineDecision == "allow" ? .approved : .denied
+            }
+        } else {
             for i in messages.indices where messages[i].confirmation?.state == .pending {
                 messages[i].confirmation?.state = .denied
             }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -456,6 +456,34 @@ public final class ChatViewModel: ObservableObject {
     /// Page size for chat message display; older messages are loaded in this increment.
     public static let messagePageSize = 50
 
+    /// Deterministic approval/reject phrases consumed inline by the daemon's
+    /// guardian router. Keep this list in sync with guardian-reply-router.ts.
+    private static let explicitInlineConfirmationDecisionPhrases: Set<String> = [
+        "approve", "approved", "approve once", "yes", "y", "allow", "go for it", "go ahead", "proceed", "do it",
+        "reject", "deny", "decline", "no", "n", "block", "cancel",
+    ]
+
+    private static func normalizeDecisionPhrase(_ text: String) -> String {
+        text
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "[.!?]+$", with: "", options: .regularExpression)
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+    }
+
+    /// Returns true when the outbound user message is a plain-text approval/reject
+    /// reply intended to answer an inline confirmation prompt.
+    private static func isLikelyInlineConfirmationDecisionMessage(
+        rawText: String,
+        hasAttachments: Bool,
+        hasSkillInvocation: Bool
+    ) -> Bool {
+        guard !hasAttachments, !hasSkillInvocation else { return false }
+        let normalized = normalizeDecisionPhrase(rawText)
+        guard !normalized.isEmpty else { return false }
+        return explicitInlineConfirmationDecisionPhrases.contains(normalized)
+    }
+
     /// Number of messages currently revealed at the top of the conversation.
     /// The view slices `messages` to `messages.suffix(displayedMessageCount)`.
     /// Grows by `messagePageSize` each time the user scrolls to the top.
@@ -903,10 +931,18 @@ public final class ChatViewModel: ObservableObject {
         let hasSkillInvocation = pendingSkillInvocation != nil
         guard !text.isEmpty || hasAttachments || hasSkillInvocation else { return }
 
-        // If there are pending tool confirmations, mark them all as denied in the UI.
-        // The daemon auto-denies them all server-side when it receives this message.
-        for i in messages.indices where messages[i].confirmation?.state == .pending {
-            messages[i].confirmation?.state = .denied
+        // For ordinary follow-up messages, pessimistically mark pending prompts as denied
+        // to match daemon auto-deny behavior. Skip this for explicit approval/reject text
+        // because those replies are consumed inline by the daemon and should not flash a
+        // premature denied state in the UI.
+        if !Self.isLikelyInlineConfirmationDecisionMessage(
+            rawText: rawText,
+            hasAttachments: hasAttachments,
+            hasSkillInvocation: hasSkillInvocation
+        ) {
+            for i in messages.indices where messages[i].confirmation?.state == .pending {
+                messages[i].confirmation?.state = .denied
+            }
         }
 
         // When "/model" or "/models" is sent, refresh model state so the picker/table has fresh data


### PR DESCRIPTION
## Summary\n- optimistically resolve exactly one pending confirmation when the user sends a deterministic approval/reject phrase (e.g. "approve", "yes", "allow", "no")\n- keep pending confirmation UI unchanged for ambiguous decision phrases (multiple pending requests)\n- preserve existing auto-deny behavior for regular non-decision follow-up messages\n\n## Testing\n- swift test --filter ChatViewModelTests/testSendMessageOptimisticallyApprovesSinglePendingConfirmationForExplicitApprovePhrase --package-path clients\n- swift test --filter ChatViewModelTests/testSendMessageOptimisticallyDeniesSinglePendingConfirmationForExplicitRejectPhrase --package-path clients\n- swift test --filter ChatViewModelTests/testSendMessageKeepsPendingConfirmationsWhenDecisionPhraseIsAmbiguousAcrossMultipleRequests --package-path clients\n- swift test --filter ChatViewModelTests/testSendMessageStillPreemptivelyDeniesPendingConfirmationForRegularFollowUpText --package-path clients\n
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
