### PR TITLE
feat: hard-cutover to rotating refresh tokens for identity credentials

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -22,7 +22,7 @@ This document owns assistant-runtime architecture details. The repo-level archit
 - Voice calls mirror the same prompt contract: `CallController` receives guardian context on setup and refreshes it immediately after successful voice challenge verification, so the first post-verification turn is grounded as `actor_role: guardian`.
 - Voice-specific behavior (DTMF/speech verification flow, relay state machine) remains voice-local; only actor-role resolution is shared.
 
-### Vellum Guardian Identity Model (Actor Tokens + Bootstrap)
+### Vellum Guardian Identity Model (Actor Tokens + Refresh Tokens)
 
 The vellum channel (macOS desktop, iOS, CLI) uses an identity-bound actor token system to authenticate guardian identity on HTTP routes. This replaces the previous implicit trust model where all local connections were assumed to be the guardian.
 
@@ -30,15 +30,29 @@ The vellum channel (macOS desktop, iOS, CLI) uses an identity-bound actor token 
 
 1. **Startup migration** — On daemon start, `ensureVellumGuardianBinding()` (in `guardian-vellum-migration.ts`) backfills a `channel='vellum'` guardian binding with a stable `guardianPrincipalId` (format: `vellum-principal-<uuid>`). Existing installations get a binding with `verifiedVia: 'startup-migration'`; new installs get one via bootstrap. This migration is idempotent and preserves bindings for other channels (Telegram, SMS, etc.).
 
-2. **Hatch bootstrap (loopback-only, macOS)** — On every launch, the macOS client calls `POST /v1/integrations/guardian/vellum/bootstrap` with `{ platform: 'macos', deviceId }`. The endpoint is loopback-only: it rejects requests with `X-Forwarded-For` and verifies the peer IP is a loopback address (`127.0.0.1`, `::1`, `::ffff:127.0.0.1`). The endpoint is idempotent: it ensures a vellum guardian principal exists, revokes any prior token for the same device binding, mints a new HMAC-SHA256 signed actor token with a 90-day TTL, stores only the SHA-256 hash, and returns `{ guardianPrincipalId, actorToken, isNew }`. The raw token is returned once and never persisted on the server. macOS re-bootstraps on each startup to refresh its token.
+2. **Bootstrap (loopback-only, macOS) — initial issuance only** — On first launch (no existing actor token), the macOS client calls `POST /v1/integrations/guardian/vellum/bootstrap` with `{ platform: 'macos', deviceId }`. The endpoint is loopback-only: it rejects requests with `X-Forwarded-For` and verifies the peer IP is a loopback address (`127.0.0.1`, `::1`, `::ffff:127.0.0.1`). The endpoint ensures a vellum guardian principal exists, revokes any prior token for the same device binding, mints a new HMAC-SHA256 signed actor token with a 30-day TTL and a rotating refresh token, stores only the SHA-256 hashes, and returns `{ guardianPrincipalId, actorToken, actorTokenExpiresAt, refreshToken, refreshTokenExpiresAt, refreshAfter, isNew }`. Bootstrap is only used for initial credential issuance — ongoing renewal is handled exclusively by the refresh endpoint.
 
-3. **iOS pairing** — iOS devices obtain actor tokens exclusively through the QR pairing flow (re-pairs on credential loss). When an iOS device completes pairing, the pairing response includes an `actorToken` minted against the same vellum guardian principal. The pairing handler in `pairing-routes.ts` calls `mintPairingActorToken()` which looks up the vellum binding and mints a device-specific token. iOS does not call the bootstrap endpoint.
+3. **iOS pairing — initial issuance only** — iOS devices obtain actor tokens exclusively through the QR pairing flow. When an iOS device completes pairing, the pairing response includes an `actorToken` and `refreshToken` minted against the same vellum guardian principal. The pairing handler in `pairing-routes.ts` calls `mintPairingActorToken()` which looks up the vellum binding and mints a device-specific token pair. iOS does not call the bootstrap endpoint. Re-pairing is only needed if both the actor token and refresh token expire.
 
 4. **IPC identity** — Local IPC connections (Unix domain socket from the macOS native app) do not send actor tokens. Instead, the daemon assigns a deterministic local actor identity via `resolveLocalIpcGuardianContext()` in `local-actor-identity.ts`. This looks up the vellum guardian binding and routes through the same `resolveGuardianContext` trust pipeline used by HTTP channel ingress. When no vellum binding exists yet (pre-bootstrap), a fallback guardian context is returned since the local macOS user is inherently the guardian of their own machine.
 
-**Actor token format:** `base64url(JSON claims) + '.' + base64url(HMAC-SHA256 signature)`. Claims include `assistantId`, `platform`, `deviceId`, `guardianPrincipalId`, `iat`, `exp` (default: 90 days from issuance), and `jti`.
+**Actor token format:** `base64url(JSON claims) + '.' + base64url(HMAC-SHA256 signature)`. Claims include `assistantId`, `platform`, `deviceId`, `guardianPrincipalId`, `iat`, `exp` (30 days from issuance), and `jti`.
 
 **Hash-only storage:** Only the SHA-256 hex digest of the raw token is persisted in the `actor_token_records` table. Token verification recomputes the hash and looks it up in the store to check revocation status. Tokens are scoped to `(assistantId, guardianPrincipalId, hashedDeviceId)` with a one-active-per-device invariant.
+
+**Refresh token lifecycle:**
+
+Refresh tokens provide a rotating credential renewal mechanism that avoids re-bootstrap or re-pairing for ongoing sessions.
+
+- **Issuance:** A refresh token is minted alongside every actor token (during bootstrap or pairing). The response includes `refreshToken`, `refreshTokenExpiresAt`, and `refreshAfter` (the timestamp at which clients should proactively refresh, set to 80% of the actor token TTL).
+- **Dual expiry:** Each refresh token has a 365-day absolute expiry (from issuance) and a 90-day inactivity expiry (from last use). The effective expiry is the earlier of the two. Using a refresh token resets the inactivity window.
+- **Single-use rotation:** Each call to `POST /v1/integrations/guardian/vellum/refresh` consumes the presented refresh token and returns a new actor token + new refresh token pair. The old refresh token is marked as rotated and cannot be reused.
+- **Token family tracking:** Refresh tokens are grouped into families (one family per initial issuance chain). All tokens in a family share a `familyId`.
+- **Replay detection:** If a client presents a refresh token that has already been rotated (i.e., it was used once and a successor was issued), the server treats this as a potential token theft. The entire token family for that device is revoked, forcing re-bootstrap or re-pairing.
+- **Device binding:** Refresh tokens are bound to `(assistantId, guardianPrincipalId, hashedDeviceId)`. A refresh request from a different device binding is rejected.
+- **Hash-only storage:** Only the SHA-256 hex digest of the refresh token is stored in the `actor_refresh_token_records` table. The raw token is returned once and never persisted on the server.
+
+**Refresh endpoint:** `POST /v1/integrations/guardian/vellum/refresh` accepts `{ refreshToken }` in the request body. It validates the token hash, checks expiry and device binding, performs replay detection, rotates the token, mints a new actor token, and returns `{ actorToken, actorTokenExpiresAt, refreshToken, refreshTokenExpiresAt, refreshAfter }`. This endpoint is only reachable through the gateway (bearer-authenticated).
 
 **Signing key management:** A 32-byte random signing key is generated on first startup and persisted at `~/.vellum/protected/actor-token-signing-key` with `chmod 0o600`. The key is loaded on subsequent startups via `loadOrCreateSigningKey()`.
 
@@ -52,11 +66,14 @@ The vellum channel (macOS desktop, iOS, CLI) uses an identity-bound actor token 
 |------|---------|
 | `src/runtime/actor-token-service.ts` | HMAC-SHA256 mint/verify, signing key management, `hashToken` |
 | `src/runtime/actor-token-store.ts` | Hash-only persistence: create, find by hash/device binding, revoke |
+| `src/runtime/actor-refresh-token-service.ts` | Refresh token rotation, replay detection, family revocation |
+| `src/runtime/actor-refresh-token-store.ts` | Refresh token hash-only persistence: create, find, rotate, revoke by family |
 | `src/runtime/middleware/actor-token.ts` | HTTP middleware: `verifyHttpActorToken`, `verifyHttpActorTokenWithLocalFallback`, `isActorBoundGuardian` |
 | `src/runtime/local-actor-identity.ts` | `resolveLocalIpcGuardianContext` — deterministic IPC identity |
 | `src/runtime/guardian-vellum-migration.ts` | `ensureVellumGuardianBinding` — startup binding backfill |
-| `src/runtime/routes/guardian-bootstrap-routes.ts` | `POST /v1/integrations/guardian/vellum/bootstrap` handler |
-| `src/runtime/routes/pairing-routes.ts` | `mintPairingActorToken` — actor token in pairing response |
+| `src/runtime/routes/guardian-bootstrap-routes.ts` | `POST /v1/integrations/guardian/vellum/bootstrap` handler (initial issuance only) |
+| `src/runtime/routes/guardian-refresh-routes.ts` | `POST /v1/integrations/guardian/vellum/refresh` handler (token rotation) |
+| `src/runtime/routes/pairing-routes.ts` | `mintPairingActorToken` — actor token + refresh token in pairing response |
 | `src/memory/guardian-bindings.ts` | Guardian binding persistence (shared across all channels) |
 
 ### Channel-Agnostic Scoped Approval Grants

--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -100,7 +100,7 @@ afterAll(() => {
 // ---------------------------------------------------------------------------
 
 describe('actor-token mint/verify', () => {
-  test('mint returns token, hash, and claims with default 90-day TTL', () => {
+  test('mint returns token, hash, and claims with default 30-day TTL', () => {
     const result = mintActorToken({
       assistantId: 'self',
       platform: 'macos',
@@ -115,10 +115,10 @@ describe('actor-token mint/verify', () => {
     expect(result.claims.deviceId).toBe('device-123');
     expect(result.claims.guardianPrincipalId).toBe('principal-abc');
     expect(result.claims.iat).toBeGreaterThan(0);
-    // Default TTL is 90 days
+    // Default TTL is 30 days
     expect(result.claims.exp).not.toBeNull();
-    const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000;
-    expect(result.claims.exp! - result.claims.iat).toBe(ninetyDaysMs);
+    const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
+    expect(result.claims.exp! - result.claims.iat).toBe(thirtyDaysMs);
     expect(result.claims.jti).toBeTruthy();
   });
 

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -1,6 +1,7 @@
 import { getDb } from './db-connection.js';
 import {
   addCoreColumns,
+  createActorRefreshTokenRecordsTable,
   createActorTokenRecordsTable,
   createAssistantInboxTables,
   createCallSessionsTables,
@@ -174,6 +175,9 @@ export function initializeDb(): void {
 
   // 28. Actor token records (hash-only actor token persistence)
   createActorTokenRecordsTable(database);
+
+  // 28b. Actor refresh token records (rotating refresh tokens with family tracking)
+  createActorRefreshTokenRecordsTable(database);
 
   // 29. Guardian principal ID columns on channel_guardian_bindings and canonical_guardian_requests
   migrateGuardianPrincipalIdColumns(database);

--- a/assistant/src/memory/migrations/039-actor-refresh-token-records.ts
+++ b/assistant/src/memory/migrations/039-actor-refresh-token-records.ts
@@ -33,7 +33,10 @@ export function createActorRefreshTokenRecordsTable(database: DrizzleDb): void {
       ON actor_refresh_token_records(token_hash)`,
   );
 
-  // Unique active refresh token per device binding
+  // Unique active refresh token per device binding.
+  // DROP first so that databases that already created the older non-unique
+  // index with the same name get upgraded to UNIQUE.
+  database.run(/*sql*/ `DROP INDEX IF EXISTS idx_refresh_tokens_active_device`);
   database.run(
     /*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_refresh_tokens_active_device
       ON actor_refresh_token_records(assistant_id, guardian_principal_id, hashed_device_id)

--- a/assistant/src/memory/migrations/039-actor-refresh-token-records.ts
+++ b/assistant/src/memory/migrations/039-actor-refresh-token-records.ts
@@ -35,7 +35,7 @@ export function createActorRefreshTokenRecordsTable(database: DrizzleDb): void {
 
   // Unique active refresh token per device binding
   database.run(
-    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_refresh_tokens_active_device
+    /*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_refresh_tokens_active_device
       ON actor_refresh_token_records(assistant_id, guardian_principal_id, hashed_device_id)
       WHERE status = 'active'`,
   );

--- a/assistant/src/memory/migrations/039-actor-refresh-token-records.ts
+++ b/assistant/src/memory/migrations/039-actor-refresh-token-records.ts
@@ -1,0 +1,48 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Create the actor_refresh_token_records table for hash-only refresh token persistence.
+ *
+ * Stores the SHA-256 hash of each refresh token with family tracking,
+ * device binding, and dual expiry (absolute + inactivity).
+ * The raw token plaintext is never stored.
+ */
+export function createActorRefreshTokenRecordsTable(database: DrizzleDb): void {
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS actor_refresh_token_records (
+      id TEXT PRIMARY KEY,
+      token_hash TEXT NOT NULL,
+      family_id TEXT NOT NULL,
+      assistant_id TEXT NOT NULL,
+      guardian_principal_id TEXT NOT NULL,
+      hashed_device_id TEXT NOT NULL,
+      platform TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'active',
+      issued_at INTEGER NOT NULL,
+      absolute_expires_at INTEGER NOT NULL,
+      inactivity_expires_at INTEGER NOT NULL,
+      last_used_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  // Token hash lookup (any status — needed for replay detection)
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_refresh_tokens_hash
+      ON actor_refresh_token_records(token_hash)`,
+  );
+
+  // Unique active refresh token per device binding
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_refresh_tokens_active_device
+      ON actor_refresh_token_records(assistant_id, guardian_principal_id, hashed_device_id)
+      WHERE status = 'active'`,
+  );
+
+  // Family lookup for replay detection (revoke entire family)
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_refresh_tokens_family
+      ON actor_refresh_token_records(family_id)`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -40,6 +40,7 @@ export { migrateGuardianActionSupersession } from './035-guardian-action-superse
 export { migrateNormalizePhoneIdentities } from './036-normalize-phone-identities.js';
 export { migrateVoiceInviteColumns } from './037-voice-invite-columns.js';
 export { createActorTokenRecordsTable } from './038-actor-token-records.js';
+export { createActorRefreshTokenRecordsTable } from './039-actor-refresh-token-records.js';
 export { createCoreTables } from './100-core-tables.js';
 export { createWatchersAndLogsTables } from './101-watchers-and-logs.js';
 export { addCoreColumns } from './102-alter-table-columns.js';

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -1162,6 +1162,25 @@ export const actorTokenRecords = sqliteTable('actor_token_records', {
   updatedAt: integer('updated_at').notNull(),
 });
 
+// ── Actor Refresh Token Records ──────────────────────────────────────
+
+export const actorRefreshTokenRecords = sqliteTable('actor_refresh_token_records', {
+  id: text('id').primaryKey(),
+  tokenHash: text('token_hash').notNull(),
+  familyId: text('family_id').notNull(),
+  assistantId: text('assistant_id').notNull(),
+  guardianPrincipalId: text('guardian_principal_id').notNull(),
+  hashedDeviceId: text('hashed_device_id').notNull(),
+  platform: text('platform').notNull(),
+  status: text('status').notNull().default('active'),
+  issuedAt: integer('issued_at').notNull(),
+  absoluteExpiresAt: integer('absolute_expires_at').notNull(),
+  inactivityExpiresAt: integer('inactivity_expires_at').notNull(),
+  lastUsedAt: integer('last_used_at'),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+});
+
 // ── Scoped Approval Grants ──────────────────────────────────────────
 
 export const scopedApprovalGrants = sqliteTable('scoped_approval_grants', {

--- a/assistant/src/runtime/actor-refresh-token-service.ts
+++ b/assistant/src/runtime/actor-refresh-token-service.ts
@@ -9,6 +9,7 @@
 
 import { createHash, randomBytes } from 'node:crypto';
 
+import { getDb } from '../memory/db.js';
 import { getLogger } from '../util/logger.js';
 import { hashToken, mintActorToken } from './actor-token-service.js';
 import {
@@ -244,59 +245,65 @@ export function rotateCredentials(params: {
     return { ok: false, error: 'device_binding_mismatch' };
   }
 
-  // Mark old refresh token as rotated (atomic CAS — fails if a concurrent request already consumed it)
-  const didRotate = markRotated(refreshTokenHash);
-  if (!didRotate) {
-    return { ok: false, error: 'refresh_reuse_detected' };
-  }
+  // Wrap the entire rotate-revoke-remint sequence in a transaction so that
+  // partial failures (e.g., DB write error after revoking old tokens) roll back
+  // atomically instead of stranding device credentials.
+  const db = getDb();
+  return db.transaction(() => {
+    // Mark old refresh token as rotated (atomic CAS — fails if a concurrent request already consumed it)
+    const didRotate = markRotated(refreshTokenHash);
+    if (!didRotate) {
+      return { ok: false as const, error: 'refresh_reuse_detected' as const };
+    }
 
-  // Revoke old access tokens for this device
-  revokeActorTokensByDevice(record.assistantId, record.guardianPrincipalId, record.hashedDeviceId);
+    // Revoke old access tokens for this device
+    revokeActorTokensByDevice(record.assistantId, record.guardianPrincipalId, record.hashedDeviceId);
 
-  // Mint new access token
-  const { token: actorToken, tokenHash: actorTokenHash, claims } = mintActorToken({
-    assistantId: record.assistantId,
-    platform: params.platform,
-    deviceId: params.deviceId,
-    guardianPrincipalId: record.guardianPrincipalId,
-    ttlMs: ACCESS_TOKEN_TTL_MS,
-  });
-
-  createActorTokenRecord({
-    tokenHash: actorTokenHash,
-    assistantId: record.assistantId,
-    guardianPrincipalId: record.guardianPrincipalId,
-    hashedDeviceId: record.hashedDeviceId,
-    platform: params.platform,
-    issuedAt: claims.iat,
-    expiresAt: claims.exp,
-  });
-
-  // Mint new refresh token in the same family, inheriting the parent's absolute
-  // expiry so rotation resets inactivity but never extends the session lifetime.
-  const refresh = mintRefreshToken({
-    assistantId: record.assistantId,
-    guardianPrincipalId: record.guardianPrincipalId,
-    hashedDeviceId: record.hashedDeviceId,
-    platform: params.platform,
-    familyId: record.familyId,
-    absoluteExpiresAt: record.absoluteExpiresAt,
-  });
-
-  log.info(
-    { familyId: record.familyId, platform: params.platform },
-    'Credential rotation completed',
-  );
-
-  return {
-    ok: true,
-    result: {
+    // Mint new access token
+    const { token: actorToken, tokenHash: actorTokenHash, claims } = mintActorToken({
+      assistantId: record.assistantId,
+      platform: params.platform,
+      deviceId: params.deviceId,
       guardianPrincipalId: record.guardianPrincipalId,
-      actorToken,
-      actorTokenExpiresAt: claims.exp!,
-      refreshToken: refresh.refreshToken,
-      refreshTokenExpiresAt: refresh.refreshTokenExpiresAt,
-      refreshAfter: refresh.refreshAfter,
-    },
-  };
+      ttlMs: ACCESS_TOKEN_TTL_MS,
+    });
+
+    createActorTokenRecord({
+      tokenHash: actorTokenHash,
+      assistantId: record.assistantId,
+      guardianPrincipalId: record.guardianPrincipalId,
+      hashedDeviceId: record.hashedDeviceId,
+      platform: params.platform,
+      issuedAt: claims.iat,
+      expiresAt: claims.exp,
+    });
+
+    // Mint new refresh token in the same family, inheriting the parent's absolute
+    // expiry so rotation resets inactivity but never extends the session lifetime.
+    const refresh = mintRefreshToken({
+      assistantId: record.assistantId,
+      guardianPrincipalId: record.guardianPrincipalId,
+      hashedDeviceId: record.hashedDeviceId,
+      platform: params.platform,
+      familyId: record.familyId,
+      absoluteExpiresAt: record.absoluteExpiresAt,
+    });
+
+    log.info(
+      { familyId: record.familyId, platform: params.platform },
+      'Credential rotation completed',
+    );
+
+    return {
+      ok: true as const,
+      result: {
+        guardianPrincipalId: record.guardianPrincipalId,
+        actorToken,
+        actorTokenExpiresAt: claims.exp!,
+        refreshToken: refresh.refreshToken,
+        refreshTokenExpiresAt: refresh.refreshTokenExpiresAt,
+        refreshAfter: refresh.refreshAfter,
+      },
+    };
+  });
 }

--- a/assistant/src/runtime/actor-refresh-token-service.ts
+++ b/assistant/src/runtime/actor-refresh-token-service.ts
@@ -115,7 +115,7 @@ export function mintRefreshToken(params: {
   return {
     refreshToken,
     refreshTokenHash,
-    refreshTokenExpiresAt: absoluteExpiresAt,
+    refreshTokenExpiresAt: Math.min(absoluteExpiresAt, inactivityExpiresAt),
     refreshAfter: now + Math.floor(ACCESS_TOKEN_TTL_MS * REFRESH_AFTER_FRACTION),
   };
 }
@@ -240,8 +240,11 @@ export function rotateCredentials(params: {
     return { ok: false, error: 'device_binding_mismatch' };
   }
 
-  // Mark old refresh token as rotated
-  markRotated(refreshTokenHash);
+  // Mark old refresh token as rotated (atomic CAS — fails if a concurrent request already consumed it)
+  const didRotate = markRotated(refreshTokenHash);
+  if (!didRotate) {
+    return { ok: false, error: 'refresh_reuse_detected' };
+  }
 
   // Revoke old access tokens for this device
   revokeActorTokensByDevice(record.assistantId, record.guardianPrincipalId, record.hashedDeviceId);

--- a/assistant/src/runtime/actor-refresh-token-service.ts
+++ b/assistant/src/runtime/actor-refresh-token-service.ts
@@ -92,12 +92,16 @@ export function mintRefreshToken(params: {
   hashedDeviceId: string;
   platform: string;
   familyId?: string;
+  /** When provided (during rotation), inherit the parent token's absolute expiry
+   *  instead of computing a fresh one. This ensures refresh rotation resets the
+   *  inactivity window but does NOT extend the absolute session lifetime. */
+  absoluteExpiresAt?: number;
 }): MintRefreshTokenResult {
   const now = Date.now();
   const familyId = params.familyId ?? randomBytes(16).toString('hex');
   const refreshToken = generateRefreshToken();
   const refreshTokenHash = hashRefreshToken(refreshToken);
-  const absoluteExpiresAt = now + REFRESH_ABSOLUTE_TTL_MS;
+  const absoluteExpiresAt = params.absoluteExpiresAt ?? now + REFRESH_ABSOLUTE_TTL_MS;
   const inactivityExpiresAt = now + REFRESH_INACTIVITY_TTL_MS;
 
   createRefreshTokenRecord({
@@ -268,13 +272,15 @@ export function rotateCredentials(params: {
     expiresAt: claims.exp,
   });
 
-  // Mint new refresh token in the same family
+  // Mint new refresh token in the same family, inheriting the parent's absolute
+  // expiry so rotation resets inactivity but never extends the session lifetime.
   const refresh = mintRefreshToken({
     assistantId: record.assistantId,
     guardianPrincipalId: record.guardianPrincipalId,
     hashedDeviceId: record.hashedDeviceId,
     platform: params.platform,
     familyId: record.familyId,
+    absoluteExpiresAt: record.absoluteExpiresAt,
   });
 
   log.info(

--- a/assistant/src/runtime/actor-refresh-token-service.ts
+++ b/assistant/src/runtime/actor-refresh-token-service.ts
@@ -1,0 +1,293 @@
+/**
+ * Refresh token service — mint, rotate, and validate refresh tokens.
+ *
+ * Implements rotating single-use refresh tokens with:
+ * - Absolute expiry (365 days)
+ * - Inactivity expiry (90 days since last refresh)
+ * - Replay detection (reuse of rotated token revokes entire family)
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+
+import { getLogger } from '../util/logger.js';
+import { hashToken, mintActorToken } from './actor-token-service.js';
+import {
+  createActorTokenRecord,
+  revokeByDeviceBinding as revokeActorTokensByDevice,
+} from './actor-token-store.js';
+import {
+  createRefreshTokenRecord,
+  findByTokenHash as findRefreshByHash,
+  markRotated,
+  revokeByDeviceBinding as revokeRefreshTokensByDevice,
+  revokeFamily,
+} from './actor-refresh-token-store.js';
+
+const log = getLogger('actor-refresh-token-service');
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Access token TTL: 30 days (reduced from 90). */
+const ACCESS_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Refresh token absolute expiry: 365 days from issuance. */
+const REFRESH_ABSOLUTE_TTL_MS = 365 * 24 * 60 * 60 * 1000;
+
+/** Refresh token inactivity expiry: 90 days since last successful refresh. */
+const REFRESH_INACTIVITY_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+
+/** Proactive refresh hint: suggest refreshing when 80% of access token TTL has elapsed. */
+const REFRESH_AFTER_FRACTION = 0.8;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type RefreshErrorCode =
+  | 'refresh_invalid'
+  | 'refresh_expired'
+  | 'refresh_reuse_detected'
+  | 'device_binding_mismatch'
+  | 'revoked';
+
+export interface RefreshResult {
+  guardianPrincipalId: string;
+  actorToken: string;
+  actorTokenExpiresAt: number;
+  refreshToken: string;
+  refreshTokenExpiresAt: number;
+  refreshAfter: number;
+}
+
+export interface MintRefreshTokenResult {
+  refreshToken: string;
+  refreshTokenHash: string;
+  refreshTokenExpiresAt: number;
+  refreshAfter: number;
+}
+
+// ---------------------------------------------------------------------------
+// Mint a fresh refresh token (used by bootstrap/pairing)
+// ---------------------------------------------------------------------------
+
+/** Hash a raw refresh token for storage. Reuses the actor-token hash function. */
+function hashRefreshToken(token: string): string {
+  return hashToken(token);
+}
+
+/** Generate a cryptographically random refresh token. */
+function generateRefreshToken(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+/**
+ * Mint a new refresh token and persist its hash.
+ * Called during bootstrap, pairing, and rotation.
+ */
+export function mintRefreshToken(params: {
+  assistantId: string;
+  guardianPrincipalId: string;
+  hashedDeviceId: string;
+  platform: string;
+  familyId?: string;
+}): MintRefreshTokenResult {
+  const now = Date.now();
+  const familyId = params.familyId ?? randomBytes(16).toString('hex');
+  const refreshToken = generateRefreshToken();
+  const refreshTokenHash = hashRefreshToken(refreshToken);
+  const absoluteExpiresAt = now + REFRESH_ABSOLUTE_TTL_MS;
+  const inactivityExpiresAt = now + REFRESH_INACTIVITY_TTL_MS;
+
+  createRefreshTokenRecord({
+    tokenHash: refreshTokenHash,
+    familyId,
+    assistantId: params.assistantId,
+    guardianPrincipalId: params.guardianPrincipalId,
+    hashedDeviceId: params.hashedDeviceId,
+    platform: params.platform,
+    issuedAt: now,
+    absoluteExpiresAt,
+    inactivityExpiresAt,
+  });
+
+  return {
+    refreshToken,
+    refreshTokenHash,
+    refreshTokenExpiresAt: absoluteExpiresAt,
+    refreshAfter: now + Math.floor(ACCESS_TOKEN_TTL_MS * REFRESH_AFTER_FRACTION),
+  };
+}
+
+/**
+ * Mint both an access token and a refresh token for initial credential issuance.
+ * Used by bootstrap and pairing flows.
+ */
+export function mintCredentialPair(params: {
+  assistantId: string;
+  platform: string;
+  deviceId: string;
+  guardianPrincipalId: string;
+  hashedDeviceId: string;
+}): {
+  actorToken: string;
+  actorTokenExpiresAt: number;
+  refreshToken: string;
+  refreshTokenExpiresAt: number;
+  refreshAfter: number;
+  guardianPrincipalId: string;
+} {
+  // Revoke any existing credentials for this device
+  revokeActorTokensByDevice(params.assistantId, params.guardianPrincipalId, params.hashedDeviceId);
+  revokeRefreshTokensByDevice(params.assistantId, params.guardianPrincipalId, params.hashedDeviceId);
+
+  // Mint new access token with 30-day TTL
+  const { token: actorToken, tokenHash: actorTokenHash, claims } = mintActorToken({
+    assistantId: params.assistantId,
+    platform: params.platform,
+    deviceId: params.deviceId,
+    guardianPrincipalId: params.guardianPrincipalId,
+    ttlMs: ACCESS_TOKEN_TTL_MS,
+  });
+
+  createActorTokenRecord({
+    tokenHash: actorTokenHash,
+    assistantId: params.assistantId,
+    guardianPrincipalId: params.guardianPrincipalId,
+    hashedDeviceId: params.hashedDeviceId,
+    platform: params.platform,
+    issuedAt: claims.iat,
+    expiresAt: claims.exp,
+  });
+
+  // Mint new refresh token
+  const refresh = mintRefreshToken({
+    assistantId: params.assistantId,
+    guardianPrincipalId: params.guardianPrincipalId,
+    hashedDeviceId: params.hashedDeviceId,
+    platform: params.platform,
+  });
+
+  return {
+    actorToken,
+    actorTokenExpiresAt: claims.exp!,
+    refreshToken: refresh.refreshToken,
+    refreshTokenExpiresAt: refresh.refreshTokenExpiresAt,
+    refreshAfter: refresh.refreshAfter,
+    guardianPrincipalId: params.guardianPrincipalId,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Rotate (the core refresh operation)
+// ---------------------------------------------------------------------------
+
+/**
+ * Rotate credentials: validate refresh token, revoke old, mint new pair.
+ *
+ * Returns either a successful result or an error code.
+ */
+export function rotateCredentials(params: {
+  refreshToken: string;
+  platform: string;
+  deviceId: string;
+}): { ok: true; result: RefreshResult } | { ok: false; error: RefreshErrorCode } {
+  const refreshTokenHash = hashRefreshToken(params.refreshToken);
+  const hashedDeviceId = createHash('sha256').update(params.deviceId).digest('hex');
+
+  // Look up the refresh token by hash (any status)
+  const record = findRefreshByHash(refreshTokenHash);
+
+  if (!record) {
+    return { ok: false, error: 'refresh_invalid' };
+  }
+
+  // Check if this is a reuse of an already-rotated token (replay detection)
+  if (record.status === 'rotated') {
+    log.warn(
+      { familyId: record.familyId, hashedDeviceId: record.hashedDeviceId },
+      'Refresh token reuse detected — revoking entire family',
+    );
+    revokeFamily(record.familyId);
+    revokeActorTokensByDevice(record.assistantId, record.guardianPrincipalId, record.hashedDeviceId);
+    return { ok: false, error: 'refresh_reuse_detected' };
+  }
+
+  if (record.status === 'revoked') {
+    return { ok: false, error: 'revoked' };
+  }
+
+  // At this point status === 'active'
+  const now = Date.now();
+
+  // Check absolute expiry
+  if (now > record.absoluteExpiresAt) {
+    return { ok: false, error: 'refresh_expired' };
+  }
+
+  // Check inactivity expiry
+  if (now > record.inactivityExpiresAt) {
+    return { ok: false, error: 'refresh_expired' };
+  }
+
+  // Verify device binding
+  if (record.hashedDeviceId !== hashedDeviceId) {
+    return { ok: false, error: 'device_binding_mismatch' };
+  }
+
+  if (record.platform !== params.platform) {
+    return { ok: false, error: 'device_binding_mismatch' };
+  }
+
+  // Mark old refresh token as rotated
+  markRotated(refreshTokenHash);
+
+  // Revoke old access tokens for this device
+  revokeActorTokensByDevice(record.assistantId, record.guardianPrincipalId, record.hashedDeviceId);
+
+  // Mint new access token
+  const { token: actorToken, tokenHash: actorTokenHash, claims } = mintActorToken({
+    assistantId: record.assistantId,
+    platform: params.platform,
+    deviceId: params.deviceId,
+    guardianPrincipalId: record.guardianPrincipalId,
+    ttlMs: ACCESS_TOKEN_TTL_MS,
+  });
+
+  createActorTokenRecord({
+    tokenHash: actorTokenHash,
+    assistantId: record.assistantId,
+    guardianPrincipalId: record.guardianPrincipalId,
+    hashedDeviceId: record.hashedDeviceId,
+    platform: params.platform,
+    issuedAt: claims.iat,
+    expiresAt: claims.exp,
+  });
+
+  // Mint new refresh token in the same family
+  const refresh = mintRefreshToken({
+    assistantId: record.assistantId,
+    guardianPrincipalId: record.guardianPrincipalId,
+    hashedDeviceId: record.hashedDeviceId,
+    platform: params.platform,
+    familyId: record.familyId,
+  });
+
+  log.info(
+    { familyId: record.familyId, platform: params.platform },
+    'Credential rotation completed',
+  );
+
+  return {
+    ok: true,
+    result: {
+      guardianPrincipalId: record.guardianPrincipalId,
+      actorToken,
+      actorTokenExpiresAt: claims.exp!,
+      refreshToken: refresh.refreshToken,
+      refreshTokenExpiresAt: refresh.refreshTokenExpiresAt,
+      refreshAfter: refresh.refreshAfter,
+    },
+  };
+}

--- a/assistant/src/runtime/actor-refresh-token-store.ts
+++ b/assistant/src/runtime/actor-refresh-token-store.ts
@@ -83,28 +83,6 @@ export function findByTokenHash(tokenHash: string): RefreshTokenRecord | null {
   return row ? rowToRecord(row) : null;
 }
 
-/** Find the active refresh token for a device binding. */
-export function findActiveByDeviceBinding(
-  assistantId: string,
-  guardianPrincipalId: string,
-  hashedDeviceId: string,
-): RefreshTokenRecord | null {
-  const db = getDb();
-  const row = db
-    .select()
-    .from(actorRefreshTokenRecords)
-    .where(
-      and(
-        eq(actorRefreshTokenRecords.assistantId, assistantId),
-        eq(actorRefreshTokenRecords.guardianPrincipalId, guardianPrincipalId),
-        eq(actorRefreshTokenRecords.hashedDeviceId, hashedDeviceId),
-        eq(actorRefreshTokenRecords.status, 'active'),
-      ),
-    )
-    .get();
-  return row ? rowToRecord(row) : null;
-}
-
 /**
  * Atomically mark a refresh token as rotated (used successfully, replaced by a new one).
  * Uses a single conditional UPDATE and checks the affected row count to ensure
@@ -130,18 +108,11 @@ export function markRotated(tokenHash: string): boolean {
 export function revokeFamily(familyId: string): number {
   const db = getDb();
   const now = Date.now();
-  const matching = db
-    .select({ id: actorRefreshTokenRecords.id })
-    .from(actorRefreshTokenRecords)
-    .where(eq(actorRefreshTokenRecords.familyId, familyId))
-    .all();
-  if (matching.length === 0) return 0;
-
   db.update(actorRefreshTokenRecords)
     .set({ status: 'revoked', updatedAt: now })
     .where(eq(actorRefreshTokenRecords.familyId, familyId))
     .run();
-  return matching.length;
+  return rawChanges();
 }
 
 /** Revoke all active refresh tokens for a device binding. */
@@ -152,39 +123,18 @@ export function revokeByDeviceBinding(
 ): number {
   const db = getDb();
   const now = Date.now();
-  const condition = and(
-    eq(actorRefreshTokenRecords.assistantId, assistantId),
-    eq(actorRefreshTokenRecords.guardianPrincipalId, guardianPrincipalId),
-    eq(actorRefreshTokenRecords.hashedDeviceId, hashedDeviceId),
-    eq(actorRefreshTokenRecords.status, 'active'),
-  );
-  const matching = db
-    .select({ id: actorRefreshTokenRecords.id })
-    .from(actorRefreshTokenRecords)
-    .where(condition)
-    .all();
-  if (matching.length === 0) return 0;
-
   db.update(actorRefreshTokenRecords)
     .set({ status: 'revoked', updatedAt: now })
-    .where(condition)
-    .run();
-  return matching.length;
-}
-
-/** Update inactivity expiry timestamp on successful use. */
-export function touchInactivityExpiry(tokenHash: string, newInactivityExpiresAt: number): void {
-  const db = getDb();
-  const now = Date.now();
-  db.update(actorRefreshTokenRecords)
-    .set({ inactivityExpiresAt: newInactivityExpiresAt, lastUsedAt: now, updatedAt: now })
     .where(
       and(
-        eq(actorRefreshTokenRecords.tokenHash, tokenHash),
+        eq(actorRefreshTokenRecords.assistantId, assistantId),
+        eq(actorRefreshTokenRecords.guardianPrincipalId, guardianPrincipalId),
+        eq(actorRefreshTokenRecords.hashedDeviceId, hashedDeviceId),
         eq(actorRefreshTokenRecords.status, 'active'),
       ),
     )
     .run();
+  return rawChanges();
 }
 
 function rowToRecord(row: typeof actorRefreshTokenRecords.$inferSelect): RefreshTokenRecord {

--- a/assistant/src/runtime/actor-refresh-token-store.ts
+++ b/assistant/src/runtime/actor-refresh-token-store.ts
@@ -1,0 +1,213 @@
+/**
+ * Hash-only refresh token persistence.
+ *
+ * Stores SHA-256 hash of each refresh token with family tracking,
+ * device binding, and dual expiry (absolute + inactivity).
+ */
+
+import { and, eq } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+
+import { getDb } from '../memory/db.js';
+import { actorRefreshTokenRecords } from '../memory/schema.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('actor-refresh-token-store');
+
+export type RefreshTokenStatus = 'active' | 'rotated' | 'revoked';
+
+export interface RefreshTokenRecord {
+  id: string;
+  tokenHash: string;
+  familyId: string;
+  assistantId: string;
+  guardianPrincipalId: string;
+  hashedDeviceId: string;
+  platform: string;
+  status: RefreshTokenStatus;
+  issuedAt: number;
+  absoluteExpiresAt: number;
+  inactivityExpiresAt: number;
+  lastUsedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/** Create a new refresh token record (hash-only). */
+export function createRefreshTokenRecord(params: {
+  tokenHash: string;
+  familyId: string;
+  assistantId: string;
+  guardianPrincipalId: string;
+  hashedDeviceId: string;
+  platform: string;
+  issuedAt: number;
+  absoluteExpiresAt: number;
+  inactivityExpiresAt: number;
+}): RefreshTokenRecord {
+  const db = getDb();
+  const now = Date.now();
+  const id = uuid();
+
+  const row = {
+    id,
+    tokenHash: params.tokenHash,
+    familyId: params.familyId,
+    assistantId: params.assistantId,
+    guardianPrincipalId: params.guardianPrincipalId,
+    hashedDeviceId: params.hashedDeviceId,
+    platform: params.platform,
+    status: 'active' as const,
+    issuedAt: params.issuedAt,
+    absoluteExpiresAt: params.absoluteExpiresAt,
+    inactivityExpiresAt: params.inactivityExpiresAt,
+    lastUsedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  db.insert(actorRefreshTokenRecords).values(row).run();
+  log.info({ id, familyId: params.familyId, platform: params.platform }, 'Refresh token record created');
+  return row;
+}
+
+/** Look up a refresh token record by hash (ANY status - needed for replay detection). */
+export function findByTokenHash(tokenHash: string): RefreshTokenRecord | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(actorRefreshTokenRecords)
+    .where(eq(actorRefreshTokenRecords.tokenHash, tokenHash))
+    .get();
+  return row ? rowToRecord(row) : null;
+}
+
+/** Find the active refresh token for a device binding. */
+export function findActiveByDeviceBinding(
+  assistantId: string,
+  guardianPrincipalId: string,
+  hashedDeviceId: string,
+): RefreshTokenRecord | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(actorRefreshTokenRecords)
+    .where(
+      and(
+        eq(actorRefreshTokenRecords.assistantId, assistantId),
+        eq(actorRefreshTokenRecords.guardianPrincipalId, guardianPrincipalId),
+        eq(actorRefreshTokenRecords.hashedDeviceId, hashedDeviceId),
+        eq(actorRefreshTokenRecords.status, 'active'),
+      ),
+    )
+    .get();
+  return row ? rowToRecord(row) : null;
+}
+
+/** Mark a refresh token as rotated (used successfully, replaced by a new one). */
+export function markRotated(tokenHash: string): boolean {
+  const db = getDb();
+  const now = Date.now();
+  const existing = db
+    .select({ id: actorRefreshTokenRecords.id })
+    .from(actorRefreshTokenRecords)
+    .where(
+      and(
+        eq(actorRefreshTokenRecords.tokenHash, tokenHash),
+        eq(actorRefreshTokenRecords.status, 'active'),
+      ),
+    )
+    .get();
+  if (!existing) return false;
+
+  db.update(actorRefreshTokenRecords)
+    .set({ status: 'rotated', lastUsedAt: now, updatedAt: now })
+    .where(
+      and(
+        eq(actorRefreshTokenRecords.tokenHash, tokenHash),
+        eq(actorRefreshTokenRecords.status, 'active'),
+      ),
+    )
+    .run();
+  return true;
+}
+
+/** Revoke all tokens in a family (replay detection response). */
+export function revokeFamily(familyId: string): number {
+  const db = getDb();
+  const now = Date.now();
+  const matching = db
+    .select({ id: actorRefreshTokenRecords.id })
+    .from(actorRefreshTokenRecords)
+    .where(eq(actorRefreshTokenRecords.familyId, familyId))
+    .all();
+  if (matching.length === 0) return 0;
+
+  db.update(actorRefreshTokenRecords)
+    .set({ status: 'revoked', updatedAt: now })
+    .where(eq(actorRefreshTokenRecords.familyId, familyId))
+    .run();
+  return matching.length;
+}
+
+/** Revoke all active refresh tokens for a device binding. */
+export function revokeByDeviceBinding(
+  assistantId: string,
+  guardianPrincipalId: string,
+  hashedDeviceId: string,
+): number {
+  const db = getDb();
+  const now = Date.now();
+  const condition = and(
+    eq(actorRefreshTokenRecords.assistantId, assistantId),
+    eq(actorRefreshTokenRecords.guardianPrincipalId, guardianPrincipalId),
+    eq(actorRefreshTokenRecords.hashedDeviceId, hashedDeviceId),
+    eq(actorRefreshTokenRecords.status, 'active'),
+  );
+  const matching = db
+    .select({ id: actorRefreshTokenRecords.id })
+    .from(actorRefreshTokenRecords)
+    .where(condition)
+    .all();
+  if (matching.length === 0) return 0;
+
+  db.update(actorRefreshTokenRecords)
+    .set({ status: 'revoked', updatedAt: now })
+    .where(condition)
+    .run();
+  return matching.length;
+}
+
+/** Update inactivity expiry timestamp on successful use. */
+export function touchInactivityExpiry(tokenHash: string, newInactivityExpiresAt: number): void {
+  const db = getDb();
+  const now = Date.now();
+  db.update(actorRefreshTokenRecords)
+    .set({ inactivityExpiresAt: newInactivityExpiresAt, lastUsedAt: now, updatedAt: now })
+    .where(
+      and(
+        eq(actorRefreshTokenRecords.tokenHash, tokenHash),
+        eq(actorRefreshTokenRecords.status, 'active'),
+      ),
+    )
+    .run();
+}
+
+function rowToRecord(row: typeof actorRefreshTokenRecords.$inferSelect): RefreshTokenRecord {
+  return {
+    id: row.id,
+    tokenHash: row.tokenHash,
+    familyId: row.familyId,
+    assistantId: row.assistantId,
+    guardianPrincipalId: row.guardianPrincipalId,
+    hashedDeviceId: row.hashedDeviceId,
+    platform: row.platform,
+    status: row.status as RefreshTokenStatus,
+    issuedAt: row.issuedAt,
+    absoluteExpiresAt: row.absoluteExpiresAt,
+    inactivityExpiresAt: row.inactivityExpiresAt,
+    lastUsedAt: row.lastUsedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/assistant/src/runtime/actor-refresh-token-store.ts
+++ b/assistant/src/runtime/actor-refresh-token-store.ts
@@ -9,6 +9,7 @@ import { and, eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
 import { getDb } from '../memory/db.js';
+import { rawChanges } from '../memory/raw-query.js';
 import { actorRefreshTokenRecords } from '../memory/schema.js';
 import { getLogger } from '../util/logger.js';
 
@@ -113,7 +114,7 @@ export function findActiveByDeviceBinding(
 export function markRotated(tokenHash: string): boolean {
   const db = getDb();
   const now = Date.now();
-  const result = db.update(actorRefreshTokenRecords)
+  db.update(actorRefreshTokenRecords)
     .set({ status: 'rotated', lastUsedAt: now, updatedAt: now })
     .where(
       and(
@@ -122,7 +123,7 @@ export function markRotated(tokenHash: string): boolean {
       ),
     )
     .run();
-  return result.changes > 0;
+  return rawChanges() > 0;
 }
 
 /** Revoke all tokens in a family (replay detection response). */

--- a/assistant/src/runtime/actor-refresh-token-store.ts
+++ b/assistant/src/runtime/actor-refresh-token-store.ts
@@ -104,23 +104,16 @@ export function findActiveByDeviceBinding(
   return row ? rowToRecord(row) : null;
 }
 
-/** Mark a refresh token as rotated (used successfully, replaced by a new one). */
+/**
+ * Atomically mark a refresh token as rotated (used successfully, replaced by a new one).
+ * Uses a single conditional UPDATE and checks the affected row count to ensure
+ * exactly one row transitioned from 'active' to 'rotated'. This prevents
+ * concurrent refresh requests from both succeeding (CAS semantics).
+ */
 export function markRotated(tokenHash: string): boolean {
   const db = getDb();
   const now = Date.now();
-  const existing = db
-    .select({ id: actorRefreshTokenRecords.id })
-    .from(actorRefreshTokenRecords)
-    .where(
-      and(
-        eq(actorRefreshTokenRecords.tokenHash, tokenHash),
-        eq(actorRefreshTokenRecords.status, 'active'),
-      ),
-    )
-    .get();
-  if (!existing) return false;
-
-  db.update(actorRefreshTokenRecords)
+  const result = db.update(actorRefreshTokenRecords)
     .set({ status: 'rotated', lastUsedAt: now, updatedAt: now })
     .where(
       and(
@@ -129,7 +122,7 @@ export function markRotated(tokenHash: string): boolean {
       ),
     )
     .run();
-  return true;
+  return result.changes > 0;
 }
 
 /** Revoke all tokens in a family (replay detection response). */

--- a/assistant/src/runtime/actor-token-service.ts
+++ b/assistant/src/runtime/actor-token-service.ts
@@ -143,8 +143,8 @@ export function hashToken(token: string): string {
 // Mint
 // ---------------------------------------------------------------------------
 
-/** Default TTL for actor tokens: 90 days in milliseconds. */
-const DEFAULT_TOKEN_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+/** Default TTL for actor tokens: 30 days in milliseconds. */
+const DEFAULT_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
 /**
  * Mint a new actor token.

--- a/assistant/src/runtime/actor-token-service.ts
+++ b/assistant/src/runtime/actor-token-service.ts
@@ -150,7 +150,7 @@ const DEFAULT_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
  * Mint a new actor token.
  *
  * @param params Token claims (assistantId, platform, deviceId, guardianPrincipalId).
- * @param ttlMs  Optional TTL in milliseconds. Defaults to 90 days.
+ * @param ttlMs  Optional TTL in milliseconds. Defaults to 30 days.
  *               Pass `null` explicitly for a non-expiring token.
  * @returns The raw token, its hash, and the embedded claims.
  */

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -132,6 +132,7 @@ import {
   handleGuardianActionsPending,
 } from './routes/guardian-action-routes.js';
 import { handleGuardianBootstrap } from './routes/guardian-bootstrap-routes.js';
+import { handleGuardianRefresh } from './routes/guardian-refresh-routes.js';
 import { handleGetIdentity,handleHealth } from './routes/identity-routes.js';
 import {
   handleBlockMember,
@@ -783,6 +784,7 @@ export class RuntimeHttpServer {
 
       // Guardian vellum channel bootstrap
       if (endpoint === 'integrations/guardian/vellum/bootstrap' && req.method === 'POST') return await handleGuardianBootstrap(req, server);
+      if (endpoint === 'integrations/guardian/vellum/refresh' && req.method === 'POST') return await handleGuardianRefresh(req);
 
       // Integrations — Twilio config
       if (endpoint === 'integrations/twilio/config' && req.method === 'GET') return handleGetTwilioConfig();

--- a/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
+++ b/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
@@ -18,11 +18,7 @@ import {
   getActiveBinding,
 } from '../../memory/guardian-bindings.js';
 import { getLogger } from '../../util/logger.js';
-import { mintActorToken } from '../actor-token-service.js';
-import {
-  createActorTokenRecord,
-  revokeByDeviceBinding,
-} from '../actor-token-store.js';
+import { mintCredentialPair } from '../actor-refresh-token-service.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import { httpError } from '../http-errors.js';
 import type { ServerWithRequestIP } from '../middleware/actor-token.js';
@@ -106,27 +102,13 @@ export async function handleGuardianBootstrap(req: Request, server: ServerWithRe
     const { guardianPrincipalId, isNew } = ensureGuardianPrincipal(assistantId);
     const hashedDeviceId = hashDeviceId(deviceId);
 
-    // Revoke any existing active tokens for this device binding
-    // so we maintain one-active-token-per-device
-    revokeByDeviceBinding(assistantId, guardianPrincipalId, hashedDeviceId);
-
-    // Mint a new actor token
-    const { token, tokenHash, claims } = mintActorToken({
+    // Mint credential pair (access token + refresh token)
+    const credentials = mintCredentialPair({
       assistantId,
       platform,
       deviceId,
       guardianPrincipalId,
-    });
-
-    // Store only the hash
-    createActorTokenRecord({
-      tokenHash,
-      assistantId,
-      guardianPrincipalId,
       hashedDeviceId,
-      platform,
-      issuedAt: claims.iat,
-      expiresAt: claims.exp,
     });
 
     log.info(
@@ -136,7 +118,11 @@ export async function handleGuardianBootstrap(req: Request, server: ServerWithRe
 
     return Response.json({
       guardianPrincipalId,
-      actorToken: token,
+      actorToken: credentials.actorToken,
+      actorTokenExpiresAt: credentials.actorTokenExpiresAt,
+      refreshToken: credentials.refreshToken,
+      refreshTokenExpiresAt: credentials.refreshTokenExpiresAt,
+      refreshAfter: credentials.refreshAfter,
       isNew,
     });
   } catch (err) {

--- a/assistant/src/runtime/routes/guardian-refresh-routes.ts
+++ b/assistant/src/runtime/routes/guardian-refresh-routes.ts
@@ -1,0 +1,53 @@
+/**
+ * POST /v1/integrations/guardian/vellum/refresh
+ *
+ * Rotates the refresh token and mints a new access token + refresh token pair.
+ * This endpoint is the runtime handler proxied through the gateway.
+ */
+
+import { getLogger } from '../../util/logger.js';
+import { rotateCredentials } from '../actor-refresh-token-service.js';
+import { httpError } from '../http-errors.js';
+
+const log = getLogger('guardian-refresh');
+
+/**
+ * Handle POST /v1/integrations/guardian/vellum/refresh
+ *
+ * Body: { platform: 'ios' | 'macos', deviceId: string, refreshToken: string }
+ * Returns: { guardianPrincipalId, actorToken, actorTokenExpiresAt, refreshToken, refreshTokenExpiresAt, refreshAfter }
+ */
+export async function handleGuardianRefresh(req: Request): Promise<Response> {
+  try {
+    const body = await req.json() as Record<string, unknown>;
+    const platform = typeof body.platform === 'string' ? body.platform.trim() : '';
+    const deviceId = typeof body.deviceId === 'string' ? body.deviceId.trim() : '';
+    const refreshToken = typeof body.refreshToken === 'string' ? body.refreshToken : '';
+
+    if (!platform || !deviceId || !refreshToken) {
+      return httpError('BAD_REQUEST', 'Missing required fields: platform, deviceId, refreshToken', 400);
+    }
+
+    if (platform !== 'ios' && platform !== 'macos') {
+      return httpError('BAD_REQUEST', 'Invalid platform. Must be "ios" or "macos".', 400);
+    }
+
+    const result = rotateCredentials({ refreshToken, platform, deviceId });
+
+    if (!result.ok) {
+      const statusCode = result.error === 'refresh_reuse_detected' ? 403
+        : result.error === 'device_binding_mismatch' ? 403
+        : result.error === 'revoked' ? 403
+        : 401;
+
+      log.warn({ error: result.error, platform }, 'Refresh token rotation failed');
+      return Response.json({ error: result.error }, { status: statusCode });
+    }
+
+    log.info({ platform, guardianPrincipalId: result.result.guardianPrincipalId }, 'Refresh token rotation succeeded');
+    return Response.json(result.result);
+  } catch (err) {
+    log.error({ err }, 'Guardian refresh failed');
+    return httpError('INTERNAL_ERROR', 'Internal server error', 500);
+  }
+}

--- a/assistant/src/runtime/routes/pairing-routes.ts
+++ b/assistant/src/runtime/routes/pairing-routes.ts
@@ -10,24 +10,28 @@ import {
 import type { ServerMessage } from '../../daemon/ipc-contract.js';
 import { PairingStore } from '../../daemon/pairing-store.js';
 import { getLogger } from '../../util/logger.js';
-import { mintActorToken } from '../actor-token-service.js';
-import {
-  createActorTokenRecord,
-  revokeByDeviceBinding,
-} from '../actor-token-store.js';
+import { mintCredentialPair } from '../actor-refresh-token-service.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import { ensureVellumGuardianBinding } from '../guardian-vellum-migration.js';
 import { httpError } from '../http-errors.js';
 
 const log = getLogger('runtime-http');
 
+interface PairingCredentials {
+  actorToken: string;
+  actorTokenExpiresAt: number;
+  refreshToken: string;
+  refreshTokenExpiresAt: number;
+  refreshAfter: number;
+}
+
 /**
- * Mint an actor token for a paired device if a vellum guardian principal exists.
- * Returns the raw actor token string, or null if no vellum binding exists.
+ * Mint credentials (access token + refresh token) for a paired device.
+ * Returns the full credential set, or null if minting fails.
  *
  * NOTE: This function MUST remain synchronous — the mintingInFlight guard depends on it.
  */
-function mintPairingActorToken(deviceId: string, platform: string): string | null {
+function mintPairingCredentials(deviceId: string, platform: string): PairingCredentials | null {
   try {
     const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
     // Pairing can run before a local client has touched the actor-token
@@ -36,30 +40,24 @@ function mintPairingActorToken(deviceId: string, platform: string): string | nul
     const guardianPrincipalId = ensureVellumGuardianBinding(assistantId);
     const hashedDeviceId = hashDeviceId(deviceId);
 
-    // Revoke previous tokens for this device
-    revokeByDeviceBinding(assistantId, guardianPrincipalId, hashedDeviceId);
-
-    const { token, tokenHash, claims } = mintActorToken({
+    const credentials = mintCredentialPair({
       assistantId,
       platform,
       deviceId,
       guardianPrincipalId,
-    });
-
-    createActorTokenRecord({
-      tokenHash,
-      assistantId,
-      guardianPrincipalId,
       hashedDeviceId,
-      platform,
-      issuedAt: claims.iat,
-      expiresAt: claims.exp,
     });
 
-    log.info({ assistantId, platform }, 'Minted actor token during pairing');
-    return token;
+    log.info({ assistantId, platform }, 'Minted credentials during pairing');
+    return {
+      actorToken: credentials.actorToken,
+      actorTokenExpiresAt: credentials.actorTokenExpiresAt,
+      refreshToken: credentials.refreshToken,
+      refreshTokenExpiresAt: credentials.refreshTokenExpiresAt,
+      refreshAfter: credentials.refreshAfter,
+    };
   } catch (err) {
-    log.warn({ err }, 'Failed to mint actor token during pairing — continuing without it');
+    log.warn({ err }, 'Failed to mint credentials during pairing — continuing without them');
     return null;
   }
 }
@@ -75,24 +73,24 @@ const PENDING_DEVICE_ID_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const pendingDeviceIds = new Map<string, { deviceId: string; createdAt: number }>();
 
 /**
- * Transient in-memory map of pairingRequestId -> { actorToken, approvedAt }.
- * Populated when a pairing is approved and the actor token is minted.
- * Entries are kept for TOKEN_RETRIEVAL_TTL_MS after approval so that
- * subsequent polls can still retrieve the token if the first response
+ * Transient in-memory map of pairingRequestId -> { credentials, approvedAt }.
+ * Populated when a pairing is approved and credentials are minted.
+ * Entries are kept for CREDENTIAL_RETRIEVAL_TTL_MS after approval so that
+ * subsequent polls can still retrieve them if the first response
  * was dropped or timed out.
  */
-const TOKEN_RETRIEVAL_TTL_MS = 5 * 60 * 1000; // 5 minutes
-const approvedActorTokens = new Map<string, { actorToken: string; approvedAt: number }>();
+const CREDENTIAL_RETRIEVAL_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const approvedCredentials = new Map<string, { credentials: PairingCredentials; approvedAt: number }>();
 
 /**
- * Sweep stale entries from the approved actor tokens map.
+ * Sweep stale entries from the approved credentials map.
  * Called lazily on each status poll.
  */
-function sweepApprovedTokens(): void {
+function sweepApprovedCredentials(): void {
   const now = Date.now();
-  for (const [id, entry] of approvedActorTokens) {
-    if (now - entry.approvedAt > TOKEN_RETRIEVAL_TTL_MS) {
-      approvedActorTokens.delete(id);
+  for (const [id, entry] of approvedCredentials) {
+    if (now - entry.approvedAt > CREDENTIAL_RETRIEVAL_TTL_MS) {
+      approvedCredentials.delete(id);
     }
   }
 }
@@ -127,7 +125,7 @@ const mintingInFlight = new Set<string>();
  */
 export function cleanupPairingState(pairingRequestId: string): void {
   pendingDeviceIds.delete(pairingRequestId);
-  approvedActorTokens.delete(pairingRequestId);
+  approvedCredentials.delete(pairingRequestId);
   mintingInFlight.delete(pairingRequestId);
 }
 
@@ -207,14 +205,20 @@ export async function handlePairingRequest(req: Request, ctx: PairingHandlerCont
       refreshDevice(hashedDeviceId, deviceName);
       ctx.pairingStore.approve(pairingRequestId, ctx.bearerToken);
       log.info({ pairingRequestId, hashedDeviceId }, 'Auto-approved allowlisted device');
-      const actorToken = mintPairingActorToken(deviceId, 'ios');
+      const credentials = mintPairingCredentials(deviceId, 'ios');
       return Response.json({
         status: 'approved',
         bearerToken: ctx.bearerToken,
         gatewayUrl: entry.gatewayUrl,
         localLanUrl: entry.localLanUrl,
         ...(ctx.featureFlagToken ? { featureFlagToken: ctx.featureFlagToken } : {}),
-        ...(actorToken ? { actorToken } : {}),
+        ...(credentials ? {
+          actorToken: credentials.actorToken,
+          actorTokenExpiresAt: credentials.actorTokenExpiresAt,
+          refreshToken: credentials.refreshToken,
+          refreshTokenExpiresAt: credentials.refreshTokenExpiresAt,
+          refreshAfter: credentials.refreshAfter,
+        } : {}),
       });
     }
 
@@ -260,7 +264,7 @@ export function handlePairingStatus(url: URL, ctx: PairingHandlerContext): Respo
 
   // Sweep stale transient entries on every poll — not just approved ones —
   // so abandoned pairing attempts don't accumulate indefinitely.
-  sweepApprovedTokens();
+  sweepApprovedCredentials();
   sweepPendingDeviceIds();
 
   const entry = ctx.pairingStore.get(id);
@@ -271,14 +275,14 @@ export function handlePairingStatus(url: URL, ctx: PairingHandlerContext): Respo
   }
 
   if (entry.status === 'approved') {
-    // Mint the actor token on first approved poll if we still have the
-    // raw deviceId from the pairing request. Once minted, the token is
-    // cached in approvedActorTokens with a TTL so subsequent polls can
-    // still retrieve it if the first response was dropped.
+    // Mint credentials on first approved poll if we still have the
+    // raw deviceId from the pairing request. Once minted, credentials are
+    // cached in approvedCredentials with a TTL so subsequent polls can
+    // still retrieve them if the first response was dropped.
     // The pending deviceId is only removed after a successful mint so
     // transient failures allow retries on subsequent polls.
-    let tokenEntry = approvedActorTokens.get(id);
-    if (!tokenEntry && !mintingInFlight.has(id)) {
+    let credentialEntry = approvedCredentials.get(id);
+    if (!credentialEntry && !mintingInFlight.has(id)) {
       const pending = pendingDeviceIds.get(id);
       const deviceIdMatchesEntry = Boolean(
         deviceId
@@ -289,11 +293,11 @@ export function handlePairingStatus(url: URL, ctx: PairingHandlerContext): Respo
       if (mintDeviceId) {
         mintingInFlight.add(id);
         try {
-          const actorToken = mintPairingActorToken(mintDeviceId, 'ios');
-          if (actorToken) {
+          const credentials = mintPairingCredentials(mintDeviceId, 'ios');
+          if (credentials) {
             pendingDeviceIds.delete(id);
-            tokenEntry = { actorToken, approvedAt: Date.now() };
-            approvedActorTokens.set(id, tokenEntry);
+            credentialEntry = { credentials, approvedAt: Date.now() };
+            approvedCredentials.set(id, credentialEntry);
           }
         } finally {
           mintingInFlight.delete(id);
@@ -307,7 +311,13 @@ export function handlePairingStatus(url: URL, ctx: PairingHandlerContext): Respo
       gatewayUrl: entry.gatewayUrl,
       localLanUrl: entry.localLanUrl,
       ...(ctx.featureFlagToken ? { featureFlagToken: ctx.featureFlagToken } : {}),
-      ...(tokenEntry ? { actorToken: tokenEntry.actorToken } : {}),
+      ...(credentialEntry ? {
+        actorToken: credentialEntry.credentials.actorToken,
+        actorTokenExpiresAt: credentialEntry.credentials.actorTokenExpiresAt,
+        refreshToken: credentialEntry.credentials.refreshToken,
+        refreshTokenExpiresAt: credentialEntry.credentials.refreshTokenExpiresAt,
+        refreshAfter: credentialEntry.credentials.refreshAfter,
+      } : {}),
     });
   }
 

--- a/clients/ARCHITECTURE.md
+++ b/clients/ARCHITECTURE.md
@@ -615,6 +615,28 @@ iOS pairing uses a v4 QR code protocol with Mac-side approval. There is no manua
 
 **Approved devices:** Devices paired with "Always Allow" are persisted to `~/.vellum/protected/approved-devices.json` (keyed by hashed deviceId). Future pairings from allowlisted devices auto-approve without a prompt. The macOS Connect tab shows an Approved Devices list with remove/clear actions.
 
+### Actor Credential Refresh (Shared: macOS + iOS)
+
+Both macOS and iOS clients use a shared credential refresh mechanism to maintain valid actor tokens without re-bootstrapping or re-pairing. Bootstrap (macOS) and pairing (iOS) are only used for initial credential issuance.
+
+**Credential storage:** The client stores the following in the Keychain alongside the bearer token:
+
+| Data | Storage | Purpose |
+|------|---------|---------|
+| Actor token | Keychain | `X-Actor-Token` header for authenticated requests |
+| Refresh token | Keychain | Presented to the refresh endpoint to rotate credentials |
+| Actor token expiry | Keychain | Absolute expiry timestamp of the current actor token |
+| Refresh token expiry | Keychain | Absolute expiry timestamp of the current refresh token |
+| `refreshAfter` | Keychain | Timestamp at which the client should proactively refresh (80% of actor token TTL) |
+
+**Proactive refresh:** Both macOS and iOS run a periodic check every 5 minutes. If `now >= refreshAfter`, the client calls `POST /v1/integrations/guardian/vellum/refresh` (through the gateway) with the current refresh token. On success, the response provides a new `actorToken`, `refreshToken`, `actorTokenExpiresAt`, `refreshTokenExpiresAt`, and `refreshAfter`. All stored credentials are updated atomically.
+
+**401 recovery:** When an HTTP request receives a 401 response, the `HTTPDaemonClient` attempts a single refresh before surfacing a "Session expired" error. If the refresh succeeds, the original request is retried with the new actor token. If the refresh also fails (e.g., refresh token expired or revoked), the client surfaces the session-expired error and the user must re-pair (iOS) or re-bootstrap (macOS).
+
+**Shared utility:** `ActorCredentialRefresher` is a shared utility used by both platforms. It encapsulates the refresh HTTP call, credential update, and error handling. `ActorTokenManager` on each platform delegates to this refresher for both proactive and reactive (401-recovery) refresh flows.
+
+**No legacy bootstrap-as-renewal:** macOS no longer re-bootstraps on every launch. Bootstrap runs only when no actor token exists at all (first launch or after credential wipe). All subsequent renewal is handled by the refresh flow.
+
 ### Prerequisites
 
 - A gateway URL must be configured (cloud tunnel or LAN). LAN pairing works automatically via `localLanUrl` in the QR payload.
@@ -628,6 +650,8 @@ iOS pairing uses a v4 QR code protocol with Mac-side approval. There is no manua
 |------|---------|-----|
 | Gateway URL | UserDefaults | `gateway_base_url` |
 | Bearer token | Keychain | provider: `runtime-bearer-token` |
+| Actor token | Keychain | provider: `actor-token` |
+| Refresh token | Keychain | provider: `actor-refresh-token` |
 | Conversation key | UserDefaults | `conversation_key` |
 | Host ID | UserDefaults | `gateway_host_id` |
 | Device ID | Keychain | provider: `pairing-device-id` |

--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -217,7 +217,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
                     let result = await ActorCredentialRefresher.refresh(
                         baseURL: httpTransport.baseURL,
-                        bearerToken: httpTransport.bearerToken
+                        bearerToken: httpTransport.bearerToken,
+                        platform: "ios",
+                        deviceId: Self.getOrCreateDeviceId()
                     )
 
                     switch result {

--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -123,6 +123,12 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // Start the ambient agent trigger so it begins timing from launch.
         ambientAgentManager.setup()
 
+        // Ensure actor credentials are present and start the proactive refresh
+        // loop. On first launch (no actor token) this is a no-op until pairing
+        // completes; on subsequent launches it schedules proactive refresh when
+        // the access token nears expiry — mirroring macOS's proceedToApp() call.
+        ensureActorCredentials()
+
         return true
     }
 

--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -123,10 +123,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // Start the ambient agent trigger so it begins timing from launch.
         ambientAgentManager.setup()
 
-        // Ensure actor credentials are present and start the proactive refresh
-        // loop. On first launch (no actor token) this is a no-op until pairing
-        // completes; on subsequent launches it schedules proactive refresh when
-        // the access token nears expiry — mirroring macOS's proceedToApp() call.
+        // Start the proactive credential refresh loop. On iOS, initial credentials
+        // come from QR pairing (bootstrap is macOS-only). If no actor token exists
+        // yet, the refresh loop simply waits until pairing provides one.
         ensureActorCredentials()
 
         return true
@@ -206,10 +205,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         actorTokenBootstrapTask = Task { [weak self] in
             guard let self else { return }
 
-            // If we have no actor token at all, we need initial bootstrap
-            if !ActorTokenManager.hasToken {
-                await self.performInitialBootstrap()
-            }
+            // On iOS, initial credentials come from QR pairing — bootstrap is macOS-only.
+            // Skip performInitialBootstrap() entirely; the pairing flow stores credentials.
 
             // Run proactive refresh loop
             while !Task.isCancelled {
@@ -243,37 +240,6 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
     /// Performs the initial actor token bootstrap with exponential backoff.
     /// Called only when no actor token exists (first launch or after credential wipe).
-    private func performInitialBootstrap() async {
-        let deviceId = Self.getOrCreateDeviceId()
-        var delay: UInt64 = 2_000_000_000
-        let maxDelay: UInt64 = 60_000_000_000
-        var connectionDelay: UInt64 = 2_000_000_000
-        let connectionMaxDelay: UInt64 = 300_000_000_000
-
-        while !Task.isCancelled {
-            guard self.clientProvider.client.isConnected else {
-                try? await Task.sleep(nanoseconds: connectionDelay)
-                connectionDelay = min(connectionDelay * 2, connectionMaxDelay)
-                continue
-            }
-
-            guard let daemon = self.clientProvider.client as? DaemonClient else { return }
-            let success = await daemon.bootstrapActorToken(
-                platform: "ios",
-                deviceId: deviceId
-            )
-
-            if success {
-                log.info("Initial actor token bootstrap succeeded")
-                return
-            }
-
-            let jitter = UInt64.random(in: 0...(delay / 4))
-            try? await Task.sleep(nanoseconds: delay + jitter)
-            delay = min(delay * 2, maxDelay)
-        }
-    }
-
     /// Stable device ID stored in Keychain, shared with QRPairingSheet.
     private static func getOrCreateDeviceId() -> String {
         if let existing = APIKeyManager.shared.getAPIKey(provider: "pairing-device-id"), !existing.isEmpty {

--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -190,47 +190,79 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     }
 
 
-    // MARK: - Actor Token Bootstrap
+    // MARK: - Actor Token Credentials
 
-    /// Bootstraps the actor token after pairing so iOS has a fresh token.
-    /// The bootstrap endpoint is idempotent so re-calling is safe.
-    /// Waits for the daemon to become reachable and retries with
-    /// exponential backoff.
-    func ensureActorTokenBootstrap() {
+    /// Schedules proactive credential refresh when the access token is near expiry.
+    /// On first launch (no actor token), falls back to bootstrap for initial issuance.
+    func ensureActorCredentials() {
         actorTokenBootstrapTask?.cancel()
 
         actorTokenBootstrapTask = Task { [weak self] in
             guard let self else { return }
 
-            let deviceId = Self.getOrCreateDeviceId()
-            var delay: UInt64 = 2_000_000_000 // 2 seconds initial
-            let maxDelay: UInt64 = 60_000_000_000 // 60 seconds cap
-
-            var connectionDelay: UInt64 = 2_000_000_000 // 2 seconds initial
-            let connectionMaxDelay: UInt64 = 300_000_000_000 // 5 minutes cap
-
-            while !Task.isCancelled {
-                guard self.clientProvider.client.isConnected else {
-                    try? await Task.sleep(nanoseconds: connectionDelay)
-                    connectionDelay = min(connectionDelay * 2, connectionMaxDelay)
-                    continue
-                }
-
-                guard let daemon = self.clientProvider.client as? DaemonClient else { return }
-                let success = await daemon.bootstrapActorToken(
-                    platform: "ios",
-                    deviceId: deviceId
-                )
-
-                if success {
-                    log.info("Actor token bootstrap succeeded")
-                    return
-                }
-
-                let jitter = UInt64.random(in: 0...(delay / 4))
-                try? await Task.sleep(nanoseconds: delay + jitter)
-                delay = min(delay * 2, maxDelay)
+            // If we have no actor token at all, we need initial bootstrap
+            if !ActorTokenManager.hasToken {
+                await self.performInitialBootstrap()
             }
+
+            // Run proactive refresh loop
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 5 * 60 * 1_000_000_000) // 5 min
+                guard !Task.isCancelled else { return }
+
+                if ActorTokenManager.needsProactiveRefresh {
+                    guard let daemon = self.clientProvider.client as? DaemonClient,
+                          daemon.isConnected,
+                          let httpTransport = daemon.httpTransport else { continue }
+
+                    let result = await ActorCredentialRefresher.refresh(
+                        baseURL: httpTransport.baseURL,
+                        bearerToken: httpTransport.bearerToken
+                    )
+
+                    switch result {
+                    case .success:
+                        log.info("Proactive token refresh succeeded")
+                    case .terminalError(let reason):
+                        log.error("Proactive token refresh failed terminally: \(reason)")
+                    case .transientError:
+                        log.warning("Proactive token refresh encountered transient error")
+                    }
+                }
+            }
+        }
+    }
+
+    /// Performs the initial actor token bootstrap with exponential backoff.
+    /// Called only when no actor token exists (first launch or after credential wipe).
+    private func performInitialBootstrap() async {
+        let deviceId = Self.getOrCreateDeviceId()
+        var delay: UInt64 = 2_000_000_000
+        let maxDelay: UInt64 = 60_000_000_000
+        var connectionDelay: UInt64 = 2_000_000_000
+        let connectionMaxDelay: UInt64 = 300_000_000_000
+
+        while !Task.isCancelled {
+            guard self.clientProvider.client.isConnected else {
+                try? await Task.sleep(nanoseconds: connectionDelay)
+                connectionDelay = min(connectionDelay * 2, connectionMaxDelay)
+                continue
+            }
+
+            guard let daemon = self.clientProvider.client as? DaemonClient else { return }
+            let success = await daemon.bootstrapActorToken(
+                platform: "ios",
+                deviceId: deviceId
+            )
+
+            if success {
+                log.info("Initial actor token bootstrap succeeded")
+                return
+            }
+
+            let jitter = UInt64.random(in: 0...(delay / 4))
+            try? await Task.sleep(nanoseconds: delay + jitter)
+            delay = min(delay * 2, maxDelay)
         }
     }
 

--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -409,13 +409,21 @@ struct QRPairingSheet: View {
             }
             let localLanUrl = response["localLanUrl"] as? String
             let featureFlagToken = response["featureFlagToken"] as? String
+            let refreshToken = response["refreshToken"] as? String
+            let actorTokenExpiresAt = response["actorTokenExpiresAt"] as? Int
+            let refreshTokenExpiresAt = response["refreshTokenExpiresAt"] as? Int
+            let refreshAfter = response["refreshAfter"] as? Int
             savePairingConfig(
                 bearerToken: bearerToken,
                 gatewayUrl: gatewayUrl,
                 hostId: payload.hostId,
                 localLanUrl: localLanUrl,
                 featureFlagToken: featureFlagToken,
-                actorToken: actorToken
+                actorToken: actorToken,
+                refreshToken: refreshToken,
+                actorTokenExpiresAt: actorTokenExpiresAt,
+                refreshTokenExpiresAt: refreshTokenExpiresAt,
+                refreshAfter: refreshAfter
             )
             connectToMac()
 
@@ -496,13 +504,21 @@ struct QRPairingSheet: View {
                     }
                     let localLanUrl = json["localLanUrl"] as? String
                     let featureFlagToken = json["featureFlagToken"] as? String
+                    let refreshToken = json["refreshToken"] as? String
+                    let actorTokenExpiresAt = json["actorTokenExpiresAt"] as? Int
+                    let refreshTokenExpiresAt = json["refreshTokenExpiresAt"] as? Int
+                    let refreshAfter = json["refreshAfter"] as? Int
                     savePairingConfig(
                         bearerToken: bearerToken,
                         gatewayUrl: gatewayUrl,
                         hostId: payload.hostId,
                         localLanUrl: localLanUrl,
                         featureFlagToken: featureFlagToken,
-                        actorToken: actorToken
+                        actorToken: actorToken,
+                        refreshToken: refreshToken,
+                        actorTokenExpiresAt: actorTokenExpiresAt,
+                        refreshTokenExpiresAt: refreshTokenExpiresAt,
+                        refreshAfter: refreshAfter
                     )
                     connectToMac()
 
@@ -527,7 +543,7 @@ struct QRPairingSheet: View {
 
     // MARK: - Config Persistence
 
-    private func savePairingConfig(bearerToken: String, gatewayUrl: String, hostId: String, localLanUrl: String?, featureFlagToken: String? = nil, actorToken: String? = nil) {
+    private func savePairingConfig(bearerToken: String, gatewayUrl: String, hostId: String, localLanUrl: String?, featureFlagToken: String? = nil, actorToken: String? = nil, refreshToken: String? = nil, actorTokenExpiresAt: Int? = nil, refreshTokenExpiresAt: Int? = nil, refreshAfter: Int? = nil) {
         UserDefaults.standard.set(gatewayUrl, forKey: UserDefaultsKeys.gatewayBaseURL)
         _ = APIKeyManager.shared.setAPIKey(bearerToken, provider: "runtime-bearer-token")
         if !hostId.isEmpty {
@@ -539,11 +555,23 @@ struct QRPairingSheet: View {
         // Don't delete on absence — the server may not send featureFlagToken yet,
         // so a missing field shouldn't wipe a previously stored token.
 
-        // Persist the actor token received during pairing so subsequent HTTP
-        // requests include the X-Actor-Token header immediately.
+        // Persist the actor token and refresh credentials received during pairing
+        // so subsequent HTTP requests include the X-Actor-Token header immediately.
         // When re-pairing to an assistant that omits the token, clear the
         // previous value so the old credential is never sent to the new gateway.
-        if let actorToken = actorToken, !actorToken.isEmpty {
+        if let actorToken = actorToken, !actorToken.isEmpty,
+           let refreshToken = refreshToken,
+           let actorTokenExpiresAt = actorTokenExpiresAt,
+           let refreshTokenExpiresAt = refreshTokenExpiresAt,
+           let refreshAfter = refreshAfter {
+            ActorTokenManager.storeCredentials(
+                actorToken: actorToken,
+                actorTokenExpiresAt: actorTokenExpiresAt,
+                refreshToken: refreshToken,
+                refreshTokenExpiresAt: refreshTokenExpiresAt,
+                refreshAfter: refreshAfter
+            )
+        } else if let actorToken = actorToken, !actorToken.isEmpty {
             ActorTokenManager.setToken(actorToken)
         } else {
             ActorTokenManager.deleteToken()
@@ -566,7 +594,7 @@ struct QRPairingSheet: View {
         // next app restart.
         if !ActorTokenManager.hasToken {
             if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-                appDelegate.ensureActorTokenBootstrap()
+                appDelegate.ensureActorCredentials()
             }
         }
 

--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -573,6 +573,7 @@ struct QRPairingSheet: View {
             )
         } else if let actorToken = actorToken, !actorToken.isEmpty {
             ActorTokenManager.setToken(actorToken)
+            ActorTokenManager.clearRefreshMetadata()
         } else {
             ActorTokenManager.deleteToken()
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -357,10 +357,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         setupAutoUpdate()
         installCLISymlinkIfNeeded()
 
-        // Ensure an actor token is present. On first launch this is the
-        // initial bootstrap; on subsequent launches it retries silently
-        // if a previous attempt failed or the token was cleared.
-        ensureActorTokenBootstrap()
+        // Ensure actor credentials are present. On first launch this performs
+        // initial bootstrap; on subsequent launches it schedules proactive
+        // refresh when the access token nears expiry.
+        ensureActorCredentials()
 
         if isFirstLaunch {
             // Enter the bootstrap state machine. The sequence is:
@@ -641,51 +641,88 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         }
     }
 
-    // MARK: - Actor Token Bootstrap
+    // MARK: - Actor Token Credentials
 
-    /// Bootstraps the actor token on every launch so macOS always has a
-    /// fresh token with a 90-day TTL. The bootstrap endpoint is idempotent
-    /// so re-calling on each startup is safe. Waits for the daemon to
-    /// become reachable and retries with exponential backoff.
-    private func ensureActorTokenBootstrap() {
+    /// Schedules proactive credential refresh when the access token is near expiry.
+    /// On first launch (no actor token), falls back to bootstrap for initial issuance.
+    private func ensureActorCredentials() {
         actorTokenBootstrapTask?.cancel()
 
         actorTokenBootstrapTask = Task { [weak self] in
             guard let self else { return }
 
-            let deviceId = PairingQRCodeSheet.computeHostId()
-            var delay: UInt64 = 2_000_000_000 // 2 seconds initial
-            let maxDelay: UInt64 = 60_000_000_000 // 60 seconds cap
-
-            // Separate backoff for waiting on daemon connection, matching the
-            // iOS implementation. Prevents busy-waiting at a fixed interval
-            // when the daemon is unreachable for extended periods.
-            var connectionDelay: UInt64 = 2_000_000_000 // 2 seconds initial
-            let connectionMaxDelay: UInt64 = 300_000_000_000 // 5 minutes cap
-
-            while !Task.isCancelled {
-                // Wait for the daemon to be connected before attempting.
-                guard self.daemonClient.isConnected else {
-                    try? await Task.sleep(nanoseconds: connectionDelay)
-                    connectionDelay = min(connectionDelay * 2, connectionMaxDelay)
-                    continue
-                }
-
-                let success = await self.daemonClient.bootstrapActorToken(
-                    platform: "macos",
-                    deviceId: deviceId
-                )
-
-                if success {
-                    log.info("Actor token bootstrap succeeded")
-                    return
-                }
-
-                // Exponential backoff with jitter
-                let jitter = UInt64.random(in: 0...(delay / 4))
-                try? await Task.sleep(nanoseconds: delay + jitter)
-                delay = min(delay * 2, maxDelay)
+            // If we have no actor token at all, we need initial bootstrap
+            if !ActorTokenManager.hasToken {
+                await self.performInitialBootstrap()
             }
+
+            // Run proactive refresh loop
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 5 * 60 * 1_000_000_000) // Check every 5 minutes
+                guard !Task.isCancelled else { return }
+
+                if ActorTokenManager.needsProactiveRefresh {
+                    guard self.daemonClient.isConnected else { continue }
+
+                    let baseURL: String
+                    let bearerToken: String?
+                    if let httpTransport = self.daemonClient.httpTransport {
+                        baseURL = httpTransport.baseURL
+                        bearerToken = httpTransport.bearerToken
+                    } else if let port = self.daemonClient.httpPort {
+                        baseURL = "http://localhost:\(port)"
+                        bearerToken = readHttpToken()
+                    } else {
+                        continue
+                    }
+
+                    let result = await ActorCredentialRefresher.refresh(
+                        baseURL: baseURL,
+                        bearerToken: bearerToken
+                    )
+
+                    switch result {
+                    case .success:
+                        log.info("Proactive token refresh succeeded")
+                    case .terminalError(let reason):
+                        log.error("Proactive token refresh failed terminally: \(reason)")
+                    case .transientError:
+                        log.warning("Proactive token refresh encountered transient error — will retry")
+                    }
+                }
+            }
+        }
+    }
+
+    /// Performs the initial actor token bootstrap with exponential backoff.
+    /// Called only when no actor token exists (first launch or after credential wipe).
+    private func performInitialBootstrap() async {
+        let deviceId = PairingQRCodeSheet.computeHostId()
+        var delay: UInt64 = 2_000_000_000
+        let maxDelay: UInt64 = 60_000_000_000
+        var connectionDelay: UInt64 = 2_000_000_000
+        let connectionMaxDelay: UInt64 = 300_000_000_000
+
+        while !Task.isCancelled {
+            guard daemonClient.isConnected else {
+                try? await Task.sleep(nanoseconds: connectionDelay)
+                connectionDelay = min(connectionDelay * 2, connectionMaxDelay)
+                continue
+            }
+
+            let success = await daemonClient.bootstrapActorToken(
+                platform: "macos",
+                deviceId: deviceId
+            )
+
+            if success {
+                log.info("Initial actor token bootstrap succeeded")
+                return
+            }
+
+            let jitter = UInt64.random(in: 0...(delay / 4))
+            try? await Task.sleep(nanoseconds: delay + jitter)
+            delay = min(delay * 2, maxDelay)
         }
     }
 
@@ -839,7 +876,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
         hasSetupDaemon = false
         setupDaemonClient()
-        ensureActorTokenBootstrap()
+        ensureActorCredentials()
     }
 
     @objc func performRetire() {

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -678,7 +678,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
                     let result = await ActorCredentialRefresher.refresh(
                         baseURL: baseURL,
-                        bearerToken: bearerToken
+                        bearerToken: bearerToken,
+                        platform: "macos",
+                        deviceId: PairingQRCodeSheet.computeHostId()
                     )
 
                     switch result {

--- a/clients/shared/App/Auth/ActorCredentialRefresher.swift
+++ b/clients/shared/App/Auth/ActorCredentialRefresher.swift
@@ -14,7 +14,7 @@ public class ActorCredentialRefresher {
     /// Attempts a single refresh. Thread-safe via @MainActor or serial dispatch.
     /// `baseURL` is the gateway URL (e.g. https://gateway.example.com).
     /// `bearerToken` is the runtime bearer for auth.
-    public static func refresh(baseURL: String, bearerToken: String?) async -> RefreshResult {
+    public static func refresh(baseURL: String, bearerToken: String?, platform: String, deviceId: String) async -> RefreshResult {
         guard let refreshToken = ActorTokenManager.getRefreshToken() else {
             return .terminalError(reason: "no_refresh_token")
         }
@@ -40,7 +40,7 @@ public class ActorCredentialRefresher {
             request.setValue(actorToken, forHTTPHeaderField: "X-Actor-Token")
         }
 
-        let body: [String: Any] = ["refreshToken": refreshToken]
+        let body: [String: Any] = ["refreshToken": refreshToken, "platform": platform, "deviceId": deviceId]
 
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
@@ -74,7 +74,7 @@ public class ActorCredentialRefresher {
             // Check for terminal errors
             if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                let error = json["error"] as? String {
-                let terminalErrors = ["refresh_reuse_detected", "revoked", "device_binding_mismatch", "invalid_refresh_token", "refresh_token_expired"]
+                let terminalErrors = ["refresh_reuse_detected", "revoked", "device_binding_mismatch", "refresh_invalid", "refresh_expired"]
                 if terminalErrors.contains(error) {
                     return .terminalError(reason: error)
                 }

--- a/clients/shared/App/Auth/ActorCredentialRefresher.swift
+++ b/clients/shared/App/Auth/ActorCredentialRefresher.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Shared credential refresher. Calls POST /v1/integrations/guardian/vellum/refresh
+/// through the gateway, updates Keychain via ActorTokenManager, and handles
+/// terminal errors that require re-pairing.
+public class ActorCredentialRefresher {
+
+    public enum RefreshResult {
+        case success
+        case terminalError(reason: String) // requires re-pair
+        case transientError // retry later
+    }
+
+    /// Attempts a single refresh. Thread-safe via @MainActor or serial dispatch.
+    /// `baseURL` is the gateway URL (e.g. https://gateway.example.com).
+    /// `bearerToken` is the runtime bearer for auth.
+    public static func refresh(baseURL: String, bearerToken: String?) async -> RefreshResult {
+        guard let refreshToken = ActorTokenManager.getRefreshToken() else {
+            return .terminalError(reason: "no_refresh_token")
+        }
+
+        // Don't attempt refresh if refresh token is already expired
+        if ActorTokenManager.isRefreshTokenExpired {
+            return .terminalError(reason: "refresh_token_expired")
+        }
+
+        guard let url = URL(string: "\(baseURL)/v1/integrations/guardian/vellum/refresh") else {
+            return .transientError
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 15
+        if let token = bearerToken, !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        // Attach current actor token for identification
+        if let actorToken = ActorTokenManager.getToken() {
+            request.setValue(actorToken, forHTTPHeaderField: "X-Actor-Token")
+        }
+
+        let body: [String: Any] = ["refreshToken": refreshToken]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let http = response as? HTTPURLResponse else {
+                return .transientError
+            }
+
+            if (200..<300).contains(http.statusCode) {
+                guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let newActorToken = json["actorToken"] as? String,
+                      let newRefreshToken = json["refreshToken"] as? String,
+                      let actorTokenExpiresAt = json["actorTokenExpiresAt"] as? Int,
+                      let refreshTokenExpiresAt = json["refreshTokenExpiresAt"] as? Int,
+                      let refreshAfter = json["refreshAfter"] as? Int else {
+                    return .transientError
+                }
+
+                ActorTokenManager.storeCredentials(
+                    actorToken: newActorToken,
+                    actorTokenExpiresAt: actorTokenExpiresAt,
+                    refreshToken: newRefreshToken,
+                    refreshTokenExpiresAt: refreshTokenExpiresAt,
+                    refreshAfter: refreshAfter
+                )
+
+                return .success
+            }
+
+            // Check for terminal errors
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let error = json["error"] as? String {
+                let terminalErrors = ["refresh_reuse_detected", "revoked", "device_binding_mismatch", "invalid_refresh_token", "refresh_token_expired"]
+                if terminalErrors.contains(error) {
+                    return .terminalError(reason: error)
+                }
+            }
+
+            return .transientError
+        } catch {
+            return .transientError
+        }
+    }
+}

--- a/clients/shared/App/Auth/ActorTokenManager.swift
+++ b/clients/shared/App/Auth/ActorTokenManager.swift
@@ -45,6 +45,15 @@ public enum ActorTokenManager {
         _ = APIKeyManager.shared.deleteAPIKey(provider: refreshTokenProvider)
     }
 
+    /// Clear all refresh-related metadata (token, expiry, refreshAfter).
+    /// Used when a bootstrap response lacks refresh fields so stale values
+    /// from prior pairings don't trigger invalid refresh attempts.
+    public static func clearRefreshMetadata() {
+        _ = APIKeyManager.shared.deleteAPIKey(provider: refreshTokenProvider)
+        _ = APIKeyManager.shared.deleteAPIKey(provider: refreshTokenExpiresAtProvider)
+        _ = APIKeyManager.shared.deleteAPIKey(provider: refreshAfterProvider)
+    }
+
     // MARK: - Expiry Timestamps
 
     public static func getActorTokenExpiresAt() -> Int? {

--- a/clients/shared/App/Auth/ActorTokenManager.swift
+++ b/clients/shared/App/Auth/ActorTokenManager.swift
@@ -9,6 +9,10 @@ import Foundation
 public enum ActorTokenManager {
     private static let provider = "actor-token"
     private static let guardianPrincipalIdProvider = "actor-token-guardian-principal-id"
+    private static let refreshTokenProvider = "actor-refresh-token"
+    private static let actorTokenExpiresAtProvider = "actor-token-expires-at"
+    private static let refreshTokenExpiresAtProvider = "refresh-token-expires-at"
+    private static let refreshAfterProvider = "actor-token-refresh-after"
 
     public static func getToken() -> String? {
         APIKeyManager.shared.getAPIKey(provider: provider)
@@ -19,13 +23,100 @@ public enum ActorTokenManager {
     }
 
     public static func deleteToken() {
-        _ = APIKeyManager.shared.deleteAPIKey(provider: provider)
-        _ = APIKeyManager.shared.deleteAPIKey(provider: guardianPrincipalIdProvider)
+        deleteAllCredentials()
     }
 
     /// Whether an actor token is currently stored.
     public static var hasToken: Bool {
         getToken() != nil
+    }
+
+    // MARK: - Refresh Token
+
+    public static func getRefreshToken() -> String? {
+        APIKeyManager.shared.getAPIKey(provider: refreshTokenProvider)
+    }
+
+    public static func setRefreshToken(_ token: String) {
+        _ = APIKeyManager.shared.setAPIKey(token, provider: refreshTokenProvider)
+    }
+
+    public static func deleteRefreshToken() {
+        _ = APIKeyManager.shared.deleteAPIKey(provider: refreshTokenProvider)
+    }
+
+    // MARK: - Expiry Timestamps
+
+    public static func getActorTokenExpiresAt() -> Int? {
+        guard let str = APIKeyManager.shared.getAPIKey(provider: actorTokenExpiresAtProvider) else { return nil }
+        return Int(str)
+    }
+
+    public static func setActorTokenExpiresAt(_ epoch: Int) {
+        _ = APIKeyManager.shared.setAPIKey(String(epoch), provider: actorTokenExpiresAtProvider)
+    }
+
+    public static func getRefreshTokenExpiresAt() -> Int? {
+        guard let str = APIKeyManager.shared.getAPIKey(provider: refreshTokenExpiresAtProvider) else { return nil }
+        return Int(str)
+    }
+
+    public static func setRefreshTokenExpiresAt(_ epoch: Int) {
+        _ = APIKeyManager.shared.setAPIKey(String(epoch), provider: refreshTokenExpiresAtProvider)
+    }
+
+    public static func getRefreshAfter() -> Int? {
+        guard let str = APIKeyManager.shared.getAPIKey(provider: refreshAfterProvider) else { return nil }
+        return Int(str)
+    }
+
+    public static func setRefreshAfter(_ epoch: Int) {
+        _ = APIKeyManager.shared.setAPIKey(String(epoch), provider: refreshAfterProvider)
+    }
+
+    // MARK: - Credential Bundle
+
+    /// Store the full credential set from bootstrap/pairing/refresh response.
+    public static func storeCredentials(
+        actorToken: String,
+        actorTokenExpiresAt: Int,
+        refreshToken: String,
+        refreshTokenExpiresAt: Int,
+        refreshAfter: Int,
+        guardianPrincipalId: String? = nil
+    ) {
+        setToken(actorToken)
+        setActorTokenExpiresAt(actorTokenExpiresAt)
+        setRefreshToken(refreshToken)
+        setRefreshTokenExpiresAt(refreshTokenExpiresAt)
+        setRefreshAfter(refreshAfter)
+        if let guardianPrincipalId {
+            setGuardianPrincipalId(guardianPrincipalId)
+        }
+    }
+
+    /// Delete all credentials (used during unpair/logout).
+    public static func deleteAllCredentials() {
+        _ = APIKeyManager.shared.deleteAPIKey(provider: provider)
+        _ = APIKeyManager.shared.deleteAPIKey(provider: guardianPrincipalIdProvider)
+        _ = APIKeyManager.shared.deleteAPIKey(provider: refreshTokenProvider)
+        _ = APIKeyManager.shared.deleteAPIKey(provider: actorTokenExpiresAtProvider)
+        _ = APIKeyManager.shared.deleteAPIKey(provider: refreshTokenExpiresAtProvider)
+        _ = APIKeyManager.shared.deleteAPIKey(provider: refreshAfterProvider)
+    }
+
+    // MARK: - Proactive Refresh Checks
+
+    /// Whether the access token needs proactive refresh.
+    public static var needsProactiveRefresh: Bool {
+        guard let refreshAfter = getRefreshAfter() else { return false }
+        return Int(Date().timeIntervalSince1970 * 1000) >= refreshAfter
+    }
+
+    /// Whether the refresh token is expired.
+    public static var isRefreshTokenExpired: Bool {
+        guard let expiresAt = getRefreshTokenExpiresAt() else { return true }
+        return Int(Date().timeIntervalSince1970 * 1000) >= expiresAt
     }
 
     // MARK: - Guardian Principal ID

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1756,6 +1756,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     public struct GuardianBootstrapResponse: Decodable {
         public let guardianPrincipalId: String
         public let actorToken: String
+        public let actorTokenExpiresAt: Int?
+        public let refreshToken: String?
+        public let refreshTokenExpiresAt: Int?
+        public let refreshAfter: Int?
         public let isNew: Bool
     }
 
@@ -1808,8 +1812,23 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             }
 
             let decoded = try JSONDecoder().decode(GuardianBootstrapResponse.self, from: data)
-            ActorTokenManager.setToken(decoded.actorToken)
-            ActorTokenManager.setGuardianPrincipalId(decoded.guardianPrincipalId)
+            if let refreshToken = decoded.refreshToken,
+               let actorTokenExpiresAt = decoded.actorTokenExpiresAt,
+               let refreshTokenExpiresAt = decoded.refreshTokenExpiresAt,
+               let refreshAfter = decoded.refreshAfter {
+                ActorTokenManager.storeCredentials(
+                    actorToken: decoded.actorToken,
+                    actorTokenExpiresAt: actorTokenExpiresAt,
+                    refreshToken: refreshToken,
+                    refreshTokenExpiresAt: refreshTokenExpiresAt,
+                    refreshAfter: refreshAfter,
+                    guardianPrincipalId: decoded.guardianPrincipalId
+                )
+            } else {
+                // Legacy fallback for older runtimes that don't return refresh tokens
+                ActorTokenManager.setToken(decoded.actorToken)
+                ActorTokenManager.setGuardianPrincipalId(decoded.guardianPrincipalId)
+            }
             log.info("Actor token bootstrap succeeded (isNew=\(decoded.isNew))")
             return true
         } catch {

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1825,9 +1825,12 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                     guardianPrincipalId: decoded.guardianPrincipalId
                 )
             } else {
-                // Legacy fallback for older runtimes that don't return refresh tokens
+                // Legacy fallback for older runtimes that don't return refresh tokens.
+                // Clear any stale refresh metadata from prior pairings so proactive
+                // refresh / 401 recovery don't send an expired token.
                 ActorTokenManager.setToken(decoded.actorToken)
                 ActorTokenManager.setGuardianPrincipalId(decoded.guardianPrincipalId)
+                ActorTokenManager.clearRefreshMetadata()
             }
             log.info("Actor token bootstrap succeeded (isNew=\(decoded.isNew))")
             return true

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -1,5 +1,9 @@
 import Foundation
 import os
+import CryptoKit
+#if os(macOS)
+import IOKit
+#endif
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "HTTPTransport")
 
@@ -343,7 +347,7 @@ public final class HTTPTransport {
 
     // MARK: - HTTP Endpoints
 
-    private func sendMessage(content: String?, sessionId: String) async {
+    private func sendMessage(content: String?, sessionId: String, isRetry: Bool = false) async {
         guard let url = URL(string: "\(baseURL)/v1/messages") else { return }
 
         var request = URLRequest(url: url)
@@ -368,8 +372,11 @@ public final class HTTPTransport {
 
             if http.statusCode == 202 || http.statusCode == 200 {
                 log.info("Message sent successfully")
-            } else if http.statusCode == 401 {
-                handleAuthenticationFailure()
+            } else if http.statusCode == 401 && !isRetry {
+                let refreshed = await handleAuthenticationFailureAsync()
+                if refreshed {
+                    await sendMessage(content: content, sessionId: sessionId, isRetry: true)
+                }
             } else {
                 let errorBody = String(data: data, encoding: .utf8) ?? "unknown"
                 log.error("Send message failed (\(http.statusCode)): \(errorBody)")
@@ -391,7 +398,7 @@ public final class HTTPTransport {
         }
     }
 
-    private func sendDecision(requestId: String, decision: String) async {
+    private func sendDecision(requestId: String, decision: String, isRetry: Bool = false) async {
         guard let url = URL(string: "\(baseURL)/v1/confirm") else { return }
 
         var request = URLRequest(url: url)
@@ -409,8 +416,11 @@ public final class HTTPTransport {
             let (_, response) = try await URLSession.shared.data(for: request)
 
             if let http = response as? HTTPURLResponse {
-                if http.statusCode == 401 {
-                    handleAuthenticationFailure()
+                if http.statusCode == 401 && !isRetry {
+                    let refreshed = await handleAuthenticationFailureAsync()
+                    if refreshed {
+                        await sendDecision(requestId: requestId, decision: decision, isRetry: true)
+                    }
                 } else if http.statusCode != 200 {
                     log.error("Decision response failed (\(http.statusCode))")
                 }
@@ -420,7 +430,7 @@ public final class HTTPTransport {
         }
     }
 
-    private func sendSecret(requestId: String, value: String?) async {
+    private func sendSecret(requestId: String, value: String?, isRetry: Bool = false) async {
         guard let url = URL(string: "\(baseURL)/v1/secret") else { return }
 
         var request = URLRequest(url: url)
@@ -438,8 +448,11 @@ public final class HTTPTransport {
             let (_, response) = try await URLSession.shared.data(for: request)
 
             if let http = response as? HTTPURLResponse {
-                if http.statusCode == 401 {
-                    handleAuthenticationFailure()
+                if http.statusCode == 401 && !isRetry {
+                    let refreshed = await handleAuthenticationFailureAsync()
+                    if refreshed {
+                        await sendSecret(requestId: requestId, value: value, isRetry: true)
+                    }
                 } else if http.statusCode != 200 {
                     log.error("Secret response failed (\(http.statusCode))")
                 }
@@ -449,7 +462,7 @@ public final class HTTPTransport {
         }
     }
 
-    private func fetchGuardianActionsPending(conversationId: String) async {
+    private func fetchGuardianActionsPending(conversationId: String, isRetry: Bool = false) async {
         let encoded = conversationId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? conversationId
         guard let url = URL(string: "\(baseURL)/v1/guardian-actions/pending?conversationId=\(encoded)") else { return }
 
@@ -460,8 +473,11 @@ public final class HTTPTransport {
             let (data, response) = try await URLSession.shared.data(for: request)
 
             if let http = response as? HTTPURLResponse {
-                if http.statusCode == 401 {
-                    handleAuthenticationFailure()
+                if http.statusCode == 401 && !isRetry {
+                    let refreshed = await handleAuthenticationFailureAsync()
+                    if refreshed {
+                        await fetchGuardianActionsPending(conversationId: conversationId, isRetry: true)
+                    }
                     return
                 }
                 guard http.statusCode == 200 else {
@@ -481,7 +497,7 @@ public final class HTTPTransport {
         }
     }
 
-    private func submitGuardianActionDecision(requestId: String, action: String, conversationId: String?) async {
+    private func submitGuardianActionDecision(requestId: String, action: String, conversationId: String?, isRetry: Bool = false) async {
         guard let url = URL(string: "\(baseURL)/v1/guardian-actions/decision") else { return }
 
         var request = URLRequest(url: url)
@@ -502,8 +518,12 @@ public final class HTTPTransport {
             let (data, response) = try await URLSession.shared.data(for: request)
 
             if let http = response as? HTTPURLResponse {
-                if http.statusCode == 401 {
-                    handleAuthenticationFailure()
+                if http.statusCode == 401 && !isRetry {
+                    let refreshed = await handleAuthenticationFailureAsync()
+                    if refreshed {
+                        await submitGuardianActionDecision(requestId: requestId, action: action, conversationId: conversationId, isRetry: true)
+                        return
+                    }
                     onMessage?(.guardianActionDecisionResponse(GuardianActionDecisionResponseMessage(
                         applied: false,
                         reason: "authentication_failed",
@@ -552,7 +572,7 @@ public final class HTTPTransport {
         let prompts: [GuardianDecisionPromptWire]
     }
 
-    private func sendConversationSeen(_ signal: IPCConversationSeenSignal) async {
+    private func sendConversationSeen(_ signal: IPCConversationSeenSignal, isRetry: Bool = false) async {
         guard let url = URL(string: "\(baseURL)/v1/conversations/seen") else { return }
 
         var request = URLRequest(url: url)
@@ -582,8 +602,11 @@ public final class HTTPTransport {
             let (_, response) = try await URLSession.shared.data(for: request)
 
             if let http = response as? HTTPURLResponse {
-                if http.statusCode == 401 {
-                    handleAuthenticationFailure()
+                if http.statusCode == 401 && !isRetry {
+                    let refreshed = await handleAuthenticationFailureAsync()
+                    if refreshed {
+                        await sendConversationSeen(signal, isRetry: true)
+                    }
                 } else if http.statusCode != 200 {
                     log.error("Conversation seen signal failed (\(http.statusCode))")
                 }
@@ -593,7 +616,7 @@ public final class HTTPTransport {
         }
     }
 
-    private func fetchSessionList(offset: Int = 0, limit: Int = 50) async {
+    private func fetchSessionList(offset: Int = 0, limit: Int = 50, isRetry: Bool = false) async {
         guard let url = URL(string: "\(baseURL)/v1/conversations?limit=\(limit)&offset=\(offset)") else { return }
 
         var request = URLRequest(url: url)
@@ -604,8 +627,12 @@ public final class HTTPTransport {
 
             guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
                 let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
-                if statusCode == 401 {
-                    handleAuthenticationFailure()
+                if statusCode == 401 && !isRetry {
+                    let refreshed = await handleAuthenticationFailureAsync()
+                    if refreshed {
+                        await fetchSessionList(offset: offset, limit: limit, isRetry: true)
+                        return
+                    }
                 }
                 log.error("Fetch session list failed")
                 onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: [], hasMore: nil)))
@@ -628,7 +655,7 @@ public final class HTTPTransport {
         }
     }
 
-    private func fetchHistory(sessionId: String) async {
+    private func fetchHistory(sessionId: String, isRetry: Bool = false) async {
         let encoded = sessionId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? sessionId
         let urlString = "\(baseURL)/v1/messages?conversationId=\(encoded)"
         guard let url = URL(string: urlString) else { return }
@@ -641,8 +668,12 @@ public final class HTTPTransport {
 
             guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
                 let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
-                if statusCode == 401 {
-                    handleAuthenticationFailure()
+                if statusCode == 401 && !isRetry {
+                    let refreshed = await handleAuthenticationFailureAsync()
+                    if refreshed {
+                        await fetchHistory(sessionId: sessionId, isRetry: true)
+                        return
+                    }
                 }
                 log.error("Fetch history failed (HTTP \(statusCode))")
                 return
@@ -877,52 +908,93 @@ public final class HTTPTransport {
 
     // MARK: - 401 Recovery
 
-    /// Attempt a single token refresh and retry the original request context.
-    /// If refresh fails terminally, surface the re-pair error to the user.
+    /// Fire-and-forget token refresh for non-async callers (health check, SSE).
+    /// Async callers that need retry should use handleAuthenticationFailureAsync() directly.
     private func handleAuthenticationFailure() {
-        // Only attempt one refresh at a time
-        guard !isRefreshing else { return }
-        isRefreshing = true
-
         Task { @MainActor [weak self] in
             guard let self else { return }
-            defer { self.isRefreshing = false }
-
-            #if os(macOS)
-            let refreshPlatform = "macos"
-            #else
-            let refreshPlatform = "ios"
-            #endif
-            let refreshDeviceId = APIKeyManager.shared.getAPIKey(provider: "pairing-device-id") ?? ""
-
-            let result = await ActorCredentialRefresher.refresh(
-                baseURL: self.baseURL,
-                bearerToken: self.bearerToken,
-                platform: refreshPlatform,
-                deviceId: refreshDeviceId
-            )
-
-            switch result {
-            case .success:
-                log.info("Token refresh succeeded — reconnecting SSE")
-                // Reconnect SSE with new credentials
-                self.stopSSE()
-                self.startSSE()
-
-            case .terminalError(let reason):
-                log.error("Token refresh failed terminally: \(reason) — re-pair required")
-                self.onMessage?(.sessionError(SessionErrorMessage(
-                    sessionId: "",
-                    code: .authenticationRequired,
-                    userMessage: "Session expired. Please re-pair your device.",
-                    retryable: false
-                )))
-
-            case .transientError:
-                log.warning("Token refresh encountered transient error — will retry on next 401")
-            }
+            _ = await self.handleAuthenticationFailureAsync()
         }
     }
+
+    /// Async variant of handleAuthenticationFailure that returns whether refresh succeeded.
+    /// Callers can use this to retry the original request on success.
+    private func handleAuthenticationFailureAsync() async -> Bool {
+        guard !isRefreshing else { return false }
+        isRefreshing = true
+        defer { self.isRefreshing = false }
+
+        #if os(macOS)
+        let refreshPlatform = "macos"
+        // macOS uses SHA-256 of IOPlatformUUID as device ID (matches PairingQRCodeSheet.computeHostId())
+        let refreshDeviceId = Self.computeMacOSDeviceId()
+        #else
+        let refreshPlatform = "ios"
+        // iOS uses Keychain-stored device ID (matches AppDelegate.getOrCreateDeviceId())
+        let refreshDeviceId = APIKeyManager.shared.getAPIKey(provider: "pairing-device-id") ?? ""
+        #endif
+
+        let result = await ActorCredentialRefresher.refresh(
+            baseURL: self.baseURL,
+            bearerToken: self.bearerToken,
+            platform: refreshPlatform,
+            deviceId: refreshDeviceId
+        )
+
+        switch result {
+        case .success:
+            log.info("Token refresh succeeded — reconnecting SSE")
+            // Reconnect SSE with new credentials
+            self.stopSSE()
+            self.startSSE()
+            return true
+
+        case .terminalError(let reason):
+            log.error("Token refresh failed terminally: \(reason) — re-pair required")
+            self.onMessage?(.sessionError(SessionErrorMessage(
+                sessionId: "",
+                code: .authenticationRequired,
+                userMessage: "Session expired. Please re-pair your device.",
+                retryable: false
+            )))
+            return false
+
+        case .transientError:
+            log.warning("Token refresh encountered transient error — will retry on next 401")
+            return false
+        }
+    }
+
+    // MARK: - macOS Device ID
+
+    #if os(macOS)
+    /// Compute a stable device ID matching PairingQRCodeSheet.computeHostId().
+    /// SHA-256 of the IOPlatformUUID + an app-specific salt.
+    private static func computeMacOSDeviceId() -> String {
+        let platformUUID = getMacOSPlatformUUID() ?? UUID().uuidString
+        let salt = "vellum-assistant-host-id"
+        let input = Data((platformUUID + salt).utf8)
+        let hash = SHA256.hash(data: input)
+        return hash.compactMap { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Read the IOPlatformUUID from the IORegistry (macOS hardware identifier).
+    private static func getMacOSPlatformUUID() -> String? {
+        let service = IOServiceGetMatchingService(
+            kIOMainPortDefault,
+            IOServiceMatching("IOPlatformExpertDevice")
+        )
+        guard service != 0 else { return nil }
+        defer { IOObjectRelease(service) }
+
+        let key = kIOPlatformUUIDKey as CFString
+        guard let uuid = IORegistryEntryCreateCFProperty(service, key, kCFAllocatorDefault, 0)?
+            .takeRetainedValue() as? String else {
+            return nil
+        }
+        return uuid
+    }
+    #endif
 
     // MARK: - Helpers
 

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -376,6 +376,13 @@ public final class HTTPTransport {
                 let refreshed = await handleAuthenticationFailureAsync()
                 if refreshed {
                     await sendMessage(content: content, sessionId: sessionId, isRetry: true)
+                } else {
+                    onMessage?(.sessionError(SessionErrorMessage(
+                        sessionId: sessionId,
+                        code: .providerApi,
+                        userMessage: "Failed to send message — authentication error. Please try again.",
+                        retryable: true
+                    )))
                 }
             } else {
                 let errorBody = String(data: data, encoding: .utf8) ?? "unknown"
@@ -420,6 +427,8 @@ public final class HTTPTransport {
                     let refreshed = await handleAuthenticationFailureAsync()
                     if refreshed {
                         await sendDecision(requestId: requestId, decision: decision, isRetry: true)
+                    } else {
+                        log.error("Decision response failed: authentication error after 401 refresh")
                     }
                 } else if http.statusCode != 200 {
                     log.error("Decision response failed (\(http.statusCode))")
@@ -452,6 +461,8 @@ public final class HTTPTransport {
                     let refreshed = await handleAuthenticationFailureAsync()
                     if refreshed {
                         await sendSecret(requestId: requestId, value: value, isRetry: true)
+                    } else {
+                        log.error("Secret response failed: authentication error after 401 refresh")
                     }
                 } else if http.statusCode != 200 {
                     log.error("Secret response failed (\(http.statusCode))")
@@ -477,6 +488,8 @@ public final class HTTPTransport {
                     let refreshed = await handleAuthenticationFailureAsync()
                     if refreshed {
                         await fetchGuardianActionsPending(conversationId: conversationId, isRetry: true)
+                    } else {
+                        log.error("Fetch guardian actions pending failed: authentication error after 401 refresh")
                     }
                     return
                 }

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -99,10 +99,17 @@ public final class HTTPTransport {
     /// SSE reconnect task handle.
     private var sseReconnectTask: Task<Void, Never>?
 
+    /// Result of an async authentication refresh attempt.
+    enum AuthRefreshResult {
+        case success
+        case transientFailure
+        case terminalFailure
+    }
+
     /// In-flight refresh task. Concurrent 401 handlers await this instead of
     /// returning false immediately, so user actions aren't dropped while a
     /// refresh triggered by another codepath is still in progress.
-    private var refreshTask: Task<Bool, Never>?
+    private var refreshTask: Task<AuthRefreshResult, Never>?
 
     /// Callback for incoming server messages (called on main actor).
     var onMessage: ((ServerMessage) -> Void)?
@@ -375,10 +382,14 @@ public final class HTTPTransport {
             if http.statusCode == 202 || http.statusCode == 200 {
                 log.info("Message sent successfully")
             } else if http.statusCode == 401 && !isRetry {
-                let refreshed = await handleAuthenticationFailureAsync()
-                if refreshed {
+                let refreshResult = await handleAuthenticationFailureAsync()
+                switch refreshResult {
+                case .success:
                     await sendMessage(content: content, sessionId: sessionId, isRetry: true)
-                } else {
+                case .terminalFailure:
+                    // performRefresh() already emitted .authenticationRequired — don't overwrite it
+                    break
+                case .transientFailure:
                     onMessage?(.sessionError(SessionErrorMessage(
                         sessionId: sessionId,
                         code: .providerApi,
@@ -426,10 +437,13 @@ public final class HTTPTransport {
 
             if let http = response as? HTTPURLResponse {
                 if http.statusCode == 401 && !isRetry {
-                    let refreshed = await handleAuthenticationFailureAsync()
-                    if refreshed {
+                    let refreshResult = await handleAuthenticationFailureAsync()
+                    switch refreshResult {
+                    case .success:
                         await sendDecision(requestId: requestId, decision: decision, isRetry: true)
-                    } else {
+                    case .terminalFailure:
+                        break
+                    case .transientFailure:
                         log.error("Decision response failed: authentication error after 401 refresh")
                     }
                 } else if http.statusCode != 200 {
@@ -460,10 +474,13 @@ public final class HTTPTransport {
 
             if let http = response as? HTTPURLResponse {
                 if http.statusCode == 401 && !isRetry {
-                    let refreshed = await handleAuthenticationFailureAsync()
-                    if refreshed {
+                    let refreshResult = await handleAuthenticationFailureAsync()
+                    switch refreshResult {
+                    case .success:
                         await sendSecret(requestId: requestId, value: value, isRetry: true)
-                    } else {
+                    case .terminalFailure:
+                        break
+                    case .transientFailure:
                         log.error("Secret response failed: authentication error after 401 refresh")
                     }
                 } else if http.statusCode != 200 {
@@ -487,10 +504,13 @@ public final class HTTPTransport {
 
             if let http = response as? HTTPURLResponse {
                 if http.statusCode == 401 && !isRetry {
-                    let refreshed = await handleAuthenticationFailureAsync()
-                    if refreshed {
+                    let refreshResult = await handleAuthenticationFailureAsync()
+                    switch refreshResult {
+                    case .success:
                         await fetchGuardianActionsPending(conversationId: conversationId, isRetry: true)
-                    } else {
+                    case .terminalFailure:
+                        break
+                    case .transientFailure:
                         log.error("Fetch guardian actions pending failed: authentication error after 401 refresh")
                     }
                     return
@@ -534,10 +554,15 @@ public final class HTTPTransport {
 
             if let http = response as? HTTPURLResponse {
                 if http.statusCode == 401 && !isRetry {
-                    let refreshed = await handleAuthenticationFailureAsync()
-                    if refreshed {
+                    let refreshResult = await handleAuthenticationFailureAsync()
+                    switch refreshResult {
+                    case .success:
                         await submitGuardianActionDecision(requestId: requestId, action: action, conversationId: conversationId, isRetry: true)
                         return
+                    case .terminalFailure:
+                        break
+                    case .transientFailure:
+                        break
                     }
                     onMessage?(.guardianActionDecisionResponse(GuardianActionDecisionResponseMessage(
                         applied: false,
@@ -618,8 +643,8 @@ public final class HTTPTransport {
 
             if let http = response as? HTTPURLResponse {
                 if http.statusCode == 401 && !isRetry {
-                    let refreshed = await handleAuthenticationFailureAsync()
-                    if refreshed {
+                    let refreshResult = await handleAuthenticationFailureAsync()
+                    if case .success = refreshResult {
                         await sendConversationSeen(signal, isRetry: true)
                     }
                 } else if http.statusCode != 200 {
@@ -643,8 +668,8 @@ public final class HTTPTransport {
             guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
                 let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
                 if statusCode == 401 && !isRetry {
-                    let refreshed = await handleAuthenticationFailureAsync()
-                    if refreshed {
+                    let refreshResult = await handleAuthenticationFailureAsync()
+                    if case .success = refreshResult {
                         await fetchSessionList(offset: offset, limit: limit, isRetry: true)
                         return
                     }
@@ -684,8 +709,8 @@ public final class HTTPTransport {
             guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
                 let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
                 if statusCode == 401 && !isRetry {
-                    let refreshed = await handleAuthenticationFailureAsync()
-                    if refreshed {
+                    let refreshResult = await handleAuthenticationFailureAsync()
+                    if case .success = refreshResult {
                         await fetchHistory(sessionId: sessionId, isRetry: true)
                         return
                     }
@@ -924,7 +949,8 @@ public final class HTTPTransport {
     // MARK: - 401 Recovery
 
     /// Fire-and-forget token refresh for non-async callers (health check, SSE).
-    /// Async callers that need retry should use handleAuthenticationFailureAsync() directly.
+    /// Async callers that need retry-or-skip semantics should use
+    /// handleAuthenticationFailureAsync() directly.
     private func handleAuthenticationFailure() {
         Task { @MainActor [weak self] in
             guard let self else { return }
@@ -932,17 +958,20 @@ public final class HTTPTransport {
         }
     }
 
-    /// Async variant of handleAuthenticationFailure that returns whether refresh succeeded.
-    /// Callers can use this to retry the original request on success.
-    private func handleAuthenticationFailureAsync() async -> Bool {
+    /// Async variant of handleAuthenticationFailure that returns the refresh outcome.
+    /// On `.success`, callers should retry the original request.
+    /// On `.terminalFailure`, callers must NOT emit their own error — `performRefresh()`
+    /// already emitted `.authenticationRequired` which is the correct final user-facing state.
+    /// On `.transientFailure`, callers may emit a generic error (refresh will retry on next 401).
+    private func handleAuthenticationFailureAsync() async -> AuthRefreshResult {
         // If a refresh is already in flight, wait for its outcome instead of
         // returning false (which would drop the caller's user action).
         if let existing = refreshTask {
             return await existing.value
         }
 
-        let task = Task<Bool, Never> { @MainActor [weak self] in
-            guard let self else { return false }
+        let task = Task<AuthRefreshResult, Never> { @MainActor [weak self] in
+            guard let self else { return .transientFailure }
             defer { self.refreshTask = nil }
             return await self.performRefresh()
         }
@@ -952,7 +981,7 @@ public final class HTTPTransport {
 
     /// Performs the actual credential refresh. Split out so handleAuthenticationFailureAsync
     /// can manage the coalescing task lifecycle separately.
-    private func performRefresh() async -> Bool {
+    private func performRefresh() async -> AuthRefreshResult {
         #if os(macOS)
         let refreshPlatform = "macos"
         // macOS uses SHA-256 of IOPlatformUUID as device ID (matches PairingQRCodeSheet.computeHostId())
@@ -976,7 +1005,7 @@ public final class HTTPTransport {
             // Reconnect SSE with new credentials
             self.stopSSE()
             self.startSSE()
-            return true
+            return .success
 
         case .terminalError(let reason):
             log.error("Token refresh failed terminally: \(reason) — re-pair required")
@@ -986,11 +1015,11 @@ public final class HTTPTransport {
                 userMessage: "Session expired. Please re-pair your device.",
                 retryable: false
             )))
-            return false
+            return .terminalFailure
 
         case .transientError:
             log.warning("Token refresh encountered transient error — will retry on next 401")
-            return false
+            return .transientFailure
         }
     }
 

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -99,8 +99,10 @@ public final class HTTPTransport {
     /// SSE reconnect task handle.
     private var sseReconnectTask: Task<Void, Never>?
 
-    /// Whether a token refresh is currently in progress (prevents overlapping refreshes).
-    private var isRefreshing = false
+    /// In-flight refresh task. Concurrent 401 handlers await this instead of
+    /// returning false immediately, so user actions aren't dropped while a
+    /// refresh triggered by another codepath is still in progress.
+    private var refreshTask: Task<Bool, Never>?
 
     /// Callback for incoming server messages (called on main actor).
     var onMessage: ((ServerMessage) -> Void)?
@@ -933,10 +935,24 @@ public final class HTTPTransport {
     /// Async variant of handleAuthenticationFailure that returns whether refresh succeeded.
     /// Callers can use this to retry the original request on success.
     private func handleAuthenticationFailureAsync() async -> Bool {
-        guard !isRefreshing else { return false }
-        isRefreshing = true
-        defer { self.isRefreshing = false }
+        // If a refresh is already in flight, wait for its outcome instead of
+        // returning false (which would drop the caller's user action).
+        if let existing = refreshTask {
+            return await existing.value
+        }
 
+        let task = Task<Bool, Never> { @MainActor [weak self] in
+            guard let self else { return false }
+            defer { self.refreshTask = nil }
+            return await self.performRefresh()
+        }
+        refreshTask = task
+        return await task.value
+    }
+
+    /// Performs the actual credential refresh. Split out so handleAuthenticationFailureAsync
+    /// can manage the coalescing task lifecycle separately.
+    private func performRefresh() async -> Bool {
         #if os(macOS)
         let refreshPlatform = "macos"
         // macOS uses SHA-256 of IOPlatformUUID as device ID (matches PairingQRCodeSheet.computeHostId())

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -888,9 +888,18 @@ public final class HTTPTransport {
             guard let self else { return }
             defer { self.isRefreshing = false }
 
+            #if os(macOS)
+            let refreshPlatform = "macos"
+            #else
+            let refreshPlatform = "ios"
+            #endif
+            let refreshDeviceId = APIKeyManager.shared.getAPIKey(provider: "pairing-device-id") ?? ""
+
             let result = await ActorCredentialRefresher.refresh(
                 baseURL: self.baseURL,
-                bearerToken: self.bearerToken
+                bearerToken: self.bearerToken,
+                platform: refreshPlatform,
+                deviceId: refreshDeviceId
             )
 
             switch result {

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -95,6 +95,9 @@ public final class HTTPTransport {
     /// SSE reconnect task handle.
     private var sseReconnectTask: Task<Void, Never>?
 
+    /// Whether a token refresh is currently in progress (prevents overlapping refreshes).
+    private var isRefreshing = false
+
     /// Callback for incoming server messages (called on main actor).
     var onMessage: ((ServerMessage) -> Void)?
 
@@ -874,16 +877,42 @@ public final class HTTPTransport {
 
     // MARK: - 401 Recovery
 
-    /// Surface a session-expired error to the client. On iOS this means
-    /// the user must re-pair via QR code since we cannot read the token from disk.
+    /// Attempt a single token refresh and retry the original request context.
+    /// If refresh fails terminally, surface the re-pair error to the user.
     private func handleAuthenticationFailure() {
-        log.error("Authentication failed — bearer token is stale")
-        onMessage?(.sessionError(SessionErrorMessage(
-            sessionId: "",
-            code: .authenticationRequired,
-            userMessage: "Session expired. Please re-pair your device.",
-            retryable: false
-        )))
+        // Only attempt one refresh at a time
+        guard !isRefreshing else { return }
+        isRefreshing = true
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.isRefreshing = false }
+
+            let result = await ActorCredentialRefresher.refresh(
+                baseURL: self.baseURL,
+                bearerToken: self.bearerToken
+            )
+
+            switch result {
+            case .success:
+                log.info("Token refresh succeeded — reconnecting SSE")
+                // Reconnect SSE with new credentials
+                self.stopSSE()
+                self.startSSE()
+
+            case .terminalError(let reason):
+                log.error("Token refresh failed terminally: \(reason) — re-pair required")
+                self.onMessage?(.sessionError(SessionErrorMessage(
+                    sessionId: "",
+                    code: .authenticationRequired,
+                    userMessage: "Session expired. Please re-pair your device.",
+                    retryable: false
+                )))
+
+            case .transientError:
+                log.warning("Token refresh encountered transient error — will retry on next 401")
+            }
+        }
     }
 
     // MARK: - Helpers

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -88,6 +88,9 @@ Guardian verification endpoints are exposed directly by the gateway and forwarde
 | POST | `/v1/integrations/guardian/outbound/start` |
 | POST | `/v1/integrations/guardian/outbound/resend` |
 | POST | `/v1/integrations/guardian/outbound/cancel` |
+| POST | `/v1/integrations/guardian/vellum/refresh` |
+
+The `/vellum/refresh` endpoint is the only public ingress for rotating actor + refresh token credentials. Clients must call this through the gateway; the runtime endpoint is not directly exposed. The gateway validates the caller's bearer token and forwards to the runtime, which handles refresh token validation, rotation, and replay detection (see [`assistant/ARCHITECTURE.md`](../assistant/ARCHITECTURE.md) for refresh token lifecycle details).
 
 **Authentication boundary:**
 

--- a/gateway/src/http/routes/guardian-control-plane-proxy.ts
+++ b/gateway/src/http/routes/guardian-control-plane-proxy.ts
@@ -107,5 +107,9 @@ export function createGuardianControlPlaneProxyHandler(config: GatewayConfig) {
     async handleCancelGuardianOutbound(req: Request): Promise<Response> {
       return proxyToRuntime(req, "/v1/integrations/guardian/outbound/cancel", "");
     },
+
+    async handleGuardianRefresh(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/integrations/guardian/vellum/refresh", "");
+    },
   };
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -548,6 +548,13 @@ function main() {
         return guardianControlPlaneProxy.handleCancelGuardianOutbound(tracedReq);
       }
 
+      // ── Guardian vellum refresh proxy ──
+      if (url.pathname === "/v1/integrations/guardian/vellum/refresh" && req.method === "POST") {
+        const authError = requireRuntimeBearerAuth();
+        if (authError) return authError;
+        return guardianControlPlaneProxy.handleGuardianRefresh(tracedReq);
+      }
+
       // ── Twilio integration control-plane proxy ──
       if (
         (url.pathname === "/v1/integrations/twilio/config" && req.method === "GET")


### PR DESCRIPTION
## Summary
- **Hard-cutover from bootstrap-as-renewal to rotating refresh tokens**: Access token TTL reduced from 90→30 days. Refresh tokens with 365-day absolute / 90-day inactivity expiry, single-use rotation, and replay detection (family revocation).
- **New server infrastructure**: `actor_refresh_token_records` table, refresh token store/service, `POST /v1/integrations/guardian/vellum/refresh` endpoint (runtime + gateway proxy).
- **Client credential lifecycle overhaul**: Shared `ActorCredentialRefresher` used by both macOS and iOS. 401 recovery now attempts refresh before surfacing re-pair. Proactive refresh every 5 min when `now >= refreshAfter`. Bootstrap/pairing only for initial issuance.
- **Legacy removal**: macOS no longer re-bootstraps on every launch. iOS no longer runs bootstrap retry loops for renewal. "Session expired" message only surfaces after refresh fails terminally.

## Original prompt
/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/.private/plans/vellum-identity-refresh-hard-cutover-one-pr-plan-2026-03-01.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
