### PR TITLE
feat: show pressed keys in real-time during keyboard shortcut recording

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -9,6 +9,8 @@ struct SettingsAppearanceTab: View {
     @State private var isRecordingGlobalHotkey = false
     @State private var isRecordingQuickInputHotkey = false
     @State private var shortcutMonitor: Any?
+    @State private var flagsMonitor: Any?
+    @State private var recordingDisplayString: String?
     @State private var shortcutConflictWarning: String?
     @State private var showTimezonePicker = false
 
@@ -95,7 +97,11 @@ struct SettingsAppearanceTab: View {
                         .font(VFont.body)
                         .foregroundColor(VColor.textSecondary)
                     Spacer()
-                    shortcutKeyPill(ShortcutHelper.displayString(for: store.globalHotkeyShortcut))
+                    if isRecordingGlobalHotkey, let display = recordingDisplayString, !display.isEmpty {
+                        shortcutKeyPill(display)
+                    } else {
+                        shortcutKeyPill(ShortcutHelper.displayString(for: store.globalHotkeyShortcut))
+                    }
 
                     if isRecordingGlobalHotkey {
                         VButton(label: "Press shortcut...", style: .outlined, size: .large) {
@@ -124,7 +130,11 @@ struct SettingsAppearanceTab: View {
                         .font(VFont.body)
                         .foregroundColor(VColor.textSecondary)
                     Spacer()
-                    shortcutKeyPill(ShortcutHelper.displayString(for: store.quickInputHotkeyShortcut))
+                    if isRecordingQuickInputHotkey, let display = recordingDisplayString, !display.isEmpty {
+                        shortcutKeyPill(display)
+                    } else {
+                        shortcutKeyPill(ShortcutHelper.displayString(for: store.quickInputHotkeyShortcut))
+                    }
 
                     if isRecordingQuickInputHotkey {
                         VButton(label: "Press shortcut...", style: .outlined, size: .large) {
@@ -261,6 +271,14 @@ struct SettingsAppearanceTab: View {
     private func startRecordingShortcut(onRecord: @escaping (String, UInt16) -> Void) {
         stopRecording()
         shortcutConflictWarning = nil
+        recordingDisplayString = nil
+
+        // Monitor modifier key changes to show pressed modifiers in real-time.
+        flagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { event in
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            recordingDisplayString = ShortcutHelper.modifierDisplayString(from: mods)
+            return event
+        }
 
         shortcutMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
@@ -291,9 +309,14 @@ struct SettingsAppearanceTab: View {
     private func stopRecording() {
         isRecordingGlobalHotkey = false
         isRecordingQuickInputHotkey = false
+        recordingDisplayString = nil
         if let monitor = shortcutMonitor {
             NSEvent.removeMonitor(monitor)
             shortcutMonitor = nil
+        }
+        if let monitor = flagsMonitor {
+            NSEvent.removeMonitor(monitor)
+            flagsMonitor = nil
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/ShortcutHelper.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ShortcutHelper.swift
@@ -76,6 +76,17 @@ enum ShortcutHelper {
         return mods
     }
 
+    /// Returns a display string for the currently held modifier keys (e.g. "⌃ ⇧ ⌘").
+    /// Used during shortcut recording to show which modifiers the user is pressing.
+    static func modifierDisplayString(from flags: NSEvent.ModifierFlags) -> String {
+        var parts: [String] = []
+        if flags.contains(.control) { parts.append("\u{2303}") }
+        if flags.contains(.option) { parts.append("\u{2325}") }
+        if flags.contains(.shift) { parts.append("\u{21E7}") }
+        if flags.contains(.command) { parts.append("\u{2318}") }
+        return parts.joined(separator: " ")
+    }
+
     // MARK: - Private
 
     private static func displayToken(_ token: String) -> String {


### PR DESCRIPTION
## Summary
- Add a `flagsChanged` event monitor during shortcut recording to track modifier keys (Cmd, Shift, Option, Control) as they are pressed
- Display the currently held modifiers in the shortcut pill UI in real-time, replacing the static saved shortcut while recording
- Add `ShortcutHelper.modifierDisplayString(from:)` to convert modifier flags to display symbols

## Original prompt
Show pressed keys in real-time during keyboard shortcut recording for Open Vellum and Quick Input

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
