### PR TITLE
fix: remove unused hasCompletedTools variable

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -16,7 +16,6 @@ extension ChatBubble {
 
     @ViewBuilder
     var trailingStatus: some View {
-        let hasCompletedTools = allToolCallsComplete && !hideToolCalls && !message.toolCalls.isEmpty
         /// True when there is at least one tool call that hasn't finished yet.
         let hasActuallyRunningTool = !hideToolCalls && message.toolCalls.contains(where: { !$0.isComplete })
         /// All individual tool calls done but message still streaming (model generating next tool call).


### PR DESCRIPTION
## Summary
- Removed unused `hasCompletedTools` local variable in `ChatBubbleToolStatusView.trailingStatus` to eliminate Swift build warning

## Original prompt
fix this: ~v/clients/macos git:(main❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run — warning: initialization of immutable value 'hasCompletedTools' was never used

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
