### PR TITLE
Remove console.log calls from providers-setup

### DIFF
--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -21,32 +21,24 @@ import { slackProvider as slackWatcherProvider } from '../watcher/providers/slac
 const log = getLogger('lifecycle');
 
 export async function initializeProvidersAndTools(config: AssistantConfig): Promise<void> {
-  console.log('[Daemon] Initializing providers and tools...');
   log.info('Daemon startup: initializing providers and tools');
   initializeProviders(config);
-  console.log('[Daemon] Providers initialized');
   await initializeTools();
-  console.log('[Daemon] Tools initialized');
 
   // Start MCP servers and register their tools
   if (config.mcp?.servers && Object.keys(config.mcp.servers).length > 0) {
-    console.log('[MCP] Initializing MCP servers:', Object.keys(config.mcp.servers).join(', '));
     const manager = getMcpServerManager();
     try {
       const serverToolInfos = await manager.start(config.mcp);
       for (const { serverId, serverConfig, tools } of serverToolInfos) {
-        console.log(`[MCP] Server "${serverId}" connected — discovered ${tools.length} tools:`, tools.map(t => t.name).join(', '));
         const mcpTools = createMcpToolsFromServer(tools, serverId, serverConfig, manager);
         registerMcpTools(mcpTools);
-        console.log(`[MCP] Registered ${mcpTools.length} tools from "${serverId}":`, mcpTools.map(t => t.name).join(', '));
       }
     } catch (err) {
-      console.error('[MCP] Server initialization failed:', err);
       log.error({ err }, 'MCP server initialization failed — continuing without MCP tools');
     }
   }
 
-  console.log('[Daemon] Providers and tools initialization complete');
   log.info('Daemon startup: providers and tools initialized');
 }
 


### PR DESCRIPTION
## Summary
- Removed all `console.log` and `console.error` calls from `assistant/src/daemon/providers-setup.ts`
- The file already uses a structured logger (`getLogger('lifecycle')`) so these were redundant

## Test plan
- [ ] Verify daemon starts without errors
- [ ] Confirm MCP server initialization still logs via structured logger

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
