### PR TITLE
Add payload normalization to shared inbound event shape

### DIFF
--- a/gateway-managed/ARCHITECTURE.md
+++ b/gateway-managed/ARCHITECTURE.md
@@ -49,6 +49,12 @@ The managed gateway is a dedicated service lane for Vellum-owned shared channel 
 - Enforces Twilio signature verification and explicit validation/auth error envelopes.
 - Defers payload normalization and dispatch wiring to follow-up PRs.
 
+## P07 PR-4 scope
+
+- Adds shared managed inbound event types for Twilio SMS and voice channels.
+- Normalizes Twilio webhook payloads into a consistent internal event shape.
+- Keeps endpoint contracts unchanged while preparing PR-5 route-resolution wiring.
+
 ## Endpoints
 
 - `GET /healthz`

--- a/gateway-managed/README.md
+++ b/gateway-managed/README.md
@@ -12,6 +12,7 @@ Managed gateway service skeleton for Vellum-owned shared channel identities.
 - Twilio signature verifier primitives with rotation/revocation/expiry support
 - managed Twilio SMS webhook endpoint skeleton with explicit auth/validation envelopes
 - managed Twilio voice webhook endpoint skeleton with explicit auth/validation envelopes
+- shared inbound event normalization for managed Twilio SMS and voice payloads
 - health and readiness endpoints:
   - `/healthz`
   - `/readyz`
@@ -76,6 +77,10 @@ Managed Twilio SMS webhook contract lives in [`managed-twilio-sms-webhook-contra
 ## Managed Twilio Voice Webhook Contract
 
 Managed Twilio voice webhook contract lives in [`managed-twilio-voice-webhook-contract.md`](./managed-twilio-voice-webhook-contract.md).
+
+## Managed Inbound Event Shape
+
+Managed Twilio payloads normalize into a shared internal event shape before route-resolution/dispatch wiring. Current normalizers live in `src/twilio-normalize.ts`.
 
 ## Staging Deployment Artifacts
 

--- a/gateway-managed/src/__tests__/twilio-normalize.test.ts
+++ b/gateway-managed/src/__tests__/twilio-normalize.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  normalizeManagedTwilioSmsPayload,
+  normalizeManagedTwilioVoicePayload,
+} from "../twilio-normalize.js";
+
+describe("managed Twilio payload normalization", () => {
+  test("normalizes SMS payload into shared managed inbound event shape", () => {
+    const receivedAt = "2026-03-01T18:30:00.000Z";
+    const event = normalizeManagedTwilioSmsPayload({
+      From: "+15550000000",
+      To: "+15559999999",
+      Body: "hello sms",
+      MessageSid: "SM123",
+    }, receivedAt);
+
+    expect(event).toEqual({
+      version: "v1",
+      sourceChannel: "sms",
+      receivedAt,
+      message: {
+        content: "hello sms",
+        conversationExternalId: "+15550000000",
+        externalMessageId: "SM123",
+      },
+      actor: {
+        actorExternalId: "+15550000000",
+        displayName: "+15550000000",
+      },
+      source: {
+        updateId: "SM123",
+        messageId: "SM123",
+        to: "+15559999999",
+      },
+      raw: {
+        From: "+15550000000",
+        To: "+15559999999",
+        Body: "hello sms",
+        MessageSid: "SM123",
+        _to: "+15559999999",
+      },
+    });
+  });
+
+  test("normalizes voice payload into shared managed inbound event shape", () => {
+    const receivedAt = "2026-03-01T18:31:00.000Z";
+    const event = normalizeManagedTwilioVoicePayload({
+      From: "+15550000001",
+      To: "+15559999998",
+      CallSid: "CA123",
+      CallStatus: "ringing",
+    }, receivedAt);
+
+    expect(event).toEqual({
+      version: "v1",
+      sourceChannel: "voice",
+      receivedAt,
+      message: {
+        content: "",
+        conversationExternalId: "+15550000001",
+        externalMessageId: "CA123",
+      },
+      actor: {
+        actorExternalId: "+15550000001",
+        displayName: "+15550000001",
+      },
+      source: {
+        updateId: "CA123",
+        messageId: "CA123",
+        to: "+15559999998",
+        callStatus: "ringing",
+      },
+      raw: {
+        From: "+15550000001",
+        To: "+15559999998",
+        CallSid: "CA123",
+        CallStatus: "ringing",
+        _to: "+15559999998",
+        _call_status: "ringing",
+      },
+    });
+  });
+});

--- a/gateway-managed/src/managed-inbound-event.ts
+++ b/gateway-managed/src/managed-inbound-event.ts
@@ -1,0 +1,22 @@
+export type ManagedInboundChannelId = "sms" | "voice";
+
+export type ManagedGatewayInboundEvent = {
+  version: "v1";
+  sourceChannel: ManagedInboundChannelId;
+  receivedAt: string;
+  message: {
+    content: string;
+    conversationExternalId: string;
+    externalMessageId: string;
+  };
+  actor: {
+    actorExternalId: string;
+    displayName?: string;
+  };
+  source: {
+    updateId: string;
+    messageId?: string;
+    [key: string]: string | undefined;
+  };
+  raw: Record<string, unknown>;
+};

--- a/gateway-managed/src/managed-twilio-sms-webhook.ts
+++ b/gateway-managed/src/managed-twilio-sms-webhook.ts
@@ -1,4 +1,5 @@
 import type { ManagedGatewayConfig } from "./config.js";
+import { normalizeManagedTwilioSmsPayload } from "./twilio-normalize.js";
 import { validateManagedTwilioSignature } from "./twilio-signature.js";
 
 export const MANAGED_TWILIO_SMS_WEBHOOK_PATH = "/webhooks/twilio/sms";
@@ -74,6 +75,11 @@ export async function handleManagedTwilioSmsWebhook(
       { status: 403 },
     );
   }
+
+  // Build normalized shared event shape now so follow-up PRs can attach
+  // route resolution and dispatch without changing this endpoint contract.
+  const _normalizedEvent = normalizeManagedTwilioSmsPayload(toRecord(params));
+  void _normalizedEvent;
 
   return Response.json(
     {

--- a/gateway-managed/src/managed-twilio-voice-webhook.ts
+++ b/gateway-managed/src/managed-twilio-voice-webhook.ts
@@ -1,4 +1,5 @@
 import type { ManagedGatewayConfig } from "./config.js";
+import { normalizeManagedTwilioVoicePayload } from "./twilio-normalize.js";
 import { validateManagedTwilioSignature } from "./twilio-signature.js";
 
 export const MANAGED_TWILIO_VOICE_WEBHOOK_PATH = "/webhooks/twilio/voice";
@@ -74,6 +75,11 @@ export async function handleManagedTwilioVoiceWebhook(
       { status: 403 },
     );
   }
+
+  // Build normalized shared event shape now so follow-up PRs can attach
+  // route resolution and dispatch without changing this endpoint contract.
+  const _normalizedEvent = normalizeManagedTwilioVoicePayload(toRecord(params));
+  void _normalizedEvent;
 
   return Response.json(
     {

--- a/gateway-managed/src/twilio-normalize.ts
+++ b/gateway-managed/src/twilio-normalize.ts
@@ -1,0 +1,71 @@
+import type { ManagedGatewayInboundEvent } from "./managed-inbound-event.js";
+
+export function normalizeManagedTwilioSmsPayload(
+  params: Record<string, string>,
+  receivedAt: string = new Date().toISOString(),
+): ManagedGatewayInboundEvent {
+  const body = params.Body || "";
+  const from = params.From || "";
+  const to = params.To || "";
+  const messageSid = params.MessageSid || "";
+
+  return {
+    version: "v1",
+    sourceChannel: "sms",
+    receivedAt,
+    message: {
+      content: body,
+      conversationExternalId: from,
+      externalMessageId: messageSid,
+    },
+    actor: {
+      actorExternalId: from,
+      displayName: from || undefined,
+    },
+    source: {
+      updateId: messageSid,
+      messageId: messageSid,
+      to,
+    },
+    raw: {
+      ...params,
+      _to: to,
+    },
+  };
+}
+
+export function normalizeManagedTwilioVoicePayload(
+  params: Record<string, string>,
+  receivedAt: string = new Date().toISOString(),
+): ManagedGatewayInboundEvent {
+  const from = params.From || "";
+  const to = params.To || "";
+  const callSid = params.CallSid || "";
+  const callStatus = params.CallStatus || "";
+
+  return {
+    version: "v1",
+    sourceChannel: "voice",
+    receivedAt,
+    message: {
+      content: "",
+      conversationExternalId: from,
+      externalMessageId: callSid,
+    },
+    actor: {
+      actorExternalId: from,
+      displayName: from || undefined,
+    },
+    source: {
+      updateId: callSid,
+      messageId: callSid,
+      to,
+      callStatus,
+    },
+    raw: {
+      ...params,
+      _to: to,
+      _call_status: callStatus,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add shared managed inbound event types for Twilio SMS/voice channels
- add Twilio SMS/voice payload normalizers into the shared managed event shape
- wire normalization into both webhook skeleton handlers without changing endpoint response contracts
- add focused normalization unit tests and keep existing endpoint tests green

## Validation
- cd gateway-managed && bun run typecheck
- cd gateway-managed && bun run build
- cd gateway-managed && bun run test

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
