### PR TITLE
fix: dismiss composer focus when clicking outside the chat bar

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -933,7 +933,10 @@ private final class ComposerNativeTextView: NSTextView {
 
     override func becomeFirstResponder() -> Bool {
         let focused = super.becomeFirstResponder()
-        if focused { onFocusChange?(true) }
+        if focused {
+            onFocusChange?(true)
+            (window as? TitleBarZoomableWindow)?.clearComposerDismissed()
+        }
         return focused
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -18,9 +18,43 @@ class TitleBarZoomableWindow: NSWindow {
     /// Weak reference to the composer text view so we can redirect typing to it.
     weak var composerTextView: NSTextView?
 
+    /// When true, `keyDown` will not auto-redirect keystrokes to the composer.
+    /// Set when the user clicks outside the composer to dismiss focus; cleared
+    /// when the composer regains focus (e.g. user clicks back into it).
+    private(set) var composerDismissed = false
+
+    func clearComposerDismissed() {
+        composerDismissed = false
+    }
+
+    override func sendEvent(_ event: NSEvent) {
+        super.sendEvent(event)
+
+        // After dispatching a left-click, check whether the composer should
+        // lose focus. If the click landed outside the composer's scroll view
+        // and the composer is still first responder (i.e. nothing else claimed
+        // focus), explicitly resign so the user can "click away" to blur.
+        if event.type == .leftMouseDown,
+           let composer = composerTextView,
+           firstResponder === composer {
+            let container = composer.enclosingScrollView ?? composer
+            let point = container.convert(event.locationInWindow, from: nil)
+            if !container.bounds.contains(point) {
+                composerDismissed = true
+                makeFirstResponder(nil)
+            }
+        }
+    }
+
     override func keyDown(with event: NSEvent) {
         // If a text view is already focused, let it handle the event normally.
         if firstResponder is NSTextView {
+            super.keyDown(with: event)
+            return
+        }
+
+        // Don't auto-redirect if the user explicitly dismissed the composer.
+        if composerDismissed {
             super.keyDown(with: event)
             return
         }


### PR DESCRIPTION
## Summary

- Override `sendEvent` in `TitleBarZoomableWindow` to detect left-clicks outside the composer's scroll view and resign first responder
- Add a `composerDismissed` flag that prevents `keyDown` from auto-redirecting keystrokes to the composer after the user clicks away
- Clear the flag in `ComposerNativeTextView.becomeFirstResponder` so clicking back into the composer re-enables auto-redirect

## Original prompt
In the desktop app when I'm in the chat, the chat always has focus. When I click outside the chat bar, I want the chat bar to lose focus - by that I mean if I type a key it doesn't add text to the chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
