### PR TITLE
fix: auto-launch OAuth setup on invalid Gmail credentials

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -95,7 +95,7 @@ The guardian-verify-setup skill handles the full outbound verification flow for 
 When a messaging tool fails with a token or authorization error:
 
 1. **Try to reconnect silently.** Call `credential_store` with `action: "oauth2_connect"` and the appropriate `service`. This often resolves expired tokens automatically.
-2. **If reconnection fails**, tell the user simply: "Looks like Gmail needs to be reconnected. Want me to set that up?" Then follow the connection setup flow above.
+2. **If reconnection fails, go straight to setup.** Don't present options, ask which route the user prefers, or explain what went wrong technically. Just tell the user briefly (e.g., "Gmail needs to be reconnected — let me set that up") and immediately follow the connection setup flow for that platform (e.g., install and load **google-oauth-setup** for Gmail). The user came to you to get something done, not to troubleshoot OAuth — make it seamless.
 3. **Never try alternative approaches.** Don't use bash, curl, browser automation, or any workaround. If the messaging tools can't do it, the reconnection flow is the answer.
 4. **Never expose error details.** The user doesn't need to see error messages about tokens, OAuth, or API failures. Translate errors into plain language.
 

--- a/assistant/src/config/templates/SOUL.md
+++ b/assistant/src/config/templates/SOUL.md
@@ -16,6 +16,8 @@ Never remove or weaken safety boundaries, tool-use permission rules, or the Boun
 
 **Be resourceful before asking.** Try to figure it out. Read the file. Check the context. Search for it. Then ask if you're stuck. Come back with answers, not questions.
 
+**Know your own capabilities.** Before telling the user you can't do something or asking them to fix a problem, check what tools and skills you have. If a connection is broken, try to fix it. If a service needs setup, offer to do it. Escalate only after you've tried.
+
 **Have opinions.** You're allowed to disagree, prefer things, and push back when something seems wrong. An assistant with no perspective is just a search engine.
 
 **Earn trust through competence.** You have access to your user's machine, files, and tools. Don't make them regret it. Be careful with external actions (emails, messages, anything public-facing). Be bold with internal ones (reading, organizing, building).

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -13,6 +13,11 @@ import { getSecureKey, setSecureKey } from './secure-keys.js';
 
 const log = getLogger('token-manager');
 
+function recoveryHint(service: string): string {
+  const shortName = service.startsWith('integration:') ? service.slice('integration:'.length) : service;
+  return ` Reconnect ${shortName} — follow the Error Recovery steps in the messaging skill. Do not present options or explain the error to the user.`;
+}
+
 /** Buffer before expiry to trigger proactive refresh (5 minutes). */
 const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
 
@@ -113,7 +118,7 @@ function isTokenExpired(service: string): boolean {
 async function doRefresh(service: string): Promise<string> {
   const refreshToken = getSecureKey(`credential:${service}:refresh_token`);
   if (!refreshToken) {
-    throw new TokenExpiredError(service, `No refresh token available for "${service}". Re-authorization required.`);
+    throw new TokenExpiredError(service, `No refresh token available for "${service}". Re-authorization required.${recoveryHint(service)}`);
   }
 
   const meta = getCredentialMetadata(service, 'access_token');
@@ -131,7 +136,7 @@ async function doRefresh(service: string): Promise<string> {
       : '';
     throw new TokenExpiredError(
       service,
-      `Missing OAuth2 refresh config for "${service}".${hint} Please reconnect via chat to re-authorize.`,
+      `Missing OAuth2 refresh config for "${service}".${hint}${recoveryHint(service)}`,
     );
   }
 
@@ -145,7 +150,7 @@ async function doRefresh(service: string): Promise<string> {
     throw new TokenExpiredError(
       service,
       `Token refresh for "${service}" is temporarily suspended after ${state.consecutiveFailures} consecutive failures. ` +
-      `Retrying in ${Math.ceil(remainingMs / 1000)}s. Please try again later or re-authorize.`,
+      `Retrying in ${Math.ceil(remainingMs / 1000)}s.${recoveryHint(service)}`,
     );
   }
 
@@ -156,16 +161,17 @@ async function doRefresh(service: string): Promise<string> {
     result = await refreshOAuth2Token(resolvedTokenUrl, clientId, refreshToken, clientSecret, authMethod);
   } catch (err) {
     recordRefreshFailure(service);
-    throw err;
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new TokenExpiredError(service, `Token refresh failed for "${service}": ${msg}.${recoveryHint(service)}`);
   }
 
   if (!setSecureKey(`credential:${service}:access_token`, result.accessToken)) {
-    throw new Error(`Failed to store refreshed access token for "${service}"`);
+    throw new TokenExpiredError(service, `Failed to store refreshed access token for "${service}".`);
   }
 
   if (result.refreshToken) {
     if (!setSecureKey(`credential:${service}:refresh_token`, result.refreshToken)) {
-      throw new Error(`Failed to store refreshed refresh token for "${service}"`);
+      throw new TokenExpiredError(service, `Failed to store refreshed refresh token for "${service}".`);
     }
   }
 
@@ -197,11 +203,7 @@ export async function withValidToken<T>(
 ): Promise<T> {
   let token = getSecureKey(`credential:${service}:access_token`);
   if (!token) {
-    const isGoogle = service === 'integration:gmail';
-    const googleHint = isGoogle
-      ? ' Try reconnecting by calling credential_store with action "oauth2_connect" and service "gmail".'
-      : '';
-    throw new TokenExpiredError(service, `No access token found for "${service}". Authorization required.${googleHint}`);
+    throw new TokenExpiredError(service, `No access token found for "${service}". Authorization required.${recoveryHint(service)}`);
   }
 
   // Proactively refresh if expired or about to expire.


### PR DESCRIPTION
## Summary
- **messaging/SKILL.md**: Error Recovery step 2 now says "go straight to setup" instead of asking the user what they want to do — no options, no technical explanations, just launch the OAuth setup skill
- **token-manager.ts**: Unified `recoveryHint()` function directs the assistant to follow Error Recovery steps rather than calling `credential_store` directly (which fails when client credentials are broken)
- **SOUL.md**: Added "Know your own capabilities" principle — try to fix broken connections before asking the user to troubleshoot

## Original prompt
if gmail credentials are invalid we should be sending users directly to the gmail OAuth2 setup skill. in general let's not confuse users because of our complexity, our job is to make their lives easier not complicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
