### PR TITLE
fix: add startup validation for events:dispatch credential scope

### DIFF
--- a/gateway-managed/src/config.ts
+++ b/gateway-managed/src/config.ts
@@ -236,6 +236,36 @@ function hasActiveTwilioAuthToken(
   return false;
 }
 
+function hasActiveBearerTokenWithScope(
+  internalAuth: ManagedGatewayInternalAuthConfig,
+  requiredScope: string,
+  nowMs: number = Date.now(),
+): boolean {
+  for (const metadata of Object.values(internalAuth.bearerTokens)) {
+    if (metadata.revoked || internalAuth.revokedTokenIds.has(metadata.tokenId)) {
+      continue;
+    }
+
+    if (metadata.expiresAt) {
+      const expiresAt = Date.parse(metadata.expiresAt);
+      if (Number.isNaN(expiresAt) || expiresAt <= nowMs) {
+        continue;
+      }
+    }
+
+    if (
+      metadata.audience !== internalAuth.audience
+      || !metadata.scopes.includes(requiredScope)
+    ) {
+      continue;
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
 function parseInternalAuthMode(raw: string | undefined): ManagedGatewayInternalAuthMode {
   const normalized = (raw || "bearer").trim().toLowerCase();
   if (normalized === "bearer" || normalized === "mtls") {
@@ -328,6 +358,16 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ManagedGateway
     if (!hasActiveTwilioAuthToken(twilio)) {
       throw new Error(
         "MANAGED_GATEWAY_TWILIO_AUTH_TOKENS must define at least one active token when managed gateway is enabled.",
+      );
+    }
+
+    if (
+      internalAuth.mode === "bearer"
+      && hasActiveTwilioAuthToken(twilio)
+      && !hasActiveBearerTokenWithScope(internalAuth, "events:dispatch")
+    ) {
+      throw new Error(
+        "At least one active bearer token must have the 'events:dispatch' scope when Twilio webhook handling is enabled.",
       );
     }
   }


### PR DESCRIPTION
Address review feedback from PR #11098: add startup-time validation that at least one active bearer token has `events:dispatch` scope when Twilio webhook handling is enabled, catching misconfiguration before traffic arrives instead of at request time.

## Changes

- Added `hasActiveBearerTokenWithScope()` helper function in `gateway-managed/src/config.ts` that checks for an active (non-revoked, non-expired) bearer token with the correct audience and required scope.
- Added startup validation check: when strict startup validation is enabled, the managed gateway is enabled, bearer auth mode is active, and Twilio auth tokens are configured, the gateway now verifies that at least one bearer token has the `events:dispatch` scope. If missing, startup fails with a clear error message.

## Context

Previously, missing `events:dispatch` scope was only detected at request time in `managed-inbound-dispatch-client.ts` (line 51-55), returning a 500 error. During a rollout from tokens that only had `routes:resolve`, the service would boot successfully but every Twilio webhook would fail at runtime — a production outage pattern that startup validation is designed to prevent.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
