### PR TITLE
fix: use correct .v-timeline-entry class name in app-builder timeline guidance

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -1565,7 +1565,7 @@ When to use each of the 8 layout variants:
 | **Bullets / Content** | Core message; 3–5 bullets max, or 2–3 sentence body |
 | **Quote** | Emotional punctuation; center-aligned, breaks visual pattern |
 | **Comparison** | Two-column before/after, entity comparison, or pros/cons |
-| **Timeline** | Chronological progression; milestones, history, roadmap, or process steps using `.v-timeline` entries |
+| **Timeline** | Chronological progression; milestones, history, roadmap, or process steps using `.v-timeline-entry` entries |
 | **Visual / Immersive** | Gradient background with glass overlay, minimal text |
 | **Closing / CTA** | Bold title, short takeaway, optional stat reinforcement |
 


### PR DESCRIPTION
Addresses Codex feedback on #10934: the timeline layout variant row referenced `.v-timeline` but the component contract uses `.v-timeline-entry`. Updated to match.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
