### PR TITLE
fix: guard A/H/D input handler for non-scoped tools in CLI

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -246,21 +246,22 @@ export async function startCli(): Promise<void> {
       const choice = trimmed.toLowerCase();
 
       // Uppercase 'A' → allowlist pattern selection (check before lowercase 'a')
-      if (trimmed === 'A' || choice === 'allowlist') {
+      // Only process when scope options exist, matching the display guard above
+      if ((trimmed === 'A' || choice === 'allowlist') && req.allowlistOptions.length > 0 && req.scopeOptions.length > 0) {
         // pendingConfirmation stays true through sub-prompts
         renderPatternSelection(req, 'always_allow');
         return;
       }
 
       // Uppercase 'H' → high-risk allowlist pattern selection
-      if (trimmed === 'H') {
+      if (trimmed === 'H' && req.allowlistOptions.length > 0 && req.scopeOptions.length > 0) {
         // pendingConfirmation stays true through sub-prompts
         renderPatternSelection(req, 'always_allow_high_risk');
         return;
       }
 
       // Uppercase 'D' → denylist pattern selection (check before lowercase 'd')
-      if (trimmed === 'D' || choice === 'denylist') {
+      if ((trimmed === 'D' || choice === 'denylist') && req.allowlistOptions.length > 0 && req.scopeOptions.length > 0) {
         // pendingConfirmation stays true through sub-prompts
         renderPatternSelection(req, 'always_deny');
         return;


### PR DESCRIPTION
Adds a guard to the CLI approval prompt input handler so that A/H/D keystrokes are ignored when there are no scope options, preventing entry into renderPatternSelection → renderScopeSelection with zero options (which causes an infinite recursive loop or silent deny). Addresses feedback from PR #11024.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
