### PR TITLE
Add route-resolution call (phone -> assistant_id) to Django

### DIFF
--- a/gateway-managed/ARCHITECTURE.md
+++ b/gateway-managed/ARCHITECTURE.md
@@ -55,6 +55,12 @@ The managed gateway is a dedicated service lane for Vellum-owned shared channel 
 - Normalizes Twilio webhook payloads into a consistent internal event shape.
 - Keeps endpoint contracts unchanged while preparing PR-5 route-resolution wiring.
 
+## P07 PR-5 scope
+
+- Adds managed route-resolution client to call Django internal resolver for `phone -> assistant_id`.
+- Wires SMS and voice webhook handlers to resolve managed routes before returning accepted stubs.
+- Surfaces explicit 404/4xx route-resolution envelopes without dispatching to runtime yet.
+
 ## Endpoints
 
 - `GET /healthz`

--- a/gateway-managed/README.md
+++ b/gateway-managed/README.md
@@ -13,6 +13,7 @@ Managed gateway service skeleton for Vellum-owned shared channel identities.
 - managed Twilio SMS webhook endpoint skeleton with explicit auth/validation envelopes
 - managed Twilio voice webhook endpoint skeleton with explicit auth/validation envelopes
 - shared inbound event normalization for managed Twilio SMS and voice payloads
+- managed route-resolution call (`phone -> assistant_id`) to Django before webhook acceptance
 - health and readiness endpoints:
   - `/healthz`
   - `/readyz`

--- a/gateway-managed/managed-twilio-sms-webhook-contract.md
+++ b/gateway-managed/managed-twilio-sms-webhook-contract.md
@@ -13,7 +13,8 @@ Authz boundary:
 - revoked or expired Twilio tokens are rejected
 
 Response contract:
-- `202`: accepted stub envelope for managed SMS webhook path
+- `202`: accepted stub envelope for managed SMS webhook path, including resolved `assistant_id` and `route_id`
 - `400`: validation error envelope (`validation_error`) for malformed payloads
 - `403`: auth failure envelope for missing/invalid signatures
+- `404`: route resolution error envelope when managed route mapping is missing
 - `405`: method-not-allowed envelope for non-POST methods

--- a/gateway-managed/managed-twilio-voice-webhook-contract.md
+++ b/gateway-managed/managed-twilio-voice-webhook-contract.md
@@ -13,7 +13,8 @@ Authz boundary:
 - revoked or expired Twilio tokens are rejected
 
 Response contract:
-- `202`: accepted stub envelope for managed voice webhook path
+- `202`: accepted stub envelope for managed voice webhook path, including resolved `assistant_id` and `route_id`
 - `400`: validation error envelope (`validation_error`) for malformed payloads
 - `403`: auth failure envelope for missing/invalid signatures
+- `404`: route resolution error envelope when managed route mapping is missing
 - `405`: method-not-allowed envelope for non-POST methods

--- a/gateway-managed/src/__tests__/managed-route-resolution-client.test.ts
+++ b/gateway-managed/src/__tests__/managed-route-resolution-client.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { loadConfig } from "../config.js";
+import {
+  resolveManagedRoute,
+} from "../managed-route-resolution-client.js";
+import type { ManagedGatewayUpstreamFetch } from "../route-resolve.js";
+
+const FAR_FUTURE = "2099-01-01T00:00:00.000Z";
+
+type EnvOverrides = Record<string, string | undefined>;
+type MockedFetch = ReturnType<typeof mock<ManagedGatewayUpstreamFetch>>;
+
+function makeConfig(overrides: EnvOverrides = {}): ReturnType<typeof loadConfig> {
+  return loadConfig({
+    ...process.env,
+    MANAGED_GATEWAY_ENABLED: "true",
+    MANAGED_GATEWAY_STRICT_STARTUP_VALIDATION: "true",
+    MANAGED_GATEWAY_DJANGO_INTERNAL_BASE_URL: "http://127.0.0.1:8000",
+    MANAGED_GATEWAY_INTERNAL_AUTH_MODE: "bearer",
+    MANAGED_GATEWAY_INTERNAL_AUTH_AUDIENCE: "managed-gateway-internal",
+    MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS: JSON.stringify({
+      "token-active": {
+        token_id: "mgw-2026-01",
+        principal: "managed-gateway-staging",
+        audience: "managed-gateway-internal",
+        scopes: ["managed-gateway:internal", "routes:resolve"],
+        expires_at: FAR_FUTURE,
+      },
+    }),
+    MANAGED_GATEWAY_INTERNAL_REVOKED_TOKEN_IDS: "",
+    MANAGED_GATEWAY_INTERNAL_MTLS_PRINCIPALS: "managed-gateway-staging",
+    MANAGED_GATEWAY_MTLS_PRINCIPAL_HEADER: "x-managed-gateway-principal",
+    MANAGED_GATEWAY_MTLS_AUDIENCE_HEADER: "x-managed-gateway-audience",
+    MANAGED_GATEWAY_MTLS_SCOPES_HEADER: "x-managed-gateway-scopes",
+    MANAGED_GATEWAY_TWILIO_AUTH_TOKENS: JSON.stringify({
+      "twilio-current": {
+        token_id: "twilio-2026-01",
+        auth_token: "twilio-current-secret",
+        expires_at: FAR_FUTURE,
+      },
+    }),
+    ...overrides,
+  });
+}
+
+describe("managed route resolution client", () => {
+  test("resolves managed route via Django internal endpoint using bearer auth", async () => {
+    let capturedUrl = "";
+    let capturedInit: RequestInit | undefined;
+    const fetchMock: MockedFetch = mock(async (input, init) => {
+      capturedUrl = String(input);
+      capturedInit = init;
+      return new Response(
+        JSON.stringify({
+          route_id: "87c8dd8f-1f92-45c4-a524-126cf59fd760",
+          assistant_id: "8aa67431-9f28-40c0-98a5-e49d83bd15ab",
+          provider: "twilio",
+          route_type: "sms",
+          identity_key: "+15559999999",
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+    const config = makeConfig();
+
+    const result = await resolveManagedRoute(config, {
+      routeType: "sms",
+      identityKey: "+15559999999",
+      fetchImpl: (...args) => fetchMock(...args),
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      route: {
+        routeId: "87c8dd8f-1f92-45c4-a524-126cf59fd760",
+        assistantId: "8aa67431-9f28-40c0-98a5-e49d83bd15ab",
+        provider: "twilio",
+        routeType: "sms",
+        identityKey: "+15559999999",
+      },
+    });
+    expect(capturedUrl).toBe("http://127.0.0.1:8000/v1/internal/managed-gateway/routes/resolve/");
+    expect(capturedInit?.method).toBe("POST");
+    expect(JSON.parse(capturedInit?.body as string)).toEqual({
+      provider: "twilio",
+      route_type: "sms",
+      identity_key: "+15559999999",
+    });
+    const headers = capturedInit?.headers as Headers;
+    expect(headers.get("authorization")).toBe("Bearer token-active");
+    expect(headers.get("content-type")).toBe("application/json");
+  });
+
+  test("uses mTLS headers when configured in mTLS mode", async () => {
+    let capturedInit: RequestInit | undefined;
+    const fetchMock: MockedFetch = mock(async (_input, init) => {
+      capturedInit = init;
+      return new Response(
+        JSON.stringify({
+          route_id: "17b5e8c3-f07f-42e4-8099-a10af4c3d056",
+          assistant_id: "4a6b3a7f-1f1f-4f5d-b18f-9c0f64baea77",
+          provider: "twilio",
+          route_type: "voice",
+          identity_key: "+15559999999",
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+    const config = makeConfig({
+      MANAGED_GATEWAY_INTERNAL_AUTH_MODE: "mtls",
+      MANAGED_GATEWAY_INTERNAL_MTLS_PRINCIPALS: "managed-gateway-staging",
+    });
+
+    const result = await resolveManagedRoute(config, {
+      routeType: "voice",
+      identityKey: "+15559999999",
+      fetchImpl: (...args) => fetchMock(...args),
+    });
+
+    expect(result.ok).toBe(true);
+    const headers = capturedInit?.headers as Headers;
+    expect(headers.get("authorization")).toBeNull();
+    expect(headers.get("x-managed-gateway-principal")).toBe("managed-gateway-staging");
+    expect(headers.get("x-managed-gateway-audience")).toBe("managed-gateway-internal");
+    expect(headers.get("x-managed-gateway-scopes")).toBe("routes:resolve");
+  });
+
+  test("returns 404 when upstream route is missing", async () => {
+    const fetchMock: MockedFetch = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          error: {
+            code: "managed_route_not_found",
+            detail: "Managed route not found.",
+          },
+        }),
+        {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+    const config = makeConfig();
+
+    const result = await resolveManagedRoute(config, {
+      routeType: "sms",
+      identityKey: "+15559999999",
+      fetchImpl: (...args) => fetchMock(...args),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 404,
+      error: {
+        code: "managed_route_not_found",
+        detail: "Managed route not found.",
+      },
+    });
+  });
+
+  test("returns internal auth unavailable when no active bearer credentials exist", async () => {
+    const config = makeConfig({
+      MANAGED_GATEWAY_STRICT_STARTUP_VALIDATION: "false",
+      MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS: "{}",
+    });
+
+    const result = await resolveManagedRoute(config, {
+      routeType: "sms",
+      identityKey: "+15559999999",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 500,
+      error: {
+        code: "internal_auth_unavailable",
+        detail: "No active managed gateway internal auth credentials are available.",
+      },
+    });
+  });
+});

--- a/gateway-managed/src/__tests__/managed-twilio-sms-webhook.test.ts
+++ b/gateway-managed/src/__tests__/managed-twilio-sms-webhook.test.ts
@@ -1,13 +1,15 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
 import { loadConfig } from "../config.js";
 import { createManagedGatewayAppFetch } from "../http.js";
 import { MANAGED_TWILIO_SMS_WEBHOOK_PATH } from "../managed-twilio-sms-webhook.js";
+import type { ManagedGatewayUpstreamFetch } from "../route-resolve.js";
 import { computeTwilioSignature } from "../twilio-signature.js";
 
 const FAR_FUTURE = "2099-01-01T00:00:00.000Z";
 
 type EnvOverrides = Record<string, string | undefined>;
+type MockedFetch = ReturnType<typeof mock<ManagedGatewayUpstreamFetch>>;
 
 function makeConfig(overrides: EnvOverrides = {}): ReturnType<typeof loadConfig> {
   return loadConfig({
@@ -55,7 +57,24 @@ function makeRequest(
 describe("managed Twilio SMS webhook skeleton", () => {
   test("returns 202 for valid signed Twilio SMS payload", async () => {
     const config = makeConfig();
-    const handler = createManagedGatewayAppFetch(config);
+    const fetchMock: MockedFetch = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          route_id: "87c8dd8f-1f92-45c4-a524-126cf59fd760",
+          assistant_id: "8aa67431-9f28-40c0-98a5-e49d83bd15ab",
+          provider: "twilio",
+          route_type: "sms",
+          identity_key: "+15559999999",
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+    const handler = createManagedGatewayAppFetch(config, {
+      fetchImpl: (...args) => fetchMock(...args),
+    });
     const payload = new URLSearchParams({
       From: "+15550000000",
       To: "+15559999999",
@@ -82,12 +101,45 @@ describe("managed Twilio SMS webhook skeleton", () => {
       from: "+15550000000",
       to: "+15559999999",
       body: "hello from managed lane",
+      assistant_id: "8aa67431-9f28-40c0-98a5-e49d83bd15ab",
+      route_id: "87c8dd8f-1f92-45c4-a524-126cf59fd760",
+      normalized_event: {
+        version: "v1",
+        sourceChannel: "sms",
+        receivedAt: expect.any(String),
+        message: {
+          content: "hello from managed lane",
+          conversationExternalId: "+15550000000",
+          externalMessageId: "SM123",
+        },
+        actor: {
+          actorExternalId: "+15550000000",
+          displayName: "+15550000000",
+        },
+        source: {
+          updateId: "SM123",
+          messageId: "SM123",
+          to: "+15559999999",
+        },
+        raw: {
+          From: "+15550000000",
+          To: "+15559999999",
+          Body: "hello from managed lane",
+          MessageSid: "SM123",
+          _to: "+15559999999",
+        },
+      },
     });
   });
 
   test("returns 400 for invalid webhook payload", async () => {
     const config = makeConfig();
-    const handler = createManagedGatewayAppFetch(config);
+    const fetchMock: MockedFetch = mock(async () => {
+      throw new Error("route resolution should not be called for invalid payload");
+    });
+    const handler = createManagedGatewayAppFetch(config, {
+      fetchImpl: (...args) => fetchMock(...args),
+    });
     const payload = new URLSearchParams({
       From: "+15550000000",
       To: "+15559999999",
@@ -110,11 +162,17 @@ describe("managed Twilio SMS webhook skeleton", () => {
         detail: "Invalid managed Twilio SMS webhook payload.",
       },
     });
+    expect(fetchMock).toHaveBeenCalledTimes(0);
   });
 
   test("returns 403 for missing Twilio signature", async () => {
     const config = makeConfig();
-    const handler = createManagedGatewayAppFetch(config);
+    const fetchMock: MockedFetch = mock(async () => {
+      throw new Error("route resolution should not be called for missing signature");
+    });
+    const handler = createManagedGatewayAppFetch(config, {
+      fetchImpl: (...args) => fetchMock(...args),
+    });
     const payload = new URLSearchParams({
       From: "+15550000000",
       To: "+15559999999",
@@ -131,11 +189,17 @@ describe("managed Twilio SMS webhook skeleton", () => {
         detail: "Missing X-Twilio-Signature header.",
       },
     });
+    expect(fetchMock).toHaveBeenCalledTimes(0);
   });
 
   test("returns 403 for invalid Twilio signature", async () => {
     const config = makeConfig();
-    const handler = createManagedGatewayAppFetch(config);
+    const fetchMock: MockedFetch = mock(async () => {
+      throw new Error("route resolution should not be called for invalid signature");
+    });
+    const handler = createManagedGatewayAppFetch(config, {
+      fetchImpl: (...args) => fetchMock(...args),
+    });
     const payload = new URLSearchParams({
       From: "+15550000000",
       To: "+15559999999",
@@ -154,16 +218,67 @@ describe("managed Twilio SMS webhook skeleton", () => {
         detail: "Invalid Twilio request signature.",
       },
     });
+    expect(fetchMock).toHaveBeenCalledTimes(0);
   });
 
   test("returns 405 for unsupported method", async () => {
     const config = makeConfig();
-    const handler = createManagedGatewayAppFetch(config);
+    const fetchMock: MockedFetch = mock(async () => {
+      throw new Error("route resolution should not be called for GET");
+    });
+    const handler = createManagedGatewayAppFetch(config, {
+      fetchImpl: (...args) => fetchMock(...args),
+    });
     const response = await handler(
       makeRequest(new URLSearchParams(), {}, "GET"),
     );
 
     expect(response.status).toBe(405);
     expect(response.headers.get("allow")).toBe("POST");
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
+
+  test("returns 404 when managed route is not found", async () => {
+    const config = makeConfig();
+    const fetchMock: MockedFetch = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          error: {
+            code: "managed_route_not_found",
+            detail: "Managed route not found.",
+          },
+        }),
+        {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+    const handler = createManagedGatewayAppFetch(config, {
+      fetchImpl: (...args) => fetchMock(...args),
+    });
+    const payload = new URLSearchParams({
+      From: "+15550000000",
+      To: "+15559999999",
+      Body: "hello",
+      MessageSid: "SM126",
+    });
+    const signature = computeTwilioSignature(
+      `http://managed-gateway.test${MANAGED_TWILIO_SMS_WEBHOOK_PATH}`,
+      Object.fromEntries(payload),
+      "twilio-current-secret",
+    );
+
+    const response = await handler(makeRequest(payload, {
+      "x-twilio-signature": signature,
+    }));
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "managed_route_not_found",
+        detail: "Managed route not found.",
+      },
+    });
   });
 });

--- a/gateway-managed/src/__tests__/managed-twilio-voice-webhook.test.ts
+++ b/gateway-managed/src/__tests__/managed-twilio-voice-webhook.test.ts
@@ -1,13 +1,15 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
 import { loadConfig } from "../config.js";
 import { createManagedGatewayAppFetch } from "../http.js";
 import { MANAGED_TWILIO_VOICE_WEBHOOK_PATH } from "../managed-twilio-voice-webhook.js";
+import type { ManagedGatewayUpstreamFetch } from "../route-resolve.js";
 import { computeTwilioSignature } from "../twilio-signature.js";
 
 const FAR_FUTURE = "2099-01-01T00:00:00.000Z";
 
 type EnvOverrides = Record<string, string | undefined>;
+type MockedFetch = ReturnType<typeof mock<ManagedGatewayUpstreamFetch>>;
 
 function makeConfig(overrides: EnvOverrides = {}): ReturnType<typeof loadConfig> {
   return loadConfig({
@@ -55,7 +57,24 @@ function makeRequest(
 describe("managed Twilio voice webhook skeleton", () => {
   test("returns 202 for valid signed Twilio voice payload", async () => {
     const config = makeConfig();
-    const handler = createManagedGatewayAppFetch(config);
+    const fetchMock: MockedFetch = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          route_id: "17b5e8c3-f07f-42e4-8099-a10af4c3d056",
+          assistant_id: "4a6b3a7f-1f1f-4f5d-b18f-9c0f64baea77",
+          provider: "twilio",
+          route_type: "voice",
+          identity_key: "+15559999999",
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+    const handler = createManagedGatewayAppFetch(config, {
+      fetchImpl: (...args) => fetchMock(...args),
+    });
     const payload = new URLSearchParams({
       From: "+15550000000",
       To: "+15559999999",
@@ -82,12 +101,47 @@ describe("managed Twilio voice webhook skeleton", () => {
       call_status: "ringing",
       from: "+15550000000",
       to: "+15559999999",
+      assistant_id: "4a6b3a7f-1f1f-4f5d-b18f-9c0f64baea77",
+      route_id: "17b5e8c3-f07f-42e4-8099-a10af4c3d056",
+      normalized_event: {
+        version: "v1",
+        sourceChannel: "voice",
+        receivedAt: expect.any(String),
+        message: {
+          content: "",
+          conversationExternalId: "+15550000000",
+          externalMessageId: "CA123",
+        },
+        actor: {
+          actorExternalId: "+15550000000",
+          displayName: "+15550000000",
+        },
+        source: {
+          updateId: "CA123",
+          messageId: "CA123",
+          to: "+15559999999",
+          callStatus: "ringing",
+        },
+        raw: {
+          From: "+15550000000",
+          To: "+15559999999",
+          CallSid: "CA123",
+          CallStatus: "ringing",
+          _to: "+15559999999",
+          _call_status: "ringing",
+        },
+      },
     });
   });
 
   test("returns 400 for invalid webhook payload", async () => {
     const config = makeConfig();
-    const handler = createManagedGatewayAppFetch(config);
+    const fetchMock: MockedFetch = mock(async () => {
+      throw new Error("route resolution should not be called for invalid payload");
+    });
+    const handler = createManagedGatewayAppFetch(config, {
+      fetchImpl: (...args) => fetchMock(...args),
+    });
     const payload = new URLSearchParams({
       From: "+15550000000",
       To: "+15559999999",
@@ -110,11 +164,17 @@ describe("managed Twilio voice webhook skeleton", () => {
         detail: "Invalid managed Twilio voice webhook payload.",
       },
     });
+    expect(fetchMock).toHaveBeenCalledTimes(0);
   });
 
   test("returns 403 for missing Twilio signature", async () => {
     const config = makeConfig();
-    const handler = createManagedGatewayAppFetch(config);
+    const fetchMock: MockedFetch = mock(async () => {
+      throw new Error("route resolution should not be called for missing signature");
+    });
+    const handler = createManagedGatewayAppFetch(config, {
+      fetchImpl: (...args) => fetchMock(...args),
+    });
     const payload = new URLSearchParams({
       From: "+15550000000",
       To: "+15559999999",
@@ -131,11 +191,17 @@ describe("managed Twilio voice webhook skeleton", () => {
         detail: "Missing X-Twilio-Signature header.",
       },
     });
+    expect(fetchMock).toHaveBeenCalledTimes(0);
   });
 
   test("returns 403 for invalid Twilio signature", async () => {
     const config = makeConfig();
-    const handler = createManagedGatewayAppFetch(config);
+    const fetchMock: MockedFetch = mock(async () => {
+      throw new Error("route resolution should not be called for invalid signature");
+    });
+    const handler = createManagedGatewayAppFetch(config, {
+      fetchImpl: (...args) => fetchMock(...args),
+    });
     const payload = new URLSearchParams({
       From: "+15550000000",
       To: "+15559999999",
@@ -154,16 +220,67 @@ describe("managed Twilio voice webhook skeleton", () => {
         detail: "Invalid Twilio request signature.",
       },
     });
+    expect(fetchMock).toHaveBeenCalledTimes(0);
   });
 
   test("returns 405 for unsupported method", async () => {
     const config = makeConfig();
-    const handler = createManagedGatewayAppFetch(config);
+    const fetchMock: MockedFetch = mock(async () => {
+      throw new Error("route resolution should not be called for GET");
+    });
+    const handler = createManagedGatewayAppFetch(config, {
+      fetchImpl: (...args) => fetchMock(...args),
+    });
     const response = await handler(
       makeRequest(new URLSearchParams(), {}, "GET"),
     );
 
     expect(response.status).toBe(405);
     expect(response.headers.get("allow")).toBe("POST");
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
+
+  test("returns 404 when managed route is not found", async () => {
+    const config = makeConfig();
+    const fetchMock: MockedFetch = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          error: {
+            code: "managed_route_not_found",
+            detail: "Managed route not found.",
+          },
+        }),
+        {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+    const handler = createManagedGatewayAppFetch(config, {
+      fetchImpl: (...args) => fetchMock(...args),
+    });
+    const payload = new URLSearchParams({
+      From: "+15550000000",
+      To: "+15559999999",
+      CallSid: "CA127",
+      CallStatus: "completed",
+    });
+    const signature = computeTwilioSignature(
+      `http://managed-gateway.test${MANAGED_TWILIO_VOICE_WEBHOOK_PATH}`,
+      Object.fromEntries(payload),
+      "twilio-current-secret",
+    );
+
+    const response = await handler(makeRequest(payload, {
+      "x-twilio-signature": signature,
+    }));
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "managed_route_not_found",
+        detail: "Managed route not found.",
+      },
+    });
   });
 });

--- a/gateway-managed/src/http.ts
+++ b/gateway-managed/src/http.ts
@@ -97,11 +97,11 @@ export function createManagedGatewayAppFetch(
     }
 
     if (pathname === MANAGED_TWILIO_SMS_WEBHOOK_PATH) {
-      return handleManagedTwilioSmsWebhook(request, config);
+      return handleManagedTwilioSmsWebhook(request, config, dependencies.fetchImpl);
     }
 
     if (pathname === MANAGED_TWILIO_VOICE_WEBHOOK_PATH) {
-      return handleManagedTwilioVoiceWebhook(request, config);
+      return handleManagedTwilioVoiceWebhook(request, config, dependencies.fetchImpl);
     }
 
     return Response.json({ error: "Not found" }, { status: 404 });

--- a/gateway-managed/src/managed-route-resolution-client.ts
+++ b/gateway-managed/src/managed-route-resolution-client.ts
@@ -1,0 +1,241 @@
+import type { ManagedGatewayConfig } from "./config.js";
+import {
+  MANAGED_GATEWAY_ROUTE_RESOLVE_PATH,
+  type ManagedGatewayUpstreamFetch,
+} from "./route-resolve.js";
+
+const ROUTE_RESOLVE_SCOPE = "routes:resolve";
+
+export type ManagedRouteResolution = {
+  routeId: string;
+  assistantId: string;
+  provider: string;
+  routeType: string;
+  identityKey: string;
+};
+
+export type ManagedRouteResolutionResult =
+  | {
+    ok: true;
+    route: ManagedRouteResolution;
+  }
+  | {
+    ok: false;
+    status: number;
+    error: {
+      code: string;
+      detail: string;
+    };
+  };
+
+export async function resolveManagedRoute(
+  config: ManagedGatewayConfig,
+  args: {
+    routeType: "sms" | "voice";
+    identityKey: string;
+    fetchImpl?: ManagedGatewayUpstreamFetch;
+  },
+): Promise<ManagedRouteResolutionResult> {
+  if (!config.djangoInternalBaseUrl) {
+    return {
+      ok: false,
+      status: 503,
+      error: {
+        code: "upstream_unconfigured",
+        detail: "Managed gateway Django internal base URL is not configured.",
+      },
+    };
+  }
+
+  const authHeaders = buildInternalAuthHeaders(config);
+  if (!authHeaders) {
+    return {
+      ok: false,
+      status: 500,
+      error: {
+        code: "internal_auth_unavailable",
+        detail: "No active managed gateway internal auth credentials are available.",
+      },
+    };
+  }
+
+  const fetchFn = args.fetchImpl || fetch;
+  const headers = new Headers(authHeaders);
+  headers.set("content-type", "application/json");
+
+  const upstreamUrl = new URL(
+    MANAGED_GATEWAY_ROUTE_RESOLVE_PATH,
+    config.djangoInternalBaseUrl,
+  ).toString();
+
+  let response: Response;
+  try {
+    response = await fetchFn(upstreamUrl, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        provider: "twilio",
+        route_type: args.routeType,
+        identity_key: args.identityKey,
+      }),
+    });
+  } catch {
+    return {
+      ok: false,
+      status: 502,
+      error: {
+        code: "upstream_unavailable",
+        detail: "Managed route resolver upstream is unavailable.",
+      },
+    };
+  }
+
+  if (response.status === 200) {
+    const payload = await safeJson(response);
+    if (!payload || typeof payload !== "object") {
+      return {
+        ok: false,
+        status: 502,
+        error: {
+          code: "upstream_invalid_response",
+          detail: "Managed route resolver upstream returned an invalid response payload.",
+        },
+      };
+    }
+
+    const routeId = asNonEmptyString(payload.route_id);
+    const assistantId = asNonEmptyString(payload.assistant_id);
+    const provider = asNonEmptyString(payload.provider);
+    const routeType = asNonEmptyString(payload.route_type);
+    const identityKey = asNonEmptyString(payload.identity_key);
+
+    if (!routeId || !assistantId || !provider || !routeType || !identityKey) {
+      return {
+        ok: false,
+        status: 502,
+        error: {
+          code: "upstream_invalid_response",
+          detail: "Managed route resolver upstream returned an invalid response payload.",
+        },
+      };
+    }
+
+    return {
+      ok: true,
+      route: {
+        routeId,
+        assistantId,
+        provider,
+        routeType,
+        identityKey,
+      },
+    };
+  }
+
+  const payload = await safeJson(response);
+  const errorPayload = asRecord(payload?.error);
+  const detail = asNonEmptyString(errorPayload?.detail)
+    || asNonEmptyString(payload?.detail)
+    || `Managed route resolver upstream returned status ${response.status}.`;
+  const code = asNonEmptyString(errorPayload?.code)
+    || (response.status === 404 ? "managed_route_not_found" : "upstream_error");
+
+  if (response.status === 400 || response.status === 401 || response.status === 404) {
+    return {
+      ok: false,
+      status: response.status,
+      error: { code, detail },
+    };
+  }
+
+  return {
+    ok: false,
+    status: 502,
+    error: {
+      code: "upstream_error",
+      detail,
+    },
+  };
+}
+
+async function safeJson(response: Response): Promise<Record<string, unknown> | null> {
+  try {
+    const parsed = await response.json();
+    if (typeof parsed === "object" && parsed !== null) {
+      return parsed as Record<string, unknown>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function buildInternalAuthHeaders(config: ManagedGatewayConfig): Headers | null {
+  if (config.internalAuth.mode === "bearer") {
+    const tokenValue = selectActiveInternalBearerToken(config);
+    if (!tokenValue) {
+      return null;
+    }
+
+    return new Headers({
+      authorization: `Bearer ${tokenValue}`,
+    });
+  }
+
+  const principal = config.internalAuth.mtlsPrincipals.values().next().value as
+    | string
+    | undefined;
+  if (!principal) {
+    return null;
+  }
+
+  return new Headers({
+    [config.internalAuth.mtlsPrincipalHeader]: principal,
+    [config.internalAuth.mtlsAudienceHeader]: config.internalAuth.audience,
+    [config.internalAuth.mtlsScopesHeader]: ROUTE_RESOLVE_SCOPE,
+  });
+}
+
+function selectActiveInternalBearerToken(
+  config: ManagedGatewayConfig,
+  nowMs: number = Date.now(),
+): string | null {
+  for (const [tokenValue, metadata] of Object.entries(config.internalAuth.bearerTokens)) {
+    if (metadata.revoked || config.internalAuth.revokedTokenIds.has(metadata.tokenId)) {
+      continue;
+    }
+
+    if (metadata.expiresAt) {
+      const expiresAt = Date.parse(metadata.expiresAt);
+      if (Number.isNaN(expiresAt) || expiresAt <= nowMs) {
+        continue;
+      }
+    }
+
+    if (
+      metadata.audience !== config.internalAuth.audience
+      || !metadata.scopes.includes(ROUTE_RESOLVE_SCOPE)
+    ) {
+      continue;
+    }
+
+    return tokenValue;
+  }
+
+  return null;
+}

--- a/gateway-managed/src/managed-twilio-sms-webhook.ts
+++ b/gateway-managed/src/managed-twilio-sms-webhook.ts
@@ -1,4 +1,9 @@
 import type { ManagedGatewayConfig } from "./config.js";
+import {
+  resolveManagedRoute,
+  type ManagedRouteResolutionResult,
+} from "./managed-route-resolution-client.js";
+import type { ManagedGatewayUpstreamFetch } from "./route-resolve.js";
 import { normalizeManagedTwilioSmsPayload } from "./twilio-normalize.js";
 import { validateManagedTwilioSignature } from "./twilio-signature.js";
 
@@ -14,6 +19,7 @@ type ManagedTwilioSmsPayload = {
 export async function handleManagedTwilioSmsWebhook(
   request: Request,
   config: ManagedGatewayConfig,
+  fetchImpl?: ManagedGatewayUpstreamFetch,
 ): Promise<Response> {
   if (request.method !== "POST") {
     return Response.json(
@@ -76,10 +82,15 @@ export async function handleManagedTwilioSmsWebhook(
     );
   }
 
-  // Build normalized shared event shape now so follow-up PRs can attach
-  // route resolution and dispatch without changing this endpoint contract.
-  const _normalizedEvent = normalizeManagedTwilioSmsPayload(toRecord(params));
-  void _normalizedEvent;
+  const normalizedEvent = normalizeManagedTwilioSmsPayload(toRecord(params));
+  const routeResolution = await resolveManagedRoute(config, {
+    routeType: "sms",
+    identityKey: payload.to,
+    fetchImpl,
+  });
+  if (!routeResolution.ok) {
+    return routeResolutionErrorResponse(routeResolution);
+  }
 
   return Response.json(
     {
@@ -91,6 +102,9 @@ export async function handleManagedTwilioSmsWebhook(
       from: payload.from,
       to: payload.to,
       body: payload.body,
+      assistant_id: routeResolution.route.assistantId,
+      route_id: routeResolution.route.routeId,
+      normalized_event: normalizedEvent,
     },
     { status: 202 },
   );
@@ -120,4 +134,18 @@ function toRecord(params: URLSearchParams): Record<string, string> {
     record[key] = value;
   }
   return record;
+}
+
+function routeResolutionErrorResponse(
+  result: Extract<ManagedRouteResolutionResult, { ok: false }>,
+): Response {
+  return Response.json(
+    {
+      error: {
+        code: result.error.code,
+        detail: result.error.detail,
+      },
+    },
+    { status: result.status },
+  );
 }

--- a/gateway-managed/src/managed-twilio-voice-webhook.ts
+++ b/gateway-managed/src/managed-twilio-voice-webhook.ts
@@ -1,4 +1,9 @@
 import type { ManagedGatewayConfig } from "./config.js";
+import {
+  resolveManagedRoute,
+  type ManagedRouteResolutionResult,
+} from "./managed-route-resolution-client.js";
+import type { ManagedGatewayUpstreamFetch } from "./route-resolve.js";
 import { normalizeManagedTwilioVoicePayload } from "./twilio-normalize.js";
 import { validateManagedTwilioSignature } from "./twilio-signature.js";
 
@@ -14,6 +19,7 @@ type ManagedTwilioVoicePayload = {
 export async function handleManagedTwilioVoiceWebhook(
   request: Request,
   config: ManagedGatewayConfig,
+  fetchImpl?: ManagedGatewayUpstreamFetch,
 ): Promise<Response> {
   if (request.method !== "POST") {
     return Response.json(
@@ -76,10 +82,15 @@ export async function handleManagedTwilioVoiceWebhook(
     );
   }
 
-  // Build normalized shared event shape now so follow-up PRs can attach
-  // route resolution and dispatch without changing this endpoint contract.
-  const _normalizedEvent = normalizeManagedTwilioVoicePayload(toRecord(params));
-  void _normalizedEvent;
+  const normalizedEvent = normalizeManagedTwilioVoicePayload(toRecord(params));
+  const routeResolution = await resolveManagedRoute(config, {
+    routeType: "voice",
+    identityKey: payload.to,
+    fetchImpl,
+  });
+  if (!routeResolution.ok) {
+    return routeResolutionErrorResponse(routeResolution);
+  }
 
   return Response.json(
     {
@@ -91,6 +102,9 @@ export async function handleManagedTwilioVoiceWebhook(
       call_status: payload.callStatus,
       from: payload.from,
       to: payload.to,
+      assistant_id: routeResolution.route.assistantId,
+      route_id: routeResolution.route.routeId,
+      normalized_event: normalizedEvent,
     },
     { status: 202 },
   );
@@ -120,4 +134,18 @@ function toRecord(params: URLSearchParams): Record<string, string> {
     record[key] = value;
   }
   return record;
+}
+
+function routeResolutionErrorResponse(
+  result: Extract<ManagedRouteResolutionResult, { ok: false }>,
+): Response {
+  return Response.json(
+    {
+      error: {
+        code: result.error.code,
+        detail: result.error.detail,
+      },
+    },
+    { status: result.status },
+  );
 }


### PR DESCRIPTION
## Summary
- add managed route-resolution client that calls Django internal `/v1/internal/managed-gateway/routes/resolve/`
- wire SMS and voice webhook handlers to resolve `To` phone numbers to `assistant_id`/`route_id` before acceptance
- propagate explicit route-resolution errors (including 404 managed route misses)
- add focused route-resolution client tests plus updated webhook contract tests

## Validation
- cd gateway-managed && bun run typecheck
- cd gateway-managed && bun run build
- cd gateway-managed && bun run test

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
