### PR TITLE
fix: reorder webhook auth before validation and use canonical URL for signature

### DIFF
--- a/gateway-managed/src/managed-twilio-sms-webhook.ts
+++ b/gateway-managed/src/managed-twilio-sms-webhook.ts
@@ -9,7 +9,10 @@ import {
 } from "./managed-route-resolution-client.js";
 import type { ManagedGatewayUpstreamFetch } from "./route-resolve.js";
 import { normalizeManagedTwilioSmsPayload } from "./twilio-normalize.js";
-import { validateManagedTwilioSignature } from "./twilio-signature.js";
+import {
+  buildManagedSignatureUrlCandidates,
+  validateManagedTwilioSignature,
+} from "./twilio-signature.js";
 
 export const MANAGED_TWILIO_SMS_WEBHOOK_PATH = "/webhooks/twilio/sms";
 
@@ -56,22 +59,11 @@ export async function handleManagedTwilioSmsWebhook(
   }
 
   const params = new URLSearchParams(rawBody);
-  const payload = parseSmsPayload(params);
-  if (!payload) {
-    return Response.json(
-      {
-        error: {
-          code: "validation_error",
-          detail: "Invalid managed Twilio SMS webhook payload.",
-        },
-      },
-      { status: 400 },
-    );
-  }
+  const paramsRecord = toRecord(params);
 
   const verification = validateManagedTwilioSignature(config, {
-    url: request.url,
-    params: toRecord(params),
+    url: buildManagedSignatureUrlCandidates(request),
+    params: paramsRecord,
     signature: request.headers.get("x-twilio-signature"),
   });
   if (!verification.ok) {
@@ -86,7 +78,20 @@ export async function handleManagedTwilioSmsWebhook(
     );
   }
 
-  const normalizedEvent = normalizeManagedTwilioSmsPayload(toRecord(params));
+  const payload = parseSmsPayload(params);
+  if (!payload) {
+    return Response.json(
+      {
+        error: {
+          code: "validation_error",
+          detail: "Invalid managed Twilio SMS webhook payload.",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const normalizedEvent = normalizeManagedTwilioSmsPayload(paramsRecord);
   const routeResolution = await resolveManagedRoute(config, {
     routeType: "sms",
     identityKey: payload.to,

--- a/gateway-managed/src/managed-twilio-voice-webhook.ts
+++ b/gateway-managed/src/managed-twilio-voice-webhook.ts
@@ -9,7 +9,10 @@ import {
 } from "./managed-route-resolution-client.js";
 import type { ManagedGatewayUpstreamFetch } from "./route-resolve.js";
 import { normalizeManagedTwilioVoicePayload } from "./twilio-normalize.js";
-import { validateManagedTwilioSignature } from "./twilio-signature.js";
+import {
+  buildManagedSignatureUrlCandidates,
+  validateManagedTwilioSignature,
+} from "./twilio-signature.js";
 
 export const MANAGED_TWILIO_VOICE_WEBHOOK_PATH = "/webhooks/twilio/voice";
 
@@ -56,22 +59,11 @@ export async function handleManagedTwilioVoiceWebhook(
   }
 
   const params = new URLSearchParams(rawBody);
-  const payload = parseVoicePayload(params);
-  if (!payload) {
-    return Response.json(
-      {
-        error: {
-          code: "validation_error",
-          detail: "Invalid managed Twilio voice webhook payload.",
-        },
-      },
-      { status: 400 },
-    );
-  }
+  const paramsRecord = toRecord(params);
 
   const verification = validateManagedTwilioSignature(config, {
-    url: request.url,
-    params: toRecord(params),
+    url: buildManagedSignatureUrlCandidates(request),
+    params: paramsRecord,
     signature: request.headers.get("x-twilio-signature"),
   });
   if (!verification.ok) {
@@ -86,7 +78,20 @@ export async function handleManagedTwilioVoiceWebhook(
     );
   }
 
-  const normalizedEvent = normalizeManagedTwilioVoicePayload(toRecord(params));
+  const payload = parseVoicePayload(params);
+  if (!payload) {
+    return Response.json(
+      {
+        error: {
+          code: "validation_error",
+          detail: "Invalid managed Twilio voice webhook payload.",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const normalizedEvent = normalizeManagedTwilioVoicePayload(paramsRecord);
   const routeResolution = await resolveManagedRoute(config, {
     routeType: "voice",
     identityKey: payload.to,

--- a/gateway-managed/src/twilio-signature.ts
+++ b/gateway-managed/src/twilio-signature.ts
@@ -50,7 +50,7 @@ export function verifyTwilioSignatureWithAuthToken(
 export function validateManagedTwilioSignature(
   config: ManagedGatewayConfig,
   args: {
-    url: string;
+    url: string | string[];
     params: Record<string, string>;
     signature: string | null | undefined;
     nowMs?: number;
@@ -74,17 +74,21 @@ export function validateManagedTwilioSignature(
     };
   }
 
-  for (const token of activeTokens) {
-    if (verifyTwilioSignatureWithAuthToken(
-      args.url,
-      args.params,
-      signature,
-      token.authToken,
-    )) {
-      return {
-        ok: true,
-        tokenId: token.tokenId,
-      };
+  const urls = Array.isArray(args.url) ? args.url : [args.url];
+
+  for (const url of urls) {
+    for (const token of activeTokens) {
+      if (verifyTwilioSignatureWithAuthToken(
+        url,
+        args.params,
+        signature,
+        token.authToken,
+      )) {
+        return {
+          ok: true,
+          tokenId: token.tokenId,
+        };
+      }
     }
   }
 
@@ -93,6 +97,53 @@ export function validateManagedTwilioSignature(
     code: "invalid_signature",
     detail: "Invalid Twilio request signature.",
   };
+}
+
+function firstHeaderValue(value: string | null): string | undefined {
+  if (!value) return undefined;
+  const first = value.split(",")[0]?.trim();
+  return first ? first : undefined;
+}
+
+/**
+ * Build URL candidates Twilio may have used when computing the webhook signature.
+ * TLS termination before the managed gateway means Twilio signs the external
+ * https:// URL but the gateway sees an internal http:// URL.
+ *
+ * Precedence:
+ * 1) Forwarded public URL from proxy/load-balancer headers
+ * 2) Raw request URL (last-resort fallback)
+ */
+export function buildManagedSignatureUrlCandidates(req: Request): string[] {
+  const parsedUrl = new URL(req.url);
+  const pathAndQuery = parsedUrl.pathname + parsedUrl.search;
+  const candidates: string[] = [];
+
+  const addBase = (base: string | undefined): void => {
+    if (!base) return;
+    const normalized = base.trim().replace(/\/+$/, "");
+    if (!normalized) return;
+    const candidate = `${normalized}${pathAndQuery}`;
+    if (!candidates.includes(candidate)) {
+      candidates.push(candidate);
+    }
+  };
+
+  const forwardedProto =
+    firstHeaderValue(req.headers.get("x-forwarded-proto")) ??
+    firstHeaderValue(req.headers.get("x-original-proto"));
+  const forwardedHost =
+    firstHeaderValue(req.headers.get("x-forwarded-host")) ??
+    firstHeaderValue(req.headers.get("x-original-host"));
+  if (forwardedProto && forwardedHost) {
+    addBase(`${forwardedProto}://${forwardedHost}`);
+  }
+
+  if (!candidates.includes(req.url)) {
+    candidates.push(req.url);
+  }
+
+  return candidates;
 }
 
 function getActiveTwilioAuthTokens(


### PR DESCRIPTION
Address review feedback from PR #11092:

1. Move Twilio signature verification before payload validation in both SMS and voice webhook handlers to prevent leaking validation state to unauthenticated callers.
2. Build verification URL from forwarded host/proto headers (x-forwarded-proto, x-forwarded-host, x-original-proto, x-original-host) instead of raw request.url to handle TLS termination correctly.
3. Update validateManagedTwilioSignature to accept url candidates array for multi-URL verification.
4. Apply same fixes to voice webhook handler which had identical issues.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
