### PR TITLE
fix: guard syncFromDaemon against empty daemon response

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
@@ -128,6 +128,9 @@ final class AppListManager: ObservableObject {
     /// Removes local apps the daemon no longer reports (e.g. filtered Home Base).
     /// Always propagates daemon descriptions to existing apps when they differ.
     func syncFromDaemon(_ daemonApps: [AppItem_Daemon]) {
+        // An empty daemon response likely means a transient error — don't wipe local state.
+        guard !daemonApps.isEmpty else { return }
+
         let existingIds = Set(apps.map(\.id))
         let daemonIds = Set(daemonApps.map(\.id))
         var newCount = 0


### PR DESCRIPTION
Add a guard to skip pruning when the daemon returns an empty app list. This prevents transient daemon failures from permanently wiping all local apps (pins, custom icons, ordering).\n\nAddresses feedback from PR #10971.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10975" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
