### PR TITLE
fix: remove bottom drop shadow from VButton primary variant (#10909)

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -142,9 +142,7 @@ private struct VButtonStyle: ButtonStyle {
     private var shadowColor: Color {
         switch style {
         case .primary:
-            return isHovered
-                ? adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._600)
-                : adaptiveColor(light: Color(hex: 0x3D5739), dark: Forest._800)
+            return .clear
         case .danger:
             return .clear
         case .tertiary, .ghost:


### PR DESCRIPTION
Removes the dark green bottom shadow (y: 2) from the primary VButton variant, giving it a flatter, cleaner appearance. All other variants already returned .clear for shadowColor.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
