### PR TITLE
fix: sanitize readiness response and preserve base path in route resolve URL

### DIFF
--- a/gateway-managed/src/http.ts
+++ b/gateway-managed/src/http.ts
@@ -39,14 +39,12 @@ export function readinessResponse(config: ManagedGatewayConfig): Response {
     );
   }
 
-  const payload: Record<string, string> = {
+  const payload: Record<string, string | boolean> = {
     status: "ready",
     service: config.serviceName,
     mode: config.mode,
+    upstreamConfigured: !!config.djangoInternalBaseUrl,
   };
-  if (config.djangoInternalBaseUrl) {
-    payload.upstreamBaseUrl = config.djangoInternalBaseUrl;
-  }
 
   return Response.json(payload);
 }

--- a/gateway-managed/src/route-resolve.ts
+++ b/gateway-managed/src/route-resolve.ts
@@ -49,9 +49,11 @@ export function createRouteResolveHandler(
         );
       }
 
+      const base = new URL(config.djangoInternalBaseUrl);
+      const basePath = base.pathname.replace(/\/+$/, "");
       const upstreamUrl = new URL(
-        MANAGED_GATEWAY_ROUTE_RESOLVE_PATH,
-        config.djangoInternalBaseUrl,
+        basePath + MANAGED_GATEWAY_ROUTE_RESOLVE_PATH,
+        base,
       ).toString();
 
       const upstreamHeaders = buildUpstreamHeaders(request, config);


### PR DESCRIPTION
Address review feedback from PR #11086: remove verbatim internal URL from readiness endpoint response, and fix URL composition to preserve base path prefix.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
