### PR TITLE
feat: add empty state to Things view when no apps exist

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -24,33 +24,39 @@ struct AppsGridView: View {
     private let maxContentWidth: CGFloat = 1400
 
     var body: some View {
-        ScrollView {
-            VStack(spacing: VSpacing.xxl) {
-                searchBar
-                    .padding(.top, VSpacing.xxl)
+        Group {
+            if appListManager.apps.isEmpty {
+                noAppsEmptyState
+            } else {
+                ScrollView {
+                    VStack(spacing: VSpacing.xxl) {
+                        searchBar
+                            .padding(.top, VSpacing.xxl)
 
-                if !filteredPinnedApps.isEmpty {
-                    pinnedSectionView
-                }
+                        if !filteredPinnedApps.isEmpty {
+                            pinnedSectionView
+                        }
 
-                if !filteredRecentApps.isEmpty {
-                    recentSectionView
-                }
+                        if !filteredRecentApps.isEmpty {
+                            recentSectionView
+                        }
 
-                if filteredPinnedApps.isEmpty && filteredRecentApps.isEmpty && !searchText.isEmpty {
-                    VEmptyState(
-                        title: "No apps matched",
-                        subtitle: "No apps matched \"\(searchText)\"",
-                        icon: "magnifyingglass"
-                    )
+                        if filteredPinnedApps.isEmpty && filteredRecentApps.isEmpty && !searchText.isEmpty {
+                            VEmptyState(
+                                title: "No apps matched",
+                                subtitle: "No apps matched \"\(searchText)\"",
+                                icon: "magnifyingglass"
+                            )
+                            .frame(maxWidth: .infinity)
+                            .padding(.top, VSpacing.xxxl)
+                        }
+                    }
+                    .frame(maxWidth: maxContentWidth)
                     .frame(maxWidth: .infinity)
-                    .padding(.top, VSpacing.xxxl)
+                    .padding(.horizontal, VSpacing.xxxl)
+                    .padding(.bottom, VSpacing.xxl)
                 }
             }
-            .frame(maxWidth: maxContentWidth)
-            .frame(maxWidth: .infinity)
-            .padding(.horizontal, VSpacing.xxxl)
-            .padding(.bottom, VSpacing.xxl)
         }
         .background(VColor.backgroundSubtle)
         .onDisappear {
@@ -68,6 +74,27 @@ struct AppsGridView: View {
                 }
             )
         }
+    }
+
+    // MARK: - Empty State
+
+    private var noAppsEmptyState: some View {
+        VStack(spacing: VSpacing.xl) {
+            Image(systemName: "square.grid.2x2")
+                .font(.system(size: 40, weight: .thin))
+                .foregroundColor(VColor.textMuted)
+
+            VStack(spacing: VSpacing.sm) {
+                Text("No things yet")
+                    .font(VFont.bodyBold)
+                    .foregroundColor(VColor.textSecondary)
+
+                Text("Ask the assistant to build something")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textMuted)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     // MARK: - Search Bar


### PR DESCRIPTION
## Summary
- Shows a centered empty state ("No things yet / Ask the assistant to build something") when the app list is empty
- Hides the search bar when there are no apps — only shows it when there's something to search
- Keeps the existing search-no-results empty state for filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10974" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
