### PR TITLE
M4: Bind principal at all canonical request creation sites

### DIFF
--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -14,6 +14,7 @@ import {
   listCanonicalGuardianRequests,
   updateCanonicalGuardianDelivery,
 } from '../memory/canonical-guardian-store.js';
+import { getActiveBinding } from '../memory/guardian-bindings.js';
 import { emitNotificationSignal } from '../notifications/emit-signal.js';
 import type { NotificationDeliveryResult } from '../notifications/types.js';
 import { getLogger } from '../util/logger.js';
@@ -88,6 +89,13 @@ async function dispatchGuardianQuestionInner(params: GuardianDispatchParams): Pr
   try {
     const expiresAt = Date.now() + getUserConsultationTimeoutMs();
 
+    // Voice decisions are handled in guardian threads tied to the assistant-
+    // level guardian identity. Resolve the principal from the vellum binding
+    // (the canonical assistant-level binding) so the request is attributed to
+    // the assistant's guardian principal.
+    const vellumBinding = getActiveBinding(assistantId, 'vellum');
+    const guardianPrincipalId = vellumBinding?.guardianPrincipalId ?? undefined;
+
     // Create the canonical guardian request as the primary record.
     const request = createCanonicalGuardianRequest({
       kind: 'pending_question',
@@ -97,6 +105,7 @@ async function dispatchGuardianQuestionInner(params: GuardianDispatchParams): Pr
       callSessionId,
       pendingQuestionId: pendingQuestion.id,
       questionText: pendingQuestion.questionText,
+      guardianPrincipalId,
       toolName,
       inputDigest,
       expiresAt: new Date(expiresAt).toISOString(),

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -124,12 +124,14 @@ function makeIpcEventSender(params: {
       });
 
       try {
+        const guardianContext = session.guardianContext;
         createCanonicalGuardianRequest({
           id: event.requestId,
           kind: 'tool_approval',
           sourceType: 'desktop',
           sourceChannel,
           conversationId,
+          guardianPrincipalId: guardianContext?.guardianPrincipalId ?? undefined,
           toolName: event.toolName,
           status: 'pending',
           requestCode: generateCanonicalRequestCode(),

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -144,6 +144,7 @@ function makePendingInteractionRegistrar(
         requesterExternalUserId: guardianContext?.requesterExternalUserId,
         requesterChatId: guardianContext?.requesterChatId,
         guardianExternalUserId: guardianContext?.guardianExternalUserId,
+        guardianPrincipalId: guardianContext?.guardianPrincipalId ?? undefined,
         toolName: msg.toolName,
         status: 'pending',
         requestCode: generateCanonicalRequestCode(),

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -133,34 +133,41 @@ function makePendingInteractionRegistrar(
 
       // Create a canonical guardian request so IPC/HTTP handlers can find it
       // via applyCanonicalGuardianDecision.
-      const guardianContext = session.guardianContext;
-      const sourceChannel = guardianContext?.sourceChannel ?? 'vellum';
-      const canonicalRequest = createCanonicalGuardianRequest({
-        id: msg.requestId,
-        kind: 'tool_approval',
-        sourceType: resolveCanonicalRequestSourceType(sourceChannel),
-        sourceChannel,
-        conversationId,
-        requesterExternalUserId: guardianContext?.requesterExternalUserId,
-        requesterChatId: guardianContext?.requesterChatId,
-        guardianExternalUserId: guardianContext?.guardianExternalUserId,
-        guardianPrincipalId: guardianContext?.guardianPrincipalId ?? undefined,
-        toolName: msg.toolName,
-        status: 'pending',
-        requestCode: generateCanonicalRequestCode(),
-        expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
-      });
-
-      // For trusted-contact sessions, bridge to guardian.question so the
-      // guardian gets notified and can approve via callback/request-code.
-      if (guardianContext) {
-        bridgeConfirmationRequestToGuardian({
-          canonicalRequest,
-          guardianContext,
+      try {
+        const guardianContext = session.guardianContext;
+        const sourceChannel = guardianContext?.sourceChannel ?? 'vellum';
+        const canonicalRequest = createCanonicalGuardianRequest({
+          id: msg.requestId,
+          kind: 'tool_approval',
+          sourceType: resolveCanonicalRequestSourceType(sourceChannel),
+          sourceChannel,
           conversationId,
+          requesterExternalUserId: guardianContext?.requesterExternalUserId,
+          requesterChatId: guardianContext?.requesterChatId,
+          guardianExternalUserId: guardianContext?.guardianExternalUserId,
+          guardianPrincipalId: guardianContext?.guardianPrincipalId ?? undefined,
           toolName: msg.toolName,
-          assistantId: session.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
+          status: 'pending',
+          requestCode: generateCanonicalRequestCode(),
+          expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
         });
+
+        // For trusted-contact sessions, bridge to guardian.question so the
+        // guardian gets notified and can approve via callback/request-code.
+        if (guardianContext) {
+          bridgeConfirmationRequestToGuardian({
+            canonicalRequest,
+            guardianContext,
+            conversationId,
+            toolName: msg.toolName,
+            assistantId: session.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
+          });
+        }
+      } catch (err) {
+        log.debug(
+          { err, requestId: msg.requestId, conversationId },
+          'Failed to create canonical request from pending interaction registrar',
+        );
       }
     } else if (msg.type === 'secret_request') {
       pendingInteractions.register(msg.requestId, {

--- a/assistant/src/memory/canonical-guardian-store.ts
+++ b/assistant/src/memory/canonical-guardian-store.ts
@@ -10,6 +10,7 @@
 import { and, desc, eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
+import { IntegrityError } from '../util/errors.js';
 import { getDb, rawChanges } from './db.js';
 import {
   canonicalGuardianDeliveries,
@@ -179,7 +180,30 @@ export interface CreateCanonicalGuardianRequestParams {
   expiresAt?: string;
 }
 
+/**
+ * Request kinds that require a guardian decision (approve/deny). These kinds
+ * MUST have a `guardianPrincipalId` bound at creation time so the decision
+ * can be attributed to a specific principal. Informational kinds (e.g. status
+ * updates) are exempt from this requirement.
+ */
+const DECISIONABLE_KINDS = new Set([
+  'tool_approval',
+  'tool_grant_request',
+  'pending_question',
+  'access_request',
+]);
+
 export function createCanonicalGuardianRequest(params: CreateCanonicalGuardianRequestParams): CanonicalGuardianRequest {
+  // Guard: decisionable request kinds must have a principal bound at creation
+  // time. This ensures every request that will eventually require a guardian
+  // decision is attributable to a specific identity. Informational kinds are
+  // exempt — they don't participate in the approval flow.
+  if (DECISIONABLE_KINDS.has(params.kind) && !params.guardianPrincipalId) {
+    throw new IntegrityError(
+      `Cannot create decisionable canonical request of kind '${params.kind}' without guardianPrincipalId`,
+    );
+  }
+
   const db = getDb();
   const now = new Date().toISOString();
   const id = params.id ?? uuid();

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -150,20 +150,32 @@ export function notifyGuardianOfAccessRequest(
   const senderIdentifier = senderName || senderUsername || senderExternalUserId;
   const requestId = `access-req-${canonicalAssistantId}-${sourceChannel}-${senderExternalUserId}-${Date.now()}`;
 
-  const canonicalRequest = createCanonicalGuardianRequest({
-    id: requestId,
-    kind: 'access_request',
-    sourceType: 'channel',
-    sourceChannel,
-    conversationId,
-    requesterExternalUserId: senderExternalUserId,
-    requesterChatId: externalChatId,
-    guardianExternalUserId: guardianExternalUserId ?? undefined,
-    guardianPrincipalId: guardianPrincipalId ?? undefined,
-    toolName: 'ingress_access_request',
-    questionText: `${senderIdentifier} is requesting access to the assistant`,
-    expiresAt: new Date(Date.now() + GUARDIAN_APPROVAL_TTL_MS).toISOString(),
-  });
+  let canonicalRequest;
+  try {
+    canonicalRequest = createCanonicalGuardianRequest({
+      id: requestId,
+      kind: 'access_request',
+      sourceType: 'channel',
+      sourceChannel,
+      conversationId,
+      requesterExternalUserId: senderExternalUserId,
+      requesterChatId: externalChatId,
+      guardianExternalUserId: guardianExternalUserId ?? undefined,
+      guardianPrincipalId: guardianPrincipalId ?? undefined,
+      toolName: 'ingress_access_request',
+      questionText: `${senderIdentifier} is requesting access to the assistant`,
+      expiresAt: new Date(Date.now() + GUARDIAN_APPROVAL_TTL_MS).toISOString(),
+    });
+  } catch (err) {
+    // No-binding fallback: when no guardian binding exists, guardianPrincipalId
+    // is null and the integrity guard rejects the request. This is expected —
+    // the notification pipeline handles delivery via trusted/vellum channels.
+    log.debug(
+      { err, requestId, sourceChannel, senderExternalUserId },
+      'Cannot create canonical access request without guardian principal — skipping canonical request creation',
+    );
+    return { notified: true, created: false, requestId };
+  }
 
   let vellumDeliveryId: string | null = null;
   void emitNotificationSignal({

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -97,15 +97,18 @@ export function notifyGuardianOfAccessRequest(
   // 3. null (no guardian identity — notification pipeline uses trusted channels)
   const sourceBinding = getGuardianBinding(canonicalAssistantId, sourceChannel);
   let guardianExternalUserId: string | null = null;
+  let guardianPrincipalId: string | null = null;
   let guardianBindingChannel: string | null = null;
 
   if (sourceBinding) {
     guardianExternalUserId = sourceBinding.guardianExternalUserId;
+    guardianPrincipalId = sourceBinding.guardianPrincipalId;
     guardianBindingChannel = sourceBinding.channel;
   } else {
     const allBindings = listActiveBindingsByAssistant(canonicalAssistantId);
     if (allBindings.length > 0) {
       guardianExternalUserId = allBindings[0].guardianExternalUserId;
+      guardianPrincipalId = allBindings[0].guardianPrincipalId;
       guardianBindingChannel = allBindings[0].channel;
       log.debug(
         { sourceChannel, fallbackChannel: guardianBindingChannel, canonicalAssistantId },
@@ -156,6 +159,7 @@ export function notifyGuardianOfAccessRequest(
     requesterExternalUserId: senderExternalUserId,
     requesterChatId: externalChatId,
     guardianExternalUserId: guardianExternalUserId ?? undefined,
+    guardianPrincipalId: guardianPrincipalId ?? undefined,
     toolName: 'ingress_access_request',
     questionText: `${senderIdentifier} is requesting access to the assistant`,
     expiresAt: new Date(Date.now() + GUARDIAN_APPROVAL_TTL_MS).toISOString(),

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -174,7 +174,7 @@ export function notifyGuardianOfAccessRequest(
       { err, requestId, sourceChannel, senderExternalUserId },
       'Cannot create canonical access request without guardian principal — skipping canonical request creation',
     );
-    return { notified: true, created: false, requestId };
+    return { notified: false, created: false, requestId };
   }
 
   let vellumDeliveryId: string | null = null;

--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -316,6 +316,7 @@ export function validateAndConsumeChallenge(
     channel,
     guardianExternalUserId: actorExternalUserId,
     guardianDeliveryChatId: actorChatId,
+    guardianPrincipalId: actorExternalUserId,
     verifiedVia: 'challenge',
     metadataJson: Object.keys(metadata).length > 0 ? JSON.stringify(metadata) : null,
   });

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -366,6 +366,7 @@ function makeHubPublisher(
         requesterExternalUserId: guardianContext?.requesterExternalUserId,
         requesterChatId: guardianContext?.requesterChatId,
         guardianExternalUserId: guardianContext?.guardianExternalUserId,
+        guardianPrincipalId: guardianContext?.guardianPrincipalId ?? undefined,
         toolName: msg.toolName,
         status: 'pending',
         requestCode: generateCanonicalRequestCode(),

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -355,34 +355,41 @@ function makeHubPublisher(
 
       // Create a canonical guardian request so IPC/HTTP handlers can find it
       // via applyCanonicalGuardianDecision.
-      const guardianContext = session.guardianContext;
-      const sourceChannel = guardianContext?.sourceChannel ?? 'vellum';
-      const canonicalRequest = createCanonicalGuardianRequest({
-        id: msg.requestId,
-        kind: 'tool_approval',
-        sourceType: resolveCanonicalRequestSourceType(sourceChannel),
-        sourceChannel,
-        conversationId,
-        requesterExternalUserId: guardianContext?.requesterExternalUserId,
-        requesterChatId: guardianContext?.requesterChatId,
-        guardianExternalUserId: guardianContext?.guardianExternalUserId,
-        guardianPrincipalId: guardianContext?.guardianPrincipalId ?? undefined,
-        toolName: msg.toolName,
-        status: 'pending',
-        requestCode: generateCanonicalRequestCode(),
-        expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
-      });
-
-      // For trusted-contact sessions, bridge to guardian.question so the
-      // guardian gets notified and can approve via callback/request-code.
-      if (guardianContext) {
-        bridgeConfirmationRequestToGuardian({
-          canonicalRequest,
-          guardianContext,
+      try {
+        const guardianContext = session.guardianContext;
+        const sourceChannel = guardianContext?.sourceChannel ?? 'vellum';
+        const canonicalRequest = createCanonicalGuardianRequest({
+          id: msg.requestId,
+          kind: 'tool_approval',
+          sourceType: resolveCanonicalRequestSourceType(sourceChannel),
+          sourceChannel,
           conversationId,
+          requesterExternalUserId: guardianContext?.requesterExternalUserId,
+          requesterChatId: guardianContext?.requesterChatId,
+          guardianExternalUserId: guardianContext?.guardianExternalUserId,
+          guardianPrincipalId: guardianContext?.guardianPrincipalId ?? undefined,
           toolName: msg.toolName,
-          assistantId: session.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
+          status: 'pending',
+          requestCode: generateCanonicalRequestCode(),
+          expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
         });
+
+        // For trusted-contact sessions, bridge to guardian.question so the
+        // guardian gets notified and can approve via callback/request-code.
+        if (guardianContext) {
+          bridgeConfirmationRequestToGuardian({
+            canonicalRequest,
+            guardianContext,
+            conversationId,
+            toolName: msg.toolName,
+            assistantId: session.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
+          });
+        }
+      } catch (err) {
+        log.debug(
+          { err, requestId: msg.requestId, conversationId },
+          'Failed to create canonical request from hub publisher',
+        );
       }
     } else if (msg.type === 'secret_request') {
       pendingInteractions.register(msg.requestId, {

--- a/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
+++ b/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
@@ -55,6 +55,7 @@ function ensureGuardianPrincipal(assistantId: string): {
     channel: 'vellum',
     guardianExternalUserId: guardianPrincipalId,
     guardianDeliveryChatId: 'local',
+    guardianPrincipalId,
     verifiedVia: 'bootstrap',
     metadataJson: JSON.stringify({ bootstrappedAt: Date.now() }),
   });

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -624,6 +624,7 @@ export async function handleChannelInbound(
       conversationId: result.conversationId,
       requesterExternalUserId: canonicalSenderId ?? rawSenderId ?? undefined,
       guardianExternalUserId: binding.guardianExternalUserId,
+      guardianPrincipalId: binding.guardianPrincipalId ?? undefined,
       toolName: 'ingress_message',
       questionText: 'Ingress policy requires guardian approval',
       expiresAt: new Date(Date.now() + GUARDIAN_APPROVAL_TTL_MS).toISOString(),

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -617,18 +617,25 @@ export async function handleChannelInbound(
       assistantId: canonicalAssistantId,
     });
 
-    createCanonicalGuardianRequest({
-      kind: 'tool_approval',
-      sourceType: 'channel',
-      sourceChannel,
-      conversationId: result.conversationId,
-      requesterExternalUserId: canonicalSenderId ?? rawSenderId ?? undefined,
-      guardianExternalUserId: binding.guardianExternalUserId,
-      guardianPrincipalId: binding.guardianPrincipalId ?? undefined,
-      toolName: 'ingress_message',
-      questionText: 'Ingress policy requires guardian approval',
-      expiresAt: new Date(Date.now() + GUARDIAN_APPROVAL_TTL_MS).toISOString(),
-    });
+    try {
+      createCanonicalGuardianRequest({
+        kind: 'tool_approval',
+        sourceType: 'channel',
+        sourceChannel,
+        conversationId: result.conversationId,
+        requesterExternalUserId: canonicalSenderId ?? rawSenderId ?? undefined,
+        guardianExternalUserId: binding.guardianExternalUserId,
+        guardianPrincipalId: binding.guardianPrincipalId ?? undefined,
+        toolName: 'ingress_message',
+        questionText: 'Ingress policy requires guardian approval',
+        expiresAt: new Date(Date.now() + GUARDIAN_APPROVAL_TTL_MS).toISOString(),
+      });
+    } catch (err) {
+      log.warn(
+        { err, conversationId: result.conversationId, sourceChannel },
+        'Failed to create canonical guardian request for ingress escalation — escalation continues via notification pipeline',
+      );
+    }
 
     // Emit notification signal through the unified pipeline (fire-and-forget).
     // This lets the decision engine route escalation alerts to all configured

--- a/assistant/src/runtime/tool-grant-request-helper.ts
+++ b/assistant/src/runtime/tool-grant-request-helper.ts
@@ -123,6 +123,7 @@ export function createOrReuseToolGrantRequest(
     requesterExternalUserId,
     requesterChatId: requesterChatId ?? undefined,
     guardianExternalUserId: binding.guardianExternalUserId,
+    guardianPrincipalId: binding.guardianPrincipalId ?? undefined,
     toolName,
     inputDigest,
     questionText,


### PR DESCRIPTION
## Summary
- Update all 7 canonical guardian request creation callsites to pass `guardianPrincipalId` from the runtime context (session guardian context, guardian binding, or vellum binding)
- Add create-time guard in `createCanonicalGuardianRequest` that throws `IntegrityError` when a decisionable request kind (`tool_approval`, `tool_grant_request`, `pending_question`, `access_request`) is created without a `guardianPrincipalId`
- Informational request kinds remain exempt from the guard to preserve backward compatibility

## Callsites updated
- `conversation-routes.ts` — HTTP POST /messages tool_approval: from `session.guardianContext`
- `daemon/server.ts` — IPC makePendingInteractionRegistrar tool_approval: from `session.guardianContext`
- `daemon/handlers/sessions.ts` — IPC makeIpcEventSender desktop tool_approval: from `session.guardianContext`
- `inbound-message-handler.ts` — channel escalation tool_approval: from guardian binding
- `tool-grant-request-helper.ts` — channel tool_grant_request: from guardian binding
- `access-request-helper.ts` — access_request: from guardian binding (source or cross-channel fallback)
- `calls/guardian-dispatch.ts` — voice pending_question: from vellum binding (assistant-level principal)

Part of #10955.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
