### PR TITLE
fix: align remaining test files with canonical identity renames and guardianPrincipalId requirement

### DIFF
--- a/assistant/src/__tests__/channel-delivery-store.test.ts
+++ b/assistant/src/__tests__/channel-delivery-store.test.ts
@@ -508,7 +508,7 @@ describe('channel-delivery-store', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         sourceChannel: 'telegram',
-        externalChatId: 'chat-del',
+        conversationExternalId: 'chat-del',
         // Note: no assistantId in the body — it comes from the route param
       }),
     });
@@ -558,7 +558,7 @@ describe('channel-delivery-store', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         sourceChannel: 'telegram',
-        externalChatId: 'chat-def',
+        conversationExternalId: 'chat-def',
       }),
     });
 

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -43,11 +43,18 @@ mock.module('../memory/channel-guardian-store.js', () => ({
 mock.module('../config/loader.js', () => ({
   getConfig: () => ({
     ui: {},
-    
+
     calls: {
       userConsultTimeoutSeconds: 120,
     },
   }),
+}));
+
+// Mock guardian-vellum-migration to use a stable principal, avoiding UNIQUE
+// constraint errors when ensureVellumGuardianBinding is called across tests.
+// Returns a known principal so guardian-dispatch can attribute requests.
+mock.module('../runtime/guardian-vellum-migration.js', () => ({
+  ensureVellumGuardianBinding: () => 'test-principal-id',
 }));
 
 const emitCalls: unknown[] = [];
@@ -113,6 +120,7 @@ function resetTables(): void {
   db.run('DELETE FROM call_events');
   db.run('DELETE FROM call_sessions');
   db.run('DELETE FROM conversations');
+  db.run('DELETE FROM channel_guardian_bindings');
   mockTelegramBinding = null;
   mockSmsBinding = null;
   emitCalls.length = 0;

--- a/assistant/src/__tests__/guardian-routing-state.test.ts
+++ b/assistant/src/__tests__/guardian-routing-state.test.ts
@@ -348,44 +348,21 @@ describe('inbound-message-handler trusted-contact interactivity', () => {
     expect(processCalls[0].options?.isInteractive).toBe(true);
   });
 
-  test('unknown actors remain non-interactive', async () => {
-    // No guardian binding, no member record => unknown trust class
+  test('unknown actors remain non-interactive (denied at gate)', async () => {
+    // No member record => non-member denied at the ACL gate,
+    // which is the strongest form of "not interactive".
     mockFindMember = () => null;
-
-    const processCalls: Array<{ options?: Record<string, unknown> }> = [];
-    const processMessage = mock(async (
-      conversationId: string,
-      _content: string,
-      _attachmentIds?: string[],
-      options?: Record<string, unknown>,
-    ) => {
-      processCalls.push({ options });
-      const messageId = `msg-unknown-${Date.now()}`;
-      const db = getDb();
-      db.insert(messages).values({
-        id: messageId,
-        conversationId,
-        role: 'user',
-        content: JSON.stringify([{ type: 'text', text: 'hello' }]),
-        createdAt: Date.now(),
-      }).run();
-      return { messageId };
-    });
 
     const req = makeInboundRequest({
       externalMessageId: `msg-unknown-${Date.now()}`,
-      // No actorExternalId => unknown trust class
-      actorExternalId: undefined,
+      actorExternalId: 'unknown-user-no-member',
     });
 
-    const res = await handleChannelInbound(req, processMessage as any, 'test-token');
+    const res = await handleChannelInbound(req, undefined, 'test-token');
     const body = await res.json() as Record<string, unknown>;
     expect(body.accepted).toBe(true);
-
-    await new Promise((resolve) => setTimeout(resolve, 300));
-
-    expect(processCalls.length).toBeGreaterThan(0);
-    expect(processCalls[0].options?.isInteractive).toBe(false);
+    expect(body.denied).toBe(true);
+    expect(body.reason).toBe('not_a_member');
   });
 });
 

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -188,6 +188,7 @@ describe('non-member access request notification', () => {
       channel: 'telegram',
       guardianExternalUserId: 'guardian-user-789',
       guardianDeliveryChatId: 'guardian-chat-789',
+      guardianPrincipalId: 'test-principal-id',
     });
 
     const req = buildInboundRequest();
@@ -229,6 +230,7 @@ describe('non-member access request notification', () => {
       channel: 'telegram',
       guardianExternalUserId: 'guardian-user-789',
       guardianDeliveryChatId: 'guardian-chat-789',
+      guardianPrincipalId: 'test-principal-id',
     });
 
     // First message
@@ -296,6 +298,7 @@ describe('non-member access request notification', () => {
       channel: 'sms',
       guardianExternalUserId: 'guardian-sms-user',
       guardianDeliveryChatId: 'guardian-sms-chat',
+      guardianPrincipalId: 'test-principal-id',
     });
 
     const req = buildInboundRequest();
@@ -327,6 +330,7 @@ describe('non-member access request notification', () => {
       channel: 'telegram',
       guardianExternalUserId: 'guardian-user-789',
       guardianDeliveryChatId: 'guardian-chat-789',
+      guardianPrincipalId: 'test-principal-id',
     });
 
     // Message without actorExternalId — the handler returns BAD_REQUEST.
@@ -399,6 +403,7 @@ describe('access-request-helper unit tests', () => {
       channel: 'sms',
       guardianExternalUserId: 'guardian-sms',
       guardianDeliveryChatId: 'sms-chat',
+      guardianPrincipalId: 'test-principal-id',
     });
 
     const result = notifyGuardianOfAccessRequest({
@@ -430,12 +435,14 @@ describe('access-request-helper unit tests', () => {
       channel: 'telegram',
       guardianExternalUserId: 'guardian-tg',
       guardianDeliveryChatId: 'tg-chat',
+      guardianPrincipalId: 'test-principal-tg',
     });
     createBinding({
       assistantId: 'self',
       channel: 'sms',
       guardianExternalUserId: 'guardian-sms',
       guardianDeliveryChatId: 'sms-chat',
+      guardianPrincipalId: 'test-principal-sms',
     });
 
     const result = notifyGuardianOfAccessRequest({

--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -265,8 +265,8 @@ describe('notification decision strategy', () => {
         sourceEventName: 'ingress.access_request',
         contextPayload: {
           senderIdentifier: 'Alice Smith',
-          senderName: 'Alice Smith',
-          senderExternalUserId: '+15559998888',
+          actorDisplayName: 'Alice Smith',
+          actorExternalId: '+15559998888',
           sourceChannel: 'voice',
           requestCode: 'V1C2E3',
         },
@@ -286,7 +286,7 @@ describe('notification decision strategy', () => {
         sourceEventName: 'ingress.access_request',
         contextPayload: {
           senderIdentifier: 'user-123',
-          senderName: 'Bob Jones',
+          actorDisplayName: 'Bob Jones',
           sourceChannel: 'telegram',
           requestCode: 'T1G2M3',
         },

--- a/assistant/src/__tests__/notification-guardian-path.test.ts
+++ b/assistant/src/__tests__/notification-guardian-path.test.ts
@@ -48,11 +48,17 @@ mock.module('../memory/channel-guardian-store.js', () => ({
 mock.module('../config/loader.js', () => ({
   getConfig: () => ({
     ui: {},
-    
+
     calls: {
       userConsultTimeoutSeconds: 120,
     },
   }),
+}));
+
+// Mock guardian-vellum-migration to use a stable principal, avoiding UNIQUE
+// constraint errors when ensureVellumGuardianBinding is called across tests.
+mock.module('../runtime/guardian-vellum-migration.js', () => ({
+  ensureVellumGuardianBinding: () => 'test-principal-id',
 }));
 
 const emitCalls: unknown[] = [];
@@ -118,6 +124,7 @@ function resetTables(): void {
   db.run('DELETE FROM call_events');
   db.run('DELETE FROM call_sessions');
   db.run('DELETE FROM conversations');
+  db.run('DELETE FROM channel_guardian_bindings');
   emitCalls.length = 0;
   mockTelegramBinding = null;
   mockThreadCreated = null;

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -41,13 +41,30 @@ mock.module('../util/logger.js', () => ({
 mock.module('../config/loader.js', () => ({
   getConfig: () => ({
     ui: {},
-    
+
     model: 'test',
     provider: 'test',
     apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     secretDetection: { enabled: false },
+  }),
+}));
+
+// Mock guardian-vellum-migration to use a stable principal matching the one
+// in createCanonicalGuardianRequest calls below ('test-principal-id').
+mock.module('../runtime/guardian-vellum-migration.js', () => ({
+  ensureVellumGuardianBinding: () => 'test-principal-id',
+}));
+
+// Mock local-actor-identity to return a stable guardian context that uses
+// the same principal as the canonical requests created in tests.
+mock.module('../runtime/local-actor-identity.js', () => ({
+  resolveLocalIpcGuardianContext: () => ({
+    sourceChannel: 'vellum',
+    trustClass: 'guardian',
+    guardianPrincipalId: 'test-principal-id',
+    guardianExternalUserId: 'test-principal-id',
   }),
 }));
 

--- a/assistant/src/__tests__/tool-grant-request-escalation.test.ts
+++ b/assistant/src/__tests__/tool-grant-request-escalation.test.ts
@@ -84,6 +84,7 @@ mock.module('../runtime/channel-guardian-service.js', () => ({
         channel: 'telegram',
         guardianExternalUserId: 'guardian-1',
         guardianDeliveryChatId: 'guardian-chat-1',
+        guardianPrincipalId: 'test-principal-id',
         status: 'active',
       };
     }

--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -103,6 +103,7 @@ let mockGuardianBinding: Record<string, unknown> | null = {
   channel: 'telegram',
   guardianExternalUserId: 'guardian-1',
   guardianDeliveryChatId: 'guardian-chat-1',
+  guardianPrincipalId: 'test-principal-id',
   status: 'active',
 };
 
@@ -259,6 +260,7 @@ describe('(a) target flow: trusted-contact inline guardian approval end-to-end',
       channel: 'telegram',
       guardianExternalUserId: 'guardian-1',
       guardianDeliveryChatId: 'guardian-chat-1',
+      guardianPrincipalId: 'test-principal-id',
       status: 'active',
     };
   });
@@ -368,6 +370,7 @@ describe('(b) prompt-path flow: confirmation_request bridges to guardian', () =>
       channel: 'telegram',
       guardianExternalUserId: 'guardian-1',
       guardianDeliveryChatId: 'guardian-chat-1',
+      guardianPrincipalId: 'test-principal-id',
       status: 'active',
     };
   });
@@ -550,6 +553,7 @@ describe('(d) unknown actor flow: fail-closed with no interactive approval', () 
       channel: 'telegram',
       guardianExternalUserId: 'guardian-1',
       guardianDeliveryChatId: 'guardian-chat-1',
+      guardianPrincipalId: 'test-principal-id',
       status: 'active',
     };
   });
@@ -734,6 +738,7 @@ describe('(f) timeout/stale flow: stale guardian decision after inline wait time
       channel: 'telegram',
       guardianExternalUserId: 'guardian-1',
       guardianDeliveryChatId: 'guardian-chat-1',
+      guardianPrincipalId: 'test-principal-id',
       status: 'active',
     };
   });
@@ -948,6 +953,7 @@ describe('cross-milestone integration checks', () => {
       channel: 'telegram',
       guardianExternalUserId: 'guardian-1',
       guardianDeliveryChatId: 'guardian-chat-1',
+      guardianPrincipalId: 'test-principal-id',
       status: 'active',
     };
   });

--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -405,8 +405,8 @@ describe('trusted contact activated notification signal', () => {
     // Verify payload
     const payload = activatedSignals[0].contextPayload as Record<string, unknown>;
     expect(payload.sourceChannel).toBe('telegram');
-    expect(payload.externalUserId).toBe('requester-user-456');
-    expect(payload.externalChatId).toBe('chat-123');
+    expect(payload.actorExternalId).toBe('requester-user-456');
+    expect(payload.conversationExternalId).toBe('chat-123');
 
     // Verify deduplication key includes the user identity
     const dedupeKey = activatedSignals[0].dedupeKey as string;

--- a/assistant/src/__tests__/trusted-contact-multichannel.test.ts
+++ b/assistant/src/__tests__/trusted-contact-multichannel.test.ts
@@ -221,7 +221,7 @@ for (const config of CHANNEL_CONFIGS) {
       // Guardian notification helper was called for the correct channel
       expect(notifyGuardianCalls.length).toBe(1);
       expect(notifyGuardianCalls[0].sourceChannel).toBe(config.channel);
-      expect(notifyGuardianCalls[0].senderExternalUserId).toBe(config.senderExternalUserId);
+      expect(notifyGuardianCalls[0].actorExternalId).toBe(config.senderExternalUserId);
     });
 
     test('verification creates active member for channel', () => {


### PR DESCRIPTION
Fixes 12 remaining CI test failures on main caused by the canonical identity refactor:

**Canonical property renames** (4 files):
- `externalChatId` → `conversationExternalId` in request bodies
- `senderExternalUserId`/`externalUserId` → `actorExternalId` in assertions
- `senderName` → `actorDisplayName` in notification payloads

**Missing `guardianPrincipalId`** (3 files):
- Decisionable canonical requests now require `guardianPrincipalId`
- Added to mock guardian bindings in tool-grant-request-escalation, trusted-contact-inline-approval-integration, and non-member-access-request tests

**`ensureVellumGuardianBinding` self-heal interference** (3 files):
- Mocked `guardian-vellum-migration.js` to return stable principal IDs
- Added `channel_guardian_bindings` cleanup to `resetTables()` in guardian-dispatch and notification-guardian-path

**ACL gate behavioral change** (1 file):
- Updated guardian-routing-state test for non-members being denied at ACL gate instead of processed non-interactively

Files: channel-delivery-store, guardian-dispatch, guardian-routing-state, non-member-access-request, notification-decision-strategy, notification-guardian-path, send-endpoint-busy, tool-grant-request-escalation, trusted-contact-inline-approval-integration, trusted-contact-lifecycle-notifications, trusted-contact-multichannel
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
