### PR TITLE
fix: load full app data for Home Base detection in apps list

### DIFF
--- a/assistant/src/daemon/handlers/apps.ts
+++ b/assistant/src/daemon/handlers/apps.ts
@@ -147,6 +147,11 @@ export function handleAppsList(socket: net.Socket, ctx: HandlerContext): void {
     const apps = allApps.filter((a) => {
       if (homeBaseId && a.id === homeBaseId) return false;
       if (isPrebuiltHomeBaseApp(a)) return false;
+      // listApps() returns metadata-only (no htmlDefinition), so the HTML marker
+      // check inside isPrebuiltHomeBaseApp is inert above. Load the full app to
+      // let the HTML fallback fire when the description prefix has been removed.
+      const fullApp = getApp(a.id);
+      if (fullApp && isPrebuiltHomeBaseApp(fullApp)) return false;
       return true;
     });
     ctx.send(socket, {


### PR DESCRIPTION
Addresses feedback on #10937: isPrebuiltHomeBaseApp HTML marker check was dead code when called from handleAppsList because listApps() doesn't load htmlDefinition. Now loads full app data for the fallback check.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
