### PR TITLE
feat: add onAllowPendingConfirmation callback to composer views

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
@@ -6,6 +6,7 @@ struct ComposerSection: View {
     let hasAPIKey: Bool
     let isSending: Bool
     let hasPendingConfirmation: Bool
+    var onAllowPendingConfirmation: (() -> Void)? = nil
     let isRecording: Bool
     let suggestion: String?
     let pendingAttachments: [ChatAttachment]
@@ -75,6 +76,7 @@ struct ComposerSection: View {
                 hasAPIKey: hasAPIKey,
                 isSending: isSending,
                 hasPendingConfirmation: hasPendingConfirmation,
+                onAllowPendingConfirmation: onAllowPendingConfirmation,
                 isRecording: isRecording,
                 suggestion: suggestion,
                 pendingAttachments: pendingAttachments,

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -49,6 +49,7 @@ struct ComposerView: View {
     let hasAPIKey: Bool
     let isSending: Bool
     let hasPendingConfirmation: Bool
+    var onAllowPendingConfirmation: (() -> Void)? = nil
     let isRecording: Bool
     let suggestion: String?
     let pendingAttachments: [ChatAttachment]
@@ -223,7 +224,12 @@ struct ComposerView: View {
                 inputText = inputText.replacingOccurrences(
                     of: "\\n$", with: "", options: .regularExpression
                 )
-                if canSend { onSend() }
+                if canSend {
+                    onSend()
+                } else if hasPendingConfirmation
+                            && inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    onAllowPendingConfirmation?()
+                }
             },
             onAcceptSuggestion: onAcceptSuggestion,
             onPaste: onPaste,


### PR DESCRIPTION
## Summary
- Adds an optional `onAllowPendingConfirmation` callback to `ComposerView` and `ComposerSection`
- When Enter is pressed with an empty composer and a pending tool confirmation exists, invokes this callback instead of doing nothing
- Defaults to `nil` so existing callsites (ChatEmptyStateView, previews) are unaffected

**Part 1 of 2** — this PR adds the plumbing. Part 2 wires it up in `ChatView` to actually trigger "Allow Once" on the active pending confirmation.

## Test plan
- [ ] Build succeeds (`cd clients/macos && ./build.sh`)
- [ ] No behavioral change yet (callback is not wired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
