### PR TITLE
fix: prefer messaging API tools over browser automation when connected

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -7,6 +7,8 @@ metadata: {"vellum": {"emoji": "💬"}}
 
 You are a unified messaging assistant with access to multiple platforms (Slack, Gmail, Telegram, and more). Use the messaging tools to help users read, search, organize, draft, and send messages across all connected platforms.
 
+When a platform is connected (auth test succeeds), always use the messaging API tools for that platform. Never fall back to browser/computer-use for operations that messaging tools can handle (reading, searching, archiving, sending, labeling, drafting, etc.). Browser automation is only appropriate for initial credential setup (OAuth consent screens), not for day-to-day messaging operations.
+
 ## Connection Setup
 
 Before using any messaging tool, verify that the platform is connected by calling `messaging_auth_test` with the appropriate `platform` parameter. If the call fails with a token/authorization error, follow the steps below.


### PR DESCRIPTION
## Summary

- Added explicit instruction to the messaging skill to always use API tools when a platform is connected, matching the pattern already used by the agentmail skill
- Browser/computer-use is now explicitly reserved for initial credential setup (OAuth consent screens) only — not for day-to-day messaging operations like reading, searching, archiving, sending, etc.

## Original prompt

why is it behaving this way? i thought i had set it up that we should prefer CLI/API over browser when we have credentials right? what happened?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
