### PR TITLE
fix: cancel threadSwitcherDismissTimer in onDisappear cleanup

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1474,6 +1474,8 @@ struct MainWindowView: View {
                 .onDisappear {
                     threadSwitcherHoverTimer?.cancel()
                     threadSwitcherHoverTimer = nil
+                    threadSwitcherDismissTimer?.cancel()
+                    threadSwitcherDismissTimer = nil
                     showThreadSwitcher = false
                 }
                 .contentShape(Rectangle())


### PR DESCRIPTION
## Summary
- Adds missing cancellation of `threadSwitcherDismissTimer` in the `onDisappear` handler to prevent a dangling `DispatchWorkItem` from firing after the view disappears.
- Addresses review feedback from Devin on PR #10947.

## Test plan
- [ ] Verify the thread switcher dismiss timer does not fire after the sidebar collapses
- [ ] Confirm no regressions in thread switcher hover/dismiss behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10951" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
