### PR TITLE
fix: launch browser visible instead of headless for user observation

### DIFF
--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -304,8 +304,9 @@ class BrowserManager {
       }
 
       const launch = launchPersistentContext ?? await getDefaultLaunchFn();
-      const ctx = await launch(profileDir, { headless: true });
-      log.info({ profileDir }, 'Browser context created');
+      const ctx = await launch(profileDir, { headless: false });
+      this._browserLaunched = true;
+      log.info({ profileDir }, 'Browser context created (visible)');
       return ctx;
     })();
 
@@ -391,8 +392,21 @@ class BrowserManager {
     // Track downloads for this page
     this.setupDownloadTracking(sessionId, page);
 
-    // In CDP mode, position the window on the side so the user can watch.
-    if (this._browserMode === 'cdp' && !this.interactiveModeSessions.has(sessionId)) {
+    // For launched browsers (not CDP-connected), create a page-level CDP session
+    // so we can position the browser window. Browser domain commands (setWindowBounds,
+    // getWindowForTarget) are accessible from page-level CDP sessions.
+    if (!this.browserCdpSession && this._browserLaunched && this._browserMode !== 'cdp') {
+      try {
+        const rawPage = page as unknown as RawPlaywrightPage;
+        this.browserCdpSession = await rawPage.context().newCDPSession(rawPage);
+        await this.ensureBrowserWindowId();
+      } catch (err) {
+        log.warn({ err }, 'Failed to create CDP session for window positioning');
+      }
+    }
+
+    // Position the browser window so the user can watch.
+    if (this.browserCdpSession && !this.interactiveModeSessions.has(sessionId)) {
       await this.positionWindowSidebar();
     }
 
@@ -622,6 +636,9 @@ class BrowserManager {
       log.debug('positionWindowSidebar: placed browser window in top-right');
     } catch (err) {
       log.warn({ err }, 'positionWindowSidebar: failed to position window');
+      // CDP session may be stale (e.g. page closed) — clear it so it gets recreated
+      this.browserCdpSession = null;
+      this.browserWindowId = null;
     }
   }
 


### PR DESCRIPTION
## Summary

- **Launch visible browser**: Changed `headless: true` to `headless: false` when launching Chromium, so the user can see what the assistant is doing in the browser window
- **CDP session for launched browsers**: After creating the first page in a launched browser, creates a page-level CDP session to enable window positioning (previously only worked when connecting to user's existing Chrome via CDP)
- **Position window for all browser modes**: Changed the positioning guard from CDP-mode-only to any browser with a CDP session, so the window is placed in the top-right corner regardless of launch mode
- **Resilient CDP cleanup**: If positioning fails (stale CDP session), clears it so it gets recreated on next page creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
