### PR TITLE
feat: make generateScopeOptions tool-aware

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -63,7 +63,7 @@ mock.module('../config/loader.js', () => ({
   setNestedValue: () => {},
 }));
 
-import { _resetLegacyDeprecationWarning,check, classifyRisk, generateAllowlistOptions, generateScopeOptions } from '../permissions/checker.js';
+import { _resetLegacyDeprecationWarning,check, classifyRisk, generateAllowlistOptions, generateScopeOptions, SCOPE_AWARE_TOOLS } from '../permissions/checker.js';
 import { getDefaultRuleTemplates } from '../permissions/defaults.js';
 import { addRule, clearCache, findHighestPriorityRule } from '../permissions/trust-store.js';
 import type { TrustRule } from '../permissions/types.js';
@@ -1341,21 +1341,42 @@ describe('Permission Checker', () => {
       expect(options[2]).toEqual({ label: 'everywhere', scope: 'everywhere' });
     });
 
-    test('scope options are always project → parent → everywhere regardless of tool', () => {
+    test('scope-aware tools all produce the same directory-based ordering', () => {
       const workingDir = join(homedir(), 'projects', 'myapp');
 
-      // Non-host tool
-      const nonHostOpts = generateScopeOptions(workingDir, 'bash');
-      expect(nonHostOpts[0].scope).toBe(workingDir);
-      expect(nonHostOpts[nonHostOpts.length - 1].scope).toBe('everywhere');
+      const bashOpts = generateScopeOptions(workingDir, 'bash');
+      expect(bashOpts[0].scope).toBe(workingDir);
+      expect(bashOpts[bashOpts.length - 1].scope).toBe('everywhere');
 
-      // Host tool — same order now
-      const hostOpts = generateScopeOptions(workingDir, 'host_bash');
-      expect(hostOpts[0].scope).toBe(workingDir);
-      expect(hostOpts[hostOpts.length - 1].scope).toBe('everywhere');
+      const hostBashOpts = generateScopeOptions(workingDir, 'host_bash');
+      expect(bashOpts.map(o => o.scope)).toEqual(hostBashOpts.map(o => o.scope));
 
-      // Same ordering for both
-      expect(nonHostOpts.map(o => o.scope)).toEqual(hostOpts.map(o => o.scope));
+      const fileOpts = generateScopeOptions(workingDir, 'file_write');
+      expect(bashOpts.map(o => o.scope)).toEqual(fileOpts.map(o => o.scope));
+    });
+
+    test('returns empty for non-scoped tools', () => {
+      const workingDir = join(homedir(), 'projects', 'myapp');
+      expect(generateScopeOptions(workingDir, 'web_fetch')).toHaveLength(0);
+      expect(generateScopeOptions(workingDir, 'browser_navigate')).toHaveLength(0);
+      expect(generateScopeOptions(workingDir, 'skill_load')).toHaveLength(0);
+      expect(generateScopeOptions(workingDir, 'credential_store')).toHaveLength(0);
+      expect(generateScopeOptions(workingDir, 'computer_use_click')).toHaveLength(0);
+      expect(generateScopeOptions(workingDir, 'my_custom_mcp_tool')).toHaveLength(0);
+    });
+
+    test('returns directory options when toolName is omitted (backward compat)', () => {
+      const options = generateScopeOptions('/home/user/project');
+      expect(options).toHaveLength(3);
+      expect(options[0].scope).toBe('/home/user/project');
+    });
+
+    test('SCOPE_AWARE_TOOLS contains only filesystem and shell tools', () => {
+      expect(SCOPE_AWARE_TOOLS).toEqual(new Set([
+        'bash', 'host_bash',
+        'file_read', 'file_write', 'file_edit',
+        'host_file_read', 'host_file_write', 'host_file_edit',
+      ]));
     });
   });
 

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -776,7 +776,19 @@ export async function generateAllowlistOptions(toolName: string, input: Record<s
   return [{ label: '*', description: 'Everything', pattern: '*' }];
 }
 
-export function generateScopeOptions(workingDir: string, _toolName?: string): ScopeOption[] {
+// Directory-based scope only applies to filesystem and shell tools.
+// All other tools auto-use "everywhere" (the client handles this).
+export const SCOPE_AWARE_TOOLS = new Set([
+  'bash', 'host_bash',
+  'file_read', 'file_write', 'file_edit',
+  'host_file_read', 'host_file_write', 'host_file_edit',
+]);
+
+export function generateScopeOptions(workingDir: string, toolName?: string): ScopeOption[] {
+  if (toolName && !SCOPE_AWARE_TOOLS.has(toolName)) {
+    return [];
+  }
+
   const home = homedir();
   const options: ScopeOption[] = [];
 


### PR DESCRIPTION
## Summary
- Add `SCOPE_AWARE_TOOLS` set defining the 8 tools (bash, host_bash, file_read/write/edit, host_file_read/write/edit) where directory-based scope is meaningful
- Update `generateScopeOptions()` to return empty array for non-scoped tools (web_fetch, browser_navigate, skill_load, credential_store, computer_use_*, etc.)
- Backward compat: when `toolName` is omitted, existing behavior is preserved
- Add tests for non-scoped tools, backward compat, and a guard test for `SCOPE_AWARE_TOOLS`

## Original prompt
Make the permission system scope-aware per tool type. Directory scope only applies to filesystem/shell tools — skip it for URL-based, system-level, and other non-filesystem tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
