### PR TITLE
fix: add --restart flag to hatch CLI for crash recovery without onboarding side effects

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -145,6 +145,7 @@ interface HatchArgs {
   name: string | null;
   remote: RemoteHost;
   daemonOnly: boolean;
+  restart: boolean;
 }
 
 function parseArgs(): HatchArgs {
@@ -154,6 +155,7 @@ function parseArgs(): HatchArgs {
   let name: string | null = null;
   let remote: RemoteHost = DEFAULT_REMOTE;
   let daemonOnly = false;
+  let restart = false;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -171,11 +173,14 @@ function parseArgs(): HatchArgs {
       console.log("  --name <name>             Custom instance name");
       console.log("  --remote <host>           Remote host (local, gcp, aws, custom)");
       console.log("  --daemon-only             Start daemon only, skip gateway");
+      console.log("  --restart                 Restart processes without onboarding side effects");
       process.exit(0);
     } else if (arg === "-d") {
       detached = true;
     } else if (arg === "--daemon-only") {
       daemonOnly = true;
+    } else if (arg === "--restart") {
+      restart = true;
     } else if (arg === "--name") {
       const next = args[i + 1];
       if (!next || next.startsWith("-")) {
@@ -204,13 +209,13 @@ function parseArgs(): HatchArgs {
       species = arg as Species;
     } else {
       console.error(
-        `Error: Unknown argument '${arg}'. Valid options: ${VALID_SPECIES.join(", ")}, -d, --daemon-only, --name <name>, --remote <${VALID_REMOTE_HOSTS.join("|")}>`,
+        `Error: Unknown argument '${arg}'. Valid options: ${VALID_SPECIES.join(", ")}, -d, --daemon-only, --restart, --name <name>, --remote <${VALID_REMOTE_HOSTS.join("|")}>`,
       );
       process.exit(1);
     }
   }
 
-  return { species, detached, name, remote, daemonOnly };
+  return { species, detached, name, remote, daemonOnly, restart };
 }
 
 function formatElapsed(ms: number): string {
@@ -545,7 +550,7 @@ async function displayPairingQRCode(runtimeUrl: string, bearerToken: string | un
   }
 }
 
-async function hatchLocal(species: Species, name: string | null, daemonOnly: boolean = false): Promise<void> {
+async function hatchLocal(species: Species, name: string | null, daemonOnly: boolean = false, restart: boolean = false): Promise<void> {
   const instanceName =
     name ?? process.env.VELLUM_ASSISTANT_NAME ?? `${species}-${generateRandomSuffix()}`;
 
@@ -627,7 +632,7 @@ async function hatchLocal(species: Species, name: string | null, daemonOnly: boo
     species,
     hatchedAt: new Date().toISOString(),
   };
-  if (!daemonOnly) {
+  if (!daemonOnly && !restart) {
     saveAssistantEntry(localEntry);
     syncConfigToLockfile();
 
@@ -656,10 +661,10 @@ export async function hatch(): Promise<void> {
   const cliVersion = getCliVersion();
   console.log(`@vellumai/cli v${cliVersion}`);
 
-  const { species, detached, name, remote, daemonOnly } = parseArgs();
+  const { species, detached, name, remote, daemonOnly, restart } = parseArgs();
 
   if (remote === "local") {
-    await hatchLocal(species, name, daemonOnly);
+    await hatchLocal(species, name, daemonOnly, restart);
     return;
   }
 

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -113,7 +113,7 @@ final class AssistantCli {
     /// waits for the socket, and registers the assistant entry.
     ///
     /// - Parameter name: Optional assistant name to reuse (for health monitor restarts).
-    func hatch(name: String? = nil, daemonOnly: Bool = false) async throws {
+    func hatch(name: String? = nil, daemonOnly: Bool = false, restart: Bool = false) async throws {
         guard let binaryURL = cliBinaryURL else {
             log.info("No bundled CLI binary found — skipping hatch (dev mode)")
             return
@@ -124,6 +124,9 @@ final class AssistantCli {
         var arguments = ["hatch", "-d"]
         if daemonOnly {
             arguments.append("--daemon-only")
+        }
+        if restart {
+            arguments.append("--restart")
         }
         if let name {
             arguments += ["--name", name]
@@ -326,8 +329,8 @@ final class AssistantCli {
                     log.warning("Daemon process not running — attempting restart")
                     await self.restartDaemon()
                 } else if !self.isGatewayAlive() {
-                    log.warning("Gateway process not running (daemon alive) — attempting restart via hatch")
-                    await self.restartDaemon(daemonOnly: false)
+                    log.warning("Gateway process not running (daemon alive) — attempting restart")
+                    await self.restartDaemon(daemonOnly: false, restart: true)
                 }
             }
         }
@@ -627,7 +630,7 @@ final class AssistantCli {
         return kill(pid, 0) == 0
     }
 
-    private func restartDaemon(daemonOnly: Bool = true) async {
+    private func restartDaemon(daemonOnly: Bool = true, restart: Bool = false) async {
         guard cliBinaryURL != nil else { return }
         guard !isRestarting else { return }
         isRestarting = true
@@ -666,7 +669,7 @@ final class AssistantCli {
         }
 
         do {
-            try await hatch(name: assistantId, daemonOnly: daemonOnly)
+            try await hatch(name: assistantId, daemonOnly: daemonOnly, restart: restart)
             log.info("Daemon restarted successfully via CLI")
             onDaemonRestarted?()
         } catch {


### PR DESCRIPTION
## Summary
- Add `--restart` flag to the CLI hatch command that starts daemon + gateway without triggering onboarding side effects (lockfile entry, config sync, QR code, symlink install)
- Use `--restart` from the macOS gateway crash recovery path instead of `daemonOnly: false`, which previously routed through the full hatch flow and caused duplicate lockfile entries on each gateway crash recovery
- Addresses review feedback on PR #10953: gateway crash recovery should not retrigger hatch onboarding side effects

## Original prompt
address the feedback here https://github.com/vellum-ai/vellum-assistant/pull/10953#discussion_r2868295036

We should probably either use (or introduce) a way to restart the daemon without retriggering all other hatch side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
