### PR TITLE
Remove stale M5 nullability scaffolding in runtime trust context types

### DIFF
--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -38,8 +38,8 @@ export interface GuardianRuntimeContext {
   trustClass: 'guardian' | 'trusted_contact' | 'unknown';
   guardianChatId?: string;
   guardianExternalUserId?: string;
-  /** Canonical principal ID for the guardian binding. Nullable for backward compatibility — M5 will make this required. */
-  guardianPrincipalId?: string | null;
+  /** Canonical principal ID for the guardian binding. */
+  guardianPrincipalId?: string;
   requesterIdentifier?: string;
   requesterDisplayName?: string;
   requesterSenderDisplayName?: string;

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -35,8 +35,8 @@ export interface ActorTrustContext {
     guardianExternalUserId: string;
     guardianDeliveryChatId: string | null;
   } | null;
-  /** Canonical principal ID from the guardian binding. Nullable for backward compatibility — M5 will make this required. */
-  guardianPrincipalId?: string | null;
+  /** Canonical principal ID from the guardian binding. */
+  guardianPrincipalId?: string;
   /** Ingress member record, if any, for this sender. */
   memberRecord: IngressMember | null;
   /** Trust classification. */

--- a/assistant/src/runtime/guardian-context-resolver.ts
+++ b/assistant/src/runtime/guardian-context-resolver.ts
@@ -24,8 +24,8 @@ export interface GuardianContext {
   trustClass: ActorTrustClass;
   guardianChatId?: string;
   guardianExternalUserId?: string;
-  /** Canonical principal ID from the guardian binding. Nullable for backward compatibility — M5 will make this required. */
-  guardianPrincipalId?: string | null;
+  /** Canonical principal ID from the guardian binding. */
+  guardianPrincipalId?: string;
   requesterIdentifier?: string;
   requesterDisplayName?: string;
   requesterSenderDisplayName?: string;


### PR DESCRIPTION
## Summary
- Remove stale M5-era backward-compatibility comments from `guardianPrincipalId` in three runtime trust context interfaces
- Normalize `guardianPrincipalId` type from `string | null` to optional `string` in `ActorTrustContext`, `GuardianContext`, and `GuardianRuntimeContext`
- DB schema remains nullable; null→undefined conversion already happens at resolution boundaries (`?? undefined`)

## Original prompt
/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/.private/plans/guardian-trust-context-simplification-execution-plan-2026-03-02.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
