### PR TITLE
fix: address PR #10917 review feedback

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -9,6 +9,7 @@ import { getAttachmentsForMessage, getFilePathForAttachment, setAttachmentThumbn
 import {
   createCanonicalGuardianRequest,
   generateCanonicalRequestCode,
+  getCanonicalGuardianRequest,
   listCanonicalGuardianRequests,
   listPendingCanonicalGuardianRequestsByDestinationConversation,
   resolveCanonicalGuardianRequest,
@@ -610,9 +611,16 @@ export async function handleUserMessage(
           if (routerResult.consumed && routerResult.type !== 'nl_keep_pending') {
             // Emit authoritative confirmation state for resolved request
             if (routerResult.requestId) {
-              const resolvedState = routerResult.decisionApplied
-                ? (routerResult.type === 'nl_deny' || routerResult.type === 'nl_deny_all' ? 'denied' : 'approved') as const
-                : 'resolved_stale' as const;
+              let resolvedState: 'approved' | 'denied' | 'resolved_stale';
+              if (!routerResult.decisionApplied) {
+                resolvedState = 'resolved_stale';
+              } else {
+                // Determine actual decision from the canonical request's resolved status.
+                // The router result type is 'canonical_decision_applied' for both approve
+                // and reject, so we query the request to get the actual resolved status.
+                const resolvedRequest = getCanonicalGuardianRequest(routerResult.requestId);
+                resolvedState = resolvedRequest?.status === 'denied' ? 'denied' : 'approved';
+              }
               session.emitConfirmationStateChanged({
                 sessionId: msg.sessionId,
                 requestId: routerResult.requestId,
@@ -621,8 +629,9 @@ export async function handleUserMessage(
                 causedByRequestId: requestId,
                 decisionText: messageText.trim(),
               });
-              // Emit activity transition: approval resumes the run, denial ends it
-              if (resolvedState === 'approved') {
+              // The agent loop continues after both approval and denial, so
+              // always emit a thinking transition when the decision was applied.
+              if (routerResult.decisionApplied) {
                 session.emitActivityState('thinking', 'confirmation_resolved', 'assistant_turn');
               }
             }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -192,8 +192,9 @@ export class Session {
     this.traceEmitter = new TraceEmitter(conversationId, sendToClient);
     this.prompter = new PermissionPrompter(sendToClient);
     this.prompter.setOnStateChanged((requestId, state, source) => {
-      this.sendToClient({
-        type: 'confirmation_state_changed',
+      // Route through emitConfirmationStateChanged so the onStateSignal
+      // listener publishes to the SSE hub for HTTP/SSE consumers.
+      this.emitConfirmationStateChanged({
         sessionId: this.conversationId,
         requestId,
         state,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -12,6 +12,7 @@ import * as attachmentsStore from '../../memory/attachments-store.js';
 import {
   createCanonicalGuardianRequest,
   generateCanonicalRequestCode,
+  getCanonicalGuardianRequest,
   listCanonicalGuardianRequests,
   listPendingCanonicalGuardianRequestsByDestinationConversation,
 } from '../../memory/canonical-guardian-store.js';
@@ -140,9 +141,16 @@ async function tryConsumeInlineApprovalReply(params: {
   // Emit authoritative confirmation state for the resolved request.
   // The onStateSignal listener routes these to the SSE hub automatically.
   if (routerResult.requestId) {
-    const resolvedState = routerResult.decisionApplied
-      ? (routerResult.type === 'nl_deny' || routerResult.type === 'nl_deny_all' ? 'denied' : 'approved') as const
-      : 'resolved_stale' as const;
+    let resolvedState: 'approved' | 'denied' | 'resolved_stale';
+    if (!routerResult.decisionApplied) {
+      resolvedState = 'resolved_stale';
+    } else {
+      // Determine actual decision from the canonical request's resolved status.
+      // The router result type is 'canonical_decision_applied' for both approve
+      // and reject, so we query the request to get the actual resolved status.
+      const resolvedRequest = getCanonicalGuardianRequest(routerResult.requestId);
+      resolvedState = resolvedRequest?.status === 'denied' ? 'denied' : 'approved';
+    }
     session.emitConfirmationStateChanged({
       sessionId: conversationId,
       requestId: routerResult.requestId,
@@ -150,6 +158,11 @@ async function tryConsumeInlineApprovalReply(params: {
       source: 'inline_nl' as const,
       decisionText: trimmedContent,
     });
+    // The agent loop continues after both approval and denial, so
+    // always emit a thinking transition when the decision was applied.
+    if (routerResult.decisionApplied) {
+      session.emitActivityState('thinking', 'confirmation_resolved', 'assistant_turn');
+    }
   }
 
   // Decision has been applied — transcript persistence is best-effort.

--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -154,7 +154,9 @@ struct ChatContentView: View {
                         }
 
                         // Typing / step indicator shown while generating
-                        if viewModel.isSending {
+                        // Suppress the indicator while awaiting a confirmation prompt —
+                        // the user should see the confirmation UI, not a spinner.
+                        if viewModel.isSending && !viewModel.hasPendingConfirmation {
                             let lastMessage = viewModel.messages.last
                             let allToolCalls = lastMessage?.toolCalls ?? []
                             let isStreaming = lastMessage?.isStreaming == true


### PR DESCRIPTION
## Summary
Address valid review feedback from PR #10917 (server-authoritative confirmation and thinking signals):

- **Fix inline NL denial type checks** (sessions.ts, conversation-routes.ts): The code used impossible `routerResult.type === 'nl_deny'` checks — `GuardianReplyResultType` has no such values. Now queries the canonical request's resolved status to determine approved vs denied.
- **Emit thinking state after inline deny decisions** (sessions.ts, conversation-routes.ts): Previously only emitted `thinking` for approved; now emits for both since the agent loop continues after denial too.
- **Route prompter confirmation state changes through SSE hub** (session.ts): The prompter's `onStateChanged` callback sent `confirmation_state_changed` via `sendToClient` directly, bypassing `onStateSignal`. Now routes through `emitConfirmationStateChanged` so HTTP/SSE consumers receive pending and timed_out state transitions.
- **Suppress iOS typing indicator during confirmation** (ChatContentView.swift): Added `!viewModel.hasPendingConfirmation` guard so the spinner is hidden while awaiting user approval input.

### Items already addressed in PR #10917:
- `firstThinkingDeltaEmitted`/`firstTextDeltaEmitted` flags are already reset in `handleToolResult` (session-agent-loop-handlers.ts:279-280)
- `lastActivityVersion` is already reset to 0 in the reconnect handler (ChatViewModel.swift:801)
- Confirmation timeout already emits `thinking` transition (session.ts:206)

Addresses feedback from: https://github.com/vellum-ai/vellum-assistant/pull/10917

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
