### PR TITLE
fix: clean up browser handoff and screencast state after PiP removal

### DIFF
--- a/assistant/src/__tests__/session-init.benchmark.test.ts
+++ b/assistant/src/__tests__/session-init.benchmark.test.ts
@@ -263,7 +263,6 @@ mock.module('../tools/browser/browser-screencast.js', () => ({
   stopAllScreencasts: () => Promise.resolve(),
   isScreencastActive: () => false,
   getSender: () => undefined,
-  getScreencastSurfaceId: () => null,
 }));
 
 mock.module('../services/published-app-updater.js', () => ({

--- a/assistant/src/tools/browser/browser-handoff.ts
+++ b/assistant/src/tools/browser/browser-handoff.ts
@@ -1,7 +1,7 @@
 import type { ServerMessage } from '../../daemon/ipc-contract.js';
 import { getLogger } from '../../util/logger.js';
 import { browserManager } from './browser-manager.js';
-import { getScreencastSurfaceId } from './browser-screencast.js';
+import { isScreencastActive } from './browser-screencast.js';
 
 const log = getLogger('browser-handoff');
 
@@ -39,17 +39,17 @@ export async function startHandoff(
     }
   }
 
-  const surfaceId = getScreencastSurfaceId(sessionId);
-  if (!surfaceId) {
-    log.warn({ sessionId }, 'No active screencast surface for handoff');
+  if (!isScreencastActive(sessionId)) {
+    log.warn({ sessionId }, 'No active browser session for handoff');
     return;
   }
 
-  // Send interactive mode change with reason and message
+  // Send interactive mode change with reason and message.
+  // surfaceId uses sessionId as a stable identifier since PiP surfaces are removed.
   sendToClient({
     type: 'browser_interactive_mode_changed',
     sessionId,
-    surfaceId,
+    surfaceId: sessionId,
     enabled: true,
     reason: options.reason,
     message: options.message,
@@ -63,7 +63,7 @@ export async function startHandoff(
   sendToClient({
     type: 'browser_interactive_mode_changed',
     sessionId,
-    surfaceId,
+    surfaceId: sessionId,
     enabled: false,
   } as ServerMessage);
 

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -719,6 +719,7 @@ class BrowserManager {
         pollTimer = setInterval(() => {
           try {
             if (page.isClosed()) {
+              this.interactiveModeSessions.delete(sessionId);
               resolver();
               return;
             }
@@ -730,6 +731,7 @@ class BrowserManager {
             }
           } catch {
             // Page may have been closed — resolve gracefully
+            this.interactiveModeSessions.delete(sessionId);
             resolver();
           }
         }, 2000);

--- a/assistant/src/tools/browser/browser-screencast.ts
+++ b/assistant/src/tools/browser/browser-screencast.ts
@@ -1,10 +1,9 @@
-import { v4 as uuid } from 'uuid';
-
 import type { ServerMessage } from '../../daemon/ipc-contract.js';
 import { browserManager, SCREENCAST_HEIGHT, SCREENCAST_WIDTH } from './browser-manager.js';
 
-// Track active screencast sessions
-const activeScreencasts = new Map<string, { surfaceId: string }>();
+// Track which sessions have an active browser page (no PiP surface — the user
+// watches the actual browser window directly).
+const activeBrowserSessions = new Set<string>();
 
 // Registry of sendToClient callbacks per session
 const sessionSenders = new Map<string, (msg: ServerMessage) => void>();
@@ -32,82 +31,55 @@ function getSender(sessionId: string): ((msg: ServerMessage) => void) | undefine
 
 export async function ensureScreencast(
   sessionId: string,
-  sendToClient: (msg: ServerMessage) => void,
+  _sendToClient: (msg: ServerMessage) => void,
 ): Promise<void> {
-  if (activeScreencasts.has(sessionId)) return;
+  if (activeBrowserSessions.has(sessionId)) return;
 
-  const surfaceId = uuid();
-  activeScreencasts.set(sessionId, { surfaceId });
+  activeBrowserSessions.add(sessionId);
 
   try {
     // Ensure the page exists (may trigger browser launch/connect)
     await browserManager.getOrCreateSessionPage(sessionId);
 
-    // Skip PiP surface and CDP screencast — the user watches the actual
+    // No PiP surface or CDP screencast — the user watches the actual
     // browser window directly (positioned in top-right via positionWindowSidebar).
   } catch (err) {
     // Roll back so future calls can retry
-    activeScreencasts.delete(sessionId);
+    activeBrowserSessions.delete(sessionId);
     throw err;
   }
 }
 
 export function updateBrowserStatus(
   sessionId: string,
-  sendToClient: (msg: ServerMessage) => void,
-  status: 'navigating' | 'idle' | 'interacting',
-  actionText?: string,
-  currentUrl?: string,
+  _sendToClient: (msg: ServerMessage) => void,
+  _status: 'navigating' | 'idle' | 'interacting',
+  _actionText?: string,
+  _currentUrl?: string,
 ): void {
-  const state = activeScreencasts.get(sessionId);
-  if (!state) return;
-
-  const update: Record<string, unknown> = { status };
-  if (actionText !== undefined) update.actionText = actionText;
-  if (currentUrl !== undefined) update.currentUrl = currentUrl;
-
-  sendToClient({
-    type: 'ui_surface_update',
-    sessionId,
-    surfaceId: state.surfaceId,
-    data: update,
-  });
+  // No-op: PiP surface was removed so there is no ui_surface to update.
+  // The function signature is preserved to avoid churn at callsites.
+  if (!activeBrowserSessions.has(sessionId)) return;
 }
 
 export async function updatePagesList(
   sessionId: string,
-  sendToClient: (msg: ServerMessage) => void,
+  _sendToClient: (msg: ServerMessage) => void,
 ): Promise<void> {
-  const state = activeScreencasts.get(sessionId);
-  if (!state) return;
-
-  const page = await browserManager.getOrCreateSessionPage(sessionId);
-  const currentUrl = page.url();
-  const title = await page.title();
-
-  sendToClient({
-    type: 'ui_surface_update',
-    sessionId,
-    surfaceId: state.surfaceId,
-    data: {
-      currentUrl,
-      pages: [{ id: sessionId, title: title || 'Untitled', url: currentUrl, active: true }],
-    },
-  });
+  // No-op: PiP surface was removed so there is no ui_surface to update.
+  if (!activeBrowserSessions.has(sessionId)) return;
 }
 
 export async function stopBrowserScreencast(
   sessionId: string,
   _sendToClient: (msg: ServerMessage) => void,
 ): Promise<void> {
-  const state = activeScreencasts.get(sessionId);
-  if (!state) return;
+  if (!activeBrowserSessions.has(sessionId)) return;
 
   // Safe no-op if CDP screencast was never started
   await browserManager.stopScreencast(sessionId);
 
-  // Skip ui_surface_dismiss — no PiP surface was shown
-  activeScreencasts.delete(sessionId);
+  activeBrowserSessions.delete(sessionId);
 }
 
 export async function getElementBounds(
@@ -139,37 +111,24 @@ export async function getElementBounds(
 
 export function updateHighlights(
   sessionId: string,
-  sendToClient: (msg: ServerMessage) => void,
-  highlights: Array<{ x: number; y: number; w: number; h: number; label: string }>,
+  _sendToClient: (msg: ServerMessage) => void,
+  _highlights: Array<{ x: number; y: number; w: number; h: number; label: string }>,
 ): void {
-  const state = activeScreencasts.get(sessionId);
-  if (!state) return;
-  sendToClient({
-    type: 'ui_surface_update',
-    sessionId,
-    surfaceId: state.surfaceId,
-    data: { highlights },
-  });
+  // No-op: PiP surface was removed so there is no ui_surface to update.
+  if (!activeBrowserSessions.has(sessionId)) return;
 }
 
 export async function stopAllScreencasts(): Promise<void> {
-  const entries = Array.from(activeScreencasts.entries());
-  for (const [sessionId] of entries) {
+  for (const sessionId of activeBrowserSessions) {
     try {
       await browserManager.stopScreencast(sessionId);
     } catch { /* best-effort */ }
-    // Skip ui_surface_dismiss — no PiP surfaces were shown
   }
-  activeScreencasts.clear();
+  activeBrowserSessions.clear();
 }
 
 export function isScreencastActive(sessionId: string): boolean {
-  return activeScreencasts.has(sessionId);
+  return activeBrowserSessions.has(sessionId);
 }
 
 export { getSender };
-
-export function getScreencastSurfaceId(sessionId: string): string | null {
-  const state = activeScreencasts.get(sessionId);
-  return state?.surfaceId ?? null;
-}


### PR DESCRIPTION
## Summary
- **interactiveModeSessions leak on page close**: In `waitForHandoffComplete()`, the `page.isClosed()` polling branch and catch block now clean up `interactiveModeSessions` before resolving, matching the URL-change and timeout branches.
- **Orphaned surfaceId / spurious ui_surface_update**: Since PiP was removed in #10936, `ensureScreencast` no longer generates a `surfaceId` or stores it in a map. The `activeScreencasts` map is replaced with a simple `activeBrowserSessions` set. Functions `updateBrowserStatus`, `updatePagesList`, and `updateHighlights` are now no-ops (signature preserved to avoid callsite churn). The `getScreencastSurfaceId` export is removed; `browser-handoff.ts` now uses `isScreencastActive()` and passes `sessionId` as the stable surfaceId for IPC contract compatibility.

Addresses feedback on #10936.

## Test plan
- [ ] Verify browser handoff completes cleanly when page is closed during interactive mode
- [ ] Verify no `ui_surface_update` messages are sent (since PiP is removed)
- [ ] Verify `interactiveModeSessions` is properly cleaned up in all exit paths of `waitForHandoffComplete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
