### PR TITLE
Add managed voice webhook endpoint skeleton

### DIFF
--- a/gateway-managed/ARCHITECTURE.md
+++ b/gateway-managed/ARCHITECTURE.md
@@ -43,6 +43,12 @@ The managed gateway is a dedicated service lane for Vellum-owned shared channel 
 - Enforces Twilio signature verification and explicit validation/auth error envelopes.
 - Defers route-resolution and downstream dispatch wiring to follow-up PRs.
 
+## P07 PR-3 scope
+
+- Adds managed Twilio voice webhook skeleton endpoint at `/webhooks/twilio/voice`.
+- Enforces Twilio signature verification and explicit validation/auth error envelopes.
+- Defers payload normalization and dispatch wiring to follow-up PRs.
+
 ## Endpoints
 
 - `GET /healthz`
@@ -51,3 +57,4 @@ The managed gateway is a dedicated service lane for Vellum-owned shared channel 
 - `GET /v1/internal/managed-gateway/readyz/`
 - `POST /v1/internal/managed-gateway/routes/resolve/`
 - `POST /webhooks/twilio/sms`
+- `POST /webhooks/twilio/voice`

--- a/gateway-managed/README.md
+++ b/gateway-managed/README.md
@@ -11,6 +11,7 @@ Managed gateway service skeleton for Vellum-owned shared channel identities.
 - staging deployment manifests, smoke checks, and rollout/rollback runbook
 - Twilio signature verifier primitives with rotation/revocation/expiry support
 - managed Twilio SMS webhook endpoint skeleton with explicit auth/validation envelopes
+- managed Twilio voice webhook endpoint skeleton with explicit auth/validation envelopes
 - health and readiness endpoints:
   - `/healthz`
   - `/readyz`
@@ -20,6 +21,7 @@ Managed gateway service skeleton for Vellum-owned shared channel identities.
   - `POST /v1/internal/managed-gateway/routes/resolve/`
 - Twilio inbound endpoint:
   - `POST /webhooks/twilio/sms`
+  - `POST /webhooks/twilio/voice`
 
 ## Configuration
 
@@ -70,6 +72,10 @@ Managed gateway route resolution contract lives in [`route-resolve-contract.md`]
 ## Managed Twilio SMS Webhook Contract
 
 Managed Twilio SMS webhook contract lives in [`managed-twilio-sms-webhook-contract.md`](./managed-twilio-sms-webhook-contract.md).
+
+## Managed Twilio Voice Webhook Contract
+
+Managed Twilio voice webhook contract lives in [`managed-twilio-voice-webhook-contract.md`](./managed-twilio-voice-webhook-contract.md).
 
 ## Staging Deployment Artifacts
 

--- a/gateway-managed/managed-twilio-voice-webhook-contract.md
+++ b/gateway-managed/managed-twilio-voice-webhook-contract.md
@@ -1,0 +1,19 @@
+# Managed Twilio Voice Webhook Contract
+
+Endpoint: `POST /webhooks/twilio/voice`
+
+Caller expectations:
+- caller is Twilio voice webhook delivery for managed shared identities
+- request body is `application/x-www-form-urlencoded`
+- payload includes `From`, `To`, `CallSid`, and `CallStatus`
+
+Authz boundary:
+- requires valid `X-Twilio-Signature`
+- signature must verify against an active token in `MANAGED_GATEWAY_TWILIO_AUTH_TOKENS`
+- revoked or expired Twilio tokens are rejected
+
+Response contract:
+- `202`: accepted stub envelope for managed voice webhook path
+- `400`: validation error envelope (`validation_error`) for malformed payloads
+- `403`: auth failure envelope for missing/invalid signatures
+- `405`: method-not-allowed envelope for non-POST methods

--- a/gateway-managed/src/__tests__/managed-twilio-voice-webhook.test.ts
+++ b/gateway-managed/src/__tests__/managed-twilio-voice-webhook.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "bun:test";
+
+import { loadConfig } from "../config.js";
+import { createManagedGatewayAppFetch } from "../http.js";
+import { MANAGED_TWILIO_VOICE_WEBHOOK_PATH } from "../managed-twilio-voice-webhook.js";
+import { computeTwilioSignature } from "../twilio-signature.js";
+
+const FAR_FUTURE = "2099-01-01T00:00:00.000Z";
+
+type EnvOverrides = Record<string, string | undefined>;
+
+function makeConfig(overrides: EnvOverrides = {}): ReturnType<typeof loadConfig> {
+  return loadConfig({
+    ...process.env,
+    MANAGED_GATEWAY_ENABLED: "true",
+    MANAGED_GATEWAY_STRICT_STARTUP_VALIDATION: "true",
+    MANAGED_GATEWAY_DJANGO_INTERNAL_BASE_URL: "http://127.0.0.1:8000",
+    MANAGED_GATEWAY_INTERNAL_AUTH_MODE: "bearer",
+    MANAGED_GATEWAY_INTERNAL_AUTH_AUDIENCE: "managed-gateway-internal",
+    MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS: JSON.stringify({
+      "token-active": {
+        token_id: "mgw-2026-01",
+        principal: "managed-gateway-staging",
+        audience: "managed-gateway-internal",
+        scopes: ["managed-gateway:internal", "routes:resolve"],
+        expires_at: FAR_FUTURE,
+      },
+    }),
+    MANAGED_GATEWAY_TWILIO_AUTH_TOKENS: JSON.stringify({
+      "twilio-current": {
+        token_id: "twilio-2026-01",
+        auth_token: "twilio-current-secret",
+        expires_at: FAR_FUTURE,
+      },
+    }),
+    ...overrides,
+  });
+}
+
+function makeRequest(
+  body: URLSearchParams,
+  headers: Record<string, string> = {},
+  method: string = "POST",
+): Request {
+  return new Request(`http://managed-gateway.test${MANAGED_TWILIO_VOICE_WEBHOOK_PATH}`, {
+    method,
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      ...headers,
+    },
+    body: method === "POST" ? body.toString() : undefined,
+  });
+}
+
+describe("managed Twilio voice webhook skeleton", () => {
+  test("returns 202 for valid signed Twilio voice payload", async () => {
+    const config = makeConfig();
+    const handler = createManagedGatewayAppFetch(config);
+    const payload = new URLSearchParams({
+      From: "+15550000000",
+      To: "+15559999999",
+      CallSid: "CA123",
+      CallStatus: "ringing",
+    });
+    const signature = computeTwilioSignature(
+      `http://managed-gateway.test${MANAGED_TWILIO_VOICE_WEBHOOK_PATH}`,
+      Object.fromEntries(payload),
+      "twilio-current-secret",
+    );
+
+    const response = await handler(makeRequest(payload, {
+      "x-twilio-signature": signature,
+    }));
+
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({
+      status: "accepted",
+      code: "managed_voice_webhook_stub",
+      provider: "twilio",
+      route_type: "voice",
+      call_sid: "CA123",
+      call_status: "ringing",
+      from: "+15550000000",
+      to: "+15559999999",
+    });
+  });
+
+  test("returns 400 for invalid webhook payload", async () => {
+    const config = makeConfig();
+    const handler = createManagedGatewayAppFetch(config);
+    const payload = new URLSearchParams({
+      From: "+15550000000",
+      To: "+15559999999",
+      CallSid: "CA124",
+    });
+    const signature = computeTwilioSignature(
+      `http://managed-gateway.test${MANAGED_TWILIO_VOICE_WEBHOOK_PATH}`,
+      Object.fromEntries(payload),
+      "twilio-current-secret",
+    );
+
+    const response = await handler(makeRequest(payload, {
+      "x-twilio-signature": signature,
+    }));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "validation_error",
+        detail: "Invalid managed Twilio voice webhook payload.",
+      },
+    });
+  });
+
+  test("returns 403 for missing Twilio signature", async () => {
+    const config = makeConfig();
+    const handler = createManagedGatewayAppFetch(config);
+    const payload = new URLSearchParams({
+      From: "+15550000000",
+      To: "+15559999999",
+      CallSid: "CA125",
+      CallStatus: "in-progress",
+    });
+
+    const response = await handler(makeRequest(payload));
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "missing_signature",
+        detail: "Missing X-Twilio-Signature header.",
+      },
+    });
+  });
+
+  test("returns 403 for invalid Twilio signature", async () => {
+    const config = makeConfig();
+    const handler = createManagedGatewayAppFetch(config);
+    const payload = new URLSearchParams({
+      From: "+15550000000",
+      To: "+15559999999",
+      CallSid: "CA126",
+      CallStatus: "completed",
+    });
+
+    const response = await handler(makeRequest(payload, {
+      "x-twilio-signature": "invalid",
+    }));
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "invalid_signature",
+        detail: "Invalid Twilio request signature.",
+      },
+    });
+  });
+
+  test("returns 405 for unsupported method", async () => {
+    const config = makeConfig();
+    const handler = createManagedGatewayAppFetch(config);
+    const response = await handler(
+      makeRequest(new URLSearchParams(), {}, "GET"),
+    );
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("POST");
+  });
+});

--- a/gateway-managed/src/http.ts
+++ b/gateway-managed/src/http.ts
@@ -4,6 +4,10 @@ import {
   MANAGED_TWILIO_SMS_WEBHOOK_PATH,
 } from "./managed-twilio-sms-webhook.js";
 import {
+  handleManagedTwilioVoiceWebhook,
+  MANAGED_TWILIO_VOICE_WEBHOOK_PATH,
+} from "./managed-twilio-voice-webhook.js";
+import {
   createRouteResolveHandler,
   MANAGED_GATEWAY_ROUTE_RESOLVE_PATH,
   type ManagedGatewayUpstreamFetch,
@@ -94,6 +98,10 @@ export function createManagedGatewayAppFetch(
 
     if (pathname === MANAGED_TWILIO_SMS_WEBHOOK_PATH) {
       return handleManagedTwilioSmsWebhook(request, config);
+    }
+
+    if (pathname === MANAGED_TWILIO_VOICE_WEBHOOK_PATH) {
+      return handleManagedTwilioVoiceWebhook(request, config);
     }
 
     return Response.json({ error: "Not found" }, { status: 404 });

--- a/gateway-managed/src/managed-twilio-voice-webhook.ts
+++ b/gateway-managed/src/managed-twilio-voice-webhook.ts
@@ -1,0 +1,117 @@
+import type { ManagedGatewayConfig } from "./config.js";
+import { validateManagedTwilioSignature } from "./twilio-signature.js";
+
+export const MANAGED_TWILIO_VOICE_WEBHOOK_PATH = "/webhooks/twilio/voice";
+
+type ManagedTwilioVoicePayload = {
+  from: string;
+  to: string;
+  callSid: string;
+  callStatus: string;
+};
+
+export async function handleManagedTwilioVoiceWebhook(
+  request: Request,
+  config: ManagedGatewayConfig,
+): Promise<Response> {
+  if (request.method !== "POST") {
+    return Response.json(
+      {
+        error: {
+          code: "method_not_allowed",
+          detail: "Only POST is supported for this endpoint.",
+        },
+      },
+      {
+        status: 405,
+        headers: { allow: "POST" },
+      },
+    );
+  }
+
+  let rawBody = "";
+  try {
+    rawBody = await request.text();
+  } catch {
+    return Response.json(
+      {
+        error: {
+          code: "invalid_request_body",
+          detail: "Failed to read request body.",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const params = new URLSearchParams(rawBody);
+  const payload = parseVoicePayload(params);
+  if (!payload) {
+    return Response.json(
+      {
+        error: {
+          code: "validation_error",
+          detail: "Invalid managed Twilio voice webhook payload.",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const verification = validateManagedTwilioSignature(config, {
+    url: request.url,
+    params: toRecord(params),
+    signature: request.headers.get("x-twilio-signature"),
+  });
+  if (!verification.ok) {
+    return Response.json(
+      {
+        error: {
+          code: verification.code,
+          detail: verification.detail,
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  return Response.json(
+    {
+      status: "accepted",
+      code: "managed_voice_webhook_stub",
+      provider: "twilio",
+      route_type: "voice",
+      call_sid: payload.callSid,
+      call_status: payload.callStatus,
+      from: payload.from,
+      to: payload.to,
+    },
+    { status: 202 },
+  );
+}
+
+function parseVoicePayload(params: URLSearchParams): ManagedTwilioVoicePayload | null {
+  const from = params.get("From")?.trim() || "";
+  const to = params.get("To")?.trim() || "";
+  const callSid = params.get("CallSid")?.trim() || "";
+  const callStatus = params.get("CallStatus")?.trim() || "";
+
+  if (!from || !to || !callSid || !callStatus) {
+    return null;
+  }
+
+  return {
+    from,
+    to,
+    callSid,
+    callStatus,
+  };
+}
+
+function toRecord(params: URLSearchParams): Record<string, string> {
+  const record: Record<string, string> = {};
+  for (const [key, value] of params.entries()) {
+    record[key] = value;
+  }
+  return record;
+}


### PR DESCRIPTION
## Summary
- add managed Twilio voice webhook skeleton endpoint at `/webhooks/twilio/voice`
- enforce Twilio signature verification plus explicit validation/auth error envelopes
- document voice webhook contract and add API contract tests (success, validation failure, auth failure, method gating)

## Validation
- cd gateway-managed && bun run typecheck
- cd gateway-managed && bun run build
- cd gateway-managed && bun run test

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
