### PR TITLE
Add staging deploy manifests + readiness checks

### DIFF
--- a/gateway-managed/ARCHITECTURE.md
+++ b/gateway-managed/ARCHITECTURE.md
@@ -25,6 +25,12 @@ The managed gateway is a dedicated service lane for Vellum-owned shared channel 
 - Enforces internal auth (`bearer` or `mtls`) with required `routes:resolve` scope.
 - Normalizes request routing keys and proxies to Django internal route resolver with explicit error envelopes.
 
+## PR-5 scope
+
+- Adds staging deployment scaffolding under `gateway-managed/deploy/` with Kubernetes stubs.
+- Adds manifest smoke checks and optional live readiness probes for staging endpoints.
+- Documents rollout and rollback procedures with explicit health/readiness checkpoints.
+
 ## Endpoints
 
 - `GET /healthz`

--- a/gateway-managed/README.md
+++ b/gateway-managed/README.md
@@ -8,6 +8,7 @@ Managed gateway service skeleton for Vellum-owned shared channel identities.
 - strict startup config validation for enabled managed gateway mode
 - internal auth middleware abstraction for bearer and mTLS service auth
 - Django internal route resolve endpoint wiring for managed route lookup
+- staging deployment manifests, smoke checks, and rollout/rollback runbook
 - health and readiness endpoints:
   - `/healthz`
   - `/readyz`
@@ -52,3 +53,14 @@ bun run test
 ## Route Resolve Contract
 
 Managed gateway route resolution contract lives in [`route-resolve-contract.md`](./route-resolve-contract.md).
+
+## Staging Deployment Artifacts
+
+- Deployment scaffolding index: [`deploy/README.md`](./deploy/README.md)
+- Kubernetes stubs:
+  - [`deploy/k8s/deployment.staging.yaml`](./deploy/k8s/deployment.staging.yaml)
+  - [`deploy/k8s/service.staging.yaml`](./deploy/k8s/service.staging.yaml)
+- Manifest + optional live probe checks:
+  - `bun run smoke:staging`
+- Rollout and rollback runbook:
+  - [`deploy/staging-rollout.md`](./deploy/staging-rollout.md)

--- a/gateway-managed/deploy/README.md
+++ b/gateway-managed/deploy/README.md
@@ -1,0 +1,9 @@
+# Managed Gateway Deployment Artifacts
+
+This directory contains staging deployment scaffolding for `gateway-managed`.
+
+Included artifacts:
+- `k8s/deployment.staging.yaml`: staging deployment stub with readiness/liveness probes
+- `k8s/service.staging.yaml`: cluster service stub exposing HTTP traffic to managed-gateway
+- `scripts/smoke-check-staging.sh`: static manifest checks and optional live probe checks
+- `staging-rollout.md`: rollout and rollback runbook with readiness checkpoints

--- a/gateway-managed/deploy/k8s/deployment.staging.yaml
+++ b/gateway-managed/deploy/k8s/deployment.staging.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: managed-gateway
+  labels:
+    app.kubernetes.io/name: managed-gateway
+    app.kubernetes.io/component: managed-gateway
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: managed-gateway
+      app.kubernetes.io/component: managed-gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: managed-gateway
+        app.kubernetes.io/component: managed-gateway
+    spec:
+      containers:
+        - name: managed-gateway
+          image: ghcr.io/vellum-ai/vellum-managed-gateway:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 7831
+          env:
+            - name: MANAGED_GATEWAY_ENABLED
+              value: "true"
+            - name: MANAGED_GATEWAY_PORT
+              value: "7831"
+            - name: MANAGED_GATEWAY_DJANGO_INTERNAL_BASE_URL
+              value: "https://django-internal.example"
+            - name: MANAGED_GATEWAY_STRICT_STARTUP_VALIDATION
+              value: "true"
+            - name: MANAGED_GATEWAY_INTERNAL_AUTH_MODE
+              value: "bearer"
+            - name: MANAGED_GATEWAY_INTERNAL_AUTH_AUDIENCE
+              value: "managed-gateway-internal"
+          readinessProbe:
+            httpGet:
+              path: /v1/internal/managed-gateway/readyz/
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /v1/internal/managed-gateway/healthz/
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 2
+            failureThreshold: 3

--- a/gateway-managed/deploy/k8s/service.staging.yaml
+++ b/gateway-managed/deploy/k8s/service.staging.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: managed-gateway
+  labels:
+    app.kubernetes.io/name: managed-gateway
+    app.kubernetes.io/component: managed-gateway
+spec:
+  selector:
+    app.kubernetes.io/name: managed-gateway
+    app.kubernetes.io/component: managed-gateway
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/gateway-managed/deploy/scripts/smoke-check-staging.sh
+++ b/gateway-managed/deploy/scripts/smoke-check-staging.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEPLOYMENT_MANIFEST="$ROOT_DIR/deploy/k8s/deployment.staging.yaml"
+SERVICE_MANIFEST="$ROOT_DIR/deploy/k8s/service.staging.yaml"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "rg is required for managed-gateway staging smoke checks" >&2
+  exit 1
+fi
+
+if [[ ! -f "$DEPLOYMENT_MANIFEST" ]]; then
+  echo "Missing deployment manifest: $DEPLOYMENT_MANIFEST" >&2
+  exit 1
+fi
+
+if [[ ! -f "$SERVICE_MANIFEST" ]]; then
+  echo "Missing service manifest: $SERVICE_MANIFEST" >&2
+  exit 1
+fi
+
+rg -q "kind: Deployment" "$DEPLOYMENT_MANIFEST"
+rg -q "name: managed-gateway" "$DEPLOYMENT_MANIFEST"
+rg -q "containerPort: 7831" "$DEPLOYMENT_MANIFEST"
+rg -q "MANAGED_GATEWAY_DJANGO_INTERNAL_BASE_URL" "$DEPLOYMENT_MANIFEST"
+rg -q "path: /v1/internal/managed-gateway/readyz/" "$DEPLOYMENT_MANIFEST"
+rg -q "path: /v1/internal/managed-gateway/healthz/" "$DEPLOYMENT_MANIFEST"
+
+rg -q "kind: Service" "$SERVICE_MANIFEST"
+rg -q "targetPort: http" "$SERVICE_MANIFEST"
+
+if [[ -n "${MANAGED_GATEWAY_STAGING_BASE_URL:-}" ]]; then
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "curl is required for live endpoint probes" >&2
+    exit 1
+  fi
+
+  base_url="${MANAGED_GATEWAY_STAGING_BASE_URL%/}"
+  curl -fsS "$base_url/v1/internal/managed-gateway/healthz/" >/dev/null
+  curl -fsS "$base_url/v1/internal/managed-gateway/readyz/" >/dev/null
+  echo "Managed-gateway live readiness probes passed at $base_url"
+else
+  echo "MANAGED_GATEWAY_STAGING_BASE_URL is not set; skipping live endpoint probes."
+fi
+
+echo "Managed-gateway staging manifest smoke checks passed."

--- a/gateway-managed/deploy/staging-rollout.md
+++ b/gateway-managed/deploy/staging-rollout.md
@@ -1,0 +1,41 @@
+# Managed Gateway Staging Rollout
+
+## Preflight
+
+1. Validate staging manifests and probe paths:
+   - `gateway-managed/deploy/scripts/smoke-check-staging.sh`
+2. Confirm deployment env values match Django internal routing and auth expectations:
+   - `gateway-managed/deploy/k8s/deployment.staging.yaml`
+
+## Rollout
+
+1. Apply staging manifests:
+   - `kubectl apply -f gateway-managed/deploy/k8s/service.staging.yaml`
+   - `kubectl apply -f gateway-managed/deploy/k8s/deployment.staging.yaml`
+2. Wait for deployment readiness:
+   - `kubectl -n <namespace> rollout status deployment/managed-gateway`
+3. Confirm pod health/readiness state:
+   - `kubectl -n <namespace> get pods -l app.kubernetes.io/component=managed-gateway`
+4. Probe service health endpoints from cluster context or via port-forward:
+   - `curl -fsS http://<managed-gateway-service>/v1/internal/managed-gateway/healthz/`
+   - `curl -fsS http://<managed-gateway-service>/v1/internal/managed-gateway/readyz/`
+
+Expected rollout signals:
+- Deployment reaches `Available=True` and `Progressing=True`.
+- Probes return `200` for both `healthz` and `readyz`.
+- No restart loop is observed on managed-gateway pods.
+
+## Rollback
+
+1. Re-apply previous known-good deployment revision:
+   - `kubectl -n <namespace> rollout undo deployment/managed-gateway`
+2. Wait for rollback readiness:
+   - `kubectl -n <namespace> rollout status deployment/managed-gateway`
+3. Re-run health/readiness probes and confirm baseline behavior:
+   - `curl -fsS http://<managed-gateway-service>/v1/internal/managed-gateway/healthz/`
+   - `curl -fsS http://<managed-gateway-service>/v1/internal/managed-gateway/readyz/`
+
+Expected rollback signals:
+- Previous revision pods become Ready.
+- Managed-gateway health/readiness endpoints return baseline successful responses.
+- Restart count and error rate return to pre-rollout levels.

--- a/gateway-managed/package.json
+++ b/gateway-managed/package.json
@@ -7,7 +7,8 @@
     "build": "bun build src/index.ts --outdir dist --target bun",
     "start": "bun run src/index.ts",
     "test": "bash scripts/test.sh",
-    "typecheck": "bunx tsc --noEmit"
+    "typecheck": "bunx tsc --noEmit",
+    "smoke:staging": "bash deploy/scripts/smoke-check-staging.sh"
   },
   "devDependencies": {
     "@types/bun": "^1.2.4",


### PR DESCRIPTION
## Summary
- add managed-gateway staging deploy scaffolding under `gateway-managed/deploy/`
- include Kubernetes deployment/service stubs with health/readiness probes
- add `deploy/scripts/smoke-check-staging.sh` for manifest checks plus optional live readiness probes
- document staging rollout and rollback checkpoints in `deploy/staging-rollout.md`
- add `bun run smoke:staging` package script and update managed-gateway docs/architecture

## Validation
- cd gateway-managed && bun run typecheck
- cd gateway-managed && bun run build
- cd gateway-managed && bun run test
- cd gateway-managed && bun run smoke:staging
- cd gateway-managed && MANAGED_GATEWAY_STAGING_BASE_URL=http://127.0.0.1:7841 bash deploy/scripts/smoke-check-staging.sh (against live local service)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
