### PR TITLE
fix: stop injecting voice instruction prefix into user messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -256,10 +256,6 @@ final class VoiceModeManager: ObservableObject {
         voiceService.resetStreamingTTS()
 
         Task {
-            // Capture context on MainActor before awaiting transcription so it
-            // reflects the app the user was looking at when they spoke, not
-            // whatever app may be frontmost after the async wait completes.
-            let ctx = DictationContextCapture.capture()
             let text = await voiceService.stopRecordingAndGetTranscription()
             let trimmed = (text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -277,52 +273,11 @@ final class VoiceModeManager: ObservableObject {
 
             partialTranscription = trimmed
 
-            // Build the context prefix from captured app context. Sanitize
-            // attacker-controlled values (window titles, selected text) to
-            // prevent prompt injection and excessive length.
-            var contextPrefix = ""
-            if !ctx.appName.isEmpty {
-                var parts: [String] = ["app: \(ctx.appName)"]
-                if !ctx.windowTitle.isEmpty {
-                    let sanitizedTitle = Self.sanitize(ctx.windowTitle, maxLength: 200)
-                    if !sanitizedTitle.isEmpty {
-                        parts.append("window: \"\(sanitizedTitle)\"")
-                    }
-                }
-                if let selected = ctx.selectedText, !selected.isEmpty {
-                    let sanitizedSelected = Self.sanitize(selected, maxLength: 500)
-                    if !sanitizedSelected.isEmpty {
-                        parts.append("selected text: \"\(sanitizedSelected)\"")
-                    }
-                }
-                contextPrefix = "[User's current \(parts.joined(separator: ", "))]\n"
-            }
-
-            // Pass context via pendingVoiceContextPrefix so it's injected into
-            // the daemon-bound text only — not into inputText, which is used for
-            // chat bubble display and thread auto-titling.
             chatViewModel.pendingVoiceMessage = true
-            if !contextPrefix.isEmpty {
-                chatViewModel.pendingVoiceContextPrefix = contextPrefix
-            }
             chatViewModel.inputText = trimmed
             chatViewModel.sendMessage()
             log.info("Voice mode: sent transcription to chat via daemon")
         }
-    }
-
-    /// Sanitize attacker-controlled text (window titles, selected text) by
-    /// truncating to a maximum length and stripping bracket patterns like
-    /// `[...]` that could be confused with instruction markers.
-    private static func sanitize(_ input: String, maxLength: Int) -> String {
-        var result = String(input.prefix(maxLength))
-        // Strip bracket patterns that could look like instruction markers
-        result = result.replacingOccurrences(
-            of: "\\[.*?\\]",
-            with: "",
-            options: .regularExpression
-        )
-        return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     // MARK: - Streaming TTS from daemon response

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -327,11 +327,6 @@ public final class ChatViewModel: ObservableObject {
     public var onVoiceTextDelta: ((String) -> Void)?
     /// When true, messages are prefixed with a concise-response instruction for voice conversations.
     public var isVoiceModeActive: Bool = false
-    /// Context prefix captured by VoiceModeManager describing the user's frontmost app.
-    /// Injected into the daemon-bound text (not rawText) alongside the voice instruction
-    /// prefix, then cleared after send. This avoids leaking context into chat bubbles
-    /// and thread auto-titles.
-    public var pendingVoiceContextPrefix: String?
     var pendingUserAttachments: [IPCAttachment]?
     /// Stores the last user message that failed to send, enabling retry.
     private(set) var lastFailedMessageText: String?
@@ -914,11 +909,7 @@ public final class ChatViewModel: ObservableObject {
 
     public func sendMessage() {
         let rawText = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let voiceContextPrefix = pendingVoiceContextPrefix ?? ""
-        pendingVoiceContextPrefix = nil
-        let text = isVoiceModeActive
-            ? "[Voice conversation — keep spoken responses brief (2-3 sentences) but fully complete the task using any tools needed. Do not give up early. Proactively use tools to fulfill requests rather than describing how. When interacting with macOS apps (Messages, Contacts, Calendar, Reminders, Notes, Mail, etc.), always use osascript with AppleScript — never query databases directly or use sqlite3. Prefer CLI tools and background automation (osascript/AppleScript) over foreground computer use, which takes over the user's screen.]\n\n\(voiceContextPrefix)\(rawText)"
-            : rawText
+        let text = rawText
         let hasAttachments = !pendingAttachments.isEmpty
         let hasSkillInvocation = pendingSkillInvocation != nil
         guard !text.isEmpty || hasAttachments || hasSkillInvocation else { return }
@@ -2012,17 +2003,6 @@ public final class ChatViewModel: ObservableObject {
         self.suggestion = nil
     }
 
-    /// Strip the voice mode instruction prefix from user messages so it
-    /// doesn't clutter the chat when conversations are reloaded from history.
-    private static let voicePrefixPattern = /^\[Voice conversation\s—[^\]]*\]\n\n/
-
-    private func stripVoicePrefix(_ text: String) -> String {
-        if let match = text.prefixMatch(of: Self.voicePrefixPattern) {
-            return String(text[match.range.upperBound...])
-        }
-        return text
-    }
-
     /// Populate messages from history data returned by the daemon.
     /// If the user hasn't sent any messages yet, replaces messages entirely.
     /// If the user already sent messages (late history_response), prepends
@@ -2142,8 +2122,7 @@ public final class ChatViewModel: ObservableObject {
             if item.text.isEmpty && toolCalls.isEmpty && attachments.isEmpty && inlineSurfaces.isEmpty { continue }
             let timestamp = Date(timeIntervalSince1970: TimeInterval(item.timestamp) / 1000.0)
 
-            // Strip voice mode instruction prefix from user messages
-            let displayText = role == .user ? stripVoicePrefix(item.text) : item.text
+            let displayText = item.text
 
             // Use the database message ID if available (for matching surfaces)
             var chatMsg: ChatMessage


### PR DESCRIPTION
## Summary
- Removes the `[Voice conversation — ...]` system prompt that was embedded in every voice mode user message
- Removes the `[User's current app: ...]` context prefix injection
- Removes `pendingVoiceContextPrefix`, `DictationContextCapture` call, and `stripVoicePrefix` workaround
- Voice messages now send just the raw transcription text, same as typed messages

## Test plan
- [ ] `./build.sh` — clean build
- [ ] Send a voice message and verify the chat bubble shows only the spoken text
- [ ] Reload the thread and verify new voice messages display cleanly
- [ ] Verify voice mode still works end-to-end (listen → transcribe → respond → TTS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)