### PR TITLE
Add Django internal router stub endpoint and wiring

### DIFF
--- a/gateway-managed/ARCHITECTURE.md
+++ b/gateway-managed/ARCHITECTURE.md
@@ -19,9 +19,16 @@ The managed gateway is a dedicated service lane for Vellum-owned shared channel 
 - Enforces deny-by-default verification for audience and required scopes.
 - Defines token lifecycle checks for expiry and revocation to support safe rotation.
 
+## PR-4 scope
+
+- Adds managed route-resolution endpoint wiring at `/v1/internal/managed-gateway/routes/resolve/`.
+- Enforces internal auth (`bearer` or `mtls`) with required `routes:resolve` scope.
+- Normalizes request routing keys and proxies to Django internal route resolver with explicit error envelopes.
+
 ## Endpoints
 
 - `GET /healthz`
 - `GET /readyz`
 - `GET /v1/internal/managed-gateway/healthz/`
 - `GET /v1/internal/managed-gateway/readyz/`
+- `POST /v1/internal/managed-gateway/routes/resolve/`

--- a/gateway-managed/README.md
+++ b/gateway-managed/README.md
@@ -7,11 +7,14 @@ Managed gateway service skeleton for Vellum-owned shared channel identities.
 - package scaffold and startup entrypoint
 - strict startup config validation for enabled managed gateway mode
 - internal auth middleware abstraction for bearer and mTLS service auth
+- Django internal route resolve endpoint wiring for managed route lookup
 - health and readiness endpoints:
   - `/healthz`
   - `/readyz`
   - `/v1/internal/managed-gateway/healthz/`
   - `/v1/internal/managed-gateway/readyz/`
+- route resolve endpoint:
+  - `POST /v1/internal/managed-gateway/routes/resolve/`
 
 ## Configuration
 
@@ -45,3 +48,7 @@ bun run test
 - Rotation: keep old and new bearer entries active during rollout overlap.
 - Revocation: set `revoked: true` on a token entry or add its `token_id` to `MANAGED_GATEWAY_INTERNAL_REVOKED_TOKEN_IDS`.
 - Expiry: set `expires_at` as ISO-8601 UTC; expired bearer tokens are rejected.
+
+## Route Resolve Contract
+
+Managed gateway route resolution contract lives in [`route-resolve-contract.md`](./route-resolve-contract.md).

--- a/gateway-managed/route-resolve-contract.md
+++ b/gateway-managed/route-resolve-contract.md
@@ -1,0 +1,25 @@
+# Managed Gateway Route Resolve Contract
+
+Endpoint: `POST /v1/internal/managed-gateway/routes/resolve/`
+
+Caller expectations:
+- caller is an internal Vellum-managed gateway client only
+- request body includes normalized routing keys: `provider`, `route_type`, `identity_key`
+- caller retries only on transport-level failures; 4xx responses are terminal
+
+Authz boundary:
+- requires managed gateway internal auth middleware (`bearer` or `mtls`)
+- requires `routes:resolve` scope
+- requires audience match to `MANAGED_GATEWAY_INTERNAL_AUTH_AUDIENCE`
+
+Request normalization:
+- `provider`: trim + lowercase
+- `route_type`: trim + lowercase
+- `identity_key`: trim + lowercase, strip `tel:` prefix, remove spaces
+
+Response contract:
+- `200`: pass-through route mapping payload from Django internal resolver
+- `400`: error envelope (`validation_error`) for invalid payload
+- `401`: error envelope for internal auth failure
+- `404`: pass-through error envelope (`managed_route_not_found`) from Django
+- `502`: error envelope for upstream transport or unexpected upstream status failures

--- a/gateway-managed/src/__tests__/probes.test.ts
+++ b/gateway-managed/src/__tests__/probes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { loadConfig } from "../config.js";
+import { createManagedGatewayAppFetch } from "../http.js";
 
 const BASE_ENV: NodeJS.ProcessEnv = {
   ...process.env,
@@ -17,50 +18,20 @@ const BASE_ENV: NodeJS.ProcessEnv = {
   }),
 };
 
-function handleRequest(url: string, env: NodeJS.ProcessEnv = process.env): Response {
+async function handleRequest(
+  url: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<Response> {
   const config = loadConfig({ ...BASE_ENV, ...env });
-  const pathname = new URL(url).pathname;
-
-  if (pathname === "/healthz" || pathname === "/v1/internal/managed-gateway/healthz/") {
-    return Response.json({
-      status: "ok",
-      service: config.serviceName,
-      mode: config.mode,
-      enabled: config.enabled,
-    });
-  }
-
-  if (pathname === "/readyz" || pathname === "/v1/internal/managed-gateway/readyz/") {
-    if (!config.enabled) {
-      return Response.json(
-        {
-          status: "not_ready",
-          service: config.serviceName,
-          mode: config.mode,
-          reason: "managed_gateway_disabled",
-        },
-        { status: 503 },
-      );
-    }
-
-    const payload: Record<string, string> = {
-      status: "ready",
-      service: config.serviceName,
-      mode: config.mode,
-    };
-    if (config.djangoInternalBaseUrl) {
-      payload.upstreamBaseUrl = config.djangoInternalBaseUrl;
-    }
-
-    return Response.json(payload);
-  }
-
-  return Response.json({ error: "Not found" }, { status: 404 });
+  const fetchHandler = createManagedGatewayAppFetch(config);
+  return fetchHandler(new Request(url));
 }
 
 describe("managed-gateway probes", () => {
   test("health endpoints return ok payload", async () => {
-    const res = handleRequest("http://managed-gateway.test/v1/internal/managed-gateway/healthz/");
+    const res = await handleRequest(
+      "http://managed-gateway.test/v1/internal/managed-gateway/healthz/",
+    );
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
       status: "ok",
@@ -71,7 +42,9 @@ describe("managed-gateway probes", () => {
   });
 
   test("readiness endpoint returns ready by default", async () => {
-    const res = handleRequest("http://managed-gateway.test/v1/internal/managed-gateway/readyz/");
+    const res = await handleRequest(
+      "http://managed-gateway.test/v1/internal/managed-gateway/readyz/",
+    );
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
       status: "ready",
@@ -82,7 +55,7 @@ describe("managed-gateway probes", () => {
   });
 
   test("readiness endpoint returns 503 when disabled", async () => {
-    const res = handleRequest(
+    const res = await handleRequest(
       "http://managed-gateway.test/v1/internal/managed-gateway/readyz/",
       {
         ...process.env,

--- a/gateway-managed/src/__tests__/route-resolve.test.ts
+++ b/gateway-managed/src/__tests__/route-resolve.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { loadConfig } from "../config.js";
+import { createManagedGatewayAppFetch } from "../http.js";
+import {
+  MANAGED_GATEWAY_ROUTE_RESOLVE_PATH,
+  type ManagedGatewayUpstreamFetch,
+} from "../route-resolve.js";
+
+const FAR_FUTURE = "2099-01-01T00:00:00.000Z";
+
+type EnvOverrides = Record<string, string | undefined>;
+type MockedFetch = ReturnType<typeof mock<ManagedGatewayUpstreamFetch>>;
+
+function makeConfig(overrides: EnvOverrides = {}): ReturnType<typeof loadConfig> {
+  return loadConfig({
+    ...process.env,
+    MANAGED_GATEWAY_ENABLED: "true",
+    MANAGED_GATEWAY_STRICT_STARTUP_VALIDATION: "true",
+    MANAGED_GATEWAY_DJANGO_INTERNAL_BASE_URL: "http://127.0.0.1:8000",
+    MANAGED_GATEWAY_INTERNAL_AUTH_MODE: "bearer",
+    MANAGED_GATEWAY_INTERNAL_AUTH_AUDIENCE: "managed-gateway-internal",
+    MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS: JSON.stringify({
+      "token-active": {
+        token_id: "mgw-2026-01",
+        principal: "managed-gateway-staging",
+        audience: "managed-gateway-internal",
+        scopes: ["managed-gateway:internal", "routes:resolve"],
+        expires_at: FAR_FUTURE,
+      },
+    }),
+    MANAGED_GATEWAY_INTERNAL_REVOKED_TOKEN_IDS: "",
+    MANAGED_GATEWAY_INTERNAL_MTLS_PRINCIPALS: "managed-gateway-staging",
+    MANAGED_GATEWAY_MTLS_PRINCIPAL_HEADER: "x-managed-gateway-principal",
+    MANAGED_GATEWAY_MTLS_AUDIENCE_HEADER: "x-managed-gateway-audience",
+    MANAGED_GATEWAY_MTLS_SCOPES_HEADER: "x-managed-gateway-scopes",
+    ...overrides,
+  });
+}
+
+function makeResolveRequest(
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+): Request {
+  return new Request(`http://managed-gateway.test${MANAGED_GATEWAY_ROUTE_RESOLVE_PATH}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("managed-gateway route resolve endpoint", () => {
+  test("returns 200 and forwards normalized payload on success", async () => {
+    let capturedUrl = "";
+    let capturedInit: RequestInit | undefined;
+    const fetchMock: MockedFetch = mock(async (input, init) => {
+      capturedUrl = String(input);
+      capturedInit = init;
+      return new Response(
+        JSON.stringify({
+          route_id: "87c8dd8f-1f92-45c4-a524-126cf59fd760",
+          assistant_id: "8aa67431-9f28-40c0-98a5-e49d83bd15ab",
+          provider: "twilio",
+          route_type: "sms",
+          identity_key: "+15550101010",
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+
+    const config = makeConfig();
+    const handler = createManagedGatewayAppFetch(config, {
+      fetchImpl: (...args) => fetchMock(...args),
+    });
+
+    const response = await handler(
+      makeResolveRequest(
+        {
+          provider: " Twilio ",
+          route_type: " SMS ",
+          identity_key: " tel:+1 555 010 1010 ",
+        },
+        { authorization: "Bearer token-active" },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      route_id: "87c8dd8f-1f92-45c4-a524-126cf59fd760",
+      assistant_id: "8aa67431-9f28-40c0-98a5-e49d83bd15ab",
+      provider: "twilio",
+      route_type: "sms",
+      identity_key: "+15550101010",
+    });
+
+    expect(capturedUrl).toBe("http://127.0.0.1:8000/v1/internal/managed-gateway/routes/resolve/");
+    expect(capturedInit?.method).toBe("POST");
+    expect(JSON.parse(capturedInit?.body as string)).toEqual({
+      provider: "twilio",
+      route_type: "sms",
+      identity_key: "+15550101010",
+    });
+
+    const upstreamHeaders = capturedInit?.headers as Headers;
+    expect(upstreamHeaders.get("authorization")).toBe("Bearer token-active");
+    expect(upstreamHeaders.get("content-type")).toBe("application/json");
+  });
+
+  test("returns 400 validation envelope for invalid payload", async () => {
+    const fetchMock: MockedFetch = mock(async () => {
+      return new Response("unreachable", { status: 500 });
+    });
+    const handler = createManagedGatewayAppFetch(makeConfig(), {
+      fetchImpl: (...args) => fetchMock(...args),
+    });
+
+    const response = await handler(
+      makeResolveRequest(
+        {
+          provider: " ",
+          route_type: "sms",
+          identity_key: "+15550101011",
+        },
+        { authorization: "Bearer token-active" },
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "validation_error",
+        detail: "Invalid route resolve payload.",
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
+
+  test("returns 401 auth envelope when token is missing", async () => {
+    const fetchMock: MockedFetch = mock(async () => {
+      return new Response("unreachable", { status: 500 });
+    });
+    const handler = createManagedGatewayAppFetch(makeConfig(), {
+      fetchImpl: (...args) => fetchMock(...args),
+    });
+
+    const response = await handler(
+      makeResolveRequest({
+        provider: "twilio",
+        route_type: "sms",
+        identity_key: "+15550101012",
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "missing_bearer",
+        detail: "Missing managed gateway bearer token.",
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
+
+  test("returns 404 envelope when Django reports no route mapping", async () => {
+    const fetchMock: MockedFetch = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          error: {
+            code: "managed_route_not_found",
+            detail: "Managed route not found.",
+          },
+        }),
+        {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+    const handler = createManagedGatewayAppFetch(makeConfig(), {
+      fetchImpl: (...args) => fetchMock(...args),
+    });
+
+    const response = await handler(
+      makeResolveRequest(
+        {
+          provider: "twilio",
+          route_type: "sms",
+          identity_key: "+15550101013",
+        },
+        { authorization: "Bearer token-active" },
+      ),
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "managed_route_not_found",
+        detail: "Managed route not found.",
+      },
+    });
+  });
+
+  test("returns 502 envelope when Django upstream is unavailable", async () => {
+    const fetchMock: MockedFetch = mock(async () => {
+      throw new Error("connection refused");
+    });
+    const handler = createManagedGatewayAppFetch(makeConfig(), {
+      fetchImpl: (...args) => fetchMock(...args),
+    });
+
+    const response = await handler(
+      makeResolveRequest(
+        {
+          provider: "twilio",
+          route_type: "sms",
+          identity_key: "+15550101014",
+        },
+        { authorization: "Bearer token-active" },
+      ),
+    );
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "upstream_unavailable",
+        detail: "Managed route resolver upstream is unavailable.",
+      },
+    });
+  });
+
+  test("keeps existing health endpoint behavior unchanged", async () => {
+    const fetchMock: MockedFetch = mock(async () => {
+      throw new Error("health endpoint should not call upstream");
+    });
+    const handler = createManagedGatewayAppFetch(makeConfig(), {
+      fetchImpl: (...args) => fetchMock(...args),
+    });
+
+    const response = await handler(
+      new Request("http://managed-gateway.test/v1/internal/managed-gateway/healthz/"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      status: "ok",
+      service: "managed-gateway",
+      mode: "skeleton",
+      enabled: true,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
+});

--- a/gateway-managed/src/http.ts
+++ b/gateway-managed/src/http.ts
@@ -1,0 +1,93 @@
+import type { ManagedGatewayConfig } from "./config.js";
+import {
+  createRouteResolveHandler,
+  MANAGED_GATEWAY_ROUTE_RESOLVE_PATH,
+  type ManagedGatewayUpstreamFetch,
+} from "./route-resolve.js";
+
+export type ManagedGatewayAppDependencies = {
+  fetchImpl?: ManagedGatewayUpstreamFetch;
+};
+
+export function healthPayload(config: ManagedGatewayConfig) {
+  return {
+    status: "ok",
+    service: config.serviceName,
+    mode: config.mode,
+    enabled: config.enabled,
+  };
+}
+
+export function readinessResponse(config: ManagedGatewayConfig): Response {
+  if (!config.enabled) {
+    return Response.json(
+      {
+        status: "not_ready",
+        service: config.serviceName,
+        mode: config.mode,
+        reason: "managed_gateway_disabled",
+      },
+      { status: 503 },
+    );
+  }
+
+  const payload: Record<string, string> = {
+    status: "ready",
+    service: config.serviceName,
+    mode: config.mode,
+  };
+  if (config.djangoInternalBaseUrl) {
+    payload.upstreamBaseUrl = config.djangoInternalBaseUrl;
+  }
+
+  return Response.json(payload);
+}
+
+export function createManagedGatewayAppFetch(
+  config: ManagedGatewayConfig,
+  dependencies: ManagedGatewayAppDependencies = {},
+): (request: Request) => Promise<Response> {
+  const routeResolveHandler = createRouteResolveHandler(
+    config,
+    dependencies.fetchImpl,
+  );
+
+  return async (request: Request): Promise<Response> => {
+    const pathname = new URL(request.url).pathname;
+
+    if (
+      pathname === "/healthz"
+      || pathname === "/v1/internal/managed-gateway/healthz/"
+    ) {
+      return Response.json(healthPayload(config));
+    }
+
+    if (
+      pathname === "/readyz"
+      || pathname === "/v1/internal/managed-gateway/readyz/"
+    ) {
+      return readinessResponse(config);
+    }
+
+    if (pathname === MANAGED_GATEWAY_ROUTE_RESOLVE_PATH) {
+      if (request.method !== "POST") {
+        return Response.json(
+          {
+            error: {
+              code: "method_not_allowed",
+              detail: "Only POST is supported for this endpoint.",
+            },
+          },
+          {
+            status: 405,
+            headers: { allow: "POST" },
+          },
+        );
+      }
+
+      return routeResolveHandler(request);
+    }
+
+    return Response.json({ error: "Not found" }, { status: 404 });
+  };
+}

--- a/gateway-managed/src/index.ts
+++ b/gateway-managed/src/index.ts
@@ -1,66 +1,15 @@
 process.title = "vellum-managed-gateway";
 
 import { loadConfig } from "./config.js";
+import { createManagedGatewayAppFetch } from "./http.js";
 
 const config = loadConfig();
-
-function healthPayload() {
-  return {
-    status: "ok",
-    service: config.serviceName,
-    mode: config.mode,
-    enabled: config.enabled,
-  };
-}
-
-function readinessResponse(): Response {
-  if (!config.enabled) {
-    return Response.json(
-      {
-        status: "not_ready",
-        service: config.serviceName,
-        mode: config.mode,
-        reason: "managed_gateway_disabled",
-      },
-      { status: 503 },
-    );
-  }
-
-  const payload: Record<string, string> = {
-    status: "ready",
-    service: config.serviceName,
-    mode: config.mode,
-  };
-  if (config.djangoInternalBaseUrl) {
-    payload.upstreamBaseUrl = config.djangoInternalBaseUrl;
-  }
-
-  return Response.json(payload);
-}
-
-function routeRequest(pathname: string): Response {
-  if (
-    pathname === "/healthz"
-    || pathname === "/v1/internal/managed-gateway/healthz/"
-  ) {
-    return Response.json(healthPayload());
-  }
-
-  if (
-    pathname === "/readyz"
-    || pathname === "/v1/internal/managed-gateway/readyz/"
-  ) {
-    return readinessResponse();
-  }
-
-  return Response.json({ error: "Not found" }, { status: 404 });
-}
+const appFetch = createManagedGatewayAppFetch(config);
 
 const server = Bun.serve({
   port: config.port,
   async fetch(req) {
-    const url = new URL(req.url);
-    return routeRequest(url.pathname);
+    return appFetch(req);
   },
 });
 

--- a/gateway-managed/src/route-resolve.ts
+++ b/gateway-managed/src/route-resolve.ts
@@ -1,0 +1,202 @@
+import type { ManagedGatewayConfig } from "./config.js";
+import { withInternalAuth } from "./internal-auth.js";
+
+export const MANAGED_GATEWAY_ROUTE_RESOLVE_PATH = "/v1/internal/managed-gateway/routes/resolve/";
+const MANAGED_GATEWAY_ROUTE_RESOLVE_SCOPE = "routes:resolve";
+
+export type ManagedGatewayUpstreamFetch = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+type ManagedGatewayRouteResolvePayload = {
+  provider: string;
+  route_type: string;
+  identity_key: string;
+};
+
+export function createRouteResolveHandler(
+  config: ManagedGatewayConfig,
+  fetchImpl?: ManagedGatewayUpstreamFetch,
+): (request: Request) => Promise<Response> {
+  const upstreamFetch: ManagedGatewayUpstreamFetch = fetchImpl || fetch;
+
+  return withInternalAuth(
+    config,
+    async (request: Request): Promise<Response> => {
+      const payload = await parseRouteResolvePayload(request);
+      if (!payload) {
+        return Response.json(
+          {
+            error: {
+              code: "validation_error",
+              detail: "Invalid route resolve payload.",
+            },
+          },
+          { status: 400 },
+        );
+      }
+
+      if (!config.djangoInternalBaseUrl) {
+        return Response.json(
+          {
+            error: {
+              code: "upstream_unconfigured",
+              detail: "Managed gateway Django internal base URL is not configured.",
+            },
+          },
+          { status: 503 },
+        );
+      }
+
+      const upstreamUrl = new URL(
+        MANAGED_GATEWAY_ROUTE_RESOLVE_PATH,
+        config.djangoInternalBaseUrl,
+      ).toString();
+
+      const upstreamHeaders = buildUpstreamHeaders(request, config);
+
+      try {
+        const upstreamResponse = await upstreamFetch(upstreamUrl, {
+          method: "POST",
+          headers: upstreamHeaders,
+          body: JSON.stringify(payload),
+        });
+        return mapUpstreamResponse(upstreamResponse);
+      } catch {
+        return Response.json(
+          {
+            error: {
+              code: "upstream_unavailable",
+              detail: "Managed route resolver upstream is unavailable.",
+            },
+          },
+          { status: 502 },
+        );
+      }
+    },
+    MANAGED_GATEWAY_ROUTE_RESOLVE_SCOPE,
+  );
+}
+
+async function parseRouteResolvePayload(
+  request: Request,
+): Promise<ManagedGatewayRouteResolvePayload | null> {
+  let parsed: unknown;
+  try {
+    parsed = await request.json();
+  } catch {
+    return null;
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+
+  const body = parsed as Record<string, unknown>;
+
+  try {
+    return {
+      provider: normalizeLookupValue(body.provider),
+      route_type: normalizeLookupValue(body.route_type),
+      identity_key: normalizeIdentityKey(body.identity_key),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function normalizeLookupValue(raw: unknown): string {
+  if (typeof raw !== "string") {
+    throw new Error("lookup field must be a string");
+  }
+
+  const normalized = raw.trim().toLowerCase();
+  if (!normalized) {
+    throw new Error("lookup field cannot be blank");
+  }
+
+  return normalized;
+}
+
+function normalizeIdentityKey(raw: unknown): string {
+  if (typeof raw !== "string") {
+    throw new Error("identity_key must be a string");
+  }
+
+  let normalized = raw.trim().toLowerCase();
+  if (normalized.startsWith("tel:")) {
+    normalized = normalized.slice("tel:".length);
+  }
+  normalized = normalized.replaceAll(" ", "");
+
+  if (!normalized) {
+    throw new Error("identity_key cannot be blank");
+  }
+
+  return normalized;
+}
+
+function buildUpstreamHeaders(
+  request: Request,
+  config: ManagedGatewayConfig,
+): Headers {
+  const headers = new Headers({
+    "content-type": "application/json",
+  });
+
+  if (config.internalAuth.mode === "bearer") {
+    const authorization = request.headers.get("authorization");
+    if (authorization) {
+      headers.set("authorization", authorization);
+    }
+    return headers;
+  }
+
+  const mtlsPrincipal = request.headers.get(config.internalAuth.mtlsPrincipalHeader);
+  if (mtlsPrincipal) {
+    headers.set(config.internalAuth.mtlsPrincipalHeader, mtlsPrincipal);
+  }
+
+  const mtlsAudience = request.headers.get(config.internalAuth.mtlsAudienceHeader);
+  if (mtlsAudience) {
+    headers.set(config.internalAuth.mtlsAudienceHeader, mtlsAudience);
+  }
+
+  const mtlsScopes = request.headers.get(config.internalAuth.mtlsScopesHeader);
+  if (mtlsScopes) {
+    headers.set(config.internalAuth.mtlsScopesHeader, mtlsScopes);
+  }
+
+  return headers;
+}
+
+function mapUpstreamResponse(upstreamResponse: Response): Response {
+  if (
+    upstreamResponse.status !== 200
+    && upstreamResponse.status !== 400
+    && upstreamResponse.status !== 401
+    && upstreamResponse.status !== 404
+  ) {
+    return Response.json(
+      {
+        error: {
+          code: "upstream_error",
+          detail: `Managed route resolver upstream returned unexpected status ${upstreamResponse.status}.`,
+        },
+      },
+      { status: 502 },
+    );
+  }
+
+  const passthroughHeaders = new Headers();
+  const contentType = upstreamResponse.headers.get("content-type");
+  if (contentType) {
+    passthroughHeaders.set("content-type", contentType);
+  }
+
+  return new Response(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    headers: passthroughHeaders,
+  });
+}


### PR DESCRIPTION
## Summary\n- add managed-gateway  endpoint\n- require internal auth with  scope and validate/normalize request payload\n- proxy normalized resolve requests to Django internal resolver with explicit upstream error handling\n- document endpoint authz/caller contract and keep existing probe behavior unchanged\n\n## Validation\n- cd gateway-managed && bun run typecheck\n- cd gateway-managed && bun run build\n- cd gateway-managed && bun run test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
