### PR TITLE
fix: replace macOS System Permissions checkmarks with VToggle (#10899)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -968,7 +968,7 @@ struct SettingsPanel: View {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text(label)
                         .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
+                        .foregroundColor(VColor.textSecondary)
                     Text(subtitle)
                         .font(VFont.caption)
                         .foregroundColor(VColor.textMuted)
@@ -977,9 +977,7 @@ struct SettingsPanel: View {
 
                 Spacer()
 
-                Image(systemName: granted ? "checkmark.circle.fill" : "circle")
-                    .font(.system(size: 16))
-                    .foregroundColor(granted ? VColor.success : VColor.textMuted)
+                VToggle(isOn: .constant(granted)).allowsHitTesting(false)
             }
             .padding(VSpacing.md)
             .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
Replaces the circle/checkmark icon in each permission row with a VToggle component, matching the visual pattern from Privacy Settings Diagnostics section. The toggle reflects the granted state; tapping the row still opens System Settings.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
