### PR TITLE
fix: handle non-scoped tool approval persistence in CLI and channel flows

### DIFF
--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -163,11 +163,13 @@ const pendingInteractionResolver: GuardianRequestResolver = {
         decision.action === 'approve_always' &&
         details &&
         details.persistentDecisionsAllowed !== false &&
-        details.allowlistOptions?.length &&
-        details.scopeOptions?.length
+        details.allowlistOptions?.length
       ) {
         const pattern = details.allowlistOptions[0].pattern;
-        const scope = details.scopeOptions[0].scope;
+        // Non-scoped tools (web_fetch, network_request, etc.) have empty
+        // scopeOptions — default to 'everywhere' so approve_always still
+        // persists a trust rule instead of silently degrading to one-time.
+        const scope = details.scopeOptions?.length ? details.scopeOptions[0].scope : 'everywhere';
         const tool = getTool(details.toolName);
         const executionTarget = tool?.origin === 'skill' ? details.executionTarget : undefined;
         addRule(details.toolName, pattern, scope, 'allow', 100, { executionTarget });

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -233,7 +233,7 @@ export async function startCli(): Promise<void> {
     process.stdout.write(`\u2502\n`);
     process.stdout.write(`\u2502 [a] Allow once\n`);
     process.stdout.write(`\u2502 [d] Deny once\n`);
-    if (req.allowlistOptions.length > 0) {
+    if (req.allowlistOptions.length > 0 && req.scopeOptions.length > 0) {
       process.stdout.write(`\u2502 [A] Allowlist...\n`);
       process.stdout.write(`\u2502 [H] Allowlist (high-risk)...\n`);
       process.stdout.write(`\u2502 [D] Denylist...\n`);

--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -151,11 +151,13 @@ export function handleChannelDecision(
     if (
       details &&
       details.persistentDecisionsAllowed !== false &&
-      details.allowlistOptions?.length &&
-      details.scopeOptions?.length
+      details.allowlistOptions?.length
     ) {
       const pattern = details.allowlistOptions[0].pattern;
-      const scope = details.scopeOptions[0].scope;
+      // Non-scoped tools (web_fetch, network_request, etc.) have empty
+      // scopeOptions — default to 'everywhere' so approve_always still
+      // persists a trust rule instead of silently degrading to one-time.
+      const scope = details.scopeOptions?.length ? details.scopeOptions[0].scope : 'everywhere';
       // Only persist executionTarget for skill-origin tools — core tools don't
       // set it in their PolicyContext, so a persisted value would prevent the
       // rule from ever matching on subsequent permission checks.


### PR DESCRIPTION
## Summary

Addresses feedback from PR #11009. Fixes two issues with non-scoped tool approval persistence:

- **Channel/guardian flows**: `approve_always` for non-scoped tools (`web_fetch`, `network_request`, etc.) now persists trust rules by defaulting scope to `everywhere` when `scopeOptions` is empty, instead of silently degrading to one-time approval.
- **CLI**: Persistent-rule options (A/H/D) are now hidden when `scopeOptions` is empty, preventing `renderScopeSelection` from rendering zero options and silently denying.

## Changes

- `assistant/src/runtime/channel-approvals.ts`: Removed `scopeOptions?.length` gate from the `approve_always` persistence condition; default scope to `'everywhere'` when `scopeOptions` is empty.
- `assistant/src/approvals/guardian-request-resolvers.ts`: Same fix in the guardian `tool_approval` resolver.
- `assistant/src/cli.ts`: Added `&& req.scopeOptions.length > 0` guard to hide A/H/D persistent-rule options when there are no scope options.

## Test plan

- [ ] Verify `web_fetch` approve_always via channel persists a trust rule with scope `everywhere`
- [ ] Verify CLI hides A/H/D options for non-scoped tools and only shows allow-once/deny-once
- [ ] Verify scoped tools (bash, file_write) still show A/H/D options and persist rules normally

---

**Prompt:**
> Address the feedback on PR #11009: Non-scoped tool approval persistence is broken in two ways: (1) Channel/guardian flows don't persist always_approve rules when scopeOptions is empty. (2) CLI renderScopeSelection renders zero options for non-scoped tools, causing silent deny.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11024" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
