### PR TITLE
fix: add friendName and guardianName to voice invite SKILL.md examples

### DIFF
--- a/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
+++ b/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
@@ -254,6 +254,8 @@ INVITE_JSON=$(curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/ingress/invites" \
   -d '{
     "sourceChannel": "voice",
     "expectedExternalUserId": "<phone_number_E164>",
+    "friendName": "<invitee display name>",
+    "guardianName": "<guardian display name>",
     "maxUses": 1,
     "note": "<optional note, e.g. the person it is for>"
   }')
@@ -263,6 +265,8 @@ printf '%s\n' "$INVITE_JSON"
 Required fields:
 - `sourceChannel` — must be `"voice"`
 - `expectedExternalUserId` — the invitee's phone number in E.164 format (e.g., `+15551234567`)
+- `friendName` — the invitee's display name (e.g., "Mom", "Dr. Smith"). Used during the voice verification call to personalize the experience.
+- `guardianName` — the guardian's display name (e.g., "Alex"). Used during the voice verification call so the invitee knows who invited them.
 
 Optional fields:
 - `maxUses` — how many times the code can be used (default: 1)
@@ -270,8 +274,9 @@ Optional fields:
 - ~~`voiceCodeDigits`~~ — always 6 digits; this parameter is accepted but ignored
 - `note` — a human-readable label for the invite (e.g., "For Mom", "Dr. Smith")
 
-The create response contains `{ ok: true, invite: { id, voiceCode, expectedExternalUserId, ... } }`.
+The create response contains `{ ok: true, invite: { id, voiceCode, expectedExternalUserId, friendName, guardianName, ... } }`.
 - `voiceCode` is the numeric code the invitee must enter and is only returned at creation time.
+- `friendName` and `guardianName` are echoed back in the response.
 - Voice invite responses do **not** include `token` or `share.url`. Do not try to build or send a deep link for voice invites.
 
 **Presenting to the guardian**: Give the guardian clear instructions to relay to the invitee:
@@ -348,6 +353,8 @@ Replace `<invite_id>` with the invite's `id` from the list response. The same re
   - `sourceChannel is required for create` — when creating an invite, always pass `"sourceChannel": "telegram"` for Telegram or `"sourceChannel": "voice"` for voice invites.
   - `expectedExternalUserId is required for voice invites` — voice invites must include the invitee's phone number.
   - `expectedExternalUserId must be in E.164 format` — the phone number must start with `+` followed by country code and number (e.g., `+15551234567`).
+  - `friendName is required for voice invites` — voice invites must include the invitee's display name.
+  - `guardianName is required for voice invites` — voice invites must include the guardian's display name.
   - `Invite not found or already revoked` — the invite ID may be invalid or the invite is already revoked.
 
 ## Typical Workflows

--- a/skills/trusted-contacts/SKILL.md
+++ b/skills/trusted-contacts/SKILL.md
@@ -254,6 +254,8 @@ INVITE_JSON=$(curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/ingress/invites" \
   -d '{
     "sourceChannel": "voice",
     "expectedExternalUserId": "<phone_number_E164>",
+    "friendName": "<invitee display name>",
+    "guardianName": "<guardian display name>",
     "maxUses": 1,
     "note": "<optional note, e.g. the person it is for>"
   }')
@@ -263,6 +265,8 @@ printf '%s\n' "$INVITE_JSON"
 Required fields:
 - `sourceChannel` — must be `"voice"`
 - `expectedExternalUserId` — the invitee's phone number in E.164 format (e.g., `+15551234567`)
+- `friendName` — the invitee's display name (e.g., "Mom", "Dr. Smith"). Used during the voice verification call to personalize the experience.
+- `guardianName` — the guardian's display name (e.g., "Alex"). Used during the voice verification call so the invitee knows who invited them.
 
 Optional fields:
 - `maxUses` — how many times the code can be used (default: 1)
@@ -270,8 +274,9 @@ Optional fields:
 - ~~`voiceCodeDigits`~~ — always 6 digits; this parameter is accepted but ignored
 - `note` — a human-readable label for the invite (e.g., "For Mom", "Dr. Smith")
 
-The create response contains `{ ok: true, invite: { id, voiceCode, expectedExternalUserId, ... } }`.
+The create response contains `{ ok: true, invite: { id, voiceCode, expectedExternalUserId, friendName, guardianName, ... } }`.
 - `voiceCode` is the numeric code the invitee must enter and is only returned at creation time.
+- `friendName` and `guardianName` are echoed back in the response.
 - Voice invite responses do **not** include `token` or `share.url`. Do not try to build or send a deep link for voice invites.
 
 **Presenting to the guardian**: Give the guardian clear instructions to relay to the invitee:
@@ -348,6 +353,8 @@ Replace `<invite_id>` with the invite's `id` from the list response. The same re
   - `sourceChannel is required for create` — when creating an invite, always pass `"sourceChannel": "telegram"` for Telegram or `"sourceChannel": "voice"` for voice invites.
   - `expectedExternalUserId is required for voice invites` — voice invites must include the invitee's phone number.
   - `expectedExternalUserId must be in E.164 format` — the phone number must start with `+` followed by country code and number (e.g., `+15551234567`).
+  - `friendName is required for voice invites` — voice invites must include the invitee's display name.
+  - `guardianName is required for voice invites` — voice invites must include the guardian's display name.
   - `Invite not found or already revoked` — the invite ID may be invalid or the invite is already revoked.
 
 ## Typical Workflows


### PR DESCRIPTION
## Summary

- Added `friendName` and `guardianName` fields to the voice invite creation curl example in both copies of `trusted-contacts/SKILL.md`
- Added both fields to the "Required fields" documentation with descriptions of their purpose
- Updated the response description to show these fields are echoed back
- Added error messages for missing `friendName` and `guardianName` to the error handling section

Addresses review feedback on PR #10901: the backend (`ingress-service.ts:177-181`) requires both fields for voice invites, but the SKILL.md documentation was missing them.

## Test plan

- [ ] Verify the skill-mirror-parity guard test passes (both SKILL.md copies are identical)
- [ ] Verify the curl example payload matches what `ingress-service.ts` expects

**Prompt:** Address review feedback on PR #10901: The synced `assistant/src/config/vellum-skills/trusted-contacts/SKILL.md` is missing `friendName` and `guardianName` fields in the voice invite creation examples. The backend (`assistant/src/runtime/ingress-service.ts:177-181`) requires both fields for voice invites. Verify the top-level `skills/trusted-contacts/SKILL.md` source and ensure both copies include these fields in the voice invite payload examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
