### PR TITLE
Add managed SMS webhook endpoint skeleton

### DIFF
--- a/gateway-managed/ARCHITECTURE.md
+++ b/gateway-managed/ARCHITECTURE.md
@@ -37,6 +37,12 @@ The managed gateway is a dedicated service lane for Vellum-owned shared channel 
 - Supports lifecycle-aware token validation (rotation overlap, revocation, and expiry).
 - Extends managed-gateway config with Twilio token catalog validation at startup.
 
+## P07 PR-2 scope
+
+- Adds managed Twilio SMS webhook skeleton endpoint at `/webhooks/twilio/sms`.
+- Enforces Twilio signature verification and explicit validation/auth error envelopes.
+- Defers route-resolution and downstream dispatch wiring to follow-up PRs.
+
 ## Endpoints
 
 - `GET /healthz`
@@ -44,3 +50,4 @@ The managed gateway is a dedicated service lane for Vellum-owned shared channel 
 - `GET /v1/internal/managed-gateway/healthz/`
 - `GET /v1/internal/managed-gateway/readyz/`
 - `POST /v1/internal/managed-gateway/routes/resolve/`
+- `POST /webhooks/twilio/sms`

--- a/gateway-managed/README.md
+++ b/gateway-managed/README.md
@@ -10,6 +10,7 @@ Managed gateway service skeleton for Vellum-owned shared channel identities.
 - Django internal route resolve endpoint wiring for managed route lookup
 - staging deployment manifests, smoke checks, and rollout/rollback runbook
 - Twilio signature verifier primitives with rotation/revocation/expiry support
+- managed Twilio SMS webhook endpoint skeleton with explicit auth/validation envelopes
 - health and readiness endpoints:
   - `/healthz`
   - `/readyz`
@@ -17,6 +18,8 @@ Managed gateway service skeleton for Vellum-owned shared channel identities.
   - `/v1/internal/managed-gateway/readyz/`
 - route resolve endpoint:
   - `POST /v1/internal/managed-gateway/routes/resolve/`
+- Twilio inbound endpoint:
+  - `POST /webhooks/twilio/sms`
 
 ## Configuration
 
@@ -63,6 +66,10 @@ bun run test
 ## Route Resolve Contract
 
 Managed gateway route resolution contract lives in [`route-resolve-contract.md`](./route-resolve-contract.md).
+
+## Managed Twilio SMS Webhook Contract
+
+Managed Twilio SMS webhook contract lives in [`managed-twilio-sms-webhook-contract.md`](./managed-twilio-sms-webhook-contract.md).
 
 ## Staging Deployment Artifacts
 

--- a/gateway-managed/managed-twilio-sms-webhook-contract.md
+++ b/gateway-managed/managed-twilio-sms-webhook-contract.md
@@ -1,0 +1,19 @@
+# Managed Twilio SMS Webhook Contract
+
+Endpoint: `POST /webhooks/twilio/sms`
+
+Caller expectations:
+- caller is Twilio webhook delivery for managed shared identities
+- request body is `application/x-www-form-urlencoded`
+- payload includes `From`, `To`, and `MessageSid`
+
+Authz boundary:
+- requires valid `X-Twilio-Signature`
+- signature must verify against an active token in `MANAGED_GATEWAY_TWILIO_AUTH_TOKENS`
+- revoked or expired Twilio tokens are rejected
+
+Response contract:
+- `202`: accepted stub envelope for managed SMS webhook path
+- `400`: validation error envelope (`validation_error`) for malformed payloads
+- `403`: auth failure envelope for missing/invalid signatures
+- `405`: method-not-allowed envelope for non-POST methods

--- a/gateway-managed/src/__tests__/managed-twilio-sms-webhook.test.ts
+++ b/gateway-managed/src/__tests__/managed-twilio-sms-webhook.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "bun:test";
+
+import { loadConfig } from "../config.js";
+import { createManagedGatewayAppFetch } from "../http.js";
+import { MANAGED_TWILIO_SMS_WEBHOOK_PATH } from "../managed-twilio-sms-webhook.js";
+import { computeTwilioSignature } from "../twilio-signature.js";
+
+const FAR_FUTURE = "2099-01-01T00:00:00.000Z";
+
+type EnvOverrides = Record<string, string | undefined>;
+
+function makeConfig(overrides: EnvOverrides = {}): ReturnType<typeof loadConfig> {
+  return loadConfig({
+    ...process.env,
+    MANAGED_GATEWAY_ENABLED: "true",
+    MANAGED_GATEWAY_STRICT_STARTUP_VALIDATION: "true",
+    MANAGED_GATEWAY_DJANGO_INTERNAL_BASE_URL: "http://127.0.0.1:8000",
+    MANAGED_GATEWAY_INTERNAL_AUTH_MODE: "bearer",
+    MANAGED_GATEWAY_INTERNAL_AUTH_AUDIENCE: "managed-gateway-internal",
+    MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS: JSON.stringify({
+      "token-active": {
+        token_id: "mgw-2026-01",
+        principal: "managed-gateway-staging",
+        audience: "managed-gateway-internal",
+        scopes: ["managed-gateway:internal", "routes:resolve"],
+        expires_at: FAR_FUTURE,
+      },
+    }),
+    MANAGED_GATEWAY_TWILIO_AUTH_TOKENS: JSON.stringify({
+      "twilio-current": {
+        token_id: "twilio-2026-01",
+        auth_token: "twilio-current-secret",
+        expires_at: FAR_FUTURE,
+      },
+    }),
+    ...overrides,
+  });
+}
+
+function makeRequest(
+  body: URLSearchParams,
+  headers: Record<string, string> = {},
+  method: string = "POST",
+): Request {
+  return new Request(`http://managed-gateway.test${MANAGED_TWILIO_SMS_WEBHOOK_PATH}`, {
+    method,
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      ...headers,
+    },
+    body: method === "POST" ? body.toString() : undefined,
+  });
+}
+
+describe("managed Twilio SMS webhook skeleton", () => {
+  test("returns 202 for valid signed Twilio SMS payload", async () => {
+    const config = makeConfig();
+    const handler = createManagedGatewayAppFetch(config);
+    const payload = new URLSearchParams({
+      From: "+15550000000",
+      To: "+15559999999",
+      Body: "hello from managed lane",
+      MessageSid: "SM123",
+    });
+    const signature = computeTwilioSignature(
+      `http://managed-gateway.test${MANAGED_TWILIO_SMS_WEBHOOK_PATH}`,
+      Object.fromEntries(payload),
+      "twilio-current-secret",
+    );
+
+    const response = await handler(makeRequest(payload, {
+      "x-twilio-signature": signature,
+    }));
+
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({
+      status: "accepted",
+      code: "managed_sms_webhook_stub",
+      provider: "twilio",
+      route_type: "sms",
+      message_sid: "SM123",
+      from: "+15550000000",
+      to: "+15559999999",
+      body: "hello from managed lane",
+    });
+  });
+
+  test("returns 400 for invalid webhook payload", async () => {
+    const config = makeConfig();
+    const handler = createManagedGatewayAppFetch(config);
+    const payload = new URLSearchParams({
+      From: "+15550000000",
+      To: "+15559999999",
+      Body: "missing sid",
+    });
+    const signature = computeTwilioSignature(
+      `http://managed-gateway.test${MANAGED_TWILIO_SMS_WEBHOOK_PATH}`,
+      Object.fromEntries(payload),
+      "twilio-current-secret",
+    );
+
+    const response = await handler(makeRequest(payload, {
+      "x-twilio-signature": signature,
+    }));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "validation_error",
+        detail: "Invalid managed Twilio SMS webhook payload.",
+      },
+    });
+  });
+
+  test("returns 403 for missing Twilio signature", async () => {
+    const config = makeConfig();
+    const handler = createManagedGatewayAppFetch(config);
+    const payload = new URLSearchParams({
+      From: "+15550000000",
+      To: "+15559999999",
+      Body: "hello",
+      MessageSid: "SM124",
+    });
+
+    const response = await handler(makeRequest(payload));
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "missing_signature",
+        detail: "Missing X-Twilio-Signature header.",
+      },
+    });
+  });
+
+  test("returns 403 for invalid Twilio signature", async () => {
+    const config = makeConfig();
+    const handler = createManagedGatewayAppFetch(config);
+    const payload = new URLSearchParams({
+      From: "+15550000000",
+      To: "+15559999999",
+      Body: "hello",
+      MessageSid: "SM125",
+    });
+
+    const response = await handler(makeRequest(payload, {
+      "x-twilio-signature": "invalid",
+    }));
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "invalid_signature",
+        detail: "Invalid Twilio request signature.",
+      },
+    });
+  });
+
+  test("returns 405 for unsupported method", async () => {
+    const config = makeConfig();
+    const handler = createManagedGatewayAppFetch(config);
+    const response = await handler(
+      makeRequest(new URLSearchParams(), {}, "GET"),
+    );
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("POST");
+  });
+});

--- a/gateway-managed/src/http.ts
+++ b/gateway-managed/src/http.ts
@@ -1,5 +1,9 @@
 import type { ManagedGatewayConfig } from "./config.js";
 import {
+  handleManagedTwilioSmsWebhook,
+  MANAGED_TWILIO_SMS_WEBHOOK_PATH,
+} from "./managed-twilio-sms-webhook.js";
+import {
   createRouteResolveHandler,
   MANAGED_GATEWAY_ROUTE_RESOLVE_PATH,
   type ManagedGatewayUpstreamFetch,
@@ -86,6 +90,10 @@ export function createManagedGatewayAppFetch(
       }
 
       return routeResolveHandler(request);
+    }
+
+    if (pathname === MANAGED_TWILIO_SMS_WEBHOOK_PATH) {
+      return handleManagedTwilioSmsWebhook(request, config);
     }
 
     return Response.json({ error: "Not found" }, { status: 404 });

--- a/gateway-managed/src/managed-twilio-sms-webhook.ts
+++ b/gateway-managed/src/managed-twilio-sms-webhook.ts
@@ -1,0 +1,117 @@
+import type { ManagedGatewayConfig } from "./config.js";
+import { validateManagedTwilioSignature } from "./twilio-signature.js";
+
+export const MANAGED_TWILIO_SMS_WEBHOOK_PATH = "/webhooks/twilio/sms";
+
+type ManagedTwilioSmsPayload = {
+  from: string;
+  to: string;
+  body: string;
+  messageSid: string;
+};
+
+export async function handleManagedTwilioSmsWebhook(
+  request: Request,
+  config: ManagedGatewayConfig,
+): Promise<Response> {
+  if (request.method !== "POST") {
+    return Response.json(
+      {
+        error: {
+          code: "method_not_allowed",
+          detail: "Only POST is supported for this endpoint.",
+        },
+      },
+      {
+        status: 405,
+        headers: { allow: "POST" },
+      },
+    );
+  }
+
+  let rawBody = "";
+  try {
+    rawBody = await request.text();
+  } catch {
+    return Response.json(
+      {
+        error: {
+          code: "invalid_request_body",
+          detail: "Failed to read request body.",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const params = new URLSearchParams(rawBody);
+  const payload = parseSmsPayload(params);
+  if (!payload) {
+    return Response.json(
+      {
+        error: {
+          code: "validation_error",
+          detail: "Invalid managed Twilio SMS webhook payload.",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const verification = validateManagedTwilioSignature(config, {
+    url: request.url,
+    params: toRecord(params),
+    signature: request.headers.get("x-twilio-signature"),
+  });
+  if (!verification.ok) {
+    return Response.json(
+      {
+        error: {
+          code: verification.code,
+          detail: verification.detail,
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  return Response.json(
+    {
+      status: "accepted",
+      code: "managed_sms_webhook_stub",
+      provider: "twilio",
+      route_type: "sms",
+      message_sid: payload.messageSid,
+      from: payload.from,
+      to: payload.to,
+      body: payload.body,
+    },
+    { status: 202 },
+  );
+}
+
+function parseSmsPayload(params: URLSearchParams): ManagedTwilioSmsPayload | null {
+  const from = params.get("From")?.trim() || "";
+  const to = params.get("To")?.trim() || "";
+  const body = params.get("Body") || "";
+  const messageSid = params.get("MessageSid")?.trim() || "";
+
+  if (!from || !to || !messageSid) {
+    return null;
+  }
+
+  return {
+    from,
+    to,
+    body,
+    messageSid,
+  };
+}
+
+function toRecord(params: URLSearchParams): Record<string, string> {
+  const record: Record<string, string> = {};
+  for (const [key, value] of params.entries()) {
+    record[key] = value;
+  }
+  return record;
+}


### PR DESCRIPTION
## Summary
- add managed Twilio SMS webhook skeleton endpoint at `/webhooks/twilio/sms`
- enforce Twilio signature verification plus explicit validation/auth error envelopes
- document webhook contract and add API contract tests (success, validation failure, auth failure, method gating)

## Validation
- cd gateway-managed && bun run typecheck
- cd gateway-managed && bun run build
- cd gateway-managed && bun run test

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
