### PR TITLE
fix: allow maxToolUseTurns=0 (unlimited) and default to 0

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -204,8 +204,8 @@ export const AssistantConfigSchema = z.object({
   maxToolUseTurns: z
     .number({ error: 'maxToolUseTurns must be a number' })
     .int('maxToolUseTurns must be an integer')
-    .positive('maxToolUseTurns must be a positive integer')
-    .default(60),
+    .nonnegative('maxToolUseTurns must be a non-negative integer')
+    .default(0),
   thinking: ThinkingConfigSchema.default(ThinkingConfigSchema.parse({})),
   contextWindow: ContextWindowConfigSchema.default(ContextWindowConfigSchema.parse({})),
   memory: MemoryConfigSchema.default(MemoryConfigSchema.parse({})),


### PR DESCRIPTION
## Summary
- Changes config schema from `.positive()` to `.nonnegative()`, allowing `0` as a valid value
- Changes default from `60` to `0` (unlimited)
- Convention: `0` = unlimited, positive integer = hard cap at that number
- The agent loop already handles 0/undefined defensively — hard limit and soft warning both guard on truthiness

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test agent-loop` — all 64 tests pass (existing tests use explicit values, not the default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
