### PR TITLE
fix: prevent chart SVGs from overflowing containers

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -34,6 +34,7 @@ These are hard prohibitions. Violating any of these produces that unmistakable "
 - **NEVER** make all text the same size and weight — establish clear hierarchy with at least 3 distinct levels
 - **NEVER** use a pure white (`#fff`) or pure dark (`#000`/`#0a0a0a`) background — ALWAYS tint it to match the domain (cream `#FEFCF9` for lifestyle, sage `#F0F5F0` for nature, cool gray `#F5F7FA` for finance, warm blush `#FDF6F3` for wellness)
 - **NEVER** leave clickable elements without hover AND active states
+- **NEVER** hand-code SVG/CSS charts (lines, bars, sparklines, gauges) — ALWAYS use `vellum.widgets.lineChart()`, `.barChart()`, `.sparkline()`, or `.progressRing()`. They handle bounds, clipping, scaling, and dark mode correctly. Hand-coded charts invariably overflow and bleed into adjacent elements.
 - **ALWAYS** use emoji as visual identifiers in stat cards, list items, and navigation — they replace icon libraries and add instant personality (🍎 for food, 🔥 for streaks, 💰 for money, 🌿 for plants)
 - **ALWAYS** apply the accent-word pattern in hero headings — color ONE key word or phrase in the accent color: "Your <span style='color: var(--accent)'>Week</span> in Motion"
 - **ALWAYS** include a contextual/personalized header — a greeting ("Good morning"), date ("Saturday, Feb 15"), or welcome ("Welcome back, Alex") — not just the app title
@@ -1178,7 +1179,7 @@ document.addEventListener('DOMContentLoaded', function() {
 - **Use widgets** for standard patterns — tables, metrics, timelines, notifications, presentations
 - **Use custom HTML** for novel or creative UIs — games, art tools, unique dashboards
 - **Mix freely** — widgets compose well together and with custom elements
-- Always prioritize the ideal user experience over using the widget library
+- Always prioritize the ideal user experience over using the widget library — EXCEPT for charts: always use `vellum.widgets.*` chart functions (lineChart, barChart, sparkline, progressRing) instead of hand-coding SVG/CSS charts. They handle overflow clipping, bounds, scaling, and dark mode. Hand-coded charts break layouts.
 
 #### Advanced techniques
 
@@ -1603,6 +1604,7 @@ When to use each of the 8 layout variants:
 - **NEVER** use `.v-slide-label` on every single slide — aim for 40–60% of slides
 - **NEVER** center-align bullet slides — only center quotes and closing slides
 - **NEVER** use the same stat value format everywhere — mix `$2.4M`, `147%`, `3x`, `12k+` for variety
+- **NEVER** hand-code charts on slides — use `vellum.widgets.lineChart()` / `.barChart()` / `.sparkline()` / `.progressRing()` rendered into a `<div>` with a fixed height. Hand-coded chart SVGs bleed into adjacent slide elements.
 
 ### Slide Pre-Ship Checklist
 

--- a/clients/macos/vellum-assistant/Resources/vellum-widgets.js
+++ b/clients/macos/vellum-assistant/Resources/vellum-widgets.js
@@ -49,6 +49,7 @@
   widgets.sparkline = function (container, data, options) {
     var el = resolveContainer(container);
     if (!el || !data || !data.length) return;
+    el.style.overflow = 'hidden';
 
     var opts = Object.assign({ width: 200, height: 40, strokeWidth: 2, fill: true }, options);
     var w = opts.width, h = opts.height;
@@ -96,6 +97,7 @@
   widgets.barChart = function (container, data, options) {
     var el = resolveContainer(container);
     if (!el || !data || !data.length) return;
+    el.style.overflow = 'hidden';
 
     var opts = Object.assign({ width: 400, height: 200, barGap: 4, showLabels: true, showValues: true, horizontal: false }, options);
     var w = opts.width, h = opts.height;
@@ -152,6 +154,7 @@
   widgets.lineChart = function (container, data, options) {
     var el = resolveContainer(container);
     if (!el || !data || !data.length) return;
+    el.style.overflow = 'hidden';
 
     var opts = Object.assign({ width: 400, height: 200, showDots: true, showGrid: true, gridLines: 4 }, options);
     var w = opts.width, h = opts.height;
@@ -222,6 +225,7 @@
   widgets.progressRing = function (container, value, options) {
     var el = resolveContainer(container);
     if (!el) return;
+    el.style.overflow = 'hidden';
 
     var opts = Object.assign({ size: 100, strokeWidth: 8 }, options);
     var s = opts.size, sw = opts.strokeWidth;


### PR DESCRIPTION
## Summary
- Add `el.style.overflow = 'hidden'` to all four chart widget functions (sparkline, barChart, lineChart, progressRing) in `vellum-widgets.js` as a safety net against SVG bleed
- Add anti-slop rules in app-builder SKILL.md prohibiting hand-coded SVG/CSS charts — must use `vellum.widgets.*` chart functions
- Update "widgets vs custom HTML" guidance to carve out a chart exception to the "prioritize UX" rule

## Original prompt
Fix chart overflow bleeding into adjacent elements: add overflow clipping to chart widget containers and mandate widget chart API in app-builder skill instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
