### PR TITLE
fix: mock config loader and feature flags in skill-projection benchmark

### DIFF
--- a/assistant/src/__tests__/skill-projection.benchmark.test.ts
+++ b/assistant/src/__tests__/skill-projection.benchmark.test.ts
@@ -22,6 +22,27 @@ mock.module('../util/logger.js', () => ({
     new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
 }));
 
+// Mock config loader and feature flags to avoid filesystem reads on CI.
+// getConfig returns a minimal config; all feature flags default to enabled.
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({}),
+  loadConfig: () => ({}),
+  applyNestedDefaults: (c: unknown) => c,
+  saveConfig: () => {},
+  invalidateConfigCache: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+  API_KEY_PROVIDERS: [],
+}));
+
+mock.module('../config/assistant-feature-flags.js', () => ({
+  isAssistantFeatureFlagEnabled: () => true,
+  loadDefaultsRegistry: () => ({}),
+  getFeatureFlagDefault: () => true,
+}));
+
 // Skill catalog: returns a configurable list of fake skills
 let catalogSkillIds: string[] = [];
 mock.module('../config/skills.js', () => ({
@@ -111,7 +132,7 @@ mock.module('../tools/skills/skill-tool-factory.js', () => ({
 // Bun's module resolver throws "Export named '…' not found".
 const statStub = () => ({ isSymbolicLink: () => false, isDirectory: () => false, isFile: () => true });
 mock.module('node:fs', () => ({
-  existsSync: () => true,
+  existsSync: (p: string) => typeof p === 'string' && p.endsWith('TOOLS.json'),
   readFileSync: () => '',
   lstatSync: statStub,
   readdirSync: () => [],


### PR DESCRIPTION
## Summary
- Mock `config/loader.js` and `config/assistant-feature-flags.js` in skill-projection benchmark to prevent filesystem reads on CI (avoids `ConfigError: Failed to parse config` crash)
- Make `existsSync` mock path-aware: only return `true` for `TOOLS.json` paths instead of unconditionally

## Original prompt
Help me get CI into a healthy state on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
