### PR TITLE
Refactor: use canonical actor-context helpers in guardian decision paths

### DIFF
--- a/assistant/src/approvals/actor-context.ts
+++ b/assistant/src/approvals/actor-context.ts
@@ -1,0 +1,38 @@
+/**
+ * Canonical actor context used by guardian decision flows.
+ *
+ * Keeps identity normalization and trusted/untrusted construction consistent
+ * across HTTP, IPC, and channel reply routing paths.
+ */
+
+export interface ActorContext {
+  /** External user ID of the deciding actor (undefined for desktop/trusted). */
+  externalUserId: string | undefined;
+  /** Channel the decision arrived on. */
+  channel: string;
+  /** Whether the actor is a trusted/desktop context. */
+  isTrusted: boolean;
+}
+
+export function buildActorContext(params: {
+  channel: string;
+  externalUserId?: string | null;
+  isTrusted: boolean;
+}): ActorContext {
+  const externalUserId = typeof params.externalUserId === 'string' && params.externalUserId.trim().length > 0
+    ? params.externalUserId.trim()
+    : undefined;
+  return {
+    externalUserId,
+    channel: params.channel,
+    isTrusted: params.isTrusted,
+  };
+}
+
+export function buildTrustedActorContext(channel: string): ActorContext {
+  return {
+    externalUserId: undefined,
+    channel,
+    isTrusted: true,
+  };
+}

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -24,6 +24,7 @@ import * as pendingInteractions from '../runtime/pending-interactions.js';
 import { getTool } from '../tools/registry.js';
 import { TC_GRANT_WAIT_MAX_MS } from '../tools/tool-approval-handler.js';
 import { getLogger } from '../util/logger.js';
+import type { ActorContext } from './actor-context.js';
 
 const log = getLogger('guardian-request-resolvers');
 
@@ -35,15 +36,7 @@ const log = getLogger('guardian-request-resolvers');
 // Types
 // ---------------------------------------------------------------------------
 
-/** Actor context for the entity making the decision. */
-export interface ActorContext {
-  /** External user ID of the deciding actor (undefined for desktop/trusted). */
-  externalUserId: string | undefined;
-  /** Channel the decision arrived on. */
-  channel: string;
-  /** Whether the actor is a trusted/desktop context. */
-  isTrusted: boolean;
-}
+export type { ActorContext } from './actor-context.js';
 
 /** The decision being applied. */
 export interface ResolverDecision {

--- a/assistant/src/daemon/handlers/guardian-actions.ts
+++ b/assistant/src/daemon/handlers/guardian-actions.ts
@@ -1,6 +1,7 @@
 import {
   applyCanonicalGuardianDecision,
 } from '../../approvals/guardian-decision-primitive.js';
+import { buildTrustedActorContext } from '../../approvals/actor-context.js';
 import { getCanonicalGuardianRequest } from '../../memory/canonical-guardian-store.js';
 import type { ApprovalAction } from '../../runtime/channel-approval-types.js';
 import { listGuardianDecisionPrompts } from '../../runtime/routes/guardian-action-routes.js';
@@ -48,11 +49,7 @@ export const guardianActionsHandlers = defineHandlers({
     const canonicalResult = await applyCanonicalGuardianDecision({
       requestId: msg.requestId,
       action: msg.action as ApprovalAction,
-      actorContext: {
-        externalUserId: undefined,
-        channel: 'vellum',
-        isTrusted: true,
-      },
+      actorContext: buildTrustedActorContext('vellum'),
       userText: undefined,
     });
 

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -3,6 +3,7 @@ import * as net from 'node:net';
 import { v4 as uuid } from 'uuid';
 
 import { createAssistantMessage, createUserMessage } from '../../agent/message-types.js';
+import { buildTrustedActorContext } from '../../approvals/actor-context.js';
 import { type InterfaceId,isChannelId, parseChannelId, parseInterfaceId } from '../../channels/types.js';
 import { getConfig } from '../../config/loader.js';
 import { getAttachmentsForMessage, getFilePathForAttachment, setAttachmentThumbnail } from '../../memory/attachments-store.js';
@@ -596,11 +597,7 @@ export async function handleUserMessage(
           const routerResult = await routeGuardianReply({
             messageText: messageText.trim(),
             channel: ipcChannel,
-            actor: {
-              externalUserId: undefined,
-              channel: ipcChannel,
-              isTrusted: true,
-            },
+            actor: buildTrustedActorContext(ipcChannel),
             conversationId: msg.sessionId,
             pendingRequestIds: pendingRequestIdsForConversation,
             approvalConversationGenerator: desktopApprovalConversationGenerator,

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -7,6 +7,7 @@
  */
 
 import { createAssistantMessage,createUserMessage } from '../agent/message-types.js';
+import { buildTrustedActorContext } from '../approvals/actor-context.js';
 import type { TurnChannelContext, TurnInterfaceContext } from '../channels/types.js';
 import { parseChannelId, parseInterfaceId } from '../channels/types.js';
 import { getConfig } from '../config/loader.js';
@@ -372,11 +373,7 @@ export async function processMessage(
     const routerResult = await routeGuardianReply({
       messageText: trimmedContent,
       channel: 'vellum',
-      actor: {
-        externalUserId: undefined,
-        channel: 'vellum',
-        isTrusted: true,
-      },
+      actor: buildTrustedActorContext('vellum'),
       conversationId: session.conversationId,
       pendingRequestIds: canonicalPendingRequestIdsForConversation,
       // Desktop path: disable NL classification to avoid consuming non-decision

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -16,6 +16,7 @@ import {
   listPendingCanonicalGuardianRequestsByDestinationConversation,
 } from '../../memory/canonical-guardian-store.js';
 import { bridgeConfirmationRequestToGuardian } from '../confirmation-request-guardian-bridge.js';
+import { buildTrustedActorContext } from '../../approvals/actor-context.js';
 import {
   getConversationByKey,
   getOrCreateConversation,
@@ -123,11 +124,7 @@ async function tryConsumeInlineApprovalReply(params: {
   const routerResult = await routeGuardianReply({
     messageText: trimmedContent,
     channel: sourceChannel,
-    actor: {
-      externalUserId: undefined,
-      channel: sourceChannel,
-      isTrusted: true,
-    },
+    actor: buildTrustedActorContext(sourceChannel),
     conversationId,
     pendingRequestIds,
     approvalConversationGenerator,

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -7,6 +7,7 @@
 import {
   applyCanonicalGuardianDecision,
 } from '../../approvals/guardian-decision-primitive.js';
+import { buildTrustedActorContext } from '../../approvals/actor-context.js';
 import {
   type CanonicalGuardianRequest,
   getCanonicalGuardianRequest,
@@ -85,11 +86,7 @@ export async function handleGuardianActionDecision(req: Request): Promise<Respon
   const canonicalResult = await applyCanonicalGuardianDecision({
     requestId,
     action: action as ApprovalAction,
-    actorContext: {
-      externalUserId: undefined,
-      channel: 'vellum',
-      isTrusted: true,
-    },
+    actorContext: buildTrustedActorContext('vellum'),
     userText: undefined,
   });
 

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -10,6 +10,7 @@ import type { ChannelId, InterfaceId } from '../../channels/types.js';
 import { CHANNEL_IDS, INTERFACE_IDS, isChannelId, parseInterfaceId } from '../../channels/types.js';
 import { getGatewayInternalBaseUrl } from '../../config/env.js';
 import { RESEND_COOLDOWN_MS } from '../../daemon/handlers/config-channels.js';
+import { buildActorContext } from '../../approvals/actor-context.js';
 import * as attachmentsStore from '../../memory/attachments-store.js';
 import {
   createCanonicalGuardianRequest,
@@ -968,11 +969,11 @@ export async function handleChannelInbound(
     const routerResult = await routeGuardianReply({
       messageText: trimmedContent,
       channel: sourceChannel,
-      actor: {
-        externalUserId: canonicalSenderId ?? rawSenderId!,
+      actor: buildActorContext({
         channel: sourceChannel,
+        externalUserId: guardianCtx.requesterExternalUserId,
         isTrusted: false,
-      },
+      }),
       conversationId: result.conversationId,
       callbackData: body.callbackData,
       pendingRequestIds,
@@ -1029,7 +1030,7 @@ export async function handleChannelInbound(
       content: trimmedContent,
       externalChatId,
       sourceChannel,
-      senderExternalUserId: canonicalSenderId ?? rawSenderId,
+      senderExternalUserId: guardianCtx.requesterExternalUserId ?? canonicalSenderId ?? rawSenderId,
       replyCallbackUrl,
       bearerToken,
       guardianCtx,


### PR DESCRIPTION
## Summary\n- add a lightweight canonical actor-context module for guardian decision flows\n- replace hand-built ActorContext literals across inbound/desktop decision entry points with shared helpers\n- use the resolved guardian context identity when building untrusted channel actor context before routing guardian replies\n\n## Validation\n- \n- bun test v1.3.9 (cf6cdbbb)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10893" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
