### PR TITLE
fix: use publish target appId and fix thread switcher cleanup

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -163,8 +163,22 @@ struct MainWindowView: View {
                 } else if response.errorCode == "credentials_missing" {
                     // Save pending publish for auto-retry after credential setup
                     sharing.pendingPublish = (html: html, title: title, appId: appId)
-                    // Open the chat dock so the user can see the credential setup flow
-                    if case .app(let currentAppId) = windowState.selection {
+                    // Open the chat dock so the user can see the credential setup flow.
+                    // Use the publish target's appId (not windowState.selection) to avoid
+                    // a race where the user navigates away before this async callback fires.
+                    if let targetAppId = appId {
+                        isAppChatOpen = true
+                        let threadId = threadManager.activeThreadId ?? threadManager.visibleThreads.first?.id
+                        if let threadId {
+                            threadManager.selectThread(id: threadId)
+                            windowState.setAppEditing(appId: targetAppId, threadId: threadId)
+                        } else {
+                            threadManager.createThread()
+                            if let newThreadId = threadManager.activeThreadId {
+                                windowState.setAppEditing(appId: targetAppId, threadId: newThreadId)
+                            }
+                        }
+                    } else if case .app(let currentAppId) = windowState.selection {
                         isAppChatOpen = true
                         let threadId = threadManager.activeThreadId ?? threadManager.visibleThreads.first?.id
                         if let threadId {
@@ -1455,12 +1469,12 @@ struct MainWindowView: View {
                             .fill(Color(hex: 0xE86B40))
                             .frame(width: 8, height: 8)
                             .offset(x: 4, y: 4)
-                            .onDisappear {
-                                threadSwitcherHoverTimer?.cancel()
-                                threadSwitcherHoverTimer = nil
-                                showThreadSwitcher = false
-                            }
                     }
+                }
+                .onDisappear {
+                    threadSwitcherHoverTimer?.cancel()
+                    threadSwitcherHoverTimer = nil
+                    showThreadSwitcher = false
                 }
                 .contentShape(Rectangle())
                 .onTapGesture {


### PR DESCRIPTION
Addresses review feedback on #10940:

- Use the original publish target `appId` instead of `windowState.selection` to prevent race when user navigates during async publish
- Move `onDisappear` cleanup to always-present ZStack so thread switcher timer state is properly cleaned up

## Changes

### 1. Publish target appId race fix
The `credentials_missing` handler previously derived `currentAppId` from `windowState.selection`. If the user clicked Publish on app A then navigated to app B before the async response returned, this would open/edit app B while sending the credential-setup prompt for app A. Now uses the publish target's `appId` parameter directly, falling back to `windowState.selection` only when `appId` is nil.

### 2. Thread switcher cleanup fix
The `onDisappear` cleanup handler (which cancels `threadSwitcherHoverTimer` and dismisses `showThreadSwitcher`) was attached to the unseen-dot Circle, which is only visible when there are unseen messages. When a user has multiple threads but no unseen messages, the cleanup never ran when the sidebar collapsed, causing state leaks. Moved `onDisappear` to the ZStack parent which is always present.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10947" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
