### PR TITLE
fix: hint at setup skill when client_id is missing in credential_store

### DIFF
--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -502,7 +502,13 @@ class CredentialStoreTool implements Tool {
 
         const authUrl = (input.auth_url as string | undefined) ?? profile?.authUrl;
         const tokenUrl = (input.token_url as string | undefined) ?? profile?.tokenUrl;
-        if (!clientId) return { content: 'Error: client_id is required for oauth2_connect action. Provide it directly or store it first with credential_store.', isError: true };
+        if (!clientId) {
+          const skillId = profile?.setupSkillId;
+          const skillHint = skillId
+            ? ` Load the "${skillId}" skill to set up credentials for ${rawService}.`
+            : ' Provide it directly or store it first with credential_store.';
+          return { content: `Error: client_id is required for oauth2_connect action.${skillHint}`, isError: true };
+        }
 
         // Fail early when client_secret is required but missing — guide the
         // agent to collect it from the user rather than letting it improvise


### PR DESCRIPTION
## Summary
- When `oauth2_connect` fails because no `client_id` exists, the error now hints at the setup skill (e.g., `Load the "google-oauth-setup" skill to set up credentials for gmail`) instead of the generic "Provide it directly or store it first"
- Uses the existing `setupSkillId` from the provider profile — the same pattern already used for missing `client_secret` (lines 513-516)
- For services without a `setupSkillId`, falls back to the original message

## Test plan
- [x] `credential-vault.test.ts` passes (40/40)
- [x] Type-check passes
- [ ] Verify that when Gmail `client_id` is missing, the LLM receives the error with the setup skill hint and loads `google-oauth-setup` instead of improvising manual instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
