### PR TITLE
fix: match nav-to-threads divider spacing with pinned apps divider

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1149,6 +1149,7 @@ struct MainWindowView: View {
             VColor.divider
                 .frame(height: 1)
                 .padding(.horizontal, VSpacing.md)
+                .padding(.vertical, VSpacing.sm)
 
             // MARK: Threads (scrollable)
             SidebarThreadsHeader(


### PR DESCRIPTION
## Summary
- Add `.padding(.vertical, VSpacing.sm)` to the nav→threads divider to match the pinned apps→nav divider spacing

## Test plan
- [ ] Divider spacing below Things matches divider spacing below pinned apps section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
