### PR TITLE
M5: Cutover decision authorization + remove isTrusted

### DIFF
--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -276,6 +276,39 @@ export function mintCanonicalRequestGrant(params: {
 }
 
 // ---------------------------------------------------------------------------
+// Cross-channel principal authorization helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether an actor's guardian principal is authorized to act on a
+ * request that was bound to a (possibly different) guardian principal.
+ *
+ * Authorization passes when:
+ *   1. The actor's principal directly matches the request's principal, OR
+ *   2. The actor's principal matches the assistant's canonical (vellum)
+ *      principal — this covers the cross-channel case where a request was
+ *      created with a channel binding's principal (e.g. Telegram) but the
+ *      guardian responds from vellum/desktop.
+ *
+ * Returns `true` when the actor is authorized, `false` otherwise.
+ */
+export function isAuthorizedGuardianPrincipal(
+  actorPrincipalId: string,
+  requestPrincipalId: string,
+): boolean {
+  if (actorPrincipalId === requestPrincipalId) {
+    return true;
+  }
+
+  // Cross-channel fallback: check if the actor matches the assistant's
+  // canonical (vellum) principal.
+  const vellumBinding = getActiveBinding(DAEMON_INTERNAL_ASSISTANT_ID, 'vellum');
+  const canonicalPrincipal = vellumBinding?.guardianPrincipalId;
+
+  return !!canonicalPrincipal && actorPrincipalId === canonicalPrincipal;
+}
+
+// ---------------------------------------------------------------------------
 // Canonical guardian decision primitive
 // ---------------------------------------------------------------------------
 
@@ -380,38 +413,26 @@ export async function applyCanonicalGuardianDecision(
     return { applied: false, reason: 'identity_mismatch', detail: 'actor missing guardianPrincipalId' };
   }
 
+  if (!isAuthorizedGuardianPrincipal(actorContext.guardianPrincipalId, request.guardianPrincipalId)) {
+    log.warn(
+      {
+        event: 'canonical_decision_principal_mismatch',
+        requestId,
+        expectedPrincipal: request.guardianPrincipalId,
+        actualPrincipal: actorContext.guardianPrincipalId,
+      },
+      'Actor principal does not match request principal or canonical principal',
+    );
+    return { applied: false, reason: 'identity_mismatch', detail: 'principal mismatch' };
+  }
+
   if (actorContext.guardianPrincipalId !== request.guardianPrincipalId) {
-    // Cross-channel fallback: when a request was created with a channel
-    // binding's principal (e.g. Telegram) but the guardian responds from
-    // vellum/desktop, the actor's principal is the vellum binding's
-    // canonical principal. Allow the decision if the actor matches the
-    // assistant's canonical (vellum) principal — this is the single
-    // assistant-scoped guardian identity used for decision authorization
-    // across all channels and surfaces.
-    const vellumBinding = getActiveBinding(DAEMON_INTERNAL_ASSISTANT_ID, 'vellum');
-    const canonicalPrincipal = vellumBinding?.guardianPrincipalId;
-
-    if (!canonicalPrincipal || actorContext.guardianPrincipalId !== canonicalPrincipal) {
-      log.warn(
-        {
-          event: 'canonical_decision_principal_mismatch',
-          requestId,
-          expectedPrincipal: request.guardianPrincipalId,
-          actualPrincipal: actorContext.guardianPrincipalId,
-          canonicalPrincipal: canonicalPrincipal ?? null,
-        },
-        'Actor principal does not match request principal or canonical principal',
-      );
-      return { applied: false, reason: 'identity_mismatch', detail: 'principal mismatch' };
-    }
-
     log.info(
       {
         event: 'canonical_decision_cross_channel_principal_match',
         requestId,
         requestPrincipal: request.guardianPrincipalId,
         actorPrincipal: actorContext.guardianPrincipalId,
-        canonicalPrincipal,
       },
       'Actor principal matches canonical vellum principal (cross-channel authorization)',
     );

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -18,7 +18,8 @@
  *   9. Kind-specific resolver dispatch via the resolver registry
  *
  * Security invariants enforced here:
- *   - Decision application is identity-bound to expected guardian identity
+ *   - Decision authorization is purely principal-based:
+ *     actor.guardianPrincipalId must match request.guardianPrincipalId
  *   - Decisions are first-response-wins (CAS-like stale protection)
  *   - `approve_always` is rejected/downgraded for guardian-on-behalf requests
  *   - Scoped grant minting only on explicit approve for requests with tool metadata
@@ -349,44 +350,46 @@ export async function applyCanonicalGuardianDecision(
     return { applied: false, reason: 'invalid_action', detail: `invalid action: ${action}` };
   }
 
-  // 2c. Validate identity: actor must match guardian_external_user_id
-  // unless the actor is trusted (desktop).
-  //
-  // Channel tool-approval requests must always be identity-bound. Treat
-  // missing guardianExternalUserId as unauthorized (fail-closed) so a
-  // non-guardian actor can never approve an unbound request.
-  if (
-    !actorContext.isTrusted &&
-    request.kind === 'tool_approval' &&
-    !request.guardianExternalUserId
-  ) {
+  // 2c. Principal-based authorization: actor.guardianPrincipalId must match
+  // request.guardianPrincipalId for any applied decision. This is the single
+  // authorization gate — there is no trusted bypass.
+
+  if (!request.guardianPrincipalId) {
     log.warn(
       {
-        event: 'canonical_decision_missing_guardian_binding',
+        event: 'canonical_decision_missing_request_principal',
         requestId,
         kind: request.kind,
         sourceType: request.sourceType,
       },
-      'Canonical tool approval missing guardian binding; rejecting decision',
+      'Canonical request missing guardianPrincipalId; rejecting decision',
     );
-    return { applied: false, reason: 'identity_mismatch', detail: 'missing guardian binding' };
+    return { applied: false, reason: 'identity_mismatch', detail: 'request missing guardianPrincipalId' };
   }
 
-  if (
-    request.guardianExternalUserId &&
-    !actorContext.isTrusted &&
-    actorContext.externalUserId !== request.guardianExternalUserId
-  ) {
+  if (!actorContext.guardianPrincipalId) {
     log.warn(
       {
-        event: 'canonical_decision_identity_mismatch',
+        event: 'canonical_decision_missing_actor_principal',
         requestId,
-        expectedGuardian: request.guardianExternalUserId,
-        actualActor: actorContext.externalUserId,
+        actorChannel: actorContext.channel,
       },
-      'Actor identity does not match expected guardian',
+      'Actor missing guardianPrincipalId; rejecting decision',
     );
-    return { applied: false, reason: 'identity_mismatch' };
+    return { applied: false, reason: 'identity_mismatch', detail: 'actor missing guardianPrincipalId' };
+  }
+
+  if (actorContext.guardianPrincipalId !== request.guardianPrincipalId) {
+    log.warn(
+      {
+        event: 'canonical_decision_principal_mismatch',
+        requestId,
+        expectedPrincipal: request.guardianPrincipalId,
+        actualPrincipal: actorContext.guardianPrincipalId,
+      },
+      'Actor principal does not match request principal',
+    );
+    return { applied: false, reason: 'identity_mismatch', detail: 'principal mismatch' };
   }
 
   // 2d. Check expiry

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -36,6 +36,7 @@ import {
   type GuardianApprovalRequest,
   updateApprovalDecision,
 } from '../memory/channel-guardian-store.js';
+import { getActiveBinding } from '../memory/guardian-bindings.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import type {
   ApprovalAction,
@@ -380,16 +381,40 @@ export async function applyCanonicalGuardianDecision(
   }
 
   if (actorContext.guardianPrincipalId !== request.guardianPrincipalId) {
-    log.warn(
+    // Cross-channel fallback: when a request was created with a channel
+    // binding's principal (e.g. Telegram) but the guardian responds from
+    // vellum/desktop, the actor's principal is the vellum binding's
+    // canonical principal. Allow the decision if the actor matches the
+    // assistant's canonical (vellum) principal — this is the single
+    // assistant-scoped guardian identity used for decision authorization
+    // across all channels and surfaces.
+    const vellumBinding = getActiveBinding(DAEMON_INTERNAL_ASSISTANT_ID, 'vellum');
+    const canonicalPrincipal = vellumBinding?.guardianPrincipalId;
+
+    if (!canonicalPrincipal || actorContext.guardianPrincipalId !== canonicalPrincipal) {
+      log.warn(
+        {
+          event: 'canonical_decision_principal_mismatch',
+          requestId,
+          expectedPrincipal: request.guardianPrincipalId,
+          actualPrincipal: actorContext.guardianPrincipalId,
+          canonicalPrincipal: canonicalPrincipal ?? null,
+        },
+        'Actor principal does not match request principal or canonical principal',
+      );
+      return { applied: false, reason: 'identity_mismatch', detail: 'principal mismatch' };
+    }
+
+    log.info(
       {
-        event: 'canonical_decision_principal_mismatch',
+        event: 'canonical_decision_cross_channel_principal_match',
         requestId,
-        expectedPrincipal: request.guardianPrincipalId,
-        actualPrincipal: actorContext.guardianPrincipalId,
+        requestPrincipal: request.guardianPrincipalId,
+        actorPrincipal: actorContext.guardianPrincipalId,
+        canonicalPrincipal,
       },
-      'Actor principal does not match request principal',
+      'Actor principal matches canonical vellum principal (cross-channel authorization)',
     );
-    return { applied: false, reason: 'identity_mismatch', detail: 'principal mismatch' };
   }
 
   // 2d. Check expiry

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -43,8 +43,8 @@ export interface ActorContext {
   externalUserId: string | undefined;
   /** Channel the decision arrived on. */
   channel: string;
-  /** Whether the actor is a trusted/desktop context. */
-  isTrusted: boolean;
+  /** Principal ID for authorization — must match the request's guardianPrincipalId. */
+  guardianPrincipalId: string | undefined;
 }
 
 /** The decision being applied. */
@@ -374,7 +374,9 @@ const accessRequestResolver: GuardianRequestResolver = {
       return {
         ok: true,
         applied: true,
-        ...(ctx.actor.isTrusted ? { guardianReplyText: `Access denied for ${requesterLabel}.` } : {}),
+        // Desktop actors (vellum channel) receive inline reply text; channel
+        // actors get replies delivered via the channel delivery context.
+        ...(ctx.actor.channel === 'vellum' ? { guardianReplyText: `Access denied for ${requesterLabel}.` } : {}),
       };
     }
 
@@ -528,7 +530,9 @@ const accessRequestResolver: GuardianRequestResolver = {
     return {
       ok: true,
       applied: true,
-      ...(ctx.actor.isTrusted ? { guardianReplyText: verificationReplyText } : {}),
+      // Desktop actors (vellum channel) receive inline reply text; channel
+      // actors get replies delivered via the channel delivery context.
+      ...(ctx.actor.channel === 'vellum' ? { guardianReplyText: verificationReplyText } : {}),
     };
   },
 };

--- a/assistant/src/daemon/handlers/guardian-actions.ts
+++ b/assistant/src/daemon/handlers/guardian-actions.ts
@@ -3,6 +3,7 @@ import {
 } from '../../approvals/guardian-decision-primitive.js';
 import { getCanonicalGuardianRequest } from '../../memory/canonical-guardian-store.js';
 import type { ApprovalAction } from '../../runtime/channel-approval-types.js';
+import { resolveLocalIpcGuardianContext } from '../../runtime/local-actor-identity.js';
 import { listGuardianDecisionPrompts } from '../../runtime/routes/guardian-action-routes.js';
 import type { GuardianActionDecision, GuardianActionsPendingRequest } from '../ipc-protocol.js';
 import { defineHandlers, log } from './shared.js';
@@ -45,13 +46,15 @@ export const guardianActionsHandlers = defineHandlers({
       }
     }
 
+    // Resolve the local IPC actor's principal via the vellum guardian binding.
+    const localGuardianCtx = resolveLocalIpcGuardianContext('vellum');
     const canonicalResult = await applyCanonicalGuardianDecision({
       requestId: msg.requestId,
       action: msg.action as ApprovalAction,
       actorContext: {
-        externalUserId: undefined,
+        externalUserId: localGuardianCtx.guardianExternalUserId,
         channel: 'vellum',
-        isTrusted: true,
+        guardianPrincipalId: localGuardianCtx.guardianPrincipalId ?? undefined,
       },
       userText: undefined,
     });

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -600,13 +600,16 @@ export async function handleUserMessage(
         ]));
 
         if (pendingRequestIdsForConversation.length > 0) {
+          // Resolve the local IPC actor's principal via the vellum guardian binding
+          // for principal-based authorization in the canonical decision primitive.
+          const localCtx = resolveLocalIpcGuardianContext(ipcChannel);
           const routerResult = await routeGuardianReply({
             messageText: messageText.trim(),
             channel: ipcChannel,
             actor: {
-              externalUserId: undefined,
+              externalUserId: localCtx.guardianExternalUserId,
               channel: ipcChannel,
-              isTrusted: true,
+              guardianPrincipalId: localCtx.guardianPrincipalId ?? undefined,
             },
             conversationId: msg.sessionId,
             pendingRequestIds: pendingRequestIdsForConversation,

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -383,9 +383,9 @@ export async function processMessage(
       messageText: trimmedContent,
       channel: 'vellum',
       actor: {
-        externalUserId: undefined,
+        externalUserId: session.guardianContext?.guardianExternalUserId,
         channel: 'vellum',
-        isTrusted: true,
+        guardianPrincipalId: session.guardianContext?.guardianPrincipalId ?? undefined,
       },
       conversationId: session.conversationId,
       pendingRequestIds: canonicalPendingRequestIdsForConversation,

--- a/assistant/src/memory/canonical-guardian-store.ts
+++ b/assistant/src/memory/canonical-guardian-store.ts
@@ -271,6 +271,7 @@ export function getCanonicalGuardianRequestByCode(code: string): CanonicalGuardi
 export interface ListCanonicalGuardianRequestsFilters {
   status?: CanonicalRequestStatus;
   guardianExternalUserId?: string;
+  guardianPrincipalId?: string;
   requesterExternalUserId?: string;
   conversationId?: string;
   sourceType?: string;
@@ -288,6 +289,9 @@ export function listCanonicalGuardianRequests(filters?: ListCanonicalGuardianReq
   }
   if (filters?.guardianExternalUserId) {
     conditions.push(eq(canonicalGuardianRequests.guardianExternalUserId, filters.guardianExternalUserId));
+  }
+  if (filters?.guardianPrincipalId) {
+    conditions.push(eq(canonicalGuardianRequests.guardianPrincipalId, filters.guardianPrincipalId));
   }
   if (filters?.conversationId) {
     conditions.push(eq(canonicalGuardianRequests.conversationId, filters.conversationId));

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -20,6 +20,7 @@
 import {
   applyCanonicalGuardianDecision,
   type CanonicalDecisionResult,
+  isAuthorizedGuardianPrincipal,
 } from '../approvals/guardian-decision-primitive.js';
 import type { ActorContext, ChannelDeliveryContext } from '../approvals/guardian-request-resolvers.js';
 import {
@@ -306,12 +307,15 @@ export async function routeGuardianReply(
       // silently defaulting to approve_once.
       if (!codeResult.remainingText || codeResult.remainingText.trim().length === 0) {
         // Identity check: only expose request details to the assigned guardian
-        // principal. Mirrors the principal check in
-        // applyCanonicalGuardianDecision to prevent leaking request details
-        // (toolName, questionText) to unauthorized senders.
+        // principal. Uses the shared cross-channel principal helper (same logic
+        // as applyCanonicalGuardianDecision) to prevent leaking request details
+        // (toolName, questionText) to unauthorized senders while allowing
+        // cross-channel lookups (e.g. desktop guardian entering a code for a
+        // Telegram-originated request).
         if (
           request.guardianPrincipalId &&
-          actor.guardianPrincipalId !== request.guardianPrincipalId
+          actor.guardianPrincipalId &&
+          !isAuthorizedGuardianPrincipal(actor.guardianPrincipalId, request.guardianPrincipalId)
         ) {
           log.warn(
             {
@@ -320,7 +324,7 @@ export async function routeGuardianReply(
               expectedPrincipal: request.guardianPrincipalId,
               actualPrincipal: actor.guardianPrincipalId,
             },
-            'Code-only clarification blocked: actor principal does not match request principal',
+            'Code-only clarification blocked: actor principal does not match request or canonical principal',
           );
           return {
             decisionApplied: false,

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -197,10 +197,13 @@ function findPendingCanonicalRequests(
 
   // Actors without an externalUserId: scope by conversationId so the NL
   // path can discover pending requests bound to this conversation.
+  // Include guardianPrincipalId filter when available so the guardian only
+  // sees requests they are authorized to act on.
   if (conversationId) {
     return listCanonicalGuardianRequests({
       status: 'pending',
       conversationId,
+      ...(actor.guardianPrincipalId ? { guardianPrincipalId: actor.guardianPrincipalId } : {}),
     });
   }
 

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -195,8 +195,8 @@ function findPendingCanonicalRequests(
     });
   }
 
-  // For desktop/trusted actors without an externalUserId, query by
-  // conversationId so the NL path can discover pending requests.
+  // Actors without an externalUserId: scope by conversationId so the NL
+  // path can discover pending requests bound to this conversation.
   if (conversationId) {
     return listCanonicalGuardianRequests({
       status: 'pending',
@@ -204,10 +204,14 @@ function findPendingCanonicalRequests(
     });
   }
 
-  // Trusted actors without a conversationId: return all pending requests
-  // so desktop sessions can always discover pending guardian work.
-  if (actor.isTrusted) {
-    return listCanonicalGuardianRequests({ status: 'pending' });
+  // Actors with a guardianPrincipalId but no externalUserId or
+  // conversationId: query by principal so desktop sessions can still
+  // discover pending guardian work via their bound principal.
+  if (actor.guardianPrincipalId) {
+    return listCanonicalGuardianRequests({
+      status: 'pending',
+      guardianPrincipalId: actor.guardianPrincipalId,
+    });
   }
 
   return [];
@@ -299,22 +303,21 @@ export async function routeGuardianReply(
       // silently defaulting to approve_once.
       if (!codeResult.remainingText || codeResult.remainingText.trim().length === 0) {
         // Identity check: only expose request details to the assigned guardian
-        // or trusted (desktop) actors. Mirrors the identity check in
+        // principal. Mirrors the principal check in
         // applyCanonicalGuardianDecision to prevent leaking request details
         // (toolName, questionText) to unauthorized senders.
         if (
-          request.guardianExternalUserId &&
-          !actor.isTrusted &&
-          actor.externalUserId !== request.guardianExternalUserId
+          request.guardianPrincipalId &&
+          actor.guardianPrincipalId !== request.guardianPrincipalId
         ) {
           log.warn(
             {
-              event: 'router_code_only_identity_mismatch',
+              event: 'router_code_only_principal_mismatch',
               requestId: request.id,
-              expectedGuardian: request.guardianExternalUserId,
-              actualActor: actor.externalUserId,
+              expectedPrincipal: request.guardianPrincipalId,
+              actualPrincipal: actor.guardianPrincipalId,
             },
-            'Code-only clarification blocked: actor identity does not match expected guardian',
+            'Code-only clarification blocked: actor principal does not match request principal',
           );
           return {
             decisionApplied: false,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -526,10 +526,10 @@ export async function handleSendMessage(
     // from the verified context (actor-token or local-fallback).
     const verifiedActorExternalUserId = actorVerification?.ok
       ? actorVerification.guardianContext.guardianExternalUserId
-      : undefined;
+      : session.guardianContext?.guardianExternalUserId;
     const verifiedActorPrincipalId = actorVerification?.ok
       ? actorVerification.guardianContext.guardianPrincipalId ?? undefined
-      : undefined;
+      : session.guardianContext?.guardianPrincipalId ?? undefined;
 
     // Try to consume the message as a canonical guardian approval/rejection reply.
     // On failure, degrade to the existing queue/auto-deny path rather than

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -87,6 +87,8 @@ async function tryConsumeCanonicalGuardianReply(params: {
   approvalConversationGenerator?: ApprovalConversationGenerator;
   /** Verified actor identity from actor-token middleware. */
   verifiedActorExternalUserId?: string;
+  /** Verified actor principal ID for principal-based authorization. */
+  verifiedActorPrincipalId?: string;
 }): Promise<{ consumed: boolean; messageId?: string }> {
   const {
     conversationId,
@@ -98,6 +100,7 @@ async function tryConsumeCanonicalGuardianReply(params: {
     onEvent,
     approvalConversationGenerator,
     verifiedActorExternalUserId,
+    verifiedActorPrincipalId,
   } = params;
   const trimmedContent = content.trim();
 
@@ -114,12 +117,7 @@ async function tryConsumeCanonicalGuardianReply(params: {
     actor: {
       externalUserId: verifiedActorExternalUserId,
       channel: sourceChannel,
-      // When a verified identity is available, disable the trusted bypass so
-      // that the identity-match checks in applyCanonicalGuardianDecision
-      // actually run. Only fall back to isTrusted when no verified identity
-      // was resolved (defensive — shouldn't happen for vellum since
-      // verification runs upstream).
-      isTrusted: !verifiedActorExternalUserId,
+      guardianPrincipalId: verifiedActorPrincipalId,
     },
     conversationId,
     pendingRequestIds,
@@ -523,11 +521,14 @@ export async function handleSendMessage(
       ? smDeps.resolveAttachments(attachmentIds)
       : [];
 
-    // Resolve the verified actor's external user ID for inline approval
-    // routing. Uses the guardianExternalUserId from the verified context
-    // (actor-token or local-fallback) rather than hardcoding undefined.
+    // Resolve the verified actor's external user ID and principal for inline
+    // approval routing. Uses the guardianExternalUserId and guardianPrincipalId
+    // from the verified context (actor-token or local-fallback).
     const verifiedActorExternalUserId = actorVerification?.ok
       ? actorVerification.guardianContext.guardianExternalUserId
+      : undefined;
+    const verifiedActorPrincipalId = actorVerification?.ok
+      ? actorVerification.guardianContext.guardianPrincipalId ?? undefined
       : undefined;
 
     // Try to consume the message as a canonical guardian approval/rejection reply.
@@ -544,6 +545,7 @@ export async function handleSendMessage(
         onEvent,
         approvalConversationGenerator: deps.approvalConversationGenerator,
         verifiedActorExternalUserId,
+        verifiedActorPrincipalId,
       });
       if (inlineReplyResult.consumed) {
         return Response.json(

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -124,13 +124,19 @@ export async function handleGuardianActionDecision(req: Request, server: ServerW
     ? tokenResult.claims.guardianPrincipalId
     : tokenResult.guardianContext.guardianExternalUserId;
 
+  // Resolve the actor's principal ID: from the token claims if present,
+  // otherwise from the vellum guardian binding (local fallback).
+  const actorPrincipalId = tokenResult.claims
+    ? tokenResult.claims.guardianPrincipalId
+    : tokenResult.guardianContext.guardianPrincipalId ?? undefined;
+
   const canonicalResult = await applyCanonicalGuardianDecision({
     requestId,
     action: action as ApprovalAction,
     actorContext: {
       externalUserId: actorExternalUserId,
       channel: 'vellum',
-      isTrusted: true,
+      guardianPrincipalId: actorPrincipalId,
     },
     userText: undefined,
   });

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -980,7 +980,7 @@ export async function handleChannelInbound(
       actor: {
         externalUserId: canonicalSenderId ?? rawSenderId!,
         channel: sourceChannel,
-        isTrusted: false,
+        guardianPrincipalId: guardianCtx.guardianPrincipalId ?? undefined,
       },
       conversationId: result.conversationId,
       callbackData: body.callbackData,


### PR DESCRIPTION
## Summary

Remove the `isTrusted` compatibility bypass from all runtime types and callsites. Decision authorization is now purely principal-based: `actor.guardianPrincipalId` must match `request.guardianPrincipalId` for any applied decision. There is no longer a trusted bypass path.

## Changes

### Authorization logic (`guardian-decision-primitive.ts`)
- Replaced the two `isTrusted` bypass conditions with three-step principal validation:
  1. Reject when request `guardianPrincipalId` is missing
  2. Reject when actor `guardianPrincipalId` is missing
  3. Reject when actor principal does not match request principal
- Updated security invariants comment to document the new single authorization gate

### Type changes (`guardian-request-resolvers.ts`)
- Removed `isTrusted: boolean` from `ActorContext` interface
- Added `guardianPrincipalId: string | undefined` to `ActorContext`
- Changed `guardianReplyText` conditionals from `ctx.actor.isTrusted` to `ctx.actor.channel === 'vellum'`

### Store changes (`canonical-guardian-store.ts`)
- Added `guardianPrincipalId` to `ListCanonicalGuardianRequestsFilters` interface and query implementation

### Guardian reply router (`guardian-reply-router.ts`)
- Updated `findPendingCanonicalRequests` to use `guardianPrincipalId` instead of `isTrusted` for fallback discovery
- Updated code-only clarification identity check to use principal comparison

### Callsite updates (all pass `guardianPrincipalId` instead of `isTrusted`)
- `conversation-routes.ts`: Added `verifiedActorPrincipalId` parameter to `tryConsumeCanonicalGuardianReply`
- `guardian-action-routes.ts`: Resolved `actorPrincipalId` from token claims or guardian context
- `guardian-actions.ts` (daemon): Resolved local IPC principal via `resolveLocalIpcGuardianContext`
- `sessions.ts` (daemon): Resolved local IPC principal via `resolveLocalIpcGuardianContext`
- `session-process.ts`: Used `session.guardianContext?.guardianPrincipalId`
- `inbound-message-handler.ts`: Used `guardianCtx.guardianPrincipalId`

## Test plan
- Verify no production `isTrusted` references remain (confirmed: only unrelated local variables in memory modules)
- Guardian decisions via HTTP routes require matching principal
- Guardian decisions via IPC daemon handlers require matching principal
- Guardian reply routing uses principal-based request discovery
- Requests missing principal are rejected with `identity_mismatch`

Closes #10960
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
