### PR TITLE
fix: improve app sync logging and always propagate daemon descriptions

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
@@ -125,18 +125,18 @@ final class AppListManager: ObservableObject {
 
     /// Sync apps from the daemon's authoritative list into the local sidebar list.
     /// Adds any apps that don't already exist locally, using their daemon createdAt timestamp.
-    /// Also updates descriptions on existing apps when the daemon provides one.
+    /// Always propagates daemon descriptions to existing apps when they differ.
     func syncFromDaemon(_ daemonApps: [AppItem_Daemon]) {
         let existingIds = Set(apps.map(\.id))
-        var didChange = false
+        var newCount = 0
+        var updatedCount = 0
         for daemonApp in daemonApps {
             if existingIds.contains(daemonApp.id) {
-                // Update description on existing apps if daemon provides one we don't have
                 if let desc = daemonApp.description,
                    let index = apps.firstIndex(where: { $0.id == daemonApp.id }),
-                   apps[index].description == nil {
+                   apps[index].description != desc {
                     apps[index].description = desc
-                    didChange = true
+                    updatedCount += 1
                 }
                 continue
             }
@@ -153,11 +153,11 @@ final class AppListManager: ObservableObject {
             item.sfSymbol = generated.sfSymbol
             item.iconBackground = generated.colors
             apps.append(item)
-            didChange = true
+            newCount += 1
         }
-        if didChange {
+        if newCount > 0 || updatedCount > 0 {
             save()
-            log.info("Synced \(self.apps.count - existingIds.count) new apps from daemon")
+            log.info("Synced from daemon: \(newCount) new app(s), \(updatedCount) description(s) updated")
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes misleading log message that reported "0 new apps" when only descriptions were updated during daemon sync
- Changes `syncFromDaemon` to always propagate daemon descriptions to existing apps (previously only applied when local description was `nil`)
- Log now accurately reports both new apps added and descriptions updated separately

Addresses review feedback on #10949.

## Test plan
- [ ] Verify description-only sync updates log correctly (e.g., "Synced from daemon: 0 new app(s), 2 description(s) updated")
- [ ] Verify new app sync still logs correctly (e.g., "Synced from daemon: 3 new app(s), 0 description(s) updated")
- [ ] Verify daemon description changes propagate to existing apps that already have descriptions set

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
