### PR TITLE
fix: align inbound-dispatch fixture with wire contract

### DIFF
--- a/gateway-managed/fixtures/inbound-dispatch-request.json
+++ b/gateway-managed/fixtures/inbound-dispatch-request.json
@@ -2,18 +2,27 @@
   "route_id": "9c13036a-11f9-4c70-8f48-39ca6e2b35b2",
   "assistant_id": "0f33135d-2457-4ffe-a284-dc484f47a6f7",
   "normalized_event": {
+    "version": "v1",
     "sourceChannel": "sms",
-    "source": {
-      "provider": "twilio",
-      "messageId": "SM123"
+    "receivedAt": "2026-03-01T00:00:00Z",
+    "message": {
+      "content": "Hello",
+      "conversationExternalId": "+15551230000",
+      "externalMessageId": "SM123"
     },
     "actor": {
       "actorExternalId": "+15551239999",
-      "actorDisplayName": "User"
+      "displayName": "User"
     },
-    "message": {
-      "content": "Hello",
-      "receivedAt": "2026-03-01T00:00:00Z"
+    "source": {
+      "updateId": "evt-abc-001",
+      "messageId": "SM123"
+    },
+    "raw": {
+      "SmsSid": "SM123",
+      "From": "+15551239999",
+      "To": "+15551230000",
+      "Body": "Hello"
     }
   }
 }

--- a/gateway-managed/fixtures/inbound-dispatch-request.json
+++ b/gateway-managed/fixtures/inbound-dispatch-request.json
@@ -7,7 +7,7 @@
     "receivedAt": "2026-03-01T00:00:00Z",
     "message": {
       "content": "Hello",
-      "conversationExternalId": "+15551230000",
+      "conversationExternalId": "+15551239999",
       "externalMessageId": "SM123"
     },
     "actor": {
@@ -19,7 +19,7 @@
       "messageId": "SM123"
     },
     "raw": {
-      "SmsSid": "SM123",
+      "MessageSid": "SM123",
       "From": "+15551239999",
       "To": "+15551230000",
       "Body": "Hello"


### PR DESCRIPTION
## Summary
- Fixes the `gateway-managed/fixtures/inbound-dispatch-request.json` fixture to match the actual `GatewayInboundEvent` wire contract defined in `gateway/src/channels/inbound-event.ts`.
- Addresses review feedback from Codex and Devin on PR #11109.

### Changes
1. Added missing `version: "v1"` at top level of `normalized_event`
2. Moved `receivedAt` from inside `message` to top level of `normalized_event`
3. Renamed `actor.actorDisplayName` to `actor.displayName`
4. Replaced `source.provider` with mandatory `source.updateId`
5. Added missing `message.conversationExternalId` and `message.externalMessageId`
6. Added missing `raw` field with representative Twilio webhook payload

## Test plan
- [ ] Verify fixture JSON is valid and matches `InboundEventBase` type from `gateway/src/channels/inbound-event.ts`
- [ ] Verify no other references to the old field names in managed-gateway fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
