### PR TITLE
fix: update outbound-send contract to reflect 5xx retry behavior

### DIFF
--- a/gateway-managed/outbound-send-contract.md
+++ b/gateway-managed/outbound-send-contract.md
@@ -5,7 +5,7 @@ Endpoint: `POST /v1/internal/managed-gateway/outbound-send/`
 Caller expectations:
 - caller is an internal Vellum-managed gateway client only
 - request body includes `route_id`, `assistant_id`, and `normalized_send`
-- caller retries only on transport-level failures; 4xx responses are terminal
+- caller retries on transport-level failures (network errors, timeouts) and 5xx HTTP responses; 4xx responses are terminal
 
 Authz boundary:
 - requires managed gateway internal auth middleware (`bearer` or `mtls`)


### PR DESCRIPTION
## Summary

- Updates `gateway-managed/outbound-send-contract.md` line 8 to accurately describe the retry behavior: the caller retries on **transport-level failures** (network errors, timeouts) **and 5xx HTTP responses**; 4xx responses remain terminal.
- Addresses Devin's review feedback on PR #11115 — the doc previously said "caller retries only on transport-level failures" but the code at `gateway-client.ts:222` retries on any `response.status >= 500 && response.status < 600`.

## Test plan

- [ ] Verify the updated contract doc matches the implementation in `assistant/src/runtime/gateway-client.ts`
- [ ] No code changes — doc-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
