### PR TITLE
fix: rename Control Center to Preferences with sliders icon

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -37,7 +37,7 @@ final class SidebarInteractionState {
     var showAllThreads: Bool = false
     var showAllScheduleThreads: Bool = false
     var showAllApps: Bool = false
-    var showControlCenterDrawer: Bool = false
+    var showPreferencesDrawer: Bool = false
     /// Thread ID that is currently the drop target during a drag-and-drop reorder.
     var dropTargetThreadId: UUID?
     /// Thread ID currently being dragged (set on drag start, cleared on drop).
@@ -561,31 +561,31 @@ struct MainWindowView: View {
                     .animation(VAnimation.panel, value: sidebarExpanded)
                 }
                 .overlay {
-                    // Click-outside-to-dismiss background for control center drawer
-                    if sidebar.showControlCenterDrawer {
+                    // Click-outside-to-dismiss background for preferences drawer
+                    if sidebar.showPreferencesDrawer {
                         Color.clear
                             .contentShape(Rectangle())
                             .onTapGesture {
                                 withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
-                                    sidebar.showControlCenterDrawer = false
+                                    sidebar.showPreferencesDrawer = false
                                 }
                             }
                     }
                 }
                 .overlay(alignment: .bottomLeading) {
-                    // Control center drawer rendered at top level so it floats above all content
-                    if sidebar.showControlCenterDrawer {
+                    // Preferences drawer rendered at top level so it floats above all content
+                    if sidebar.showPreferencesDrawer {
                         let drawerWidth = sidebarExpandedWidth - VSpacing.sm * 2
                         let drawerX = sidebarExpanded
                             ? 16 + VSpacing.sm
                             : 16 + sidebarCollapsedWidth - VSpacing.xs
                         DrawerMenuView(
                             onSettings: {
-                                sidebar.showControlCenterDrawer = false
+                                sidebar.showPreferencesDrawer = false
                                 windowState.selection = .panel(.settings)
                             },
                             onDebug: {
-                                sidebar.showControlCenterDrawer = false
+                                sidebar.showPreferencesDrawer = false
                                 windowState.selection = .panel(.debug)
                             }
                         )
@@ -1379,11 +1379,11 @@ struct MainWindowView: View {
 
             Spacer(minLength: VSpacing.sm)
 
-            // Control Center row (fixed)
-            ControlCenterRow(
+            // Preferences row (fixed)
+            PreferencesRow(
                 onToggle: {
                     withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
-                        sidebar.showControlCenterDrawer.toggle()
+                        sidebar.showPreferencesDrawer.toggle()
                     }
                 }
             )
@@ -1561,9 +1561,9 @@ struct MainWindowView: View {
 
             Spacer()
 
-            SidebarNavRow(icon: "gearshape", label: "Control Center", isActive: false, isExpanded: false) {
+            SidebarNavRow(icon: "slider.horizontal.3", label: "Preferences", isActive: false, isExpanded: false) {
                 withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
-                    sidebar.showControlCenterDrawer.toggle()
+                    sidebar.showPreferencesDrawer.toggle()
                 }
             }
 
@@ -1785,13 +1785,13 @@ private struct SidebarThreadsHeader: View {
     }
 }
 
-private struct ControlCenterRow: View {
+private struct PreferencesRow: View {
     let onToggle: () -> Void
 
     var body: some View {
         VButton(
-            label: "Control Center",
-            leftIcon: "gearshape",
+            label: "Preferences",
+            leftIcon: "slider.horizontal.3",
             rightIcon: "chevron.up",
             style: .secondary,
             size: .medium,


### PR DESCRIPTION
## Summary
- Rename "Control Center" button/menu to "Preferences" throughout the sidebar
- Swap gear icon (`gearshape`) for horizontal sliders icon (`slider.horizontal.3`)
- Rename internal variable `showControlCenterDrawer` → `showPreferencesDrawer` and struct `ControlCenterRow` → `PreferencesRow`

## Original prompt
your recommendation of Preferences with sliders icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
