### PR TITLE
fix: accept 'everywhere' scope for non-scoped tools

### DIFF
--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -197,9 +197,14 @@ export async function handleTrustRule(req: Request, server: ServerWithRequestIP)
     return httpError('FORBIDDEN', 'pattern does not match any server-provided allowlist option', 403);
   }
 
-  // Validate scope against server-provided scope options
+  // Validate scope against server-provided scope options.
+  // Non-scoped tools have empty scopeOptions — only "everywhere" is valid for them.
   const validScopes = (confirmation.scopeOptions ?? []).map((o) => o.scope);
-  if (!validScopes.includes(scope)) {
+  if (validScopes.length === 0) {
+    if (scope !== 'everywhere') {
+      return httpError('FORBIDDEN', 'non-scoped tools only accept scope "everywhere"', 403);
+    }
+  } else if (!validScopes.includes(scope)) {
     return httpError('FORBIDDEN', 'scope does not match any server-provided scope option', 403);
   }
 

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -237,7 +237,6 @@ export class PermissionChecker {
           persistentDecisionsAllowed
           && (response.decision === 'always_allow' || response.decision === 'always_allow_high_risk')
           && response.selectedPattern
-          && response.selectedScope
         ) {
           const ruleOptions: {
             allowHighRisk?: boolean;
@@ -253,7 +252,8 @@ export class PermissionChecker {
           }
 
           const hasOptions = Object.keys(ruleOptions).length > 0;
-          addRule(name, response.selectedPattern, response.selectedScope, 'allow', 100, hasOptions ? ruleOptions : undefined);
+          const effectiveScope = response.selectedScope ?? 'everywhere';
+          addRule(name, response.selectedPattern, effectiveScope, 'allow', 100, hasOptions ? ruleOptions : undefined);
         }
 
         return { allowed: true, decision, riskLevel };


### PR DESCRIPTION
## Summary
- Update HTTP trust-rules endpoint (`approval-routes.ts`) to accept `"everywhere"` when `scopeOptions` is empty (non-scoped tools), instead of rejecting all scopes
- Update permission-checker to default `selectedScope` to `"everywhere"` when the client sends `always_allow` without a scope, so persistent trust rules are always created

## Original prompt
Backend fixes to support tool-aware scope options — ensure non-scoped tools can still create persistent trust rules via "Always Allow".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
