### PR TITLE
fix: prevent SwiftUI view-update death spiral in interleaved chat content

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -11,14 +11,17 @@ final class AvatarAppearanceManager {
     private(set) var customAvatarImage: NSImage?
 
     /// Cached fallback avatar to avoid rebuilding on every access.
-    private var cachedFallbackAvatar: NSImage?
+    /// @ObservationIgnored so that populating the cache inside a computed getter
+    /// doesn't fire an observation notification and trigger another SwiftUI
+    /// view-update pass (which would create a re-render loop).
+    @ObservationIgnored private var cachedFallbackAvatar: NSImage?
     /// The name used to build the cached fallback, so we can invalidate when identity changes.
-    private var cachedFallbackName: String?
+    @ObservationIgnored private var cachedFallbackName: String?
     /// Cached chat-size avatar (56pt for 2x Retina).
-    private var cachedChatAvatar: NSImage?
+    @ObservationIgnored private var cachedChatAvatar: NSImage?
     /// Cached full-size fallback avatar for larger displays (identity panel, constellation).
-    private var cachedFullFallbackAvatar: NSImage?
-    private var cachedFullFallbackName: String?
+    @ObservationIgnored private var cachedFullFallbackAvatar: NSImage?
+    @ObservationIgnored private var cachedFullFallbackName: String?
 
     /// Bundled initial avatar loaded once from Resources.
     private static let bundledInitialAvatar: NSImage? = {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -21,7 +21,10 @@ extension ChatBubble {
     }
 
     /// Groups consecutive tool call refs for rendering.
-    enum ContentGroup {
+    /// Hashable so ForEach can use stable identity based on content rather than
+    /// array offset, which avoids spurious view invalidation when the array is
+    /// recreated with identical values on each render pass.
+    enum ContentGroup: Hashable {
         case text(Int)
         case toolCalls([Int])
         case surface(Int)
@@ -50,8 +53,12 @@ extension ChatBubble {
     var interleavedContent: some View {
         let groups = groupContentBlocks()
 
-        // Render all content groups in order: text, tool calls, and surfaces
-        ForEach(Array(groups.enumerated()), id: \.offset) { _, group in
+        // Render all content groups in order: text, tool calls, and surfaces.
+        // Uses \.self identity (backed by Hashable conformance) instead of
+        // \.offset so SwiftUI can skip re-evaluating children whose content
+        // hasn't changed — prevents a view-update death spiral on long
+        // conversations with many interleaved blocks.
+        ForEach(groups, id: \.self) { group in
             switch group {
             case .text(let i):
                 if i < message.textSegments.count {


### PR DESCRIPTION
## Summary
- Make `ContentGroup` conform to `Hashable` and use `\.self` identity in the interleaved content `ForEach`, so SwiftUI can skip re-evaluating children whose content hasn't changed
- Mark `AvatarAppearanceManager` cache fields `@ObservationIgnored` to prevent lazy cache population from firing observation notifications mid-body-evaluation
- Together these fix the sustained 100% CPU freeze ("Not Responding") seen in long conversations with many interleaved text/tool-call blocks

## Original prompt
Fix the SwiftUI freeze (100% CPU in AttributeGraph update loop) caused by non-stable ForEach identity in interleaved chat content and @Observable cache mutations during view body evaluation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
