### PR TITLE
fix: resolve type errors in guardian reply router and test mocks

### DIFF
--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -5,9 +5,9 @@ const routeGuardianReplyMock = mock(async () => ({
   decisionApplied: false,
   type: 'not_consumed' as const,
 })) as any;
-const listPendingByDestinationMock = mock(() => [] as Array<{ id: string }>);
-const listCanonicalMock = mock(() => [] as Array<{ id: string }>);
-const addMessageMock = mock(async (_conversationId: string, role: string) => ({
+const listPendingByDestinationMock = mock((_conversationId: string, _sourceChannel?: string) => [] as Array<{ id: string; kind?: string }>);
+const listCanonicalMock = mock((_filters?: Record<string, unknown>) => [] as Array<{ id: string }>);
+const addMessageMock = mock(async (_conversationId: string, role: string, _content?: string, _metadata?: Record<string, unknown>) => ({
   id: role === 'user' ? 'persisted-user-id' : 'persisted-assistant-id',
 }));
 

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -492,7 +492,7 @@ export async function routeGuardianReply(
     // Attach the engine's reply text for stale/expired/identity-mismatch cases,
     // but preserve resolver-authored replies (for example verification codes)
     // and explicit resolver-failure text.
-    const hasResolverReplyText = Boolean(result.canonicalResult?.resolverReplyText);
+    const hasResolverReplyText = Boolean(result.canonicalResult?.applied && result.canonicalResult.resolverReplyText);
     if (engineResult.replyText && result.type !== 'canonical_resolver_failed' && !hasResolverReplyText) {
       result.replyText = engineResult.replyText;
     }


### PR DESCRIPTION
## Summary
- Fix mock parameter signatures in `conversation-routes-guardian-reply.test.ts` to match actual function signatures (`listPendingCanonicalGuardianRequestsByDestinationConversation`, `listCanonicalGuardianRequests`, `addMessage`)
- Add `kind` to mock return type for `listPendingByDestinationMock` to match `CanonicalGuardianRequest` usage in tests
- Narrow `CanonicalDecisionResult` union type before accessing `resolverReplyText` in `guardian-reply-router.ts` (property only exists on `applied: true` branch)

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22535530041/job/65282142501

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
