### PR TITLE
Dispatch managed Twilio inbound webhooks via Django path

### DIFF
--- a/gateway-managed/.env.example
+++ b/gateway-managed/.env.example
@@ -7,7 +7,7 @@ MANAGED_GATEWAY_STRICT_STARTUP_VALIDATION=true
 MANAGED_GATEWAY_INTERNAL_AUTH_MODE=bearer
 MANAGED_GATEWAY_INTERNAL_AUTH_AUDIENCE=managed-gateway-internal
 # Example:
-# {"token-current":{"token_id":"mgw-2026-01","principal":"managed-gateway-staging","audience":"managed-gateway-internal","scopes":["managed-gateway:internal","routes:resolve"],"expires_at":"2026-12-31T23:59:59Z"}}
+# {"token-current":{"token_id":"mgw-2026-01","principal":"managed-gateway-staging","audience":"managed-gateway-internal","scopes":["managed-gateway:internal","routes:resolve","events:dispatch"],"expires_at":"2026-12-31T23:59:59Z"}}
 MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS={}
 MANAGED_GATEWAY_INTERNAL_REVOKED_TOKEN_IDS=
 MANAGED_GATEWAY_INTERNAL_MTLS_PRINCIPALS=

--- a/gateway-managed/ARCHITECTURE.md
+++ b/gateway-managed/ARCHITECTURE.md
@@ -61,6 +61,12 @@ The managed gateway is a dedicated service lane for Vellum-owned shared channel 
 - Wires SMS and voice webhook handlers to resolve managed routes before returning accepted stubs.
 - Surfaces explicit 404/4xx route-resolution envelopes without dispatching to runtime yet.
 
+## P07 PR-6 scope
+
+- Adds managed inbound dispatch client to call Django internal dispatch endpoint after route resolution.
+- Wires SMS and voice webhook handlers to forward normalized events through Django -> vembda -> runtime.
+- Surfaces explicit dispatch upstream error envelopes while preserving fail-closed route ownership checks.
+
 ## Endpoints
 
 - `GET /healthz`
@@ -68,5 +74,6 @@ The managed gateway is a dedicated service lane for Vellum-owned shared channel 
 - `GET /v1/internal/managed-gateway/healthz/`
 - `GET /v1/internal/managed-gateway/readyz/`
 - `POST /v1/internal/managed-gateway/routes/resolve/`
+- `POST /v1/internal/managed-gateway/inbound/dispatch/`
 - `POST /webhooks/twilio/sms`
 - `POST /webhooks/twilio/voice`

--- a/gateway-managed/README.md
+++ b/gateway-managed/README.md
@@ -14,6 +14,7 @@ Managed gateway service skeleton for Vellum-owned shared channel identities.
 - managed Twilio voice webhook endpoint skeleton with explicit auth/validation envelopes
 - shared inbound event normalization for managed Twilio SMS and voice payloads
 - managed route-resolution call (`phone -> assistant_id`) to Django before webhook acceptance
+- managed inbound dispatch call (`route -> Django -> vembda -> runtime`) after route resolution
 - health and readiness endpoints:
   - `/healthz`
   - `/readyz`
@@ -21,6 +22,8 @@ Managed gateway service skeleton for Vellum-owned shared channel identities.
   - `/v1/internal/managed-gateway/readyz/`
 - route resolve endpoint:
   - `POST /v1/internal/managed-gateway/routes/resolve/`
+- inbound dispatch endpoint:
+  - `POST /v1/internal/managed-gateway/inbound/dispatch/`
 - Twilio inbound endpoint:
   - `POST /webhooks/twilio/sms`
   - `POST /webhooks/twilio/voice`
@@ -71,6 +74,10 @@ bun run test
 
 Managed gateway route resolution contract lives in [`route-resolve-contract.md`](./route-resolve-contract.md).
 
+## Inbound Dispatch Contract
+
+Managed gateway inbound dispatch contract lives in [`inbound-dispatch-contract.md`](./inbound-dispatch-contract.md).
+
 ## Managed Twilio SMS Webhook Contract
 
 Managed Twilio SMS webhook contract lives in [`managed-twilio-sms-webhook-contract.md`](./managed-twilio-sms-webhook-contract.md).
@@ -81,7 +88,7 @@ Managed Twilio voice webhook contract lives in [`managed-twilio-voice-webhook-co
 
 ## Managed Inbound Event Shape
 
-Managed Twilio payloads normalize into a shared internal event shape before route-resolution/dispatch wiring. Current normalizers live in `src/twilio-normalize.ts`.
+Managed Twilio payloads normalize into a shared internal event shape before route-resolution and managed dispatch forwarding. Current normalizers live in `src/twilio-normalize.ts`.
 
 ## Staging Deployment Artifacts
 

--- a/gateway-managed/inbound-dispatch-contract.md
+++ b/gateway-managed/inbound-dispatch-contract.md
@@ -1,0 +1,20 @@
+# Managed Gateway Inbound Dispatch Contract
+
+Endpoint: `POST /v1/internal/managed-gateway/inbound/dispatch/`
+
+Caller expectations:
+- caller is an internal Vellum-managed gateway client only
+- request body includes `route_id`, `assistant_id`, and `normalized_event`
+- caller retries only on transport-level failures; 4xx responses are terminal
+
+Authz boundary:
+- requires managed gateway internal auth middleware (`bearer` or `mtls`)
+- requires `events:dispatch` scope
+- requires audience match to `MANAGED_GATEWAY_INTERNAL_AUTH_AUDIENCE`
+
+Response contract:
+- `202`: accepted dispatch envelope with `route_id`, `assistant_id`, optional `event_id`, and optional `duplicate`
+- `400`: error envelope (`validation_error`) for invalid payloads
+- `401`: error envelope for internal auth failure
+- `404`: pass-through error envelope (`managed_route_not_found`) from Django route ownership checks
+- `502`: error envelope for upstream transport or unexpected upstream status failures

--- a/gateway-managed/managed-twilio-sms-webhook-contract.md
+++ b/gateway-managed/managed-twilio-sms-webhook-contract.md
@@ -13,8 +13,9 @@ Authz boundary:
 - revoked or expired Twilio tokens are rejected
 
 Response contract:
-- `202`: accepted stub envelope for managed SMS webhook path, including resolved `assistant_id` and `route_id`
+- `202`: accepted dispatch envelope for managed SMS webhook path, including resolved route metadata and dispatch receipt
 - `400`: validation error envelope (`validation_error`) for malformed payloads
 - `403`: auth failure envelope for missing/invalid signatures
 - `404`: route resolution error envelope when managed route mapping is missing
+- `502`: dispatch upstream error envelope when Django/vembda/runtime forwarding fails
 - `405`: method-not-allowed envelope for non-POST methods

--- a/gateway-managed/managed-twilio-voice-webhook-contract.md
+++ b/gateway-managed/managed-twilio-voice-webhook-contract.md
@@ -13,8 +13,9 @@ Authz boundary:
 - revoked or expired Twilio tokens are rejected
 
 Response contract:
-- `202`: accepted stub envelope for managed voice webhook path, including resolved `assistant_id` and `route_id`
+- `202`: accepted dispatch envelope for managed voice webhook path, including resolved route metadata and dispatch receipt
 - `400`: validation error envelope (`validation_error`) for malformed payloads
 - `403`: auth failure envelope for missing/invalid signatures
 - `404`: route resolution error envelope when managed route mapping is missing
+- `502`: dispatch upstream error envelope when Django/vembda/runtime forwarding fails
 - `405`: method-not-allowed envelope for non-POST methods

--- a/gateway-managed/route-resolve-contract.md
+++ b/gateway-managed/route-resolve-contract.md
@@ -23,3 +23,6 @@ Response contract:
 - `401`: error envelope for internal auth failure
 - `404`: pass-through error envelope (`managed_route_not_found`) from Django
 - `502`: error envelope for upstream transport or unexpected upstream status failures
+
+Related contract:
+- inbound dispatch: [`inbound-dispatch-contract.md`](./inbound-dispatch-contract.md)

--- a/gateway-managed/src/__tests__/managed-inbound-dispatch-client.test.ts
+++ b/gateway-managed/src/__tests__/managed-inbound-dispatch-client.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { loadConfig } from "../config.js";
+import {
+  dispatchManagedInboundEvent,
+} from "../managed-inbound-dispatch-client.js";
+import type { ManagedGatewayUpstreamFetch } from "../route-resolve.js";
+
+const FAR_FUTURE = "2099-01-01T00:00:00.000Z";
+
+type EnvOverrides = Record<string, string | undefined>;
+type MockedFetch = ReturnType<typeof mock<ManagedGatewayUpstreamFetch>>;
+
+function makeConfig(overrides: EnvOverrides = {}): ReturnType<typeof loadConfig> {
+  return loadConfig({
+    ...process.env,
+    MANAGED_GATEWAY_ENABLED: "true",
+    MANAGED_GATEWAY_STRICT_STARTUP_VALIDATION: "true",
+    MANAGED_GATEWAY_DJANGO_INTERNAL_BASE_URL: "http://127.0.0.1:8000",
+    MANAGED_GATEWAY_INTERNAL_AUTH_MODE: "bearer",
+    MANAGED_GATEWAY_INTERNAL_AUTH_AUDIENCE: "managed-gateway-internal",
+    MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS: JSON.stringify({
+      "token-active": {
+        token_id: "mgw-2026-01",
+        principal: "managed-gateway-staging",
+        audience: "managed-gateway-internal",
+        scopes: ["managed-gateway:internal", "routes:resolve", "events:dispatch"],
+        expires_at: FAR_FUTURE,
+      },
+    }),
+    MANAGED_GATEWAY_INTERNAL_REVOKED_TOKEN_IDS: "",
+    MANAGED_GATEWAY_INTERNAL_MTLS_PRINCIPALS: "managed-gateway-staging",
+    MANAGED_GATEWAY_MTLS_PRINCIPAL_HEADER: "x-managed-gateway-principal",
+    MANAGED_GATEWAY_MTLS_AUDIENCE_HEADER: "x-managed-gateway-audience",
+    MANAGED_GATEWAY_MTLS_SCOPES_HEADER: "x-managed-gateway-scopes",
+    MANAGED_GATEWAY_TWILIO_AUTH_TOKENS: JSON.stringify({
+      "twilio-current": {
+        token_id: "twilio-2026-01",
+        auth_token: "twilio-current-secret",
+        expires_at: FAR_FUTURE,
+      },
+    }),
+    ...overrides,
+  });
+}
+
+describe("managed inbound dispatch client", () => {
+  test("dispatches normalized event via Django internal endpoint using bearer auth", async () => {
+    let capturedUrl = "";
+    let capturedInit: RequestInit | undefined;
+    const fetchMock: MockedFetch = mock(async (input, init) => {
+      capturedUrl = String(input);
+      capturedInit = init;
+      return new Response(
+        JSON.stringify({
+          status: "accepted",
+          route_id: "87c8dd8f-1f92-45c4-a524-126cf59fd760",
+          assistant_id: "8aa67431-9f28-40c0-98a5-e49d83bd15ab",
+          event_id: "evt_123",
+          duplicate: false,
+        }),
+        {
+          status: 202,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+    const config = makeConfig();
+
+    const result = await dispatchManagedInboundEvent(config, {
+      route: {
+        routeId: "87c8dd8f-1f92-45c4-a524-126cf59fd760",
+        assistantId: "8aa67431-9f28-40c0-98a5-e49d83bd15ab",
+        provider: "twilio",
+        routeType: "sms",
+        identityKey: "+15559999999",
+      },
+      normalizedEvent: {
+        version: "v1",
+        sourceChannel: "sms",
+        receivedAt: "2026-03-01T00:00:00Z",
+        message: {
+          content: "hello from managed lane",
+          conversationExternalId: "+15550000000",
+          externalMessageId: "SM123",
+        },
+        actor: {
+          actorExternalId: "+15550000000",
+          displayName: "+15550000000",
+        },
+        source: {
+          updateId: "SM123",
+          messageId: "SM123",
+        },
+        raw: {
+          Body: "hello from managed lane",
+          From: "+15550000000",
+          To: "+15559999999",
+          MessageSid: "SM123",
+        },
+      },
+      fetchImpl: (...args) => fetchMock(...args),
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      dispatch: {
+        status: "accepted",
+        routeId: "87c8dd8f-1f92-45c4-a524-126cf59fd760",
+        assistantId: "8aa67431-9f28-40c0-98a5-e49d83bd15ab",
+        eventId: "evt_123",
+        duplicate: false,
+      },
+    });
+    expect(capturedUrl).toBe("http://127.0.0.1:8000/v1/internal/managed-gateway/inbound/dispatch/");
+    expect(capturedInit?.method).toBe("POST");
+
+    const requestBody = JSON.parse(capturedInit?.body as string) as Record<string, unknown>;
+    expect(requestBody.route_id).toBe("87c8dd8f-1f92-45c4-a524-126cf59fd760");
+    expect(requestBody.assistant_id).toBe("8aa67431-9f28-40c0-98a5-e49d83bd15ab");
+    expect(requestBody.normalized_event).toBeDefined();
+
+    const headers = capturedInit?.headers as Headers;
+    expect(headers.get("authorization")).toBe("Bearer token-active");
+    expect(headers.get("content-type")).toBe("application/json");
+  });
+
+  test("uses mTLS headers when configured in mTLS mode", async () => {
+    let capturedInit: RequestInit | undefined;
+    const fetchMock: MockedFetch = mock(async (_input, init) => {
+      capturedInit = init;
+      return new Response(
+        JSON.stringify({
+          status: "accepted",
+          route_id: "17b5e8c3-f07f-42e4-8099-a10af4c3d056",
+          assistant_id: "4a6b3a7f-1f1f-4f5d-b18f-9c0f64baea77",
+          duplicate: true,
+        }),
+        {
+          status: 202,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+    const config = makeConfig({
+      MANAGED_GATEWAY_INTERNAL_AUTH_MODE: "mtls",
+      MANAGED_GATEWAY_INTERNAL_MTLS_PRINCIPALS: "managed-gateway-staging",
+    });
+
+    const result = await dispatchManagedInboundEvent(config, {
+      route: {
+        routeId: "17b5e8c3-f07f-42e4-8099-a10af4c3d056",
+        assistantId: "4a6b3a7f-1f1f-4f5d-b18f-9c0f64baea77",
+        provider: "twilio",
+        routeType: "voice",
+        identityKey: "+15559999999",
+      },
+      normalizedEvent: {
+        version: "v1",
+        sourceChannel: "voice",
+        receivedAt: "2026-03-01T00:00:00Z",
+        message: {
+          content: "",
+          conversationExternalId: "+15550000000",
+          externalMessageId: "CA123",
+        },
+        actor: {
+          actorExternalId: "+15550000000",
+          displayName: "+15550000000",
+        },
+        source: {
+          updateId: "CA123",
+          messageId: "CA123",
+        },
+        raw: {
+          CallSid: "CA123",
+          From: "+15550000000",
+          To: "+15559999999",
+          CallStatus: "ringing",
+        },
+      },
+      fetchImpl: (...args) => fetchMock(...args),
+    });
+
+    expect(result.ok).toBe(true);
+    const headers = capturedInit?.headers as Headers;
+    expect(headers.get("authorization")).toBeNull();
+    expect(headers.get("x-managed-gateway-principal")).toBe("managed-gateway-staging");
+    expect(headers.get("x-managed-gateway-audience")).toBe("managed-gateway-internal");
+    expect(headers.get("x-managed-gateway-scopes")).toBe("events:dispatch");
+  });
+
+  test("returns 404 when upstream route is missing", async () => {
+    const fetchMock: MockedFetch = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          error: {
+            code: "managed_route_not_found",
+            detail: "Managed route not found.",
+          },
+        }),
+        {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+    const config = makeConfig();
+
+    const result = await dispatchManagedInboundEvent(config, {
+      route: {
+        routeId: "87c8dd8f-1f92-45c4-a524-126cf59fd760",
+        assistantId: "8aa67431-9f28-40c0-98a5-e49d83bd15ab",
+        provider: "twilio",
+        routeType: "sms",
+        identityKey: "+15559999999",
+      },
+      normalizedEvent: {
+        version: "v1",
+        sourceChannel: "sms",
+        receivedAt: "2026-03-01T00:00:00Z",
+        message: {
+          content: "hello from managed lane",
+          conversationExternalId: "+15550000000",
+          externalMessageId: "SM123",
+        },
+        actor: {
+          actorExternalId: "+15550000000",
+          displayName: "+15550000000",
+        },
+        source: {
+          updateId: "SM123",
+          messageId: "SM123",
+        },
+        raw: {
+          Body: "hello from managed lane",
+          From: "+15550000000",
+          To: "+15559999999",
+          MessageSid: "SM123",
+        },
+      },
+      fetchImpl: (...args) => fetchMock(...args),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 404,
+      error: {
+        code: "managed_route_not_found",
+        detail: "Managed route not found.",
+      },
+    });
+  });
+
+  test("returns internal auth unavailable when no active bearer credentials exist", async () => {
+    const config = makeConfig({
+      MANAGED_GATEWAY_STRICT_STARTUP_VALIDATION: "false",
+      MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS: "{}",
+    });
+
+    const result = await dispatchManagedInboundEvent(config, {
+      route: {
+        routeId: "87c8dd8f-1f92-45c4-a524-126cf59fd760",
+        assistantId: "8aa67431-9f28-40c0-98a5-e49d83bd15ab",
+        provider: "twilio",
+        routeType: "sms",
+        identityKey: "+15559999999",
+      },
+      normalizedEvent: {
+        version: "v1",
+        sourceChannel: "sms",
+        receivedAt: "2026-03-01T00:00:00Z",
+        message: {
+          content: "hello from managed lane",
+          conversationExternalId: "+15550000000",
+          externalMessageId: "SM123",
+        },
+        actor: {
+          actorExternalId: "+15550000000",
+          displayName: "+15550000000",
+        },
+        source: {
+          updateId: "SM123",
+          messageId: "SM123",
+        },
+        raw: {
+          Body: "hello from managed lane",
+          From: "+15550000000",
+          To: "+15559999999",
+          MessageSid: "SM123",
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 500,
+      error: {
+        code: "internal_auth_unavailable",
+        detail: "No active managed gateway internal auth credentials are available.",
+      },
+    });
+  });
+});

--- a/gateway-managed/src/__tests__/managed-twilio-sms-webhook.test.ts
+++ b/gateway-managed/src/__tests__/managed-twilio-sms-webhook.test.ts
@@ -24,7 +24,7 @@ function makeConfig(overrides: EnvOverrides = {}): ReturnType<typeof loadConfig>
         token_id: "mgw-2026-01",
         principal: "managed-gateway-staging",
         audience: "managed-gateway-internal",
-        scopes: ["managed-gateway:internal", "routes:resolve"],
+        scopes: ["managed-gateway:internal", "routes:resolve", "events:dispatch"],
         expires_at: FAR_FUTURE,
       },
     }),
@@ -57,20 +57,42 @@ function makeRequest(
 describe("managed Twilio SMS webhook skeleton", () => {
   test("returns 202 for valid signed Twilio SMS payload", async () => {
     const config = makeConfig();
+    let callCount = 0;
     const fetchMock: MockedFetch = mock(async () => {
-      return new Response(
-        JSON.stringify({
-          route_id: "87c8dd8f-1f92-45c4-a524-126cf59fd760",
-          assistant_id: "8aa67431-9f28-40c0-98a5-e49d83bd15ab",
-          provider: "twilio",
-          route_type: "sms",
-          identity_key: "+15559999999",
-        }),
-        {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        },
-      );
+      callCount += 1;
+      if (callCount === 1) {
+        return new Response(
+          JSON.stringify({
+            route_id: "87c8dd8f-1f92-45c4-a524-126cf59fd760",
+            assistant_id: "8aa67431-9f28-40c0-98a5-e49d83bd15ab",
+            provider: "twilio",
+            route_type: "sms",
+            identity_key: "+15559999999",
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+
+      if (callCount === 2) {
+        return new Response(
+          JSON.stringify({
+            status: "accepted",
+            route_id: "87c8dd8f-1f92-45c4-a524-126cf59fd760",
+            assistant_id: "8aa67431-9f28-40c0-98a5-e49d83bd15ab",
+            event_id: "evt_123",
+            duplicate: false,
+          }),
+          {
+            status: 202,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+
+      throw new Error(`unexpected upstream call #${callCount}`);
     });
     const handler = createManagedGatewayAppFetch(config, {
       fetchImpl: (...args) => fetchMock(...args),
@@ -94,7 +116,7 @@ describe("managed Twilio SMS webhook skeleton", () => {
     expect(response.status).toBe(202);
     expect(await response.json()).toEqual({
       status: "accepted",
-      code: "managed_sms_webhook_stub",
+      code: "managed_sms_webhook_dispatched",
       provider: "twilio",
       route_type: "sms",
       message_sid: "SM123",
@@ -129,7 +151,13 @@ describe("managed Twilio SMS webhook skeleton", () => {
           _to: "+15559999999",
         },
       },
+      dispatch: {
+        status: "accepted",
+        event_id: "evt_123",
+        duplicate: false,
+      },
     });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   test("returns 400 for invalid webhook payload", async () => {
@@ -280,5 +308,68 @@ describe("managed Twilio SMS webhook skeleton", () => {
         detail: "Managed route not found.",
       },
     });
+  });
+
+  test("returns 502 when dispatch upstream fails", async () => {
+    const config = makeConfig();
+    let callCount = 0;
+    const fetchMock: MockedFetch = mock(async () => {
+      callCount += 1;
+      if (callCount === 1) {
+        return new Response(
+          JSON.stringify({
+            route_id: "87c8dd8f-1f92-45c4-a524-126cf59fd760",
+            assistant_id: "8aa67431-9f28-40c0-98a5-e49d83bd15ab",
+            provider: "twilio",
+            route_type: "sms",
+            identity_key: "+15559999999",
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          error: {
+            code: "upstream_error",
+            detail: "runtime unavailable",
+          },
+        }),
+        {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+    const handler = createManagedGatewayAppFetch(config, {
+      fetchImpl: (...args) => fetchMock(...args),
+    });
+    const payload = new URLSearchParams({
+      From: "+15550000000",
+      To: "+15559999999",
+      Body: "hello",
+      MessageSid: "SM127",
+    });
+    const signature = computeTwilioSignature(
+      `http://managed-gateway.test${MANAGED_TWILIO_SMS_WEBHOOK_PATH}`,
+      Object.fromEntries(payload),
+      "twilio-current-secret",
+    );
+
+    const response = await handler(makeRequest(payload, {
+      "x-twilio-signature": signature,
+    }));
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "upstream_error",
+        detail: "runtime unavailable",
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/gateway-managed/src/__tests__/managed-twilio-voice-webhook.test.ts
+++ b/gateway-managed/src/__tests__/managed-twilio-voice-webhook.test.ts
@@ -24,7 +24,7 @@ function makeConfig(overrides: EnvOverrides = {}): ReturnType<typeof loadConfig>
         token_id: "mgw-2026-01",
         principal: "managed-gateway-staging",
         audience: "managed-gateway-internal",
-        scopes: ["managed-gateway:internal", "routes:resolve"],
+        scopes: ["managed-gateway:internal", "routes:resolve", "events:dispatch"],
         expires_at: FAR_FUTURE,
       },
     }),
@@ -57,20 +57,42 @@ function makeRequest(
 describe("managed Twilio voice webhook skeleton", () => {
   test("returns 202 for valid signed Twilio voice payload", async () => {
     const config = makeConfig();
+    let callCount = 0;
     const fetchMock: MockedFetch = mock(async () => {
-      return new Response(
-        JSON.stringify({
-          route_id: "17b5e8c3-f07f-42e4-8099-a10af4c3d056",
-          assistant_id: "4a6b3a7f-1f1f-4f5d-b18f-9c0f64baea77",
-          provider: "twilio",
-          route_type: "voice",
-          identity_key: "+15559999999",
-        }),
-        {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        },
-      );
+      callCount += 1;
+      if (callCount === 1) {
+        return new Response(
+          JSON.stringify({
+            route_id: "17b5e8c3-f07f-42e4-8099-a10af4c3d056",
+            assistant_id: "4a6b3a7f-1f1f-4f5d-b18f-9c0f64baea77",
+            provider: "twilio",
+            route_type: "voice",
+            identity_key: "+15559999999",
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+
+      if (callCount === 2) {
+        return new Response(
+          JSON.stringify({
+            status: "accepted",
+            route_id: "17b5e8c3-f07f-42e4-8099-a10af4c3d056",
+            assistant_id: "4a6b3a7f-1f1f-4f5d-b18f-9c0f64baea77",
+            event_id: "evt_456",
+            duplicate: true,
+          }),
+          {
+            status: 202,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+
+      throw new Error(`unexpected upstream call #${callCount}`);
     });
     const handler = createManagedGatewayAppFetch(config, {
       fetchImpl: (...args) => fetchMock(...args),
@@ -94,7 +116,7 @@ describe("managed Twilio voice webhook skeleton", () => {
     expect(response.status).toBe(202);
     expect(await response.json()).toEqual({
       status: "accepted",
-      code: "managed_voice_webhook_stub",
+      code: "managed_voice_webhook_dispatched",
       provider: "twilio",
       route_type: "voice",
       call_sid: "CA123",
@@ -131,7 +153,13 @@ describe("managed Twilio voice webhook skeleton", () => {
           _call_status: "ringing",
         },
       },
+      dispatch: {
+        status: "accepted",
+        event_id: "evt_456",
+        duplicate: true,
+      },
     });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   test("returns 400 for invalid webhook payload", async () => {
@@ -282,5 +310,68 @@ describe("managed Twilio voice webhook skeleton", () => {
         detail: "Managed route not found.",
       },
     });
+  });
+
+  test("returns 502 when dispatch upstream fails", async () => {
+    const config = makeConfig();
+    let callCount = 0;
+    const fetchMock: MockedFetch = mock(async () => {
+      callCount += 1;
+      if (callCount === 1) {
+        return new Response(
+          JSON.stringify({
+            route_id: "17b5e8c3-f07f-42e4-8099-a10af4c3d056",
+            assistant_id: "4a6b3a7f-1f1f-4f5d-b18f-9c0f64baea77",
+            provider: "twilio",
+            route_type: "voice",
+            identity_key: "+15559999999",
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          error: {
+            code: "upstream_error",
+            detail: "runtime unavailable",
+          },
+        }),
+        {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+    const handler = createManagedGatewayAppFetch(config, {
+      fetchImpl: (...args) => fetchMock(...args),
+    });
+    const payload = new URLSearchParams({
+      From: "+15550000000",
+      To: "+15559999999",
+      CallSid: "CA128",
+      CallStatus: "completed",
+    });
+    const signature = computeTwilioSignature(
+      `http://managed-gateway.test${MANAGED_TWILIO_VOICE_WEBHOOK_PATH}`,
+      Object.fromEntries(payload),
+      "twilio-current-secret",
+    );
+
+    const response = await handler(makeRequest(payload, {
+      "x-twilio-signature": signature,
+    }));
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "upstream_error",
+        detail: "runtime unavailable",
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/gateway-managed/src/managed-inbound-dispatch-client.ts
+++ b/gateway-managed/src/managed-inbound-dispatch-client.ts
@@ -1,24 +1,24 @@
 import type { ManagedGatewayConfig } from "./config.js";
+import type { ManagedGatewayInboundEvent } from "./managed-inbound-event.js";
 import { buildManagedInternalAuthHeaders } from "./managed-internal-auth-headers.js";
-import {
-  MANAGED_GATEWAY_ROUTE_RESOLVE_PATH,
-  type ManagedGatewayUpstreamFetch,
-} from "./route-resolve.js";
+import type { ManagedRouteResolution } from "./managed-route-resolution-client.js";
+import type { ManagedGatewayUpstreamFetch } from "./route-resolve.js";
 
-const ROUTE_RESOLVE_SCOPE = "routes:resolve";
+export const MANAGED_GATEWAY_INBOUND_DISPATCH_PATH = "/v1/internal/managed-gateway/inbound/dispatch/";
+const INBOUND_DISPATCH_SCOPE = "events:dispatch";
 
-export type ManagedRouteResolution = {
+export type ManagedInboundDispatchReceipt = {
+  status: string;
   routeId: string;
   assistantId: string;
-  provider: string;
-  routeType: string;
-  identityKey: string;
+  eventId?: string;
+  duplicate?: boolean;
 };
 
-export type ManagedRouteResolutionResult =
+export type ManagedInboundDispatchResult =
   | {
     ok: true;
-    route: ManagedRouteResolution;
+    dispatch: ManagedInboundDispatchReceipt;
   }
   | {
     ok: false;
@@ -29,14 +29,14 @@ export type ManagedRouteResolutionResult =
     };
   };
 
-export async function resolveManagedRoute(
+export async function dispatchManagedInboundEvent(
   config: ManagedGatewayConfig,
   args: {
-    routeType: "sms" | "voice";
-    identityKey: string;
+    route: ManagedRouteResolution;
+    normalizedEvent: ManagedGatewayInboundEvent;
     fetchImpl?: ManagedGatewayUpstreamFetch;
   },
-): Promise<ManagedRouteResolutionResult> {
+): Promise<ManagedInboundDispatchResult> {
   if (!config.djangoInternalBaseUrl) {
     return {
       ok: false,
@@ -48,7 +48,7 @@ export async function resolveManagedRoute(
     };
   }
 
-  const authHeaders = buildManagedInternalAuthHeaders(config, ROUTE_RESOLVE_SCOPE);
+  const authHeaders = buildManagedInternalAuthHeaders(config, INBOUND_DISPATCH_SCOPE);
   if (!authHeaders) {
     return {
       ok: false,
@@ -65,7 +65,7 @@ export async function resolveManagedRoute(
   headers.set("content-type", "application/json");
 
   const upstreamUrl = new URL(
-    MANAGED_GATEWAY_ROUTE_RESOLVE_PATH,
+    MANAGED_GATEWAY_INBOUND_DISPATCH_PATH,
     config.djangoInternalBaseUrl,
   ).toString();
 
@@ -75,9 +75,9 @@ export async function resolveManagedRoute(
       method: "POST",
       headers,
       body: JSON.stringify({
-        provider: "twilio",
-        route_type: args.routeType,
-        identity_key: args.identityKey,
+        route_id: args.route.routeId,
+        assistant_id: args.route.assistantId,
+        normalized_event: args.normalizedEvent,
       }),
     });
   } catch {
@@ -86,12 +86,12 @@ export async function resolveManagedRoute(
       status: 502,
       error: {
         code: "upstream_unavailable",
-        detail: "Managed route resolver upstream is unavailable.",
+        detail: "Managed inbound dispatch upstream is unavailable.",
       },
     };
   }
 
-  if (response.status === 200) {
+  if (response.status === 202) {
     const payload = await safeJson(response);
     if (!payload || typeof payload !== "object") {
       return {
@@ -99,37 +99,41 @@ export async function resolveManagedRoute(
         status: 502,
         error: {
           code: "upstream_invalid_response",
-          detail: "Managed route resolver upstream returned an invalid response payload.",
+          detail: "Managed inbound dispatch upstream returned an invalid response payload.",
         },
       };
     }
 
+    const statusValue = asNonEmptyString(payload.status);
     const routeId = asNonEmptyString(payload.route_id);
     const assistantId = asNonEmptyString(payload.assistant_id);
-    const provider = asNonEmptyString(payload.provider);
-    const routeType = asNonEmptyString(payload.route_type);
-    const identityKey = asNonEmptyString(payload.identity_key);
-
-    if (!routeId || !assistantId || !provider || !routeType || !identityKey) {
+    if (!statusValue || !routeId || !assistantId) {
       return {
         ok: false,
         status: 502,
         error: {
           code: "upstream_invalid_response",
-          detail: "Managed route resolver upstream returned an invalid response payload.",
+          detail: "Managed inbound dispatch upstream returned an invalid response payload.",
         },
       };
     }
 
+    const receipt: ManagedInboundDispatchReceipt = {
+      status: statusValue,
+      routeId,
+      assistantId,
+    };
+    const eventId = asNonEmptyString(payload.event_id);
+    if (eventId) {
+      receipt.eventId = eventId;
+    }
+    if (typeof payload.duplicate === "boolean") {
+      receipt.duplicate = payload.duplicate;
+    }
+
     return {
       ok: true,
-      route: {
-        routeId,
-        assistantId,
-        provider,
-        routeType,
-        identityKey,
-      },
+      dispatch: receipt,
     };
   }
 
@@ -137,7 +141,7 @@ export async function resolveManagedRoute(
   const errorPayload = asRecord(payload?.error);
   const detail = asNonEmptyString(errorPayload?.detail)
     || asNonEmptyString(payload?.detail)
-    || `Managed route resolver upstream returned status ${response.status}.`;
+    || `Managed inbound dispatch upstream returned status ${response.status}.`;
   const code = asNonEmptyString(errorPayload?.code)
     || (response.status === 404 ? "managed_route_not_found" : "upstream_error");
 

--- a/gateway-managed/src/managed-internal-auth-headers.ts
+++ b/gateway-managed/src/managed-internal-auth-headers.ts
@@ -1,0 +1,60 @@
+import type { ManagedGatewayConfig } from "./config.js";
+
+export function buildManagedInternalAuthHeaders(
+  config: ManagedGatewayConfig,
+  requiredScope: string,
+): Headers | null {
+  if (config.internalAuth.mode === "bearer") {
+    const tokenValue = selectActiveInternalBearerToken(config, requiredScope);
+    if (!tokenValue) {
+      return null;
+    }
+
+    return new Headers({
+      authorization: `Bearer ${tokenValue}`,
+    });
+  }
+
+  const principal = config.internalAuth.mtlsPrincipals.values().next().value as
+    | string
+    | undefined;
+  if (!principal) {
+    return null;
+  }
+
+  return new Headers({
+    [config.internalAuth.mtlsPrincipalHeader]: principal,
+    [config.internalAuth.mtlsAudienceHeader]: config.internalAuth.audience,
+    [config.internalAuth.mtlsScopesHeader]: requiredScope,
+  });
+}
+
+function selectActiveInternalBearerToken(
+  config: ManagedGatewayConfig,
+  requiredScope: string,
+  nowMs: number = Date.now(),
+): string | null {
+  for (const [tokenValue, metadata] of Object.entries(config.internalAuth.bearerTokens)) {
+    if (metadata.revoked || config.internalAuth.revokedTokenIds.has(metadata.tokenId)) {
+      continue;
+    }
+
+    if (metadata.expiresAt) {
+      const expiresAt = Date.parse(metadata.expiresAt);
+      if (Number.isNaN(expiresAt) || expiresAt <= nowMs) {
+        continue;
+      }
+    }
+
+    if (
+      metadata.audience !== config.internalAuth.audience
+      || !metadata.scopes.includes(requiredScope)
+    ) {
+      continue;
+    }
+
+    return tokenValue;
+  }
+
+  return null;
+}

--- a/gateway-managed/src/managed-twilio-sms-webhook.ts
+++ b/gateway-managed/src/managed-twilio-sms-webhook.ts
@@ -1,5 +1,9 @@
 import type { ManagedGatewayConfig } from "./config.js";
 import {
+  dispatchManagedInboundEvent,
+  type ManagedInboundDispatchResult,
+} from "./managed-inbound-dispatch-client.js";
+import {
   resolveManagedRoute,
   type ManagedRouteResolutionResult,
 } from "./managed-route-resolution-client.js";
@@ -91,11 +95,19 @@ export async function handleManagedTwilioSmsWebhook(
   if (!routeResolution.ok) {
     return routeResolutionErrorResponse(routeResolution);
   }
+  const dispatchResult = await dispatchManagedInboundEvent(config, {
+    route: routeResolution.route,
+    normalizedEvent,
+    fetchImpl,
+  });
+  if (!dispatchResult.ok) {
+    return dispatchErrorResponse(dispatchResult);
+  }
 
   return Response.json(
     {
       status: "accepted",
-      code: "managed_sms_webhook_stub",
+      code: "managed_sms_webhook_dispatched",
       provider: "twilio",
       route_type: "sms",
       message_sid: payload.messageSid,
@@ -105,6 +117,13 @@ export async function handleManagedTwilioSmsWebhook(
       assistant_id: routeResolution.route.assistantId,
       route_id: routeResolution.route.routeId,
       normalized_event: normalizedEvent,
+      dispatch: {
+        status: dispatchResult.dispatch.status,
+        ...(dispatchResult.dispatch.eventId ? { event_id: dispatchResult.dispatch.eventId } : {}),
+        ...(typeof dispatchResult.dispatch.duplicate === "boolean"
+          ? { duplicate: dispatchResult.dispatch.duplicate }
+          : {}),
+      },
     },
     { status: 202 },
   );
@@ -138,6 +157,20 @@ function toRecord(params: URLSearchParams): Record<string, string> {
 
 function routeResolutionErrorResponse(
   result: Extract<ManagedRouteResolutionResult, { ok: false }>,
+): Response {
+  return Response.json(
+    {
+      error: {
+        code: result.error.code,
+        detail: result.error.detail,
+      },
+    },
+    { status: result.status },
+  );
+}
+
+function dispatchErrorResponse(
+  result: Extract<ManagedInboundDispatchResult, { ok: false }>,
 ): Response {
   return Response.json(
     {

--- a/gateway-managed/src/managed-twilio-voice-webhook.ts
+++ b/gateway-managed/src/managed-twilio-voice-webhook.ts
@@ -1,5 +1,9 @@
 import type { ManagedGatewayConfig } from "./config.js";
 import {
+  dispatchManagedInboundEvent,
+  type ManagedInboundDispatchResult,
+} from "./managed-inbound-dispatch-client.js";
+import {
   resolveManagedRoute,
   type ManagedRouteResolutionResult,
 } from "./managed-route-resolution-client.js";
@@ -91,11 +95,19 @@ export async function handleManagedTwilioVoiceWebhook(
   if (!routeResolution.ok) {
     return routeResolutionErrorResponse(routeResolution);
   }
+  const dispatchResult = await dispatchManagedInboundEvent(config, {
+    route: routeResolution.route,
+    normalizedEvent,
+    fetchImpl,
+  });
+  if (!dispatchResult.ok) {
+    return dispatchErrorResponse(dispatchResult);
+  }
 
   return Response.json(
     {
       status: "accepted",
-      code: "managed_voice_webhook_stub",
+      code: "managed_voice_webhook_dispatched",
       provider: "twilio",
       route_type: "voice",
       call_sid: payload.callSid,
@@ -105,6 +117,13 @@ export async function handleManagedTwilioVoiceWebhook(
       assistant_id: routeResolution.route.assistantId,
       route_id: routeResolution.route.routeId,
       normalized_event: normalizedEvent,
+      dispatch: {
+        status: dispatchResult.dispatch.status,
+        ...(dispatchResult.dispatch.eventId ? { event_id: dispatchResult.dispatch.eventId } : {}),
+        ...(typeof dispatchResult.dispatch.duplicate === "boolean"
+          ? { duplicate: dispatchResult.dispatch.duplicate }
+          : {}),
+      },
     },
     { status: 202 },
   );
@@ -138,6 +157,20 @@ function toRecord(params: URLSearchParams): Record<string, string> {
 
 function routeResolutionErrorResponse(
   result: Extract<ManagedRouteResolutionResult, { ok: false }>,
+): Response {
+  return Response.json(
+    {
+      error: {
+        code: result.error.code,
+        detail: result.error.detail,
+      },
+    },
+    { status: result.status },
+  );
+}
+
+function dispatchErrorResponse(
+  result: Extract<ManagedInboundDispatchResult, { ok: false }>,
 ): Response {
   return Response.json(
     {


### PR DESCRIPTION
Summary:
- add managed inbound dispatch client in gateway-managed to call Django internal /v1/internal/managed-gateway/inbound/dispatch/
- wire managed Twilio SMS and voice webhook handlers to dispatch normalized events after route resolution and return dispatch receipts
- add dispatch client tests, expand SMS and voice webhook tests for two-hop resolve plus dispatch flow, and update managed gateway contracts/docs/env examples

Validation:
- cd gateway-managed && bun run typecheck
- cd gateway-managed && bun run build
- cd gateway-managed && bun run test