### PR TITLE
fix: apply base path preservation to all upstream URL clients

### DIFF
--- a/gateway-managed/src/__tests__/probes.test.ts
+++ b/gateway-managed/src/__tests__/probes.test.ts
@@ -57,7 +57,7 @@ describe("managed-gateway probes", () => {
       status: "ready",
       service: "managed-gateway",
       mode: "skeleton",
-      upstreamBaseUrl: "http://127.0.0.1:8000",
+      upstreamConfigured: true,
     });
   });
 

--- a/gateway-managed/src/managed-inbound-dispatch-client.ts
+++ b/gateway-managed/src/managed-inbound-dispatch-client.ts
@@ -3,6 +3,7 @@ import type { ManagedGatewayInboundEvent } from "./managed-inbound-event.js";
 import { buildManagedInternalAuthHeaders } from "./managed-internal-auth-headers.js";
 import type { ManagedRouteResolution } from "./managed-route-resolution-client.js";
 import type { ManagedGatewayUpstreamFetch } from "./route-resolve.js";
+import { buildUpstreamUrl } from "./upstream-url.js";
 
 export const MANAGED_GATEWAY_INBOUND_DISPATCH_PATH = "/v1/internal/managed-gateway/inbound/dispatch/";
 const INBOUND_DISPATCH_SCOPE = "events:dispatch";
@@ -64,10 +65,10 @@ export async function dispatchManagedInboundEvent(
   const headers = new Headers(authHeaders);
   headers.set("content-type", "application/json");
 
-  const upstreamUrl = new URL(
-    MANAGED_GATEWAY_INBOUND_DISPATCH_PATH,
+  const upstreamUrl = buildUpstreamUrl(
     config.djangoInternalBaseUrl,
-  ).toString();
+    MANAGED_GATEWAY_INBOUND_DISPATCH_PATH,
+  );
 
   let response: Response;
   try {

--- a/gateway-managed/src/managed-route-resolution-client.ts
+++ b/gateway-managed/src/managed-route-resolution-client.ts
@@ -5,6 +5,7 @@ import {
   type ManagedGatewayUpstreamFetch,
   normalizeIdentityKey,
 } from "./route-resolve.js";
+import { buildUpstreamUrl } from "./upstream-url.js";
 
 const ROUTE_RESOLVE_SCOPE = "routes:resolve";
 
@@ -65,10 +66,10 @@ export async function resolveManagedRoute(
   const headers = new Headers(authHeaders);
   headers.set("content-type", "application/json");
 
-  const upstreamUrl = new URL(
-    MANAGED_GATEWAY_ROUTE_RESOLVE_PATH,
+  const upstreamUrl = buildUpstreamUrl(
     config.djangoInternalBaseUrl,
-  ).toString();
+    MANAGED_GATEWAY_ROUTE_RESOLVE_PATH,
+  );
 
   let response: Response;
   try {

--- a/gateway-managed/src/route-resolve.ts
+++ b/gateway-managed/src/route-resolve.ts
@@ -1,5 +1,6 @@
 import type { ManagedGatewayConfig } from "./config.js";
 import { withInternalAuth } from "./internal-auth.js";
+import { buildUpstreamUrl } from "./upstream-url.js";
 
 export const MANAGED_GATEWAY_ROUTE_RESOLVE_PATH = "/v1/internal/managed-gateway/routes/resolve/";
 const MANAGED_GATEWAY_ROUTE_RESOLVE_SCOPE = "routes:resolve";
@@ -49,12 +50,10 @@ export function createRouteResolveHandler(
         );
       }
 
-      const base = new URL(config.djangoInternalBaseUrl);
-      const basePath = base.pathname.replace(/\/+$/, "");
-      const upstreamUrl = new URL(
-        basePath + MANAGED_GATEWAY_ROUTE_RESOLVE_PATH,
-        base,
-      ).toString();
+      const upstreamUrl = buildUpstreamUrl(
+        config.djangoInternalBaseUrl,
+        MANAGED_GATEWAY_ROUTE_RESOLVE_PATH,
+      );
 
       const upstreamHeaders = buildUpstreamHeaders(request, config);
 

--- a/gateway-managed/src/upstream-url.ts
+++ b/gateway-managed/src/upstream-url.ts
@@ -1,0 +1,14 @@
+/**
+ * Composes an upstream URL by preserving the base URL's path prefix.
+ *
+ * `new URL(path, base)` discards any path component on `base` — this helper
+ * extracts the base pathname, strips trailing slashes, prepends it to `path`,
+ * and normalises away accidental leading double-slashes so that `new URL()`
+ * never interprets the result as a network-path reference.
+ */
+export function buildUpstreamUrl(baseUrl: string, path: string): string {
+  const base = new URL(baseUrl);
+  const basePath = base.pathname.replace(/\/+$/, "").replace(/^\/\/+/, "/");
+  const combined = basePath + path;
+  return new URL(combined, base).toString();
+}


### PR DESCRIPTION
## Summary

Address review feedback from PR #11100:

- **Update readiness probe test** — the test asserted `upstreamBaseUrl: "http://127.0.0.1:8000"` but production code now returns `upstreamConfigured: true`. Updated to match.
- **Apply base path fix to `managed-route-resolution-client.ts`** — the `new URL(path, base)` pattern dropped the base path prefix. Now uses `buildUpstreamUrl()`.
- **Apply base path fix to `managed-inbound-dispatch-client.ts`** — identical issue, same fix.
- **Sanitize leading double slashes** — when `base.pathname` has accidental double slashes (e.g. `https://host//api`), concatenation could produce `//api/...` which `new URL()` treats as a network-path reference. The new `buildUpstreamUrl()` helper normalizes this.
- **Extract shared `buildUpstreamUrl()` helper** in `gateway-managed/src/upstream-url.ts` to eliminate duplication across the 3 callsites.

## Test plan

- [ ] Verify `bun test` passes in `gateway-managed/`
- [ ] Confirm readiness probe test matches new response shape
- [ ] Confirm base path is preserved for all upstream URL clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
