### PR TITLE
feat: wire Cmd+Enter to Send setting to composer keyDown

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -4,6 +4,17 @@ import VellumAssistantShared
 import AppKit
 #endif
 
+private struct CmdEnterToSendKey: EnvironmentKey {
+    static let defaultValue: Bool = false
+}
+
+extension EnvironmentValues {
+    var cmdEnterToSend: Bool {
+        get { self[CmdEnterToSendKey.self] }
+        set { self[CmdEnterToSendKey.self] = newValue }
+    }
+}
+
 struct SlashCommand {
     let name: String
     let description: String
@@ -556,6 +567,7 @@ struct ComposerView: View {
 private struct ComposerTextView: NSViewRepresentable {
     @Binding var text: String
     let placeholder: String?
+    @Environment(\.cmdEnterToSend) private var cmdEnterToSend
     let hasGhostSuffix: Bool
     let isEnabled: Bool
     let minHeight: CGFloat
@@ -629,6 +641,7 @@ private struct ComposerTextView: NSViewRepresentable {
 
         scrollView.documentView = textView
         context.coordinator.textView = textView
+        textView.cmdEnterToSend = cmdEnterToSend
         context.coordinator.configureCallbacks()
         context.coordinator.syncHeight()
 
@@ -637,6 +650,9 @@ private struct ComposerTextView: NSViewRepresentable {
 
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         context.coordinator.parent = self
+        if let textView = context.coordinator.textView {
+            textView.cmdEnterToSend = cmdEnterToSend
+        }
         context.coordinator.configureCallbacks()
 
         guard let textView = context.coordinator.textView else { return }
@@ -765,6 +781,7 @@ private final class ComposerNativeTextView: NSTextView {
     var onFocusChange: ((Bool) -> Void)?
     var onSlashNavigate: ((SlashNavigation) -> Void)?
     var isSlashMenuOpen = false
+    var cmdEnterToSend = false
     var placeholderText: String?
     var placeholderColor: NSColor = .placeholderTextColor
     var hasGhostSuffix = false
@@ -863,14 +880,18 @@ private final class ComposerNativeTextView: NSTextView {
             }
         }
 
-        // Enter sends; Shift+Enter inserts newline.
-        // If ghost suggestion is visible, accept it first then send.
+        // Enter / Cmd+Enter send behavior depends on cmdEnterToSend setting.
+        // Shift+Enter always inserts a newline regardless of mode.
         if event.keyCode == 36 || event.keyCode == 76 {
             if modifiers == [.shift] {
                 insertNewline(nil)
                 return
             }
-            if modifiers.isEmpty {
+
+            let shouldSend = cmdEnterToSend ? modifiers == [.command] : modifiers.isEmpty
+            let shouldInsertNewline = cmdEnterToSend && modifiers.isEmpty
+
+            if shouldSend {
                 if hasGhostSuffix {
                     onAcceptSuggestion?()
                     onSubmit?()
@@ -879,6 +900,10 @@ private final class ComposerNativeTextView: NSTextView {
                 } else {
                     onSubmit?()
                 }
+                return
+            }
+            if shouldInsertNewline {
+                insertNewline(nil)
                 return
             }
             return

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -773,6 +773,7 @@ struct ActiveChatViewWrapper: View {
             loadPreviousMessagePage: { await viewModel.loadPreviousMessagePage() },
             isBootstrapping: isBootstrapping
         )
+        .environment(\.cmdEnterToSend, settingsStore.cmdEnterToSend)
     }
 }
 


### PR DESCRIPTION
## Summary
- Define SwiftUI environment key `cmdEnterToSend` to bridge the setting to the NSTextView
- Inject environment value from PanelCoordinator (which owns SettingsStore)
- Update ComposerNativeTextView keyDown: when setting is on, bare Enter inserts newline and Cmd+Enter sends; when off, original behavior preserved
- Shift+Enter always inserts newline regardless of mode

## Original prompt
Add a toggle in settings in the desktop app where I can change the enter to send behavior in chat to cmd + enter to send for messages in the chat. In cmd+enter to send mode, enter should start a new line.

## Test plan
- [ ] Toggle "Cmd+Enter to Send" OFF in Settings > Appearance — verify Enter sends, Shift+Enter inserts newline (original behavior)
- [ ] Toggle "Cmd+Enter to Send" ON — verify bare Enter inserts newline, Cmd+Enter sends
- [ ] With setting ON, verify Shift+Enter still inserts newline
- [ ] With setting ON, verify ghost suggestion acceptance still works with Cmd+Enter
- [ ] With setting ON, verify slash menu selection still works with Cmd+Enter
- [ ] Toggle setting while composing — verify behavior updates immediately without restarting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
