### PR TITLE
fix: clear app chat state when navigating away from app views

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -25,6 +25,12 @@ public final class MainWindowState: ObservableObject {
             if case .thread(let id) = selection {
                 persistentThreadId = id
             }
+            // Chat dock is only relevant inside app views. Clear it when
+            // navigating away so other pages never show a stale split layout.
+            switch selection {
+            case .app, .appEditing: break
+            default: isAppChatOpen = false
+            }
         }
     }
 
@@ -151,7 +157,6 @@ public final class MainWindowState: ObservableObject {
 
     /// Dismiss the current overlay (app, panel, etc.) and return to the persistent thread.
     func dismissOverlay() {
-        isAppChatOpen = false
         if let threadId = persistentThreadId {
             selection = .thread(threadId)
         } else {
@@ -198,7 +203,6 @@ public final class MainWindowState: ObservableObject {
 
     /// Navigate directly to the Apps panel (always full-width, no toggle).
     func showAppsPanel() {
-        isAppChatOpen = false
         selection = .panel(.apps)
         lastActivePanelString = String(describing: SidePanelType.apps)
     }
@@ -215,7 +219,6 @@ public final class MainWindowState: ObservableObject {
     /// Reset all dynamic workspace state. Callers should also reset
     /// view-local state like `showSharePicker` separately.
     func closeDynamicPanel() {
-        isAppChatOpen = false
         selection = nil
         activeDynamicSurface = nil
         activeDynamicParsedSurface = nil


### PR DESCRIPTION
## Summary
- Move `isAppChatOpen` clearing into the `selection` didSet so it resets automatically when navigating to any non-app view (threads, panels, nil)
- Remove redundant explicit clears from `dismissOverlay()`, `closeDynamicPanel()`, and `showAppsPanel()` — the setter now handles all paths

## Test plan
- [ ] Open app → enable chat dock → navigate to Intelligence/Apps/thread → chat is not visible
- [ ] Open app → enable chat dock → close app → navigate anywhere → no stuck chat
- [ ] Chat dock still works correctly within app views (`.app` ↔ `.appEditing`)
- [ ] All 5 `MainWindowAppsNavigationTests` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
