### PR TITLE
Fix iOS post-pair message failures by hardening actor-token pairing flow

### DIFF
--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -787,6 +787,71 @@ describe('pairing actor-token flow', () => {
     store.stop();
   });
 
+  test('approved status can recover token mint using deviceId query when transient pairing state is missing', async () => {
+    ensureVellumGuardianBinding('self');
+
+    const { PairingStore } = await import('../daemon/pairing-store.js');
+    const {
+      cleanupPairingState,
+      handlePairingRequest,
+      handlePairingStatus,
+    } = await import('../runtime/routes/pairing-routes.js');
+
+    const store = new PairingStore();
+    store.start();
+
+    const pairingRequestId = 'test-recover-' + Date.now();
+    const pairingSecret = 'test-secret-recover';
+    const bearerToken = 'test-bearer-recover';
+    const deviceId = 'ios-device-recover';
+
+    store.register({
+      pairingRequestId,
+      pairingSecret,
+      gatewayUrl: 'https://gw.test',
+    });
+
+    const ctx = {
+      pairingStore: store,
+      bearerToken,
+      featureFlagToken: undefined,
+      pairingBroadcast: () => {},
+    };
+
+    // iOS initiates pairing so the request is device-bound
+    const pairReq = new Request('http://localhost/v1/pairing/request', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        pairingRequestId,
+        pairingSecret,
+        deviceId,
+        deviceName: 'Recovery iPhone',
+      }),
+    });
+
+    const pairRes = await handlePairingRequest(pairReq, ctx);
+    expect(pairRes.status).toBe(200);
+
+    // macOS approves, then transient in-memory pairing state is lost (e.g. restart)
+    store.approve(pairingRequestId, bearerToken);
+    cleanupPairingState(pairingRequestId);
+
+    // Poll includes deviceId so token mint can recover from persisted hashedDeviceId
+    const statusUrl = new URL(
+      `http://localhost/v1/pairing/status?id=${pairingRequestId}&secret=${pairingSecret}&deviceId=${encodeURIComponent(deviceId)}`,
+    );
+    const statusRes = handlePairingStatus(statusUrl, ctx);
+    expect(statusRes.status).toBe(200);
+    const statusBody = await statusRes.json() as Record<string, unknown>;
+
+    expect(statusBody.status).toBe('approved');
+    expect(statusBody.actorToken).toBeTruthy();
+    expect(statusBody.bearerToken).toBe(bearerToken);
+
+    store.stop();
+  });
+
   test('mintingInFlight guard prevents concurrent mints (synchronous check)', async () => {
     ensureVellumGuardianBinding('self');
 

--- a/assistant/src/runtime/routes/pairing-routes.ts
+++ b/assistant/src/runtime/routes/pairing-routes.ts
@@ -9,14 +9,14 @@ import {
 } from '../../daemon/approved-devices-store.js';
 import type { ServerMessage } from '../../daemon/ipc-contract.js';
 import { PairingStore } from '../../daemon/pairing-store.js';
-import { getActiveBinding } from '../../memory/guardian-bindings.js';
 import { getLogger } from '../../util/logger.js';
-import { normalizeAssistantId } from '../../util/platform.js';
 import { mintActorToken } from '../actor-token-service.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import {
   createActorTokenRecord,
   revokeByDeviceBinding,
 } from '../actor-token-store.js';
+import { ensureVellumGuardianBinding } from '../guardian-vellum-migration.js';
 import { httpError } from '../http-errors.js';
 
 const log = getLogger('runtime-http');
@@ -29,11 +29,11 @@ const log = getLogger('runtime-http');
  */
 function mintPairingActorToken(deviceId: string, platform: string): string | null {
   try {
-    const assistantId = normalizeAssistantId('self');
-    const binding = getActiveBinding(assistantId, 'vellum');
-    if (!binding) return null;
-
-    const guardianPrincipalId = binding.guardianExternalUserId;
+    const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
+    // Pairing can run before a local client has touched the actor-token
+    // bootstrap path. Ensure the vellum guardian principal exists so iOS
+    // pairings always have a mint target.
+    const guardianPrincipalId = ensureVellumGuardianBinding(assistantId);
     const hashedDeviceId = hashDeviceId(deviceId);
 
     // Revoke previous tokens for this device
@@ -248,6 +248,7 @@ export function handlePairingStatus(url: URL, ctx: PairingHandlerContext): Respo
   const id = url.searchParams.get('id') ?? '';
   // Note: secret is redacted from logs
   const secret = url.searchParams.get('secret') ?? '';
+  const deviceId = (url.searchParams.get('deviceId') ?? '').trim();
 
   if (!id || !secret) {
     return httpError('BAD_REQUEST', 'Missing required params: id, secret', 400);
@@ -279,10 +280,16 @@ export function handlePairingStatus(url: URL, ctx: PairingHandlerContext): Respo
     let tokenEntry = approvedActorTokens.get(id);
     if (!tokenEntry && !mintingInFlight.has(id)) {
       const pending = pendingDeviceIds.get(id);
-      if (pending) {
+      const deviceIdMatchesEntry = Boolean(
+        deviceId
+        && entry.hashedDeviceId
+        && hashDeviceId(deviceId) === entry.hashedDeviceId,
+      );
+      const mintDeviceId = pending?.deviceId ?? (deviceIdMatchesEntry ? deviceId : undefined);
+      if (mintDeviceId) {
         mintingInFlight.add(id);
         try {
-          const actorToken = mintPairingActorToken(pending.deviceId, 'ios');
+          const actorToken = mintPairingActorToken(mintDeviceId, 'ios');
           if (actorToken) {
             pendingDeviceIds.delete(id);
             tokenEntry = { actorToken, approvedAt: Date.now() };

--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -401,9 +401,14 @@ struct QRPairingSheet: View {
                 phase = .error
                 return
             }
+            guard let actorToken = response["actorToken"] as? String, !actorToken.isEmpty else {
+                errorMessage = "Pairing succeeded but device identity token is missing. Update your Assistant and pair again."
+                failureReason = "Missing actorToken in approved pairing response"
+                phase = .error
+                return
+            }
             let localLanUrl = response["localLanUrl"] as? String
             let featureFlagToken = response["featureFlagToken"] as? String
-            let actorToken = response["actorToken"] as? String
             savePairingConfig(
                 bearerToken: bearerToken,
                 gatewayUrl: gatewayUrl,
@@ -450,7 +455,13 @@ struct QRPairingSheet: View {
     }
 
     private func pollPairingStatus(baseURL: String, payload: DaemonQRPayloadV4) async {
-        guard let url = URL(string: "\(baseURL)/pairing/status?id=\(payload.pairingRequestId)&secret=\(payload.pairingSecret)") else {
+        var components = URLComponents(string: "\(baseURL)/pairing/status")
+        components?.queryItems = [
+            URLQueryItem(name: "id", value: payload.pairingRequestId),
+            URLQueryItem(name: "secret", value: payload.pairingSecret),
+            URLQueryItem(name: "deviceId", value: getOrCreateDeviceId()),
+        ]
+        guard let url = components?.url else {
             return
         }
 
@@ -477,9 +488,14 @@ struct QRPairingSheet: View {
                         phase = .error
                         return
                     }
+                    guard let actorToken = json["actorToken"] as? String, !actorToken.isEmpty else {
+                        errorMessage = "Pairing succeeded but device identity token is missing. Update your Assistant and pair again."
+                        failureReason = "Missing actorToken in approved pairing poll response"
+                        phase = .error
+                        return
+                    }
                     let localLanUrl = json["localLanUrl"] as? String
                     let featureFlagToken = json["featureFlagToken"] as? String
-                    let actorToken = json["actorToken"] as? String
                     savePairingConfig(
                         bearerToken: bearerToken,
                         gatewayUrl: gatewayUrl,


### PR DESCRIPTION
## Summary
This fixes iOS chat sends failing after fresh pairing (surfacing as `HTTP 429` in the app after repeated failed sends).

### What changed
- Runtime pairing token mint now uses the daemon internal assistant scope and ensures a vellum guardian binding exists before minting.
- `GET /v1/pairing/status` now accepts optional `deviceId` and can recover actor-token minting from persisted device binding when transient in-memory pairing state is unavailable.
- iOS pairing status polls now include `deviceId`.
- iOS pairing now fails fast with a clear error if an approved response is missing `actorToken` (instead of silently pairing then failing on first message send).
- Added regression coverage for approved-status token recovery via `deviceId`.

## Why this fixes the bug
When iOS sends chat messages without a valid `X-Actor-Token`, runtime rejects requests as unauthorized. Repeated unauthorized attempts are then rate-limited upstream, which appears in iOS as `HTTP 429`. This change hardens the pairing handoff so actor token delivery/recovery is deterministic before chat send begins.

## Validation
- `cd assistant && bun test src/__tests__/actor-token-service.test.ts -t "pairing actor-token flow"`
- `cd assistant && bun test src/__tests__/pairing-routes.test.ts`
- `cd assistant && bunx tsc --noEmit`

## Notes
- iOS full build was not run in this environment because `xcodegen` is not installed.

## Original user report
"I am unable to send messages from the ios app after freshly pairing. Help me debug why"