### PR TITLE
fix: Settings sections — full-width layout and increased button-row spacing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -260,6 +260,7 @@ struct SettingsAccountTab: View {
             }
         }
         .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
     }
 
@@ -352,6 +353,7 @@ struct SettingsAccountTab: View {
                 }
             }
             .padding(VSpacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .vCard(background: VColor.surfaceSubtle)
         }
     }
@@ -369,7 +371,7 @@ struct SettingsAccountTab: View {
                 .font(VFont.sectionTitle)
                 .foregroundColor(VColor.textPrimary)
 
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(alignment: .leading, spacing: VSpacing.lg) {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text("Retire this assistant")
                         .font(VFont.body)
@@ -390,6 +392,7 @@ struct SettingsAccountTab: View {
             }
         }
         .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
     }
 
@@ -456,7 +459,7 @@ struct SettingsAccountTab: View {
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
 
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         Text("Hatch a new assistant")
                             .font(VFont.body)
@@ -472,6 +475,7 @@ struct SettingsAccountTab: View {
                 }
             }
             .padding(VSpacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .vCard(background: VColor.surfaceSubtle)
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAutomationTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAutomationTab.swift
@@ -18,7 +18,7 @@ struct SettingsAutomationTab: View {
                         .font(VFont.sectionTitle)
                         .foregroundColor(VColor.textPrimary)
 
-                    VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
                             Text("Manage Reminders")
                                 .font(VFont.body)
@@ -33,6 +33,7 @@ struct SettingsAutomationTab: View {
                     }
                 }
                 .padding(VSpacing.lg)
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .vCard(background: VColor.surfaceSubtle)
 
                 VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -40,7 +41,7 @@ struct SettingsAutomationTab: View {
                         .font(VFont.sectionTitle)
                         .foregroundColor(VColor.textPrimary)
 
-                    VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
                             Text("Manage Scheduled Tasks")
                                 .font(VFont.body)
@@ -55,6 +56,7 @@ struct SettingsAutomationTab: View {
                     }
                 }
                 .padding(VSpacing.lg)
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .vCard(background: VColor.surfaceSubtle)
             }
 
@@ -135,6 +137,7 @@ struct HeartbeatAutomationSection: View {
                 .foregroundColor(VColor.textMuted)
         }
         .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
     }
 
@@ -238,6 +241,7 @@ struct HeartbeatAutomationSection: View {
             }
         }
         .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -291,7 +291,7 @@ struct SettingsChannelsTab: View {
             } else if telegramSetupExpanded {
                 telegramCredentialEntry
             } else {
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
                     HStack(spacing: VSpacing.sm) {
                         Image(systemName: "exclamationmark.triangle")
                             .foregroundColor(VColor.warning)
@@ -325,6 +325,7 @@ struct SettingsChannelsTab: View {
             }
         }
         .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
     }
 
@@ -464,7 +465,7 @@ struct SettingsChannelsTab: View {
             } else if slackChannelSetupExpanded {
                 slackChannelCredentialEntry
             } else {
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
                     HStack(spacing: VSpacing.sm) {
                         Image(systemName: "exclamationmark.triangle")
                             .foregroundColor(VColor.warning)
@@ -488,6 +489,7 @@ struct SettingsChannelsTab: View {
 
         }
         .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
     }
 
@@ -574,7 +576,7 @@ struct SettingsChannelsTab: View {
             } else if twilioSetupExpanded {
                 twilioCredentialEntry
             } else {
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
                     HStack(spacing: VSpacing.sm) {
                         Image(systemName: "exclamationmark.triangle")
                             .foregroundColor(VColor.warning)
@@ -632,6 +634,7 @@ struct SettingsChannelsTab: View {
             }
         }
         .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
     }
 
@@ -662,7 +665,7 @@ struct SettingsChannelsTab: View {
             } else if voiceSetupExpanded {
                 voiceCredentialEntry
             } else {
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
                     HStack(spacing: VSpacing.sm) {
                         Image(systemName: "exclamationmark.triangle")
                             .foregroundColor(VColor.warning)
@@ -721,6 +724,7 @@ struct SettingsChannelsTab: View {
             }
         }
         .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -118,6 +118,7 @@ struct VoiceSettingsView: View {
             }
         }
         .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
     }
 
@@ -314,6 +315,7 @@ struct VoiceSettingsView: View {
                 .accessibilityLabel("Enable wake word listening")
         }
         .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
     }
 
@@ -360,6 +362,7 @@ struct VoiceSettingsView: View {
             }
         }
         .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
     }
 
@@ -392,6 +395,7 @@ struct VoiceSettingsView: View {
             .accessibilityLabel("Conversation timeout duration")
         }
         .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
     }
 
@@ -493,6 +497,7 @@ struct VoiceSettingsView: View {
             }
         }
         .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
     }
 


### PR DESCRIPTION
Closes #10889

## Changes

**SettingsAccountTab.swift**
- Added `.frame(maxWidth: .infinity, alignment: .leading)` to `assistantInfoSection`, `switchAssistantSection`, `retireAssistantSection`, and `hatchNewAssistantSection`
- Changed inner VStack spacing from `VSpacing.sm` to `VSpacing.lg` in `retireAssistantSection` and `hatchNewAssistantSection` (content + button rows)

**SettingsChannelsTab.swift**
- Added `.frame(maxWidth: .infinity, alignment: .leading)` to `telegramCard`, `slackChannelCard`, `twilioCard`, and `voiceCard`
- Changed inner VStack spacing from `VSpacing.sm` to `VSpacing.lg` in "not configured" states with Set Up button rows for all four cards

**VoiceSettingsView.swift**
- Added `.frame(maxWidth: .infinity, alignment: .leading)` to `pttKeyPicker`, `enableSection`, `keywordSection`, `timeoutSection`, and `ttsKeySection`

**SettingsAutomationTab.swift**
- Added `.frame(maxWidth: .infinity, alignment: .leading)` to Reminders section, Scheduled Tasks section, `checklistCard`, and `runsCard`
- Changed inner VStack spacing from `VSpacing.sm` to `VSpacing.lg` in Reminders and Scheduled Tasks sections (content + button rows)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
