### PR TITLE
fix: add inline prompt guidance to tool-permission-prompts Playwright test

### DIFF
--- a/playwright/cases/tool-permission-prompts.md
+++ b/playwright/cases/tool-permission-prompts.md
@@ -13,11 +13,11 @@ Verify that when the assistant attempts to run a tool that requires user permiss
 1. Launch the App
 2. Open a chat thread
 3. Send a message that triggers a tool requiring permission, such as "create a file called test.txt on my Desktop"
-4. Wait for the assistant to respond
-5. Verify that a tool permission prompt appears asking the user to allow or deny the action
+4. Wait for a permission prompt to appear **inline in the chat** — it will show buttons like "Allow Once", "Always Allow", and "Don't Allow" directly within the conversation. Do NOT click any of these buttons.
+5. Verify that the inline permission prompt is visible with action buttons before the tool has executed
 
 ## Expected
 
-- A permission prompt should appear before the tool is executed
+- A permission prompt should appear **inline in the chat** before the tool is executed, with buttons such as "Allow Once", "Always Allow", and "Don't Allow"
 - The prompt should clearly identify the tool and action being requested
-- The tool should NOT execute until the user responds to the prompt
+- The tool should NOT execute until the user responds to the prompt — do NOT click any approval buttons during this test


### PR DESCRIPTION
## Summary
- The `tool-permission-prompts` Playwright test was failing because the AI agent didn't know WHERE the permission prompt appears (inline in chat) or WHAT it looks like (buttons: Allow Once / Always Allow / Don't Allow)
- The companion `permission-denial-handling` test passes because it includes this exact guidance
- Added the same inline prompt description and button names to `tool-permission-prompts.md`, and clarified the agent should not click any approval buttons during verification

## Original prompt
yeah can you fix it?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
