### PR TITLE
fix: align agent loop DEFAULT_CONFIG with schema default (0 = unlimited)

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -41,7 +41,7 @@ export type AgentEvent =
 
 const DEFAULT_CONFIG: AgentLoopConfig = {
   maxTokens: 16000,
-  maxToolUseTurns: 60,
+  maxToolUseTurns: 0,
   minTurnIntervalMs: 150,
 };
 


### PR DESCRIPTION
## Summary
- Updates `DEFAULT_CONFIG.maxToolUseTurns` in `agent/loop.ts` from `60` to `0` to match the schema default changed in #11016
- Ensures the fallback default is consistent: `0` = unlimited turns

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test agent-loop` — all 64 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
