### PR TITLE
refactor: remove gateway assistant-scoped runtime-proxy rewrite (#11058)

### DIFF
--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -267,7 +267,7 @@ Telegram messages follow three paths through the system:
 ```
 Inbound (user → assistant):
   Telegram → Gateway POST /webhooks/telegram → verify secret → normalize → route
-    → Runtime POST /v1/assistants/:id/channels/inbound
+    → Runtime POST /v1/channels/inbound
     (replyCallbackUrl = ${gatewayInternalBaseUrl}/deliver/telegram)
 
 Outbound reply (assistant → user, triggered by inbound):

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -5,7 +5,7 @@ Standalone service that serves as the public ingress boundary for all external w
 ## Architecture
 
 ```
-Telegram → gateway/ → Assistant Runtime (/v1/assistants/:id/channels/inbound) → gateway/ → Telegram
+Telegram → gateway/ → Assistant Runtime (/v1/channels/inbound) → gateway/ → Telegram
 
 Client → gateway/ (Bearer auth) → Assistant Runtime (any path)
 ```
@@ -316,12 +316,12 @@ By default (`GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH=true`), proxied requests must in
 
 ```bash
 # Unauthorized (expect 401 when auth required)
-curl -i http://localhost:7830/v1/assistants/test/health
+curl -i http://localhost:7830/v1/health
 
 # Authorized (expect 200)
 curl -i \
   -H "Authorization: Bearer $RUNTIME_PROXY_BEARER_TOKEN" \
-  http://localhost:7830/v1/assistants/test/health
+  http://localhost:7830/v1/health
 
 # Telegram still uses webhook secret flow, not bearer auth
 curl -i -X POST http://localhost:7830/webhooks/telegram

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -68,40 +68,39 @@ afterEach(() => {
 });
 
 describe("runtime proxy handler", () => {
-  test("rewrites legacy /v1/assistants/:assistantId/... to flat /v1/... for upstream", async () => {
-    const captured: { url: string }[] = [];
+  test("rejects legacy /v1/assistants/:assistantId/... paths with 400", async () => {
+    const fetchCalls: string[] = [];
     fetchMock = mock(async (input: string | URL | Request) => {
-      captured.push({ url: String(input) });
+      fetchCalls.push(String(input));
       return new Response(JSON.stringify({ ok: true }), { status: 200 });
     });
 
     const handler = createRuntimeProxyHandler(makeConfig());
     const req = new Request("http://localhost:7830/v1/assistants/test-assistant/channels/inbound");
-    await handler(req);
+    const res = await handler(req);
 
-    expect(captured[0].url).toBe("http://localhost:7821/v1/channels/inbound");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.source).toBe("gateway");
+    // Request was rejected before proxying
+    expect(fetchCalls.length).toBe(0);
   });
 
-  test("forwards request to upstream with correct path and query (legacy assistant-scoped rewrite)", async () => {
-    const captured: { url: string; method: string }[] = [];
-    fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
-      captured.push({ url: String(input), method: init?.method ?? "GET" });
-      return new Response(JSON.stringify({ ok: true }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
+  test("rejects legacy assistant-scoped path with query string", async () => {
+    const fetchCalls: string[] = [];
+    fetchMock = mock(async (input: string | URL | Request) => {
+      fetchCalls.push(String(input));
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
     });
 
     const handler = createRuntimeProxyHandler(makeConfig());
     const req = new Request("http://localhost:7830/v1/assistants/test/health?foo=bar");
     const res = await handler(req);
 
-    expect(res.status).toBe(200);
-    // Legacy /v1/assistants/test/health is rewritten to /v1/health
-    expect(captured[0].url).toBe("http://localhost:7821/v1/health?foo=bar");
-    expect(captured[0].method).toBe("GET");
+    expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body).toEqual({ ok: true });
+    expect(body.source).toBe("gateway");
+    expect(fetchCalls.length).toBe(0);
   });
 
   test("forwards POST body to upstream", async () => {

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -45,15 +45,20 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
       }
     }
 
-    // The daemon uses flat /v1/... paths. Rewrite any legacy
-    // /v1/assistants/:assistantId/... requests from clients to flat paths.
-    let upstreamPath = url.pathname;
-    const assistantScopedMatch = url.pathname.match(/^\/v1\/assistants\/[^/]+\/(.+)$/);
-    if (assistantScopedMatch) {
-      upstreamPath = `/v1/${assistantScopedMatch[1]}`;
+    // Reject legacy assistant-scoped paths — the daemon only accepts
+    // flat /v1/... paths and we no longer rewrite on the caller's behalf.
+    if (/^\/v1\/assistants\/[^/]+\//.test(url.pathname)) {
+      log.warn(
+        { method: req.method, path: url.pathname },
+        "Rejected legacy assistant-scoped path — use canonical /v1/... paths",
+      );
+      return Response.json(
+        { error: "Legacy assistant-scoped paths are no longer supported. Use /v1/... instead.", source: "gateway" },
+        { status: 400 },
+      );
     }
 
-    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${url.search}`;
+    const upstream = `${config.assistantRuntimeBaseUrl}${url.pathname}${url.search}`;
 
     const reqHeaders = stripHopByHop(new Headers(req.headers));
     reqHeaders.delete("host");


### PR DESCRIPTION
Part of legacy compatibility removal Phase 1. Removes assistant-scoped path rewrite logic from gateway runtime-proxy, keeping only canonical /v1/... upstream paths. Legacy /v1/assistants/:assistantId/... requests are now explicitly rejected with 400 instead of silently rewritten. Updates tests to assert rejection behavior and fixes documentation references. Closes #11058.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
