### PR TITLE
fix: remove PiP overlay, reposition browser window to top-right

### DIFF
--- a/assistant/src/tools/browser/browser-handoff.ts
+++ b/assistant/src/tools/browser/browser-handoff.ts
@@ -28,6 +28,8 @@ export async function startHandoff(
   log.info({ sessionId, reason: options.reason }, 'Starting handoff to user');
 
   // Bring Chrome to the front so the user can interact directly.
+  // The window is already sized/positioned in top-right via positionWindowSidebar(),
+  // so no repositioning needed.
   if (options.bringToFront) {
     try {
       const page = await browserManager.getOrCreateSessionPage(sessionId);
@@ -35,16 +37,11 @@ export async function startHandoff(
     } catch (err) {
       log.warn({ err, sessionId }, 'Failed to bring browser to front');
     }
-    await browserManager.moveWindowOnscreen();
   }
 
   const surfaceId = getScreencastSurfaceId(sessionId);
   if (!surfaceId) {
     log.warn({ sessionId }, 'No active screencast surface for handoff');
-    // Move window back offscreen if we brought it to front
-    if (options.bringToFront) {
-      await browserManager.positionWindowSidebar();
-    }
     return;
   }
 
@@ -60,13 +57,8 @@ export async function startHandoff(
 
   browserManager.setInteractiveMode(sessionId, true);
 
-  // Wait for user to hand back control (5 min timeout)
+  // Wait for user to hand back control (5 min timeout, or auto-detect URL change)
   await browserManager.waitForHandoffComplete(sessionId);
-
-  // Move Chrome back offscreen after handoff.
-  if (options.bringToFront) {
-    await browserManager.positionWindowSidebar();
-  }
 
   sendToClient({
     type: 'browser_interactive_mode_changed',

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -617,9 +617,9 @@ class BrowserManager {
     try {
       await this.browserCdpSession.send('Browser.setWindowBounds', {
         windowId,
-        bounds: { left: 740, top: 60, width: 680, height: 520, windowState: 'normal' },
+        bounds: { left: 480, top: 40, width: 940, height: 700, windowState: 'normal' },
       });
-      log.debug('positionWindowSidebar: placed browser window on right side');
+      log.debug('positionWindowSidebar: placed browser window in top-right');
     } catch (err) {
       log.warn({ err }, 'positionWindowSidebar: failed to position window');
     }
@@ -635,7 +635,7 @@ class BrowserManager {
     try {
       await this.browserCdpSession.send('Browser.setWindowBounds', {
         windowId,
-        bounds: { left: 100, top: 100, width: 1280, height: 960, windowState: 'normal' },
+        bounds: { left: 200, top: 40, width: 1100, height: 820, windowState: 'normal' },
       });
       log.debug('moveWindowOnscreen: moved window onscreen via CDP');
     } catch (err) {
@@ -669,9 +669,16 @@ class BrowserManager {
       existing();
     }
 
+    // Capture the initial URL so we can auto-detect page changes
+    const page = this.pages.get(sessionId);
+    const initialUrl = page && !page.isClosed() ? page.url() : null;
+
     return new Promise<void>((resolve) => {
+      let pollTimer: ReturnType<typeof setInterval> | null = null;
+
       const resolver = () => {
         clearTimeout(timer);
+        if (pollTimer) clearInterval(pollTimer);
         if (this.handoffResolvers.get(sessionId) === resolver) {
           this.handoffResolvers.delete(sessionId);
         }
@@ -679,6 +686,7 @@ class BrowserManager {
       };
 
       const timer = setTimeout(() => {
+        if (pollTimer) clearInterval(pollTimer);
         if (this.handoffResolvers.get(sessionId) === resolver) {
           this.handoffResolvers.delete(sessionId);
         }
@@ -687,6 +695,28 @@ class BrowserManager {
       }, timeoutMs);
 
       this.handoffResolvers.set(sessionId, resolver);
+
+      // Poll for URL changes — auto-resolve when the page navigates
+      // (e.g., CAPTCHA solved, login redirect)
+      if (initialUrl && page) {
+        pollTimer = setInterval(() => {
+          try {
+            if (page.isClosed()) {
+              resolver();
+              return;
+            }
+            const currentUrl = page.url();
+            if (currentUrl !== initialUrl) {
+              log.info({ sessionId, from: initialUrl, to: currentUrl }, 'Handoff auto-resolved: URL changed');
+              this.interactiveModeSessions.delete(sessionId);
+              resolver();
+            }
+          } catch {
+            // Page may have been closed — resolve gracefully
+            resolver();
+          }
+        }, 2000);
+      }
     });
   }
 

--- a/assistant/src/tools/browser/browser-screencast.ts
+++ b/assistant/src/tools/browser/browser-screencast.ts
@@ -1,7 +1,7 @@
 import { v4 as uuid } from 'uuid';
 
-import type { BrowserFrame, BrowserViewSurfaceData, ServerMessage } from '../../daemon/ipc-contract.js';
-import { browserManager, SCREENCAST_HEIGHT,SCREENCAST_WIDTH } from './browser-manager.js';
+import type { ServerMessage } from '../../daemon/ipc-contract.js';
+import { browserManager, SCREENCAST_HEIGHT, SCREENCAST_WIDTH } from './browser-manager.js';
 
 // Track active screencast sessions
 const activeScreencasts = new Map<string, { surfaceId: string }>();
@@ -40,44 +40,12 @@ export async function ensureScreencast(
   activeScreencasts.set(sessionId, { surfaceId });
 
   try {
-    // Get current page info
-    const page = await browserManager.getOrCreateSessionPage(sessionId);
-    const currentUrl = page.url();
-    const title = await page.title();
+    // Ensure the page exists (may trigger browser launch/connect)
+    await browserManager.getOrCreateSessionPage(sessionId);
 
-    // Send surface show
-    sendToClient({
-      type: 'ui_surface_show',
-      sessionId,
-      surfaceId,
-      surfaceType: 'browser_view',
-      title: 'Browser',
-      data: {
-        sessionId,
-        currentUrl: currentUrl || 'about:blank',
-        status: 'idle',
-        pages: [{ id: sessionId, title: title || 'New Tab', url: currentUrl || 'about:blank', active: true }],
-      } satisfies BrowserViewSurfaceData,
-      display: 'panel',
-    });
-
-    // Start CDP screencast
-    await browserManager.startScreencast(sessionId, (frame) => {
-      sendToClient({
-        type: 'browser_frame',
-        sessionId,
-        surfaceId,
-        frame: frame.data,
-        metadata: frame.metadata,
-      } satisfies BrowserFrame);
-    });
+    // Skip PiP surface and CDP screencast — the user watches the actual
+    // browser window directly (positioned in top-right via positionWindowSidebar).
   } catch (err) {
-    // Dismiss the surface we already showed so the client doesn't have an orphaned panel
-    sendToClient({
-      type: 'ui_surface_dismiss',
-      sessionId,
-      surfaceId,
-    });
     // Roll back so future calls can retry
     activeScreencasts.delete(sessionId);
     throw err;
@@ -130,19 +98,15 @@ export async function updatePagesList(
 
 export async function stopBrowserScreencast(
   sessionId: string,
-  sendToClient: (msg: ServerMessage) => void,
+  _sendToClient: (msg: ServerMessage) => void,
 ): Promise<void> {
   const state = activeScreencasts.get(sessionId);
   if (!state) return;
 
+  // Safe no-op if CDP screencast was never started
   await browserManager.stopScreencast(sessionId);
 
-  sendToClient({
-    type: 'ui_surface_dismiss',
-    sessionId,
-    surfaceId: state.surfaceId,
-  });
-
+  // Skip ui_surface_dismiss — no PiP surface was shown
   activeScreencasts.delete(sessionId);
 }
 
@@ -190,18 +154,11 @@ export function updateHighlights(
 
 export async function stopAllScreencasts(): Promise<void> {
   const entries = Array.from(activeScreencasts.entries());
-  for (const [sessionId, state] of entries) {
+  for (const [sessionId] of entries) {
     try {
       await browserManager.stopScreencast(sessionId);
     } catch { /* best-effort */ }
-    const sender = sessionSenders.get(sessionId);
-    if (sender) {
-      sender({
-        type: 'ui_surface_dismiss',
-        sessionId,
-        surfaceId: state.surfaceId,
-      });
-    }
+    // Skip ui_surface_dismiss — no PiP surfaces were shown
   }
   activeScreencasts.clear();
 }


### PR DESCRIPTION
## Summary

- **Remove PiP overlay**: Skip `ui_surface_show` and CDP `Page.startScreencast` in `ensureScreencast()` — no more low-res floating panel. Skip corresponding `ui_surface_dismiss` on cleanup.
- **Reposition browser window**: Change `positionWindowSidebar()` from small sidebar (680×520 at left=740) to medium top-right (940×700 at left=480). Update `moveWindowOnscreen()` similarly.
- **Auto-detect handoff completion**: Poll page URL every 2s during handoff — auto-resolves when the page navigates (e.g., CAPTCHA solved, login redirect). Remove unnecessary `moveWindowOnscreen()`/`positionWindowSidebar()` calls from handoff flow since the window is already visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
