### PR TITLE
fix: make token recovery hints context-aware and preserve transient errors

### DIFF
--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -13,9 +13,14 @@ import { getSecureKey, setSecureKey } from './secure-keys.js';
 
 const log = getLogger('token-manager');
 
+const MESSAGING_SERVICES = new Set(['integration:gmail', 'integration:slack']);
+
 function recoveryHint(service: string): string {
   const shortName = service.startsWith('integration:') ? service.slice('integration:'.length) : service;
-  return ` Reconnect ${shortName} — follow the Error Recovery steps in the messaging skill. Do not present options or explain the error to the user.`;
+  if (MESSAGING_SERVICES.has(service)) {
+    return ` Reconnect ${shortName} — follow the Error Recovery steps in the messaging skill. Do not present options or explain the error to the user.`;
+  }
+  return ` Re-authorization required for ${shortName}. Do not present options or explain the error to the user.`;
 }
 
 /** Buffer before expiry to trigger proactive refresh (5 minutes). */
@@ -161,8 +166,14 @@ async function doRefresh(service: string): Promise<string> {
     result = await refreshOAuth2Token(resolvedTokenUrl, clientId, refreshToken, clientSecret, authMethod);
   } catch (err) {
     recordRefreshFailure(service);
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new TokenExpiredError(service, `Token refresh failed for "${service}": ${msg}.${recoveryHint(service)}`);
+    if (isCredentialError(err)) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new TokenExpiredError(service, `Token refresh failed for "${service}": ${msg}.${recoveryHint(service)}`);
+    }
+    // Transient errors (network failures, 5xx) are re-thrown as-is so
+    // upstream retry/backoff logic can handle them without triggering
+    // unnecessary reauthorization flows.
+    throw err;
   }
 
   if (!setSecureKey(`credential:${service}:access_token`, result.accessToken)) {
@@ -227,5 +238,27 @@ function is401Error(err: unknown): boolean {
     if ('status' in err && (err as { status: number }).status === 401) return true;
     if ('statusCode' in err && (err as { statusCode: number }).statusCode === 401) return true;
   }
+  return false;
+}
+
+/**
+ * Distinguish credential-specific refresh failures (which need reauthorization)
+ * from transient errors (network timeouts, 5xx) that can be retried.
+ *
+ * refreshOAuth2Token() throws Error with messages like:
+ *   "OAuth2 token refresh failed (HTTP 401: invalid_client)"
+ *   "OAuth2 token refresh failed (HTTP 400: invalid_grant)"
+ *   "OAuth2 token refresh failed (HTTP 500)"
+ *
+ * Credential errors: 400 with invalid_grant, 401, 403.
+ * Everything else (5xx, network errors, non-credential 400s) is transient.
+ */
+function isCredentialError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const msg = err.message;
+  // 401/403 are always credential errors
+  if (/HTTP\s+40[13]\b/.test(msg)) return true;
+  // 400 with invalid_grant means the refresh token is revoked/expired
+  if (/HTTP\s+400\b/.test(msg) && /invalid_grant/.test(msg)) return true;
   return false;
 }


### PR DESCRIPTION
Addresses reviewer feedback on #10988:

1. **Context-aware recovery hints**: `recoveryHint()` now only references the messaging skill for messaging services (gmail, slack). Other services get a generic re-authorization hint.
2. **Preserve transient errors**: Refresh failures are no longer unconditionally wrapped as `TokenExpiredError`. Transient errors (network, 5xx) are re-thrown as-is so retry/backoff logic can handle them. Only credential-specific failures (401, 403, `invalid_grant`) trigger reauthorization guidance.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
