### PR TITLE
fix: regenerate IPC Swift contract

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -3179,6 +3179,7 @@ public struct IPCNotificationIntent: Codable, Sendable {
     public let deepLinkMetadata: [String: AnyCodable]?
     /// When set, this notification is guardian-sensitive and should only be
     /// displayed by clients whose guardian identity matches this principal ID.
+    /// Clients not bound to this guardian should ignore the notification.
     public let targetGuardianPrincipalId: String?
 
     public init(type: String, deliveryId: String? = nil, sourceEventName: String, title: String, body: String, deepLinkMetadata: [String: AnyCodable]? = nil, targetGuardianPrincipalId: String? = nil) {


### PR DESCRIPTION
## Summary
- Regenerate `IPCContractGenerated.swift` to match the latest `ipc-contract.ts` changes (added comment on `targetGuardianPrincipalId`)

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22534962752/job/65280618695

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
