### PR TITLE
fix: validate --restart flag constraints in hatch CLI

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -551,6 +551,11 @@ async function displayPairingQRCode(runtimeUrl: string, bearerToken: string | un
 }
 
 async function hatchLocal(species: Species, name: string | null, daemonOnly: boolean = false, restart: boolean = false): Promise<void> {
+  if (restart && !name && !process.env.VELLUM_ASSISTANT_NAME) {
+    console.error("Error: Cannot restart without a known assistant ID. Provide --name or ensure VELLUM_ASSISTANT_NAME is set.");
+    process.exit(1);
+  }
+
   const instanceName =
     name ?? process.env.VELLUM_ASSISTANT_NAME ?? `${species}-${generateRandomSuffix()}`;
 
@@ -662,6 +667,11 @@ export async function hatch(): Promise<void> {
   console.log(`@vellumai/cli v${cliVersion}`);
 
   const { species, detached, name, remote, daemonOnly, restart } = parseArgs();
+
+  if (restart && remote !== "local") {
+    console.error("Error: --restart is only supported for local hatch targets.");
+    process.exit(1);
+  }
 
   if (remote === "local") {
     await hatchLocal(species, name, daemonOnly, restart);


### PR DESCRIPTION
## Summary
Address valid review feedback from PR #10966:

- Reject --restart for non-local hatch targets (fail fast with clear error)
- Require a known assistant ID when using --restart (error if no --name or VELLUM_ASSISTANT_NAME)

Addresses feedback from: https://github.com/vellum-ai/vellum-assistant/pull/10966

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
