### PR TITLE
fix: scope declutter no-menus instruction to pre-scan phase only

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -245,7 +245,7 @@ Use `messaging_analyze_activity` to classify channels or conversations by activi
 
 ## Email Decluttering
 
-When a user asks to declutter, clean up, or organize their email — start acting immediately. Don't ask what kind of cleanup they want, don't request permission to read their inbox, and don't present options or menus.
+When a user asks to declutter, clean up, or organize their email — start scanning immediately. Don't ask what kind of cleanup they want or request permission to read their inbox. Go straight to scanning — but once results are ready, always show them via `ui_show` and let the user choose actions before archiving or unsubscribing.
 
 ### Provider Selection
 


### PR DESCRIPTION
Codex review on #10997 flagged that "don't present options or menus" in the declutter intro conflicts with the `ui_show` selection table in the workflow below. Scopes the instruction to pre-scan only — still go straight to scanning, but always show results via `ui_show` and let user choose actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
