### PR TITLE
fix: split CSS gradient variants into separate code blocks for app-builder

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -92,14 +92,24 @@ These are hard prohibitions. Violating any of these produces that unmistakable "
 Copy-paste-ready CSS techniques. All work in the sandboxed WebView with no external dependencies.
 
 ### Animated Gradient Background
+
+Choose **one** of the following color variants (do not combine both):
+
+**Variant A — Warm pastels (light, airy feel):**
 ```css
-/* Warm pastels */
 body {
   background: linear-gradient(-45deg, #fef3c7, #fce7f3, #e0e7ff, #d1fae5);
   background-size: 400% 400%;
   animation: gradientShift 15s ease infinite;
 }
-/* Dark jewel tones */
+@keyframes gradientShift {
+  0%, 100% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+}
+```
+
+**Variant B — Dark jewel tones (deep, rich feel):**
+```css
 body {
   background: linear-gradient(-45deg, #0f172a, #1e1b4b, #172554, #0c4a6e);
   background-size: 400% 400%;


### PR DESCRIPTION
Addresses review feedback on #10952. Both Devin and Codex flagged that having two body selectors in the same CSS block causes warm pastels to be overridden by dark jewel tones due to CSS cascade. Split them into clearly labeled alternative code blocks so the LLM picks one, not both.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
