### PR TITLE
fix: prioritize Gmail over AgentMail for ambiguous email requests

### DIFF
--- a/assistant/src/config/bundled-skills/agentmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/agentmail/SKILL.md
@@ -14,6 +14,10 @@ Example: `host_bash("vellum email status --json")`
 
 Never use browser/computer-use unless user explicitly approves fallback.
 
+## When to Use This Skill
+
+This skill manages the **assistant's own** AgentMail address (`@agentmail.to`) — not the user's personal email. Only use this skill when the user explicitly asks the assistant to send email **from the assistant's own address**, manage the assistant's inbox, or perform operations on the assistant's AgentMail account. Generic email requests ("send an email", "check my email", "draft a reply") are about the **user's Gmail** and should be handled by the Messaging skill instead.
+
 ## Rules
 
 - Always run `vellum email` commands via `host_bash` and parse JSON output.

--- a/assistant/src/config/bundled-skills/email-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/email-setup/SKILL.md
@@ -9,7 +9,7 @@ You are setting up your own personal email address. This is a one-time operation
 
 ## Prerequisites
 
-Only proceed if the user explicitly asks you to create or set up your email address. Do NOT proactively run this skill.
+Only proceed if the user explicitly asks you to create or set up **your own** (the assistant's) email address — e.g., "set up your email", "create your email address", "I want you to have your own email". Generic email requests like "send an email", "check my email", or "set up email" are about the **user's Gmail** and should be handled by the Messaging skill, not this one. Do NOT proactively run this skill.
 
 ## Step 1: Check if Email Already Exists
 

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -7,6 +7,12 @@ metadata: {"vellum": {"emoji": "💬"}}
 
 You are a unified messaging assistant with access to multiple platforms (Slack, Gmail, Telegram, and more). Use the messaging tools to help users read, search, organize, draft, and send messages across all connected platforms.
 
+## Email Routing Priority
+
+When the user mentions "email" — sending, reading, checking, decluttering, drafting, or anything else — **always default to the user's own email (Gmail)** unless they explicitly ask about the assistant's own email address (e.g., "set up your email", "send from your address", "check your inbox"). The vast majority of email requests are about the user's Gmail, not the assistant's AgentMail address.
+
+Do not offer AgentMail as an option or mention it unless the user specifically asks. If Gmail is not connected, guide them through Gmail setup — do not suggest AgentMail as an alternative.
+
 ## Communication Style
 
 - **Be action-oriented.** When the user asks to do something ("declutter", "check my email"), start doing it immediately. Don't ask for permission to read their inbox — that's obviously what they want.

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -811,6 +811,12 @@ function buildDynamicSkillWorkflowSection(config: import('./schema.js').Assistan
     );
   }
 
+  lines.push(
+    '',
+    '### Messaging Skill',
+    'When the user asks about email, messaging, inbox management, or wants to read/send/search messages on any platform (Gmail, Slack, Telegram, SMS), load the "messaging" skill using `skill_load`. The messaging skill handles connection setup, credential flows, and all messaging operations — do not improvise setup instructions from general knowledge.',
+  );
+
   return lines.join('\n');
 }
 


### PR DESCRIPTION
## Summary

- Added "Email Routing Priority" section to the Messaging skill — generic email requests now always default to the user's Gmail
- Scoped AgentMail (Email CLI Ops) skill with a "When to Use This Skill" gate that limits it to the assistant's own `@agentmail.to` address
- Tightened Email Setup skill prerequisites to only trigger on "set up **your** email" (assistant's), not generic "set up email"
- Added system prompt routing hint to direct email/messaging queries to the messaging skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
