### PR TITLE
fix: gate messaging skill hint behind feature flag

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -811,11 +811,13 @@ function buildDynamicSkillWorkflowSection(config: import('./schema.js').Assistan
     );
   }
 
-  lines.push(
-    '',
-    '### Messaging Skill',
-    'When the user asks about email, messaging, inbox management, or wants to read/send/search messages on any platform (Gmail, Slack, Telegram, SMS), load the "messaging" skill using `skill_load`. The messaging skill handles connection setup, credential flows, and all messaging operations — do not improvise setup instructions from general knowledge.',
-  );
+  if (isAssistantFeatureFlagEnabled('feature_flags.messaging.enabled', config)) {
+    lines.push(
+      '',
+      '### Messaging Skill',
+      'When the user asks about email, messaging, inbox management, or wants to read/send/search messages on any platform (Gmail, Slack, Telegram, SMS), load the "messaging" skill using `skill_load`. The messaging skill handles connection setup, credential flows, and all messaging operations — do not improvise setup instructions from general knowledge.',
+    );
+  }
 
   return lines.join('\n');
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -42,6 +42,14 @@
       "defaultEnabled": true
     },
     {
+      "id": "messaging",
+      "scope": "assistant",
+      "key": "feature_flags.messaging.enabled",
+      "label": "Messaging",
+      "description": "Enable messaging skill section in the system prompt",
+      "defaultEnabled": true
+    },
+    {
       "id": "collect-usage-data",
       "scope": "assistant",
       "key": "feature_flags.collect-usage-data.enabled",


### PR DESCRIPTION
Gate the messaging skill system-prompt hint behind `isAssistantFeatureFlagEnabled` to match the browser/twitter pattern. Both Codex and Devin flagged this on PRs #11010 and #11015.

## Changes

- **`assistant/src/config/system-prompt.ts`**: Wrapped the messaging skill hint in `buildDynamicSkillWorkflowSection` with `isAssistantFeatureFlagEnabled('feature_flags.messaging.enabled', config)`, matching the existing browser and twitter gates.
- **`meta/feature-flags/feature-flag-registry.json`**: Declared the `messaging` feature flag in the unified registry with `defaultEnabled: true` (preserves existing behavior).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
