### PR TITLE
fix: set sizingOptions on updateBootstrapInterstitial hosting controller

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -468,7 +468,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 self?.bootstrapInterstitialRetry()
             }
         )
-        window.contentViewController = NSHostingController(rootView: updatedView)
+        let hostingController = NSHostingController(rootView: updatedView)
+        hostingController.sizingOptions = []  // Prevent auto-resizing from SwiftUI
+        window.contentViewController = hostingController
     }
 
     /// Dismisses the bootstrap interstitial window and cancels any retry tasks.


### PR DESCRIPTION
## Summary
Address valid review feedback from PR #10968:

- Set `sizingOptions = []` on the NSHostingController created in `updateBootstrapInterstitial` to prevent it from undoing the sizing fix applied in `showBootstrapInterstitial`.

Addresses feedback from: https://github.com/vellum-ai/vellum-assistant/pull/10968

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
