### PR TITLE
fix: align SMS testConnection() with isConnected() for assistant-scoped phone numbers

### DIFF
--- a/assistant/src/messaging/providers/sms/adapter.ts
+++ b/assistant/src/messaging/providers/sms/adapter.ts
@@ -108,6 +108,25 @@ export const smsMessagingProvider: MessagingProvider = {
 
     const phoneNumber = getPhoneNumber();
     if (!phoneNumber) {
+      // Mirror isConnected(): fall back to assistant-scoped phone numbers
+      try {
+        const config = loadConfig();
+        const mappings = config.sms?.assistantPhoneNumbers as Record<string, string> | undefined;
+        if (mappings && Object.keys(mappings).length > 0) {
+          const accountSid = getSecureKey('credential:twilio:account_sid')!;
+          return {
+            connected: true,
+            user: 'assistant-scoped',
+            platform: 'sms',
+            metadata: {
+              accountSid: accountSid.slice(0, 6) + '...',
+              assistantPhoneNumbers: Object.keys(mappings).length,
+            },
+          };
+        }
+      } catch {
+        // Config may not be available yet
+      }
       return {
         connected: false,
         user: 'unknown',


### PR DESCRIPTION
## Summary

- `testConnection()` in the SMS adapter now checks `config.sms.assistantPhoneNumbers` when no default phone number is configured, mirroring the existing `isConnected()` fallback logic.
- Previously, `isConnected()` returned `true` with only assistant-scoped phone numbers configured, but `testConnection()` returned `connected: false` — this inconsistency caused the SMS provider to appear disconnected in connection tests despite being functional.
- When connected via assistant-scoped numbers, the response includes metadata with the count of configured assistant phone numbers.

## Test plan

- [ ] Verify `testConnection()` returns `connected: true` when `assistantPhoneNumbers` has entries but no default phone number is set
- [ ] Verify `testConnection()` still returns `connected: false` when neither default phone number nor `assistantPhoneNumbers` are configured
- [ ] Verify `testConnection()` still returns `connected: true` with the phone number in metadata when a default phone number is configured

---

**Prompt:** Address review feedback on PR #10901: Update `testConnection()` to also check `config.sms.assistantPhoneNumbers` when no default phone number is configured, mirroring the `isConnected()` logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
