### PR TITLE
fix: constrain macOS bootstrap interstitial modal dimensions

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -431,8 +431,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         )
 
         let hostingController = NSHostingController(rootView: interstitialView)
+        hostingController.sizingOptions = []  // Prevent auto-resizing from SwiftUI
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 500, height: 400),
+            contentRect: NSRect(x: 0, y: 0, width: 380, height: 300),
             styleMask: [.titled, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -443,6 +444,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         window.isMovableByWindowBackground = true
         window.backgroundColor = NSColor(VColor.background)
         window.isReleasedWhenClosed = false
+        window.setContentSize(NSSize(width: 380, height: 300))
         window.center()
 
         NSApp.setActivationPolicy(.regular)

--- a/clients/macos/vellum-assistant/Features/Chat/BootstrapInterstitialView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/BootstrapInterstitialView.swift
@@ -50,7 +50,7 @@ struct BootstrapInterstitialView: View {
             )
             .frame(maxWidth: 380)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .frame(width: 380, height: 300)
     }
 }
 
@@ -59,7 +59,7 @@ struct BootstrapInterstitialView: View {
         VColor.background.ignoresSafeArea()
         BootstrapInterstitialView(isRetrying: true)
     }
-    .frame(width: 500, height: 400)
+    .frame(width: 380, height: 300)
 }
 
 #Preview("BootstrapInterstitialView - Error") {
@@ -70,5 +70,5 @@ struct BootstrapInterstitialView: View {
             isRetrying: false
         )
     }
-    .frame(width: 500, height: 400)
+    .frame(width: 380, height: 300)
 }


### PR DESCRIPTION
## Summary
- Fixed the macOS bootstrap interstitial window being excessively tall by giving the view a fixed 380x300 frame instead of unbounded `.infinity` sizing
- Disabled NSHostingController auto-sizing (`sizingOptions = []`) and explicitly set window content size to prevent SwiftUI from expanding the window
- Updated preview frames to match the new dimensions

## Original prompt
help me improve this startup UI. Notice how tall it is. It should be a reasonably dimensioned modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
