### PR TITLE
M3: Propagate principal through runtime contexts

### DIFF
--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -38,6 +38,8 @@ export interface GuardianRuntimeContext {
   trustClass: 'guardian' | 'trusted_contact' | 'unknown';
   guardianChatId?: string;
   guardianExternalUserId?: string;
+  /** Canonical principal ID for the guardian binding. Nullable for backward compatibility — M5 will make this required. */
+  guardianPrincipalId?: string | null;
   requesterIdentifier?: string;
   requesterDisplayName?: string;
   requesterSenderDisplayName?: string;

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -35,6 +35,8 @@ export interface ActorTrustContext {
     guardianExternalUserId: string;
     guardianDeliveryChatId: string | null;
   } | null;
+  /** Canonical principal ID from the guardian binding. Nullable for backward compatibility — M5 will make this required. */
+  guardianPrincipalId?: string | null;
   /** Ingress member record, if any, for this sender. */
   memberRecord: IngressMember | null;
   /** Trust classification. */
@@ -102,6 +104,7 @@ export function resolveActorTrust(input: ResolveActorTrustInput): ActorTrustCont
     return {
       canonicalSenderId: null,
       guardianBindingMatch: null,
+      guardianPrincipalId: undefined,
       memberRecord: null,
       trustClass: 'unknown',
       actorMetadata: {
@@ -181,6 +184,7 @@ export function resolveActorTrust(input: ResolveActorTrustInput): ActorTrustCont
   return {
     canonicalSenderId,
     guardianBindingMatch,
+    guardianPrincipalId: binding?.guardianPrincipalId ?? undefined,
     memberRecord,
     trustClass,
     actorMetadata: {
@@ -210,6 +214,7 @@ export function toGuardianRuntimeContextFromTrust(
     guardianChatId: ctx.guardianBindingMatch?.guardianDeliveryChatId ??
       (ctx.trustClass === 'guardian' ? externalChatId : undefined),
     guardianExternalUserId: ctx.guardianBindingMatch?.guardianExternalUserId,
+    guardianPrincipalId: ctx.guardianPrincipalId,
     requesterIdentifier: ctx.actorMetadata.identifier,
     requesterDisplayName: ctx.actorMetadata.displayName,
     requesterSenderDisplayName: ctx.actorMetadata.senderDisplayName,

--- a/assistant/src/runtime/guardian-context-resolver.ts
+++ b/assistant/src/runtime/guardian-context-resolver.ts
@@ -24,6 +24,8 @@ export interface GuardianContext {
   trustClass: ActorTrustClass;
   guardianChatId?: string;
   guardianExternalUserId?: string;
+  /** Canonical principal ID from the guardian binding. Nullable for backward compatibility — M5 will make this required. */
+  guardianPrincipalId?: string | null;
   requesterIdentifier?: string;
   requesterDisplayName?: string;
   requesterSenderDisplayName?: string;
@@ -50,6 +52,7 @@ export function resolveGuardianContext(input: ResolveGuardianContextInput): Guar
     guardianChatId: trust.guardianBindingMatch?.guardianDeliveryChatId ??
       (trust.trustClass === 'guardian' ? input.externalChatId : undefined),
     guardianExternalUserId: canonicalGuardianExternalUserId,
+    guardianPrincipalId: trust.guardianPrincipalId,
     requesterIdentifier: trust.actorMetadata.identifier,
     requesterDisplayName: trust.actorMetadata.displayName,
     requesterSenderDisplayName: trust.actorMetadata.senderDisplayName,
@@ -150,6 +153,7 @@ export function toGuardianRuntimeContext(sourceChannel: ChannelId, ctx: Guardian
     trustClass: ctx.trustClass,
     guardianChatId: ctx.guardianChatId,
     guardianExternalUserId: ctx.guardianExternalUserId,
+    guardianPrincipalId: ctx.guardianPrincipalId,
     requesterIdentifier: ctx.requesterIdentifier,
     requesterDisplayName: ctx.requesterDisplayName,
     requesterSenderDisplayName: ctx.requesterSenderDisplayName,

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -52,6 +52,7 @@ export function resolveLocalIpcGuardianContext(
     return {
       sourceChannel,
       trustClass: 'guardian',
+      guardianPrincipalId: undefined,
     };
   }
 


### PR DESCRIPTION
## Summary
Extend actor context types with `guardianPrincipalId`. Propagate through actor-token middleware, local actor identity, and IPC session paths. Part of #10955.

## Changes
- **`GuardianRuntimeContext`** (`session-runtime-assembly.ts`): Added optional `guardianPrincipalId` field
- **`ActorTrustContext`** (`actor-trust-resolver.ts`): Added optional `guardianPrincipalId` field, populated from the guardian binding
- **`GuardianContext`** (`guardian-context-resolver.ts`): Added optional `guardianPrincipalId` field, propagated through `resolveGuardianContext` and `toGuardianRuntimeContext`
- **`toGuardianRuntimeContextFromTrust`** (`actor-trust-resolver.ts`): Propagates `guardianPrincipalId` to the runtime context
- **`resolveLocalIpcGuardianContext`** (`local-actor-identity.ts`): Explicitly sets `guardianPrincipalId: undefined` in the pre-bootstrap fallback path

## Design
- Field is optional (`string | null | undefined`) for backward compatibility — M5 will make it required
- No decision logic changes — purely propagation through runtime context types
- All three identity resolution pathways (actor-token HTTP, local IPC, channel routes) now carry `guardianPrincipalId`

## Test plan
- [ ] Existing tests continue to pass (field is additive/optional)
- [ ] Actor token middleware path resolves `guardianPrincipalId` from the binding via `resolveGuardianContext`
- [ ] Local IPC fallback path includes `guardianPrincipalId` (undefined when no binding, populated when binding exists)
- [ ] Channel route path propagates through `toGuardianRuntimeContextFromTrust`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
