### PR TITLE
fix: guard stale build watcher kill loop with VELLUM_NO_WATCH check

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -744,12 +744,16 @@ if [ "$CMD" = "run" ]; then
     echo "Launching..."
     # Kill any previous build.sh watcher processes so they don't linger
     # after their terminal is closed and trigger surprise rebuilds.
-    my_pid=$$
-    for pid in $(pgrep -f "build\.sh run" 2>/dev/null || true); do
-        if [ "$pid" != "$my_pid" ]; then
-            kill "$pid" 2>/dev/null || true
-        fi
-    done
+    # Skip when invoked as a nested rebuild (VELLUM_NO_WATCH=1) to avoid
+    # killing the parent watcher process.
+    if [ -z "${VELLUM_NO_WATCH:-}" ]; then
+        my_pid=$$
+        for pid in $(pgrep -f "build\.sh run" 2>/dev/null || true); do
+            if [ "$pid" != "$my_pid" ]; then
+                kill "$pid" 2>/dev/null || true
+            fi
+        done
+    fi
 
     # Kill existing instance if running (SIGTERM for clean shutdown)
     if pgrep -x "$BUNDLE_DISPLAY_NAME" > /dev/null; then


### PR DESCRIPTION
## Summary

- Wraps the stale `build.sh` watcher kill loop (pgrep/kill) with a `VELLUM_NO_WATCH` guard so nested rebuild invocations don't kill the parent watcher process
- Addresses review feedback from Codex and Devin on PR #10833: the child rebuild's `pgrep -f "build.sh run"` matches and kills the parent, breaking auto-rebuild after the first detected change

## Test plan

- [ ] Run `./build.sh run` and verify the file watcher starts normally
- [ ] Trigger a file change and confirm the nested rebuild (with `VELLUM_NO_WATCH=1`) does not kill the parent watcher
- [ ] Confirm auto-rebuild continues to work after the first detected change

---

**Original prompt:** Guard the stale build watcher kill loop in `clients/macos/build.sh` with a `VELLUM_NO_WATCH` check so nested rebuild invocations don't kill the parent watcher process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
