### PR TITLE
feat: collect and surface guardian pronouns in system prompt

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -71,6 +71,7 @@ mock.module('../config/loader.js', () => ({
 
 mock.module('../config/user-reference.js', () => ({
   resolveUserReference: () => 'TestUser',
+  resolveUserPronouns: () => null,
 }));
 
 mock.module('../tools/credentials/metadata-store.js', () => ({

--- a/assistant/src/__tests__/skill-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags-integration.test.ts
@@ -66,6 +66,7 @@ mock.module('../config/loader.js', () => ({
 
 mock.module('../config/user-reference.js', () => ({
   resolveUserReference: () => 'TestUser',
+  resolveUserPronouns: () => null,
 }));
 
 mock.module('../tools/credentials/metadata-store.js', () => ({

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -57,6 +57,7 @@ mock.module('../config/loader.js', () => ({
 
 mock.module('../config/user-reference.js', () => ({
   resolveUserReference: () => 'John',
+  resolveUserPronouns: () => null,
 }));
 
 // Import after mock

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -11,7 +11,7 @@ import { getBaseDataDir, getIsContainerized } from './env-registry.js';
 import { getConfig } from './loader.js';
 import { skillFlagKey } from './skill-state.js';
 import { loadSkillCatalog, type SkillSummary } from './skills.js';
-import { resolveUserReference } from './user-reference.js';
+import { resolveUserPronouns, resolveUserReference } from './user-reference.js';
 
 const log = getLogger('system-prompt');
 
@@ -489,16 +489,23 @@ export function buildChannelCommandIntentSection(): string {
 
 export function buildExternalCommsIdentitySection(): string {
   const userRef = resolveUserReference();
-  return [
+  const userPronouns = resolveUserPronouns();
+  const lines = [
     '## External Communications Identity',
     '',
     'When communicating with people outside your user\'s household (phone calls, messages to non-guardian contacts, emails to third parties, etc.):',
     '',
     `- Refer to yourself as an **assistant**, not an "AI assistant" or "artificial intelligence". Keep identity framing simple and natural.`,
     `- When introducing who you represent, say you are acting on behalf of **${userRef}**.`,
+  ];
+  if (userPronouns) {
+    lines.push(`- Your user's pronouns are **${userPronouns}**. Use these when referring to your user in the third person.`);
+  }
+  lines.push(
     '- Do not volunteer that you are an AI unless directly asked. If asked, answer honestly.',
     '- This is guidance for natural, human-like communication — not a hard constraint. Occasional variations are acceptable.',
-  ].join('\n');
+  );
+  return lines.join('\n');
 }
 
 export function buildSwarmGuidanceSection(): string {

--- a/assistant/src/config/templates/BOOTSTRAP.md
+++ b/assistant/src/config/templates/BOOTSTRAP.md
@@ -33,7 +33,8 @@ Once they respond, follow the remaining steps in order, one at a time:
    - What they do for work (role, field, day-to-day)
    - What they do for fun (hobbies, interests)
    - What tools they rely on daily (apps, platforms, workflows)
-   Weave these into the conversation. Inferred answers are fine when confidence is high. If something is unclear, ask one short follow-up, but don't turn it into an interview. One or two natural exchanges should cover it. If the user declines to share something, respect that and move on (see Privacy below).
+   - Their pronouns (he/him, she/her, they/them, etc.)
+   Weave these into the conversation. Inferred answers are fine when confidence is high — for pronouns, if the user's name is strongly gendered, you can infer with reasonable confidence, but default to they/them if unsure. If something is unclear, ask one short follow-up, but don't turn it into an interview. One or two natural exchanges should cover it. If the user declines to share something, respect that and move on (see Privacy below).
 
 6. **Show them what you can take off their plate.** Based on everything you've learned, present exactly 2 actionable task suggestions. Each should feel specific to this user, not generic. Frame it as: here's what you can hand off to me right now. Avoid language like "let's build automations" or "let's set up workflows." If `ui_show` is available (dashboard channels), show the suggestions as a card with 2 action buttons. Use `surface_type: "card"` with a short title and body, and add one `relay_prompt` action per suggestion. Each action's `data.prompt` should contain a natural-language request the user would say. Example structure:
    ```
@@ -54,18 +55,18 @@ Ask one question at a time. Don't dump a form on them.
 
 ## Privacy
 
-Only the assistant's name is hard-required. Everything else about the user (their name, work role, hobbies, daily tools) is best-effort. Ask naturally, not as a form. If something is unclear, you can ask one short follow-up, but if the user declines or dodges, do not push. Just move on.
+Only the assistant's name is hard-required. Everything else about the user (their name, pronouns, work role, hobbies, daily tools) is best-effort. Ask naturally, not as a form. If something is unclear, you can ask one short follow-up, but if the user declines or dodges, do not push. Just move on.
 
 A field is "resolved" when any of these is true:
 - The user gave an explicit answer
 - You confidently inferred it from conversation
 - The user declined, dodged, or sidestepped it (treat all of these as declined)
 
-When saving to `USER.md`, mark declined fields so you don't re-ask later (e.g., `Work role: declined_by_user`). Inferred values can note the source (e.g., `Daily tools: inferred: Slack, Figma`).
+When saving to `USER.md`, mark declined fields so you don't re-ask later (e.g., `Work role: declined_by_user`). Inferred values can note the source (e.g., `Daily tools: inferred: Slack, Figma`). For pronouns, if inferred from name, note the source (e.g., `Pronouns: inferred: he/him`).
 
 ## Saving What You Learn
 
-Save what you learn as you go. Update `IDENTITY.md` (name, nature, personality, emoji, style tendency) and `USER.md` (their name, how to address them, goals, locale, work role, hobbies, daily tools) using `file_edit`. If the conversation reveals how the user wants you to behave (e.g., "be direct," "don't be too chatty"), save those behavioral guidelines to `SOUL.md` — that file is about your personality and how you operate, not the user's data. Just do it quietly. Don't tell the user which files you're editing or mention tool names.
+Save what you learn as you go. Update `IDENTITY.md` (name, nature, personality, emoji, style tendency) and `USER.md` (their name, pronouns, how to address them, goals, locale, work role, hobbies, daily tools) using `file_edit`. If the conversation reveals how the user wants you to behave (e.g., "be direct," "don't be too chatty"), save those behavioral guidelines to `SOUL.md` — that file is about your personality and how you operate, not the user's data. Just do it quietly. Don't tell the user which files you're editing or mention tool names.
 
 When saving to `IDENTITY.md`, be specific about the tone, energy, and conversational style you discovered during onboarding. This file persists after onboarding, so everything about how you should come across needs to be captured there -- not just your name and emoji, but the full vibe: how you talk, how much energy you bring, whether you're blunt or gentle, funny or serious.
 
@@ -74,7 +75,7 @@ When saving to `IDENTITY.md`, be specific about the tone, energy, and conversati
 Do NOT delete this file until ALL of the following are true:
 - You have a name (hard requirement)
 - You've figured out your vibe and adopted it
-- User detail fields are resolved: name, work role, hobbies/interests, and daily tools. Resolved means the user provided a value, you confidently inferred one, or the user declined/dodged it. All four must be in one of those states.
+- User detail fields are resolved: name, pronouns, work role, hobbies/interests, and daily tools. Resolved means the user provided a value, you confidently inferred one, or the user declined/dodged it. All five must be in one of those states.
 - 2 suggestions shown (via `ui_show` or as text if UI unavailable)
 - The user selected one, deferred both, or typed an alternate direction
 - Home Base has been created silently

--- a/assistant/src/config/templates/USER.md
+++ b/assistant/src/config/templates/USER.md
@@ -17,6 +17,7 @@ _(What do they care about? What projects are they working on? What annoys them? 
 _Each field below should end up in one of three states: an explicit value, an inferred value (note the source), or `declined_by_user`. All fields must be resolved before onboarding completes, but declining is a valid resolution._
 
 - Preferred name/reference:
+- Pronouns:
 - Goals:
 - Locale:
 - Work role:

--- a/assistant/src/config/user-reference.ts
+++ b/assistant/src/config/user-reference.ts
@@ -28,16 +28,28 @@ export function resolveUserReference(): string {
  * file is missing, the field is empty, or the value is a sentinel like
  * `declined_by_user`.
  *
- * Checks the Onboarding Snapshot section first (structured `- Pronouns:`
- * field), then falls back to a file-wide `Pronouns:` match so that
- * pronouns set or updated outside of onboarding are still picked up.
+ * Priority order:
+ *   1. Any `Pronouns:` line outside the Onboarding Snapshot section
+ *      (explicit user update post-onboarding takes precedence).
+ *   2. The structured `- Pronouns:` field inside the Onboarding Snapshot.
  */
 export function resolveUserPronouns(): string | null {
   const content = readTextFileSync(getWorkspacePromptPath('USER.md'));
   if (content == null) return null;
 
-  // Prefer the structured field in the Onboarding Snapshot section.
   const snapshotIdx = content.indexOf('## Onboarding Snapshot');
+
+  // 1. Check for a Pronouns line outside the Onboarding Snapshot section.
+  //    This represents an explicit post-onboarding update and takes priority.
+  if (snapshotIdx >= 0) {
+    const beforeSnapshot = content.slice(0, snapshotIdx);
+    const outsideMatch = beforeSnapshot.match(/Pronouns:[ \t]*(.*)/);
+    if (outsideMatch && outsideMatch[1].trim()) {
+      return cleanPronounValue(outsideMatch[1].trim());
+    }
+  }
+
+  // 2. Fall back to the structured field in the Onboarding Snapshot.
   if (snapshotIdx >= 0) {
     const section = content.slice(snapshotIdx);
     const match = section.match(/^- Pronouns:[ \t]*(.*)/m);
@@ -46,11 +58,12 @@ export function resolveUserPronouns(): string | null {
     }
   }
 
-  // Fallback: match anywhere in the file (e.g. set in the Details section
-  // after onboarding).
-  const fallback = content.match(/Pronouns:[ \t]*(.*)/);
-  if (fallback && fallback[1].trim()) {
-    return cleanPronounValue(fallback[1].trim());
+  // 3. No Onboarding Snapshot header at all — match anywhere.
+  if (snapshotIdx < 0) {
+    const fallback = content.match(/Pronouns:[ \t]*(.*)/);
+    if (fallback && fallback[1].trim()) {
+      return cleanPronounValue(fallback[1].trim());
+    }
   }
 
   return null;

--- a/assistant/src/config/user-reference.ts
+++ b/assistant/src/config/user-reference.ts
@@ -58,14 +58,6 @@ export function resolveUserPronouns(): string | null {
     }
   }
 
-  // 3. No Onboarding Snapshot header at all — match anywhere.
-  if (snapshotIdx < 0) {
-    const fallback = content.match(/Pronouns:[ \t]*(.*)/);
-    if (fallback && fallback[1].trim()) {
-      return cleanPronounValue(fallback[1].trim());
-    }
-  }
-
   return null;
 }
 

--- a/assistant/src/config/user-reference.ts
+++ b/assistant/src/config/user-reference.ts
@@ -22,3 +22,23 @@ export function resolveUserReference(): string {
 
   return DEFAULT_USER_REFERENCE;
 }
+
+/**
+ * Resolve the user's pronouns from the Onboarding Snapshot section of
+ * USER.md.  Returns `null` when the file is missing, the field is empty,
+ * or the value is a sentinel like `declined_by_user`.
+ */
+export function resolveUserPronouns(): string | null {
+  const content = readTextFileSync(getWorkspacePromptPath('USER.md'));
+  if (content != null) {
+    const match = content.match(/Pronouns:[ \t]*(.*)/);
+    if (match && match[1].trim()) {
+      const raw = match[1].trim();
+      if (raw === 'declined_by_user') return null;
+      // Strip "inferred: " prefix for clean output
+      return raw.replace(/^inferred:\s*/i, '');
+    }
+  }
+
+  return null;
+}

--- a/assistant/src/config/user-reference.ts
+++ b/assistant/src/config/user-reference.ts
@@ -24,27 +24,40 @@ export function resolveUserReference(): string {
 }
 
 /**
- * Resolve the user's pronouns from the Onboarding Snapshot section of
- * USER.md.  Returns `null` when the file is missing, the field is empty,
- * or the value is a sentinel like `declined_by_user`.
+ * Resolve the user's pronouns from USER.md.  Returns `null` when the
+ * file is missing, the field is empty, or the value is a sentinel like
+ * `declined_by_user`.
  *
- * The match is scoped to lines after "## Onboarding Snapshot" to avoid
- * false matches against free-form notes earlier in the file.
+ * Checks the Onboarding Snapshot section first (structured `- Pronouns:`
+ * field), then falls back to a file-wide `Pronouns:` match so that
+ * pronouns set or updated outside of onboarding are still picked up.
  */
 export function resolveUserPronouns(): string | null {
   const content = readTextFileSync(getWorkspacePromptPath('USER.md'));
-  if (content != null) {
-    // Only search within the Onboarding Snapshot section
-    const snapshotIdx = content.indexOf('## Onboarding Snapshot');
-    const section = snapshotIdx >= 0 ? content.slice(snapshotIdx) : content;
+  if (content == null) return null;
+
+  // Prefer the structured field in the Onboarding Snapshot section.
+  const snapshotIdx = content.indexOf('## Onboarding Snapshot');
+  if (snapshotIdx >= 0) {
+    const section = content.slice(snapshotIdx);
     const match = section.match(/^- Pronouns:[ \t]*(.*)/m);
     if (match && match[1].trim()) {
-      const raw = match[1].trim();
-      if (raw === 'declined_by_user') return null;
-      // Strip "inferred: " prefix for clean output
-      return raw.replace(/^inferred:\s*/i, '');
+      return cleanPronounValue(match[1].trim());
     }
   }
 
+  // Fallback: match anywhere in the file (e.g. set in the Details section
+  // after onboarding).
+  const fallback = content.match(/Pronouns:[ \t]*(.*)/);
+  if (fallback && fallback[1].trim()) {
+    return cleanPronounValue(fallback[1].trim());
+  }
+
   return null;
+}
+
+function cleanPronounValue(raw: string): string | null {
+  if (raw === 'declined_by_user') return null;
+  // Strip "inferred: " prefix for clean output
+  return raw.replace(/^inferred:\s*/i, '');
 }

--- a/assistant/src/config/user-reference.ts
+++ b/assistant/src/config/user-reference.ts
@@ -27,11 +27,17 @@ export function resolveUserReference(): string {
  * Resolve the user's pronouns from the Onboarding Snapshot section of
  * USER.md.  Returns `null` when the file is missing, the field is empty,
  * or the value is a sentinel like `declined_by_user`.
+ *
+ * The match is scoped to lines after "## Onboarding Snapshot" to avoid
+ * false matches against free-form notes earlier in the file.
  */
 export function resolveUserPronouns(): string | null {
   const content = readTextFileSync(getWorkspacePromptPath('USER.md'));
   if (content != null) {
-    const match = content.match(/Pronouns:[ \t]*(.*)/);
+    // Only search within the Onboarding Snapshot section
+    const snapshotIdx = content.indexOf('## Onboarding Snapshot');
+    const section = snapshotIdx >= 0 ? content.slice(snapshotIdx) : content;
+    const match = section.match(/^- Pronouns:[ \t]*(.*)/m);
     if (match && match[1].trim()) {
       const raw = match[1].trim();
       if (raw === 'declined_by_user') return null;


### PR DESCRIPTION
## Summary
- Adds pronoun collection to the BOOTSTRAP.md onboarding flow as a natural conversation topic, with inference from name when confident
- Adds a `Pronouns:` field to the USER.md onboarding snapshot template
- Adds `resolveUserPronouns()` to read pronouns from USER.md and surfaces them in the External Communications Identity section of the system prompt

## Original prompt
It is helpful for the assistant to know their guardian's pronouns. We should:
1. Add a collection step for this in BOOTSTRAP.md 
2. Infer it if we weren't able to collect it
3. Ensure that it gets included in the system prompt as context for the assistant alongside other guardian-related information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
