### PR TITLE
feat: add all-Swift agent test runner with AX element tools

### DIFF
--- a/playwright/.gitignore
+++ b/playwright/.gitignore
@@ -1,2 +1,3 @@
 test-results/
 playwright-report/
+agent-xcode/.build/

--- a/playwright/agent-xcode/Package.swift
+++ b/playwright/agent-xcode/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "agent-xcode",
+    platforms: [.macOS(.v14)],
+    targets: [
+        .executableTarget(
+            name: "agent-xcode",
+            path: "Sources",
+            linkerSettings: [
+                .linkedFramework("ApplicationServices"),
+                .linkedFramework("CoreGraphics"),
+                .linkedFramework("AppKit"),
+            ]
+        ),
+    ]
+)

--- a/playwright/agent-xcode/Sources/AXTree.swift
+++ b/playwright/agent-xcode/Sources/AXTree.swift
@@ -1,0 +1,342 @@
+import ApplicationServices
+import AppKit
+import Foundation
+
+// MARK: - AX Element Model
+
+struct AXElement: Identifiable {
+    let id: Int
+    let role: String
+    let title: String?
+    let value: String?
+    let frame: CGRect
+    let isEnabled: Bool
+    let isFocused: Bool
+    let children: [AXElement]
+    let identifier: String?
+    let placeholderValue: String?
+    let url: String?
+}
+
+// MARK: - AX Tree Enumerator
+
+final class AXTreeEnumerator {
+    private var nextId = 1
+    private var totalElementsEnumerated = 0
+    private let maxElementsPerEnumeration = 10000
+    private static let axMessagingTimeoutSeconds: Float = 5.0
+
+    static let interactiveRoles: Set<String> = [
+        "AXButton", "AXTextField", "AXTextArea", "AXCheckBox", "AXRadioButton",
+        "AXPopUpButton", "AXComboBox", "AXSlider", "AXLink", "AXMenuItem",
+        "AXMenuButton", "AXIncrementor", "AXDisclosureTriangle", "AXTab",
+        "AXTabGroup", "AXSegmentedControl",
+    ]
+
+    private static let containerRoles: Set<String> = [
+        "AXGroup", "AXScrollArea", "AXSplitGroup", "AXTabGroup", "AXToolbar",
+        "AXTable", "AXOutline", "AXList", "AXBrowser", "AXWebArea", "AXRow",
+        "AXCell", "AXSheet", "AXDrawer",
+        "AXSection", "AXForm", "AXLandmarkMain", "AXLandmarkNavigation",
+        "AXLandmarkBanner", "AXLandmarkContentInfo", "AXLandmarkSearch",
+        "AXArticle", "AXDocument", "AXApplication",
+    ]
+
+    private static let textInputRoles: Set<String> = [
+        "AXTextField", "AXTextArea", "AXComboBox",
+    ]
+
+    // MARK: - Enumerate by App Name
+
+    func enumerateApp(named appName: String) -> (elements: [AXElement], windowTitle: String, appName: String)? {
+        let runningApps = NSWorkspace.shared.runningApplications
+        guard let app = runningApps.first(where: {
+            $0.localizedName?.lowercased() == appName.lowercased() && !$0.isTerminated
+        }) else {
+            return nil
+        }
+
+        let pid = app.processIdentifier
+        let name = app.localizedName ?? appName
+        let appElement = AXUIElementCreateApplication(pid)
+        AXUIElementSetMessagingTimeout(appElement, Self.axMessagingTimeoutSeconds)
+
+        // Enable enhanced AX for web content in browsers
+        AXUIElementSetAttributeValue(appElement, "AXEnhancedUserInterface" as CFString, true as CFTypeRef)
+
+        var windowValue: CFTypeRef?
+        let windowResult = AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, &windowValue)
+        guard windowResult == .success, let windowRef = windowValue else {
+            // Try getting the first window instead
+            var windowsRef: CFTypeRef?
+            guard AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &windowsRef) == .success,
+                  let windows = windowsRef as? [AXUIElement],
+                  let firstWindow = windows.first else {
+                return nil
+            }
+            return enumerateWindow(firstWindow, appName: name)
+        }
+        guard CFGetTypeID(windowRef) == AXUIElementGetTypeID() else { return nil }
+        return enumerateWindow(windowRef as! AXUIElement, appName: name)
+    }
+
+    private func enumerateWindow(_ windowElement: AXUIElement, appName: String) -> (elements: [AXElement], windowTitle: String, appName: String) {
+        let windowTitle = getStringAttribute(windowElement, kAXTitleAttribute as CFString) ?? "Untitled"
+        nextId = 1
+        totalElementsEnumerated = 0
+        let elements = enumerateElementSafely(element: windowElement, depth: 0, maxDepth: 25)
+        return (elements: elements, windowTitle: windowTitle, appName: appName)
+    }
+
+    // MARK: - Element Enumeration
+
+    private func enumerateElementSafely(element: AXUIElement, depth: Int, maxDepth: Int) -> [AXElement] {
+        guard totalElementsEnumerated < maxElementsPerEnumeration else { return [] }
+        totalElementsEnumerated += 1
+        return enumerateElement(element: element, depth: depth, maxDepth: maxDepth)
+    }
+
+    private func enumerateElement(element: AXUIElement, depth: Int, maxDepth: Int) -> [AXElement] {
+        guard depth < maxDepth else { return [] }
+
+        let role = getStringAttribute(element, kAXRoleAttribute as CFString) ?? ""
+        let title = getStringAttribute(element, kAXTitleAttribute as CFString)
+            ?? getStringAttribute(element, kAXDescriptionAttribute as CFString)
+        let value = getValueAttribute(element)
+        let identifier = getStringAttribute(element, kAXIdentifierAttribute as CFString)
+        let placeholderValue = getStringAttribute(element, kAXPlaceholderValueAttribute as CFString)
+        let isEnabled = getBoolAttribute(element, kAXEnabledAttribute as CFString) ?? true
+        let isFocused = getBoolAttribute(element, kAXFocusedAttribute as CFString) ?? false
+        let frame = getFrameAttribute(element)
+        let url = getStringAttribute(element, "AXURL" as CFString)
+
+        let isInteractive = Self.interactiveRoles.contains(role)
+        let isContainer = Self.containerRoles.contains(role)
+        let hasTextContent = (title != nil && !title!.isEmpty) || (value != nil && !value!.isEmpty)
+        let isStaticText = role == "AXStaticText" || role == "AXHeading"
+
+        // Enumerate children
+        var childElements: [AXElement] = []
+        var childrenRef: CFTypeRef?
+
+        if AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef) == .success,
+           let children = childrenRef as? [AXUIElement] {
+            if children.count >= 1000 {
+                // Skip corrupted children
+            } else {
+                for (index, child) in children.enumerated() {
+                    guard totalElementsEnumerated < maxElementsPerEnumeration else {
+                        break
+                    }
+                    _ = index
+                    childElements.append(contentsOf: enumerateElementSafely(element: child, depth: depth + 1, maxDepth: maxDepth))
+                }
+            }
+        }
+
+        if isInteractive {
+            let id = nextId
+            nextId += 1
+            return [AXElement(
+                id: id, role: role, title: title, value: value, frame: frame,
+                isEnabled: isEnabled, isFocused: isFocused, children: [],
+                identifier: identifier, placeholderValue: placeholderValue, url: url
+            )]
+        }
+
+        if isStaticText && hasTextContent {
+            let id = nextId
+            nextId += 1
+            return [AXElement(
+                id: id, role: role, title: title, value: value, frame: frame,
+                isEnabled: isEnabled, isFocused: isFocused, children: [],
+                identifier: identifier, placeholderValue: placeholderValue, url: url
+            )]
+        }
+
+        if isContainer && !childElements.isEmpty {
+            let id = nextId
+            nextId += 1
+            return [AXElement(
+                id: id, role: role, title: title, value: value, frame: frame,
+                isEnabled: isEnabled, isFocused: isFocused, children: childElements,
+                identifier: identifier, placeholderValue: placeholderValue, url: url
+            )]
+        }
+
+        return childElements
+    }
+
+    // MARK: - AX Attribute Helpers
+
+    private func getStringAttribute(_ element: AXUIElement, _ attribute: CFString) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success else { return nil }
+        return value as? String
+    }
+
+    private func getBoolAttribute(_ element: AXUIElement, _ attribute: CFString) -> Bool? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success else { return nil }
+        return (value as? NSNumber)?.boolValue
+    }
+
+    private func getValueAttribute(_ element: AXUIElement) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &value) == .success else { return nil }
+        if let str = value as? String { return str }
+        if let num = value as? NSNumber { return num.stringValue }
+        return nil
+    }
+
+    private func getFrameAttribute(_ element: AXUIElement) -> CGRect {
+        var positionValue: CFTypeRef?
+        var sizeValue: CFTypeRef?
+
+        guard AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &positionValue) == .success,
+              AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeValue) == .success
+        else { return .zero }
+
+        var point = CGPoint.zero
+        var size = CGSize.zero
+
+        if let posRef = positionValue, CFGetTypeID(posRef) == AXValueGetTypeID() {
+            AXValueGetValue(posRef as! AXValue, .cgPoint, &point)
+        }
+        if let sizeRef = sizeValue, CFGetTypeID(sizeRef) == AXValueGetTypeID() {
+            AXValueGetValue(sizeRef as! AXValue, .cgSize, &size)
+        }
+
+        return CGRect(origin: point, size: size)
+    }
+
+    // MARK: - Formatting
+
+    static func formatAXTree(elements: [AXElement], windowTitle: String, appName: String) -> String {
+        var lines: [String] = []
+        lines.append("Window: \"\(windowTitle)\" (\(appName))")
+
+        var interactive: [String] = []
+        var staticTexts: [String] = []
+        var prunedCount = 0
+        collectFormatted(elements: elements, interactive: &interactive, staticTexts: &staticTexts, prunedCount: &prunedCount)
+
+        if !interactive.isEmpty {
+            lines.append("Interactive elements:")
+            for line in interactive {
+                lines.append("  \(line)")
+            }
+            if prunedCount > 0 {
+                lines.append("  (\(prunedCount) unlabeled elements hidden)")
+            }
+        }
+
+        if !staticTexts.isEmpty {
+            lines.append("")
+            lines.append("Visible text:")
+            for text in staticTexts.prefix(30) {
+                lines.append("  \(text)")
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    private static func collectFormatted(elements: [AXElement], interactive: inout [String], staticTexts: inout [String], prunedCount: inout Int) {
+        for element in elements {
+            let isInteractiveRole = interactiveRoles.contains(element.role)
+            let isText = element.role == "AXStaticText" || element.role == "AXHeading"
+
+            if isInteractiveRole {
+                let hasTitle = element.title != nil && !element.title!.isEmpty
+                let isTextInput = textInputRoles.contains(element.role)
+                let hasPlaceholder = element.placeholderValue != nil && !element.placeholderValue!.isEmpty
+                let hasUrl = element.url != nil && !element.url!.isEmpty
+
+                if !hasTitle && !isTextInput && !element.isFocused && !hasPlaceholder && !hasUrl {
+                    prunedCount += 1
+                    collectFormatted(elements: element.children, interactive: &interactive, staticTexts: &staticTexts, prunedCount: &prunedCount)
+                    continue
+                }
+
+                let cleanedRole = cleanRole(element.role)
+                let centerX = Int(element.frame.midX)
+                let centerY = Int(element.frame.midY)
+                var line = "[\(element.id)] \(cleanedRole)"
+                if let title = element.title, !title.isEmpty {
+                    line += " \"\(title)\""
+                }
+                line += " at (\(centerX), \(centerY))"
+                if element.isFocused { line += " FOCUSED" }
+                if !element.isEnabled { line += " disabled" }
+                if let value = element.value, !value.isEmpty {
+                    let truncated = value.count > 50 ? String(value.prefix(50)) + "..." : value
+                    line += " value: \"\(truncated)\""
+                } else if let placeholder = element.placeholderValue, !placeholder.isEmpty {
+                    line += " placeholder: \"\(placeholder)\""
+                }
+                if let url = element.url, !url.isEmpty {
+                    line += " → \(url)"
+                }
+                interactive.append(line)
+            } else if isText {
+                if let title = element.title, !title.isEmpty {
+                    staticTexts.append(title)
+                } else if let value = element.value, !value.isEmpty {
+                    staticTexts.append(value)
+                }
+            }
+
+            collectFormatted(elements: element.children, interactive: &interactive, staticTexts: &staticTexts, prunedCount: &prunedCount)
+        }
+    }
+
+    private static func cleanRole(_ role: String) -> String {
+        var cleaned = role
+        if cleaned.hasPrefix("AX") {
+            cleaned = String(cleaned.dropFirst(2))
+        }
+        var result = ""
+        for char in cleaned {
+            if char.isUppercase && !result.isEmpty {
+                result += " "
+            }
+            result += String(char).lowercased()
+        }
+        return result
+    }
+
+    static func flattenElements(_ elements: [AXElement]) -> [AXElement] {
+        var result: [AXElement] = []
+        for element in elements {
+            result.append(element)
+            result.append(contentsOf: flattenElements(element.children))
+        }
+        return result
+    }
+
+    // MARK: - State File (for element-based clicking)
+
+    /// Build a map from element ID → center point and write to a JSON state file.
+    static func writeStateFile(elements: [AXElement], path: String = "/tmp/ax-helper-state.json") {
+        let flat = flattenElements(elements)
+        var map: [String: [String: Int]] = [:]
+        for el in flat {
+            map[String(el.id)] = ["x": Int(el.frame.midX), "y": Int(el.frame.midY)]
+        }
+        if let data = try? JSONSerialization.data(withJSONObject: map, options: [.sortedKeys]) {
+            try? data.write(to: URL(fileURLWithPath: path))
+        }
+    }
+
+    /// Read the state file and return coordinates for a given element ID.
+    static func readCoordinates(forElementId id: Int, path: String = "/tmp/ax-helper-state.json") -> CGPoint? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let map = try? JSONSerialization.jsonObject(with: data) as? [String: [String: Int]],
+              let coords = map[String(id)],
+              let x = coords["x"], let y = coords["y"] else {
+            return nil
+        }
+        return CGPoint(x: x, y: y)
+    }
+}

--- a/playwright/agent-xcode/Sources/ActionExecutor.swift
+++ b/playwright/agent-xcode/Sources/ActionExecutor.swift
@@ -1,0 +1,98 @@
+import CoreGraphics
+import AppKit
+import ApplicationServices
+import Foundation
+
+enum ActionError: LocalizedError {
+    case eventCreationFailed
+    case accessibilityNotGranted
+
+    var errorDescription: String? {
+        switch self {
+        case .eventCreationFailed: return "Failed to create CGEvent"
+        case .accessibilityNotGranted: return "Accessibility permission not granted"
+        }
+    }
+}
+
+final class ActionExecutor {
+    private let eventSource: CGEventSource?
+
+    init() {
+        eventSource = CGEventSource(stateID: .hidSystemState)
+    }
+
+    static func checkAccessibilityPermission(prompt: Bool = false) -> Bool {
+        let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): prompt] as CFDictionary
+        return AXIsProcessTrustedWithOptions(options)
+    }
+
+    // MARK: - Mouse
+
+    func click(at point: CGPoint) throws {
+        try mouseMove(to: point)
+        usleep(30_000)
+
+        guard let mouseDown = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left) else {
+            throw ActionError.eventCreationFailed
+        }
+        mouseDown.post(tap: .cghidEventTap)
+        usleep(50_000)
+
+        guard let mouseUp = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left) else {
+            throw ActionError.eventCreationFailed
+        }
+        mouseUp.post(tap: .cghidEventTap)
+    }
+
+    private func mouseMove(to point: CGPoint) throws {
+        guard let moveEvent = CGEvent(mouseEventSource: eventSource, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left) else {
+            throw ActionError.eventCreationFailed
+        }
+        moveEvent.post(tap: .cghidEventTap)
+    }
+
+    // MARK: - Keyboard
+
+    func typeText(_ text: String) throws {
+        let pasteboard = NSPasteboard.general
+        let previousContents = pasteboard.string(forType: .string)
+
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+
+        // Verify clipboard contents before pasting
+        let verifiedContents = pasteboard.string(forType: .string)
+        guard verifiedContents == text else {
+            return // Clipboard was modified by another process
+        }
+
+        try keyCombo(keyCode: 9, modifiers: .maskCommand) // Cmd+V
+        usleep(100_000)
+
+        // Restore clipboard after a short delay
+        let saved = previousContents
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            let pb = NSPasteboard.general
+            pb.clearContents()
+            if let saved = saved {
+                pb.setString(saved, forType: .string)
+            }
+        }
+    }
+
+    func keyCombo(keyCode: CGKeyCode, modifiers: CGEventFlags) throws {
+        guard let keyDown = CGEvent(keyboardEventSource: eventSource, virtualKey: keyCode, keyDown: true) else {
+            throw ActionError.eventCreationFailed
+        }
+        keyDown.flags = modifiers
+        keyDown.post(tap: .cghidEventTap)
+        usleep(50_000)
+
+        guard let keyUp = CGEvent(keyboardEventSource: eventSource, virtualKey: keyCode, keyDown: false) else {
+            throw ActionError.eventCreationFailed
+        }
+        keyUp.flags = modifiers
+        keyUp.post(tap: .cghidEventTap)
+    }
+}

--- a/playwright/agent-xcode/Sources/Agent.swift
+++ b/playwright/agent-xcode/Sources/Agent.swift
@@ -3,6 +3,7 @@ import Foundation
 // MARK: - Constants
 
 private let maxIterations = 1000
+private let maxTestDurationMs = 5 * 60 * 1000 // 5 minutes per test
 private let model = "claude-sonnet-4-6"
 
 private let systemPrompt = """
@@ -25,6 +26,13 @@ Rules:
 - Use MULTIPLE tool calls per turn (e.g. launch_app + wait together).
 - Be DECISIVE. Once you have enough info to judge pass/fail, call report_result immediately.
 - When waiting for an app response, wait 5-10s, query_elements once, then judge and report.
+- You have a strict 5-minute time limit and a limited iteration budget. Work efficiently.
+
+Efficiency guidelines (CRITICAL — work as fast as possible):
+- Do NOT query the full AX tree every single time. Query once when you first encounter a new screen, then reference the elements you found. Only re-query if your element reference fails.
+- When waiting for the app or assistant to respond, use a SINGLE wait call of 3-5 seconds, then check. Do not use many short waits.
+- If you are stuck on a step for more than 3-4 attempts, report the test as failed rather than continuing to retry.
+- Issue the report_result call AS SOON AS you have enough evidence to make a pass/fail determination. Do not perform extra verification beyond what the test requires.
 """
 
 // MARK: - Agent
@@ -48,9 +56,11 @@ func runAgent(options: AgentOptions) async throws -> TestResult {
         Message(role: "user", content: [.text("Execute the following test case:\n\n\(options.testContent)")])
     ]
 
+    let startTime = Date()
+
     for iteration in 0..<maxIterations {
         if options.verbose {
-            print("  [agent] iteration \(iteration + 1)")
+            print("  [agent] iteration \(iteration + 1)/\(maxIterations)")
         }
 
         let request = MessagesRequest(
@@ -94,9 +104,14 @@ func runAgent(options: AgentOptions) async throws -> TestResult {
 
         // If stop reason is not tool_use, the agent is done without reporting
         if response.stop_reason != "tool_use" {
+            let lastText = response.content.compactMap { block -> String? in
+                if case .text(_, let text) = block { return text }
+                return nil
+            }.joined(separator: "\n")
             return TestResult(
                 passed: false,
-                message: "Agent stopped without reporting a test result (no report_result call)."
+                message: "Agent stopped without reporting a test result (no report_result call).",
+                reasoning: lastText.isEmpty ? "The model produced no text before stopping." : lastText
             )
         }
 
@@ -124,7 +139,21 @@ func runAgent(options: AgentOptions) async throws -> TestResult {
             }
         }
 
-        messages.append(Message(role: "user", content: toolResultBlocks))
+        // Build the user message with tool results and optional budget warning
+        var userContent = toolResultBlocks
+
+        // Inject budget awareness into the tool results message
+        let elapsedMs = Int(Date().timeIntervalSince(startTime) * 1000)
+        let remainingIterations = maxIterations - iteration - 1
+        let remainingSecs = max(0, (maxTestDurationMs - elapsedMs) / 1000)
+
+        if remainingIterations <= 5 || remainingSecs <= 30 {
+            userContent.append(.text("⚠️ URGENT: You have \(remainingIterations) iterations and ~\(remainingSecs)s remaining. You MUST call report_result NOW with your best assessment of pass/fail. Do not perform any more test steps."))
+        } else if remainingIterations <= 15 || remainingSecs <= 90 {
+            userContent.append(.text("⏱️ Budget check: \(remainingIterations) iterations and ~\(remainingSecs)s remaining. Wrap up your verification and call report_result soon."))
+        }
+
+        messages.append(Message(role: "user", content: userContent))
 
         if let finalResult = finalTestResult {
             return finalResult
@@ -133,6 +162,7 @@ func runAgent(options: AgentOptions) async throws -> TestResult {
 
     return TestResult(
         passed: false,
-        message: "Agent exceeded maximum iterations (\(maxIterations)) without reporting a result."
+        message: "Agent exceeded maximum iterations (\(maxIterations)) without reporting a result.",
+        reasoning: "The agent ran for \(maxIterations) iterations without calling report_result. This likely indicates an infinite loop or the agent getting stuck."
     )
 }

--- a/playwright/agent-xcode/Sources/Agent.swift
+++ b/playwright/agent-xcode/Sources/Agent.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+// MARK: - Constants
+
+private let maxIterations = 1000
+private let model = "claude-sonnet-4-6"
+
+private let systemPrompt = """
+You are a QA test automation agent for a macOS desktop app. Execute test cases and report results.
+
+Tools:
+- query_elements: Get the AX tree — shows all interactive elements with IDs, roles, titles, values, and visible text. This is your ONLY way to see the UI.
+- click_element: Click element by ID.
+- type_into_element: Click + type text into element by ID.
+- query_and_click: Query AX tree + click matching element in one step.
+- query_and_type: Query AX tree + type into matching element in one step.
+- launch_app: Launch the app.
+- run_shell, applescript, wait: Fallbacks.
+- type_env_var: Type env var value securely (for API keys).
+- report_result: Report pass/fail. Call exactly once when done.
+
+Rules:
+- NEVER take screenshots. The AX tree has everything you need — element roles, titles, values, and all visible text.
+- Use query_and_click / query_and_type to combine discovery + action in one step.
+- Use MULTIPLE tool calls per turn (e.g. launch_app + wait together).
+- Be DECISIVE. Once you have enough info to judge pass/fail, call report_result immediately.
+- When waiting for an app response, wait 5-10s, query_elements once, then judge and report.
+"""
+
+// MARK: - Agent
+
+struct AgentOptions {
+    let testContent: String
+    let appName: String
+    let verbose: Bool
+}
+
+func runAgent(options: AgentOptions) async throws -> TestResult {
+    guard let apiKey = ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"] else {
+        return TestResult(passed: false, message: "ANTHROPIC_API_KEY environment variable is not set")
+    }
+
+    let client = AnthropicClient(apiKey: apiKey)
+    let tools = buildToolRegistry(appName: options.appName)
+    let definitions = toolDefinitions(from: tools)
+
+    var messages: [Message] = [
+        Message(role: "user", content: [.text("Execute the following test case:\n\n\(options.testContent)")])
+    ]
+
+    for iteration in 0..<maxIterations {
+        if options.verbose {
+            print("  [agent] iteration \(iteration + 1)")
+        }
+
+        let request = MessagesRequest(
+            model: model,
+            max_tokens: 4096,
+            system: systemPrompt,
+            tools: definitions,
+            messages: messages
+        )
+
+        let apiStart = Date()
+        let response = try await client.createMessage(request: request, verbose: options.verbose)
+        let apiMs = Int(Date().timeIntervalSince(apiStart) * 1000)
+
+        // Log assistant content
+        if options.verbose {
+            let tokens = response.usage.map { "in:\($0.input_tokens ?? 0) out:\($0.output_tokens ?? 0)" } ?? ""
+            print("  [agent] API call: \(apiMs)ms \(tokens)")
+            for block in response.content {
+                switch block {
+                case .text(_, let text):
+                    print("  [agent] text: \(text)")
+                case .toolUse(let id, let name, let input):
+                    print("  [agent] tool_use: \(name)(\(input)) [id: \(id)]")
+                }
+            }
+        }
+
+        // Build assistant message content blocks
+        var assistantBlocks: [ContentBlock] = []
+        for block in response.content {
+            switch block {
+            case .text(_, let text):
+                assistantBlocks.append(.text(text))
+            case .toolUse(let id, let name, let input):
+                assistantBlocks.append(.toolUse(id: id, name: name, input: input))
+            }
+        }
+
+        messages.append(Message(role: "assistant", content: assistantBlocks))
+
+        // If stop reason is not tool_use, the agent is done without reporting
+        if response.stop_reason != "tool_use" {
+            return TestResult(
+                passed: false,
+                message: "Agent stopped without reporting a test result (no report_result call)."
+            )
+        }
+
+        // Process tool calls
+        var toolResultBlocks: [ContentBlock] = []
+        var finalTestResult: TestResult?
+
+        for block in response.content {
+            guard case .toolUse(let id, let name, let input) = block else { continue }
+
+            let result = executeTool(name: name, input: input, tools: tools)
+
+            if options.verbose {
+                print("  [agent] result: \(result.success ? "ok" : "FAIL") - \(result.data ?? "")")
+            }
+
+            toolResultBlocks.append(.toolResult(
+                toolUseId: id,
+                content: [.text(result.data ?? "")],
+                isError: !result.success
+            ))
+
+            if let testResult = result.testResult {
+                finalTestResult = testResult
+            }
+        }
+
+        messages.append(Message(role: "user", content: toolResultBlocks))
+
+        if let finalResult = finalTestResult {
+            return finalResult
+        }
+    }
+
+    return TestResult(
+        passed: false,
+        message: "Agent exceeded maximum iterations (\(maxIterations)) without reporting a result."
+    )
+}

--- a/playwright/agent-xcode/Sources/AnthropicClient.swift
+++ b/playwright/agent-xcode/Sources/AnthropicClient.swift
@@ -1,0 +1,289 @@
+import Foundation
+
+// MARK: - Request Types
+
+struct MessagesRequest: Encodable {
+    let model: String
+    let max_tokens: Int
+    let system: String
+    let tools: [ToolDefinition]
+    let messages: [Message]
+}
+
+struct ToolDefinition: Encodable {
+    let name: String
+    let description: String
+    let input_schema: JSONValue
+}
+
+struct Message: Encodable {
+    let role: String
+    let content: [ContentBlock]
+}
+
+enum ContentBlock: Encodable {
+    case text(String)
+    case toolUse(id: String, name: String, input: [String: JSONValue])
+    case toolResult(toolUseId: String, content: [ToolResultContent], isError: Bool)
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .text(let text):
+            try container.encode(TextBlock(type: "text", text: text))
+        case .toolUse(let id, let name, let input):
+            try container.encode(ToolUseBlock(type: "tool_use", id: id, name: name, input: input))
+        case .toolResult(let toolUseId, let content, let isError):
+            try container.encode(ToolResultBlock(type: "tool_result", tool_use_id: toolUseId, content: content, is_error: isError))
+        }
+    }
+}
+
+struct TextBlock: Encodable {
+    let type: String
+    let text: String
+}
+
+struct ToolUseBlock: Encodable {
+    let type: String
+    let id: String
+    let name: String
+    let input: [String: JSONValue]
+}
+
+struct ToolResultBlock: Encodable {
+    let type: String
+    let tool_use_id: String
+    let content: [ToolResultContent]
+    let is_error: Bool
+}
+
+enum ToolResultContent: Encodable {
+    case text(String)
+    case image(source: ImageSource)
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .text(let text):
+            try container.encode(["type": "text", "text": text])
+        case .image(let source):
+            try container.encode(ImageContentBlock(type: "image", source: source))
+        }
+    }
+}
+
+struct ImageContentBlock: Encodable {
+    let type: String
+    let source: ImageSource
+}
+
+struct ImageSource: Encodable {
+    let type: String
+    let media_type: String
+    let data: String
+}
+
+// MARK: - Response Types
+
+struct MessagesResponse: Decodable {
+    let id: String
+    let content: [ResponseContentBlock]
+    let stop_reason: String?
+    let usage: Usage?
+}
+
+struct Usage: Decodable {
+    let input_tokens: Int?
+    let output_tokens: Int?
+}
+
+enum ResponseContentBlock: Decodable {
+    case text(id: String?, text: String)
+    case toolUse(id: String, name: String, input: [String: JSONValue])
+
+    enum CodingKeys: String, CodingKey {
+        case type, id, text, name, input
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+
+        switch type {
+        case "text":
+            let id = try container.decodeIfPresent(String.self, forKey: .id)
+            let text = try container.decode(String.self, forKey: .text)
+            self = .text(id: id, text: text)
+        case "tool_use":
+            let id = try container.decode(String.self, forKey: .id)
+            let name = try container.decode(String.self, forKey: .name)
+            let input = try container.decode([String: JSONValue].self, forKey: .input)
+            self = .toolUse(id: id, name: name, input: input)
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Unknown content type: \(type)")
+        }
+    }
+}
+
+// MARK: - JSON Value (dynamic JSON)
+
+enum JSONValue: Codable, CustomStringConvertible {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+    case object([String: JSONValue])
+    case array([JSONValue])
+    case null
+
+    var description: String {
+        switch self {
+        case .string(let s): return "\"\(s)\""
+        case .int(let i): return "\(i)"
+        case .double(let d): return "\(d)"
+        case .bool(let b): return "\(b)"
+        case .object(let o): return "\(o)"
+        case .array(let a): return "\(a)"
+        case .null: return "null"
+        }
+    }
+
+    var stringValue: String? {
+        if case .string(let s) = self { return s }
+        return nil
+    }
+
+    var intValue: Int? {
+        switch self {
+        case .int(let i): return i
+        case .double(let d): return Int(d)
+        default: return nil
+        }
+    }
+
+    var boolValue: Bool? {
+        if case .bool(let b) = self { return b }
+        return nil
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let b = try? container.decode(Bool.self) {
+            self = .bool(b)
+        } else if let i = try? container.decode(Int.self) {
+            self = .int(i)
+        } else if let d = try? container.decode(Double.self) {
+            self = .double(d)
+        } else if let s = try? container.decode(String.self) {
+            self = .string(s)
+        } else if let a = try? container.decode([JSONValue].self) {
+            self = .array(a)
+        } else if let o = try? container.decode([String: JSONValue].self) {
+            self = .object(o)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Cannot decode JSONValue")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let s): try container.encode(s)
+        case .int(let i): try container.encode(i)
+        case .double(let d): try container.encode(d)
+        case .bool(let b): try container.encode(b)
+        case .object(let o): try container.encode(o)
+        case .array(let a): try container.encode(a)
+        case .null: try container.encodeNil()
+        }
+    }
+}
+
+// MARK: - Anthropic Client
+
+final class AnthropicClient {
+    private let apiKey: String
+    private let baseURL = "https://api.anthropic.com/v1/messages"
+    private let session: URLSession
+
+    static let maxRetries = 5
+    static let initialRetryDelayMs = 5000
+
+    init(apiKey: String) {
+        self.apiKey = apiKey
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 300
+        config.timeoutIntervalForResource = 600
+        self.session = URLSession(configuration: config)
+    }
+
+    func createMessage(request: MessagesRequest, verbose: Bool = false) async throws -> MessagesResponse {
+        var lastError: Error?
+
+        for retry in 0...Self.maxRetries {
+            do {
+                return try await sendRequest(request)
+            } catch let error as APIError {
+                lastError = error
+                let isRetryable = error.statusCode == 429 || error.statusCode == 529 || error.statusCode == 503
+                if !isRetryable || retry >= Self.maxRetries {
+                    throw error
+                }
+                let delay = Self.initialRetryDelayMs * (1 << retry) // exponential backoff
+                if verbose {
+                    print("  [api] HTTP \(error.statusCode) — retrying in \(delay / 1000)s (attempt \(retry + 1)/\(Self.maxRetries))")
+                }
+                try await Task.sleep(nanoseconds: UInt64(delay) * 1_000_000)
+            } catch {
+                lastError = error
+                if retry >= Self.maxRetries {
+                    throw error
+                }
+                let delay = Self.initialRetryDelayMs * (1 << retry)
+                if verbose {
+                    print("  [api] Error: \(error.localizedDescription) — retrying in \(delay / 1000)s")
+                }
+                try await Task.sleep(nanoseconds: UInt64(delay) * 1_000_000)
+            }
+        }
+
+        throw lastError ?? APIError(statusCode: 0, message: "Unknown error")
+    }
+
+    private func sendRequest(_ request: MessagesRequest) async throws -> MessagesResponse {
+        var urlRequest = URLRequest(url: URL(string: baseURL)!)
+        urlRequest.httpMethod = "POST"
+        urlRequest.addValue(apiKey, forHTTPHeaderField: "x-api-key")
+        urlRequest.addValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        urlRequest.addValue("application/json", forHTTPHeaderField: "content-type")
+
+        let encoder = JSONEncoder()
+        urlRequest.httpBody = try encoder.encode(request)
+
+        let (data, response) = try await session.data(for: urlRequest)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError(statusCode: 0, message: "Invalid response type")
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let body = String(data: data, encoding: .utf8) ?? "No response body"
+            throw APIError(statusCode: httpResponse.statusCode, message: body)
+        }
+
+        let decoder = JSONDecoder()
+        return try decoder.decode(MessagesResponse.self, from: data)
+    }
+}
+
+struct APIError: LocalizedError {
+    let statusCode: Int
+    let message: String
+
+    var errorDescription: String? {
+        "API error \(statusCode): \(message)"
+    }
+}

--- a/playwright/agent-xcode/Sources/Fixtures.swift
+++ b/playwright/agent-xcode/Sources/Fixtures.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+struct FixtureContext {
+    let teardown: () -> Void
+}
+
+func setupFixture(_ fixtureName: String, appDisplayName: String) throws -> FixtureContext {
+    switch fixtureName {
+    case "desktop-app":
+        return try createDesktopAppFixture(appDisplayName: appDisplayName)
+    default:
+        throw FixtureError.unknownFixture(fixtureName)
+    }
+}
+
+private func createDesktopAppFixture(appDisplayName: String) throws -> FixtureContext {
+    // Resolve app path relative to the runner location
+    let cwd = FileManager.default.currentDirectoryPath
+    let appDir: String
+    if cwd.contains("agent-xcode") {
+        // Running from playwright/agent-xcode/
+        appDir = (cwd as NSString).appendingPathComponent("../../clients/macos/dist")
+    } else if cwd.contains("playwright") {
+        // Running from playwright/
+        appDir = (cwd as NSString).appendingPathComponent("../clients/macos/dist")
+    } else {
+        appDir = (cwd as NSString).appendingPathComponent("clients/macos/dist")
+    }
+
+    let appPath = (appDir as NSString).appendingPathComponent("\(appDisplayName).app")
+    let resolvedPath = (appPath as NSString).standardizingPath
+
+    guard FileManager.default.fileExists(atPath: resolvedPath) else {
+        throw FixtureError.appNotFound(resolvedPath)
+    }
+
+    // Clear previous onboarding state
+    let clearDefaults = Process()
+    clearDefaults.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+    clearDefaults.arguments = ["delete", "com.vellum.vellum-assistant"]
+    try? clearDefaults.run()
+    clearDefaults.waitUntilExit()
+
+    return FixtureContext(teardown: {
+        // Quit the app on teardown
+        let quit = Process()
+        quit.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        quit.arguments = ["-e", "tell application \"\(appDisplayName)\" to quit"]
+        try? quit.run()
+        quit.waitUntilExit()
+    })
+}
+
+enum FixtureError: LocalizedError {
+    case unknownFixture(String)
+    case appNotFound(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unknownFixture(let name): return "Unknown fixture: \(name)"
+        case .appNotFound(let path): return "Built macOS app not found at: \(path)"
+        }
+    }
+}

--- a/playwright/agent-xcode/Sources/TestCase.swift
+++ b/playwright/agent-xcode/Sources/TestCase.swift
@@ -4,11 +4,15 @@ struct TestCase {
     let name: String
     let filePath: String
     let fixture: String?
+    let requiredEnv: [String]?
+    let experimental: Bool
     let rawContent: String
 }
 
 struct ParsedFrontmatter {
     let fixture: String?
+    let requiredEnv: [String]?
+    let experimental: Bool
     let body: String
 }
 
@@ -46,15 +50,27 @@ func parseFrontmatter(_ content: String) -> ParsedFrontmatter {
     }
 
     var fixture: String?
+    var requiredEnv: [String]?
+    var experimental: Bool = false
     for line in frontmatterLines {
         let parts = line.split(separator: ":", maxSplits: 1)
-        if parts.count == 2 && parts[0].trimmingCharacters(in: .whitespaces) == "fixture" {
-            fixture = parts[1].trimmingCharacters(in: .whitespaces)
+        guard parts.count == 2 else { continue }
+        let key = parts[0].trimmingCharacters(in: .whitespaces)
+        let value = parts[1].trimmingCharacters(in: .whitespaces)
+        switch key {
+        case "fixture":
+            fixture = value
+        case "required_env":
+            requiredEnv = value.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
+        case "experimental":
+            experimental = value.lowercased() == "true"
+        default:
+            break
         }
     }
 
     let body = bodyLines.joined(separator: "\n")
-    return ParsedFrontmatter(fixture: fixture, body: body)
+    return ParsedFrontmatter(fixture: fixture, requiredEnv: requiredEnv, experimental: experimental, body: body)
 }
 
 func discoverTestCases(casesDir: String, filter: String?) -> [TestCase] {
@@ -79,7 +95,7 @@ func discoverTestCases(casesDir: String, filter: String?) -> [TestCase] {
             continue
         }
 
-        cases.append(TestCase(name: name, filePath: filePath, fixture: parsed.fixture, rawContent: rawContent))
+        cases.append(TestCase(name: name, filePath: filePath, fixture: parsed.fixture, requiredEnv: parsed.requiredEnv, experimental: parsed.experimental, rawContent: rawContent))
     }
 
     return cases

--- a/playwright/agent-xcode/Sources/TestCase.swift
+++ b/playwright/agent-xcode/Sources/TestCase.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+struct TestCase {
+    let name: String
+    let filePath: String
+    let fixture: String?
+    let rawContent: String
+}
+
+struct ParsedFrontmatter {
+    let fixture: String?
+    let body: String
+}
+
+func parseFrontmatter(_ content: String) -> ParsedFrontmatter {
+    // Match YAML frontmatter between --- delimiters
+    guard let range = content.range(of: "^---\n([\\s\\S]*?)\n---\n([\\s\\S]*)$", options: .regularExpression) else {
+        return ParsedFrontmatter(fixture: nil, body: content)
+    }
+
+    let matched = String(content[range])
+    let lines = matched.components(separatedBy: "\n")
+
+    // Find the second "---" to split frontmatter from body
+    var frontmatterLines: [String] = []
+    var bodyLines: [String] = []
+    var foundFirstDelimiter = false
+    var foundSecondDelimiter = false
+
+    for line in lines {
+        if line == "---" {
+            if !foundFirstDelimiter {
+                foundFirstDelimiter = true
+                continue
+            } else if !foundSecondDelimiter {
+                foundSecondDelimiter = true
+                continue
+            }
+        }
+
+        if foundSecondDelimiter {
+            bodyLines.append(line)
+        } else if foundFirstDelimiter {
+            frontmatterLines.append(line)
+        }
+    }
+
+    var fixture: String?
+    for line in frontmatterLines {
+        let parts = line.split(separator: ":", maxSplits: 1)
+        if parts.count == 2 && parts[0].trimmingCharacters(in: .whitespaces) == "fixture" {
+            fixture = parts[1].trimmingCharacters(in: .whitespaces)
+        }
+    }
+
+    let body = bodyLines.joined(separator: "\n")
+    return ParsedFrontmatter(fixture: fixture, body: body)
+}
+
+func discoverTestCases(casesDir: String, filter: String?) -> [TestCase] {
+    let fm = FileManager.default
+    guard let files = try? fm.contentsOfDirectory(atPath: casesDir) else {
+        return []
+    }
+
+    let mdFiles = files.filter { $0.hasSuffix(".md") }.sorted()
+    var cases: [TestCase] = []
+
+    for file in mdFiles {
+        let filePath = (casesDir as NSString).appendingPathComponent(file)
+        guard let rawContent = try? String(contentsOfFile: filePath, encoding: .utf8) else {
+            continue
+        }
+
+        let parsed = parseFrontmatter(rawContent)
+        let name = (file as NSString).deletingPathExtension
+
+        if let filter = filter, !name.contains(filter) {
+            continue
+        }
+
+        cases.append(TestCase(name: name, filePath: filePath, fixture: parsed.fixture, rawContent: rawContent))
+    }
+
+    return cases
+}

--- a/playwright/agent-xcode/Sources/Tools.swift
+++ b/playwright/agent-xcode/Sources/Tools.swift
@@ -6,6 +6,7 @@ import AppKit
 struct TestResult {
     let passed: Bool
     let message: String
+    let reasoning: String
 }
 
 // MARK: - Tool Result
@@ -557,15 +558,20 @@ private func buildReportResultTool() -> Tool {
                 ]),
                 "message": .object([
                     "type": .string("string"),
-                    "description": .string("A message describing the test result."),
+                    "description": .string("A short summary of the test outcome (e.g. 'All steps completed successfully' or 'Button not found')."),
+                ]),
+                "reasoning": .object([
+                    "type": .string("string"),
+                    "description": .string("Detailed step-by-step reasoning for why the test passed or failed. Include what you observed at each step, what you expected to see, and where things diverged if the test failed."),
                 ]),
             ]),
-            "required": .array([.string("passed"), .string("message")]),
+            "required": .array([.string("passed"), .string("message"), .string("reasoning")]),
         ]),
         execute: { input in
             let passed = input["passed"]?.boolValue ?? false
             let message = input["message"]?.stringValue ?? (passed ? "Test passed" : "Test failed")
-            return .result(TestResult(passed: passed, message: message))
+            let reasoning = input["reasoning"]?.stringValue ?? ""
+            return .result(TestResult(passed: passed, message: message, reasoning: reasoning))
         }
     )
 }

--- a/playwright/agent-xcode/Sources/Tools.swift
+++ b/playwright/agent-xcode/Sources/Tools.swift
@@ -1,0 +1,571 @@
+import Foundation
+import AppKit
+
+// MARK: - Test Result
+
+struct TestResult {
+    let passed: Bool
+    let message: String
+}
+
+// MARK: - Tool Result
+
+struct ToolResult {
+    let success: Bool
+    let data: String?
+    let testResult: TestResult?
+
+    static func ok(_ data: String) -> ToolResult {
+        ToolResult(success: true, data: data, testResult: nil)
+    }
+
+    static func error(_ data: String) -> ToolResult {
+        ToolResult(success: false, data: data, testResult: nil)
+    }
+
+    static func result(_ testResult: TestResult) -> ToolResult {
+        ToolResult(success: true, data: "Test result reported.", testResult: testResult)
+    }
+}
+
+// MARK: - Tool Protocol
+
+struct Tool {
+    let name: String
+    let description: String
+    let inputSchema: JSONValue
+    let execute: ([String: JSONValue]) -> ToolResult
+}
+
+// MARK: - Tool Registry
+
+func buildToolRegistry(appName: String) -> [Tool] {
+    let executor = ActionExecutor()
+    let enumerator = AXTreeEnumerator()
+
+    // Resolve app path: look relative to cwd for the built .app
+    let cwd = FileManager.default.currentDirectoryPath
+    let candidatePaths = [
+        "\(cwd)/../clients/macos/dist/\(appName).app",      // from playwright/agent-xcode
+        "\(cwd)/../../clients/macos/dist/\(appName).app",    // from playwright/agent-xcode/.build
+        "\(cwd)/clients/macos/dist/\(appName).app",          // from repo root
+    ]
+    let appPath = candidatePaths
+        .map { ($0 as NSString).standardizingPath }
+        .first(where: { FileManager.default.fileExists(atPath: $0) })
+
+    return [
+        buildQueryElementsTool(enumerator: enumerator, appName: appName),
+        buildClickElementTool(executor: executor),
+        buildTypeIntoElementTool(executor: executor),
+        buildQueryAndClickTool(enumerator: enumerator, executor: executor, appName: appName),
+        buildQueryAndTypeTool(enumerator: enumerator, executor: executor, appName: appName),
+        buildLaunchAppTool(appName: appName, appPath: appPath),
+        buildRunShellTool(),
+        buildWaitTool(),
+        buildTypeEnvVarTool(executor: executor),
+        buildAppleScriptTool(),
+        buildReportResultTool(),
+    ]
+}
+
+func toolDefinitions(from tools: [Tool]) -> [ToolDefinition] {
+    tools.map { ToolDefinition(name: $0.name, description: $0.description, input_schema: $0.inputSchema) }
+}
+
+func executeTool(name: String, input: [String: JSONValue], tools: [Tool]) -> ToolResult {
+    guard let tool = tools.first(where: { $0.name == name }) else {
+        return .error("Unknown tool: \(name)")
+    }
+    return tool.execute(input)
+}
+
+// MARK: - Tool Implementations
+
+private func buildQueryElementsTool(enumerator: AXTreeEnumerator, appName: String) -> Tool {
+    Tool(
+        name: "query_elements",
+        description: "Query the accessibility tree of the macOS application to discover interactive elements. Returns a list of elements with IDs that can be used with click_element and type_into_element. ALWAYS call this first before trying to interact with the UI.",
+        inputSchema: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "app_name": .object([
+                    "type": .string("string"),
+                    "description": .string("Name of the app to query. Defaults to the test app."),
+                ]),
+            ]),
+            "required": .array([]),
+        ]),
+        execute: { input in
+            let targetApp = input["app_name"]?.stringValue ?? appName
+            guard let result = enumerator.enumerateApp(named: targetApp) else {
+                return .error("Could not enumerate app '\(targetApp)'. Is it running?")
+            }
+            AXTreeEnumerator.writeStateFile(elements: result.elements)
+            let formatted = AXTreeEnumerator.formatAXTree(
+                elements: result.elements,
+                windowTitle: result.windowTitle,
+                appName: result.appName
+            )
+            return .ok(formatted)
+        }
+    )
+}
+
+private func buildClickElementTool(executor: ActionExecutor) -> Tool {
+    Tool(
+        name: "click_element",
+        description: "Click on a UI element by its ID (from query_elements). Use this instead of AppleScript for clicking buttons, checkboxes, etc.",
+        inputSchema: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "element_id": .object([
+                    "type": .string("integer"),
+                    "description": .string("The element ID from query_elements output."),
+                ]),
+            ]),
+            "required": .array([.string("element_id")]),
+        ]),
+        execute: { input in
+            guard let elementId = input["element_id"]?.intValue else {
+                return .error("element_id is required and must be an integer")
+            }
+            guard let point = AXTreeEnumerator.readCoordinates(forElementId: elementId) else {
+                return .error("Element \(elementId) not found. Call query_elements first to get fresh element IDs.")
+            }
+            do {
+                try executor.click(at: point)
+                return .ok("Clicked element \(elementId) at (\(Int(point.x)), \(Int(point.y)))")
+            } catch {
+                return .error("Click failed: \(error.localizedDescription)")
+            }
+        }
+    )
+}
+
+private func buildTypeIntoElementTool(executor: ActionExecutor) -> Tool {
+    Tool(
+        name: "type_into_element",
+        description: "Click on a UI element to focus it, then type text into it. The text is pasted via clipboard for reliability.",
+        inputSchema: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "element_id": .object([
+                    "type": .string("integer"),
+                    "description": .string("The element ID from query_elements output."),
+                ]),
+                "text": .object([
+                    "type": .string("string"),
+                    "description": .string("The text to type into the element."),
+                ]),
+            ]),
+            "required": .array([.string("element_id"), .string("text")]),
+        ]),
+        execute: { input in
+            guard let elementId = input["element_id"]?.intValue else {
+                return .error("element_id is required")
+            }
+            guard let text = input["text"]?.stringValue else {
+                return .error("text is required")
+            }
+            guard let point = AXTreeEnumerator.readCoordinates(forElementId: elementId) else {
+                return .error("Element \(elementId) not found. Call query_elements first.")
+            }
+            do {
+                try executor.click(at: point)
+                usleep(200_000) // Wait for focus
+                try executor.typeText(text)
+                return .ok("Typed \(text.count) characters into element \(elementId)")
+            } catch {
+                return .error("Type failed: \(error.localizedDescription)")
+            }
+        }
+    )
+}
+
+private func buildQueryAndClickTool(enumerator: AXTreeEnumerator, executor: ActionExecutor, appName: String) -> Tool {
+    Tool(
+        name: "query_and_click",
+        description: "Query the AX tree and click an element matching a title/role in one step. Saves a round trip vs query_elements + click_element.",
+        inputSchema: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "title": .object([
+                    "type": .string("string"),
+                    "description": .string("Text to match in the element title (case-insensitive substring match)."),
+                ]),
+                "role": .object([
+                    "type": .string("string"),
+                    "description": .string("Optional AX role to filter by (e.g. 'button', 'text field'). Matched after stripping 'AX' prefix and lowercasing."),
+                ]),
+                "app_name": .object([
+                    "type": .string("string"),
+                    "description": .string("App name to query. Defaults to the test app."),
+                ]),
+            ]),
+            "required": .array([.string("title")]),
+        ]),
+        execute: { input in
+            guard let searchTitle = input["title"]?.stringValue else {
+                return .error("title is required")
+            }
+            let targetApp = input["app_name"]?.stringValue ?? appName
+            let roleFilter = input["role"]?.stringValue?.lowercased()
+
+            guard let result = enumerator.enumerateApp(named: targetApp) else {
+                return .error("Could not enumerate app '\(targetApp)'. Is it running?")
+            }
+            AXTreeEnumerator.writeStateFile(elements: result.elements)
+
+            let flat = AXTreeEnumerator.flattenElements(result.elements)
+            let searchLower = searchTitle.lowercased()
+            let match = flat.first(where: { el in
+                let titleMatch = el.title?.lowercased().contains(searchLower) == true
+                if let roleFilter = roleFilter {
+                    let cleanedRole = el.role.hasPrefix("AX") ? String(el.role.dropFirst(2)).lowercased() : el.role.lowercased()
+                    return titleMatch && cleanedRole.contains(roleFilter)
+                }
+                return titleMatch
+            })
+
+            guard let element = match else {
+                let formatted = AXTreeEnumerator.formatAXTree(elements: result.elements, windowTitle: result.windowTitle, appName: result.appName)
+                return .error("No element matching '\(searchTitle)' found. Current tree:\n\(formatted)")
+            }
+
+            let point = CGPoint(x: element.frame.midX, y: element.frame.midY)
+            do {
+                try executor.click(at: point)
+                return .ok("Clicked [\(element.id)] \(element.role) \"\(element.title ?? "")\" at (\(Int(point.x)), \(Int(point.y)))")
+            } catch {
+                return .error("Click failed: \(error.localizedDescription)")
+            }
+        }
+    )
+}
+
+private func buildQueryAndTypeTool(enumerator: AXTreeEnumerator, executor: ActionExecutor, appName: String) -> Tool {
+    Tool(
+        name: "query_and_type",
+        description: "Query the AX tree, find an input element matching a title/placeholder, click it, and type text. Saves multiple round trips.",
+        inputSchema: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "title": .object([
+                    "type": .string("string"),
+                    "description": .string("Text to match in the element title or placeholder (case-insensitive substring)."),
+                ]),
+                "text": .object([
+                    "type": .string("string"),
+                    "description": .string("The text to type into the matched element."),
+                ]),
+                "app_name": .object([
+                    "type": .string("string"),
+                    "description": .string("App name to query. Defaults to the test app."),
+                ]),
+            ]),
+            "required": .array([.string("title"), .string("text")]),
+        ]),
+        execute: { input in
+            guard let searchTitle = input["title"]?.stringValue else {
+                return .error("title is required")
+            }
+            guard let text = input["text"]?.stringValue else {
+                return .error("text is required")
+            }
+            let targetApp = input["app_name"]?.stringValue ?? appName
+
+            guard let result = enumerator.enumerateApp(named: targetApp) else {
+                return .error("Could not enumerate app '\(targetApp)'. Is it running?")
+            }
+            AXTreeEnumerator.writeStateFile(elements: result.elements)
+
+            let flat = AXTreeEnumerator.flattenElements(result.elements)
+            let searchLower = searchTitle.lowercased()
+            let match = flat.first(where: { el in
+                let titleMatch = el.title?.lowercased().contains(searchLower) == true
+                let placeholderMatch = el.placeholderValue?.lowercased().contains(searchLower) == true
+                return titleMatch || placeholderMatch
+            })
+
+            guard let element = match else {
+                let formatted = AXTreeEnumerator.formatAXTree(elements: result.elements, windowTitle: result.windowTitle, appName: result.appName)
+                return .error("No element matching '\(searchTitle)' found. Current tree:\n\(formatted)")
+            }
+
+            let point = CGPoint(x: element.frame.midX, y: element.frame.midY)
+            do {
+                try executor.click(at: point)
+                usleep(200_000)
+                try executor.typeText(text)
+                return .ok("Typed \(text.count) chars into [\(element.id)] \(element.role) \"\(element.title ?? element.placeholderValue ?? "")\"")
+            } catch {
+                return .error("Type failed: \(error.localizedDescription)")
+            }
+        }
+    )
+}
+
+private func buildLaunchAppTool(appName: String, appPath: String?) -> Tool {
+    Tool(
+        name: "launch_app",
+        description: "Launch the macOS desktop application under test.",
+        inputSchema: .object([
+            "type": .string("object"),
+            "properties": .object([:]),
+            "required": .array([]),
+        ]),
+        execute: { _ in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+            if let appPath = appPath {
+                // Use the full path to the built .app to avoid launching a stale installed copy
+                process.arguments = ["-a", appPath]
+            } else {
+                process.arguments = ["-a", appName]
+            }
+            do {
+                try process.run()
+                process.waitUntilExit()
+                if process.terminationStatus != 0 {
+                    return .error("launch failed with exit code \(process.terminationStatus)")
+                }
+                Thread.sleep(forTimeInterval: 2.0) // Wait for app to launch
+                return .ok("Launched \(appPath ?? appName)")
+            } catch {
+                return .error("Failed to launch app: \(error.localizedDescription)")
+            }
+        }
+    )
+}
+
+private func buildRunShellTool() -> Tool {
+    Tool(
+        name: "run_shell",
+        description: "Execute a shell command and return its output. Use for inspecting files, checking process state, etc.",
+        inputSchema: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "command": .object([
+                    "type": .string("string"),
+                    "description": .string("The shell command to execute."),
+                ]),
+                "timeout_ms": .object([
+                    "type": .string("integer"),
+                    "description": .string("Timeout in milliseconds. Default: 30000."),
+                ]),
+            ]),
+            "required": .array([.string("command")]),
+        ]),
+        execute: { input in
+            guard let command = input["command"]?.stringValue else {
+                return .error("command is required")
+            }
+            let timeoutMs = input["timeout_ms"]?.intValue ?? 30000
+
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/bin/bash")
+            process.arguments = ["-c", command]
+
+            let stdout = Pipe()
+            let stderr = Pipe()
+            process.standardOutput = stdout
+            process.standardError = stderr
+
+            do {
+                try process.run()
+
+                // Timeout handling
+                let deadline = DispatchTime.now() + .milliseconds(timeoutMs)
+                let group = DispatchGroup()
+                group.enter()
+                DispatchQueue.global().async {
+                    process.waitUntilExit()
+                    group.leave()
+                }
+                let result = group.wait(timeout: deadline)
+                if result == .timedOut {
+                    process.terminate()
+                    return .error("Command timed out after \(timeoutMs)ms")
+                }
+
+                let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
+                let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+                let output = String(data: stdoutData, encoding: .utf8) ?? ""
+                let errorOutput = String(data: stderrData, encoding: .utf8) ?? ""
+
+                if process.terminationStatus != 0 {
+                    return .error("Exit code \(process.terminationStatus)\nstdout: \(output)\nstderr: \(errorOutput)")
+                }
+
+                return .ok(output + (errorOutput.isEmpty ? "" : "\nstderr: \(errorOutput)"))
+            } catch {
+                return .error("Failed to run command: \(error.localizedDescription)")
+            }
+        }
+    )
+}
+
+private func buildWaitTool() -> Tool {
+    Tool(
+        name: "wait",
+        description: "Wait for a specified number of milliseconds. Use to allow UI to settle after actions.",
+        inputSchema: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "ms": .object([
+                    "type": .string("integer"),
+                    "description": .string("Number of milliseconds to wait."),
+                ]),
+            ]),
+            "required": .array([.string("ms")]),
+        ]),
+        execute: { input in
+            let ms = input["ms"]?.intValue ?? 1000
+            Thread.sleep(forTimeInterval: Double(ms) / 1000.0)
+            return .ok("Waited \(ms)ms")
+        }
+    )
+}
+
+private func buildTypeEnvVarTool(executor: ActionExecutor) -> Tool {
+    Tool(
+        name: "type_env_var",
+        description: "Type the value of an environment variable into the currently focused input field. The value is never returned in the response — use this for secrets like API keys.",
+        inputSchema: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "env_var": .object([
+                    "type": .string("string"),
+                    "description": .string("The name of the environment variable to type."),
+                ]),
+                "element_id": .object([
+                    "type": .string("integer"),
+                    "description": .string("Optional element ID to click before typing (from query_elements)."),
+                ]),
+            ]),
+            "required": .array([.string("env_var")]),
+        ]),
+        execute: { input in
+            guard let envVarName = input["env_var"]?.stringValue else {
+                return .error("env_var is required")
+            }
+            guard let value = ProcessInfo.processInfo.environment[envVarName] else {
+                return .error("Environment variable '\(envVarName)' is not set")
+            }
+
+            // Optionally click an element first to focus it
+            if let elementId = input["element_id"]?.intValue,
+               let point = AXTreeEnumerator.readCoordinates(forElementId: elementId) {
+                do {
+                    try executor.click(at: point)
+                    usleep(200_000)
+                } catch {
+                    return .error("Failed to click element \(elementId): \(error.localizedDescription)")
+                }
+            }
+
+            do {
+                try executor.typeText(value)
+                return .ok("Typed value of \(envVarName) (\(value.count) characters)")
+            } catch {
+                return .error("Failed to type env var: \(error.localizedDescription)")
+            }
+        }
+    )
+}
+
+private func buildAppleScriptTool() -> Tool {
+    Tool(
+        name: "applescript",
+        description: "Run an AppleScript. Use this as a fallback for menu bar interactions, drag operations, or complex workflows that can't be done with query_elements/click_element. Prefer the element-based tools for simple clicks and typing.",
+        inputSchema: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "script": .object([
+                    "type": .string("string"),
+                    "description": .string("The AppleScript source to execute."),
+                ]),
+            ]),
+            "required": .array([.string("script")]),
+        ]),
+        execute: { input in
+            guard let script = input["script"]?.stringValue else {
+                return .error("script is required")
+            }
+
+            // Write script to temp file to avoid escaping issues
+            let tempPath = "/tmp/agent-xcode-applescript.scpt"
+            do {
+                try script.write(toFile: tempPath, atomically: true, encoding: .utf8)
+            } catch {
+                return .error("Failed to write script file: \(error.localizedDescription)")
+            }
+
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+            process.arguments = [tempPath]
+
+            let stdout = Pipe()
+            let stderr = Pipe()
+            process.standardOutput = stdout
+            process.standardError = stderr
+
+            do {
+                try process.run()
+
+                // 30-second timeout
+                let group = DispatchGroup()
+                group.enter()
+                DispatchQueue.global().async {
+                    process.waitUntilExit()
+                    group.leave()
+                }
+                let result = group.wait(timeout: .now() + 30)
+                if result == .timedOut {
+                    process.terminate()
+                    return .error("AppleScript timed out after 30 seconds")
+                }
+
+                let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
+                let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+                let output = String(data: stdoutData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                let errorOutput = String(data: stderrData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+                if process.terminationStatus != 0 {
+                    return .error(errorOutput.isEmpty ? "AppleScript failed with exit code \(process.terminationStatus)" : errorOutput)
+                }
+
+                return .ok(output.isEmpty ? "AppleScript executed successfully" : output)
+            } catch {
+                return .error("Failed to run AppleScript: \(error.localizedDescription)")
+            }
+        }
+    )
+}
+
+private func buildReportResultTool() -> Tool {
+    Tool(
+        name: "report_result",
+        description: "Report the final test result. Call this exactly once when the test is complete. Pass passed=true if all assertions passed, or passed=false with an explanation if any step failed.",
+        inputSchema: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "passed": .object([
+                    "type": .string("boolean"),
+                    "description": .string("Whether the test passed."),
+                ]),
+                "message": .object([
+                    "type": .string("string"),
+                    "description": .string("A message describing the test result."),
+                ]),
+            ]),
+            "required": .array([.string("passed"), .string("message")]),
+        ]),
+        execute: { input in
+            let passed = input["passed"]?.boolValue ?? false
+            let message = input["message"]?.stringValue ?? (passed ? "Test passed" : "Test failed")
+            return .result(TestResult(passed: passed, message: message))
+        }
+    )
+}

--- a/playwright/agent-xcode/Sources/main.swift
+++ b/playwright/agent-xcode/Sources/main.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+// MARK: - CLI Entry Point
+
+func main() async {
+    let args = CommandLine.arguments
+    let verbose = args.contains("--verbose")
+    let filter = args.first(where: { !$0.starts(with: "--") && $0 != args[0] })
+    let appDisplayName = ProcessInfo.processInfo.environment["APP_DISPLAY_NAME"] ?? "Vellum"
+
+    // Check accessibility permission
+    guard ActionExecutor.checkAccessibilityPermission() else {
+        print("ERROR: Accessibility permission not granted.")
+        print("Grant permission in System Settings > Privacy & Security > Accessibility")
+        exit(1)
+    }
+
+    // Discover test cases
+    let scriptPath = URL(fileURLWithPath: args[0]).deletingLastPathComponent().path
+    let casesDir: String
+    if scriptPath.contains(".build") {
+        // Running from .build/release or .build/debug — go up to playwright/cases
+        let agentXcodeDir = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        casesDir = agentXcodeDir.appendingPathComponent("../cases").standardized.path
+    } else {
+        casesDir = (scriptPath as NSString).appendingPathComponent("../cases")
+    }
+
+    let testCases = discoverTestCases(casesDir: casesDir, filter: filter)
+
+    if testCases.isEmpty {
+        print("No test cases found in \(casesDir)")
+        exit(0)
+    }
+
+    print("\nFound \(testCases.count) test case(s)\(filter != nil ? " matching \"\(filter!)\"" : ""):\n")
+    for tc in testCases {
+        let fixtureInfo = tc.fixture != nil ? " [fixture: \(tc.fixture!)]" : ""
+        print("  - \(tc.name)\(fixtureInfo)")
+    }
+    print()
+
+    // Run tests
+    var results: [(name: String, passed: Bool, message: String, durationMs: Int)] = []
+
+    for testCase in testCases {
+        print("▶ Running: \(testCase.name)")
+        let startTime = Date()
+
+        var fixtureCtx: FixtureContext?
+
+        do {
+            // Setup fixture
+            if let fixtureName = testCase.fixture {
+                fixtureCtx = try setupFixture(fixtureName, appDisplayName: appDisplayName)
+            }
+
+            // Parse content
+            let parsed = parseFrontmatter(testCase.rawContent)
+
+            // Run agent
+            let result = try await runAgent(options: AgentOptions(
+                testContent: parsed.body,
+                appName: appDisplayName,
+                verbose: verbose
+            ))
+
+            let durationMs = Int(Date().timeIntervalSince(startTime) * 1000)
+            results.append((name: testCase.name, passed: result.passed, message: result.message, durationMs: durationMs))
+
+            let icon = result.passed ? "✓" : "✗"
+            let duration = String(format: "%.1f", Double(durationMs) / 1000.0)
+            print("  \(icon) \(testCase.name) (\(duration)s)")
+            if !result.passed {
+                print("    \(result.message)")
+            }
+            print()
+        } catch {
+            let durationMs = Int(Date().timeIntervalSince(startTime) * 1000)
+            results.append((name: testCase.name, passed: false, message: "Runner error: \(error.localizedDescription)", durationMs: durationMs))
+            let duration = String(format: "%.1f", Double(durationMs) / 1000.0)
+            print("  ✗ \(testCase.name) (\(duration)s)")
+            print("    Runner error: \(error.localizedDescription)")
+            print()
+        }
+
+        // Teardown fixture
+        fixtureCtx?.teardown()
+    }
+
+    // Summary
+    let passed = results.filter { $0.passed }.count
+    let failed = results.filter { !$0.passed }.count
+    let totalDuration = results.reduce(0) { $0 + $1.durationMs }
+
+    print(String(repeating: "─", count: 60))
+    print("Results: \(passed) passed, \(failed) failed (\(String(format: "%.1f", Double(totalDuration) / 1000.0))s total)")
+    print(String(repeating: "─", count: 60))
+
+    exit(failed > 0 ? 1 : 0)
+}
+
+// Run the async main
+let semaphore = DispatchSemaphore(value: 0)
+Task {
+    await main()
+    semaphore.signal()
+}
+semaphore.wait()

--- a/playwright/agent-xcode/Sources/main.swift
+++ b/playwright/agent-xcode/Sources/main.swift
@@ -5,6 +5,7 @@ import Foundation
 func main() async {
     let args = CommandLine.arguments
     let verbose = args.contains("--verbose")
+    let runExperimental = args.contains("--experimental") || ProcessInfo.processInfo.environment["RUN_EXPERIMENTAL"] != nil
     let filter = args.first(where: { !$0.starts(with: "--") && $0 != args[0] })
     let appDisplayName = ProcessInfo.processInfo.environment["APP_DISPLAY_NAME"] ?? "Vellum"
 
@@ -41,9 +42,27 @@ func main() async {
     print()
 
     // Run tests
-    var results: [(name: String, passed: Bool, message: String, durationMs: Int)] = []
+    var results: [(name: String, passed: Bool, message: String, reasoning: String, durationMs: Int)] = []
+    var skipped: [String] = []
 
     for testCase in testCases {
+        // Skip experimental tests unless --experimental or RUN_EXPERIMENTAL is set
+        if testCase.experimental && !runExperimental {
+            skipped.append(testCase.name)
+            print("⏭ Skipping (experimental): \(testCase.name)")
+            continue
+        }
+
+        // Check required env vars
+        if let requiredEnv = testCase.requiredEnv {
+            let missing = requiredEnv.filter { ProcessInfo.processInfo.environment[$0] == nil }
+            if !missing.isEmpty {
+                skipped.append(testCase.name)
+                print("⏭ Skipping (missing env: \(missing.joined(separator: ", "))): \(testCase.name)")
+                continue
+            }
+        }
+
         print("▶ Running: \(testCase.name)")
         let startTime = Date()
 
@@ -66,18 +85,21 @@ func main() async {
             ))
 
             let durationMs = Int(Date().timeIntervalSince(startTime) * 1000)
-            results.append((name: testCase.name, passed: result.passed, message: result.message, durationMs: durationMs))
+            results.append((name: testCase.name, passed: result.passed, message: result.message, reasoning: result.reasoning, durationMs: durationMs))
 
             let icon = result.passed ? "✓" : "✗"
             let duration = String(format: "%.1f", Double(durationMs) / 1000.0)
             print("  \(icon) \(testCase.name) (\(duration)s)")
             if !result.passed {
                 print("    \(result.message)")
+                if !result.reasoning.isEmpty {
+                    print("    Reasoning: \(result.reasoning)")
+                }
             }
             print()
         } catch {
             let durationMs = Int(Date().timeIntervalSince(startTime) * 1000)
-            results.append((name: testCase.name, passed: false, message: "Runner error: \(error.localizedDescription)", durationMs: durationMs))
+            results.append((name: testCase.name, passed: false, message: "Runner error: \(error.localizedDescription)", reasoning: "An unexpected error occurred in the runner before the agent could report a result.", durationMs: durationMs))
             let duration = String(format: "%.1f", Double(durationMs) / 1000.0)
             print("  ✗ \(testCase.name) (\(duration)s)")
             print("    Runner error: \(error.localizedDescription)")
@@ -94,8 +116,30 @@ func main() async {
     let totalDuration = results.reduce(0) { $0 + $1.durationMs }
 
     print(String(repeating: "─", count: 60))
-    print("Results: \(passed) passed, \(failed) failed (\(String(format: "%.1f", Double(totalDuration) / 1000.0))s total)")
+    var summaryParts = ["\(passed) passed", "\(failed) failed"]
+    if !skipped.isEmpty {
+        summaryParts.append("\(skipped.count) skipped")
+    }
+    print("Results: \(summaryParts.joined(separator: ", ")) (\(String(format: "%.1f", Double(totalDuration) / 1000.0))s total)")
     print(String(repeating: "─", count: 60))
+
+    // Write JSON test report for artifact consumption
+    let reportDir = (casesDir as NSString).appendingPathComponent("../../test-results")
+    let resolvedReportDir = (reportDir as NSString).standardizingPath
+    try? FileManager.default.createDirectory(atPath: resolvedReportDir, withIntermediateDirectories: true)
+    let report: [[String: Any]] = results.map { r in
+        [
+            "name": r.name,
+            "passed": r.passed,
+            "message": r.message,
+            "reasoning": r.reasoning,
+            "durationMs": r.durationMs,
+        ]
+    }
+    if let jsonData = try? JSONSerialization.data(withJSONObject: ["tests": report], options: [.prettyPrinted, .sortedKeys]) {
+        let reportPath = (resolvedReportDir as NSString).appendingPathComponent("test-report.json")
+        try? jsonData.write(to: URL(fileURLWithPath: reportPath))
+    }
 
     exit(failed > 0 ? 1 : 0)
 }


### PR DESCRIPTION
Adds an all-Swift agent test runner at `playwright/agent-xcode/` that uses AXUIElement APIs directly instead of Playwright + AppleScript, and syncs improvements from the TypeScript agent runner (reasoning field, budget awareness, efficiency guidelines, experimental/required_env frontmatter, JSON report output).

## Summary
- Standalone Swift CLI at `playwright/agent-xcode/` that queries the macOS accessibility tree for structured element data (IDs, roles, titles, coordinates, visible text) via `query_elements`
- No screenshots needed — the AX tree provides everything, eliminating expensive base64 image round-trips
- Combo tools (`query_and_click`, `query_and_type`) reduce API iterations by combining discovery + action in one step
- Uses `claude-sonnet-4-6` for faster/cheaper test runs
- Rebased onto main and ported TS runner improvements: `reasoning` field on `report_result`, iteration/time budget warnings, efficiency guidelines in system prompt, `experimental`/`required_env` frontmatter support, JSON test report output

## Review & Testing Checklist for Human
- [ ] **Build verification**: Run `swift build -c release` in `playwright/agent-xcode/` — this is macOS-only Swift code that cannot be validated by Linux CI
- [ ] **Interactive+container AX node children**: `AXTabGroup` is in both `interactiveRoles` and `containerRoles`, but interactive nodes return `children: []` (line ~170 of AXTree.swift). This means nested controls inside tab groups are invisible to the agent. Consider whether this needs fixing before merge.
- [ ] **No hard timeout enforcement**: The Swift agent loop injects budget *warnings* but doesn't abort when `maxTestDurationMs` is exceeded (unlike the TS version which uses `AbortSignal`). Verify this is acceptable or add a hard timeout.
- [ ] **Run at least one test case end-to-end** (e.g. `privacy-and-boundaries`) to confirm the reasoning field flows correctly through `report_result` → `TestResult` → runner output + JSON report
- [ ] **Verify `hatch-gcp-assistant` is correctly skipped** as experimental when `--experimental` is not passed

### Notes
Originally generated with [Claude Code](https://claude.com/claude-code), rebased and synced by Devin.

---

- Requested by: @dvargas92495
- Session: https://app.devin.ai/sessions/835285f9fac54e8da44192f671a3a3be
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
