### PR TITLE
fix: address latent review feedback on pointer generation hardening

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -376,14 +376,15 @@ export async function runDaemon(): Promise<void> {
 
         // Constrain pointer generation to a tool-disabled path so call-
         // status events cannot trigger unintended side-effect tools.
-        // Setting toolsDisabled causes the resolveTools callback to return
-        // an empty tool list, preventing the LLM from seeing or invoking
-        // any tools during the pointer agent loop.
+        // Incrementing toolsDisabledDepth causes the resolveTools callback
+        // to return an empty tool list, preventing the LLM from seeing or
+        // invoking any tools during the pointer agent loop.
         //
-        // The outer try/finally ensures toolsDisabled is always reset even
-        // if persistUserMessage or any other step throws before the agent
-        // loop's own try/finally would run.
-        session.toolsDisabled = true;
+        // A depth counter (rather than a boolean) ensures that overlapping
+        // pointer requests on the same session don't clear each other's
+        // constraint — each caller increments on entry and decrements in
+        // its own finally block.
+        session.toolsDisabledDepth++;
         try {
           const messageId = await session.persistUserMessage(
             instruction,
@@ -468,7 +469,7 @@ export async function runDaemon(): Promise<void> {
           }
         } finally {
           // Restore tool availability so subsequent turns aren't affected.
-          session.toolsDisabled = false;
+          session.toolsDisabledDepth--;
         }
       });
       runtimeHttp.setPairingBroadcast((msg) => server.broadcast(msg as ServerMessage));

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -376,8 +376,10 @@ export async function runDaemon(): Promise<void> {
 
         // Constrain pointer generation to a tool-disabled path so call-
         // status events cannot trigger unintended side-effect tools.
-        const prevAllowedTools = session.allowedToolNames;
-        session.allowedToolNames = new Set<string>();
+        // Setting toolsDisabled causes the resolveTools callback to return
+        // an empty tool list, preventing the LLM from seeing or invoking
+        // any tools during the pointer agent loop.
+        session.toolsDisabled = true;
 
         const messageId = await session.persistUserMessage(
           instruction,
@@ -411,9 +413,8 @@ export async function runDaemon(): Promise<void> {
             }
           });
         } finally {
-          // Restore previous tool allowlist so subsequent turns aren't
-          // affected by the pointer generation constraint.
-          session.allowedToolNames = prevAllowedTools;
+          // Restore tool availability so subsequent turns aren't affected.
+          session.toolsDisabled = false;
         }
         if (agentLoopError) {
           // Remove any assistant messages persisted during the failed run
@@ -434,14 +435,21 @@ export async function runDaemon(): Promise<void> {
         // outcome keyword, etc.). If the model omitted or rewrote them,
         // remove both the instruction and generated messages and throw so
         // the deterministic fallback fires.
+        //
+        // Find the assistant message generated *after* the pointer
+        // instruction (messageId) rather than the conversation-wide latest,
+        // because runAgentLoop's finally block may drain queued work that
+        // appends unrelated assistant messages.
         if (requiredFacts && requiredFacts.length > 0) {
           const allMessages = conversationStore.getMessages(conversationId);
-          const assistantMessages = allMessages.filter((m) => m.role === 'assistant');
-          const latest = assistantMessages[assistantMessages.length - 1];
-          if (latest) {
+          const instructionIdx = allMessages.findIndex((m) => m.id === messageId);
+          const pointerReply = instructionIdx >= 0
+            ? allMessages.find((m, i) => i > instructionIdx && m.role === 'assistant')
+            : undefined;
+          if (pointerReply) {
             let generatedText = '';
             try {
-              const blocks = JSON.parse(latest.content) as Array<{ type: string; text?: string }>;
+              const blocks = JSON.parse(pointerReply.content) as Array<{ type: string; text?: string }>;
               generatedText = blocks
                 .filter((b) => b.type === 'text')
                 .map((b) => b.text ?? '')
@@ -454,7 +462,7 @@ export async function runDaemon(): Promise<void> {
                 { conversationId, missingFacts },
                 'Generated pointer text failed fact validation — falling back to deterministic',
               );
-              await rollback([latest.id]);
+              await rollback([pointerReply.id]);
               throw new Error('Generated pointer text failed fact validation');
             }
           }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -406,8 +406,19 @@ export async function runDaemon(): Promise<void> {
             try { await session.loadFromDb(); } catch { /* best effort */ }
           };
 
+          // Snapshot message IDs before the agent loop so we can diff
+          // afterwards to find exactly which messages this run created,
+          // avoiding positional heuristics that break under concurrency.
+          const preRunMessageIds = new Set(
+            conversationStore.getMessages(conversationId).map((m) => m.id),
+          );
+
           let agentLoopError: string | undefined;
+          let generatedText = '';
           await session.runAgentLoop(instruction, messageId, (msg) => {
+            if ('type' in msg && msg.type === 'assistant_text_delta' && 'text' in msg) {
+              generatedText += (msg as { text: string }).text;
+            }
             if ('type' in msg && (msg.type === 'error' || msg.type === 'session_error')) {
               agentLoopError = 'message' in msg
                 ? (msg as { message: string }).message
@@ -416,17 +427,18 @@ export async function runDaemon(): Promise<void> {
                   : 'Agent loop failed';
             }
           });
+
+          // Identify messages created during this run by diffing against
+          // the pre-run snapshot. This is race-safe: only messages that
+          // appeared in this conversation during *our* agent loop are
+          // considered, regardless of concurrent pointer events.
+          const postRunMessages = conversationStore.getMessages(conversationId);
+          const createdMessageIds = postRunMessages
+            .filter((m) => !preRunMessageIds.has(m.id) && m.id !== messageId)
+            .map((m) => m.id);
+
           if (agentLoopError) {
-            // Remove any assistant messages persisted during the failed run
-            // (e.g. session_error text) so the deterministic fallback is the
-            // only visible pointer output for this event. Scope to the
-            // assistant message immediately following the instruction to
-            // avoid deleting messages from other concurrent turns.
-            const allMsgs = conversationStore.getMessages(conversationId);
-            const instrIdx = allMsgs.findIndex((m) => m.id === messageId);
-            const nextMsg = instrIdx >= 0 ? allMsgs[instrIdx + 1] : undefined;
-            const extraIds = nextMsg && nextMsg.role === 'assistant' ? [nextMsg.id] : [];
-            await rollback(extraIds);
+            await rollback(createdMessageIds);
             throw new Error(agentLoopError);
           }
 
@@ -436,35 +448,19 @@ export async function runDaemon(): Promise<void> {
           // remove both the instruction and generated messages and throw so
           // the deterministic fallback fires.
           //
-          // Find the assistant message generated *after* the pointer
-          // instruction (messageId) rather than the conversation-wide latest,
-          // because runAgentLoop's finally block may drain queued work that
-          // appends unrelated assistant messages.
+          // Validation uses text accumulated from assistant_text_delta
+          // events during the agent loop rather than a DB lookup, avoiding
+          // any positional ambiguity when concurrent pointer events
+          // interleave messages in the conversation.
           if (requiredFacts && requiredFacts.length > 0) {
-            const allMessages = conversationStore.getMessages(conversationId);
-            const instructionIdx = allMessages.findIndex((m) => m.id === messageId);
-            const pointerReply = instructionIdx >= 0
-              ? allMessages.find((m, i) => i > instructionIdx && m.role === 'assistant')
-              : undefined;
-            if (pointerReply) {
-              let generatedText = '';
-              try {
-                const blocks = JSON.parse(pointerReply.content) as Array<{ type: string; text?: string }>;
-                generatedText = blocks
-                  .filter((b) => b.type === 'text')
-                  .map((b) => b.text ?? '')
-                  .join('');
-              } catch { /* non-JSON content — treat as empty */ }
-
-              const missingFacts = requiredFacts.filter((fact) => !generatedText.includes(fact));
-              if (missingFacts.length > 0) {
-                log.warn(
-                  { conversationId, missingFacts },
-                  'Generated pointer text failed fact validation — falling back to deterministic',
-                );
-                await rollback([pointerReply.id]);
-                throw new Error('Generated pointer text failed fact validation');
-              }
+            const missingFacts = requiredFacts.filter((fact) => !generatedText.includes(fact));
+            if (missingFacts.length > 0) {
+              log.warn(
+                { conversationId, missingFacts },
+                'Generated pointer text failed fact validation — falling back to deterministic',
+              );
+              await rollback(createdMessageIds);
+              throw new Error('Generated pointer text failed fact validation');
             }
           }
         } finally {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -379,30 +379,33 @@ export async function runDaemon(): Promise<void> {
         // Setting toolsDisabled causes the resolveTools callback to return
         // an empty tool list, preventing the LLM from seeing or invoking
         // any tools during the pointer agent loop.
+        //
+        // The outer try/finally ensures toolsDisabled is always reset even
+        // if persistUserMessage or any other step throws before the agent
+        // loop's own try/finally would run.
         session.toolsDisabled = true;
-
-        const messageId = await session.persistUserMessage(
-          instruction,
-          [],
-          undefined,
-          { pointerInstruction: true },
-          '[Call status event]',
-        );
-
-        // Helper: roll back persisted messages on failure, then reload
-        // in-memory history from the (now cleaned) DB. Reloading avoids
-        // stale-index issues when context compaction reassigns the
-        // messages array during runAgentLoop.
-        const rollback = async (extraMessageIds?: string[]) => {
-          try { conversationStore.deleteMessageById(messageId); } catch { /* best effort */ }
-          for (const id of extraMessageIds ?? []) {
-            try { conversationStore.deleteMessageById(id); } catch { /* best effort */ }
-          }
-          try { await session.loadFromDb(); } catch { /* best effort */ }
-        };
-
-        let agentLoopError: string | undefined;
         try {
+          const messageId = await session.persistUserMessage(
+            instruction,
+            [],
+            undefined,
+            { pointerInstruction: true },
+            '[Call status event]',
+          );
+
+          // Helper: roll back persisted messages on failure, then reload
+          // in-memory history from the (now cleaned) DB. Reloading avoids
+          // stale-index issues when context compaction reassigns the
+          // messages array during runAgentLoop.
+          const rollback = async (extraMessageIds?: string[]) => {
+            try { conversationStore.deleteMessageById(messageId); } catch { /* best effort */ }
+            for (const id of extraMessageIds ?? []) {
+              try { conversationStore.deleteMessageById(id); } catch { /* best effort */ }
+            }
+            try { await session.loadFromDb(); } catch { /* best effort */ }
+          };
+
+          let agentLoopError: string | undefined;
           await session.runAgentLoop(instruction, messageId, (msg) => {
             if ('type' in msg && (msg.type === 'error' || msg.type === 'session_error')) {
               agentLoopError = 'message' in msg
@@ -412,60 +415,60 @@ export async function runDaemon(): Promise<void> {
                   : 'Agent loop failed';
             }
           });
+          if (agentLoopError) {
+            // Remove any assistant messages persisted during the failed run
+            // (e.g. session_error text) so the deterministic fallback is the
+            // only visible pointer output for this event. Scope to the
+            // assistant message immediately following the instruction to
+            // avoid deleting messages from other concurrent turns.
+            const allMsgs = conversationStore.getMessages(conversationId);
+            const instrIdx = allMsgs.findIndex((m) => m.id === messageId);
+            const nextMsg = instrIdx >= 0 ? allMsgs[instrIdx + 1] : undefined;
+            const extraIds = nextMsg && nextMsg.role === 'assistant' ? [nextMsg.id] : [];
+            await rollback(extraIds);
+            throw new Error(agentLoopError);
+          }
+
+          // Post-generation fact check: verify the assistant's response
+          // includes all required factual details (phone number, duration,
+          // outcome keyword, etc.). If the model omitted or rewrote them,
+          // remove both the instruction and generated messages and throw so
+          // the deterministic fallback fires.
+          //
+          // Find the assistant message generated *after* the pointer
+          // instruction (messageId) rather than the conversation-wide latest,
+          // because runAgentLoop's finally block may drain queued work that
+          // appends unrelated assistant messages.
+          if (requiredFacts && requiredFacts.length > 0) {
+            const allMessages = conversationStore.getMessages(conversationId);
+            const instructionIdx = allMessages.findIndex((m) => m.id === messageId);
+            const pointerReply = instructionIdx >= 0
+              ? allMessages.find((m, i) => i > instructionIdx && m.role === 'assistant')
+              : undefined;
+            if (pointerReply) {
+              let generatedText = '';
+              try {
+                const blocks = JSON.parse(pointerReply.content) as Array<{ type: string; text?: string }>;
+                generatedText = blocks
+                  .filter((b) => b.type === 'text')
+                  .map((b) => b.text ?? '')
+                  .join('');
+              } catch { /* non-JSON content — treat as empty */ }
+
+              const missingFacts = requiredFacts.filter((fact) => !generatedText.includes(fact));
+              if (missingFacts.length > 0) {
+                log.warn(
+                  { conversationId, missingFacts },
+                  'Generated pointer text failed fact validation — falling back to deterministic',
+                );
+                await rollback([pointerReply.id]);
+                throw new Error('Generated pointer text failed fact validation');
+              }
+            }
+          }
         } finally {
           // Restore tool availability so subsequent turns aren't affected.
           session.toolsDisabled = false;
-        }
-        if (agentLoopError) {
-          // Remove any assistant messages persisted during the failed run
-          // (e.g. session_error text) so the deterministic fallback is the
-          // only visible pointer output for this event. Scope to the
-          // assistant message immediately following the instruction to
-          // avoid deleting messages from other concurrent turns.
-          const allMsgs = conversationStore.getMessages(conversationId);
-          const instrIdx = allMsgs.findIndex((m) => m.id === messageId);
-          const nextMsg = instrIdx >= 0 ? allMsgs[instrIdx + 1] : undefined;
-          const extraIds = nextMsg && nextMsg.role === 'assistant' ? [nextMsg.id] : [];
-          await rollback(extraIds);
-          throw new Error(agentLoopError);
-        }
-
-        // Post-generation fact check: verify the assistant's response
-        // includes all required factual details (phone number, duration,
-        // outcome keyword, etc.). If the model omitted or rewrote them,
-        // remove both the instruction and generated messages and throw so
-        // the deterministic fallback fires.
-        //
-        // Find the assistant message generated *after* the pointer
-        // instruction (messageId) rather than the conversation-wide latest,
-        // because runAgentLoop's finally block may drain queued work that
-        // appends unrelated assistant messages.
-        if (requiredFacts && requiredFacts.length > 0) {
-          const allMessages = conversationStore.getMessages(conversationId);
-          const instructionIdx = allMessages.findIndex((m) => m.id === messageId);
-          const pointerReply = instructionIdx >= 0
-            ? allMessages.find((m, i) => i > instructionIdx && m.role === 'assistant')
-            : undefined;
-          if (pointerReply) {
-            let generatedText = '';
-            try {
-              const blocks = JSON.parse(pointerReply.content) as Array<{ type: string; text?: string }>;
-              generatedText = blocks
-                .filter((b) => b.type === 'text')
-                .map((b) => b.text ?? '')
-                .join('');
-            } catch { /* non-JSON content — treat as empty */ }
-
-            const missingFacts = requiredFacts.filter((fact) => !generatedText.includes(fact));
-            if (missingFacts.length > 0) {
-              log.warn(
-                { conversationId, missingFacts },
-                'Generated pointer text failed fact validation — falling back to deterministic',
-              );
-              await rollback([pointerReply.id]);
-              throw new Error('Generated pointer text failed fact validation');
-            }
-          }
         }
       });
       runtimeHttp.setPairingBroadcast((msg) => server.broadcast(msg as ServerMessage));

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -111,6 +111,7 @@ export interface AgentLoopSessionContext {
 
   readonly coreToolNames: Set<string>;
   allowedToolNames?: Set<string>;
+  toolsDisabled?: boolean;
   preactivatedSkillIds?: string[];
   readonly skillProjectionState: Map<string, string>;
   readonly skillProjectionCache: SkillProjectionCache;

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -111,7 +111,7 @@ export interface AgentLoopSessionContext {
 
   readonly coreToolNames: Set<string>;
   allowedToolNames?: Set<string>;
-  toolsDisabled?: boolean;
+  toolsDisabledDepth: number;
   preactivatedSkillIds?: string[];
   readonly skillProjectionState: Map<string, string>;
   readonly skillProjectionCache: SkillProjectionCache;

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -307,6 +307,8 @@ export interface SkillProjectionContext {
   readonly skillProjectionCache: SkillProjectionCache;
   readonly coreToolNames: Set<string>;
   allowedToolNames?: Set<string>;
+  /** When true, the resolveTools callback returns no tools at all. */
+  toolsDisabled?: boolean;
 }
 
 /**
@@ -322,6 +324,14 @@ export function createResolveToolsCallback(
   if (toolDefs.length === 0) return undefined;
 
   return (history: Message[]) => {
+    // When tools are explicitly disabled (e.g. during pointer generation),
+    // return an empty tool list so the LLM never sees tool definitions and
+    // keep the allowlist empty so no tool execution can slip through.
+    if (ctx.toolsDisabled) {
+      ctx.allowedToolNames = new Set<string>();
+      return [];
+    }
+
     const effectivePreactivated = [
       ...DEFAULT_PREACTIVATED_SKILL_IDS,
       ...(ctx.preactivatedSkillIds ?? []),

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -307,8 +307,8 @@ export interface SkillProjectionContext {
   readonly skillProjectionCache: SkillProjectionCache;
   readonly coreToolNames: Set<string>;
   allowedToolNames?: Set<string>;
-  /** When true, the resolveTools callback returns no tools at all. */
-  toolsDisabled?: boolean;
+  /** When > 0, the resolveTools callback returns no tools at all. */
+  toolsDisabledDepth: number;
 }
 
 /**
@@ -327,7 +327,7 @@ export function createResolveToolsCallback(
     // When tools are explicitly disabled (e.g. during pointer generation),
     // return an empty tool list so the LLM never sees tool definitions and
     // keep the allowlist empty so no tool execution can slip through.
-    if (ctx.toolsDisabled) {
+    if (ctx.toolsDisabledDepth > 0) {
       ctx.allowedToolNames = new Set<string>();
       return [];
     }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -121,7 +121,7 @@ export class Session {
   /** @internal */ workingDir: string;
   /** @internal */ sandboxOverride?: boolean;
   /** @internal */ allowedToolNames?: Set<string>;
-  /** @internal */ toolsDisabled?: boolean;
+  /** @internal */ toolsDisabledDepth = 0;
   /** @internal */ preactivatedSkillIds?: string[];
   /** @internal */ coreToolNames: Set<string>;
   /** @internal */ readonly skillProjectionState = new Map<string, string>();

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -121,6 +121,7 @@ export class Session {
   /** @internal */ workingDir: string;
   /** @internal */ sandboxOverride?: boolean;
   /** @internal */ allowedToolNames?: Set<string>;
+  /** @internal */ toolsDisabled?: boolean;
   /** @internal */ preactivatedSkillIds?: string[];
   /** @internal */ coreToolNames: Set<string>;
   /** @internal */ readonly skillProjectionState = new Map<string, string>();


### PR DESCRIPTION
## Summary
- Add `toolsDisabled` flag to Session/SkillProjectionContext that `createResolveToolsCallback` respects by returning an empty tool list, fixing the bug where the empty `allowedToolNames` set was overwritten by the resolver each turn
- Fix fact validation to target the specific assistant message generated after the pointer instruction (by index) rather than the conversation-wide latest, preventing accidental deletion of unrelated messages

## Original prompt
address the latent feedback left on this PR: https://github.com/vellum-ai/vellum-assistant/pull/11048

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
