### PR TITLE
fix: avoid expensive getApp calls in apps list filter

### DIFF
--- a/assistant/src/daemon/handlers/apps.ts
+++ b/assistant/src/daemon/handlers/apps.ts
@@ -144,14 +144,32 @@ export function handleAppsList(socket: net.Socket, ctx: HandlerContext): void {
   try {
     const allApps = listApps();
     const homeBaseId = resolveHomeBaseAppId();
+
+    // When no home base was found by ID, do a single targeted search for an app
+    // matching the HTML marker. listApps() returns metadata-only (no htmlDefinition),
+    // so the HTML marker check requires loading the full app from disk. We limit
+    // this expensive operation to the case where homeBaseId is null and stop after
+    // finding the first match.
+    const excludeIds = new Set<string>();
+    if (homeBaseId) {
+      excludeIds.add(homeBaseId);
+    } else {
+      for (const a of allApps) {
+        if (isPrebuiltHomeBaseApp(a)) {
+          excludeIds.add(a.id);
+          continue;
+        }
+        const fullApp = getApp(a.id);
+        if (fullApp && isPrebuiltHomeBaseApp(fullApp)) {
+          excludeIds.add(a.id);
+          break;
+        }
+      }
+    }
+
     const apps = allApps.filter((a) => {
-      if (homeBaseId && a.id === homeBaseId) return false;
+      if (excludeIds.has(a.id)) return false;
       if (isPrebuiltHomeBaseApp(a)) return false;
-      // listApps() returns metadata-only (no htmlDefinition), so the HTML marker
-      // check inside isPrebuiltHomeBaseApp is inert above. Load the full app to
-      // let the HTML fallback fire when the description prefix has been removed.
-      const fullApp = getApp(a.id);
-      if (fullApp && isPrebuiltHomeBaseApp(fullApp)) return false;
       return true;
     });
     ctx.send(socket, {


### PR DESCRIPTION
Addresses review feedback on #10942:

- Move expensive getApp() HTML fallback outside the filter loop
- Only perform full app loads when homeBaseId is null (no ID-based match found)
- Short-circuit after finding first HTML marker match
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
