### PR TITLE
fix: add scope fallback to always_deny path and restrict to non-scoped tools

### DIFF
--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -30,6 +30,9 @@ let checkResultOverride: { decision: string; reason: string } | undefined;
 /** Function override for check() — when set, takes precedence over the static override. */
 let checkFnOverride: ((toolName: string, input: Record<string, unknown>, workingDir: string, policyContext?: PolicyContext) => Promise<{ decision: string; reason: string }>) | undefined;
 
+/** Override for generateScopeOptions — when set, returns this value instead of the default. */
+let scopeOptionsOverride: ScopeOption[] | undefined;
+
 /** Spy on addRule to capture calls without replacing the real implementation. */
 let addRuleSpy: ReturnType<typeof spyOn> | undefined;
 
@@ -61,7 +64,7 @@ mock.module('../permissions/checker.js', () => ({
     return { decision: 'allow', reason: 'allowed' };
   },
   generateAllowlistOptions: () => [{ label: 'exact', description: 'exact', pattern: 'exact' }],
-  generateScopeOptions: () => [{ label: '/tmp', scope: '/tmp' }],
+  generateScopeOptions: () => scopeOptionsOverride ?? [{ label: '/tmp', scope: '/tmp' }],
 }));
 
 mock.module('../memory/tool-usage-store.js', () => ({
@@ -317,6 +320,7 @@ describe('ToolExecutor contextual rule creation', () => {
     getToolOverride = undefined;
     checkResultOverride = undefined;
     checkFnOverride = undefined;
+    scopeOptionsOverride = undefined;
     if (addRuleSpy) { addRuleSpy.mockRestore(); addRuleSpy = undefined; }
   });
 
@@ -434,13 +438,26 @@ describe('ToolExecutor contextual rule creation', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  test('always_allow without selectedScope defaults scope to everywhere', async () => {
+  test('always_allow without selectedScope for scoped tool does not create a rule', async () => {
     checkResultOverride = { decision: 'prompt', reason: 'test prompt' };
     const spy = setupAddRuleSpy();
 
     const prompter = makePrompterWithDecision('always_allow', 'file_read:*', undefined);
     const executor = new ToolExecutor(prompter);
     const result = await executor.execute('file_read', { path: 'test.txt' }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test('always_allow without selectedScope for non-scoped tool creates rule with everywhere scope', async () => {
+    checkResultOverride = { decision: 'prompt', reason: 'test prompt' };
+    scopeOptionsOverride = [];
+    const spy = setupAddRuleSpy();
+
+    const prompter = makePrompterWithDecision('always_allow', 'some_tool:*', undefined);
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute('some_tool', {}, makeContext());
 
     expect(result.isError).toBe(false);
     expect(spy).toHaveBeenCalledTimes(1);

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -207,9 +207,14 @@ export class PermissionChecker {
         }
 
         if (response.decision === 'always_deny') {
-          const ruleSaved = !!(persistentDecisionsAllowed && response.selectedPattern && response.selectedScope);
+          // For non-scoped tools (empty scopeOptions), default to 'everywhere' since
+          // the client has no scope picker and will send undefined.
+          const effectiveDenyScope = scopeOptions.length === 0
+            ? (response.selectedScope ?? 'everywhere')
+            : response.selectedScope;
+          const ruleSaved = !!(persistentDecisionsAllowed && response.selectedPattern && effectiveDenyScope);
           if (ruleSaved) {
-            addRule(name, response.selectedPattern!, response.selectedScope!, 'deny');
+            addRule(name, response.selectedPattern!, effectiveDenyScope!, 'deny');
           }
           const denialReason = ruleSaved ? 'Permission denied by user (rule saved)' : 'Permission denied by user';
           const denialMessage = ruleSaved
@@ -252,8 +257,14 @@ export class PermissionChecker {
           }
 
           const hasOptions = Object.keys(ruleOptions).length > 0;
-          const effectiveScope = response.selectedScope ?? 'everywhere';
-          addRule(name, response.selectedPattern, effectiveScope, 'allow', 100, hasOptions ? ruleOptions : undefined);
+          // Only default to 'everywhere' for non-scoped tools (empty scopeOptions).
+          // For scoped tools, require an explicit scope to prevent silent permission widening.
+          const effectiveScope = scopeOptions.length === 0
+            ? (response.selectedScope ?? 'everywhere')
+            : response.selectedScope;
+          if (effectiveScope) {
+            addRule(name, response.selectedPattern, effectiveScope, 'allow', 100, hasOptions ? ruleOptions : undefined);
+          }
         }
 
         return { allowed: true, decision, riskLevel };


### PR DESCRIPTION
Addresses feedback from PR #11011. (1) Adds 'everywhere' fallback to always_deny path for symmetry with always_allow. (2) Renames test to clarify scoped-tool behavior and adds new test for non-scoped tools. (3) Restricts the 'everywhere' fallback to only apply when scopeOptions is empty (non-scoped tools), preventing silent permission widening for scoped tools when a legacy/buggy client omits scope.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
