### PR TITLE
fix: restrict unsubscribe UI to Gmail in email declutter workflow

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -242,19 +242,21 @@ Help users identify and clean up high-volume senders like newsletters, marketing
 
 1. **Scan**: Call `gmail_sender_digest` (or `messaging_sender_digest` for non-Gmail). Default query targets promotions from the last 90 days.
 2. **Present**: Show results as a `ui_show` table with `selectionMode: "multiple"`:
-   - **Columns (exactly 3)**: Sender, Emails Found, Unsub?
+   - **Gmail columns (exactly 3)**: Sender, Emails Found, Unsub?
+   - **Non-Gmail columns (exactly 2)**: Sender, Emails Found (omit the Unsub? column — unsubscribe is not available)
    - **Pre-select all rows** (`selected: true`) — users deselect what they want to keep
    - **Caption**: "Showing emails from last 90 days in Promotions" (or adjusted to match the query used)
-   - **Action buttons (exactly 2)**: "Archive & Unsubscribe" (primary), "Archive Only" (secondary). **NEVER offer Delete, Trash, or any destructive action.**
+   - **Gmail action buttons (exactly 2)**: "Archive & Unsubscribe" (primary), "Archive Only" (secondary). **NEVER offer Delete, Trash, or any destructive action.**
+   - **Non-Gmail action button (exactly 1)**: "Archive Selected" (primary). Do not offer an unsubscribe button — it is Gmail-specific. **NEVER offer Delete, Trash, or any destructive action.**
 3. **Live progress**: After the user clicks an action button:
    - **Dismiss the table immediately** with `ui_dismiss` — it collapses to a completion chip
    - **Show a `task_progress` card** with one step per selected sender (e.g., "Archiving TechCrunch (247 emails)"). Update each step from `in_progress` → `completed` as each sender finishes.
    - When all senders are processed, set the progress card's `status: "completed"`.
 4. **Act on selection**: For each selected sender:
    - Use `gmail_archive_by_query` (or `messaging_archive_by_sender` for non-Gmail) with the sender's `search_query` — this archives all matching messages in one call, regardless of volume
-   - If the action is "Archive & Unsubscribe" and `has_unsubscribe` is true, call `gmail_unsubscribe` with the sender's `newest_message_id` (Gmail only)
-5. **Accurate summary**: Use the **actual counts returned by `gmail_archive_by_query`**, not the scan counts from `gmail_sender_digest`. The scan is a sample; the archive is comprehensive. Format: "Cleaned up [total_archived] emails from [sender_count] senders. Unsubscribed from [unsub_count]."
-6. **Ongoing protection offer**: After reporting results, offer auto-archive filters:
+   - If Gmail and the action is "Archive & Unsubscribe" and `has_unsubscribe` is true, call `gmail_unsubscribe` with the sender's `newest_message_id`
+5. **Accurate summary**: Use the **actual counts returned by the archive tool**, not the scan counts from the digest. The scan is a sample; the archive is comprehensive. Format: "Cleaned up [total_archived] emails from [sender_count] senders." For Gmail, append: "Unsubscribed from [unsub_count]."
+6. **Ongoing protection offer (Gmail only)**: After reporting results, offer auto-archive filters:
    - "Want me to set up auto-archive filters so future emails from these senders skip your inbox?"
    - If yes, call `gmail_filters` with `action: "create"` for each sender with `from` set to the sender's email and `remove_label_ids: ["INBOX"]`.
    - Then offer a recurring declutter schedule: "Want me to scan for new clutter monthly?" If yes, use `schedule_create` to set up a monthly declutter check.


### PR DESCRIPTION
## Summary
- Fixed the email decluttering workflow in the messaging SKILL.md to properly differentiate between Gmail and non-Gmail providers for UI elements
- Non-Gmail flows now show only 2 columns (Sender, Emails Found) instead of 3, omitting the Gmail-specific "Unsub?" column
- Non-Gmail flows now show a single "Archive Selected" action button instead of "Archive & Unsubscribe" + "Archive Only"
- The unsubscribe step (step 4) is now explicitly gated on Gmail
- The summary format (step 5) now conditionally appends the unsubscribe count only for Gmail
- The ongoing protection offer (step 6) is now explicitly marked as Gmail-only

## Context
Addresses review feedback from PR #10855 — the P2 finding that the declutter workflow always required an "Archive & Unsubscribe" button, conflicting with the provider rule that non-Gmail flows should skip unsubscribe offers.

Note: The P1 finding about `messaging_sender_digest` and `messaging_archive_by_sender` not existing was a false positive — both tools are registered in TOOLS.json (lines 1021 and 1050) with corresponding executor files.

## Test plan
- [ ] Verify Gmail declutter flow still shows 3 columns and 2 action buttons (Archive & Unsubscribe, Archive Only)
- [ ] Verify non-Gmail declutter flow shows 2 columns and 1 action button (Archive Selected)
- [ ] Verify ongoing protection offer only appears for Gmail flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
