### PR TITLE
fix: remove per-row VCard from System Permissions rows (#10906)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -984,14 +984,6 @@ struct SettingsPanel: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .vCard(background: VColor.surfaceSubtle)
-        .onHover { hovering in
-            if hovering {
-                NSCursor.pointingHand.push()
-            } else {
-                NSCursor.pop()
-            }
-        }
     }
 
     // MARK: - Permission Helpers


### PR DESCRIPTION
Removes the individual .vCard() wrapping from each permission row so they appear as plain lightweight rows inside the section card, rather than nested bordered cards.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
