### PR TITLE
fix: widen composer hit-test boundary to include action buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -695,6 +695,24 @@ private struct ComposerTextView: NSViewRepresentable {
         // Register the composer with the window so typing auto-focuses it.
         if let zoomableWindow = textView.window as? TitleBarZoomableWindow {
             zoomableWindow.composerTextView = textView
+
+            // Walk up from the scroll view to find the composer container —
+            // the first ancestor whose frame is wider, encompassing the
+            // sibling action buttons (Attach, Mic, Send). Re-evaluated on
+            // each update because layout can change (compact vs expanded).
+            if let scrollView = textView.enclosingScrollView {
+                var container: NSView = scrollView
+                var candidate = scrollView.superview
+                while let view = candidate,
+                      view !== zoomableWindow.contentView {
+                    if view.frame.width > scrollView.frame.width {
+                        container = view
+                        break
+                    }
+                    candidate = view.superview
+                }
+                zoomableWindow.composerContainerView = container
+            }
         }
 
         if context.coordinator.lastFocusRequestID != focusRequestID {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -18,6 +18,11 @@ class TitleBarZoomableWindow: NSWindow {
     /// Weak reference to the composer text view so we can redirect typing to it.
     weak var composerTextView: NSTextView?
 
+    /// Weak reference to the outermost NSView that contains the entire composer
+    /// UI (text field + action buttons). Used for hit-testing blur dismissal so
+    /// clicks on sibling controls (Attach, Mic, Send) aren't treated as outside.
+    weak var composerContainerView: NSView?
+
     /// When true, `keyDown` will not auto-redirect keystrokes to the composer.
     /// Set when the user clicks outside the composer to dismiss focus; cleared
     /// when the composer regains focus (e.g. user clicks back into it).
@@ -31,13 +36,15 @@ class TitleBarZoomableWindow: NSWindow {
         super.sendEvent(event)
 
         // After dispatching a left-click, check whether the composer should
-        // lose focus. If the click landed outside the composer's scroll view
+        // lose focus. If the click landed outside the composer container
         // and the composer is still first responder (i.e. nothing else claimed
         // focus), explicitly resign so the user can "click away" to blur.
         if event.type == .leftMouseDown,
            let composer = composerTextView,
            firstResponder === composer {
-            let container = composer.enclosingScrollView ?? composer
+            let container = composerContainerView
+                ?? composer.enclosingScrollView
+                ?? composer
             let point = container.convert(event.locationInWindow, from: nil)
             if !container.bounds.contains(point) {
                 composerDismissed = true


### PR DESCRIPTION
## Summary

- Add `composerContainerView` property to `TitleBarZoomableWindow` to track the full composer container view (text field + action buttons)
- In `sendEvent`, use `composerContainerView` for bounds-checking instead of just the scroll view, so clicks on Attach/Mic/Send buttons are not treated as "outside"
- In `ComposerView.swift` `updateNSView`, walk up from the scroll view to find the first ancestor wider than the scroll view (the HStack/VStack containing both text field and action buttons) and register it as the container
- Falls back to `enclosingScrollView` if no container is found

Addresses feedback from PR #11008 (Codex P2, Devin red).

## Test plan

- [ ] Click the Attach button while composer is focused — composer should NOT lose focus
- [ ] Click the Microphone button while composer is focused — composer should NOT lose focus
- [ ] Click the Send button while composer is focused — composer should NOT lose focus
- [ ] Click the Stop button while composer is focused — composer should NOT lose focus
- [ ] Click outside the composer (e.g. chat message area) — composer SHOULD lose focus
- [ ] After clicking outside, type a character — keystrokes should NOT auto-redirect to composer
- [ ] Click back into the composer text area — typing should work normally again

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
