### PR TITLE
fix: clear phone state on iOS when Twilio credentials are removed

### DIFF
--- a/clients/ios/Views/Settings/TwilioSettingsSection.swift
+++ b/clients/ios/Views/Settings/TwilioSettingsSection.swift
@@ -301,13 +301,18 @@ struct TwilioSettingsSection: View {
             let success = json["success"] as? Bool ?? false
             if success {
                 hasCredentials = json["hasCredentials"] as? Bool ?? false
-                if applyPhoneNumber || json["phoneNumber"] != nil {
-                    phoneNumber = json["phoneNumber"] as? String
-                }
-                if applyNumbers {
-                    availableNumbers = Self.decodeTwilioNumbers(from: json["numbers"])
-                } else if json["numbers"] != nil {
-                    availableNumbers = Self.decodeTwilioNumbers(from: json["numbers"])
+                if !hasCredentials {
+                    phoneNumber = nil
+                    availableNumbers = []
+                } else {
+                    if applyPhoneNumber || json["phoneNumber"] != nil {
+                        phoneNumber = json["phoneNumber"] as? String
+                    }
+                    if applyNumbers {
+                        availableNumbers = Self.decodeTwilioNumbers(from: json["numbers"])
+                    } else if json["numbers"] != nil {
+                        availableNumbers = Self.decodeTwilioNumbers(from: json["numbers"])
+                    }
                 }
                 errorMessage = nil
                 return true


### PR DESCRIPTION
## Summary
- When `DELETE /v1/integrations/twilio/credentials` returns `hasCredentials: false`, the iOS client now clears `phoneNumber` and `availableNumbers` — matching the macOS `SettingsStore.swift` behavior that already had this guard
- Without this fix, stale phone assignment data remained in the iOS settings UI after clearing credentials

## Original prompt
address this late PR feedback https://github.com/vellum-ai/vellum-assistant/pull/10967#discussion_r2868371496

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
