### PR TITLE
fix: harden internal auth bearer lookup and mTLS audience check

### DIFF
--- a/gateway-managed/src/__tests__/internal-auth.test.ts
+++ b/gateway-managed/src/__tests__/internal-auth.test.ts
@@ -74,6 +74,20 @@ describe("internal auth - bearer", () => {
     ).toThrow("Unknown managed gateway bearer token.");
   });
 
+  test("rejects bearer token matching Object prototype property", () => {
+    const config = makeConfig({});
+
+    for (const proto of ["constructor", "toString", "__proto__"]) {
+      expect(() =>
+        authenticateInternalRequest(
+          makeRequest({ authorization: `Bearer ${proto}` }),
+          config,
+          "routes:resolve",
+        ),
+      ).toThrow("Unknown managed gateway bearer token.");
+    }
+  });
+
   test("rejects expired bearer token", () => {
     const config = makeConfig({
       MANAGED_GATEWAY_INTERNAL_BEARER_TOKENS: JSON.stringify({
@@ -249,6 +263,24 @@ describe("internal auth - mtls", () => {
         "routes:resolve",
       ),
     ).toThrow("Managed gateway mTLS principal is not authorized.");
+  });
+
+  test("rejects mTLS request when audience header is missing", () => {
+    const config = makeConfig({
+      MANAGED_GATEWAY_INTERNAL_AUTH_MODE: "mtls",
+      MANAGED_GATEWAY_INTERNAL_MTLS_PRINCIPALS: "managed-gateway-staging",
+    });
+
+    expect(() =>
+      authenticateInternalRequest(
+        makeRequest({
+          "x-managed-gateway-principal": "managed-gateway-staging",
+          "x-managed-gateway-scopes": "managed-gateway:internal,routes:resolve",
+        }),
+        config,
+        "routes:resolve",
+      ),
+    ).toThrow("Missing managed gateway mTLS audience.");
   });
 
   test("rejects mTLS scope mismatch", () => {

--- a/gateway-managed/src/internal-auth.ts
+++ b/gateway-managed/src/internal-auth.ts
@@ -89,7 +89,9 @@ function authenticateBearer(
     );
   }
 
-  const metadata = config.internalAuth.bearerTokens[tokenValue];
+  const metadata = Object.hasOwn(config.internalAuth.bearerTokens, tokenValue)
+    ? config.internalAuth.bearerTokens[tokenValue]
+    : undefined;
   if (!metadata) {
     throw new ManagedGatewayInternalAuthError(
       "unknown_bearer",
@@ -134,8 +136,14 @@ function authenticateMtls(
   }
 
   const audienceHeader = config.internalAuth.mtlsAudienceHeader;
-  const audience =
-    request.headers.get(audienceHeader)?.trim() || config.internalAuth.audience;
+  const audience = request.headers.get(audienceHeader)?.trim() || "";
+  if (!audience) {
+    throw new ManagedGatewayInternalAuthError(
+      "missing_mtls_audience",
+      401,
+      "Missing managed gateway mTLS audience.",
+    );
+  }
   ensureAudience(audience, config.internalAuth.audience, "mTLS");
 
   const scopesHeader = config.internalAuth.mtlsScopesHeader;


### PR DESCRIPTION
Address review feedback from PR #11081: use Object.hasOwn() for bearer token lookup to prevent prototype poisoning, and reject mTLS requests missing audience header instead of defaulting.

## Changes

- **Bearer token lookup**: Use `Object.hasOwn()` before accessing `config.internalAuth.bearerTokens[tokenValue]` to prevent prototype property matching (e.g., `constructor`, `toString`)
- **mTLS audience check**: Reject requests with missing audience header (`missing_mtls_audience` / 401) instead of silently defaulting to the expected value
- **Tests**: Added test for prototype property rejection in bearer path; added test for missing mTLS audience header rejection
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
