### PR TITLE
fix: remove force unwrap crash in wake word activation path

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
@@ -117,7 +117,11 @@ final class WakeWordCoordinator: ObservableObject {
         audioMonitor.stopMonitoring()
 
         // 3. Ensure we have an active ChatViewModel (create a new thread if needed)
-        let chatViewModel = ensureChatViewModel()
+        guard let chatViewModel = ensureChatViewModel() else {
+            log.error("Wake word activation failed — no ChatViewModel available, resuming wake word listening")
+            audioMonitor.startMonitoring()
+            return
+        }
 
         // 4. Show voice mode panel and activate (same as the UI button)
         windowState.selection = .panel(.voiceMode)
@@ -133,14 +137,13 @@ final class WakeWordCoordinator: ObservableObject {
     }
 
     /// Returns the active ChatViewModel, creating a new thread if none exists.
-    private func ensureChatViewModel() -> ChatViewModel {
+    private func ensureChatViewModel() -> ChatViewModel? {
         if let existing = threadManager.activeViewModel {
             return existing
         }
         // No active thread — create one, which sets it as active
         threadManager.createThread()
-        // activeViewModel should now be set after createThread
-        return threadManager.activeViewModel!
+        return threadManager.activeViewModel
     }
 
     // MARK: - PTT Recording Observation


### PR DESCRIPTION
## Summary
- Removes a force unwrap (`threadManager.activeViewModel!`) in `WakeWordCoordinator.ensureChatViewModel()` that crashed the app when the wake word fired before the thread manager was fully initialized
- Adds graceful recovery: if no `ChatViewModel` is available, logs an error and resumes wake word listening instead of crashing
- Same recovery pattern already existed for the voice mode activation failure path

## Test plan
- [ ] Enable wake word, say wake phrase — verify voice mode activates normally
- [ ] Kill daemon mid-session, say wake phrase — verify app doesn't crash and wake word listening resumes
- [ ] Say wake phrase immediately after cold launch — verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
