### PR TITLE
M2: Backfill + startup invariants for guardian principal

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -37,6 +37,7 @@ import {
   migrateNotificationDeliveryThreadDecision,
   migrateReminderRoutingIntent,
   migrateSchemaIndexesAndColumns,
+  migrateBackfillGuardianPrincipalId,
   migrateGuardianPrincipalIdColumns,
   migrateVoiceInviteColumns,
   migrateVoiceInviteDisplayMetadata,
@@ -176,6 +177,9 @@ export function initializeDb(): void {
 
   // 29. Guardian principal ID columns on channel_guardian_bindings and canonical_guardian_requests
   migrateGuardianPrincipalIdColumns(database);
+
+  // 30. Backfill guardianPrincipalId for existing bindings and requests, expire unresolvable pending requests
+  migrateBackfillGuardianPrincipalId(database);
 
   validateMigrationState(database);
 }

--- a/assistant/src/memory/migrations/126-backfill-guardian-principal-id.ts
+++ b/assistant/src/memory/migrations/126-backfill-guardian-principal-id.ts
@@ -125,35 +125,46 @@ export function migrateBackfillGuardianPrincipalId(database: DrizzleDb): void {
           }
 
           // 3b. Desktop-originated pending requests missing guardian info
-          // entirely — bind to the assistant principal.
+          // entirely — bind to the assistant principal. Only applies to
+          // requests that also lack a guardian external user ID; requests
+          // that carry an external ID but failed step 3a mapping should be
+          // expired, not reassigned.
           if (assistantPrincipal) {
             raw.query(
               `UPDATE canonical_guardian_requests
                SET guardian_principal_id = ?, updated_at = ?
                WHERE status = 'pending'
                  AND guardian_principal_id IS NULL
+                 AND guardian_external_user_id IS NULL
                  AND (source_type = 'desktop' OR source_channel = 'vellum')`,
             ).run(assistantPrincipal, now);
           }
 
-          // 3c. Expire any remaining pending requests that still have no
-          // guardian_principal_id — these cannot be safely bound.
+          // 3c. Expire remaining pending requests that still have no
+          // guardian_principal_id AND whose TTL has already elapsed.
+          // Requests without an expires_at or whose TTL has not yet passed
+          // are left alone so in-flight operations (e.g. voice
+          // pending_question records) are not prematurely killed by the
+          // migration.
           const stillUnbound = raw.query(
             `SELECT id FROM canonical_guardian_requests
-             WHERE status = 'pending' AND guardian_principal_id IS NULL`,
-          ).all() as Array<{ id: string }>;
+             WHERE status = 'pending'
+               AND guardian_principal_id IS NULL
+               AND expires_at IS NOT NULL
+               AND expires_at < ?`,
+          ).all(now) as Array<{ id: string }>;
 
           for (const req of stillUnbound) {
             expireStmt.run(now, req.id);
           }
 
-          // Also expire requests identified in 3a that had no binding match
+          // Also expire requests identified in 3a that had no binding match,
+          // but only if their TTL has already elapsed (same rationale as 3c).
           for (const id of unboundRequestIds) {
-            // Re-check in case step 3b already handled it
             const check = raw.query(
-              `SELECT guardian_principal_id FROM canonical_guardian_requests WHERE id = ? AND status = 'pending'`,
-            ).get(id) as { guardian_principal_id: string | null } | null;
-            if (check && !check.guardian_principal_id) {
+              `SELECT guardian_principal_id, expires_at FROM canonical_guardian_requests WHERE id = ? AND status = 'pending'`,
+            ).get(id) as { guardian_principal_id: string | null; expires_at: string | null } | null;
+            if (check && !check.guardian_principal_id && check.expires_at && check.expires_at < now) {
               expireStmt.run(now, id);
             }
           }

--- a/assistant/src/memory/migrations/126-backfill-guardian-principal-id.ts
+++ b/assistant/src/memory/migrations/126-backfill-guardian-principal-id.ts
@@ -1,0 +1,169 @@
+import { type DrizzleDb, getSqliteFrom } from '../db-connection.js';
+import { withCrashRecovery } from './validate-migration-state.js';
+
+/**
+ * Backfill guardianPrincipalId for existing channel_guardian_bindings and
+ * canonical_guardian_requests rows.
+ *
+ * Strategy:
+ *
+ * 1. Derive the assistant's canonical principal from the active 'vellum'
+ *    binding's guardianExternalUserId. This is the stable identity used for
+ *    all guardian decisions from the desktop client.
+ *
+ * 2. Backfill channel_guardian_bindings: for every active binding that has
+ *    a guardianExternalUserId but is missing guardianPrincipalId, set
+ *    guardianPrincipalId = guardianExternalUserId. Each channel's external
+ *    user ID *is* the principal identity for that channel.
+ *
+ * 3. Backfill canonical_guardian_requests (pending only):
+ *    a. If the request has a guardianExternalUserId that maps to an active
+ *       binding, use that binding's guardianPrincipalId (now backfilled).
+ *    b. For desktop-originated requests (sourceType = 'desktop' or
+ *       sourceChannel = 'vellum') that lack guardianExternalUserId,
+ *       use the assistant principal derived in step 1.
+ *    c. Pending requests that cannot be deterministically bound are expired.
+ *
+ * 4. Idempotent: uses checkpoint key + only updates rows with NULL
+ *    guardianPrincipalId.
+ */
+export function migrateBackfillGuardianPrincipalId(database: DrizzleDb): void {
+  withCrashRecovery(database, 'migration_backfill_guardian_principal_id_v1', () => {
+    const raw = getSqliteFrom(database);
+
+    // Guard: tables must exist
+    const bindingsTableExists = raw.query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'channel_guardian_bindings'`,
+    ).get();
+    if (!bindingsTableExists) return;
+
+    const requestsTableExists = raw.query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'canonical_guardian_requests'`,
+    ).get();
+
+    // Guard: guardian_principal_id column must exist on bindings table
+    const bindingColExists = raw.query(
+      `SELECT 1 FROM pragma_table_info('channel_guardian_bindings') WHERE name = 'guardian_principal_id'`,
+    ).get();
+    if (!bindingColExists) return;
+
+    try {
+      raw.exec('BEGIN');
+
+      // ── Step 1: Backfill channel_guardian_bindings ──────────────────
+      // For every active binding missing guardianPrincipalId, set it to
+      // the binding's own guardianExternalUserId. Each channel binding's
+      // external user ID serves as that binding's principal identity.
+      raw.exec(/*sql*/ `
+        UPDATE channel_guardian_bindings
+        SET guardian_principal_id = guardian_external_user_id,
+            updated_at = ${Date.now()}
+        WHERE status = 'active'
+          AND guardian_external_user_id IS NOT NULL
+          AND guardian_principal_id IS NULL
+      `);
+
+      // ── Step 2: Derive assistant principal from vellum binding ─────
+      // The vellum binding's guardianExternalUserId is the canonical
+      // assistant principal used for desktop-originated requests.
+      const vellumBinding = raw.query(
+        `SELECT guardian_external_user_id, guardian_principal_id FROM channel_guardian_bindings WHERE assistant_id = 'self' AND channel = 'vellum' AND status = 'active' LIMIT 1`,
+      ).get() as { guardian_external_user_id: string; guardian_principal_id: string | null } | null;
+
+      // Use the (now-backfilled) principal from the vellum binding
+      const assistantPrincipal = vellumBinding?.guardian_principal_id ?? vellumBinding?.guardian_external_user_id ?? null;
+
+      // ── Step 3: Backfill canonical_guardian_requests ────────────────
+      if (requestsTableExists) {
+        const requestColExists = raw.query(
+          `SELECT 1 FROM pragma_table_info('canonical_guardian_requests') WHERE name = 'guardian_principal_id'`,
+        ).get();
+
+        if (requestColExists) {
+          const now = new Date().toISOString();
+
+          // 3a. Pending requests with a guardianExternalUserId that maps
+          // to an active binding — use the binding's principal.
+          const pendingWithGuardian = raw.query(
+            `SELECT r.id, r.guardian_external_user_id
+             FROM canonical_guardian_requests r
+             WHERE r.status = 'pending'
+               AND r.guardian_principal_id IS NULL
+               AND r.guardian_external_user_id IS NOT NULL`,
+          ).all() as Array<{ id: string; guardian_external_user_id: string }>;
+
+          // Build a lookup of guardianExternalUserId -> principalId from
+          // active bindings (all already backfilled in step 1).
+          const activeBindings = raw.query(
+            `SELECT guardian_external_user_id, guardian_principal_id
+             FROM channel_guardian_bindings
+             WHERE assistant_id = 'self' AND status = 'active' AND guardian_principal_id IS NOT NULL`,
+          ).all() as Array<{ guardian_external_user_id: string; guardian_principal_id: string }>;
+
+          const externalToP = new Map<string, string>();
+          for (const b of activeBindings) {
+            externalToP.set(b.guardian_external_user_id, b.guardian_principal_id);
+          }
+
+          const updateStmt = raw.prepare(
+            `UPDATE canonical_guardian_requests SET guardian_principal_id = ?, updated_at = ? WHERE id = ?`,
+          );
+          const expireStmt = raw.prepare(
+            `UPDATE canonical_guardian_requests SET status = 'expired', updated_at = ? WHERE id = ?`,
+          );
+
+          const unboundRequestIds: string[] = [];
+
+          for (const req of pendingWithGuardian) {
+            const principal = externalToP.get(req.guardian_external_user_id);
+            if (principal) {
+              updateStmt.run(principal, now, req.id);
+            } else {
+              // Cannot deterministically map — will expire below
+              unboundRequestIds.push(req.id);
+            }
+          }
+
+          // 3b. Desktop-originated pending requests missing guardian info
+          // entirely — bind to the assistant principal.
+          if (assistantPrincipal) {
+            raw.query(
+              `UPDATE canonical_guardian_requests
+               SET guardian_principal_id = ?, updated_at = ?
+               WHERE status = 'pending'
+                 AND guardian_principal_id IS NULL
+                 AND (source_type = 'desktop' OR source_channel = 'vellum')`,
+            ).run(assistantPrincipal, now);
+          }
+
+          // 3c. Expire any remaining pending requests that still have no
+          // guardian_principal_id — these cannot be safely bound.
+          const stillUnbound = raw.query(
+            `SELECT id FROM canonical_guardian_requests
+             WHERE status = 'pending' AND guardian_principal_id IS NULL`,
+          ).all() as Array<{ id: string }>;
+
+          for (const req of stillUnbound) {
+            expireStmt.run(now, req.id);
+          }
+
+          // Also expire requests identified in 3a that had no binding match
+          for (const id of unboundRequestIds) {
+            // Re-check in case step 3b already handled it
+            const check = raw.query(
+              `SELECT guardian_principal_id FROM canonical_guardian_requests WHERE id = ? AND status = 'pending'`,
+            ).get(id) as { guardian_principal_id: string | null } | null;
+            if (check && !check.guardian_principal_id) {
+              expireStmt.run(now, id);
+            }
+          }
+        }
+      }
+
+      raw.exec('COMMIT');
+    } catch (e) {
+      try { raw.exec('ROLLBACK'); } catch { /* no active transaction */ }
+      throw e;
+    }
+  });
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -66,6 +66,7 @@ export { migrateCanonicalGuardianRequesterChatId } from './122-canonical-guardia
 export { migrateCanonicalGuardianDeliveriesDestinationIndex } from './123-canonical-guardian-deliveries-destination-index.js';
 export { migrateVoiceInviteDisplayMetadata } from './124-voice-invite-display-metadata.js';
 export { migrateGuardianPrincipalIdColumns } from './125-guardian-principal-id-columns.js';
+export { migrateBackfillGuardianPrincipalId } from './126-backfill-guardian-principal-id.js';
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -95,6 +95,11 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     version: 14,
     description: 'Normalize phone-like identity fields to E.164 format across guardian bindings, verification challenges, canonical requests, ingress members, and rate limits',
   },
+  {
+    key: 'migration_backfill_guardian_principal_id_v1',
+    version: 15,
+    description: 'Backfill guardianPrincipalId for existing channel_guardian_bindings and canonical_guardian_requests rows, expire unresolvable pending requests',
+  },
 ];
 
 export interface MigrationValidationResult {

--- a/assistant/src/runtime/guardian-vellum-migration.ts
+++ b/assistant/src/runtime/guardian-vellum-migration.ts
@@ -5,23 +5,29 @@
  * 'vellum' channel with a guardianPrincipalId. This is required for
  * the identity-bound hatch bootstrap flow.
  *
- * - If a vellum binding already exists, no-op.
+ * - If a vellum binding already exists with a guardianPrincipalId, no-op.
+ * - If a vellum binding exists but lacks guardianPrincipalId, backfill it
+ *   from the binding's guardianExternalUserId.
  * - If no vellum binding exists, creates one with a fresh principal.
  * - Preserves existing guardian bindings for other channels unchanged.
  */
 
+import { eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
 import {
   createBinding,
   getActiveBinding,
 } from '../memory/guardian-bindings.js';
+import { getDb } from '../memory/db.js';
+import { channelGuardianBindings } from '../memory/schema.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('guardian-vellum-migration');
 
 /**
- * Ensure a vellum guardian binding exists for the given assistant.
+ * Ensure a vellum guardian binding exists for the given assistant,
+ * with a populated guardianPrincipalId.
  * Called during daemon startup to backfill existing installations.
  *
  * Returns the guardianPrincipalId (existing or newly created).
@@ -29,11 +35,28 @@ const log = getLogger('guardian-vellum-migration');
 export function ensureVellumGuardianBinding(assistantId: string = 'self'): string {
   const existing = getActiveBinding(assistantId, 'vellum');
   if (existing) {
+    // If the binding exists but is missing guardianPrincipalId, backfill it
+    // from the binding's guardianExternalUserId (the canonical identity).
+    if (!existing.guardianPrincipalId) {
+      const principalId = existing.guardianExternalUserId;
+      const db = getDb();
+      db.update(channelGuardianBindings)
+        .set({ guardianPrincipalId: principalId, updatedAt: Date.now() })
+        .where(eq(channelGuardianBindings.id, existing.id))
+        .run();
+
+      log.info(
+        { assistantId, guardianPrincipalId: principalId },
+        'Backfilled guardianPrincipalId on existing vellum binding',
+      );
+      return principalId;
+    }
+
     log.debug(
-      { assistantId, guardianPrincipalId: existing.guardianExternalUserId },
-      'Vellum guardian binding already exists',
+      { assistantId, guardianPrincipalId: existing.guardianPrincipalId },
+      'Vellum guardian binding already exists with principal',
     );
-    return existing.guardianExternalUserId;
+    return existing.guardianPrincipalId;
   }
 
   const guardianPrincipalId = `vellum-principal-${uuid()}`;
@@ -43,6 +66,7 @@ export function ensureVellumGuardianBinding(assistantId: string = 'self'): strin
     channel: 'vellum',
     guardianExternalUserId: guardianPrincipalId,
     guardianDeliveryChatId: 'local',
+    guardianPrincipalId,
     verifiedVia: 'startup-migration',
     metadataJson: JSON.stringify({ migratedAt: Date.now() }),
   });


### PR DESCRIPTION
Backfill guardianPrincipalId for existing channel_guardian_bindings and canonical_guardian_requests rows. Update guardian-vellum-migration to set principal on binding creation. Expire unresolvable pending requests. Part of #10955.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
