### PR TITLE
fix: remove duplicate confirmation/activity emissions from inline NL path

### DIFF
--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -52,6 +52,7 @@ import { mintGrantFromDecision } from './approval-primitive.js';
 import {
   type ActorContext,
   type ChannelDeliveryContext,
+  type ResolverEmissionContext,
   getResolver,
 } from './guardian-request-resolvers.js';
 
@@ -295,6 +296,8 @@ export interface ApplyCanonicalGuardianDecisionParams {
   userText?: string;
   /** Optional channel delivery context — present when the decision arrived via a channel message. */
   channelDeliveryContext?: ChannelDeliveryContext;
+  /** Optional emission context threaded to handleConfirmationResponse for correct source attribution. */
+  emissionContext?: ResolverEmissionContext;
 }
 
 export type CanonicalDecisionResult =
@@ -319,7 +322,7 @@ export type CanonicalDecisionResult =
 export async function applyCanonicalGuardianDecision(
   params: ApplyCanonicalGuardianDecisionParams,
 ): Promise<CanonicalDecisionResult> {
-  const { requestId, action, actorContext, userText, channelDeliveryContext } = params;
+  const { requestId, action, actorContext, userText, channelDeliveryContext, emissionContext } = params;
 
   // 1. Look up the canonical request
   const request = getCanonicalGuardianRequest(requestId);
@@ -434,6 +437,7 @@ export async function applyCanonicalGuardianDecision(
       decision: { action: effectiveAction, userText },
       actor: actorContext,
       channelDeliveryContext,
+      emissionContext,
     });
 
     if (!resolverResult.ok) {

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -65,6 +65,13 @@ export interface ChannelDeliveryContext {
   bearerToken?: string;
 }
 
+/** Emission context threaded from callers to handleConfirmationResponse. */
+export interface ResolverEmissionContext {
+  source?: 'button' | 'inline_nl' | 'auto_deny' | 'timeout' | 'system';
+  causedByRequestId?: string;
+  decisionText?: string;
+}
+
 /** Context passed to each resolver after CAS resolution succeeds. */
 export interface ResolverContext {
   /** The canonical request record (already resolved to its terminal status). */
@@ -75,6 +82,8 @@ export interface ResolverContext {
   actor: ActorContext;
   /** Optional channel delivery context — present when the decision arrived via a channel message. */
   channelDeliveryContext?: ChannelDeliveryContext;
+  /** Optional emission context threaded to handleConfirmationResponse for correct source attribution. */
+  emissionContext?: ResolverEmissionContext;
 }
 
 /** Discriminated result from a resolver. */
@@ -167,7 +176,7 @@ const pendingInteractionResolver: GuardianRequestResolver = {
 
     // Map action to the permission system's UserDecision type and notify session.
     const userDecision = decision.action === 'reject' ? 'deny' as const : 'allow' as const;
-    resolved.session.handleConfirmationResponse(request.id, userDecision);
+    resolved.session.handleConfirmationResponse(request.id, userDecision, undefined, undefined, undefined, ctx.emissionContext);
 
     log.info(
       {

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -616,9 +616,19 @@ export async function handleUserMessage(
           });
 
           if (routerResult.consumed && routerResult.type !== 'nl_keep_pending') {
-            // Confirmation state and activity emissions are handled centrally
-            // by handleConfirmationResponse (called via the resolver chain),
-            // so no manual emission is needed here.
+            // Success-path emissions (approved/denied) are handled centrally
+            // by handleConfirmationResponse (called via the resolver chain).
+            // However, stale/failed paths never reach handleConfirmationResponse,
+            // so we emit resolved_stale here for those cases.
+            if (routerResult.requestId && !routerResult.decisionApplied) {
+              session.emitConfirmationStateChanged({
+                requestId: routerResult.requestId,
+                state: 'resolved_stale',
+                source: 'inline_nl',
+                causedByRequestId: requestId,
+                decisionText: messageText.trim(),
+              });
+            }
 
             const consumedChannelMeta = {
               userMessageChannel: ipcChannel,

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -9,7 +9,6 @@ import { getAttachmentsForMessage, getFilePathForAttachment, setAttachmentThumbn
 import {
   createCanonicalGuardianRequest,
   generateCanonicalRequestCode,
-  getCanonicalGuardianRequest,
   listCanonicalGuardianRequests,
   listPendingCanonicalGuardianRequestsByDestinationConversation,
   resolveCanonicalGuardianRequest,
@@ -609,35 +608,17 @@ export async function handleUserMessage(
             conversationId: msg.sessionId,
             pendingRequestIds: pendingRequestIdsForConversation,
             approvalConversationGenerator: desktopApprovalConversationGenerator,
+            emissionContext: {
+              source: 'inline_nl',
+              causedByRequestId: requestId,
+              decisionText: messageText.trim(),
+            },
           });
 
           if (routerResult.consumed && routerResult.type !== 'nl_keep_pending') {
-            // Emit authoritative confirmation state for resolved request
-            if (routerResult.requestId) {
-              let resolvedState: 'approved' | 'denied' | 'resolved_stale';
-              if (!routerResult.decisionApplied) {
-                resolvedState = 'resolved_stale';
-              } else {
-                // Determine actual decision from the canonical request's resolved status.
-                // The router result type is 'canonical_decision_applied' for both approve
-                // and reject, so we query the request to get the actual resolved status.
-                const resolvedRequest = getCanonicalGuardianRequest(routerResult.requestId);
-                resolvedState = resolvedRequest?.status === 'denied' ? 'denied' : 'approved';
-              }
-              session.emitConfirmationStateChanged({
-                sessionId: msg.sessionId,
-                requestId: routerResult.requestId,
-                state: resolvedState,
-                source: 'inline_nl',
-                causedByRequestId: requestId,
-                decisionText: messageText.trim(),
-              });
-              // The agent loop continues after both approval and denial, so
-              // always emit a thinking transition when the decision was applied.
-              if (routerResult.decisionApplied) {
-                session.emitActivityState('thinking', 'confirmation_resolved', 'assistant_turn');
-              }
-            }
+            // Confirmation state and activity emissions are handled centrally
+            // by handleConfirmationResponse (called via the resolver chain),
+            // so no manual emission is needed here.
 
             const consumedChannelMeta = {
               userMessageChannel: ipcChannel,

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -622,6 +622,7 @@ export async function handleUserMessage(
             // so we emit resolved_stale here for those cases.
             if (routerResult.requestId && !routerResult.decisionApplied) {
               session.emitConfirmationStateChanged({
+                sessionId: msg.sessionId,
                 requestId: routerResult.requestId,
                 state: 'resolved_stale',
                 source: 'inline_nl',

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -21,7 +21,7 @@ import {
   applyCanonicalGuardianDecision,
   type CanonicalDecisionResult,
 } from '../approvals/guardian-decision-primitive.js';
-import type { ActorContext, ChannelDeliveryContext } from '../approvals/guardian-request-resolvers.js';
+import type { ActorContext, ChannelDeliveryContext, ResolverEmissionContext } from '../approvals/guardian-request-resolvers.js';
 import {
   type CanonicalGuardianRequest,
   getCanonicalGuardianRequest,
@@ -67,6 +67,8 @@ export interface GuardianReplyContext {
   approvalConversationGenerator?: ApprovalConversationGenerator;
   /** Optional channel delivery context for resolver-driven side effects. */
   channelDeliveryContext?: ChannelDeliveryContext;
+  /** Optional emission context threaded to handleConfirmationResponse for correct source attribution. */
+  emissionContext?: ResolverEmissionContext;
 }
 
 export type GuardianReplyResultType =
@@ -242,7 +244,7 @@ function notConsumed(): GuardianReplyResult {
 export async function routeGuardianReply(
   ctx: GuardianReplyContext,
 ): Promise<GuardianReplyResult> {
-  const { messageText, actor, conversationId, callbackData, approvalConversationGenerator, channelDeliveryContext } = ctx;
+  const { messageText, actor, conversationId, callbackData, approvalConversationGenerator, channelDeliveryContext, emissionContext } = ctx;
   const pendingRequests = findPendingCanonicalRequests(actor, ctx.pendingRequestIds, conversationId);
   const scopedPendingRequestIds = ctx.pendingRequestIds ? new Set(ctx.pendingRequestIds) : null;
 
@@ -254,7 +256,7 @@ export async function routeGuardianReply(
   if (callbackData) {
     const parsed = parseCallbackAction(callbackData);
     if (parsed) {
-      return applyDecision(parsed.requestId, parsed.action, actor, undefined, channelDeliveryContext);
+      return applyDecision(parsed.requestId, parsed.action, actor, undefined, channelDeliveryContext, emissionContext);
     }
   }
 
@@ -340,7 +342,7 @@ export async function routeGuardianReply(
       // If the text indicates rejection, use reject; otherwise approve_once.
       const action = inferActionFromText(codeResult.remainingText);
 
-      return applyDecision(request.id, action, actor, codeResult.remainingText, channelDeliveryContext);
+      return applyDecision(request.id, action, actor, codeResult.remainingText, channelDeliveryContext, emissionContext);
     }
   }
 
@@ -382,6 +384,7 @@ export async function routeGuardianReply(
           actor,
           messageText,
           channelDeliveryContext,
+          emissionContext,
         );
       }
 
@@ -482,7 +485,7 @@ export async function routeGuardianReply(
       };
     }
 
-    const result = await applyDecision(targetId, decisionAction, actor, messageText, channelDeliveryContext);
+    const result = await applyDecision(targetId, decisionAction, actor, messageText, channelDeliveryContext, emissionContext);
 
     // Attach the engine's reply text for stale/expired/identity-mismatch cases,
     // but preserve the explicit failure text when the resolver failed — the engine
@@ -511,6 +514,7 @@ async function applyDecision(
   actor: ActorContext,
   userText?: string,
   channelDeliveryContext?: ChannelDeliveryContext,
+  emissionContext?: ResolverEmissionContext,
 ): Promise<GuardianReplyResult> {
   const canonicalResult = await applyCanonicalGuardianDecision({
     requestId,
@@ -518,6 +522,7 @@ async function applyDecision(
     actorContext: actor,
     userText,
     channelDeliveryContext,
+    emissionContext,
   });
 
   if (canonicalResult.applied) {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -151,9 +151,18 @@ async function tryConsumeInlineApprovalReply(params: {
     return { consumed: false };
   }
 
-  // Confirmation state and activity emissions are handled centrally by
-  // handleConfirmationResponse (called via the resolver chain), so no
-  // manual emission is needed here.
+  // Success-path emissions (approved/denied) are handled centrally
+  // by handleConfirmationResponse (called via the resolver chain).
+  // However, stale/failed paths never reach handleConfirmationResponse,
+  // so we emit resolved_stale here for those cases.
+  if (routerResult.requestId && !routerResult.decisionApplied) {
+    session.emitConfirmationStateChanged({
+      requestId: routerResult.requestId,
+      state: 'resolved_stale',
+      source: 'inline_nl',
+      decisionText: trimmedContent,
+    });
+  }
 
   // Decision has been applied — transcript persistence is best-effort.
   // If DB writes fail, we still return consumed: true so the approval text

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -157,6 +157,7 @@ async function tryConsumeInlineApprovalReply(params: {
   // so we emit resolved_stale here for those cases.
   if (routerResult.requestId && !routerResult.decisionApplied) {
     session.emitConfirmationStateChanged({
+      sessionId: conversationId,
       requestId: routerResult.requestId,
       state: 'resolved_stale',
       source: 'inline_nl',

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -12,7 +12,6 @@ import * as attachmentsStore from '../../memory/attachments-store.js';
 import {
   createCanonicalGuardianRequest,
   generateCanonicalRequestCode,
-  getCanonicalGuardianRequest,
   listCanonicalGuardianRequests,
   listPendingCanonicalGuardianRequestsByDestinationConversation,
 } from '../../memory/canonical-guardian-store.js';
@@ -142,38 +141,19 @@ async function tryConsumeInlineApprovalReply(params: {
     conversationId,
     pendingRequestIds,
     approvalConversationGenerator,
+    emissionContext: {
+      source: 'inline_nl',
+      decisionText: trimmedContent,
+    },
   });
 
   if (!routerResult.consumed || routerResult.type === 'nl_keep_pending') {
     return { consumed: false };
   }
 
-  // Emit authoritative confirmation state for the resolved request.
-  // The onStateSignal listener routes these to the SSE hub automatically.
-  if (routerResult.requestId) {
-    let resolvedState: 'approved' | 'denied' | 'resolved_stale';
-    if (!routerResult.decisionApplied) {
-      resolvedState = 'resolved_stale';
-    } else {
-      // Determine actual decision from the canonical request's resolved status.
-      // The router result type is 'canonical_decision_applied' for both approve
-      // and reject, so we query the request to get the actual resolved status.
-      const resolvedRequest = getCanonicalGuardianRequest(routerResult.requestId);
-      resolvedState = resolvedRequest?.status === 'denied' ? 'denied' : 'approved';
-    }
-    session.emitConfirmationStateChanged({
-      sessionId: conversationId,
-      requestId: routerResult.requestId,
-      state: resolvedState,
-      source: 'inline_nl' as const,
-      decisionText: trimmedContent,
-    });
-    // The agent loop continues after both approval and denial, so
-    // always emit a thinking transition when the decision was applied.
-    if (routerResult.decisionApplied) {
-      session.emitActivityState('thinking', 'confirmation_resolved', 'assistant_turn');
-    }
-  }
+  // Confirmation state and activity emissions are handled centrally by
+  // handleConfirmationResponse (called via the resolver chain), so no
+  // manual emission is needed here.
 
   // Decision has been applied — transcript persistence is best-effort.
   // If DB writes fail, we still return consumed: true so the approval text


### PR DESCRIPTION
## Summary
- Thread `emissionContext` through the `routeGuardianReply` → `applyCanonicalGuardianDecision` → resolver chain so `handleConfirmationResponse` emits with the correct `source: 'inline_nl'` for NL approvals
- Remove duplicate manual `emitConfirmationStateChanged` and `emitActivityState` calls from both IPC (`sessions.ts`) and HTTP (`conversation-routes.ts`) handlers that now redundantly fire after `routeGuardianReply`
- Follow-up to #10917 and #10931 — addresses duplicate emission bug found during review

## Test plan
- [x] All 12 behavioral tests in `session-confirmation-signals.test.ts` pass
- [x] All 322 IPC snapshot tests pass
- [x] `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
