### PR TITLE
fix: align migration registry key with actual checkpoint key

### DIFF
--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -96,7 +96,7 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description: 'Normalize phone-like identity fields to E.164 format across guardian bindings, verification challenges, canonical requests, ingress members, and rate limits',
   },
   {
-    key: 'migration_backfill_guardian_principal_id_v2',
+    key: 'migration_backfill_guardian_principal_id_v3',
     version: 15,
     description: 'Backfill guardianPrincipalId for existing channel_guardian_bindings and canonical_guardian_requests rows, expire unresolvable pending requests',
   },


### PR DESCRIPTION
The migration registry declared the backfill-guardian-principal-id migration as _v2 but the migration itself writes checkpoint _v3. Aligns registry to match.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
