### PR TITLE
fix: align scope-fallback test with selectedScope default behavior

### DIFF
--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -434,7 +434,7 @@ describe('ToolExecutor contextual rule creation', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  test('always_allow without selectedScope does not create a rule', async () => {
+  test('always_allow without selectedScope defaults scope to everywhere', async () => {
     checkResultOverride = { decision: 'prompt', reason: 'test prompt' };
     const spy = setupAddRuleSpy();
 
@@ -443,7 +443,9 @@ describe('ToolExecutor contextual rule creation', () => {
     const result = await executor.execute('file_read', { path: 'test.txt' }, makeContext());
 
     expect(result.isError).toBe(false);
-    expect(spy).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [, , scope] = spy.mock.calls[0];
+    expect(scope).toBe('everywhere');
   });
 
   test('always_allow_high_risk for core tool sets allowHighRisk without execution target', async () => {


### PR DESCRIPTION
## Summary
- Updated `tool-executor.test.ts` to match the behavior introduced in #11011 where missing `selectedScope` defaults to `'everywhere'` instead of skipping rule creation
- The test now asserts that a rule IS created with scope `'everywhere'` when `selectedScope` is undefined

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22536909901/job/65285992965

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
