### PR TITLE
fix: keyboard shortcuts — single combined pill instead of per-key tags (#10903)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -270,21 +270,17 @@ struct SettingsAppearanceTab: View {
     }
 
     private func shortcutKeyPill(_ text: String) -> some View {
-        HStack(spacing: VSpacing.xs) {
-            ForEach(text.components(separatedBy: " "), id: \.self) { token in
-                Text(token)
-                    .font(VFont.mono)
-                    .foregroundColor(VColor.textSecondary)
-                    .padding(.horizontal, VSpacing.sm)
-                    .padding(.vertical, VSpacing.xs)
-                    .background(VColor.surface)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.xl)
-                            .stroke(VColor.surfaceBorder, lineWidth: 1)
-                    )
-            }
-        }
+        Text(text)
+            .font(VFont.mono)
+            .foregroundColor(VColor.textSecondary)
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+            .background(VColor.surface)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.xl)
+                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+            )
     }
 
     private func stopRecording() {
@@ -308,21 +304,17 @@ private struct ShortcutRow: View {
                 .font(VFont.body)
                 .foregroundColor(VColor.textSecondary)
             Spacer()
-            HStack(spacing: VSpacing.xs) {
-                ForEach(shortcut.components(separatedBy: " "), id: \.self) { token in
-                    Text(token)
-                        .font(VFont.mono)
-                        .foregroundColor(VColor.textSecondary)
-                        .padding(.horizontal, VSpacing.sm)
-                        .padding(.vertical, VSpacing.xs)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.xl)
-                                .stroke(VColor.surfaceBorder, lineWidth: 1)
-                        )
-                }
-            }
+            Text(shortcut)
+                .font(VFont.mono)
+                .foregroundColor(VColor.textSecondary)
+                .padding(.horizontal, VSpacing.sm)
+                .padding(.vertical, VSpacing.xs)
+                .background(VColor.surface)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.xl)
+                        .stroke(VColor.surfaceBorder, lineWidth: 1)
+                )
         }
         .padding(.vertical, VSpacing.md)
     }

--- a/clients/macos/vellum-assistant/Features/Settings/ShortcutHelper.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ShortcutHelper.swift
@@ -9,7 +9,7 @@ enum ShortcutHelper {
     /// display string like "Command Shift Space".
     static func displayString(for shortcut: String) -> String {
         let parts = shortcut.lowercased().split(separator: "+").map(String.init)
-        return parts.map { displayToken($0) }.joined(separator: " ")
+        return parts.map { displayToken($0) }.joined()
     }
 
     /// Parses a shortcut string into modifier flags and a key string suitable


### PR DESCRIPTION
Combines all shortcut key tokens (⌘⇧G) into a single pill instead of separate pills per key. Changes ShortcutHelper.displayString() to join without spaces, and simplifies shortcutKeyPill() and ShortcutRow to use a single Text view.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
