### PR TITLE
fix: route Cmd+Enter through performKeyEquivalent for reliable send

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -941,6 +941,17 @@ private final class ComposerNativeTextView: NSTextView {
     }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        // macOS routes Cmd+key events through performKeyEquivalent before
+        // keyDown, so Cmd+Enter must be intercepted here and forwarded to
+        // keyDown where the send/accept/slash-menu logic lives.
+        if cmdEnterToSend,
+           event.modifierFlags.contains(.command),
+           !event.modifierFlags.contains(.shift),
+           (event.keyCode == 36 || event.keyCode == 76) {
+            self.keyDown(with: event)
+            return true
+        }
+
         if event.modifierFlags.contains(.command),
            event.charactersIgnoringModifiers?.lowercased() == "v" {
             if pasteboardHasImageContent {


### PR DESCRIPTION
Addresses feedback from PR #11014 (and Codex P1 on #11012). macOS routes Cmd+key events through `performKeyEquivalent:` before `keyDown:`, so the Cmd+Enter send logic was unreachable. Adds an intercept in `performKeyEquivalent` that detects Cmd+Enter and forwards to `keyDown` for processing.

## Changes

- Added Cmd+Enter intercept at the top of `performKeyEquivalent(with:)` in `ComposerNativeTextView`
- When `cmdEnterToSend` is enabled and Cmd+Enter (keyCode 36 or 76) is pressed without Shift, forwards the event to `keyDown(with:)` and returns `true` to mark it handled
- This ensures the existing send/accept/slash-menu logic in `keyDown` is reached

## Test plan

- [ ] Enable "Cmd+Enter to Send" in settings
- [ ] Verify Cmd+Enter sends the message
- [ ] Verify plain Enter inserts a newline (when Cmd+Enter mode is on)
- [ ] Verify Shift+Enter still inserts a newline in both modes
- [ ] Verify default mode (Enter to send) still works
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
