### PR TITLE
fix: fix Docker build for gateway dependency and add package.json export

### DIFF
--- a/gateway-managed/Dockerfile
+++ b/gateway-managed/Dockerfile
@@ -2,11 +2,15 @@ FROM oven/bun:1.2
 
 WORKDIR /app
 
-COPY package.json bun.lock ./
+# Copy gateway package first (required by file:../gateway dependency)
+COPY gateway/package.json /gateway/package.json
+COPY gateway/src /gateway/src
+
+COPY gateway-managed/package.json gateway-managed/bun.lock ./
 RUN bun install --frozen-lockfile
 
-COPY src ./src
-COPY tsconfig.json ./tsconfig.json
+COPY gateway-managed/src ./src
+COPY gateway-managed/tsconfig.json ./tsconfig.json
 
 EXPOSE 7831
 

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -3,7 +3,8 @@
   "version": "0.4.6",
   "type": "module",
   "exports": {
-    "./twilio/verify": "./src/twilio/verify.ts"
+    "./twilio/verify": "./src/twilio/verify.ts",
+    "./package.json": "./package.json"
   },
   "scripts": {
     "dev": "bun run --watch src/index.ts",


### PR DESCRIPTION
Address review feedback from PR #11105:

- Update managed-gateway Dockerfile to use repo-root build context and copy gateway/ package into the container so the `file:../gateway` dependency resolves during `bun install`
- Add `./package.json` to gateway exports field so `_require.resolve('@vellumai/vellum-gateway/package.json')` works in the CLI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
