### PR TITLE
fix: update test mocks and assertions for 9 failing CI test files

### DIFF
--- a/assistant/src/__tests__/call-pointer-messages.test.ts
+++ b/assistant/src/__tests__/call-pointer-messages.test.ts
@@ -230,25 +230,25 @@ describe('addPointerMessage', () => {
     expect(generatorCalled.value).toBe(false);
   });
 
-  test('private threadType is detected as trusted audience', () => {
+  test('private threadType is detected as trusted audience', async () => {
     const convId = 'conv-ptr-private';
     ensureConversation(convId, { threadType: 'private' });
 
     setPointerCopyGenerator(async () => 'generated text');
 
-    addPointerMessage(convId, 'completed', '+15559876543', { duration: '1m' });
+    await addPointerMessage(convId, 'completed', '+15559876543', { duration: '1m' });
     const text = getLatestAssistantText(convId);
     // In test env, falls back to deterministic even on trusted path
     expect(text).toContain('Call to +15559876543 completed (1m)');
   });
 
-  test('vellum origin channel is detected as trusted audience', () => {
+  test('vellum origin channel is detected as trusted audience', async () => {
     const convId = 'conv-ptr-vellum';
     ensureConversation(convId, { originChannel: 'vellum' });
 
     setPointerCopyGenerator(async () => 'generated text');
 
-    addPointerMessage(convId, 'failed', '+15559876543', { reason: 'busy' });
+    await addPointerMessage(convId, 'failed', '+15559876543', { reason: 'busy' });
     const text = getLatestAssistantText(convId);
     expect(text).toContain('failed: busy');
   });

--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -54,6 +54,10 @@ mock.module('../memory/conversation-store.js', () => ({
   ) => addMessageMock(conversationId, role, content, metadata),
 }));
 
+mock.module('../runtime/local-actor-identity.js', () => ({
+  resolveLocalIpcGuardianContext: () => ({ trustClass: 'guardian', sourceChannel: 'vellum' }),
+}));
+
 import { handleSendMessage } from '../runtime/routes/conversation-routes.js';
 
 const testServer = {

--- a/assistant/src/__tests__/conversation-routes.test.ts
+++ b/assistant/src/__tests__/conversation-routes.test.ts
@@ -17,6 +17,10 @@ mock.module('../memory/attachments-store.js', () => ({
   getAttachmentsByIds: () => [],
 }));
 
+mock.module('../runtime/local-actor-identity.js', () => ({
+  resolveLocalIpcGuardianContext: (sourceChannel: string) => ({ trustClass: 'guardian', sourceChannel }),
+}));
+
 import type { ServerWithRequestIP } from '../runtime/middleware/actor-token.js';
 import { handleSendMessage } from '../runtime/routes/conversation-routes.js';
 

--- a/assistant/src/__tests__/handle-user-message-secret-resume.test.ts
+++ b/assistant/src/__tests__/handle-user-message-secret-resume.test.ts
@@ -41,6 +41,7 @@ describe('handleUserMessage secret redirect continuation', () => {
       setGuardianContext: () => {},
       setCommandIntent: () => {},
       updateClient: () => {},
+      emitActivityState: () => {},
       processMessage: (content: string, _attachments: unknown[], _onEvent: unknown, requestId: string) => {
         processCalls.push({ content, requestId });
         return Promise.resolve();

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -101,6 +101,8 @@ interface TestSession {
   setGuardianContext: (ctx: unknown) => void;
   setCommandIntent: (intent: unknown) => void;
   updateClient: (sendToClient: (msg: ServerMessage) => void, hasNoClient?: boolean) => void;
+  emitActivityState: (...args: unknown[]) => void;
+  emitConfirmationStateChanged: (...args: unknown[]) => void;
   processMessage: (...args: unknown[]) => Promise<string>;
 }
 
@@ -155,6 +157,8 @@ function makeSession(overrides: Partial<TestSession> = {}): TestSession {
     setGuardianContext: () => {},
     setCommandIntent: () => {},
     updateClient: () => {},
+    emitActivityState: () => {},
+    emitConfirmationStateChanged: () => {},
     processMessage: async () => 'msg-id',
     ...overrides,
   };
@@ -482,6 +486,8 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
       'always_allow',
       undefined,
       undefined,
+      undefined,
+      { source: 'button' },
     ]);
     expect(resolveCanonicalGuardianRequestMock).toHaveBeenCalledWith(
       'req-confirm-allow',

--- a/assistant/src/__tests__/headless-browser-navigate.test.ts
+++ b/assistant/src/__tests__/headless-browser-navigate.test.ts
@@ -32,6 +32,8 @@ mock.module('../tools/browser/browser-manager.js', () => {
       getOrCreateSessionPage: getOrCreateSessionPageMock,
       clearSnapshotMap: mock(() => {}),
       supportsRouteInterception: true,
+      isInteractive: () => false,
+      positionWindowSidebar: () => {},
     },
   };
 });

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -2840,10 +2840,7 @@ describe('relay-server', () => {
       last: true,
     }));
 
-    // Wait for cooldown
-    await new Promise((resolve) => setTimeout(resolve, 3100));
-
-    // Accept callback offer
+    // Accept callback offer (callback decisions bypass cooldown)
     await relay.handleMessage(JSON.stringify({
       type: 'prompt',
       voicePrompt: 'Yes, please call me back',
@@ -2855,7 +2852,7 @@ describe('relay-server', () => {
     const eventsBeforeTimeout = getCallEvents(session.id);
     expect(eventsBeforeTimeout.some((e) => e.eventType === 'voice_guardian_wait_callback_opt_in_set')).toBe(true);
 
-    // Wait for timeout
+    // Wait for timeout (2s) plus settling time
     await new Promise((resolve) => setTimeout(resolve, 2500));
 
     expect(relay.getConnectionState()).toBe('disconnecting');
@@ -2960,7 +2957,7 @@ describe('relay-server', () => {
 
     expect(relay.getConnectionState()).toBe('awaiting_guardian_decision');
 
-    // Trigger callback offer and opt-in
+    // Trigger callback offer and opt-in (callback decisions bypass cooldown)
     await relay.handleMessage(JSON.stringify({
       type: 'prompt',
       voicePrompt: 'Hurry up please',
@@ -2968,11 +2965,9 @@ describe('relay-server', () => {
       last: true,
     }));
 
-    await new Promise((resolve) => setTimeout(resolve, 3100));
-
     await relay.handleMessage(JSON.stringify({
       type: 'prompt',
-      voicePrompt: 'Yes please',
+      voicePrompt: 'Yes, call me back please',
       lang: 'en-US',
       last: true,
     }));
@@ -3019,15 +3014,13 @@ describe('relay-server', () => {
       last: true,
     }));
 
-    // Opt into callback
+    // Opt into callback (callback decisions bypass cooldown)
     await relay.handleMessage(JSON.stringify({
       type: 'prompt',
       voicePrompt: 'Hurry up please',
       lang: 'en-US',
       last: true,
     }));
-
-    await new Promise((resolve) => setTimeout(resolve, 3100));
 
     await relay.handleMessage(JSON.stringify({
       type: 'prompt',
@@ -3036,7 +3029,7 @@ describe('relay-server', () => {
       last: true,
     }));
 
-    // Wait for timeout to fire
+    // Wait for timeout to fire (2s) plus settling time
     await new Promise((resolve) => setTimeout(resolve, 2500));
 
     // Now transport close too (simulating race)
@@ -3067,9 +3060,6 @@ describe('relay-server', () => {
       assistantId: 'self',
     });
 
-    // Add the caller as a trusted contact so findMember resolves
-    addTrustedVoiceContact('+15557770024');
-
     const { relay } = createMockWs(session.id);
 
     await relay.handleMessage(JSON.stringify({
@@ -3088,15 +3078,18 @@ describe('relay-server', () => {
 
     expect(relay.getConnectionState()).toBe('awaiting_guardian_decision');
 
-    // Opt into callback
+    // Add the caller as a trusted contact AFTER the access request flow
+    // is entered so resolveActorTrust doesn't skip the flow. The handoff
+    // code uses findMember to resolve requesterMemberId at handoff time.
+    addTrustedVoiceContact('+15557770024');
+
+    // Opt into callback (callback decisions bypass cooldown)
     await relay.handleMessage(JSON.stringify({
       type: 'prompt',
       voicePrompt: 'Hurry up',
       lang: 'en-US',
       last: true,
     }));
-
-    await new Promise((resolve) => setTimeout(resolve, 3100));
 
     await relay.handleMessage(JSON.stringify({
       type: 'prompt',
@@ -3105,7 +3098,7 @@ describe('relay-server', () => {
       last: true,
     }));
 
-    // Wait for timeout
+    // Wait for timeout (2s) plus settling time
     await new Promise((resolve) => setTimeout(resolve, 2500));
 
     await new Promise((resolve) => setTimeout(resolve, 200));
@@ -3159,15 +3152,13 @@ describe('relay-server', () => {
 
     expect(relay.getConnectionState()).toBe('awaiting_guardian_decision');
 
-    // Opt into callback
+    // Opt into callback (callback decisions bypass cooldown)
     await relay.handleMessage(JSON.stringify({
       type: 'prompt',
       voicePrompt: 'Come on hurry up',
       lang: 'en-US',
       last: true,
     }));
-
-    await new Promise((resolve) => setTimeout(resolve, 3100));
 
     await relay.handleMessage(JSON.stringify({
       type: 'prompt',
@@ -3176,7 +3167,7 @@ describe('relay-server', () => {
       last: true,
     }));
 
-    // Wait for timeout
+    // Wait for timeout (2s) plus settling time
     await new Promise((resolve) => setTimeout(resolve, 2500));
 
     await new Promise((resolve) => setTimeout(resolve, 200));

--- a/assistant/src/__tests__/session-agent-loop.test.ts
+++ b/assistant/src/__tests__/session-agent-loop.test.ts
@@ -311,6 +311,7 @@ function makeCtx(overrides?: Partial<AgentLoopSessionContext> & { agentLoopRun?:
 
     refreshWorkspaceTopLevelContextIfNeeded: () => {},
     markWorkspaceTopLevelDirty: () => {},
+    emitActivityState: () => {},
     getQueueDepth: () => 0,
     hasQueuedMessages: () => false,
     canHandoffAtCheckpoint: () => false,

--- a/assistant/src/runtime/guardian-vellum-migration.ts
+++ b/assistant/src/runtime/guardian-vellum-migration.ts
@@ -17,6 +17,7 @@ import {
   getActiveBinding,
 } from '../memory/guardian-bindings.js';
 import { getLogger } from '../util/logger.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
 
 const log = getLogger('guardian-vellum-migration');
 
@@ -26,7 +27,7 @@ const log = getLogger('guardian-vellum-migration');
  *
  * Returns the guardianPrincipalId (existing or newly created).
  */
-export function ensureVellumGuardianBinding(assistantId: string = 'self'): string {
+export function ensureVellumGuardianBinding(assistantId: string = DAEMON_INTERNAL_ASSISTANT_ID): string {
   const existing = getActiveBinding(assistantId, 'vellum');
   if (existing) {
     log.debug(


### PR DESCRIPTION
## Summary
- Add missing mock methods (`emitActivityState`, `emitConfirmationStateChanged`, `isInteractive`, `positionWindowSidebar`) to test doubles for session and browser manager
- Fix `guardian-vellum-migration.ts` to import `DAEMON_INTERNAL_ASSISTANT_ID` instead of hardcoding `'self'`
- Mock `resolveLocalIpcGuardianContext` in conversation-routes tests to avoid `channel_guardian_bindings` table dependency
- Add `await` to async `addPointerMessage` calls where trusted audience triggers async path
- Fix relay-server callback tests: remove incorrect cooldown waits (callback decisions bypass cooldown), fix callback opt-in text ("Yes please" → "Yes, call me back please") to match regex classifier, move `addTrustedVoiceContact` after access request flow entry so trusted caller doesn't skip the flow

## Test plan
- [x] All 9 previously failing test files pass individually
- [x] No regressions in other tests

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22535757810/job/65282754684

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
