### PR TITLE
fix: add rounded border to keyboard shortcut pills (#10925)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -293,6 +293,10 @@ struct SettingsAppearanceTab: View {
         .padding(.vertical, VSpacing.xs)
         .background(VColor.surfaceSubtle)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.xl)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
     }
 }
 
@@ -318,6 +322,10 @@ private struct ShortcutRow: View {
             .padding(.vertical, VSpacing.xs)
             .background(VColor.surfaceSubtle)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.xl)
+                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+            )
         }
         .padding(.vertical, VSpacing.md)
     }


### PR DESCRIPTION
Adds a VColor.surfaceBorder stroke overlay to shortcutKeyPill and ShortcutRow so pills are visible in dark mode where the surfaceSubtle background blends with the section card.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
