### PR TITLE
fix: restrict Cmd+Enter intercept to Command-only modifier

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -962,9 +962,10 @@ private final class ComposerNativeTextView: NSTextView {
         // macOS routes Cmd+key events through performKeyEquivalent before
         // keyDown, so Cmd+Enter must be intercepted here and forwarded to
         // keyDown where the send/accept/slash-menu logic lives.
+        // Match exact .command only — Cmd+Opt+Enter, Cmd+Ctrl+Enter, etc.
+        // must propagate normally, matching the keyDown equality check.
         if cmdEnterToSend,
-           event.modifierFlags.contains(.command),
-           !event.modifierFlags.contains(.shift),
+           event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
            (event.keyCode == 36 || event.keyCode == 76) {
             self.keyDown(with: event)
             return true


### PR DESCRIPTION
Restricts the performKeyEquivalent Cmd+Enter intercept in ComposerView.swift to only match exact .command modifier (not .command + other modifiers like Option or Control). Previously Cmd+Opt+Enter and Cmd+Ctrl+Enter were captured and swallowed without action, blocking normal key-equivalent propagation. Addresses feedback from PR #11025.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
