### PR TITLE
M2: Consolidate GuardianContext and ActorTrustContext into one canonical trust model

### DIFF
--- a/assistant/src/__tests__/guardian-grant-minting.test.ts
+++ b/assistant/src/__tests__/guardian-grant-minting.test.ts
@@ -137,6 +137,7 @@ function registerPendingInteraction(
 
 function makeGuardianContext(): GuardianContext {
   return {
+    sourceChannel: 'telegram',
     trustClass: 'guardian',
     denialReason: undefined,
   };
@@ -555,6 +556,7 @@ describe('approval interception trust-class regression coverage', () => {
       actorExternalId: 'intruder-user-1',
       replyCallbackUrl: 'https://gateway.test/deliver',
       guardianCtx: {
+        sourceChannel: 'telegram',
         trustClass: 'unknown',
       },
       assistantId: ASSISTANT_ID,
@@ -581,6 +583,7 @@ describe('approval interception trust-class regression coverage', () => {
       actorExternalId: undefined,
       replyCallbackUrl: 'https://gateway.test/deliver',
       guardianCtx: {
+        sourceChannel: 'telegram',
         trustClass: 'unknown',
         denialReason: 'no_identity',
       },

--- a/assistant/src/__tests__/guardian-routing-state.test.ts
+++ b/assistant/src/__tests__/guardian-routing-state.test.ts
@@ -103,6 +103,7 @@ function resetTables(): void {
 describe('resolveRoutingState', () => {
   test('guardian actors are always interactive and route-resolvable', () => {
     const ctx: GuardianContext = {
+      sourceChannel: 'telegram',
       trustClass: 'guardian',
       guardianExternalUserId: 'guardian-123',
       guardianChatId: 'chat-123',
@@ -118,6 +119,7 @@ describe('resolveRoutingState', () => {
   test('guardian actors are interactive even without guardianExternalUserId', () => {
     // Edge case: guardian is chatting in their own chat, no separate binding needed
     const ctx: GuardianContext = {
+      sourceChannel: 'telegram',
       trustClass: 'guardian',
     };
     const state = resolveRoutingState(ctx);
@@ -127,6 +129,7 @@ describe('resolveRoutingState', () => {
 
   test('trusted contact with resolvable guardian route is interactive', () => {
     const ctx: GuardianContext = {
+      sourceChannel: 'telegram',
       trustClass: 'trusted_contact',
       guardianExternalUserId: 'guardian-456',
       guardianChatId: 'guardian-chat-456',
@@ -141,6 +144,7 @@ describe('resolveRoutingState', () => {
 
   test('trusted contact without guardian route is NOT interactive (fail-fast)', () => {
     const ctx: GuardianContext = {
+      sourceChannel: 'telegram',
       trustClass: 'trusted_contact',
       // No guardianExternalUserId — no guardian binding for this channel
     };
@@ -154,10 +158,12 @@ describe('resolveRoutingState', () => {
 
   test('unknown actors are never interactive regardless of guardian route', () => {
     const withRoute: GuardianContext = {
+      sourceChannel: 'telegram',
       trustClass: 'unknown',
       guardianExternalUserId: 'guardian-789',
     };
     const withoutRoute: GuardianContext = {
+      sourceChannel: 'telegram',
       trustClass: 'unknown',
     };
 

--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -316,6 +316,7 @@ describe('(a) target flow: trusted-contact inline guardian approval end-to-end',
   test('complete flow: routing state allows interactive + bridge notifies guardian + tool resumes', async () => {
     // Step 1: Verify routing state allows interactive turns for trusted contacts
     const guardianCtx: GuardianContext = {
+      sourceChannel: 'telegram',
       trustClass: 'trusted_contact',
       guardianExternalUserId: 'guardian-1',
       guardianChatId: 'guardian-chat-1',
@@ -463,6 +464,7 @@ describe('(c) no-binding flow: trusted contact fails fast without guardian bindi
 
   test('routing state blocks prompt waiting when no guardian binding exists', () => {
     const ctx: GuardianContext = {
+      sourceChannel: 'telegram',
       trustClass: 'trusted_contact',
       // No guardianExternalUserId — mirrors no binding
     };
@@ -592,10 +594,12 @@ describe('(d) unknown actor flow: fail-closed with no interactive approval', () 
 
   test('unknown actors have promptWaitingAllowed=false regardless of guardian route', () => {
     const withRoute: GuardianContext = {
+      sourceChannel: 'telegram',
       trustClass: 'unknown',
       guardianExternalUserId: 'guardian-1',
     };
     const withoutRoute: GuardianContext = {
+      sourceChannel: 'telegram',
       trustClass: 'unknown',
     };
 
@@ -961,6 +965,7 @@ describe('cross-milestone integration checks', () => {
   test('M1+M4: routing state interactivity drives inline wait eligibility', async () => {
     // With guardian binding: interactive + inline wait allowed
     const withBinding: GuardianContext = {
+      sourceChannel: 'telegram',
       trustClass: 'trusted_contact',
       guardianExternalUserId: 'guardian-1',
     };
@@ -968,6 +973,7 @@ describe('cross-milestone integration checks', () => {
 
     // Without guardian binding: not interactive + inline wait should not enter dead-end
     const withoutBinding: GuardianContext = {
+      sourceChannel: 'telegram',
       trustClass: 'trusted_contact',
     };
     expect(resolveRoutingState(withoutBinding).promptWaitingAllowed).toBe(false);

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -20,6 +20,8 @@ import { canonicalizeInboundIdentity } from '../util/canonicalize-identity.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
 import { getGuardianBinding } from './channel-guardian-service.js';
 
+export type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -203,17 +205,24 @@ export function resolveActorTrust(input: ResolveActorTrustInput): ActorTrustCont
 /**
  * Convert an ActorTrustContext into the runtime trust context shape used by
  * sessions/tooling.
+ *
+ * This is the single canonical conversion from resolved trust to runtime
+ * context. The guardianExternalUserId is canonicalized to handle phone-
+ * channel formatting variance (e.g. stored binding vs E.164).
  */
 export function toGuardianRuntimeContextFromTrust(
   ctx: ActorTrustContext,
   conversationExternalId: string,
 ): GuardianRuntimeContext {
+  const canonicalGuardianExternalUserId = ctx.guardianBindingMatch?.guardianExternalUserId
+    ? canonicalizeInboundIdentity(ctx.actorMetadata.channel, ctx.guardianBindingMatch.guardianExternalUserId) ?? undefined
+    : undefined;
   return {
     sourceChannel: ctx.actorMetadata.channel,
     trustClass: ctx.trustClass,
     guardianChatId: ctx.guardianBindingMatch?.guardianDeliveryChatId ??
       (ctx.trustClass === 'guardian' ? conversationExternalId : undefined),
-    guardianExternalUserId: ctx.guardianBindingMatch?.guardianExternalUserId,
+    guardianExternalUserId: canonicalGuardianExternalUserId,
     guardianPrincipalId: ctx.guardianPrincipalId,
     requesterIdentifier: ctx.actorMetadata.identifier,
     requesterDisplayName: ctx.actorMetadata.displayName,

--- a/assistant/src/runtime/guardian-context-resolver.ts
+++ b/assistant/src/runtime/guardian-context-resolver.ts
@@ -1,17 +1,21 @@
 /**
  * Shared inbound trust resolution for channel actors.
  *
- * This module provides a compact route-level shape used by channel routes
- * while delegating canonical classification to the unified actor trust
- * resolver.
+ * GuardianContext is a type alias for GuardianRuntimeContext — the
+ * canonical runtime trust context used by sessions, tooling, and channel
+ * routes. This module re-exports the alias and provides routing-state
+ * helpers that operate on the canonical type.
+ *
+ * Trust resolution itself lives in actor-trust-resolver.ts; the resolved
+ * ActorTrustContext is converted to GuardianRuntimeContext via
+ * toGuardianRuntimeContextFromTrust.
  */
-import type { ChannelId } from '../channels/types.js';
 import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
-import { canonicalizeInboundIdentity } from '../util/canonicalize-identity.js';
 import {
   type DenialReason,
   resolveActorTrust,
   type ResolveActorTrustInput,
+  toGuardianRuntimeContextFromTrust,
   type TrustClass,
 } from './actor-trust-resolver.js';
 export type { DenialReason } from './actor-trust-resolver.js';
@@ -19,50 +23,28 @@ export type { DenialReason } from './actor-trust-resolver.js';
 /** Trust classification used by route-level channel logic. */
 export type ActorTrustClass = TrustClass;
 
-/** Guardian actor context used by route-level approval logic. */
-export interface GuardianContext {
-  trustClass: ActorTrustClass;
-  guardianChatId?: string;
-  guardianExternalUserId?: string;
-  /** Canonical principal ID from the guardian binding. */
-  guardianPrincipalId?: string;
-  requesterIdentifier?: string;
-  requesterDisplayName?: string;
-  requesterSenderDisplayName?: string;
-  requesterMemberDisplayName?: string;
-  requesterExternalUserId?: string;
-  requesterChatId?: string;
-  memberStatus?: string;
-  memberPolicy?: string;
-  denialReason?: DenialReason;
-}
+/**
+ * GuardianContext is the canonical runtime trust context.
+ *
+ * Previously this was a separate interface with extra fields (memberStatus,
+ * memberPolicy). Those fields were only needed for InboundActorContext
+ * construction, which now sources them directly from ActorTrustContext.
+ * This alias unifies the two shapes and removes the redundant conversion
+ * layer.
+ */
+export type GuardianContext = GuardianRuntimeContext;
 
 export type ResolveGuardianContextInput = ResolveActorTrustInput;
 
 /**
  * Resolve route-level trust context from canonical identity state.
+ *
+ * Delegates to resolveActorTrust for classification, then converts to
+ * the canonical GuardianRuntimeContext via toGuardianRuntimeContextFromTrust.
  */
 export function resolveGuardianContext(input: ResolveGuardianContextInput): GuardianContext {
   const trust = resolveActorTrust(input);
-  const canonicalGuardianExternalUserId = trust.guardianBindingMatch?.guardianExternalUserId
-    ? canonicalizeInboundIdentity(input.sourceChannel, trust.guardianBindingMatch.guardianExternalUserId) ?? undefined
-    : undefined;
-  return {
-    trustClass: trust.trustClass,
-    guardianChatId: trust.guardianBindingMatch?.guardianDeliveryChatId ??
-      (trust.trustClass === 'guardian' ? input.conversationExternalId : undefined),
-    guardianExternalUserId: canonicalGuardianExternalUserId,
-    guardianPrincipalId: trust.guardianPrincipalId,
-    requesterIdentifier: trust.actorMetadata.identifier,
-    requesterDisplayName: trust.actorMetadata.displayName,
-    requesterSenderDisplayName: trust.actorMetadata.senderDisplayName,
-    requesterMemberDisplayName: trust.actorMetadata.memberDisplayName,
-    requesterExternalUserId: trust.canonicalSenderId ?? undefined,
-    requesterChatId: input.conversationExternalId,
-    memberStatus: trust.memberRecord?.status ?? undefined,
-    memberPolicy: trust.memberRecord?.policy ?? undefined,
-    denialReason: trust.denialReason,
-  };
+  return toGuardianRuntimeContextFromTrust(trust, input.conversationExternalId);
 }
 
 // ---------------------------------------------------------------------------
@@ -102,7 +84,7 @@ export interface RoutingState {
  * Trusted contacts are only interactive when a guardian binding exists
  * to receive approval notifications. Unknown actors are never interactive.
  */
-export function resolveRoutingState(ctx: GuardianContext): RoutingState {
+export function resolveRoutingState(ctx: Pick<GuardianRuntimeContext, 'trustClass' | 'guardianExternalUserId'>): RoutingState {
   const isGuardian = ctx.trustClass === 'guardian';
   const isTrustedContact = ctx.trustClass === 'trusted_contact';
 
@@ -141,25 +123,5 @@ export function resolveRoutingState(ctx: GuardianContext): RoutingState {
  * (the shape persisted in stored payloads and used by the retry sweep).
  */
 export function resolveRoutingStateFromRuntime(ctx: GuardianRuntimeContext): RoutingState {
-  return resolveRoutingState({
-    trustClass: ctx.trustClass,
-    guardianExternalUserId: ctx.guardianExternalUserId,
-  });
-}
-
-export function toGuardianRuntimeContext(sourceChannel: ChannelId, ctx: GuardianContext): GuardianRuntimeContext {
-  return {
-    sourceChannel,
-    trustClass: ctx.trustClass,
-    guardianChatId: ctx.guardianChatId,
-    guardianExternalUserId: ctx.guardianExternalUserId,
-    guardianPrincipalId: ctx.guardianPrincipalId,
-    requesterIdentifier: ctx.requesterIdentifier,
-    requesterDisplayName: ctx.requesterDisplayName,
-    requesterSenderDisplayName: ctx.requesterSenderDisplayName,
-    requesterMemberDisplayName: ctx.requesterMemberDisplayName,
-    requesterExternalUserId: ctx.requesterExternalUserId,
-    requesterChatId: ctx.requesterChatId,
-    denialReason: ctx.denialReason,
-  };
+  return resolveRoutingState(ctx);
 }

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -16,10 +16,7 @@ import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.
 import { getActiveBinding } from '../memory/guardian-bindings.js';
 import { getLogger } from '../util/logger.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
-import {
-  resolveGuardianContext,
-  toGuardianRuntimeContext,
-} from './guardian-context-resolver.js';
+import { resolveGuardianContext } from './guardian-context-resolver.js';
 import { ensureVellumGuardianBinding } from './guardian-vellum-migration.js';
 
 const log = getLogger('local-actor-identity');
@@ -58,7 +55,8 @@ export function resolveLocalIpcGuardianContext(
       conversationExternalId: 'local',
       actorExternalId: principalId,
     });
-    return toGuardianRuntimeContext(sourceChannel, guardianCtx);
+    // Overlay the caller's actual sourceChannel onto the resolved context.
+    return { ...guardianCtx, sourceChannel };
   }
 
   const guardianPrincipalId = binding.guardianExternalUserId;
@@ -78,5 +76,5 @@ export function resolveLocalIpcGuardianContext(
 
   // Overlay the caller's actual sourceChannel onto the resolved context
   // so downstream consumers see the correct channel provenance.
-  return toGuardianRuntimeContext(sourceChannel, guardianCtx);
+  return { ...guardianCtx, sourceChannel };
 }

--- a/assistant/src/runtime/middleware/actor-token.ts
+++ b/assistant/src/runtime/middleware/actor-token.ts
@@ -14,17 +14,13 @@
  * guardian context pathway when no actor token is present.
  */
 
-import type { ChannelId } from '../../channels/types.js';
 import type { GuardianRuntimeContext } from '../../daemon/session-runtime-assembly.js';
 import { getActiveBinding } from '../../memory/guardian-bindings.js';
 import { getLogger } from '../../util/logger.js';
 import { type ActorTokenClaims, hashToken, verifyActorToken } from '../actor-token-service.js';
 import { findActiveByTokenHash } from '../actor-token-store.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
-import {
-  resolveGuardianContext,
-  toGuardianRuntimeContext,
-} from '../guardian-context-resolver.js';
+import { resolveGuardianContext } from '../guardian-context-resolver.js';
 import { resolveLocalIpcGuardianContext } from '../local-actor-identity.js';
 
 const log = getLogger('actor-token-middleware');
@@ -120,12 +116,10 @@ export function verifyHttpActorToken(req: Request): ActorTokenVerification {
     actorExternalId: claims.guardianPrincipalId,
   });
 
-  const guardianContext = toGuardianRuntimeContext('vellum' as ChannelId, guardianCtx);
-
   return {
     ok: true,
     claims,
-    guardianContext,
+    guardianContext: guardianCtx,
   };
 }
 

--- a/assistant/src/runtime/routes/channel-route-shared.ts
+++ b/assistant/src/runtime/routes/channel-route-shared.ts
@@ -12,7 +12,6 @@ import type {
 } from '../channel-approval-types.js';
 import type { DenialReason } from '../guardian-context-resolver.js';
 export type { ActorTrustClass, DenialReason, GuardianContext } from '../guardian-context-resolver.js';
-export { toGuardianRuntimeContext } from '../guardian-context-resolver.js';
 
 /** Canonicalize assistantId for channel ingress paths. */
 export function canonicalChannelAssistantId(_assistantId: string): string {

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -70,7 +70,6 @@ import {
   GUARDIAN_APPROVAL_TTL_MS,
   type GuardianContext,
   stripVerificationFailurePrefix,
-  toGuardianRuntimeContext,
   verifyGatewayOrigin,
 } from './channel-route-shared.js';
 import { handleApprovalInterception } from './guardian-approval-interception.js';
@@ -1141,7 +1140,7 @@ export async function handleChannelInbound(
       senderName: body.actorDisplayName,
       senderExternalUserId: body.actorExternalId,
       senderUsername: body.actorUsername,
-      guardianCtx: toGuardianRuntimeContext(sourceChannel, guardianCtx),
+      guardianCtx,
       replyCallbackUrl,
       assistantId: canonicalAssistantId,
     });
@@ -1687,7 +1686,7 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
             uxBrief: metadataUxBrief,
           },
           assistantId,
-          guardianContext: toGuardianRuntimeContext(sourceChannel, guardianCtx),
+          guardianContext: guardianCtx,
           isInteractive: resolveRoutingState(guardianCtx).promptWaitingAllowed,
           ...(cmdIntent ? { commandIntent: cmdIntent } : {}),
         },


### PR DESCRIPTION
## Summary
- Make `GuardianContext` a type alias for `GuardianRuntimeContext`, eliminating a redundant intermediate type
- Remove the `toGuardianRuntimeContext` conversion helper (no-op now that the types are unified)
- Simplify `resolveGuardianContext` to delegate to `resolveActorTrust` + `toGuardianRuntimeContextFromTrust`
- Canonicalize `guardianExternalUserId` in `toGuardianRuntimeContextFromTrust` (previously only done in the now-removed `resolveGuardianContext`)
- `memberStatus` and `memberPolicy` fields from the old `GuardianContext` were unused by all consumers; `InboundActorContext` already sources them directly from `ActorTrustContext.memberRecord`

Part of #11156

🤖 Generated with [Claude Code](https://claude.com/claude-code)