### PR TITLE
fix: use explicit modifier set for Cmd+Enter intercept to handle CapsLock and numpad

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -964,8 +964,12 @@ private final class ComposerNativeTextView: NSTextView {
         // keyDown where the send/accept/slash-menu logic lives.
         // Match exact .command only — Cmd+Opt+Enter, Cmd+Ctrl+Enter, etc.
         // must propagate normally, matching the keyDown equality check.
+        // Use an explicit modifier set instead of .deviceIndependentFlagsMask
+        // because the latter includes .numericPad and .capsLock, which would
+        // cause this check to fail when CapsLock is on or numpad Enter
+        // (keyCode 76) is pressed.
         if cmdEnterToSend,
-           event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
+           event.modifierFlags.intersection([.shift, .command, .control, .option]) == [.command],
            (event.keyCode == 36 || event.keyCode == 76) {
             self.keyDown(with: event)
             return true


### PR DESCRIPTION
## Summary

- Replaces `.deviceIndependentFlagsMask` with explicit modifier set `[.shift, .command, .control, .option]` in `performKeyEquivalent` for the Cmd+Enter intercept
- `.deviceIndependentFlagsMask` includes `.numericPad` and `.capsLock`, which caused Cmd+Enter to fail when CapsLock was on or when using numpad Enter (keyCode 76)
- Aligns with the existing `keyDown` modifier filter at line 876 which already uses the explicit set

Addresses review feedback from Codex and Devin on PR #11031.

## Test plan

- [ ] Verify Cmd+Enter sends messages with CapsLock off
- [ ] Verify Cmd+Enter sends messages with CapsLock on
- [ ] Verify numpad Enter (keyCode 76) + Cmd sends messages
- [ ] Verify Cmd+Opt+Enter, Cmd+Ctrl+Enter still propagate normally (not intercepted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
