### PR TITLE
Add internal auth middleware (service bearer/mTLS abstraction)

### DIFF
--- a/gateway-managed/.env.example
+++ b/gateway-managed/.env.example
@@ -4,3 +4,13 @@ MANAGED_GATEWAY_SERVICE_NAME=managed-gateway
 MANAGED_GATEWAY_MODE=skeleton
 MANAGED_GATEWAY_DJANGO_INTERNAL_BASE_URL=http://127.0.0.1:8000
 MANAGED_GATEWAY_STRICT_STARTUP_VALIDATION=true
+MANAGED_GATEWAY_INTERNAL_AUTH_MODE=bearer
+MANAGED_GATEWAY_INTERNAL_AUTH_AUDIENCE=managed-gateway-internal
+# Example:
+# {"token-current":{"token_id":"mgw-2026-01","principal":"managed-gateway-staging","audience":"managed-gateway-internal","scopes":["managed-gateway:internal","routes:resolve"],"expires_at":"2026-12-31T23:59:59Z"}}
+MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS={}
+MANAGED_GATEWAY_INTERNAL_REVOKED_TOKEN_IDS=
+MANAGED_GATEWAY_INTERNAL_MTLS_PRINCIPALS=
+MANAGED_GATEWAY_MTLS_PRINCIPAL_HEADER=x-managed-gateway-principal
+MANAGED_GATEWAY_MTLS_AUDIENCE_HEADER=x-managed-gateway-audience
+MANAGED_GATEWAY_MTLS_SCOPES_HEADER=x-managed-gateway-scopes

--- a/gateway-managed/ARCHITECTURE.md
+++ b/gateway-managed/ARCHITECTURE.md
@@ -13,6 +13,12 @@ The managed gateway is a dedicated service lane for Vellum-owned shared channel 
 - Fails fast on missing or invalid `MANAGED_GATEWAY_DJANGO_INTERNAL_BASE_URL`.
 - Supports safe defaults when disabled or when strict validation is explicitly turned off.
 
+## PR-3 scope
+
+- Adds internal auth middleware abstraction with `bearer` and `mtls` modes.
+- Enforces deny-by-default verification for audience and required scopes.
+- Defines token lifecycle checks for expiry and revocation to support safe rotation.
+
 ## Endpoints
 
 - `GET /healthz`

--- a/gateway-managed/README.md
+++ b/gateway-managed/README.md
@@ -6,6 +6,7 @@ Managed gateway service skeleton for Vellum-owned shared channel identities.
 
 - package scaffold and startup entrypoint
 - strict startup config validation for enabled managed gateway mode
+- internal auth middleware abstraction for bearer and mTLS service auth
 - health and readiness endpoints:
   - `/healthz`
   - `/readyz`
@@ -17,6 +18,11 @@ Managed gateway service skeleton for Vellum-owned shared channel identities.
 - `MANAGED_GATEWAY_ENABLED` (default `true`)
 - `MANAGED_GATEWAY_DJANGO_INTERNAL_BASE_URL` (required when enabled and strict validation is on)
 - `MANAGED_GATEWAY_STRICT_STARTUP_VALIDATION` (default `true`)
+- `MANAGED_GATEWAY_INTERNAL_AUTH_MODE` (`bearer` or `mtls`)
+- `MANAGED_GATEWAY_INTERNAL_AUTH_AUDIENCE` (expected audience for internal callers)
+- `MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS` (JSON token catalog)
+- `MANAGED_GATEWAY_INTERNAL_REVOKED_TOKEN_IDS` (comma-separated token IDs)
+- `MANAGED_GATEWAY_INTERNAL_MTLS_PRINCIPALS` (comma-separated principal IDs)
 
 ## Run locally
 
@@ -32,3 +38,10 @@ bun run dev
 cd gateway-managed
 bun run test
 ```
+
+## Internal Auth Lifecycle
+
+- Issuance: add a new entry to `MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS` with `token_id`, `principal`, `audience`, `scopes`, and optional `expires_at`.
+- Rotation: keep old and new bearer entries active during rollout overlap.
+- Revocation: set `revoked: true` on a token entry or add its `token_id` to `MANAGED_GATEWAY_INTERNAL_REVOKED_TOKEN_IDS`.
+- Expiry: set `expires_at` as ISO-8601 UTC; expired bearer tokens are rejected.

--- a/gateway-managed/src/__tests__/config.test.ts
+++ b/gateway-managed/src/__tests__/config.test.ts
@@ -4,7 +4,21 @@ import { loadConfig } from "../config.js";
 
 const BASE_ENV: NodeJS.ProcessEnv = {
   ...process.env,
+  MANAGED_GATEWAY_ENABLED: "true",
+  MANAGED_GATEWAY_STRICT_STARTUP_VALIDATION: "true",
   MANAGED_GATEWAY_DJANGO_INTERNAL_BASE_URL: "http://127.0.0.1:8000",
+  MANAGED_GATEWAY_INTERNAL_AUTH_MODE: "bearer",
+  MANAGED_GATEWAY_INTERNAL_AUTH_AUDIENCE: "managed-gateway-internal",
+  MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS: JSON.stringify({
+    "token-active": {
+      token_id: "mgw-active",
+      principal: "managed-gateway-staging",
+      audience: "managed-gateway-internal",
+      scopes: ["managed-gateway:internal", "routes:resolve"],
+    },
+  }),
+  MANAGED_GATEWAY_INTERNAL_MTLS_PRINCIPALS: "managed-gateway-staging",
+  MANAGED_GATEWAY_INTERNAL_REVOKED_TOKEN_IDS: "",
 };
 
 describe("loadConfig", () => {
@@ -68,5 +82,38 @@ describe("loadConfig", () => {
     expect(config.enabled).toBe(true);
     expect(config.strictStartupValidation).toBe(false);
     expect(config.djangoInternalBaseUrl).toBeNull();
+  });
+
+  test("rejects unsupported internal auth mode", () => {
+    expect(() =>
+      loadConfig({
+        ...BASE_ENV,
+        MANAGED_GATEWAY_INTERNAL_AUTH_MODE: "invalid-mode",
+      }),
+    ).toThrow("MANAGED_GATEWAY_INTERNAL_AUTH_MODE must be one of: bearer, mtls.");
+  });
+
+  test("requires bearer token catalog when bearer mode is enabled", () => {
+    expect(() =>
+      loadConfig({
+        ...BASE_ENV,
+        MANAGED_GATEWAY_INTERNAL_AUTH_MODE: "bearer",
+        MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS: "{}",
+      }),
+    ).toThrow(
+      "MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS must define at least one token when bearer mode is enabled.",
+    );
+  });
+
+  test("requires mtls principal list when mtls mode is enabled", () => {
+    expect(() =>
+      loadConfig({
+        ...BASE_ENV,
+        MANAGED_GATEWAY_INTERNAL_AUTH_MODE: "mtls",
+        MANAGED_GATEWAY_INTERNAL_MTLS_PRINCIPALS: "",
+      }),
+    ).toThrow(
+      "MANAGED_GATEWAY_INTERNAL_MTLS_PRINCIPALS must define at least one principal when mTLS mode is enabled.",
+    );
   });
 });

--- a/gateway-managed/src/__tests__/internal-auth.test.ts
+++ b/gateway-managed/src/__tests__/internal-auth.test.ts
@@ -1,0 +1,336 @@
+import { describe, expect, test } from "bun:test";
+
+import { loadConfig } from "../config.js";
+import {
+  authenticateInternalRequest,
+  ManagedGatewayInternalAuthError,
+  withInternalAuth,
+} from "../internal-auth.js";
+
+const FAR_FUTURE = "2099-01-01T00:00:00.000Z";
+const FAR_PAST = "2000-01-01T00:00:00.000Z";
+
+type EnvOverrides = Record<string, string | undefined>;
+
+function makeConfig(overrides: EnvOverrides): ReturnType<typeof loadConfig> {
+  const baseEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    MANAGED_GATEWAY_ENABLED: "true",
+    MANAGED_GATEWAY_STRICT_STARTUP_VALIDATION: "true",
+    MANAGED_GATEWAY_DJANGO_INTERNAL_BASE_URL: "http://127.0.0.1:8000",
+    MANAGED_GATEWAY_INTERNAL_AUTH_MODE: "bearer",
+    MANAGED_GATEWAY_INTERNAL_AUTH_AUDIENCE: "managed-gateway-internal",
+    MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS: JSON.stringify({
+      "token-active": {
+        token_id: "mgw-2026-01",
+        principal: "managed-gateway-staging",
+        audience: "managed-gateway-internal",
+        scopes: ["managed-gateway:internal", "routes:resolve"],
+        expires_at: FAR_FUTURE,
+      },
+    }),
+    MANAGED_GATEWAY_INTERNAL_REVOKED_TOKEN_IDS: "",
+    MANAGED_GATEWAY_INTERNAL_MTLS_PRINCIPALS: "managed-gateway-staging",
+    MANAGED_GATEWAY_MTLS_PRINCIPAL_HEADER: "x-managed-gateway-principal",
+    MANAGED_GATEWAY_MTLS_AUDIENCE_HEADER: "x-managed-gateway-audience",
+    MANAGED_GATEWAY_MTLS_SCOPES_HEADER: "x-managed-gateway-scopes",
+    ...overrides,
+  };
+
+  return loadConfig(baseEnv);
+}
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+  return new Request("http://managed-gateway.test/v1/internal/managed-gateway/routes/resolve/", {
+    headers,
+  });
+}
+
+describe("internal auth - bearer", () => {
+  test("rejects missing bearer token", () => {
+    const config = makeConfig({});
+
+    expect(() =>
+      authenticateInternalRequest(makeRequest(), config, "routes:resolve"),
+    ).toThrow("Missing managed gateway bearer token.");
+  });
+
+  test("rejects unknown bearer token", () => {
+    const config = makeConfig({});
+
+    expect(() =>
+      authenticateInternalRequest(
+        makeRequest({ authorization: "Bearer token-unknown" }),
+        config,
+        "routes:resolve",
+      ),
+    ).toThrow("Unknown managed gateway bearer token.");
+  });
+
+  test("rejects expired bearer token", () => {
+    const config = makeConfig({
+      MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS: JSON.stringify({
+        "token-expired": {
+          token_id: "mgw-expired",
+          principal: "managed-gateway-staging",
+          audience: "managed-gateway-internal",
+          scopes: ["managed-gateway:internal", "routes:resolve"],
+          expires_at: FAR_PAST,
+        },
+      }),
+    });
+
+    expect(() =>
+      authenticateInternalRequest(
+        makeRequest({ authorization: "Bearer token-expired" }),
+        config,
+        "routes:resolve",
+      ),
+    ).toThrow("Managed gateway bearer token is expired.");
+  });
+
+  test("rejects bearer token missing required scope", () => {
+    const config = makeConfig({
+      MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS: JSON.stringify({
+        "token-missing-scope": {
+          token_id: "mgw-missing-scope",
+          principal: "managed-gateway-staging",
+          audience: "managed-gateway-internal",
+          scopes: ["managed-gateway:internal"],
+          expires_at: FAR_FUTURE,
+        },
+      }),
+    });
+
+    expect(() =>
+      authenticateInternalRequest(
+        makeRequest({ authorization: "Bearer token-missing-scope" }),
+        config,
+        "routes:resolve",
+      ),
+    ).toThrow("missing required scope routes:resolve");
+  });
+
+  test("rejects bearer audience mismatch", () => {
+    const config = makeConfig({
+      MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS: JSON.stringify({
+        "token-wrong-aud": {
+          token_id: "mgw-wrong-aud",
+          principal: "managed-gateway-staging",
+          audience: "some-other-audience",
+          scopes: ["managed-gateway:internal", "routes:resolve"],
+          expires_at: FAR_FUTURE,
+        },
+      }),
+    });
+
+    expect(() =>
+      authenticateInternalRequest(
+        makeRequest({ authorization: "Bearer token-wrong-aud" }),
+        config,
+        "routes:resolve",
+      ),
+    ).toThrow("Managed gateway bearer audience mismatch.");
+  });
+
+  test("accepts valid bearer token", () => {
+    const config = makeConfig({});
+
+    const principal = authenticateInternalRequest(
+      makeRequest({ authorization: "Bearer token-active" }),
+      config,
+      "routes:resolve",
+    );
+
+    expect(principal.principalId).toBe("managed-gateway-staging");
+    expect(principal.authMode).toBe("bearer");
+    expect(principal.audience).toBe("managed-gateway-internal");
+    expect(principal.scopes).toContain("routes:resolve");
+  });
+
+  test("accepts rotated bearer tokens during overlap", () => {
+    const config = makeConfig({
+      MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS: JSON.stringify({
+        "token-old": {
+          token_id: "mgw-2026-01",
+          principal: "managed-gateway-staging",
+          audience: "managed-gateway-internal",
+          scopes: ["managed-gateway:internal", "routes:resolve"],
+          expires_at: FAR_FUTURE,
+        },
+        "token-new": {
+          token_id: "mgw-2026-02",
+          principal: "managed-gateway-staging",
+          audience: "managed-gateway-internal",
+          scopes: ["managed-gateway:internal", "routes:resolve"],
+          expires_at: FAR_FUTURE,
+        },
+      }),
+    });
+
+    expect(
+      authenticateInternalRequest(
+        makeRequest({ authorization: "Bearer token-old" }),
+        config,
+        "routes:resolve",
+      ).principalId,
+    ).toBe("managed-gateway-staging");
+
+    expect(
+      authenticateInternalRequest(
+        makeRequest({ authorization: "Bearer token-new" }),
+        config,
+        "routes:resolve",
+      ).principalId,
+    ).toBe("managed-gateway-staging");
+  });
+
+  test("rejects revoked old token after rotation and accepts new token", () => {
+    const config = makeConfig({
+      MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS: JSON.stringify({
+        "token-old": {
+          token_id: "mgw-2026-01",
+          principal: "managed-gateway-staging",
+          audience: "managed-gateway-internal",
+          scopes: ["managed-gateway:internal", "routes:resolve"],
+          expires_at: FAR_FUTURE,
+        },
+        "token-new": {
+          token_id: "mgw-2026-02",
+          principal: "managed-gateway-staging",
+          audience: "managed-gateway-internal",
+          scopes: ["managed-gateway:internal", "routes:resolve"],
+          expires_at: FAR_FUTURE,
+        },
+      }),
+      MANAGED_GATEWAY_INTERNAL_REVOKED_TOKEN_IDS: "mgw-2026-01",
+    });
+
+    expect(() =>
+      authenticateInternalRequest(
+        makeRequest({ authorization: "Bearer token-old" }),
+        config,
+        "routes:resolve",
+      ),
+    ).toThrow("Managed gateway bearer token has been revoked.");
+
+    expect(
+      authenticateInternalRequest(
+        makeRequest({ authorization: "Bearer token-new" }),
+        config,
+        "routes:resolve",
+      ).principalId,
+    ).toBe("managed-gateway-staging");
+  });
+});
+
+describe("internal auth - mtls", () => {
+  test("rejects unauthorized mTLS principal", () => {
+    const config = makeConfig({
+      MANAGED_GATEWAY_INTERNAL_AUTH_MODE: "mtls",
+      MANAGED_GATEWAY_INTERNAL_MTLS_PRINCIPALS: "managed-gateway-staging",
+    });
+
+    expect(() =>
+      authenticateInternalRequest(
+        makeRequest({
+          "x-managed-gateway-principal": "managed-gateway-dev",
+          "x-managed-gateway-audience": "managed-gateway-internal",
+          "x-managed-gateway-scopes": "managed-gateway:internal,routes:resolve",
+        }),
+        config,
+        "routes:resolve",
+      ),
+    ).toThrow("Managed gateway mTLS principal is not authorized.");
+  });
+
+  test("rejects mTLS scope mismatch", () => {
+    const config = makeConfig({
+      MANAGED_GATEWAY_INTERNAL_AUTH_MODE: "mtls",
+      MANAGED_GATEWAY_INTERNAL_MTLS_PRINCIPALS: "managed-gateway-staging",
+    });
+
+    expect(() =>
+      authenticateInternalRequest(
+        makeRequest({
+          "x-managed-gateway-principal": "managed-gateway-staging",
+          "x-managed-gateway-audience": "managed-gateway-internal",
+          "x-managed-gateway-scopes": "managed-gateway:internal",
+        }),
+        config,
+        "routes:resolve",
+      ),
+    ).toThrow("missing required scope routes:resolve");
+  });
+
+  test("accepts valid mTLS principal, audience, and scope", () => {
+    const config = makeConfig({
+      MANAGED_GATEWAY_INTERNAL_AUTH_MODE: "mtls",
+      MANAGED_GATEWAY_INTERNAL_MTLS_PRINCIPALS: "managed-gateway-staging",
+    });
+
+    const principal = authenticateInternalRequest(
+      makeRequest({
+        "x-managed-gateway-principal": "managed-gateway-staging",
+        "x-managed-gateway-audience": "managed-gateway-internal",
+        "x-managed-gateway-scopes": "managed-gateway:internal,routes:resolve",
+      }),
+      config,
+      "routes:resolve",
+    );
+
+    expect(principal.authMode).toBe("mtls");
+    expect(principal.principalId).toBe("managed-gateway-staging");
+  });
+});
+
+describe("internal auth middleware", () => {
+  test("returns explicit 401 envelope for auth errors", async () => {
+    const config = makeConfig({});
+    const handler = withInternalAuth(config, async () => {
+      return Response.json({ ok: true });
+    }, "routes:resolve");
+
+    const response = await handler(makeRequest());
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "missing_bearer",
+        detail: "Missing managed gateway bearer token.",
+      },
+    });
+  });
+
+  test("passes principal to handler when authentication succeeds", async () => {
+    const config = makeConfig({});
+    const handler = withInternalAuth(config, async (_request, principal) => {
+      return Response.json({ principalId: principal.principalId, authMode: principal.authMode });
+    }, "routes:resolve");
+
+    const response = await handler(
+      makeRequest({ authorization: "Bearer token-active" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      principalId: "managed-gateway-staging",
+      authMode: "bearer",
+    });
+  });
+
+  test("throws typed auth error for inspection when needed", () => {
+    const config = makeConfig({});
+
+    try {
+      authenticateInternalRequest(makeRequest(), config, "routes:resolve");
+      throw new Error("Expected auth error");
+    } catch (error) {
+      expect(error instanceof ManagedGatewayInternalAuthError).toBe(true);
+      if (error instanceof ManagedGatewayInternalAuthError) {
+        expect(error.code).toBe("missing_bearer");
+        expect(error.status).toBe(401);
+      }
+    }
+  });
+});

--- a/gateway-managed/src/__tests__/probes.test.ts
+++ b/gateway-managed/src/__tests__/probes.test.ts
@@ -5,6 +5,16 @@ import { loadConfig } from "../config.js";
 const BASE_ENV: NodeJS.ProcessEnv = {
   ...process.env,
   MANAGED_GATEWAY_DJANGO_INTERNAL_BASE_URL: "http://127.0.0.1:8000",
+  MANAGED_GATEWAY_INTERNAL_AUTH_MODE: "bearer",
+  MANAGED_GATEWAY_INTERNAL_AUTH_AUDIENCE: "managed-gateway-internal",
+  MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS: JSON.stringify({
+    "token-active": {
+      token_id: "mgw-active",
+      principal: "managed-gateway-staging",
+      audience: "managed-gateway-internal",
+      scopes: ["managed-gateway:internal", "routes:resolve"],
+    },
+  }),
 };
 
 function handleRequest(url: string, env: NodeJS.ProcessEnv = process.env): Response {

--- a/gateway-managed/src/config.ts
+++ b/gateway-managed/src/config.ts
@@ -1,3 +1,25 @@
+export type ManagedGatewayInternalAuthMode = "bearer" | "mtls";
+
+export type ManagedGatewayBearerTokenMetadata = {
+  tokenId: string;
+  principal: string;
+  audience: string;
+  scopes: string[];
+  expiresAt: string | null;
+  revoked: boolean;
+};
+
+export type ManagedGatewayInternalAuthConfig = {
+  mode: ManagedGatewayInternalAuthMode;
+  audience: string;
+  bearerTokens: Record<string, ManagedGatewayBearerTokenMetadata>;
+  revokedTokenIds: Set<string>;
+  mtlsPrincipals: Set<string>;
+  mtlsPrincipalHeader: string;
+  mtlsAudienceHeader: string;
+  mtlsScopesHeader: string;
+};
+
 export type ManagedGatewayConfig = {
   port: number;
   enabled: boolean;
@@ -5,6 +27,7 @@ export type ManagedGatewayConfig = {
   mode: string;
   strictStartupValidation: boolean;
   djangoInternalBaseUrl: string | null;
+  internalAuth: ManagedGatewayInternalAuthConfig;
 };
 
 function parseBoolean(raw: string | undefined, defaultValue: boolean): boolean {
@@ -12,6 +35,128 @@ function parseBoolean(raw: string | undefined, defaultValue: boolean): boolean {
   if (raw === "true") return true;
   if (raw === "false") return false;
   throw new Error("Boolean env values must be true/false.");
+}
+
+function parseCsv(raw: string | undefined): Set<string> {
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(",")
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0),
+  );
+}
+
+function parseScopes(raw: unknown): string[] {
+  if (typeof raw === "string") {
+    return raw
+      .split(",")
+      .map((scope) => scope.trim())
+      .filter((scope) => scope.length > 0);
+  }
+
+  if (Array.isArray(raw)) {
+    return raw
+      .map((scope) => (typeof scope === "string" ? scope.trim() : ""))
+      .filter((scope) => scope.length > 0);
+  }
+
+  throw new Error("Bearer token scopes must be a string or string array.");
+}
+
+function parseExpiry(raw: unknown): string | null {
+  if (raw === undefined || raw === null || raw === "") {
+    return null;
+  }
+
+  if (typeof raw !== "string") {
+    throw new Error("Bearer token expires_at must be a string.");
+  }
+
+  const parsedEpoch = Date.parse(raw);
+  if (Number.isNaN(parsedEpoch)) {
+    throw new Error("Bearer token expires_at must be an ISO-8601 datetime.");
+  }
+
+  return raw;
+}
+
+function parseBearerTokens(
+  rawValue: string | undefined,
+  defaultAudience: string,
+): Record<string, ManagedGatewayBearerTokenMetadata> {
+  const source = rawValue?.trim() || "{}";
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch {
+    throw new Error("MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS must be valid JSON.");
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(
+      "MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS must be a JSON object keyed by token value.",
+    );
+  }
+
+  const result: Record<string, ManagedGatewayBearerTokenMetadata> = {};
+
+  for (const [tokenValue, rawMetadata] of Object.entries(parsed)) {
+    if (typeof rawMetadata !== "object" || rawMetadata === null || Array.isArray(rawMetadata)) {
+      throw new Error("Each managed-gateway bearer token entry must be an object.");
+    }
+
+    const metadata = rawMetadata as Record<string, unknown>;
+
+    const tokenIdRaw = metadata.token_id ?? metadata.tokenId ?? tokenValue;
+    if (typeof tokenIdRaw !== "string" || tokenIdRaw.trim().length === 0) {
+      throw new Error("Each managed-gateway bearer token must define token_id.");
+    }
+
+    const principalRaw = metadata.principal ?? "managed-gateway";
+    if (typeof principalRaw !== "string" || principalRaw.trim().length === 0) {
+      throw new Error("Each managed-gateway bearer token must define principal.");
+    }
+
+    const audienceRaw = metadata.audience ?? defaultAudience;
+    if (typeof audienceRaw !== "string" || audienceRaw.trim().length === 0) {
+      throw new Error("Each managed-gateway bearer token must define audience.");
+    }
+
+    const scopesRaw = metadata.scopes ?? ["managed-gateway:internal"];
+    const scopes = parseScopes(scopesRaw);
+    if (scopes.length === 0) {
+      throw new Error("Each managed-gateway bearer token must define at least one scope.");
+    }
+
+    const revokedRaw = metadata.revoked;
+    if (revokedRaw !== undefined && typeof revokedRaw !== "boolean") {
+      throw new Error("Each managed-gateway bearer token revoked value must be boolean.");
+    }
+
+    result[tokenValue] = {
+      tokenId: tokenIdRaw.trim(),
+      principal: principalRaw.trim(),
+      audience: audienceRaw.trim(),
+      scopes,
+      expiresAt: parseExpiry(metadata.expires_at ?? metadata.expiresAt),
+      revoked: revokedRaw === true,
+    };
+  }
+
+  return result;
+}
+
+function parseInternalAuthMode(raw: string | undefined): ManagedGatewayInternalAuthMode {
+  const normalized = (raw || "bearer").trim().toLowerCase();
+  if (normalized === "bearer" || normalized === "mtls") {
+    return normalized;
+  }
+
+  throw new Error(
+    "MANAGED_GATEWAY_INTERNAL_AUTH_MODE must be one of: bearer, mtls.",
+  );
 }
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): ManagedGatewayConfig {
@@ -30,6 +175,27 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ManagedGateway
   const djangoInternalBaseUrl = djangoInternalBaseUrlRaw?.trim() || null;
 
   const enabled = parseBoolean(env.MANAGED_GATEWAY_ENABLED, true);
+
+  const authAudience =
+    env.MANAGED_GATEWAY_INTERNAL_AUTH_AUDIENCE || "managed-gateway-internal";
+  const internalAuth: ManagedGatewayInternalAuthConfig = {
+    mode: parseInternalAuthMode(env.MANAGED_GATEWAY_INTERNAL_AUTH_MODE),
+    audience: authAudience,
+    bearerTokens: parseBearerTokens(
+      env.MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS,
+      authAudience,
+    ),
+    revokedTokenIds: parseCsv(env.MANAGED_GATEWAY_INTERNAL_REVOKED_TOKEN_IDS),
+    mtlsPrincipals: parseCsv(env.MANAGED_GATEWAY_INTERNAL_MTLS_PRINCIPALS),
+    mtlsPrincipalHeader:
+      env.MANAGED_GATEWAY_MTLS_PRINCIPAL_HEADER ||
+      "x-managed-gateway-principal",
+    mtlsAudienceHeader:
+      env.MANAGED_GATEWAY_MTLS_AUDIENCE_HEADER || "x-managed-gateway-audience",
+    mtlsScopesHeader:
+      env.MANAGED_GATEWAY_MTLS_SCOPES_HEADER || "x-managed-gateway-scopes",
+  };
+
   if (strictStartupValidation && enabled) {
     if (!djangoInternalBaseUrl) {
       throw new Error(
@@ -51,6 +217,21 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ManagedGateway
         "MANAGED_GATEWAY_DJANGO_INTERNAL_BASE_URL must use http or https.",
       );
     }
+
+    if (
+      internalAuth.mode === "bearer"
+      && Object.keys(internalAuth.bearerTokens).length === 0
+    ) {
+      throw new Error(
+        "MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS must define at least one token when bearer mode is enabled.",
+      );
+    }
+
+    if (internalAuth.mode === "mtls" && internalAuth.mtlsPrincipals.size === 0) {
+      throw new Error(
+        "MANAGED_GATEWAY_INTERNAL_MTLS_PRINCIPALS must define at least one principal when mTLS mode is enabled.",
+      );
+    }
   }
 
   return {
@@ -60,5 +241,6 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ManagedGateway
     mode: env.MANAGED_GATEWAY_MODE || "skeleton",
     strictStartupValidation,
     djangoInternalBaseUrl,
+    internalAuth,
   };
 }

--- a/gateway-managed/src/internal-auth.ts
+++ b/gateway-managed/src/internal-auth.ts
@@ -1,0 +1,221 @@
+import type {
+  ManagedGatewayBearerTokenMetadata,
+  ManagedGatewayConfig,
+} from "./config.js";
+
+const DEFAULT_REQUIRED_SCOPE = "managed-gateway:internal";
+
+export type ManagedGatewayInternalPrincipal = {
+  principalId: string;
+  authMode: "bearer" | "mtls";
+  audience: string;
+  scopes: string[];
+};
+
+export class ManagedGatewayInternalAuthError extends Error {
+  constructor(
+    readonly code: string,
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export type ManagedGatewayHandler = (
+  request: Request,
+  principal: ManagedGatewayInternalPrincipal,
+) => Response | Promise<Response>;
+
+export function withInternalAuth(
+  config: ManagedGatewayConfig,
+  handler: ManagedGatewayHandler,
+  requiredScope: string = DEFAULT_REQUIRED_SCOPE,
+): (request: Request) => Promise<Response> {
+  return async (request: Request): Promise<Response> => {
+    try {
+      const principal = authenticateInternalRequest(request, config, requiredScope);
+      return await handler(request, principal);
+    } catch (error) {
+      if (error instanceof ManagedGatewayInternalAuthError) {
+        return Response.json(
+          {
+            error: {
+              code: error.code,
+              detail: error.message,
+            },
+          },
+          { status: error.status },
+        );
+      }
+
+      throw error;
+    }
+  };
+}
+
+export function authenticateInternalRequest(
+  request: Request,
+  config: ManagedGatewayConfig,
+  requiredScope: string = DEFAULT_REQUIRED_SCOPE,
+): ManagedGatewayInternalPrincipal {
+  if (config.internalAuth.mode === "bearer") {
+    return authenticateBearer(request, config, requiredScope);
+  }
+
+  return authenticateMtls(request, config, requiredScope);
+}
+
+function authenticateBearer(
+  request: Request,
+  config: ManagedGatewayConfig,
+  requiredScope: string,
+): ManagedGatewayInternalPrincipal {
+  const authorization = request.headers.get("authorization")?.trim() || "";
+  if (!authorization.startsWith("Bearer ")) {
+    throw new ManagedGatewayInternalAuthError(
+      "missing_bearer",
+      401,
+      "Missing managed gateway bearer token.",
+    );
+  }
+
+  const tokenValue = authorization.slice("Bearer ".length).trim();
+  if (!tokenValue) {
+    throw new ManagedGatewayInternalAuthError(
+      "missing_bearer",
+      401,
+      "Missing managed gateway bearer token.",
+    );
+  }
+
+  const metadata = config.internalAuth.bearerTokens[tokenValue];
+  if (!metadata) {
+    throw new ManagedGatewayInternalAuthError(
+      "unknown_bearer",
+      401,
+      "Unknown managed gateway bearer token.",
+    );
+  }
+
+  ensureBearerTokenIsActive(metadata, config);
+  ensureAudience(metadata.audience, config.internalAuth.audience, "bearer");
+  ensureScope(metadata.scopes, requiredScope, "bearer");
+
+  return {
+    principalId: metadata.principal,
+    authMode: "bearer",
+    audience: metadata.audience,
+    scopes: metadata.scopes,
+  };
+}
+
+function authenticateMtls(
+  request: Request,
+  config: ManagedGatewayConfig,
+  requiredScope: string,
+): ManagedGatewayInternalPrincipal {
+  const principalHeader = config.internalAuth.mtlsPrincipalHeader;
+  const principalId = request.headers.get(principalHeader)?.trim() || "";
+  if (!principalId) {
+    throw new ManagedGatewayInternalAuthError(
+      "missing_mtls_principal",
+      401,
+      "Missing managed gateway mTLS principal.",
+    );
+  }
+
+  if (!config.internalAuth.mtlsPrincipals.has(principalId)) {
+    throw new ManagedGatewayInternalAuthError(
+      "unauthorized_mtls_principal",
+      401,
+      "Managed gateway mTLS principal is not authorized.",
+    );
+  }
+
+  const audienceHeader = config.internalAuth.mtlsAudienceHeader;
+  const audience =
+    request.headers.get(audienceHeader)?.trim() || config.internalAuth.audience;
+  ensureAudience(audience, config.internalAuth.audience, "mTLS");
+
+  const scopesHeader = config.internalAuth.mtlsScopesHeader;
+  const scopes = (request.headers.get(scopesHeader) || "")
+    .split(",")
+    .map((scope) => scope.trim())
+    .filter((scope) => scope.length > 0);
+
+  ensureScope(scopes, requiredScope, "mTLS");
+
+  return {
+    principalId,
+    authMode: "mtls",
+    audience,
+    scopes,
+  };
+}
+
+function ensureBearerTokenIsActive(
+  metadata: ManagedGatewayBearerTokenMetadata,
+  config: ManagedGatewayConfig,
+): void {
+  if (metadata.revoked || config.internalAuth.revokedTokenIds.has(metadata.tokenId)) {
+    throw new ManagedGatewayInternalAuthError(
+      "revoked_bearer",
+      401,
+      "Managed gateway bearer token has been revoked.",
+    );
+  }
+
+  if (!metadata.expiresAt) {
+    return;
+  }
+
+  const expiresAt = Date.parse(metadata.expiresAt);
+  if (Number.isNaN(expiresAt)) {
+    throw new ManagedGatewayInternalAuthError(
+      "invalid_bearer_expiry",
+      401,
+      "Managed gateway bearer token expiry metadata is invalid.",
+    );
+  }
+
+  if (Date.now() >= expiresAt) {
+    throw new ManagedGatewayInternalAuthError(
+      "expired_bearer",
+      401,
+      "Managed gateway bearer token is expired.",
+    );
+  }
+}
+
+function ensureAudience(
+  actualAudience: string,
+  expectedAudience: string,
+  authKind: "bearer" | "mTLS",
+): void {
+  if (actualAudience === expectedAudience) {
+    return;
+  }
+
+  throw new ManagedGatewayInternalAuthError(
+    "audience_mismatch",
+    401,
+    `Managed gateway ${authKind} audience mismatch.`,
+  );
+}
+
+function ensureScope(
+  scopes: string[],
+  requiredScope: string,
+  authKind: "bearer" | "mTLS",
+): void {
+  if (scopes.includes(requiredScope)) {
+    return;
+  }
+
+  throw new ManagedGatewayInternalAuthError(
+    "missing_scope",
+    401,
+    `Managed gateway ${authKind} credentials are missing required scope ${requiredScope}.`,
+  );
+}


### PR DESCRIPTION
## Summary\n- add managed-gateway internal auth abstraction supporting bearer and mTLS modes\n- enforce deny-by-default audience and required-scope checks\n- add token lifecycle handling for expiry and revocation, plus rotation overlap tests\n- document auth lifecycle and add config validation/tests\n\n## Validation\n- cd gateway-managed && bun run typecheck\n- cd gateway-managed && bun run build\n- cd gateway-managed && bun run test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
