### PR TITLE
Add pill-style VSegmentedControl and replace native segmented pickers

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -572,12 +572,14 @@ struct SettingsPanel: View {
                     .font(VFont.body)
                     .foregroundColor(VColor.textSecondary)
                 Spacer()
-                Picker("", selection: $store.twitterMode) {
-                    Text("Local (BYO App)").tag("local_byo")
-                    Text("Managed").tag("managed")
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
+                VSegmentedControl(
+                    items: [
+                        (label: "Local (BYO App)", tag: "local_byo"),
+                        (label: "Managed", tag: "managed"),
+                    ],
+                    selection: $store.twitterMode,
+                    style: .pill
+                )
                 .fixedSize()
                 .onChange(of: store.twitterMode) { _, newValue in
                     store.setTwitterMode(newValue)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -25,19 +25,22 @@ struct SettingsAppearanceTab: View {
                         .font(VFont.body)
                         .foregroundColor(VColor.textSecondary)
                     Spacer()
-                    Picker("", selection: Binding(
-                        get: { themePreference },
-                        set: { newValue in
-                            themePreference = newValue
-                            AppDelegate.shared?.applyThemePreference()
-                        }
-                    )) {
-                        Text("System").tag("system")
-                        Text("Light").tag("light")
-                        Text("Dark").tag("dark")
-                    }
-                    .pickerStyle(.segmented)
-                    .frame(width: 200)
+                    VSegmentedControl(
+                        items: [
+                            (label: "System", tag: "system"),
+                            (label: "Light", tag: "light"),
+                            (label: "Dark", tag: "dark"),
+                        ],
+                        selection: Binding(
+                            get: { themePreference },
+                            set: { newValue in
+                                themePreference = newValue
+                                AppDelegate.shared?.applyThemePreference()
+                            }
+                        ),
+                        style: .pill
+                    )
+                    .frame(width: 220)
                 }
 
                 Divider()

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -30,14 +30,11 @@ struct RecordingSourcePickerView: View {
                 .padding(.bottom, VSpacing.md)
 
             // Scope picker (Display / Window)
-            Picker("Capture", selection: $viewModel.captureScope) {
-                ForEach(CaptureScope.allCases, id: \.self) { scope in
-                    Text(scope.rawValue).tag(scope)
-                }
-            }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .controlSize(.large)
+            VSegmentedControl(
+                items: CaptureScope.allCases.map { (label: $0.rawValue, tag: $0) },
+                selection: $viewModel.captureScope,
+                style: .pill
+            )
             .padding(.horizontal, VSpacing.lg)
             .padding(.bottom, VSpacing.sm)
 

--- a/clients/shared/DesignSystem/Components/Navigation/VSegmentedControl.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VSegmentedControl.swift
@@ -1,38 +1,137 @@
 import SwiftUI
 
-public struct VSegmentedControl: View {
-    public let items: [String]
-    @Binding public var selection: Int
+public enum VSegmentedControlStyle {
+    case underline
+    case pill
+}
 
-    public init(items: [String], selection: Binding<Int>) {
+public struct VSegmentedControl<SelectionValue: Hashable>: View {
+    public let items: [(label: String, tag: SelectionValue)]
+    @Binding public var selection: SelectionValue
+    public let style: VSegmentedControlStyle
+
+    public init(items: [(label: String, tag: SelectionValue)], selection: Binding<SelectionValue>, style: VSegmentedControlStyle = .underline) {
         self.items = items
         self._selection = selection
+        self.style = style
     }
 
     public var body: some View {
+        switch style {
+        case .underline:
+            underlineBody
+        case .pill:
+            pillBody
+        }
+    }
+
+    // MARK: - Underline Style
+
+    private var underlineBody: some View {
         HStack(spacing: 0) {
             ForEach(items.indices, id: \.self) { index in
-                Button(action: { selection = index }) {
+                let item = items[index]
+                Button(action: { selection = item.tag }) {
                     VStack(spacing: VSpacing.xs) {
-                        Text(items[index])
+                        Text(item.label)
                             .font(VFont.captionMedium)
-                            .foregroundColor(selection == index ? VColor.textPrimary : VColor.textMuted)
+                            .foregroundColor(selection == item.tag ? VColor.textPrimary : VColor.textMuted)
                             .padding(.horizontal, VSpacing.xl)
                             .padding(.vertical, VSpacing.xs)
 
                         Rectangle()
-                            .fill(selection == index ? VColor.accent : .clear)
+                            .fill(selection == item.tag ? VColor.accent : .clear)
                             .frame(height: 2)
                     }
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel(items[index])
-                .accessibilityAddTraits(selection == index ? .isSelected : [])
+                .accessibilityLabel(item.label)
+                .accessibilityAddTraits(selection == item.tag ? .isSelected : [])
             }
             Spacer()
         }
         .padding(.horizontal, VSpacing.sm)
+    }
+
+    // MARK: - Pill Style
+
+    private var pillBody: some View {
+        HStack(spacing: 2) {
+            ForEach(items.indices, id: \.self) { index in
+                let item = items[index]
+                PillSegment(
+                    label: item.label,
+                    isSelected: selection == item.tag,
+                    action: { selection = item.tag }
+                )
+            }
+        }
+        .padding(2)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.surfaceSubtle)
+        )
+        .animation(VAnimation.fast, value: selection)
+    }
+}
+
+// MARK: - Int convenience initializer
+
+public extension VSegmentedControl where SelectionValue == Int {
+    init(items: [String], selection: Binding<Int>, style: VSegmentedControlStyle = .underline) {
+        self.init(
+            items: items.enumerated().map { (label: $0.element, tag: $0.offset) },
+            selection: selection,
+            style: style
+        )
+    }
+}
+
+// MARK: - Pill Segment
+
+private struct PillSegment: View {
+    let label: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        Button(action: action) {
+            Text(label)
+                .font(VFont.body)
+                .fixedSize()
+                .foregroundColor(isSelected ? selectedTextColor : VColor.textSecondary)
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.vertical, VSpacing.xs + 2)
+                .frame(maxWidth: .infinity)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.md - 1)
+                        .fill(segmentBackground)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+        .accessibilityLabel(label)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private var selectedTextColor: Color {
+        .white
+    }
+
+    private var segmentBackground: Color {
+        if isSelected {
+            return Forest._600
+        } else if isHovered {
+            return VColor.ghostHover
+        } else {
+            return .clear
+        }
     }
 }
 
@@ -40,18 +139,32 @@ public struct VSegmentedControl: View {
 struct VSegmentedControl_Preview: PreviewProvider {
     static var previews: some View {
         VSegmentedControlPreviewWrapper()
-            .frame(width: 500, height: 60)
+            .frame(width: 500, height: 120)
             .previewDisplayName("VSegmentedControl")
     }
 }
 
 private struct VSegmentedControlPreviewWrapper: View {
     @State private var selection = 1
+    @State private var pillSelection = "dark"
 
     var body: some View {
         ZStack {
             VColor.background.ignoresSafeArea()
-            VSegmentedControl(items: ["Profile", "Settings", "Channels", "Overview"], selection: $selection)
+            VStack(spacing: VSpacing.xl) {
+                VSegmentedControl(items: ["Profile", "Settings", "Channels", "Overview"], selection: $selection)
+
+                VSegmentedControl(
+                    items: [
+                        (label: "System", tag: "system"),
+                        (label: "Light", tag: "light"),
+                        (label: "Dark", tag: "dark"),
+                    ],
+                    selection: $pillSelection,
+                    style: .pill
+                )
+                .frame(width: 240)
+            }
         }
     }
 }

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -20,13 +20,16 @@ struct ButtonsGallerySection: View {
                 VStack(alignment: .leading, spacing: VSpacing.xl) {
                     // Controls
                     HStack(spacing: VSpacing.xl) {
-                        Picker("Style", selection: $selectedStyle) {
-                            Text("Primary").tag(VButton.Style.primary)
-                            Text("Tertiary").tag(VButton.Style.tertiary)
-                            Text("Secondary").tag(VButton.Style.secondary)
-                            Text("Danger").tag(VButton.Style.danger)
-                        }
-                        .pickerStyle(.segmented)
+                        VSegmentedControl(
+                            items: [
+                                (label: "Primary", tag: VButton.Style.primary),
+                                (label: "Tertiary", tag: VButton.Style.tertiary),
+                                (label: "Secondary", tag: VButton.Style.secondary),
+                                (label: "Danger", tag: VButton.Style.danger),
+                            ],
+                            selection: $selectedStyle,
+                            style: .pill
+                        )
                         .frame(maxWidth: 300)
 
                         Toggle("Full Width", isOn: $isFullWidth)

--- a/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct NavigationGallerySection: View {
     @State private var segmentSelection = 0
+    @State private var pillSelection = "active"
     @State private var selectedTab = 0
 
     private let segmentItems = ["All", "Active", "Archived", "Drafts"]
@@ -39,6 +40,35 @@ struct NavigationGallerySection: View {
                             .frame(maxWidth: .infinity)
                             .padding(VSpacing.xl)
                     }
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - VSegmentedControl (Pill)
+            GallerySectionHeader(
+                title: "VSegmentedControl (Pill)",
+                description: "Pill-style segmented control with filled accent background on selection."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    Text("Selected: \(pillSelection)")
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textMuted)
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    VSegmentedControl(
+                        items: [
+                            (label: "All", tag: "all"),
+                            (label: "Active", tag: "active"),
+                            (label: "Archived", tag: "archived"),
+                        ],
+                        selection: $pillSelection,
+                        style: .pill
+                    )
+                    .frame(maxWidth: 300)
                 }
             }
 


### PR DESCRIPTION
## Summary
- Add `.pill` style to `VSegmentedControl` with Forest green accent fill, white text, hover states, and generic `Hashable` selection support
- Replace 4 native `.pickerStyle(.segmented)` pickers on macOS (theme picker, Twitter mode, capture scope, button style gallery) with `VSegmentedControl(.pill)`
- Add pill-style example to the Navigation gallery section

## Test plan
- [ ] Open Settings > Appearance — verify theme picker uses green pill style in both light and dark mode
- [ ] Open Settings > Twitter — verify integration mode picker renders as pill
- [ ] Open Screen Recording picker — verify Display/Window scope picker renders as pill
- [ ] Open Component Gallery > Buttons — verify style picker renders as pill
- [ ] Open Component Gallery > Navigation — verify new pill section appears
- [ ] Verify underline-style VSegmentedControl still works (unchanged API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
