### PR TITLE
feat: add Cmd+Enter to Send setting and UI toggle

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -141,6 +141,25 @@ struct SettingsAppearanceTab: View {
                 Divider().background(VColor.surfaceBorder)
 
                 ShortcutRow(label: "Start voice input", shortcut: "Hold Fn")
+
+                Divider().background(VColor.surfaceBorder)
+
+                HStack(alignment: .center, spacing: VSpacing.sm) {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Send with ⌘Enter")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                        Text("When enabled, Enter inserts a new line and ⌘Enter sends.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    Spacer()
+                    VToggle(isOn: Binding(
+                        get: { store.cmdEnterToSend },
+                        set: { store.cmdEnterToSend = $0 }
+                    ))
+                }
+                .padding(.vertical, VSpacing.md)
             }
             .padding(VSpacing.lg)
             .vCard(background: VColor.surfaceSubtle)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -67,6 +67,7 @@ public final class SettingsStore: ObservableObject {
     @Published var globalHotkeyShortcut: String
     @Published var quickInputHotkeyShortcut: String
     @Published var quickInputHotkeyKeyCode: Int
+    @Published var cmdEnterToSend: Bool
 
     // MARK: - Media Embed Settings
 
@@ -318,6 +319,8 @@ public final class SettingsStore: ObservableObject {
         // Default to enabled for notifications
         self.activityNotificationsEnabled = UserDefaults.standard.object(forKey: "activityNotificationsEnabled") as? Bool ?? true
 
+        self.cmdEnterToSend = UserDefaults.standard.object(forKey: "cmdEnterToSend") as? Bool ?? false
+
         self.globalHotkeyShortcut = UserDefaults.standard.string(forKey: "globalHotkeyShortcut") ?? "cmd+shift+g"
         self.quickInputHotkeyShortcut = UserDefaults.standard.string(forKey: "quickInputHotkeyShortcut") ?? "cmd+shift+/"
         let storedQIKeyCode = UserDefaults.standard.object(forKey: "quickInputHotkeyKeyCode") as? Int
@@ -365,6 +368,12 @@ public final class SettingsStore: ObservableObject {
             .dropFirst()
             .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
             .sink { value in UserDefaults.standard.set(value, forKey: "activityNotificationsEnabled") }
+            .store(in: &cancellables)
+
+        $cmdEnterToSend
+            .dropFirst()
+            .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
+            .sink { value in UserDefaults.standard.set(value, forKey: "cmdEnterToSend") }
             .store(in: &cancellables)
 
         // Persist shortcut changes immediately so the hotkey re-registers without delay


### PR DESCRIPTION
## Summary
- Add `cmdEnterToSend` boolean setting to SettingsStore, persisted via UserDefaults
- Add toggle row in Settings > Appearance > Keyboard Shortcuts section
- Setting defaults to off (Enter sends, matching current behavior)
- This is part 1 of 2 — wiring the setting to the composer keyDown behavior comes in the next PR

## Original prompt
Add a toggle in settings in the desktop app where I can change the enter to send behavior in chat to cmd + enter to send for messages in the chat. In cmd+enter to send mode, enter should start a new line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11012" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
