### PR TITLE
fix: route Vercel credential setup through vercel-token-setup skill

### DIFF
--- a/assistant/src/config/bundled-skills/vercel-token-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/vercel-token-setup/SKILL.md
@@ -2,6 +2,7 @@
 name: "Vercel Token Setup"
 description: "Set up a Vercel API token for publishing apps using browser automation"
 includes: ["browser"]
+credential-setup-for: "vercel:api_token"
 metadata: {"vellum": {"emoji": "▲"}}
 ---
 

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -65,6 +65,8 @@ export interface SkillSummary {
   toolManifest?: SkillToolManifestMeta;
   /** IDs of child skills that this skill includes (metadata-only, not auto-activated). */
   includes?: string[];
+  /** Declares which credential this skill sets up (e.g. "vercel:api_token"). */
+  credentialSetupFor?: string;
 }
 
 export interface SkillDefinition extends SkillSummary {
@@ -251,6 +253,7 @@ interface ParsedFrontmatter {
   disableModelInvocation: boolean;
   metadata?: VellumMetadata;
   includes?: string[];
+  credentialSetupFor?: string;
 }
 
 function parseIncludes(raw: string | undefined, skillFilePath: string): string[] | undefined {
@@ -338,6 +341,7 @@ function parseFrontmatter(content: string, skillFilePath: string): ParsedFrontma
   }
 
   const includes = parseIncludes(fields.includes, skillFilePath);
+  const credentialSetupFor = fields['credential-setup-for']?.trim() || undefined;
 
   return {
     name,
@@ -348,6 +352,7 @@ function parseFrontmatter(content: string, skillFilePath: string): ParsedFrontma
     disableModelInvocation,
     metadata,
     includes,
+    credentialSetupFor,
   };
 }
 
@@ -471,6 +476,7 @@ function readSkillFromDirectory(directoryPath: string, skillsDir: string, source
       metadata: parsed.metadata,
       toolManifest: detectToolManifest(directoryPath),
       includes: parsed.includes,
+      credentialSetupFor: parsed.credentialSetupFor,
     };
   } catch (err) {
     log.warn({ err, skillFilePath }, 'Failed to read skill file');
@@ -512,6 +518,7 @@ function readBundledSkillFromDirectory(directoryPath: string): SkillDefinition |
       metadata: parsed.metadata,
       toolManifest: detectToolManifest(directoryPath),
       includes: parsed.includes,
+      credentialSetupFor: parsed.credentialSetupFor,
     };
   } catch (err) {
     log.warn({ err, skillFilePath }, 'Failed to read bundled skill file');
@@ -566,6 +573,7 @@ function loadBundledSkills(): SkillSummary[] {
       metadata: skill.metadata,
       toolManifest: skill.toolManifest,
       includes: skill.includes,
+      credentialSetupFor: skill.credentialSetupFor,
     });
   }
 
@@ -686,6 +694,7 @@ function skillSummaryFromDefinition(skill: SkillDefinition, source: SkillSource)
     metadata: skill.metadata,
     toolManifest: skill.toolManifest,
     includes: skill.includes,
+    credentialSetupFor: skill.credentialSetupFor,
   };
 }
 
@@ -731,6 +740,7 @@ export function loadSkillCatalog(workspaceSkillsDir?: string, extraDirs?: string
             metadata: parsed.metadata,
             toolManifest: detectToolManifest(directory),
             includes: parsed.includes,
+            credentialSetupFor: parsed.credentialSetupFor,
           });
         } catch (err) {
           log.warn({ err, directory }, 'Failed to read skill from extraDirs');
@@ -813,6 +823,7 @@ export function loadSkillCatalog(workspaceSkillsDir?: string, extraDirs?: string
           metadata: parsed.metadata,
           toolManifest: detectToolManifest(directory),
           includes: parsed.includes,
+          credentialSetupFor: parsed.credentialSetupFor,
         };
 
         if (seenIds.has(id)) {

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -839,13 +839,15 @@ function formatSkillsCatalog(skills: SkillSummary[]): string {
     const nameAttr = escapeXml(skill.name);
     const descAttr = escapeXml(skill.description);
     const locAttr = escapeXml(skill.directoryPath);
-    lines.push(`<skill id="${idAttr}" name="${nameAttr}" description="${descAttr}" location="${locAttr}" />`);
+    const credAttr = skill.credentialSetupFor ? ` credential-setup-for="${escapeXml(skill.credentialSetupFor)}"` : '';
+    lines.push(`<skill id="${idAttr}" name="${nameAttr}" description="${descAttr}" location="${locAttr}"${credAttr} />`);
   }
   lines.push('</available_skills>');
 
   return [
     '## Available Skills',
     'The following skills are available. Before executing one, call the `skill_load` tool with its `id` to load the full instructions.',
+    'When a credential is missing, check if any skill declares `credential-setup-for` matching that service — if so, load that skill.',
     '',
     lines.join('\n'),
   ].join('\n');

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -193,7 +193,7 @@ struct MainWindowView: View {
                     }
                     // Inject message into active session to trigger assistant-driven setup
                     if let viewModel = threadManager.activeViewModel {
-                        viewModel.inputText = "I want to publish my app but I don't have a Vercel API token set up yet. Can you help me create one and then publish my app?"
+                        viewModel.inputText = "I need to set up a Vercel API token to publish my app. Please load the vercel-token-setup skill and follow its instructions."
                         viewModel.sendMessage()
                     }
                     startCredentialPollForPublish()


### PR DESCRIPTION
## Summary

- **Client-side**: Updated the injected message when Vercel credentials are missing to explicitly tell the assistant to load the `vercel-token-setup` skill, ensuring it follows the browser automation path instead of improvising
- **Daemon-side**: Added `credential-setup-for` metadata field to skill frontmatter, parsing, and system prompt catalog so the assistant can automatically map missing credentials to the right setup skill
- **Skills**: Annotated `vercel-token-setup` with `credential-setup-for: "vercel:api_token"`

## Test plan

- [x] `bunx tsc --noEmit` — no new type errors
- [x] `bun test src/__tests__/skills.test.ts` — 44/44 pass
- [x] `bun test src/__tests__/system-prompt.test.ts` — 50/50 pass
- [ ] Build macOS app, trigger publish without Vercel credentials, verify assistant loads `vercel-token-setup` skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
