### PR TITLE
feat: forward hatch logs to XDG-compatible location

### DIFF
--- a/assistant/src/util/logger.ts
+++ b/assistant/src/util/logger.ts
@@ -99,6 +99,16 @@ function buildRotatingLogger(config: LogFileConfig): pino.Logger {
     );
   }
 
+  // When stdout is not a TTY (e.g. desktop app redirects to a hatch log file),
+  // write to the rotating file only — the hatch log already captured early
+  // startup output and echoing pino output there is unnecessary duplication.
+  if (!process.stdout.isTTY) {
+    return pino(
+      { name: 'assistant', level, serializers: logSerializers },
+      fileStream,
+    );
+  }
+
   return pino(
     { name: 'assistant', level, serializers: logSerializers },
     pino.multistream([

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawn } from "child_process";
-import { existsSync, mkdirSync, openSync, readFileSync, unlinkSync, writeFileSync } from "fs";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import { createRequire } from "module";
 import { createConnection } from "net";
 import { homedir } from "os";
@@ -18,11 +18,24 @@ function getHatchLogDir(): string {
 }
 
 /** Open (or create) a log file in append mode, returning the file descriptor.
- *  Creates the parent directory if it doesn't exist. */
-function openHatchLogFile(name: string): number {
-  const dir = getHatchLogDir();
-  mkdirSync(dir, { recursive: true });
-  return openSync(join(dir, name), "a");
+ *  Creates the parent directory if it doesn't exist. Returns "ignore" if the
+ *  directory or file cannot be created (permissions, read-only filesystem, etc.)
+ *  so that spawn falls back to discarding output instead of aborting startup. */
+function openHatchLogFile(name: string): number | "ignore" {
+  try {
+    const dir = getHatchLogDir();
+    mkdirSync(dir, { recursive: true });
+    return openSync(join(dir, name), "a");
+  } catch {
+    return "ignore";
+  }
+}
+
+/** Close a file descriptor returned by openHatchLogFile (no-op for "ignore"). */
+function closeHatchLogFile(fd: number | "ignore"): void {
+  if (typeof fd === "number") {
+    try { closeSync(fd); } catch { /* best-effort */ }
+  }
 }
 
 function isAssistantSourceDir(dir: string): boolean {
@@ -391,18 +404,24 @@ export async function startLocalDaemon(): Promise<void> {
       }
 
       const daemonLogFd = openHatchLogFile("daemon.log");
-      const child = spawn(daemonBinary, [], {
-        cwd: dirname(daemonBinary),
-        detached: true,
-        stdio: ["ignore", daemonLogFd, daemonLogFd],
-        env: daemonEnv,
-      });
-      child.unref();
+      let daemonPid: number | undefined;
+      try {
+        const child = spawn(daemonBinary, [], {
+          cwd: dirname(daemonBinary),
+          detached: true,
+          stdio: ["ignore", daemonLogFd, daemonLogFd],
+          env: daemonEnv,
+        });
+        child.unref();
+        daemonPid = child.pid;
+      } finally {
+        closeHatchLogFile(daemonLogFd);
+      }
 
       // Write PID file immediately so the health monitor can find the process
       // and concurrent hatch() calls see it as alive.
-      if (child.pid) {
-        writeFileSync(pidFile, String(child.pid), "utf-8");
+      if (daemonPid) {
+        writeFileSync(pidFile, String(daemonPid), "utf-8");
       }
     }
 
@@ -550,21 +569,29 @@ export async function startGateway(assistantId?: string): Promise<string> {
     }
 
     const gatewayLogFd = openHatchLogFile("gateway.log");
-    gateway = spawn(gatewayBinary, [], {
-      detached: true,
-      stdio: ["ignore", gatewayLogFd, gatewayLogFd],
-      env: gatewayEnv,
-    });
+    try {
+      gateway = spawn(gatewayBinary, [], {
+        detached: true,
+        stdio: ["ignore", gatewayLogFd, gatewayLogFd],
+        env: gatewayEnv,
+      });
+    } finally {
+      closeHatchLogFile(gatewayLogFd);
+    }
   } else {
     // Source tree / bunx: resolve the gateway source directory and run via bun.
     const gatewayDir = resolveGatewayDir();
     const gwLogFd = openHatchLogFile("gateway.log");
-    gateway = spawn("bun", ["run", "src/index.ts"], {
-      cwd: gatewayDir,
-      detached: true,
-      stdio: ["ignore", gwLogFd, gwLogFd],
-      env: gatewayEnv,
-    });
+    try {
+      gateway = spawn("bun", ["run", "src/index.ts"], {
+        cwd: gatewayDir,
+        detached: true,
+        stdio: ["ignore", gwLogFd, gwLogFd],
+        env: gatewayEnv,
+      });
+    } finally {
+      closeHatchLogFile(gwLogFd);
+    }
   }
 
   gateway.unref();

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawn } from "child_process";
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, openSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import { createRequire } from "module";
 import { createConnection } from "net";
 import { homedir } from "os";
@@ -10,6 +10,20 @@ import { GATEWAY_PORT } from "./constants.js";
 import { stopProcessByPidFile } from "./process.js";
 
 const _require = createRequire(import.meta.url);
+
+/** Returns the XDG-compatible log directory for Vellum hatch logs. */
+function getHatchLogDir(): string {
+  const configHome = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+  return join(configHome, "vellum", "logs");
+}
+
+/** Open (or create) a log file in append mode, returning the file descriptor.
+ *  Creates the parent directory if it doesn't exist. */
+function openHatchLogFile(name: string): number {
+  const dir = getHatchLogDir();
+  mkdirSync(dir, { recursive: true });
+  return openSync(join(dir, name), "a");
+}
 
 function isAssistantSourceDir(dir: string): boolean {
   const pkgPath = join(dir, "package.json");
@@ -376,10 +390,11 @@ export async function startLocalDaemon(): Promise<void> {
         }
       }
 
+      const daemonLogFd = openHatchLogFile("daemon.log");
       const child = spawn(daemonBinary, [], {
         cwd: dirname(daemonBinary),
         detached: true,
-        stdio: "ignore",
+        stdio: ["ignore", daemonLogFd, daemonLogFd],
         env: daemonEnv,
       });
       child.unref();
@@ -534,18 +549,20 @@ export async function startGateway(assistantId?: string): Promise<string> {
       );
     }
 
+    const gatewayLogFd = openHatchLogFile("gateway.log");
     gateway = spawn(gatewayBinary, [], {
       detached: true,
-      stdio: "ignore",
+      stdio: ["ignore", gatewayLogFd, gatewayLogFd],
       env: gatewayEnv,
     });
   } else {
     // Source tree / bunx: resolve the gateway source directory and run via bun.
     const gatewayDir = resolveGatewayDir();
+    const gwLogFd = openHatchLogFile("gateway.log");
     gateway = spawn("bun", ["run", "src/index.ts"], {
       cwd: gatewayDir,
       detached: true,
-      stdio: "ignore",
+      stdio: ["ignore", gwLogFd, gwLogFd],
       env: gatewayEnv,
     });
   }


### PR DESCRIPTION
## Summary

- Redirects daemon and gateway process stdout/stderr to `~/.config/vellum/logs/daemon.log` and `gateway.log` (respects `XDG_CONFIG_HOME`) instead of discarding with `stdio: "ignore"`
- Captures early startup failures that occur before the daemon's own pino logger initializes (e.g. before `~/.vellum/workspace` is created)
- Applies to all three spawn sites: desktop daemon binary, desktop gateway binary, and source-tree gateway

## Context

When the desktop app runs a local hatch (`vellum-cli hatch -d`), the daemon and gateway are spawned as detached processes. Previously their stdio was set to `"ignore"`, meaning all output went to `/dev/null`. If either process crashed before creating `~/.vellum/workspace/` and initializing its rotating log files, there was zero diagnostic output available — `~/.vellum/workspace` would be empty and the user would see "A background process may have crashed" with no way to investigate.

## Test plan

- [ ] Verify `~/.config/vellum/logs/daemon.log` and `gateway.log` are created after a local hatch from the desktop app
- [ ] Verify log files capture daemon/gateway output (startup messages, errors)
- [ ] Verify files append across restarts (no data loss on re-hatch)
- [ ] Verify custom `XDG_CONFIG_HOME` is respected if set

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
