### PR TITLE
fix: restore headless fallback and fix browser positioning guard

### DIFF
--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -248,8 +248,9 @@ export async function executeBrowserNavigate(
       routeHandler = null;
     }
 
-    // In CDP mode, position the browser on the side unless a handoff is active.
-    if (browserManager.browserMode === 'cdp' && !browserManager.isInteractive(context.sessionId)) {
+    // Reposition the browser window after navigation so the user can watch.
+    // positionWindowSidebar() is a no-op when browserCdpSession is unavailable.
+    if (!browserManager.isInteractive(context.sessionId)) {
       await browserManager.positionWindowSidebar();
     }
 

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -10,6 +10,15 @@ import { checkBrowserRuntime } from './runtime-check.js';
 
 const log = getLogger('browser-manager');
 
+/**
+ * Returns true when the host has a GUI capable of displaying a browser window.
+ * macOS and Windows always have a display; Linux requires DISPLAY or WAYLAND_DISPLAY.
+ */
+function canDisplayGui(): boolean {
+  if (process.platform === 'darwin' || process.platform === 'win32') return true;
+  return !!(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
+}
+
 // Screencast capture dimensions — used by coordinate math across the browser module
 // to map between page coordinates and screencast-frame coordinates.
 export const SCREENCAST_WIDTH = 1280;
@@ -260,9 +269,12 @@ class BrowserManager {
         }
 
         if (invokingSessionId && this.sessionSenders.get(invokingSessionId) && this._browserMode === 'headless') {
+          const willBeHeaded = canDisplayGui();
           log.info(
-            { sessionId: invokingSessionId },
-            'CDP unavailable/declined; staying in headless mode (no visible browser window will be auto-launched)',
+            { sessionId: invokingSessionId, willBeHeaded },
+            willBeHeaded
+              ? 'CDP unavailable/declined; launching visible browser (display available)'
+              : 'CDP unavailable/declined; staying in headless mode (no display available)',
           );
         }
       }
@@ -304,9 +316,10 @@ class BrowserManager {
       }
 
       const launch = launchPersistentContext ?? await getDefaultLaunchFn();
-      const ctx = await launch(profileDir, { headless: false });
+      const headless = !canDisplayGui();
+      const ctx = await launch(profileDir, { headless });
       this._browserLaunched = true;
-      log.info({ profileDir }, 'Browser context created (visible)');
+      log.info({ profileDir, headless }, headless ? 'Browser context created (headless)' : 'Browser context created (visible)');
       return ctx;
     })();
 


### PR DESCRIPTION
## Summary

Addresses review feedback on #10939:

- **Restore headless fallback** for non-GUI environments (CI, remote Linux, background task runs) by introducing `canDisplayGui()` — macOS/Windows always have a display, Linux requires `DISPLAY` or `WAYLAND_DISPLAY`. Only launch headed when the host can actually show a window.
- **Update second positioning call site** in `browser-execution.ts` to remove stale `browserMode === 'cdp'` guard. The old check meant launched (non-CDP) browsers were never repositioned after navigation. `positionWindowSidebar()` already safely no-ops when no CDP session is available, so the guard is unnecessary.
- **Fix misleading log message** at `browser-manager.ts:265` that said "staying in headless mode" when the code was about to launch a visible browser. The log now accurately reflects whether the browser will be headed or headless.

## Test plan

- [ ] Verify browser launches headless on Linux CI (no `DISPLAY` env var)
- [ ] Verify browser launches visible on macOS desktop
- [ ] Verify browser window repositions after navigation for both CDP and launched browsers
- [ ] Verify log messages accurately describe the browser mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
