### PR TITLE
fix: address review feedback from #10859

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-sender-digest.ts
@@ -20,7 +20,8 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
       if (result.senders.length === 0) {
         return ok(JSON.stringify({
           senders: [],
-          total_scanned: 0,
+          total_scanned: result.totalScanned,
+          query_used: result.queryUsed,
           message: 'No emails found matching the query. Try broadening the search (e.g. remove category filter or extend date range).',
         }));
       }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -126,7 +126,9 @@ public struct InlineSurfaceRouter: View {
         }
         .onChange(of: surface) { oldSurface, newSurface in
             if newSurface.completionState != nil { return }
-            if oldSurface.data != newSurface.data || oldSurface.actions != newSurface.actions {
+            // Reset clicked state when content/actions change, or when completion is cleared
+            // (transition from completed back to active) so buttons become actionable again.
+            if oldSurface.data != newSurface.data || oldSurface.actions != newSurface.actions || oldSurface.completionState != nil {
                 clickedActionLabel = nil
             }
         }


### PR DESCRIPTION
## Summary
- **messaging-sender-digest.ts**: Use `result.totalScanned` and `result.queryUsed` instead of hardcoded `0` when the senders array is empty. This ensures the LLM receives accurate scan metadata even when no senders are found (e.g., messages were scanned but had unparseable From headers).
- **InlineSurfaceRouter.swift**: Also clear `clickedActionLabel` when `completionState` transitions from non-nil to nil (completion cleared), even if `data`/`actions` haven't changed. This prevents stale checkmark UI from blocking users from re-running actions after a surface transitions back to active.

Addresses review feedback from #10859.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10933" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
