### PR TITLE
fix: make HTTPTransport public for cross-module access

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -590,7 +590,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     /// HTTP transport used when connecting to a remote assistant via gateway.
     /// Non-nil when `config.transport` is `.http`.
-    var httpTransport: HTTPTransport?
+    public var httpTransport: HTTPTransport?
 
     let encoder = JSONEncoder()
     let decoder = JSONDecoder()

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -46,10 +46,10 @@ struct ConversationsListResponse: Decodable {
 /// - Translating IPC message types to HTTP API calls
 /// - Auto-reconnect with exponential backoff
 @MainActor
-final class HTTPTransport {
+public final class HTTPTransport {
 
-    let baseURL: String
-    private(set) var bearerToken: String?
+    public let baseURL: String
+    public private(set) var bearerToken: String?
     private let conversationKey: String
     private let sourceChannel: String
 


### PR DESCRIPTION
## Summary
- Made `HTTPTransport` class, `baseURL`, and `bearerToken` properties `public` so they can be accessed from the `VellumAssistantLib` module
- Made `DaemonClient.httpTransport` property `public` for the same reason
- Fixes macOS CI build error: `'httpTransport' is inaccessible due to 'internal' protection level` in `SettingsStore.swift`

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22535393869/job/65281724793

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
