### PR TITLE
fix: deduplicate assistant entries in lockfile on save

### DIFF
--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -99,7 +99,7 @@ export function loadAllAssistants(): AssistantEntry[] {
 }
 
 export function saveAssistantEntry(entry: AssistantEntry): void {
-  const entries = readAssistants();
+  const entries = readAssistants().filter((e) => e.assistantId !== entry.assistantId);
   entries.unshift(entry);
   writeAssistants(entries);
 }


### PR DESCRIPTION
## Summary
- `saveAssistantEntry` was blindly prepending to the assistants array without deduplication, causing the lockfile (`~/.vellum.lock.json`) to accumulate identical entries on every hatch/restart
- The "Switch Assistant" UI then showed dozens of identical rows
- Fix: filter out existing entries with the same `assistantId` before inserting the new one

## Test plan
- [ ] Hatch multiple times and verify only one entry per `assistantId` appears in `~/.vellum.lock.json`
- [ ] Verify "Switch Assistant" UI shows a single entry after multiple restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
