### PR TITLE
feat: wire Enter-to-allow-once in ChatView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -216,6 +216,11 @@ struct ChatView: View {
                             hasAPIKey: hasAPIKey,
                             isSending: isSending,
                             hasPendingConfirmation: messages.contains(where: { $0.confirmation?.state == .pending }),
+                            onAllowPendingConfirmation: {
+                                if let requestId = PendingConfirmationFocusSelector.activeRequestId(from: messages) {
+                                    onConfirmationAllow(requestId)
+                                }
+                            },
                             isRecording: isRecording,
                             suggestion: suggestion,
                             pendingAttachments: pendingAttachments,


### PR DESCRIPTION
## Summary
- Connects the `onAllowPendingConfirmation` callback (added in #11020) in `ChatView`
- When Enter is pressed with an empty composer and a tool confirmation is pending, resolves the active pending confirmation via `PendingConfirmationFocusSelector.activeRequestId` and calls `onConfirmationAllow`
- This completes the Enter-to-allow-once feature: pressing Enter with an empty chat bar now triggers "Allow Once" on the active tool confirmation

**Part 2 of 2** — follows #11020 which added the plumbing.

## Test plan
- [ ] Build succeeds (`cd clients/macos && ./build.sh`)
- [ ] Trigger a tool confirmation (e.g., ask the assistant to use the browser)
- [ ] With empty composer, press Enter → should approve the confirmation
- [ ] Type text, press Enter → should send the message (not approve)
- [ ] No pending confirmation + empty composer + Enter → should do nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
