### PR TITLE
P08 PR-4: Add runtime-side branch to select managed outbound lane

### DIFF
--- a/assistant/src/__tests__/gateway-client-managed-outbound.test.ts
+++ b/assistant/src/__tests__/gateway-client-managed-outbound.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+import { deliverChannelReply } from '../runtime/gateway-client.js';
+
+type FetchCall = {
+  url: string;
+  init: RequestInit;
+};
+
+describe('gateway-client managed outbound lane', () => {
+  const originalFetch = globalThis.fetch;
+  const calls: FetchCall[] = [];
+
+  beforeEach(() => {
+    calls.length = 0;
+    globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+      calls.push({ url, init: init ?? {} });
+      return new Response(JSON.stringify({ status: 'accepted' }), { status: 202 });
+    }) as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test('translates managed callback URL into managed outbound-send request', async () => {
+    await deliverChannelReply(
+      'https://platform.test/v1/internal/managed-gateway/outbound-send/?route_id=route-123&assistant_id=assistant-123&source_channel=sms&source_update_id=SM-inbound-123&callback_token=runtime-token',
+      {
+        chatId: '+15550001111',
+        text: 'hello from runtime',
+      },
+    );
+
+    expect(calls).toHaveLength(1);
+    const call = calls[0];
+    expect(call.url).toBe('https://platform.test/v1/internal/managed-gateway/outbound-send/');
+
+    const headers = call.init.headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(headers['X-Managed-Gateway-Callback-Token']).toBe('runtime-token');
+    expect(headers.Authorization).toBeUndefined();
+
+    const body = JSON.parse(String(call.init.body)) as {
+      route_id: string;
+      assistant_id: string;
+      normalized_send: {
+        sourceChannel: string;
+        message: {
+          to: string;
+          content: string;
+          externalMessageId: string;
+        };
+        source: {
+          requestId: string;
+        };
+        raw: {
+          sourceUpdateId: string;
+        };
+      };
+    };
+    expect(body.route_id).toBe('route-123');
+    expect(body.assistant_id).toBe('assistant-123');
+    expect(body.normalized_send.sourceChannel).toBe('sms');
+    expect(body.normalized_send.message.to).toBe('+15550001111');
+    expect(body.normalized_send.message.content).toBe('hello from runtime');
+    expect(body.normalized_send.message.externalMessageId).toStartWith('mgw-send-');
+    expect(body.normalized_send.source.requestId).toBe(
+      body.normalized_send.message.externalMessageId,
+    );
+    expect(body.normalized_send.raw.sourceUpdateId).toBe('SM-inbound-123');
+  });
+
+  test('falls back to standard callback delivery for non-managed callback URL', async () => {
+    await deliverChannelReply(
+      'https://gateway.test/deliver/sms',
+      {
+        chatId: '+15550001111',
+        text: 'standard gateway callback',
+      },
+      'runtime-bearer',
+    );
+
+    expect(calls).toHaveLength(1);
+    const call = calls[0];
+    expect(call.url).toBe('https://gateway.test/deliver/sms');
+
+    const headers = call.init.headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(headers.Authorization).toBe('Bearer runtime-bearer');
+
+    const body = JSON.parse(String(call.init.body)) as { chatId: string; text: string };
+    expect(body).toEqual({
+      chatId: '+15550001111',
+      text: 'standard gateway callback',
+    });
+  });
+});

--- a/assistant/src/runtime/gateway-client.ts
+++ b/assistant/src/runtime/gateway-client.ts
@@ -5,6 +5,10 @@ import type { RuntimeAttachmentMetadata } from './http-types.js';
 const log = getLogger('gateway-client');
 
 const DELIVERY_TIMEOUT_MS = 30_000;
+const MANAGED_OUTBOUND_SEND_PATH = '/v1/internal/managed-gateway/outbound-send/';
+const MANAGED_CALLBACK_TOKEN_HEADER = 'X-Managed-Gateway-Callback-Token';
+const SMS_ATTACHMENTS_FALLBACK_TEXT =
+  'I have a media attachment to share, but SMS currently supports text only.';
 
 export interface ChannelReplyPayload {
   chatId: string;
@@ -15,11 +19,26 @@ export interface ChannelReplyPayload {
   chatAction?: 'typing';
 }
 
+interface ManagedOutboundCallbackContext {
+  requestUrl: string;
+  routeId: string;
+  assistantId: string;
+  sourceChannel: 'sms' | 'voice';
+  sourceUpdateId?: string;
+  callbackToken?: string;
+}
+
 export async function deliverChannelReply(
   callbackUrl: string,
   payload: ChannelReplyPayload,
   bearerToken?: string,
 ): Promise<void> {
+  const managedCallback = parseManagedOutboundCallback(callbackUrl);
+  if (managedCallback) {
+    await deliverManagedOutboundReply(managedCallback, payload, bearerToken);
+    return;
+  }
+
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (bearerToken) {
     headers['Authorization'] = `Bearer ${bearerToken}`;
@@ -49,6 +68,164 @@ export async function deliverChannelReply(
   } else {
     log.info({ chatId: payload.chatId, callbackUrl }, 'Channel reply delivered');
   }
+}
+
+function parseManagedOutboundCallback(
+  callbackUrl: string,
+): ManagedOutboundCallbackContext | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(callbackUrl);
+  } catch {
+    return null;
+  }
+
+  const normalizedPath = parsed.pathname.endsWith('/')
+    ? parsed.pathname
+    : `${parsed.pathname}/`;
+  if (normalizedPath !== MANAGED_OUTBOUND_SEND_PATH) {
+    return null;
+  }
+
+  const routeId = parsed.searchParams.get('route_id')?.trim();
+  const assistantId = parsed.searchParams.get('assistant_id')?.trim();
+  const sourceChannel = parsed.searchParams.get('source_channel')?.trim();
+
+  if (!routeId || !assistantId || (sourceChannel !== 'sms' && sourceChannel !== 'voice')) {
+    throw new Error(
+      'Managed outbound callback URL is missing required route_id, assistant_id, or source_channel.',
+    );
+  }
+
+  const sourceUpdateId = parsed.searchParams.get('source_update_id')?.trim();
+  const callbackToken = parsed.searchParams.get('callback_token')?.trim();
+
+  parsed.searchParams.delete('route_id');
+  parsed.searchParams.delete('assistant_id');
+  parsed.searchParams.delete('source_channel');
+  parsed.searchParams.delete('source_update_id');
+  parsed.searchParams.delete('callback_token');
+
+  return {
+    requestUrl: parsed.toString(),
+    routeId,
+    assistantId,
+    sourceChannel,
+    sourceUpdateId,
+    callbackToken,
+  };
+}
+
+async function deliverManagedOutboundReply(
+  callback: ManagedOutboundCallbackContext,
+  payload: ChannelReplyPayload,
+  bearerToken?: string,
+): Promise<void> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (callback.callbackToken) {
+    headers[MANAGED_CALLBACK_TOKEN_HEADER] = callback.callbackToken;
+  } else if (bearerToken) {
+    headers.Authorization = `Bearer ${bearerToken}`;
+  }
+
+  const hasAttachments = Array.isArray(payload.attachments) && payload.attachments.length > 0;
+  const text = payload.approval?.plainTextFallback ?? payload.text;
+  const normalizedText =
+    typeof text === 'string' && text.trim().length > 0
+      ? text
+      : hasAttachments
+        ? SMS_ATTACHMENTS_FALLBACK_TEXT
+        : '';
+  if (!normalizedText) {
+    throw new Error('Managed outbound delivery requires text or plainTextFallback.');
+  }
+
+  const requestId = buildManagedOutboundRequestId(callback, payload, normalizedText);
+  const response = await fetch(callback.requestUrl, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      route_id: callback.routeId,
+      assistant_id: callback.assistantId,
+      normalized_send: {
+        version: 'v1',
+        sourceChannel: callback.sourceChannel,
+        message: {
+          to: payload.chatId,
+          content: normalizedText,
+          externalMessageId: requestId,
+        },
+        source: {
+          requestId: requestId,
+        },
+        raw: {
+          chatId: payload.chatId,
+          text: payload.text ?? null,
+          assistantId: payload.assistantId ?? null,
+          chatAction: payload.chatAction ?? null,
+          hasAttachments,
+          sourceUpdateId: callback.sourceUpdateId ?? null,
+        },
+      },
+    }),
+    signal: AbortSignal.timeout(DELIVERY_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '<unreadable>');
+    log.error(
+      {
+        status: response.status,
+        body,
+        callbackUrl: callback.requestUrl,
+        routeId: callback.routeId,
+        requestId,
+        chatId: payload.chatId,
+      },
+      'Managed outbound delivery failed',
+    );
+    throw new Error(`Managed outbound delivery failed (${response.status}): ${body}`);
+  }
+
+  log.info(
+    {
+      routeId: callback.routeId,
+      assistantId: callback.assistantId,
+      sourceChannel: callback.sourceChannel,
+      requestId,
+      chatId: payload.chatId,
+    },
+    'Managed outbound delivery accepted',
+  );
+}
+
+function buildManagedOutboundRequestId(
+  callback: ManagedOutboundCallbackContext,
+  payload: ChannelReplyPayload,
+  normalizedText: string,
+): string {
+  const bodyMaterial = JSON.stringify({
+    callback: {
+      routeId: callback.routeId,
+      assistantId: callback.assistantId,
+      sourceChannel: callback.sourceChannel,
+      sourceUpdateId: callback.sourceUpdateId ?? null,
+    },
+    payload: {
+      chatId: payload.chatId,
+      text: normalizedText,
+      assistantId: payload.assistantId ?? null,
+      chatAction: payload.chatAction ?? null,
+      hasAttachments: Array.isArray(payload.attachments) && payload.attachments.length > 0,
+      approvalRequestId: payload.approval?.requestId ?? null,
+      approvalActions: payload.approval?.actions.map(action => action.id) ?? null,
+    },
+  });
+
+  const digest = Bun.hash(bodyMaterial)
+    .toString(16)
+    .padStart(16, '0');
+  return `mgw-send-${digest}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a runtime `gateway-client` managed branch that detects managed callback URLs and translates channel replies into `/v1/internal/managed-gateway/outbound-send/` requests
- strip callback metadata query params from the outbound request URL and pass runtime callback auth through `X-Managed-Gateway-Callback-Token`
- add focused runtime tests for managed callback translation and non-managed callback passthrough behavior

## Validation
- `cd assistant && bun test src/__tests__/gateway-client-managed-outbound.test.ts`
- `cd assistant && bunx tsc --noEmit`

## Companion
- platform PR: https://github.com/vellum-ai/vellum-assistant-platform/pull/1255

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
