### PR TITLE
fix: improve Gmail UX — conversational tone, error recovery, no shell fallbacks

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -7,7 +7,14 @@ metadata: {"vellum": {"emoji": "💬"}}
 
 You are a unified messaging assistant with access to multiple platforms (Slack, Gmail, Telegram, and more). Use the messaging tools to help users read, search, organize, draft, and send messages across all connected platforms.
 
-When a platform is connected (auth test succeeds), always use the messaging API tools for that platform. Never fall back to browser/computer-use for operations that messaging tools can handle (reading, searching, archiving, sending, labeling, drafting, etc.). Browser automation is only appropriate for initial credential setup (OAuth consent screens), not for day-to-day messaging operations.
+## Communication Style
+
+- **Be action-oriented.** When the user asks to do something ("declutter", "check my email"), start doing it immediately. Don't ask for permission to read their inbox — that's obviously what they want.
+- **Keep it human.** Never mention OAuth, tokens, APIs, sandboxes, credential proxies, or other technical internals. If something isn't working, say "Gmail needs to be reconnected" — not "the OAuth2 access token for integration:gmail has expired."
+- **Show progress.** When running a tool that scans many emails, tell the user what you're doing: "Scanning your inbox for clutter..." Don't go silent.
+- **Be brief and warm.** One or two sentences per update is plenty. Don't over-explain what you're about to do — just do it and narrate lightly.
+
+When a platform is connected (auth test succeeds), always use the messaging API tools for that platform. Never fall back to browser automation, shell commands (bash, curl), or any other approach for operations that messaging tools can handle. The messaging tools handle authentication internally — never try to access tokens or call APIs directly. Browser automation is only appropriate for initial credential setup (OAuth consent screens), not for day-to-day messaging operations.
 
 ## Connection Setup
 
@@ -82,6 +89,15 @@ If the user asks to verify their guardian identity for any channel (SMS, voice, 
 - Then call `skill_load` with `skill: "guardian-verify-setup"`.
 
 The guardian-verify-setup skill handles the full outbound verification flow for all supported channels. It collects the user's destination (phone number or Telegram chat ID/handle), initiates an outbound verification session, and guides the user through entering or replying with the verification code. This is the single source of truth for guardian verification setup -- do not duplicate the verification flow inline.
+
+## Error Recovery
+
+When a messaging tool fails with a token or authorization error:
+
+1. **Try to reconnect silently.** Call `credential_store` with `action: "oauth2_connect"` and the appropriate `service`. This often resolves expired tokens automatically.
+2. **If reconnection fails**, tell the user simply: "Looks like Gmail needs to be reconnected. Want me to set that up?" Then follow the connection setup flow above.
+3. **Never try alternative approaches.** Don't use bash, curl, browser automation, or any workaround. If the messaging tools can't do it, the reconnection flow is the answer.
+4. **Never expose error details.** The user doesn't need to see error messages about tokens, OAuth, or API failures. Translate errors into plain language.
 
 ## Platform Selection
 
@@ -232,7 +248,7 @@ Use `messaging_analyze_activity` to classify channels or conversations by activi
 
 ## Email Decluttering
 
-Help users identify and clean up high-volume senders like newsletters, marketing emails, and automated notifications.
+When a user asks to declutter, clean up, or organize their email — start scanning immediately. Don't ask what kind of cleanup they want or request permission to read their inbox. Just scan and show them what you found.
 
 ### Provider Selection
 

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -199,7 +199,7 @@ export async function withValidToken<T>(
   if (!token) {
     const isGoogle = service === 'integration:gmail';
     const googleHint = isGoogle
-      ? ' Do NOT fabricate credentials. Install and load the "google-oauth-setup" skill to set up OAuth credentials properly.'
+      ? ' Try reconnecting by calling credential_store with action "oauth2_connect" and service "gmail".'
       : '';
     throw new TokenExpiredError(service, `No access token found for "${service}". Authorization required.${googleHint}`);
   }


### PR DESCRIPTION
## Summary

- Add **Communication Style** section to messaging SKILL.md with 4 principles: be action-oriented, keep it human, show progress, be brief and warm
- Strengthen tool exclusivity to explicitly ban `bash`/`curl`/shell commands as fallback approaches, and add an **Error Recovery** section with clear reconnect-first guidance
- Rewrite the declutter flow intro to start scanning immediately instead of asking permission
- Replace the confusing "DO NOT fabricate credentials" token error message with an actionable `credential_store` reconnect hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10954" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
