### PR TITLE
fix: auto-select 'everywhere' scope for non-scoped tools in Always Allow

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -35,7 +35,7 @@ public struct ToolConfirmationBubble: View {
     }
 
     private var hasRuleOptions: Bool {
-        !confirmation.allowlistOptions.isEmpty && !confirmation.scopeOptions.isEmpty
+        !confirmation.allowlistOptions.isEmpty
     }
 
     private var needsScopeChoice: Bool {
@@ -542,10 +542,10 @@ public struct ToolConfirmationBubble: View {
                         itemCount: confirmation.scopeOptions.count
                     )
                 } else {
-                    // No scope options available — fall back to one-time allow
+                    // No scope options (non-scoped tool) — auto-use "everywhere"
                     showAlwaysAllowMenu = false
                     popoverKeyboardModel = nil
-                    onAllow()
+                    onAlwaysAllow(confirmation.requestId, option.pattern, "everywhere", alwaysAllowDecision)
                 }
             }
         } else if showScopePickerMenu {
@@ -653,8 +653,8 @@ public struct ToolConfirmationBubble: View {
                 itemCount: confirmation.scopeOptions.count
             )
         } else {
-            // No scope options — fall back to one-time allow
-            onAllow()
+            // No scope options (non-scoped tool) — auto-use "everywhere"
+            onAlwaysAllow(confirmation.requestId, pattern, "everywhere", alwaysAllowDecision)
         }
     }
 
@@ -683,7 +683,7 @@ public struct ToolConfirmationBubble: View {
 
     @ViewBuilder
     private var alwaysAllowInlineButton: some View {
-        if hasRuleOptions && confirmation.allowlistOptions.count > 1 {
+        if !confirmation.allowlistOptions.isEmpty && confirmation.allowlistOptions.count > 1 {
             alwaysAllowDropdown
         } else {
             let patternDesc = confirmation.allowlistOptions.first?.description ?? ""
@@ -780,10 +780,10 @@ public struct ToolConfirmationBubble: View {
                                     itemCount: confirmation.scopeOptions.count
                                 )
                             } else {
-                                // No scope options available — fall back to one-time allow
+                                // No scope options (non-scoped tool) — auto-use "everywhere"
                                 showAlwaysAllowMenu = false
                                 popoverKeyboardModel = nil
-                                onAllow()
+                                onAlwaysAllow(confirmation.requestId, option.pattern, "everywhere", alwaysAllowDecision)
                             }
                         }
 


### PR DESCRIPTION
## Summary
- When a tool has no scope options (non-scoped tools like web_fetch, browser_navigate, etc.), the "Always Allow" button now auto-selects scope "everywhere" and creates a persistent trust rule — instead of falling back to a one-time allow
- Three code paths updated: single-option inline button, keyboard Enter handler, and dropdown pattern row tap
- `hasRuleOptions` no longer requires non-empty `scopeOptions`, so "Always Allow" shows for all tools with allowlist options
- Multi-option allowlist dropdown now shows even without scope options

## Original prompt
Client fix to support tool-aware scope options — auto-select "everywhere" scope for non-scoped tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
