### PR TITLE
fix: sync bundled feature-flag-registry with canonical meta/ copy

### DIFF
--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -42,6 +42,14 @@
       "defaultEnabled": true
     },
     {
+      "id": "messaging",
+      "scope": "assistant",
+      "key": "feature_flags.messaging.enabled",
+      "label": "Messaging",
+      "description": "Enable messaging skill section in the system prompt",
+      "defaultEnabled": true
+    },
+    {
       "id": "collect-usage-data",
       "scope": "assistant",
       "key": "feature_flags.collect-usage-data.enabled",


### PR DESCRIPTION
## Summary
- The bundled `assistant/src/config/feature-flag-registry.json` was missing the `messaging` feature flag entry that was added to the canonical `meta/feature-flags/feature-flag-registry.json`
- This caused the guard test `assistant-feature-flag-guard.test.ts` to fail in CI because the bundled copy didn't match the canonical copy

## Original prompt
fix this CI failure: https://github.com/vellum-ai/vellum-assistant/actions/runs/22537056849/job/65286387592

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
