### PR TITLE
fix: normalize identity_key before managed route lookup

### DIFF
--- a/gateway-managed/src/managed-route-resolution-client.ts
+++ b/gateway-managed/src/managed-route-resolution-client.ts
@@ -3,6 +3,7 @@ import { buildManagedInternalAuthHeaders } from "./managed-internal-auth-headers
 import {
   MANAGED_GATEWAY_ROUTE_RESOLVE_PATH,
   type ManagedGatewayUpstreamFetch,
+  normalizeIdentityKey,
 } from "./route-resolve.js";
 
 const ROUTE_RESOLVE_SCOPE = "routes:resolve";
@@ -77,7 +78,7 @@ export async function resolveManagedRoute(
       body: JSON.stringify({
         provider: "twilio",
         route_type: args.routeType,
-        identity_key: args.identityKey,
+        identity_key: normalizeIdentityKey(args.identityKey),
       }),
     });
   } catch {

--- a/gateway-managed/src/route-resolve.ts
+++ b/gateway-managed/src/route-resolve.ts
@@ -119,7 +119,7 @@ function normalizeLookupValue(raw: unknown): string {
   return normalized;
 }
 
-function normalizeIdentityKey(raw: unknown): string {
+export function normalizeIdentityKey(raw: unknown): string {
   if (typeof raw !== "string") {
     throw new Error("identity_key must be a string");
   }


### PR DESCRIPTION
## Summary

Address review feedback from PR #11096: apply identity_key normalization (trim, lowercase, strip `tel:` prefix, remove spaces) before route resolution to match the normalization that the previous internal path performed.

- Export `normalizeIdentityKey` from `route-resolve.ts`
- Call it in `managed-route-resolution-client.ts` before sending `identity_key` in the request body

## Test plan

- [ ] Verify that identity keys with leading/trailing whitespace, mixed case, `tel:` prefix, or embedded spaces are normalized before route lookup
- [ ] Existing route resolution tests continue to pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
