### PR TITLE
fix: sort imports in http-server.ts

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -87,6 +87,7 @@ import {
   handleGetAttachmentContent,
   handleUploadAttachment,
 } from './routes/attachment-routes.js';
+import { handleGetBrainGraph, handleServeBrainGraphUI, handleServeHomeBaseUI } from './routes/brain-graph-routes.js';
 import {
   handleAnswerCall,
   handleCancelCall,
@@ -126,7 +127,6 @@ import {
   handleGuardianActionDecision,
   handleGuardianActionsPending,
 } from './routes/guardian-action-routes.js';
-import { handleGetBrainGraph, handleServeBrainGraphUI, handleServeHomeBaseUI } from './routes/brain-graph-routes.js';
 import { handleGetIdentity,handleHealth } from './routes/identity-routes.js';
 import {
   handleBlockMember,


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `assistant/src/runtime/http-server.ts` by moving the `brain-graph-routes.js` import to its correct alphabetical position

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22532551326/job/65274177101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
