### PR TITLE
feat: add toolsDisabledDepth resolver tests and document snapshot caveat

### DIFF
--- a/assistant/src/__tests__/session-tool-setup-tools-disabled.test.ts
+++ b/assistant/src/__tests__/session-tool-setup-tools-disabled.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for the toolsDisabledDepth mechanism in createResolveToolsCallback.
+ *
+ * Covers:
+ * - Resolver returns empty tools when toolsDisabledDepth > 0
+ * - Resolver returns normal tools when toolsDisabledDepth is back to 0
+ * - allowedToolNames is cleared while disabled and restored on next normal call
+ * - Depth counter survives overlapping increments/decrements
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+
+import type { Message, ToolDefinition } from '../providers/types.js';
+import type { SkillProjectionCache } from '../daemon/session-skill-tools.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+mock.module('../daemon/session-skill-tools.js', () => ({
+  projectSkillTools: mock((_history: Message[], _opts: unknown) => ({
+    allowedToolNames: new Set<string>(),
+    toolDefinitions: [],
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import {
+  createResolveToolsCallback,
+  type SkillProjectionContext,
+} from '../daemon/session-tool-setup.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeToolDef(name: string): ToolDefinition {
+  return { name, description: `${name} tool`, input_schema: {} };
+}
+
+function makeCtx(overrides: Partial<SkillProjectionContext> = {}): SkillProjectionContext {
+  return {
+    skillProjectionState: new Map(),
+    skillProjectionCache: {} as SkillProjectionCache,
+    coreToolNames: new Set(['tool_a', 'tool_b']),
+    toolsDisabledDepth: 0,
+    ...overrides,
+  };
+}
+
+const EMPTY_HISTORY: Message[] = [];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createResolveToolsCallback — toolsDisabledDepth', () => {
+  test('returns undefined when no tool definitions provided', () => {
+    const ctx = makeCtx();
+    const resolve = createResolveToolsCallback([], ctx);
+    expect(resolve).toBeUndefined();
+  });
+
+  test('returns normal tools when toolsDisabledDepth is 0', () => {
+    const toolDefs = [makeToolDef('tool_a'), makeToolDef('tool_b')];
+    const ctx = makeCtx();
+    const resolve = createResolveToolsCallback(toolDefs, ctx)!;
+
+    const tools = resolve(EMPTY_HISTORY);
+    expect(tools.length).toBeGreaterThanOrEqual(2);
+    expect(tools.map((t) => t.name)).toContain('tool_a');
+    expect(tools.map((t) => t.name)).toContain('tool_b');
+    expect(ctx.allowedToolNames?.size).toBeGreaterThan(0);
+  });
+
+  test('returns empty tools when toolsDisabledDepth > 0', () => {
+    const toolDefs = [makeToolDef('tool_a'), makeToolDef('tool_b')];
+    const ctx = makeCtx({ toolsDisabledDepth: 1 });
+    const resolve = createResolveToolsCallback(toolDefs, ctx)!;
+
+    const tools = resolve(EMPTY_HISTORY);
+    expect(tools).toEqual([]);
+    expect(ctx.allowedToolNames).toEqual(new Set());
+  });
+
+  test('returns empty tools when toolsDisabledDepth is > 1 (overlapping callers)', () => {
+    const toolDefs = [makeToolDef('tool_a')];
+    const ctx = makeCtx({ toolsDisabledDepth: 3 });
+    const resolve = createResolveToolsCallback(toolDefs, ctx)!;
+
+    const tools = resolve(EMPTY_HISTORY);
+    expect(tools).toEqual([]);
+    expect(ctx.allowedToolNames).toEqual(new Set());
+  });
+
+  test('restores normal tools after depth returns to 0', () => {
+    const toolDefs = [makeToolDef('tool_a'), makeToolDef('tool_b')];
+    const ctx = makeCtx({ toolsDisabledDepth: 0 });
+    const resolve = createResolveToolsCallback(toolDefs, ctx)!;
+
+    // First call: normal
+    let tools = resolve(EMPTY_HISTORY);
+    expect(tools.length).toBeGreaterThanOrEqual(2);
+
+    // Simulate pointer processor incrementing depth
+    ctx.toolsDisabledDepth++;
+    tools = resolve(EMPTY_HISTORY);
+    expect(tools).toEqual([]);
+    expect(ctx.allowedToolNames).toEqual(new Set());
+
+    // Simulate pointer processor decrementing depth (back to 0)
+    ctx.toolsDisabledDepth--;
+    tools = resolve(EMPTY_HISTORY);
+    expect(tools.length).toBeGreaterThanOrEqual(2);
+    expect(ctx.allowedToolNames!.has('tool_a')).toBe(true);
+    expect(ctx.allowedToolNames!.has('tool_b')).toBe(true);
+  });
+
+  test('overlapping increments keep tools disabled until all decremented', () => {
+    const toolDefs = [makeToolDef('tool_a')];
+    const ctx = makeCtx();
+    const resolve = createResolveToolsCallback(toolDefs, ctx)!;
+
+    // Two overlapping pointer requests
+    ctx.toolsDisabledDepth++;
+    ctx.toolsDisabledDepth++;
+    expect(resolve(EMPTY_HISTORY)).toEqual([]);
+
+    // First one finishes
+    ctx.toolsDisabledDepth--;
+    expect(ctx.toolsDisabledDepth).toBe(1);
+    expect(resolve(EMPTY_HISTORY)).toEqual([]);
+
+    // Second one finishes
+    ctx.toolsDisabledDepth--;
+    expect(ctx.toolsDisabledDepth).toBe(0);
+    const tools = resolve(EMPTY_HISTORY);
+    expect(tools.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('clears allowedToolNames on every disabled call', () => {
+    const toolDefs = [makeToolDef('tool_a')];
+    const ctx = makeCtx({ toolsDisabledDepth: 1 });
+    const resolve = createResolveToolsCallback(toolDefs, ctx)!;
+
+    // Pre-populate allowedToolNames as if a previous normal turn set them
+    ctx.allowedToolNames = new Set(['tool_a', 'skill_x']);
+
+    resolve(EMPTY_HISTORY);
+    expect(ctx.allowedToolNames).toEqual(new Set());
+  });
+});

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -440,9 +440,9 @@ export async function runDaemon(): Promise<void> {
           });
 
           // Identify messages created during this run by diffing against
-          // the pre-run snapshot. This is race-safe: only messages that
-          // appeared in this conversation during *our* agent loop are
-          // considered, regardless of concurrent pointer events.
+          // the pre-run snapshot. This captures all messages added to the
+          // conversation during the loop window, which may include messages
+          // from concurrent pointer events (see over-capture caveat above).
           const postRunMessages = conversationStore.getMessages(conversationId);
           const createdMessageIds = postRunMessages
             .filter((m) => !preRunMessageIds.has(m.id) && m.id !== messageId)

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -409,6 +409,17 @@ export async function runDaemon(): Promise<void> {
           // Snapshot message IDs before the agent loop so we can diff
           // afterwards to find exactly which messages this run created,
           // avoiding positional heuristics that break under concurrency.
+          //
+          // Caveat: the diff captures *all* new messages in the
+          // conversation during the loop window, not just those from
+          // this specific agent loop.  If a concurrent pointer event
+          // falls back to a deterministic addMessage() while our loop
+          // is in flight, that message lands in our diff.  The race
+          // requires two pointer events for the same conversation
+          // within the agent loop window *and* this run must fail or
+          // fail fact-check — narrow enough to accept.  A future
+          // improvement could tag messages with a per-run correlation
+          // ID so rollback only targets its own output.
           const preRunMessageIds = new Set(
             conversationStore.getMessages(conversationId).map((m) => m.id),
           );


### PR DESCRIPTION
## Summary
- Add test suite for `createResolveToolsCallback` toolsDisabledDepth behavior: empty tools when depth > 0, normal tools when back to 0, overlapping callers, allowedToolNames clearing
- Document the snapshot-based message diff over-capture caveat in lifecycle.ts with explanation of when the race can occur and a note on future correlation-ID improvement

## Original prompt
address the latent feedback left in https://github.com/vellum-ai/vellum-assistant/pull/11050#issuecomment-3980056710

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
