### PR TITLE
fix: transcript parity for deterministic post-approval voice handoff

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -2267,9 +2267,10 @@ describe('relay-server', () => {
     // Verify no provider (LLM) call was made as part of the approval handoff
     expect(mockSendMessage.mock.calls.length).toBe(providerCallCountBefore);
 
-    // Verify events
+    // Verify events — including assistant_spoke for transcript parity
     const events = getCallEvents(session.id);
     expect(events.some((e) => e.eventType === 'inbound_acl_access_approved')).toBe(true);
+    expect(events.some((e) => e.eventType === 'assistant_spoke')).toBe(true);
     expect(events.some((e) => e.eventType === 'inbound_acl_post_approval_handoff_spoken')).toBe(true);
 
     // Session should be in_progress

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -1334,10 +1334,18 @@ export class RelayConnection {
     // routing through handleUserInstruction, which would start a fresh
     // model turn and risk reintroduction/disclosure reset.
     const guardianLabel = this.resolveGuardianLabel();
-    this.sendTextToken(
-      `Great! ${guardianLabel} said I can speak with you. How can I help?`,
-      true,
-    );
+    const handoffText = `Great! ${guardianLabel} said I can speak with you. How can I help?`;
+    this.sendTextToken(handoffText, true);
+
+    // Record the deterministic handoff as an assistant_spoke event and
+    // fire the transcript notifier so it appears in conversation history
+    // and real-time transcript subscribers — matching the parity of text
+    // spoken through the normal runTurn() pipeline.
+    recordCallEvent(this.callSessionId, 'assistant_spoke', { text: handoffText });
+    const session = getCallSession(this.callSessionId);
+    if (session) {
+      fireCallTranscriptNotifier(session.conversationId, this.callSessionId, 'assistant', handoffText);
+    }
 
     recordCallEvent(this.callSessionId, 'inbound_acl_post_approval_handoff_spoken', {
       from: fromNumber,


### PR DESCRIPTION
## Summary
- Emit `assistant_spoke` call event for the deterministic post-approval handoff text so it appears in call event history
- Fire `fireCallTranscriptNotifier` so real-time transcript subscribers see the handoff text
- Add test assertion verifying `assistant_spoke` event is recorded on approval

Follow-up to #11082 — addresses the P3 transcript parity gap noted in the Devin review.

## Original prompt
address the P3 in https://github.com/vellum-ai/vellum-assistant/pull/11082#issuecomment-3980659879 as a follow up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11097" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
