### PR TITLE
refactor: remove /v1/messages legacy processor fallback (#11059)

### DIFF
--- a/assistant/src/__tests__/conversation-routes.test.ts
+++ b/assistant/src/__tests__/conversation-routes.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, mock, test } from 'bun:test';
 
-import type { RuntimeMessageSessionOptions } from '../runtime/http-types.js';
-
 mock.module('../util/logger.js', () => ({
   getLogger: () => new Proxy({} as Record<string, unknown>, {
     get: () => () => {},
@@ -29,37 +27,23 @@ const mockLoopbackServer: ServerWithRequestIP = {
 };
 
 describe('handleSendMessage', () => {
-  test('legacy fallback passes guardian context to processor', async () => {
-    let capturedOptions: RuntimeMessageSessionOptions | undefined;
-    let capturedSourceChannel: string | undefined;
-
+  test('returns 503 when sendMessageDeps is not configured', async () => {
     const req = new Request('http://localhost/v1/messages', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        conversationKey: 'legacy-fallback-key',
-        content: 'Hello from legacy fallback',
+        conversationKey: 'no-deps-key',
+        content: 'Hello without deps',
         sourceChannel: 'telegram',
         interface: 'telegram',
       }),
     });
 
-    const res = await handleSendMessage(req, {
-      processMessage: async (_conversationId, _content, _attachmentIds, options, sourceChannel) => {
-        capturedOptions = options;
-        capturedSourceChannel = sourceChannel;
-        return { messageId: 'msg-legacy-fallback' };
-      },
-    }, mockLoopbackServer);
+    const res = await handleSendMessage(req, {}, mockLoopbackServer);
 
-    const body = await res.json() as { accepted: boolean; messageId: string };
-    expect(res.status).toBe(202);
-    expect(body.accepted).toBe(true);
-    expect(body.messageId).toBe('msg-legacy-fallback');
-    expect(capturedSourceChannel).toBe('telegram');
-    expect(capturedOptions?.guardianContext).toEqual(expect.objectContaining({
-      trustClass: 'guardian',
-      sourceChannel: 'telegram',
-    }));
+    expect(res.status).toBe(503);
+    const body = await res.json() as { error: { code: string; message: string } };
+    expect(body.error.code).toBe('SERVICE_UNAVAILABLE');
+    expect(body.error.message).toBe('Message processing not configured');
   });
 });

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -724,8 +724,6 @@ export class RuntimeHttpServer {
 
       if (endpoint === 'messages' && req.method === 'POST') {
         return await handleSendMessage(req, {
-          processMessage: this.processMessage,
-          persistAndProcessMessage: this.persistAndProcessMessage,
           sendMessageDeps: this.sendMessageDeps,
           approvalConversationGenerator: this.approvalConversationGenerator,
         }, server);

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -30,8 +30,6 @@ import { routeGuardianReply } from '../guardian-reply-router.js';
 import { httpError } from '../http-errors.js';
 import type {
   ApprovalConversationGenerator,
-  MessageProcessor,
-  NonBlockingMessageProcessor,
   RuntimeAttachmentMetadata,
   RuntimeMessagePayload,
   SendMessageDeps,
@@ -408,8 +406,6 @@ function makeHubPublisher(
 export async function handleSendMessage(
   req: Request,
   deps: {
-    processMessage?: MessageProcessor;
-    persistAndProcessMessage?: NonBlockingMessageProcessor;
     sendMessageDeps?: SendMessageDeps;
     approvalConversationGenerator?: ApprovalConversationGenerator;
   },
@@ -469,8 +465,13 @@ export async function handleSendMessage(
 
   const mapping = getOrCreateConversation(conversationKey);
 
-  // ── Queue-if-busy path (preferred when sendMessageDeps is wired) ────
-  if (deps.sendMessageDeps) {
+  // ── Fail fast when sendMessageDeps is not wired ─────────────────────
+  if (!deps.sendMessageDeps) {
+    return httpError('SERVICE_UNAVAILABLE', 'Message processing not configured', 503);
+  }
+
+  // ── Queue-if-busy path ──────────────────────────────────────────────
+  {
     // Vellum HTTP requests prefer actor-token identity. When absent (e.g. CLI
     // bearer-auth only), fall back to local IPC identity resolution so
     // bearer-authenticated local clients are not rejected.
@@ -609,44 +610,6 @@ export async function handleSendMessage(
     });
 
     return Response.json({ accepted: true, messageId }, { status: 202 });
-  }
-
-  // ── Legacy path (fallback when sendMessageDeps not wired) ───────────
-  const processor = deps.persistAndProcessMessage ?? deps.processMessage;
-  if (!processor) {
-    return httpError('SERVICE_UNAVAILABLE', 'Message processing not configured', 503);
-  }
-
-  // Require actor token for vellum channel requests on the legacy path too,
-  // with local IPC fallback for bearer-authenticated CLI clients.
-  const legacyActorVerification = sourceChannel === 'vellum' ? verifyHttpActorTokenWithLocalFallback(req, server) : null;
-  if (legacyActorVerification && !legacyActorVerification.ok) {
-    return httpError(
-      legacyActorVerification.status === 401 ? 'UNAUTHORIZED' : 'FORBIDDEN',
-      legacyActorVerification.message,
-      legacyActorVerification.status,
-    );
-  }
-
-  const guardianContext = legacyActorVerification?.ok
-    ? legacyActorVerification.guardianContext
-    : resolveLocalIpcGuardianContext(sourceChannel) ?? { trustClass: 'guardian' as const, sourceChannel };
-
-  try {
-    const result = await processor(
-      mapping.conversationId,
-      content ?? '',
-      hasAttachments ? attachmentIds : undefined,
-      { guardianContext },
-      sourceChannel,
-      sourceInterface,
-    );
-    return Response.json({ accepted: true, messageId: result.messageId }, { status: 202 });
-  } catch (err) {
-    if (err instanceof Error && err.message === 'Session is already processing a message') {
-      return httpError('CONFLICT', 'Session is busy processing another message. Please retry.', 409);
-    }
-    throw err;
   }
 }
 


### PR DESCRIPTION
Part of legacy compatibility removal Phase 1. Removes fallback to legacy processMessage in handleSendMessage, keeping only canonical queue-if-busy path. Closes #11059.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
