### PR TITLE
fix: add missing mock exports for skill-projection benchmark

### DIFF
--- a/assistant/src/__tests__/skill-projection.benchmark.test.ts
+++ b/assistant/src/__tests__/skill-projection.benchmark.test.ts
@@ -35,6 +35,21 @@ mock.module('../config/skills.js', () => ({
       bundled: false,
       userInvocable: false,
     })),
+  // Needed by transitive deps (skill-state.ts imports this)
+  checkSkillRequirements: () => ({ eligible: true, missing: {} }),
+  getSkillsDir: () => '/tmp/fake-skills',
+  getBundledSkillsDir: () => '/tmp/fake-bundled-skills',
+  resolveSkillSelector: () => ({ found: false }),
+  loadSkillBySelector: () => ({ found: false }),
+  readCachedSkillIcon: () => undefined,
+}));
+
+// Mock skill-state.js to break the transitive import chain — the benchmark
+// only needs skillFlagKey and doesn't exercise resolveSkillStates.
+mock.module('../config/skill-state.js', () => ({
+  skillFlagKey: (id: string) => `feature_flags.${id}.enabled`,
+  isSkillFeatureEnabled: () => true,
+  resolveSkillStates: () => [],
 }));
 
 mock.module('../skills/tool-manifest.js', () => ({


### PR DESCRIPTION
## Summary
- Add `checkSkillRequirements` and other exports to `skills.js` mock to satisfy transitive dependency from `skill-state.ts`
- Mock `skill-state.js` directly to break the transitive import chain (`session-skill-tools` → `skill-state` → `skills`) and prevent future export-mismatch breakage

## Original prompt
Help me get CI into a healthy state on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
