### PR TITLE
refactor: remove legacy provenanceActorRole code paths

### DIFF
--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -197,15 +197,15 @@ Runtime profile flow (per turn):
 
 ### Provenance-Aware Memory Pipeline
 
-Every persisted message carries provenance metadata (`provenanceActorRole`, `provenanceSourceChannel`, etc.) derived from the `GuardianRuntimeContext` resolved by `guardian-context-resolver.ts`. This metadata records which actor produced the message and through which channel, enabling downstream trust decisions without re-resolving identity at read time.
+Every persisted message carries provenance metadata (`provenanceTrustClass`, `provenanceSourceChannel`, etc.) derived from the `GuardianRuntimeContext` resolved by `guardian-context-resolver.ts`. This metadata records the trust class of the actor who produced the message and through which channel, enabling downstream trust decisions without re-resolving identity at read time.
 
-Two trust gates enforce actor-role-based access control over the memory pipeline:
+Two trust gates enforce trust-class-based access control over the memory pipeline:
 
-- **Write gate** (`indexer.ts`): The `extract_items` and `resolve_conflicts` jobs only run for messages from trusted actors (guardian or legacy/undefined provenance). Messages from untrusted actors (non-guardian, unverified_channel) are still segmented and embedded — so they appear in conversation context — but no profile extraction or conflict resolution is triggered. This prevents untrusted channels from injecting or mutating long-term memory items.
+- **Write gate** (`indexer.ts`): The `extract_items` and `resolve_conflicts` jobs only run for messages from trusted actors (guardian or undefined provenance). Messages from untrusted actors (`trusted_contact`, `unknown`) are still segmented and embedded — so they appear in conversation context — but no profile extraction or conflict resolution is triggered. This prevents untrusted channels from injecting or mutating long-term memory items.
 
 - **Read gate** (`session-memory.ts`): When the current session's actor is untrusted, the memory recall pipeline returns a no-op context — no recall injection, no dynamic profile, no conflict clarification prompts. This ensures untrusted actors cannot surface or exploit previously extracted memory.
 
-Trust policy is **cross-channel and actor-role-based**: decisions use `guardianContext.actorRole`, not the channel string. Desktop/IPC sessions default to `actorRole: 'guardian'`. External channels (Telegram, SMS, WhatsApp, voice) provide explicit guardian context via the resolver. Legacy messages without provenance metadata are treated as trusted for backwards compatibility; going forward, all new messages carry provenance.
+Trust policy is **cross-channel and trust-class-based**: decisions use `guardianContext.trustClass`, not the channel string. Desktop/IPC sessions default to `trustClass: 'guardian'`. External channels (Telegram, SMS, WhatsApp, voice) provide explicit guardian context via the resolver. Messages without provenance metadata are treated as trusted (guardian); all new messages carry provenance.
 
 ---
 

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -213,7 +213,7 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
         assistantMessageChannel: 'vellum',
         userMessageInterface: 'macos',
         assistantMessageInterface: 'macos',
-        provenanceActorRole: 'guardian',
+        provenanceTrustClass: 'guardian',
       }),
     );
     expect(addMessageMock).toHaveBeenCalledWith(
@@ -225,7 +225,7 @@ describe('handleUserMessage pending-confirmation reply interception', () => {
         assistantMessageChannel: 'vellum',
         userMessageInterface: 'macos',
         assistantMessageInterface: 'macos',
-        provenanceActorRole: 'guardian',
+        provenanceTrustClass: 'guardian',
       }),
     );
     expect(sent.map((msg) => msg.type)).toEqual([

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -641,7 +641,7 @@ export async function handleUserMessage(
               assistantMessageChannel: ipcChannel,
               userMessageInterface: ipcInterface,
               assistantMessageInterface: ipcInterface,
-              provenanceActorRole: 'guardian' as const,
+              provenanceTrustClass: 'guardian' as const,
             };
 
             const consumedUserMessage = createUserMessage(messageText, msg.attachments ?? []);

--- a/assistant/src/daemon/session-lifecycle.ts
+++ b/assistant/src/daemon/session-lifecycle.ts
@@ -29,19 +29,11 @@ type GuardianTrustClass = GuardianRuntimeContext['trustClass'];
 function parseProvenanceTrustClass(metadata: string | null): GuardianTrustClass | undefined {
   if (!metadata) return undefined;
   try {
-    const parsed = JSON.parse(metadata) as {
-      provenanceTrustClass?: unknown;
-      provenanceActorRole?: unknown;
-    };
+    const parsed = JSON.parse(metadata) as { provenanceTrustClass?: unknown };
     const trustClass = parsed?.provenanceTrustClass;
     if (trustClass === 'guardian' || trustClass === 'trusted_contact' || trustClass === 'unknown') {
       return trustClass;
     }
-    // Legacy fallback for rows persisted before provenanceTrustClass existed.
-    const legacyRole = parsed?.provenanceActorRole;
-    if (legacyRole === 'guardian') return 'guardian';
-    if (legacyRole === 'non-guardian') return 'trusted_contact';
-    if (legacyRole === 'unverified_channel') return 'unknown';
   } catch {
     // Ignore malformed metadata and treat as unknown provenance.
   }

--- a/assistant/src/memory/job-handlers/backfill.ts
+++ b/assistant/src/memory/job-handlers/backfill.ts
@@ -29,16 +29,9 @@ type ProvenanceTrustClass = 'guardian' | 'trusted_contact' | 'unknown';
 function parseProvenanceTrustClass(rawMetadata: string | null): ProvenanceTrustClass | undefined {
   if (!rawMetadata) return undefined;
   try {
-    const parsedJson: unknown = JSON.parse(rawMetadata);
-    const parsed = messageMetadataSchema.safeParse(parsedJson);
+    const parsed = messageMetadataSchema.safeParse(JSON.parse(rawMetadata));
     if (!parsed.success) return undefined;
-    if (parsed.data.provenanceTrustClass) return parsed.data.provenanceTrustClass;
-    // Legacy fallback for rows written before provenanceTrustClass existed.
-    const legacyRole = (parsedJson as { provenanceActorRole?: unknown }).provenanceActorRole;
-    if (legacyRole === 'guardian') return 'guardian';
-    if (legacyRole === 'non-guardian') return 'trusted_contact';
-    if (legacyRole === 'unverified_channel') return 'unknown';
-    return undefined;
+    return parsed.data.provenanceTrustClass;
   } catch {
     return undefined;
   }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -155,7 +155,7 @@ async function tryConsumeCanonicalGuardianReply(params: {
       assistantMessageChannel: sourceChannel,
       userMessageInterface: sourceInterface,
       assistantMessageInterface: sourceInterface,
-      provenanceActorRole: 'guardian' as const,
+      provenanceTrustClass: 'guardian' as const,
     };
 
     const userMessage = createUserMessage(content, attachments);


### PR DESCRIPTION
## Summary
- Replace `provenanceActorRole: 'guardian'` writes with `provenanceTrustClass: 'guardian'` in conversation-routes.ts and sessions.ts
- Remove legacy `provenanceActorRole` → `provenanceTrustClass` fallback mappings from session-lifecycle.ts and backfill.ts
- Update test fixtures and architecture docs to use canonical field names

## Original prompt
Remove legacy provenance actor role code paths and rely on new canonical provenanceTrustClass code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
