### PR TITLE
fix: return 400 validation error for invalid identity keys instead of 502

### DIFF
--- a/gateway-managed/src/managed-route-resolution-client.ts
+++ b/gateway-managed/src/managed-route-resolution-client.ts
@@ -70,6 +70,20 @@ export async function resolveManagedRoute(
     config.djangoInternalBaseUrl,
   ).toString();
 
+  let normalizedIdentityKey: string;
+  try {
+    normalizedIdentityKey = normalizeIdentityKey(args.identityKey);
+  } catch {
+    return {
+      ok: false,
+      status: 400,
+      error: {
+        code: "validation_error",
+        detail: "Invalid identity key.",
+      },
+    };
+  }
+
   let response: Response;
   try {
     response = await fetchFn(upstreamUrl, {
@@ -78,7 +92,7 @@ export async function resolveManagedRoute(
       body: JSON.stringify({
         provider: "twilio",
         route_type: args.routeType,
-        identity_key: normalizeIdentityKey(args.identityKey),
+        identity_key: normalizedIdentityKey,
       }),
     });
   } catch {


### PR DESCRIPTION
Address review feedback from PR #11102: move `normalizeIdentityKey()` outside the fetch try/catch so normalization failures produce a proper 400 `validation_error` instead of a misleading 502 `upstream_unavailable`.

## Changes

In `gateway-managed/src/managed-route-resolution-client.ts`, `normalizeIdentityKey()` was called inside the `try` block intended for fetch errors. If normalization threw (e.g., for blank identity keys like `"tel:"` or whitespace-only input), the error was caught by the fetch handler and returned a misleading `502 upstream_unavailable`.

Now `normalizeIdentityKey()` runs before the fetch `try` block with its own `try/catch` that returns `{ ok: false, status: 400, error: { code: "validation_error", detail: "Invalid identity key." } }`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
