### PR TITLE
fix: make Apps navigation deterministic — always full-width, no stuck chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -151,6 +151,7 @@ public final class MainWindowState: ObservableObject {
 
     /// Dismiss the current overlay (app, panel, etc.) and return to the persistent thread.
     func dismissOverlay() {
+        isAppChatOpen = false
         if let threadId = persistentThreadId {
             selection = .thread(threadId)
         } else {
@@ -195,6 +196,13 @@ public final class MainWindowState: ObservableObject {
         }
     }
 
+    /// Navigate directly to the Apps panel (always full-width, no toggle).
+    func showAppsPanel() {
+        isAppChatOpen = false
+        selection = .panel(.apps)
+        lastActivePanelString = String(describing: SidePanelType.apps)
+    }
+
     func refreshAPIKeyStatus(isConnected: Bool) {
         hasAPIKey = APIKeyManager.hasAnyKey() || isConnected
     }
@@ -207,6 +215,7 @@ public final class MainWindowState: ObservableObject {
     /// Reset all dynamic workspace state. Callers should also reset
     /// view-local state like `showSharePicker` separately.
     func closeDynamicPanel() {
+        isAppChatOpen = false
         selection = nil
         activeDynamicSurface = nil
         activeDynamicParsedSurface = nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1226,7 +1226,7 @@ struct MainWindowView: View {
                 windowState.togglePanel(.intelligence)
             }
             SidebarNavRow(icon: "square.grid.2x2", label: "Things", isActive: windowState.activePanel == .apps) {
-                windowState.togglePanel(.apps)
+                windowState.showAppsPanel()
             }
 
             // Divider between nav items and threads
@@ -1423,7 +1423,7 @@ struct MainWindowView: View {
                 windowState.togglePanel(.intelligence)
             }
             SidebarNavRow(icon: "square.grid.2x2", label: "Things", isActive: windowState.activePanel == .apps, isExpanded: false) {
-                windowState.togglePanel(.apps)
+                windowState.showAppsPanel()
             }
 
             VColor.divider

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -315,53 +315,16 @@ extension MainWindowView {
                     .background(adaptiveColor(light: Moss._50, dark: Moss._950))
                 }
             } else if panelType == .apps {
-                if isAppChatOpen {
-                    // VSplitView: ChatView (left) + Apps grid (right)
-                    let contentWidth = Double(geometry.size.width) / zoomManager.zoomLevel - Double(VSpacing.sm)
-                    let effectiveWidth = Binding<Double>(
-                        get: { appPanelWidth > 0 ? appPanelWidth : contentWidth * 0.7 },
-                        set: { appPanelWidth = $0 }
-                    )
-                    VSplitView(
-                        panelWidth: effectiveWidth,
-                        showPanel: true,
-                        main: {
-                            chatView
-                        },
-                        panel: {
-                            AppsGridView(
-                                appListManager: appListManager,
-                                daemonClient: daemonClient,
-                                onOpenApp: { appId in
-                                    try? daemonClient.sendAppOpen(appId: appId)
-                                    windowState.selection = .app(appId)
-                                }
-                            )
-                            .background(adaptiveColor(light: Moss._100, dark: Moss._900))
-                            .clipShape(UnevenRoundedRectangle(topLeadingRadius: VRadius.xl, bottomLeadingRadius: VRadius.xl))
-                        }
-                    )
-                    .onAppear {
-                        if threadManager.activeViewModel == nil {
-                            if let firstThread = threadManager.visibleThreads.first {
-                                threadManager.selectThread(id: firstThread.id)
-                            } else {
-                                threadManager.createThread()
-                            }
-                        }
+                AppsGridView(
+                    appListManager: appListManager,
+                    daemonClient: daemonClient,
+                    onOpenApp: { appId in
+                        try? daemonClient.sendAppOpen(appId: appId)
+                        windowState.selection = .app(appId)
                     }
-                } else {
-                    AppsGridView(
-                        appListManager: appListManager,
-                        daemonClient: daemonClient,
-                        onOpenApp: { appId in
-                            try? daemonClient.sendAppOpen(appId: appId)
-                            windowState.selection = .app(appId)
-                        }
-                    )
-                    .overlay(alignment: .topTrailing) { panelDismissButton }
-                    .background(adaptiveColor(light: Moss._50, dark: Moss._950))
-                }
+                )
+                .overlay(alignment: .topTrailing) { panelDismissButton }
+                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
             } else if panelType == .documentEditor {
                 let config = windowState.layoutConfig
                 VSplitView(

--- a/clients/macos/vellum-assistantTests/MainWindowAppsNavigationTests.swift
+++ b/clients/macos/vellum-assistantTests/MainWindowAppsNavigationTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class MainWindowAppsNavigationTests: XCTestCase {
+
+    // MARK: - showAppsPanel()
+
+    func testShowAppsPanelSetsSelectionToApps() {
+        let state = MainWindowState(hasAPIKey: false)
+        state.selection = .thread(UUID())
+
+        state.showAppsPanel()
+
+        XCTAssertEqual(state.selection, .panel(.apps))
+    }
+
+    func testShowAppsPanelIsIdempotent() {
+        let state = MainWindowState(hasAPIKey: false)
+        state.showAppsPanel()
+        XCTAssertEqual(state.selection, .panel(.apps))
+
+        // Calling again should remain on apps, not toggle away.
+        state.showAppsPanel()
+        XCTAssertEqual(state.selection, .panel(.apps))
+    }
+
+    func testShowAppsPanelClearsConversationVisible() {
+        let state = MainWindowState(hasAPIKey: false)
+        // Simulate a prior app-edit flow that left isAppChatOpen = true
+        // by toggling the chat dock while in an app editing state.
+        let threadId = UUID()
+        state.selection = .appEditing(appId: "test-app", threadId: threadId)
+
+        // Now navigate to apps panel.
+        state.showAppsPanel()
+
+        XCTAssertEqual(state.selection, .panel(.apps))
+        // isConversationVisible should be false for apps panel after showAppsPanel.
+        XCTAssertFalse(state.isConversationVisible)
+    }
+
+    // MARK: - dismissOverlay() clears sticky state
+
+    func testDismissOverlayClearsAppChatState() {
+        let state = MainWindowState(hasAPIKey: false)
+        let threadId = UUID()
+        state.selection = .thread(threadId)
+        // Navigate to app editing then dismiss.
+        state.selection = .appEditing(appId: "test-app", threadId: threadId)
+        state.dismissOverlay()
+
+        // After dismissing, navigating to apps should not show conversation.
+        state.showAppsPanel()
+        XCTAssertFalse(state.isConversationVisible)
+    }
+
+    // MARK: - closeDynamicPanel() clears sticky state
+
+    func testCloseDynamicPanelClearsAppChatState() {
+        let state = MainWindowState(hasAPIKey: false)
+        state.selection = .app("test-app")
+        state.closeDynamicPanel()
+
+        // After closing dynamic panel, apps should not show conversation.
+        state.showAppsPanel()
+        XCTAssertFalse(state.isConversationVisible)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `showAppsPanel()` method that clears `isAppChatOpen`, sets selection to `.panel(.apps)`, and persists panel state — no toggle semantics
- Route both sidebar Apps buttons (expanded + collapsed) through `showAppsPanel()`
- Remove split-layout branch for Apps panel in `PanelCoordinator` — always renders full-width `AppsGridView`
- Harden `dismissOverlay()` and `closeDynamicPanel()` to clear `isAppChatOpen` so exiting workspace/panel flows can't leave sticky chat state

## Test plan
- [ ] Click Apps → opens full-width apps UI
- [ ] Click Apps again while on Apps → stays on Apps (no toggle away)
- [ ] Open app → Edit (chat appears) → Close app → Click Apps → full-width apps, no stuck chat
- [ ] Thread selection, drag-and-drop, context menu still work
- [ ] 5 new unit tests pass (`MainWindowAppsNavigationTests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
