### PR TITLE
fix: prune stale apps from local list during daemon sync

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
@@ -125,11 +125,19 @@ final class AppListManager: ObservableObject {
 
     /// Sync apps from the daemon's authoritative list into the local sidebar list.
     /// Adds any apps that don't already exist locally, using their daemon createdAt timestamp.
+    /// Removes local apps the daemon no longer reports (e.g. filtered Home Base).
     /// Always propagates daemon descriptions to existing apps when they differ.
     func syncFromDaemon(_ daemonApps: [AppItem_Daemon]) {
         let existingIds = Set(apps.map(\.id))
+        let daemonIds = Set(daemonApps.map(\.id))
         var newCount = 0
         var updatedCount = 0
+
+        // Remove local apps the daemon no longer reports
+        let prunedCount = apps.count
+        apps.removeAll { !daemonIds.contains($0.id) }
+        let removedCount = prunedCount - apps.count
+
         for daemonApp in daemonApps {
             if existingIds.contains(daemonApp.id) {
                 if let desc = daemonApp.description,
@@ -155,9 +163,9 @@ final class AppListManager: ObservableObject {
             apps.append(item)
             newCount += 1
         }
-        if newCount > 0 || updatedCount > 0 {
+        if newCount > 0 || updatedCount > 0 || removedCount > 0 {
             save()
-            log.info("Synced from daemon: \(newCount) new app(s), \(updatedCount) description(s) updated")
+            log.info("Synced from daemon: \(newCount) new, \(updatedCount) updated, \(removedCount) pruned")
         }
     }
 


### PR DESCRIPTION
## Summary
- `syncFromDaemon` was additive-only — apps the daemon filters out (like Home Base) persisted in the client's local `app-list.json` forever
- Now prunes local apps that are absent from the daemon's authoritative response, so filtered apps (e.g. Home Base) disappear on next launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
