### PR TITLE
fix: remove overly-broad empty-list guard from syncFromDaemon

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
@@ -128,9 +128,6 @@ final class AppListManager: ObservableObject {
     /// Removes local apps the daemon no longer reports (e.g. filtered Home Base).
     /// Always propagates daemon descriptions to existing apps when they differ.
     func syncFromDaemon(_ daemonApps: [AppItem_Daemon]) {
-        // An empty daemon response likely means a transient error — don't wipe local state.
-        guard !daemonApps.isEmpty else { return }
-
         let existingIds = Set(apps.map(\.id))
         let daemonIds = Set(daemonApps.map(\.id))
         var newCount = 0


### PR DESCRIPTION
Removes the `guard !daemonApps.isEmpty else { return }` added in #10975. Zero apps is a legitimate daemon state (e.g. user deleted all apps, or only Home Base exists which gets filtered). The guard prevented pruning stale local entries in that case.

Addresses feedback from Codex on #10975.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
