### PR TITLE
fix: add gateway crash recovery and bootstrap interstitial diagnostics

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -494,10 +494,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
     /// Starts a background task that polls daemon readiness every 2 seconds.
     /// When the daemon connects, dismisses the interstitial and proceeds
-    /// with the mandatory wake-up send.
+    /// with the mandatory wake-up send. Shows escalating diagnostic messages
+    /// if the daemon takes too long to connect.
     private func startBootstrapRetryCoordinator() {
         bootstrapRetryTask?.cancel()
         updateBootstrapInterstitial(isRetrying: true)
+
+        let retryStart = CFAbsoluteTimeGetCurrent()
 
         bootstrapRetryTask = Task {
             while !Task.isCancelled {
@@ -511,6 +514,16 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                         bootstrapRetryTask = nil
                     }
                     return
+                }
+
+                // Surface escalating diagnostics so the user isn't staring
+                // at a spinner with no context.
+                let elapsed = CFAbsoluteTimeGetCurrent() - retryStart
+                if elapsed > 30 {
+                    updateBootstrapInterstitial(
+                        errorMessage: bootstrapDiagnosticMessage(elapsed: elapsed),
+                        isRetrying: true
+                    )
                 }
 
                 // If the daemon socket doesn't exist, the daemon process
@@ -545,6 +558,22 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
             }
+        }
+    }
+
+    /// Returns a user-facing diagnostic message based on how long the bootstrap
+    /// retry has been running. Messages escalate in specificity over time.
+    private func bootstrapDiagnosticMessage(elapsed: CFAbsoluteTime) -> String {
+        if elapsed > 120 {
+            return "Your assistant is taking unusually long to start. "
+                + "Try quitting the app (\u{2318}Q) and reopening it. "
+                + "If the issue persists, retire and re-hatch your assistant."
+        } else if elapsed > 60 {
+            return "This is taking longer than expected. "
+                + "A background process may have crashed. "
+                + "The app will keep retrying automatically."
+        } else {
+            return "Still working on it \u{2014} this can take a minute on first launch."
         }
     }
 

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -66,6 +66,10 @@ final class AssistantCli {
         vellumDir.appendingPathComponent("vellum.sock")
     }
 
+    private var gatewayPidFileURL: URL {
+        vellumDir.appendingPathComponent("gateway.pid")
+    }
+
     // MARK: - Health Monitor State
 
     /// Called after the daemon is restarted by the health monitor so the
@@ -264,6 +268,7 @@ final class AssistantCli {
             log.info("No bundled CLI binary found — skipping stop (dev mode)")
             // Still try to clean up via PID file in dev mode
             killViaPIDFile()
+            killGatewayViaPIDFile()
             return
         }
 
@@ -291,6 +296,7 @@ final class AssistantCli {
             log.error("CLI stop failed: \(error.localizedDescription)")
             // Fallback: kill via PID file directly
             killViaPIDFile()
+            killGatewayViaPIDFile()
         }
     }
 
@@ -318,6 +324,9 @@ final class AssistantCli {
 
                 if !self.isDaemonAlive() {
                     log.warning("Daemon process not running — attempting restart")
+                    await self.restartDaemon()
+                } else if !self.isGatewayAlive() {
+                    log.warning("Gateway process not running (daemon alive) — attempting restart via hatch")
                     await self.restartDaemon()
                 }
             }
@@ -582,6 +591,26 @@ final class AssistantCli {
         return assistants.contains { ($0["assistantId"] as? String) == assistantId }
     }
 
+    /// Returns `true` if the gateway process is alive based on the PID file.
+    /// Returns `true` when the PID file doesn't exist — the gateway may not
+    /// have been started yet (e.g. dev mode) and absence != crash.
+    private func isGatewayAlive() -> Bool {
+        guard FileManager.default.fileExists(atPath: gatewayPidFileURL.path) else {
+            return true
+        }
+        let pidData: Data
+        do {
+            pidData = try Data(contentsOf: gatewayPidFileURL)
+        } catch {
+            return true
+        }
+        guard let pidString = String(data: pidData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let pid = pid_t(pidString) else {
+            return true
+        }
+        return kill(pid, 0) == 0
+    }
+
     /// Returns `true` if the daemon process is alive based on the PID file.
     private func isDaemonAlive() -> Bool {
         let pidData: Data
@@ -642,6 +671,40 @@ final class AssistantCli {
             onDaemonRestarted?()
         } catch {
             log.error("Failed to restart daemon: \(error.localizedDescription)")
+        }
+    }
+
+    /// Kill the gateway directly via PID file — fallback when CLI binary is unavailable.
+    private func killGatewayViaPIDFile() {
+        guard FileManager.default.fileExists(atPath: gatewayPidFileURL.path) else { return }
+        let pidData: Data
+        do {
+            pidData = try Data(contentsOf: gatewayPidFileURL)
+        } catch {
+            return
+        }
+        guard let pidString = String(data: pidData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let pid = pid_t(pidString),
+              kill(pid, 0) == 0 else {
+            return
+        }
+
+        log.info("Killing gateway via PID file (pid \(pid))")
+        kill(pid, SIGTERM)
+
+        let deadline = Date().addingTimeInterval(2.0)
+        while kill(pid, 0) == 0 && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+
+        if kill(pid, 0) == 0 {
+            kill(pid, SIGKILL)
+        }
+
+        do {
+            try FileManager.default.removeItem(at: gatewayPidFileURL)
+        } catch {
+            log.error("Failed to remove gateway PID file: \(error)")
         }
     }
 

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -327,7 +327,7 @@ final class AssistantCli {
                     await self.restartDaemon()
                 } else if !self.isGatewayAlive() {
                     log.warning("Gateway process not running (daemon alive) — attempting restart via hatch")
-                    await self.restartDaemon()
+                    await self.restartDaemon(daemonOnly: false)
                 }
             }
         }
@@ -627,7 +627,7 @@ final class AssistantCli {
         return kill(pid, 0) == 0
     }
 
-    private func restartDaemon() async {
+    private func restartDaemon(daemonOnly: Bool = true) async {
         guard cliBinaryURL != nil else { return }
         guard !isRestarting else { return }
         isRestarting = true
@@ -666,7 +666,7 @@ final class AssistantCli {
         }
 
         do {
-            try await hatch(name: assistantId, daemonOnly: true)
+            try await hatch(name: assistantId, daemonOnly: daemonOnly)
             log.info("Daemon restarted successfully via CLI")
             onDaemonRestarted?()
         } catch {

--- a/clients/macos/vellum-assistant/Features/Chat/BootstrapInterstitialView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/BootstrapInterstitialView.swift
@@ -27,6 +27,7 @@ struct BootstrapInterstitialView: View {
                     .font(VFont.body)
                     .foregroundColor(VColor.textSecondary)
                     .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 VButton(
                     label: "Try Again",
@@ -47,7 +48,7 @@ struct BootstrapInterstitialView: View {
                             .stroke(VColor.surfaceBorder, lineWidth: 1)
                     )
             )
-            .frame(maxWidth: 320)
+            .frame(maxWidth: 380)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }


### PR DESCRIPTION
## Summary
- Add gateway health monitoring to `AssistantCli.swift` — the health check loop now detects when the gateway process has crashed (PID file exists but process dead) and triggers a restart via `hatch --daemon-only`, reusing the existing backoff/cooldown logic
- Add escalating diagnostic messages to the bootstrap interstitial after 30s/60s/120s of failed daemon connection, so users get actionable guidance instead of an indefinite spinner
- Widen the interstitial card from 320→380px and add `fixedSize(horizontal: false, vertical: true)` to ensure longer diagnostic messages wrap properly

## Context
After PR #10895 introduced the guardian channel identity-bound cutover, a user retired and re-hatched their assistant. The `vellum-gateway` binary crashed due to macOS code signing issues (`SIGKILL`). Unlike the daemon (which has a 5-second health check that auto-restarts it), the gateway had **no crash recovery**. The user was stuck on the "Still starting your assistant" screen with no diagnostic feedback.

## Original prompt
implement the plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10953" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
