### PR TITLE
fix: scan all apps for HTML-marker Home Base exclusion

### DIFF
--- a/assistant/src/daemon/handlers/apps.ts
+++ b/assistant/src/daemon/handlers/apps.ts
@@ -148,8 +148,7 @@ export function handleAppsList(socket: net.Socket, ctx: HandlerContext): void {
     // When no home base was found by ID, do a single targeted search for an app
     // matching the HTML marker. listApps() returns metadata-only (no htmlDefinition),
     // so the HTML marker check requires loading the full app from disk. We limit
-    // this expensive operation to the case where homeBaseId is null and stop after
-    // finding the first match.
+    // this expensive operation to the case where homeBaseId is null.
     const excludeIds = new Set<string>();
     if (homeBaseId) {
       excludeIds.add(homeBaseId);
@@ -162,7 +161,7 @@ export function handleAppsList(socket: net.Socket, ctx: HandlerContext): void {
         const fullApp = getApp(a.id);
         if (fullApp && isPrebuiltHomeBaseApp(fullApp)) {
           excludeIds.add(a.id);
-          break;
+          continue;
         }
       }
     }


### PR DESCRIPTION
Removes the early break in the Home Base app pre-scan so all apps with HTML markers are excluded from the list, not just the first match. Addresses feedback from PR #10945.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10950" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
