### PR TITLE
revert: undo legacy-compat-rm blitz PRs #11085, #11087, #11088

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -377,7 +377,7 @@ describe('inbound text matching approval phrases triggers decision handling', ()
 // 4. Non-decision messages during pending approval (no conversational engine)
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('non-decision messages during pending approval (no conversational engine)', () => {
+describe('non-decision messages during pending approval (legacy fallback)', () => {
   beforeEach(() => {
     createBinding({
       assistantId: 'self',
@@ -2950,7 +2950,7 @@ describe('trusted-contact self-approval blocked before guardian approval row exi
     deliverSpy.mockRestore();
   });
 
-  test('trusted contact cannot self-approve when no guardian approval row exists', async () => {
+  test('trusted contact cannot self-approve via legacy parser when no guardian approval row exists', async () => {
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
 
     const initReq = makeInboundRequest({
@@ -2970,8 +2970,8 @@ describe('trusted-contact self-approval blocked before guardian approval row exi
 
     deliverSpy.mockClear();
 
-    // No conversational engine — the non-guardian self-approval guard
-    // blocks the decision before it can reach any parser.
+    // No conversational engine — falls through to legacy parser path.
+    // "approve" would normally be parsed as an approval decision.
     const req = makeInboundRequest({
       content: 'approve',
       conversationExternalId: 'tc-selfapproval-chat',

--- a/assistant/src/__tests__/conversation-routes.test.ts
+++ b/assistant/src/__tests__/conversation-routes.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, mock, test } from 'bun:test';
 
+import type { RuntimeMessageSessionOptions } from '../runtime/http-types.js';
+
 mock.module('../util/logger.js', () => ({
   getLogger: () => new Proxy({} as Record<string, unknown>, {
     get: () => () => {},
@@ -27,23 +29,37 @@ const mockLoopbackServer: ServerWithRequestIP = {
 };
 
 describe('handleSendMessage', () => {
-  test('returns 503 when sendMessageDeps is not configured', async () => {
+  test('legacy fallback passes guardian context to processor', async () => {
+    let capturedOptions: RuntimeMessageSessionOptions | undefined;
+    let capturedSourceChannel: string | undefined;
+
     const req = new Request('http://localhost/v1/messages', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        conversationKey: 'no-deps-key',
-        content: 'Hello without deps',
+        conversationKey: 'legacy-fallback-key',
+        content: 'Hello from legacy fallback',
         sourceChannel: 'telegram',
         interface: 'telegram',
       }),
     });
 
-    const res = await handleSendMessage(req, {}, mockLoopbackServer);
+    const res = await handleSendMessage(req, {
+      processMessage: async (_conversationId, _content, _attachmentIds, options, sourceChannel) => {
+        capturedOptions = options;
+        capturedSourceChannel = sourceChannel;
+        return { messageId: 'msg-legacy-fallback' };
+      },
+    }, mockLoopbackServer);
 
-    expect(res.status).toBe(503);
-    const body = await res.json() as { error: { code: string; message: string } };
-    expect(body.error.code).toBe('SERVICE_UNAVAILABLE');
-    expect(body.error.message).toBe('Message processing not configured');
+    const body = await res.json() as { accepted: boolean; messageId: string };
+    expect(res.status).toBe(202);
+    expect(body.accepted).toBe(true);
+    expect(body.messageId).toBe('msg-legacy-fallback');
+    expect(capturedSourceChannel).toBe('telegram');
+    expect(capturedOptions?.guardianContext).toEqual(expect.objectContaining({
+      trustClass: 'guardian',
+      sourceChannel: 'telegram',
+    }));
   });
 });

--- a/assistant/src/runtime/channel-approval-parser.ts
+++ b/assistant/src/runtime/channel-approval-parser.ts
@@ -5,8 +5,10 @@
  * rejection, or "approve always" intent. This module is transport-agnostic
  * and can be used by any channel adapter (Telegram, SMS, etc.).
  *
- * Used by the guardian-action grant minter for deterministic keyword
- * matching in the grant minting fast path.
+ * Both the standard and guardian approval flows now use the conversational
+ * approval engine as the primary classifier. This deterministic parser is
+ * retained only as a legacy fallback for when the conversational engine is
+ * not injected (i.e. approvalConversationGenerator is undefined).
  */
 
 import type { ApprovalAction, ApprovalDecisionResult } from './channel-approval-types.js';

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -95,9 +95,9 @@ export interface GuardianReplyResult {
   /** Detailed result from the canonical decision primitive (when a decision was attempted). */
   canonicalResult?: CanonicalDecisionResult;
   /**
-   * When true, the caller should skip approval interception for this
+   * When true, the caller should skip legacy approval interception for this
    * message. Set by the invite handoff bypass so that "open invite flow"
-   * reaches the assistant even when other guardian approvals are pending.
+   * reaches the assistant even when other legacy guardian approvals are pending.
    */
   skipApprovalInterception?: boolean;
 }
@@ -390,7 +390,7 @@ export async function routeGuardianReply(
   // Desktop sessions intentionally do not enable NL classification; when the
   // caller has exactly one known pending request and sends an explicit
   // approve/reject phrase ("approve", "yes", "reject", "no"), apply the
-  // decision directly instead of returning not_consumed.
+  // decision directly instead of falling through to legacy handlers.
   if (messageText.length > 0 && pendingRequests.length > 0) {
     const inferredAction = inferDecisionActionFromFreeText(messageText);
     if (inferredAction) {
@@ -597,17 +597,10 @@ async function applyDecision(
     `Guardian reply router: canonical decision not applied (${canonicalResult.reason})`,
   );
 
-  // When the canonical request doesn't exist, treat it as stale — the
-  // canonical decision path handles all guardian decisions deterministically.
+  // When the canonical request doesn't exist, allow the message to fall
+  // through so the legacy handleApprovalInterception handler can process it.
   if (canonicalResult.reason === 'not_found') {
-    return {
-      decisionApplied: false,
-      consumed: true,
-      type: 'canonical_decision_stale',
-      requestId,
-      canonicalResult,
-      replyText: 'This request was not found.',
-    };
+    return notConsumed();
   }
 
   const request = getCanonicalGuardianRequest(requestId);

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -724,6 +724,8 @@ export class RuntimeHttpServer {
 
       if (endpoint === 'messages' && req.method === 'POST') {
         return await handleSendMessage(req, {
+          processMessage: this.processMessage,
+          persistAndProcessMessage: this.persistAndProcessMessage,
           sendMessageDeps: this.sendMessageDeps,
           approvalConversationGenerator: this.approvalConversationGenerator,
         }, server);

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -30,6 +30,8 @@ import { routeGuardianReply } from '../guardian-reply-router.js';
 import { httpError } from '../http-errors.js';
 import type {
   ApprovalConversationGenerator,
+  MessageProcessor,
+  NonBlockingMessageProcessor,
   RuntimeAttachmentMetadata,
   RuntimeMessagePayload,
   SendMessageDeps,
@@ -406,6 +408,8 @@ function makeHubPublisher(
 export async function handleSendMessage(
   req: Request,
   deps: {
+    processMessage?: MessageProcessor;
+    persistAndProcessMessage?: NonBlockingMessageProcessor;
     sendMessageDeps?: SendMessageDeps;
     approvalConversationGenerator?: ApprovalConversationGenerator;
   },
@@ -465,13 +469,8 @@ export async function handleSendMessage(
 
   const mapping = getOrCreateConversation(conversationKey);
 
-  // ── Fail fast when sendMessageDeps is not wired ─────────────────────
-  if (!deps.sendMessageDeps) {
-    return httpError('SERVICE_UNAVAILABLE', 'Message processing not configured', 503);
-  }
-
-  // ── Queue-if-busy path ──────────────────────────────────────────────
-  {
+  // ── Queue-if-busy path (preferred when sendMessageDeps is wired) ────
+  if (deps.sendMessageDeps) {
     // Vellum HTTP requests prefer actor-token identity. When absent (e.g. CLI
     // bearer-auth only), fall back to local IPC identity resolution so
     // bearer-authenticated local clients are not rejected.
@@ -610,6 +609,44 @@ export async function handleSendMessage(
     });
 
     return Response.json({ accepted: true, messageId }, { status: 202 });
+  }
+
+  // ── Legacy path (fallback when sendMessageDeps not wired) ───────────
+  const processor = deps.persistAndProcessMessage ?? deps.processMessage;
+  if (!processor) {
+    return httpError('SERVICE_UNAVAILABLE', 'Message processing not configured', 503);
+  }
+
+  // Require actor token for vellum channel requests on the legacy path too,
+  // with local IPC fallback for bearer-authenticated CLI clients.
+  const legacyActorVerification = sourceChannel === 'vellum' ? verifyHttpActorTokenWithLocalFallback(req, server) : null;
+  if (legacyActorVerification && !legacyActorVerification.ok) {
+    return httpError(
+      legacyActorVerification.status === 401 ? 'UNAUTHORIZED' : 'FORBIDDEN',
+      legacyActorVerification.message,
+      legacyActorVerification.status,
+    );
+  }
+
+  const guardianContext = legacyActorVerification?.ok
+    ? legacyActorVerification.guardianContext
+    : resolveLocalIpcGuardianContext(sourceChannel) ?? { trustClass: 'guardian' as const, sourceChannel };
+
+  try {
+    const result = await processor(
+      mapping.conversationId,
+      content ?? '',
+      hasAttachments ? attachmentIds : undefined,
+      { guardianContext },
+      sourceChannel,
+      sourceInterface,
+    );
+    return Response.json({ accepted: true, messageId: result.messageId }, { status: 202 });
+  } catch (err) {
+    if (err instanceof Error && err.message === 'Session is already processing a message') {
+      return httpError('CONFLICT', 'Session is busy processing another message. Please retry.', 409);
+    }
+    throw err;
   }
 }
 

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -16,6 +16,7 @@ import { emitNotificationSignal } from '../../notifications/emit-signal.js';
 import { getLogger } from '../../util/logger.js';
 import { runApprovalConversationTurn } from '../approval-conversation-turn.js';
 import { composeApprovalMessageGenerative } from '../approval-message-composer.js';
+import { parseApprovalDecision } from '../channel-approval-parser.js';
 import type {
   ApprovalDecisionResult,
 } from '../channel-approval-types.js';
@@ -393,7 +394,152 @@ export async function handleApprovalInterception(
         return { handled: true, type: 'stale_ignored' };
       }
 
-      // No content or no engine — nothing to do, fall through to standard
+      // ── Legacy fallback when no conversational engine is available ──
+      // Use the deterministic parser to handle guardian plain-text so that
+      // simple yes/no replies still work when the engine is not injected.
+      if (content && !approvalConversationGenerator) {
+        const legacyGuardianDecision = parseApprovalDecision(content);
+        if (legacyGuardianDecision) {
+          // Guardians cannot approve_always — downgrade to approve_once.
+          if (legacyGuardianDecision.action === 'approve_always') {
+            legacyGuardianDecision.action = 'approve_once';
+          }
+
+          // Resolve the target approval: when a [ref:<requestId>] tag is
+          // present, look up the specific pending approval by that requestId
+          // so the decision applies to the correct conversation even when
+          // multiple guardian approvals are pending.
+          let targetLegacyApproval = guardianApproval;
+          if (legacyGuardianDecision.requestId) {
+            const resolvedByRequest = getPendingApprovalByRequestAndGuardianChat(
+              legacyGuardianDecision.requestId,
+              sourceChannel,
+              conversationExternalId,
+              assistantId,
+            );
+            if (!resolvedByRequest) {
+              // The referenced request doesn't match any pending guardian
+              // approval — it may have expired or already been resolved.
+              try {
+                const staleText = await composeApprovalMessageGenerative({
+                  scenario: 'guardian_disambiguation',
+                  channel: sourceChannel,
+                }, {}, approvalCopyGenerator);
+                await deliverChannelReply(replyCallbackUrl, {
+                  chatId: conversationExternalId,
+                  text: staleText,
+                  assistantId,
+                }, bearerToken);
+              } catch (err) {
+                log.error({ err, conversationExternalId }, 'Failed to deliver stale approval notice (legacy path)');
+              }
+              return { handled: true, type: 'stale_ignored' };
+            }
+            targetLegacyApproval = resolvedByRequest;
+          }
+
+          // Re-validate guardian identity against the resolved target.
+          // The default guardianApproval was already checked, but a
+          // requestId-resolved approval may belong to a different guardian.
+          if (actorExternalId !== targetLegacyApproval.guardianExternalUserId) {
+            log.warn(
+              { conversationExternalId, actorExternalId, expectedGuardian: targetLegacyApproval.guardianExternalUserId, requestId: legacyGuardianDecision.requestId },
+              'Guardian identity mismatch on legacy ref-resolved target approval',
+            );
+            try {
+              const mismatchText = await composeApprovalMessageGenerative({
+                scenario: 'guardian_identity_mismatch',
+                channel: sourceChannel,
+              }, {}, approvalCopyGenerator);
+              await deliverChannelReply(replyCallbackUrl, {
+                chatId: conversationExternalId,
+                text: mismatchText,
+                assistantId,
+              }, bearerToken);
+            } catch (err) {
+              log.error({ err, conversationExternalId }, 'Failed to deliver guardian identity mismatch notice (legacy path)');
+            }
+            return { handled: true, type: 'guardian_decision_applied' };
+          }
+
+          // Access request approvals need a separate decision path.
+          if (targetLegacyApproval.toolName === 'ingress_access_request') {
+            const accessResult = await handleAccessRequestApproval(
+              targetLegacyApproval,
+              legacyGuardianDecision.action === 'reject' ? 'deny' : 'approve',
+              actorExternalId,
+              replyCallbackUrl,
+              assistantId,
+              bearerToken,
+            );
+            return accessResult;
+          }
+
+          // Apply the decision through the unified guardian decision primitive.
+          const result = applyGuardianDecision({
+            approval: targetLegacyApproval,
+            decision: legacyGuardianDecision,
+            actorExternalUserId: actorExternalId,
+            actorChannel: sourceChannel,
+          });
+
+          if (result.applied) {
+            // Notify the requester's chat about the outcome
+            const outcomeText = await composeApprovalMessageGenerative({
+              scenario: 'guardian_decision_outcome',
+              decision: legacyGuardianDecision.action === 'reject' ? 'denied' : 'approved',
+              toolName: targetLegacyApproval.toolName,
+              channel: sourceChannel,
+            }, {}, approvalCopyGenerator);
+            try {
+              await deliverChannelReply(replyCallbackUrl, {
+                chatId: targetLegacyApproval.requesterChatId,
+                text: outcomeText,
+                assistantId,
+              }, bearerToken);
+            } catch (err) {
+              log.error({ err, conversationId: targetLegacyApproval.conversationId }, 'Failed to notify requester of guardian decision (legacy path)');
+            }
+
+            return { handled: true, type: 'guardian_decision_applied' };
+          }
+
+          // Race condition: request was already resolved. Deliver stale notice.
+          try {
+            const staleText = await composeApprovalMessageGenerative({
+              scenario: 'approval_already_resolved',
+              channel: sourceChannel,
+            }, {}, approvalCopyGenerator);
+            await deliverChannelReply(replyCallbackUrl, {
+              chatId: conversationExternalId,
+              text: staleText,
+              assistantId,
+            }, bearerToken);
+          } catch (err) {
+            log.error({ err, conversationId: targetLegacyApproval.conversationId }, 'Failed to deliver stale guardian legacy fallback notice');
+          }
+          return { handled: true, type: 'stale_ignored' };
+        }
+
+        // No decision could be parsed — send a generic reminder to the guardian
+        try {
+          const reminderText = await composeApprovalMessageGenerative({
+            scenario: 'reminder_prompt',
+            toolName: guardianApproval.toolName,
+            channel: sourceChannel,
+          }, {}, approvalCopyGenerator);
+          await deliverChannelReply(replyCallbackUrl, {
+            chatId: conversationExternalId,
+            text: reminderText,
+            assistantId,
+          }, bearerToken);
+        } catch (err) {
+          log.error({ err, conversationId: guardianApproval.conversationId }, 'Failed to deliver guardian reminder (legacy path)');
+        }
+        return { handled: true, type: 'assistant_turn' };
+      }
+
+      // No content and no engine — nothing to do, fall through to standard
       // approval interception below.
     }
   }
@@ -602,8 +748,8 @@ export async function handleApprovalInterception(
       // to the guardian. In the window between the pending confirmation being
       // created (isInteractive=true) and the guardian approval row being
       // persisted, any non-guardian actor could otherwise fall through to the
-      // standard conversational engine and resolve their own pending request
-      // via handleChannelDecision.
+      // standard conversational engine / legacy parser and resolve their own
+      // pending request via handleChannelDecision.
       if (guardianCtx.trustClass !== 'guardian' && guardianCtx.guardianExternalUserId) {
         log.info(
           { conversationId, conversationExternalId, guardianExternalUserId: guardianCtx.guardianExternalUserId },
@@ -736,7 +882,42 @@ export async function handleApprovalInterception(
     return { handled: true, type: 'stale_ignored' };
   }
 
-  // No decision could be extracted — deliver a simple status reply.
+  // Fallback: no conversational generator available or no content — use
+  // the legacy deterministic path as a safety net. This preserves backward
+  // compatibility when the generator is not injected.
+  if (content) {
+    const legacyDecision = parseApprovalDecision(content);
+    if (legacyDecision) {
+      if (legacyDecision.requestId) {
+        if (pending.length === 0 || !pending.some(p => p.requestId === legacyDecision.requestId)) {
+          return { handled: true, type: 'stale_ignored' };
+        }
+      }
+      const result = handleChannelDecision(conversationId, legacyDecision);
+      if (result.applied) {
+        return { handled: true, type: 'decision_applied' };
+      }
+
+      // Race condition: request was already resolved.
+      try {
+        const staleText = await composeApprovalMessageGenerative({
+          scenario: 'approval_already_resolved',
+          channel: sourceChannel,
+        }, {}, approvalCopyGenerator);
+        await deliverChannelReply(replyCallbackUrl, {
+          chatId: conversationExternalId,
+          text: staleText,
+          assistantId,
+        }, bearerToken);
+      } catch (err) {
+        log.error({ err, conversationId }, 'Failed to deliver stale approval notice (legacy path)');
+      }
+      return { handled: true, type: 'stale_ignored' };
+    }
+  }
+
+  // No decision could be extracted and no conversational engine is available —
+  // deliver a simple status reply rather than a reminder prompt.
   try {
     const statusText = await composeApprovalMessageGenerative({
       scenario: 'reminder_prompt',

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -932,14 +932,15 @@ export async function handleChannelInbound(
   });
 
   // Hoisted flag: set by the canonical guardian reply router when the invite
-  // handoff bypass fires. Prevents approval interception from swallowing the
-  // message when other approvals are pending in the same chat.
+  // handoff bypass fires. Prevents legacy approval interception from swallowing
+  // the message when other approvals are pending in the same chat.
   let skipApprovalInterception = false;
 
   // ── Canonical guardian reply router ──
-  // Routes inbound guardian messages through the canonical decision pipeline.
-  // Handles deterministic callbacks (button presses), request code prefixes,
-  // and NL classification via the conversational approval engine.
+  // Attempts to route inbound messages through the canonical decision pipeline
+  // before falling through to the legacy approval interception. Handles
+  // deterministic callbacks (button presses), request code prefixes, and
+  // NL classification via the conversational approval engine.
   if (
     !result.duplicate &&
     replyCallbackUrl &&
@@ -1027,8 +1028,8 @@ export async function handleChannelInbound(
   // ── Approval interception ──
   // Keep this active whenever callback context is available.
   // Skipped when the canonical router flagged skipApprovalInterception (e.g.
-  // invite handoff bypass) to prevent the interceptor from swallowing messages
-  // that should reach the assistant.
+  // invite handoff bypass) to prevent the legacy interceptor from swallowing
+  // messages that should reach the assistant.
   if (
     replyCallbackUrl &&
     !result.duplicate &&

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -267,7 +267,7 @@ Telegram messages follow three paths through the system:
 ```
 Inbound (user → assistant):
   Telegram → Gateway POST /webhooks/telegram → verify secret → normalize → route
-    → Runtime POST /v1/channels/inbound
+    → Runtime POST /v1/assistants/:id/channels/inbound
     (replyCallbackUrl = ${gatewayInternalBaseUrl}/deliver/telegram)
 
 Outbound reply (assistant → user, triggered by inbound):

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -5,7 +5,7 @@ Standalone service that serves as the public ingress boundary for all external w
 ## Architecture
 
 ```
-Telegram → gateway/ → Assistant Runtime (/v1/channels/inbound) → gateway/ → Telegram
+Telegram → gateway/ → Assistant Runtime (/v1/assistants/:id/channels/inbound) → gateway/ → Telegram
 
 Client → gateway/ (Bearer auth) → Assistant Runtime (any path)
 ```
@@ -316,12 +316,12 @@ By default (`GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH=true`), proxied requests must in
 
 ```bash
 # Unauthorized (expect 401 when auth required)
-curl -i http://localhost:7830/v1/health
+curl -i http://localhost:7830/v1/assistants/test/health
 
 # Authorized (expect 200)
 curl -i \
   -H "Authorization: Bearer $RUNTIME_PROXY_BEARER_TOKEN" \
-  http://localhost:7830/v1/health
+  http://localhost:7830/v1/assistants/test/health
 
 # Telegram still uses webhook secret flow, not bearer auth
 curl -i -X POST http://localhost:7830/webhooks/telegram

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -68,39 +68,40 @@ afterEach(() => {
 });
 
 describe("runtime proxy handler", () => {
-  test("rejects legacy /v1/assistants/:assistantId/... paths with 400", async () => {
-    const fetchCalls: string[] = [];
+  test("rewrites legacy /v1/assistants/:assistantId/... to flat /v1/... for upstream", async () => {
+    const captured: { url: string }[] = [];
     fetchMock = mock(async (input: string | URL | Request) => {
-      fetchCalls.push(String(input));
+      captured.push({ url: String(input) });
       return new Response(JSON.stringify({ ok: true }), { status: 200 });
     });
 
     const handler = createRuntimeProxyHandler(makeConfig());
     const req = new Request("http://localhost:7830/v1/assistants/test-assistant/channels/inbound");
-    const res = await handler(req);
+    await handler(req);
 
-    expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(body.source).toBe("gateway");
-    // Request was rejected before proxying
-    expect(fetchCalls.length).toBe(0);
+    expect(captured[0].url).toBe("http://localhost:7821/v1/channels/inbound");
   });
 
-  test("rejects legacy assistant-scoped path with query string", async () => {
-    const fetchCalls: string[] = [];
-    fetchMock = mock(async (input: string | URL | Request) => {
-      fetchCalls.push(String(input));
-      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  test("forwards request to upstream with correct path and query (legacy assistant-scoped rewrite)", async () => {
+    const captured: { url: string; method: string }[] = [];
+    fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
+      captured.push({ url: String(input), method: init?.method ?? "GET" });
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
     });
 
     const handler = createRuntimeProxyHandler(makeConfig());
     const req = new Request("http://localhost:7830/v1/assistants/test/health?foo=bar");
     const res = await handler(req);
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
+    // Legacy /v1/assistants/test/health is rewritten to /v1/health
+    expect(captured[0].url).toBe("http://localhost:7821/v1/health?foo=bar");
+    expect(captured[0].method).toBe("GET");
     const body = await res.json();
-    expect(body.source).toBe("gateway");
-    expect(fetchCalls.length).toBe(0);
+    expect(body).toEqual({ ok: true });
   });
 
   test("forwards POST body to upstream", async () => {

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -45,20 +45,15 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
       }
     }
 
-    // Reject legacy assistant-scoped paths — the daemon only accepts
-    // flat /v1/... paths and we no longer rewrite on the caller's behalf.
-    if (/^\/v1\/assistants\/[^/]+\//.test(url.pathname)) {
-      log.warn(
-        { method: req.method, path: url.pathname },
-        "Rejected legacy assistant-scoped path — use canonical /v1/... paths",
-      );
-      return Response.json(
-        { error: "Legacy assistant-scoped paths are no longer supported. Use /v1/... instead.", source: "gateway" },
-        { status: 400 },
-      );
+    // The daemon uses flat /v1/... paths. Rewrite any legacy
+    // /v1/assistants/:assistantId/... requests from clients to flat paths.
+    let upstreamPath = url.pathname;
+    const assistantScopedMatch = url.pathname.match(/^\/v1\/assistants\/[^/]+\/(.+)$/);
+    if (assistantScopedMatch) {
+      upstreamPath = `/v1/${assistantScopedMatch[1]}`;
     }
 
-    const upstream = `${config.assistantRuntimeBaseUrl}${url.pathname}${url.search}`;
+    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${url.search}`;
 
     const reqHeaders = stripHopByHop(new Headers(req.headers));
     reqHeaders.delete("host");


### PR DESCRIPTION
## Summary
- Reverts #11088 (remove guardian deterministic fallback from approval routing)
- Reverts #11087 (remove /v1/messages legacy processor fallback)
- Reverts #11085 (remove gateway assistant-scoped runtime-proxy rewrite)

These legacy compatibility removal changes are being rolled back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
