### PR TITLE
fix: propagate daemon description removals to local apps

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
@@ -143,10 +143,9 @@ final class AppListManager: ObservableObject {
 
         for daemonApp in daemonApps {
             if existingIds.contains(daemonApp.id) {
-                if let desc = daemonApp.description,
-                   let index = apps.firstIndex(where: { $0.id == daemonApp.id }),
-                   apps[index].description != desc {
-                    apps[index].description = desc
+                if let index = apps.firstIndex(where: { $0.id == daemonApp.id }),
+                   apps[index].description != daemonApp.description {
+                    apps[index].description = daemonApp.description
                     updatedCount += 1
                 }
                 continue


### PR DESCRIPTION
Update syncFromDaemon to propagate nil descriptions from the daemon to local apps. Previously, only non-nil description updates were synced, so clearing a description on the daemon side was never reflected locally.

Addresses feedback from PR #10963.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10976" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
