### PR TITLE
fix: add credential-setup-for metadata to google-oauth-setup skill

### DIFF
--- a/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
@@ -2,6 +2,7 @@
 name: "Google OAuth Setup"
 description: "Set up Google Cloud OAuth credentials for Gmail and Calendar using browser automation"
 user-invocable: true
+credential-setup-for: "gmail"
 includes: ["browser", "public-ingress"]
 metadata: {"vellum": {"emoji": "\ud83d\udd11"}}
 ---


### PR DESCRIPTION
## Summary
- Adds `credential-setup-for: "gmail"` to the `google-oauth-setup` skill frontmatter
- The system prompt tells the LLM: *"When a credential is missing, check if any skill declares `credential-setup-for` matching that service — if so, load that skill."* But `google-oauth-setup` never declared this attribute, so the LLM had no automatic routing to it when Gmail credentials were missing — it improvised manual OAuth instructions instead of loading the automated browser-based setup skill.

## Test plan
- [x] `skills.test.ts` passes (44/44)
- [ ] Verify that when Gmail credentials are missing, the LLM now sees `credential-setup-for="gmail"` in the skills catalog and loads `google-oauth-setup` automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
