### PR TITLE
fix: align Enter-to-allow with visible confirmations and exclude system permissions

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -211,13 +211,19 @@ struct ChatView: View {
                                 .animation(VAnimation.fast, value: editorContentHeight)
                         }
 
+                        let composerMessages: [ChatMessage] = {
+                            let all = messages.filter { !$0.isSubagentNotification }
+                            guard displayedMessageCount < all.count else { return all }
+                            return Array(all.suffix(displayedMessageCount))
+                        }()
+
                         ComposerSection(
                             inputText: $inputText,
                             hasAPIKey: hasAPIKey,
                             isSending: isSending,
-                            hasPendingConfirmation: messages.contains(where: { $0.confirmation?.state == .pending }),
+                            hasPendingConfirmation: PendingConfirmationFocusSelector.activeRequestId(from: composerMessages) != nil,
                             onAllowPendingConfirmation: {
-                                if let requestId = PendingConfirmationFocusSelector.activeRequestId(from: messages) {
+                                if let requestId = PendingConfirmationFocusSelector.activeRequestId(from: composerMessages) {
                                     onConfirmationAllow(requestId)
                                 }
                             },


### PR DESCRIPTION
Addresses feedback from PR #11021.

1. **Codex P1 — wrong message source**: The `onAllowPendingConfirmation` callback was resolving `requestId` from the full `messages` array, but the keyboard activation in `MessageListView` operates on the paginated/filtered `visibleMessages` subset. With `displayedMessageCount = 50`, these sets can diverge, causing Enter to approve an off-screen confirmation instead of the one the user sees. Fix: compute `composerMessages` using the same filter+suffix logic as `MessageListView.visibleMessages` and use it for both `hasPendingConfirmation` and `onAllowPendingConfirmation`.

2. **Devin — system permission mismatch**: `hasPendingConfirmation` checked `messages.contains(where: { $0.confirmation?.state == .pending })` which returns true for `request_system_permission` requests. But `PendingConfirmationFocusSelector.activeRequestId` excludes system permission requests (they use a dedicated card without keyboard support). This mismatch caused pressing Enter to silently do nothing when the only pending confirmation was a system permission. Fix: use `PendingConfirmationFocusSelector.activeRequestId(from:) != nil` for the `hasPendingConfirmation` parameter so both checks agree.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
