### PR TITLE
P08 PR-5: Add idempotency-key and retry-safe send behavior

### DIFF
--- a/assistant/src/__tests__/gateway-client-managed-outbound.test.ts
+++ b/assistant/src/__tests__/gateway-client-managed-outbound.test.ts
@@ -44,6 +44,7 @@ describe('gateway-client managed outbound lane', () => {
     const headers = call.init.headers as Record<string, string>;
     expect(headers['Content-Type']).toBe('application/json');
     expect(headers['X-Managed-Gateway-Callback-Token']).toBe('runtime-token');
+    expect(headers['X-Idempotency-Key']).toStartWith('mgw-send-');
     expect(headers.Authorization).toBeUndefined();
 
     const body = JSON.parse(String(call.init.body)) as {
@@ -74,6 +75,49 @@ describe('gateway-client managed outbound lane', () => {
       body.normalized_send.message.externalMessageId,
     );
     expect(body.normalized_send.raw.sourceUpdateId).toBe('SM-inbound-123');
+  });
+
+  test('retries managed outbound send on retriable upstream responses with stable idempotency key', async () => {
+    calls.length = 0;
+    let attempt = 0;
+    globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+      calls.push({ url, init: init ?? {} });
+      attempt += 1;
+      if (attempt === 1) {
+        return new Response('temporary upstream error', { status: 502 });
+      }
+      return new Response(JSON.stringify({ status: 'accepted' }), { status: 202 });
+    }) as unknown as typeof globalThis.fetch;
+
+    await deliverChannelReply(
+      'https://platform.test/v1/internal/managed-gateway/outbound-send/?route_id=route-retry&assistant_id=assistant-retry&source_channel=sms&source_update_id=SM-retry',
+      {
+        chatId: '+15550002222',
+        text: 'retry this outbound send',
+      },
+    );
+
+    expect(calls).toHaveLength(2);
+
+    const firstHeaders = calls[0].init.headers as Record<string, string>;
+    const secondHeaders = calls[1].init.headers as Record<string, string>;
+    expect(firstHeaders['X-Idempotency-Key']).toBeDefined();
+    expect(secondHeaders['X-Idempotency-Key']).toBe(firstHeaders['X-Idempotency-Key']);
+
+    const firstBody = JSON.parse(String(calls[0].init.body)) as {
+      normalized_send: { source: { requestId: string } };
+    };
+    const secondBody = JSON.parse(String(calls[1].init.body)) as {
+      normalized_send: { source: { requestId: string } };
+    };
+    expect(secondBody.normalized_send.source.requestId).toBe(
+      firstBody.normalized_send.source.requestId,
+    );
   });
 
   test('falls back to standard callback delivery for non-managed callback URL', async () => {

--- a/assistant/src/runtime/gateway-client.ts
+++ b/assistant/src/runtime/gateway-client.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import { getLogger } from '../util/logger.js';
 import type { ApprovalUIMetadata } from './channel-approval-types.js';
 import type { RuntimeAttachmentMetadata } from './http-types.js';
@@ -7,6 +9,9 @@ const log = getLogger('gateway-client');
 const DELIVERY_TIMEOUT_MS = 30_000;
 const MANAGED_OUTBOUND_SEND_PATH = '/v1/internal/managed-gateway/outbound-send/';
 const MANAGED_CALLBACK_TOKEN_HEADER = 'X-Managed-Gateway-Callback-Token';
+const MANAGED_IDEMPOTENCY_HEADER = 'X-Idempotency-Key';
+const MANAGED_OUTBOUND_MAX_ATTEMPTS = 3;
+const MANAGED_OUTBOUND_RETRY_BASE_MS = 150;
 const SMS_ATTACHMENTS_FALLBACK_TEXT =
   'I have a media attachment to share, but SMS currently supports text only.';
 
@@ -141,62 +146,112 @@ async function deliverManagedOutboundReply(
   }
 
   const requestId = buildManagedOutboundRequestId(callback, payload, normalizedText);
-  const response = await fetch(callback.requestUrl, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({
-      route_id: callback.routeId,
-      assistant_id: callback.assistantId,
-      normalized_send: {
-        version: 'v1',
-        sourceChannel: callback.sourceChannel,
-        message: {
-          to: payload.chatId,
-          content: normalizedText,
-          externalMessageId: requestId,
-        },
-        source: {
-          requestId: requestId,
-        },
-        raw: {
-          chatId: payload.chatId,
-          text: payload.text ?? null,
-          assistantId: payload.assistantId ?? null,
-          chatAction: payload.chatAction ?? null,
-          hasAttachments,
-          sourceUpdateId: callback.sourceUpdateId ?? null,
-        },
+  headers[MANAGED_IDEMPOTENCY_HEADER] = requestId;
+
+  const requestBody = JSON.stringify({
+    route_id: callback.routeId,
+    assistant_id: callback.assistantId,
+    normalized_send: {
+      version: 'v1',
+      sourceChannel: callback.sourceChannel,
+      message: {
+        to: payload.chatId,
+        content: normalizedText,
+        externalMessageId: requestId,
       },
-    }),
-    signal: AbortSignal.timeout(DELIVERY_TIMEOUT_MS),
+      source: {
+        requestId: requestId,
+      },
+      raw: {
+        chatId: payload.chatId,
+        text: payload.text ?? null,
+        assistantId: payload.assistantId ?? null,
+        chatAction: payload.chatAction ?? null,
+        hasAttachments,
+        sourceUpdateId: callback.sourceUpdateId ?? null,
+      },
+    },
   });
 
-  if (!response.ok) {
-    const body = await response.text().catch(() => '<unreadable>');
+  for (let attempt = 1; attempt <= MANAGED_OUTBOUND_MAX_ATTEMPTS; attempt++) {
+    let response: Response;
+    try {
+      response = await fetch(callback.requestUrl, {
+        method: 'POST',
+        headers,
+        body: requestBody,
+        signal: AbortSignal.timeout(DELIVERY_TIMEOUT_MS),
+      });
+    } catch (error) {
+      if (attempt < MANAGED_OUTBOUND_MAX_ATTEMPTS) {
+        const retryDelayMs = MANAGED_OUTBOUND_RETRY_BASE_MS * attempt;
+        log.warn(
+          {
+            callbackUrl: callback.requestUrl,
+            routeId: callback.routeId,
+            requestId,
+            chatId: payload.chatId,
+            attempt,
+            retryDelayMs,
+            error,
+          },
+          'Managed outbound delivery attempt failed before response; retrying',
+        );
+        await sleep(retryDelayMs);
+        continue;
+      }
+      throw error;
+    }
+
+    if (response.ok) {
+      log.info(
+        {
+          routeId: callback.routeId,
+          assistantId: callback.assistantId,
+          sourceChannel: callback.sourceChannel,
+          requestId,
+          chatId: payload.chatId,
+          attempt,
+        },
+        'Managed outbound delivery accepted',
+      );
+      return;
+    }
+
+    const responseBody = await response.text().catch(() => '<unreadable>');
+    if (response.status >= 500 && response.status < 600 && attempt < MANAGED_OUTBOUND_MAX_ATTEMPTS) {
+      const retryDelayMs = MANAGED_OUTBOUND_RETRY_BASE_MS * attempt;
+      log.warn(
+        {
+          callbackUrl: callback.requestUrl,
+          routeId: callback.routeId,
+          requestId,
+          chatId: payload.chatId,
+          attempt,
+          status: response.status,
+          responseBody,
+          retryDelayMs,
+        },
+        'Managed outbound delivery got retriable upstream response; retrying',
+      );
+      await sleep(retryDelayMs);
+      continue;
+    }
+
     log.error(
       {
         status: response.status,
-        body,
+        body: responseBody,
         callbackUrl: callback.requestUrl,
         routeId: callback.routeId,
         requestId,
         chatId: payload.chatId,
+        attempt,
       },
       'Managed outbound delivery failed',
     );
-    throw new Error(`Managed outbound delivery failed (${response.status}): ${body}`);
+    throw new Error(`Managed outbound delivery failed (${response.status}): ${responseBody}`);
   }
-
-  log.info(
-    {
-      routeId: callback.routeId,
-      assistantId: callback.assistantId,
-      sourceChannel: callback.sourceChannel,
-      requestId,
-      chatId: payload.chatId,
-    },
-    'Managed outbound delivery accepted',
-  );
 }
 
 function buildManagedOutboundRequestId(
@@ -222,10 +277,17 @@ function buildManagedOutboundRequestId(
     },
   });
 
-  const digest = Bun.hash(bodyMaterial)
-    .toString(16)
-    .padStart(16, '0');
+  const digest = createHash('sha256')
+    .update(bodyMaterial)
+    .digest('hex')
+    .slice(0, 40);
   return `mgw-send-${digest}`;
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
 }
 
 /**

--- a/gateway-managed/outbound-send-contract.md
+++ b/gateway-managed/outbound-send-contract.md
@@ -11,11 +11,13 @@ Authz boundary:
 - requires managed gateway internal auth middleware (`bearer` or `mtls`)
 - requires `messages:send` scope
 - requires audience match to `MANAGED_GATEWAY_INTERNAL_AUTH_AUDIENCE`
+- runtime-managed callbacks may authenticate with `X-Managed-Gateway-Callback-Token` when configured on the platform
 
 Response contract:
 - `202`: accepted send envelope with `route_id`, `assistant_id`, `provider`, `route_type`, `identity_key`, optional `delivery_id`, optional `provider_status`, and optional `credential_id`
 - `400`: error envelope (`validation_error`) for invalid payloads
 - `401`: error envelope for internal auth failure
 - `404`: pass-through error envelope (`managed_route_not_found`) from Django route ownership checks
+- `409`: error envelope (`idempotency_conflict`) when `normalized_send.source.requestId` is reused with a different payload
 - `502`: error envelope for provider transport failures or non-2xx Twilio responses
 - `503`: error envelope when managed Twilio provider credentials/config are missing or no active token remains


### PR DESCRIPTION
## Summary
- add managed outbound retry behavior in runtime `gateway-client` for retriable `5xx` responses while preserving a stable idempotency key/request ID across retry attempts
- switch managed outbound request-id derivation to SHA-256 for a stable deterministic key, and attach `X-Idempotency-Key` on outbound requests
- update managed gateway contract docs for callback-token auth and `409 idempotency_conflict`, and extend runtime tests to assert stable idempotency across retries

## Validation
- `bun test assistant/src/__tests__/gateway-client-managed-outbound.test.ts`
- `cd assistant && bunx tsc --noEmit`

## Companion
- platform PR: https://github.com/vellum-ai/vellum-assistant-platform/pull/1256

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
