### PR TITLE
refactor: remove guardian deterministic fallback from approval routing (#11060)

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -377,7 +377,7 @@ describe('inbound text matching approval phrases triggers decision handling', ()
 // 4. Non-decision messages during pending approval (no conversational engine)
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('non-decision messages during pending approval (legacy fallback)', () => {
+describe('non-decision messages during pending approval (no conversational engine)', () => {
   beforeEach(() => {
     createBinding({
       assistantId: 'self',
@@ -2950,7 +2950,7 @@ describe('trusted-contact self-approval blocked before guardian approval row exi
     deliverSpy.mockRestore();
   });
 
-  test('trusted contact cannot self-approve via legacy parser when no guardian approval row exists', async () => {
+  test('trusted contact cannot self-approve when no guardian approval row exists', async () => {
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
 
     const initReq = makeInboundRequest({
@@ -2970,8 +2970,8 @@ describe('trusted-contact self-approval blocked before guardian approval row exi
 
     deliverSpy.mockClear();
 
-    // No conversational engine — falls through to legacy parser path.
-    // "approve" would normally be parsed as an approval decision.
+    // No conversational engine — the non-guardian self-approval guard
+    // blocks the decision before it can reach any parser.
     const req = makeInboundRequest({
       content: 'approve',
       conversationExternalId: 'tc-selfapproval-chat',

--- a/assistant/src/runtime/channel-approval-parser.ts
+++ b/assistant/src/runtime/channel-approval-parser.ts
@@ -5,10 +5,8 @@
  * rejection, or "approve always" intent. This module is transport-agnostic
  * and can be used by any channel adapter (Telegram, SMS, etc.).
  *
- * Both the standard and guardian approval flows now use the conversational
- * approval engine as the primary classifier. This deterministic parser is
- * retained only as a legacy fallback for when the conversational engine is
- * not injected (i.e. approvalConversationGenerator is undefined).
+ * Used by the guardian-action grant minter for deterministic keyword
+ * matching in the grant minting fast path.
  */
 
 import type { ApprovalAction, ApprovalDecisionResult } from './channel-approval-types.js';

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -95,9 +95,9 @@ export interface GuardianReplyResult {
   /** Detailed result from the canonical decision primitive (when a decision was attempted). */
   canonicalResult?: CanonicalDecisionResult;
   /**
-   * When true, the caller should skip legacy approval interception for this
+   * When true, the caller should skip approval interception for this
    * message. Set by the invite handoff bypass so that "open invite flow"
-   * reaches the assistant even when other legacy guardian approvals are pending.
+   * reaches the assistant even when other guardian approvals are pending.
    */
   skipApprovalInterception?: boolean;
 }
@@ -390,7 +390,7 @@ export async function routeGuardianReply(
   // Desktop sessions intentionally do not enable NL classification; when the
   // caller has exactly one known pending request and sends an explicit
   // approve/reject phrase ("approve", "yes", "reject", "no"), apply the
-  // decision directly instead of falling through to legacy handlers.
+  // decision directly instead of returning not_consumed.
   if (messageText.length > 0 && pendingRequests.length > 0) {
     const inferredAction = inferDecisionActionFromFreeText(messageText);
     if (inferredAction) {
@@ -597,10 +597,17 @@ async function applyDecision(
     `Guardian reply router: canonical decision not applied (${canonicalResult.reason})`,
   );
 
-  // When the canonical request doesn't exist, allow the message to fall
-  // through so the legacy handleApprovalInterception handler can process it.
+  // When the canonical request doesn't exist, treat it as stale — the
+  // canonical decision path handles all guardian decisions deterministically.
   if (canonicalResult.reason === 'not_found') {
-    return notConsumed();
+    return {
+      decisionApplied: false,
+      consumed: true,
+      type: 'canonical_decision_stale',
+      requestId,
+      canonicalResult,
+      replyText: 'This request was not found.',
+    };
   }
 
   const request = getCanonicalGuardianRequest(requestId);

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -16,7 +16,6 @@ import { emitNotificationSignal } from '../../notifications/emit-signal.js';
 import { getLogger } from '../../util/logger.js';
 import { runApprovalConversationTurn } from '../approval-conversation-turn.js';
 import { composeApprovalMessageGenerative } from '../approval-message-composer.js';
-import { parseApprovalDecision } from '../channel-approval-parser.js';
 import type {
   ApprovalDecisionResult,
 } from '../channel-approval-types.js';
@@ -394,152 +393,7 @@ export async function handleApprovalInterception(
         return { handled: true, type: 'stale_ignored' };
       }
 
-      // ── Legacy fallback when no conversational engine is available ──
-      // Use the deterministic parser to handle guardian plain-text so that
-      // simple yes/no replies still work when the engine is not injected.
-      if (content && !approvalConversationGenerator) {
-        const legacyGuardianDecision = parseApprovalDecision(content);
-        if (legacyGuardianDecision) {
-          // Guardians cannot approve_always — downgrade to approve_once.
-          if (legacyGuardianDecision.action === 'approve_always') {
-            legacyGuardianDecision.action = 'approve_once';
-          }
-
-          // Resolve the target approval: when a [ref:<requestId>] tag is
-          // present, look up the specific pending approval by that requestId
-          // so the decision applies to the correct conversation even when
-          // multiple guardian approvals are pending.
-          let targetLegacyApproval = guardianApproval;
-          if (legacyGuardianDecision.requestId) {
-            const resolvedByRequest = getPendingApprovalByRequestAndGuardianChat(
-              legacyGuardianDecision.requestId,
-              sourceChannel,
-              conversationExternalId,
-              assistantId,
-            );
-            if (!resolvedByRequest) {
-              // The referenced request doesn't match any pending guardian
-              // approval — it may have expired or already been resolved.
-              try {
-                const staleText = await composeApprovalMessageGenerative({
-                  scenario: 'guardian_disambiguation',
-                  channel: sourceChannel,
-                }, {}, approvalCopyGenerator);
-                await deliverChannelReply(replyCallbackUrl, {
-                  chatId: conversationExternalId,
-                  text: staleText,
-                  assistantId,
-                }, bearerToken);
-              } catch (err) {
-                log.error({ err, conversationExternalId }, 'Failed to deliver stale approval notice (legacy path)');
-              }
-              return { handled: true, type: 'stale_ignored' };
-            }
-            targetLegacyApproval = resolvedByRequest;
-          }
-
-          // Re-validate guardian identity against the resolved target.
-          // The default guardianApproval was already checked, but a
-          // requestId-resolved approval may belong to a different guardian.
-          if (actorExternalId !== targetLegacyApproval.guardianExternalUserId) {
-            log.warn(
-              { conversationExternalId, actorExternalId, expectedGuardian: targetLegacyApproval.guardianExternalUserId, requestId: legacyGuardianDecision.requestId },
-              'Guardian identity mismatch on legacy ref-resolved target approval',
-            );
-            try {
-              const mismatchText = await composeApprovalMessageGenerative({
-                scenario: 'guardian_identity_mismatch',
-                channel: sourceChannel,
-              }, {}, approvalCopyGenerator);
-              await deliverChannelReply(replyCallbackUrl, {
-                chatId: conversationExternalId,
-                text: mismatchText,
-                assistantId,
-              }, bearerToken);
-            } catch (err) {
-              log.error({ err, conversationExternalId }, 'Failed to deliver guardian identity mismatch notice (legacy path)');
-            }
-            return { handled: true, type: 'guardian_decision_applied' };
-          }
-
-          // Access request approvals need a separate decision path.
-          if (targetLegacyApproval.toolName === 'ingress_access_request') {
-            const accessResult = await handleAccessRequestApproval(
-              targetLegacyApproval,
-              legacyGuardianDecision.action === 'reject' ? 'deny' : 'approve',
-              actorExternalId,
-              replyCallbackUrl,
-              assistantId,
-              bearerToken,
-            );
-            return accessResult;
-          }
-
-          // Apply the decision through the unified guardian decision primitive.
-          const result = applyGuardianDecision({
-            approval: targetLegacyApproval,
-            decision: legacyGuardianDecision,
-            actorExternalUserId: actorExternalId,
-            actorChannel: sourceChannel,
-          });
-
-          if (result.applied) {
-            // Notify the requester's chat about the outcome
-            const outcomeText = await composeApprovalMessageGenerative({
-              scenario: 'guardian_decision_outcome',
-              decision: legacyGuardianDecision.action === 'reject' ? 'denied' : 'approved',
-              toolName: targetLegacyApproval.toolName,
-              channel: sourceChannel,
-            }, {}, approvalCopyGenerator);
-            try {
-              await deliverChannelReply(replyCallbackUrl, {
-                chatId: targetLegacyApproval.requesterChatId,
-                text: outcomeText,
-                assistantId,
-              }, bearerToken);
-            } catch (err) {
-              log.error({ err, conversationId: targetLegacyApproval.conversationId }, 'Failed to notify requester of guardian decision (legacy path)');
-            }
-
-            return { handled: true, type: 'guardian_decision_applied' };
-          }
-
-          // Race condition: request was already resolved. Deliver stale notice.
-          try {
-            const staleText = await composeApprovalMessageGenerative({
-              scenario: 'approval_already_resolved',
-              channel: sourceChannel,
-            }, {}, approvalCopyGenerator);
-            await deliverChannelReply(replyCallbackUrl, {
-              chatId: conversationExternalId,
-              text: staleText,
-              assistantId,
-            }, bearerToken);
-          } catch (err) {
-            log.error({ err, conversationId: targetLegacyApproval.conversationId }, 'Failed to deliver stale guardian legacy fallback notice');
-          }
-          return { handled: true, type: 'stale_ignored' };
-        }
-
-        // No decision could be parsed — send a generic reminder to the guardian
-        try {
-          const reminderText = await composeApprovalMessageGenerative({
-            scenario: 'reminder_prompt',
-            toolName: guardianApproval.toolName,
-            channel: sourceChannel,
-          }, {}, approvalCopyGenerator);
-          await deliverChannelReply(replyCallbackUrl, {
-            chatId: conversationExternalId,
-            text: reminderText,
-            assistantId,
-          }, bearerToken);
-        } catch (err) {
-          log.error({ err, conversationId: guardianApproval.conversationId }, 'Failed to deliver guardian reminder (legacy path)');
-        }
-        return { handled: true, type: 'assistant_turn' };
-      }
-
-      // No content and no engine — nothing to do, fall through to standard
+      // No content or no engine — nothing to do, fall through to standard
       // approval interception below.
     }
   }
@@ -748,8 +602,8 @@ export async function handleApprovalInterception(
       // to the guardian. In the window between the pending confirmation being
       // created (isInteractive=true) and the guardian approval row being
       // persisted, any non-guardian actor could otherwise fall through to the
-      // standard conversational engine / legacy parser and resolve their own
-      // pending request via handleChannelDecision.
+      // standard conversational engine and resolve their own pending request
+      // via handleChannelDecision.
       if (guardianCtx.trustClass !== 'guardian' && guardianCtx.guardianExternalUserId) {
         log.info(
           { conversationId, conversationExternalId, guardianExternalUserId: guardianCtx.guardianExternalUserId },
@@ -882,42 +736,7 @@ export async function handleApprovalInterception(
     return { handled: true, type: 'stale_ignored' };
   }
 
-  // Fallback: no conversational generator available or no content — use
-  // the legacy deterministic path as a safety net. This preserves backward
-  // compatibility when the generator is not injected.
-  if (content) {
-    const legacyDecision = parseApprovalDecision(content);
-    if (legacyDecision) {
-      if (legacyDecision.requestId) {
-        if (pending.length === 0 || !pending.some(p => p.requestId === legacyDecision.requestId)) {
-          return { handled: true, type: 'stale_ignored' };
-        }
-      }
-      const result = handleChannelDecision(conversationId, legacyDecision);
-      if (result.applied) {
-        return { handled: true, type: 'decision_applied' };
-      }
-
-      // Race condition: request was already resolved.
-      try {
-        const staleText = await composeApprovalMessageGenerative({
-          scenario: 'approval_already_resolved',
-          channel: sourceChannel,
-        }, {}, approvalCopyGenerator);
-        await deliverChannelReply(replyCallbackUrl, {
-          chatId: conversationExternalId,
-          text: staleText,
-          assistantId,
-        }, bearerToken);
-      } catch (err) {
-        log.error({ err, conversationId }, 'Failed to deliver stale approval notice (legacy path)');
-      }
-      return { handled: true, type: 'stale_ignored' };
-    }
-  }
-
-  // No decision could be extracted and no conversational engine is available —
-  // deliver a simple status reply rather than a reminder prompt.
+  // No decision could be extracted — deliver a simple status reply.
   try {
     const statusText = await composeApprovalMessageGenerative({
       scenario: 'reminder_prompt',

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -932,15 +932,14 @@ export async function handleChannelInbound(
   });
 
   // Hoisted flag: set by the canonical guardian reply router when the invite
-  // handoff bypass fires. Prevents legacy approval interception from swallowing
-  // the message when other approvals are pending in the same chat.
+  // handoff bypass fires. Prevents approval interception from swallowing the
+  // message when other approvals are pending in the same chat.
   let skipApprovalInterception = false;
 
   // ── Canonical guardian reply router ──
-  // Attempts to route inbound messages through the canonical decision pipeline
-  // before falling through to the legacy approval interception. Handles
-  // deterministic callbacks (button presses), request code prefixes, and
-  // NL classification via the conversational approval engine.
+  // Routes inbound guardian messages through the canonical decision pipeline.
+  // Handles deterministic callbacks (button presses), request code prefixes,
+  // and NL classification via the conversational approval engine.
   if (
     !result.duplicate &&
     replyCallbackUrl &&
@@ -1028,8 +1027,8 @@ export async function handleChannelInbound(
   // ── Approval interception ──
   // Keep this active whenever callback context is available.
   // Skipped when the canonical router flagged skipApprovalInterception (e.g.
-  // invite handoff bypass) to prevent the legacy interceptor from swallowing
-  // messages that should reach the assistant.
+  // invite handoff bypass) to prevent the interceptor from swallowing messages
+  // that should reach the assistant.
   if (
     replyCallbackUrl &&
     !result.duplicate &&


### PR DESCRIPTION
Part of legacy compatibility removal Phase 1. Removes deterministic text parser fallback from guardian approval routing, keeping only canonical conversational/structured decision path. Closes #11060.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
