### PR TITLE
fix: add bearer token config and fix imagePullPolicy in staging manifest

### DIFF
--- a/gateway-managed/deploy/k8s/deployment.staging.yaml
+++ b/gateway-managed/deploy/k8s/deployment.staging.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
         - name: managed-gateway
           image: ghcr.io/vellum-ai/vellum-managed-gateway:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 7831
@@ -35,6 +35,11 @@ spec:
               value: "true"
             - name: MANAGED_GATEWAY_INTERNAL_AUTH_MODE
               value: "bearer"
+            - name: MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS
+              valueFrom:
+                secretKeyRef:
+                  name: managed-gateway-secrets
+                  key: internal-bearer-tokens
             - name: MANAGED_GATEWAY_INTERNAL_AUTH_AUDIENCE
               value: "managed-gateway-internal"
             - name: MANAGED_GATEWAY_TWILIO_AUTH_TOKENS


### PR DESCRIPTION
## Summary
- Add `MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS` env var sourced from a Kubernetes Secret (`managed-gateway-secrets` / `internal-bearer-tokens`) to prevent crash loop when strict startup validation is enabled with bearer auth mode.
- Change `imagePullPolicy` from `IfNotPresent` to `Always` for the `:latest` tag so staging always pulls updated images.

Addresses review feedback from PR #11089.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
