### PR TITLE
fix: match permission row spacing to Advanced Feature Flag section (#10923)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -964,7 +964,7 @@ struct SettingsPanel: View {
 
     private func permissionRow(label: String, subtitle: String, granted: Bool, action: @escaping () -> Void) -> some View {
         Button(action: action) {
-            HStack(spacing: VSpacing.md) {
+            HStack {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text(label)
                         .font(VFont.body)
@@ -979,7 +979,6 @@ struct SettingsPanel: View {
 
                 VToggle(isOn: .constant(granted)).allowsHitTesting(false)
             }
-            .padding(VSpacing.md)
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
         }


### PR DESCRIPTION
Removes the per-row .padding(VSpacing.md) from permissionRow so spacing matches the Advanced Feature Flag section rows (which have no per-row padding and rely on the section VStack spacing only).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
