### PR TITLE
fix: remove redundant AgentLoop turn cap from computer-use session

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -532,9 +532,6 @@ export class ComputerUseSession {
         maxTokens: 4096,
         maxInputTokens: cuConfig.contextWindow.maxInputTokens,
         toolChoice: { type: 'any' },
-        // Allow MAX_STEPS non-terminal actions plus one terminal turn
-        // (computer_use_done/computer_use_respond), since AgentLoop caps tool turns globally.
-        maxToolUseTurns: MAX_STEPS + 1,
       },
       toolDefs,
       toolExecutor,


### PR DESCRIPTION
## Summary
- Removes the explicit `maxToolUseTurns: MAX_STEPS + 1` override from the computer-use session's AgentLoop config
- The computer-use session already enforces its own step limit independently (`this.stepCount > MAX_STEPS` with abort controller), so the AgentLoop cap was redundant
- Now that the default is unlimited (0), the redundant backstop is unnecessary

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test agent-loop` — all 64 tests pass
- Computer-use session step enforcement is unchanged (still caps at MAX_STEPS=50 via its own stepCount check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
