### PR TITLE
fix: hide Home Base from the default apps list

### DIFF
--- a/assistant/src/daemon/handlers/apps.ts
+++ b/assistant/src/daemon/handlers/apps.ts
@@ -7,6 +7,8 @@ import { v4 as uuid } from 'uuid';
 
 import { packageApp } from '../../bundler/app-bundler.js';
 import { defaultGallery } from '../../gallery/default-gallery.js';
+import { resolveHomeBaseAppId } from '../../home-base/bootstrap.js';
+import { isPrebuiltHomeBaseApp } from '../../home-base/prebuilt-home-base-updater.js';
 import { getAppDiff, getAppFileAtVersion, getAppHistory, restoreAppVersion } from '../../memory/app-git-service.js';
 import { createApp, createAppRecord, deleteAppRecord, getApp, getAppPreview, listApps, queryAppRecords, updateApp,updateAppRecord } from '../../memory/app-store.js';
 import { createSharedAppLink } from '../../memory/shared-app-links-store.js';
@@ -140,7 +142,13 @@ export function handleAppUpdatePreview(msg: AppUpdatePreviewRequest, socket: net
 
 export function handleAppsList(socket: net.Socket, ctx: HandlerContext): void {
   try {
-    const apps = listApps();
+    const allApps = listApps();
+    const homeBaseId = resolveHomeBaseAppId();
+    const apps = allApps.filter((a) => {
+      if (homeBaseId && a.id === homeBaseId) return false;
+      if (isPrebuiltHomeBaseApp(a)) return false;
+      return true;
+    });
     ctx.send(socket, {
       type: 'apps_list_response',
       apps: apps.map((a) => {


### PR DESCRIPTION
## Summary

- Filter Home Base apps out of the `apps_list` daemon response so they no longer appear in the macOS/iOS apps grid
- Uses `resolveHomeBaseAppId()` (linked ID) and `isPrebuiltHomeBaseApp()` (description/HTML marker) to catch both linked and unlinked prebuilt Home Base apps
- Home Base retains its own dedicated UI section — only the general apps list is affected

## Original prompt
remove home base from default list of apps that are visible to the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
