### PR TITLE
feat: make trust class explicit in tool and memory policy gates (#11159)

### DIFF
--- a/assistant/src/__tests__/account-registry.test.ts
+++ b/assistant/src/__tests__/account-registry.test.ts
@@ -45,6 +45,7 @@ const _ctx: ToolContext = {
   workingDir: '/tmp',
   sessionId: 'test-session',
   conversationId: 'test-conv',
+  guardianTrustClass: 'guardian',
 };
 
 afterAll(() => {

--- a/assistant/src/__tests__/app-builder-tool-scripts.test.ts
+++ b/assistant/src/__tests__/app-builder-tool-scripts.test.ts
@@ -53,6 +53,7 @@ function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
     workingDir: '/tmp',
     sessionId: 'session-1',
     conversationId: 'conv-1',
+    guardianTrustClass: 'guardian',
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/asset-materialize-tool.test.ts
+++ b/assistant/src/__tests__/asset-materialize-tool.test.ts
@@ -69,6 +69,7 @@ const dummyContext: ToolContext = {
   workingDir: sandboxDir,
   sessionId: 'sess-test',
   conversationId: 'conv-test',
+  guardianTrustClass: 'guardian',
 };
 
 // ---------------------------------------------------------------------------
@@ -322,6 +323,7 @@ describe('AssetMaterializeTool visibility policy', () => {
       workingDir: sandboxDir,
       sessionId: 'sess-test',
       conversationId: otherConv.id,
+      guardianTrustClass: 'guardian',
     };
 
     const result = await assetMaterializeTool.execute(
@@ -344,6 +346,7 @@ describe('AssetMaterializeTool visibility policy', () => {
       workingDir: sandboxDir,
       sessionId: 'sess-test',
       conversationId: privateConv.id,
+      guardianTrustClass: 'guardian',
     };
 
     const result = await assetMaterializeTool.execute(
@@ -367,6 +370,7 @@ describe('AssetMaterializeTool visibility policy', () => {
       workingDir: sandboxDir,
       sessionId: 'sess-test',
       conversationId: otherConv.id,
+      guardianTrustClass: 'guardian',
     };
 
     const result = await assetMaterializeTool.execute(
@@ -391,6 +395,7 @@ describe('AssetMaterializeTool visibility policy', () => {
       workingDir: sandboxDir,
       sessionId: 'sess-test',
       conversationId: standardConv.id,
+      guardianTrustClass: 'guardian',
     };
 
     const result = await assetMaterializeTool.execute(
@@ -417,6 +422,7 @@ describe('AssetMaterializeTool visibility policy', () => {
       workingDir: sandboxDir,
       sessionId: 'sess-test',
       conversationId: privateConv2.id,
+      guardianTrustClass: 'guardian',
     };
 
     const result = await assetMaterializeTool.execute(
@@ -444,6 +450,7 @@ describe('AssetMaterializeTool visibility policy', () => {
       workingDir: sandboxDir,
       sessionId: 'sess-test',
       conversationId: otherConv.id,
+      guardianTrustClass: 'guardian',
     };
 
     const result = await assetMaterializeTool.execute(

--- a/assistant/src/__tests__/asset-search-tool.test.ts
+++ b/assistant/src/__tests__/asset-search-tool.test.ts
@@ -88,6 +88,7 @@ const dummyContext: ToolContext = {
   workingDir: '/tmp',
   sessionId: 'sess-test',
   conversationId: 'conv-test',
+  guardianTrustClass: 'guardian',
 };
 
 // ---------------------------------------------------------------------------
@@ -378,6 +379,7 @@ describe('AssetSearchTool visibility policy', () => {
       workingDir: '/tmp',
       sessionId: 'sess-test',
       conversationId: otherConv.id,
+      guardianTrustClass: 'guardian',
     };
 
     const result = await assetSearchTool.execute({}, context);
@@ -396,6 +398,7 @@ describe('AssetSearchTool visibility policy', () => {
       workingDir: '/tmp',
       sessionId: 'sess-test',
       conversationId: privateConv.id,
+      guardianTrustClass: 'guardian',
     };
 
     const result = await assetSearchTool.execute({}, context);
@@ -415,6 +418,7 @@ describe('AssetSearchTool visibility policy', () => {
       workingDir: '/tmp',
       sessionId: 'sess-test',
       conversationId: otherPrivateConv.id,
+      guardianTrustClass: 'guardian',
     };
 
     const result = await assetSearchTool.execute({}, context);
@@ -434,6 +438,7 @@ describe('AssetSearchTool visibility policy', () => {
       workingDir: '/tmp',
       sessionId: 'sess-test',
       conversationId: standardConv.id,
+      guardianTrustClass: 'guardian',
     };
 
     const result = await assetSearchTool.execute({}, context);
@@ -457,6 +462,7 @@ describe('AssetSearchTool visibility policy', () => {
       workingDir: '/tmp',
       sessionId: 'sess-test',
       conversationId: otherConv.id,
+      guardianTrustClass: 'guardian',
     };
 
     const result = await assetSearchTool.execute({}, context);
@@ -472,6 +478,7 @@ describe('AssetSearchTool visibility policy', () => {
       workingDir: '/tmp',
       sessionId: 'sess-test',
       conversationId: conv.id,
+      guardianTrustClass: 'guardian',
     };
 
     const result = await assetSearchTool.execute({}, context);

--- a/assistant/src/__tests__/browser-fill-credential.test.ts
+++ b/assistant/src/__tests__/browser-fill-credential.test.ts
@@ -81,6 +81,7 @@ const ctx: ToolContext = {
   sessionId: 'test-session',
   conversationId: 'test-conversation',
   workingDir: '/tmp',
+  guardianTrustClass: 'guardian',
 };
 
 function resetMockPage() {

--- a/assistant/src/__tests__/call-start-guardian-guard.test.ts
+++ b/assistant/src/__tests__/call-start-guardian-guard.test.ts
@@ -45,6 +45,7 @@ function makeContext(): ToolContext {
     sessionId: 'session-1',
     conversationId: 'conversation-1',
     assistantId: 'self',
+    guardianTrustClass: 'guardian',
   };
 }
 

--- a/assistant/src/__tests__/claude-code-tool-profiles.test.ts
+++ b/assistant/src/__tests__/claude-code-tool-profiles.test.ts
@@ -44,6 +44,7 @@ function makeContext(overrides?: Partial<ToolContext>): ToolContext {
   return {
     sessionId: 'test-session',
     workingDir: '/tmp/test',
+    guardianTrustClass: 'guardian',
     onOutput: () => {},
     ...overrides,
   } as ToolContext;

--- a/assistant/src/__tests__/computer-use-tools.test.ts
+++ b/assistant/src/__tests__/computer-use-tools.test.ts
@@ -34,6 +34,7 @@ const ctx: ToolContext = {
   workingDir: '/tmp',
   sessionId: 'test-session',
   conversationId: 'test-conversation',
+  guardianTrustClass: 'guardian',
 };
 
 // ── Tool definitions ────────────────────────────────────────────────

--- a/assistant/src/__tests__/contacts-tools.test.ts
+++ b/assistant/src/__tests__/contacts-tools.test.ts
@@ -55,6 +55,7 @@ const ctx: ToolContext = {
   workingDir: '/tmp',
   sessionId: 'test-session',
   conversationId: 'test-conversation',
+  guardianTrustClass: 'guardian',
 };
 
 function clearContacts(): void {

--- a/assistant/src/__tests__/credential-security-e2e.test.ts
+++ b/assistant/src/__tests__/credential-security-e2e.test.ts
@@ -95,6 +95,7 @@ function makeContext(overrides: Record<string, unknown> = {}) {
     workingDir: '/tmp',
     sessionId: 's1',
     conversationId: 'c1',
+    guardianTrustClass: 'guardian' as const,
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -55,6 +55,7 @@ const _ctx: ToolContext = {
   workingDir: '/tmp',
   sessionId: 'test-session',
   conversationId: 'test-conv',
+  guardianTrustClass: 'guardian',
 };
 
 afterAll(() => {

--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -62,6 +62,7 @@ const _ctx: ToolContext = {
   workingDir: '/tmp',
   sessionId: 'test-session',
   conversationId: 'test-conv',
+  guardianTrustClass: 'guardian',
 };
 
 // We'll manually instantiate the tool for testing

--- a/assistant/src/__tests__/delete-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/delete-managed-skill-tool.test.ts
@@ -29,6 +29,7 @@ function makeContext(): ToolContext {
     workingDir: '/tmp',
     sessionId: 'test-session',
     conversationId: 'test-conversation',
+    guardianTrustClass: 'guardian',
   };
 }
 

--- a/assistant/src/__tests__/file-edit-tool.test.ts
+++ b/assistant/src/__tests__/file-edit-tool.test.ts
@@ -20,6 +20,7 @@ function makeContext(workingDir: string): ToolContext {
     workingDir,
     sessionId: 'test-session',
     conversationId: 'test-conversation',
+    guardianTrustClass: 'guardian',
   };
 }
 

--- a/assistant/src/__tests__/file-read-tool.test.ts
+++ b/assistant/src/__tests__/file-read-tool.test.ts
@@ -20,6 +20,7 @@ function makeContext(workingDir: string): ToolContext {
     workingDir,
     sessionId: 'test-session',
     conversationId: 'test-conversation',
+    guardianTrustClass: 'guardian',
   };
 }
 

--- a/assistant/src/__tests__/file-write-tool.test.ts
+++ b/assistant/src/__tests__/file-write-tool.test.ts
@@ -20,6 +20,7 @@ function makeContext(workingDir: string): ToolContext {
     workingDir,
     sessionId: 'test-session',
     conversationId: 'test-conversation',
+    guardianTrustClass: 'guardian',
   };
 }
 

--- a/assistant/src/__tests__/followup-tools.test.ts
+++ b/assistant/src/__tests__/followup-tools.test.ts
@@ -55,6 +55,7 @@ const ctx: ToolContext = {
   workingDir: '/tmp',
   sessionId: 'test-session',
   conversationId: 'test-conversation',
+  guardianTrustClass: 'guardian',
 };
 
 function clearFollowups(): void {

--- a/assistant/src/__tests__/guardian-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/guardian-control-plane-policy.test.ts
@@ -87,6 +87,7 @@ function makeContext(overrides?: Partial<ToolContext>): ToolContext {
     workingDir: '/tmp/project',
     sessionId: 'session-1',
     conversationId: 'conversation-1',
+    guardianTrustClass: 'guardian',
     ...overrides,
   };
 }
@@ -405,10 +406,10 @@ describe('enforceGuardianOnlyPolicy', () => {
     expect(result.reason).toBeUndefined();
   });
 
-  test('undefined actor role is NOT denied for guardian endpoint', () => {
+  test('guardian actor role is NOT denied for guardian endpoint (explicit)', () => {
     const result = enforceGuardianOnlyPolicy('bash', {
       command: 'curl http://localhost:3000/v1/integrations/guardian/outbound/start',
-    }, undefined);
+    }, 'guardian');
     expect(result.denied).toBe(false);
   });
 
@@ -477,12 +478,12 @@ describe('ToolExecutor guardian-only policy gate', () => {
     expect(result.content).toBe('ok');
   });
 
-  test('undefined guardianTrustClass is NOT blocked from guardian endpoint', async () => {
+  test('guardian trust class is NOT blocked from guardian endpoint (default)', async () => {
     const executor = new ToolExecutor(makePrompter());
     const result = await executor.execute(
       'bash',
       { command: 'curl http://localhost:3000/v1/integrations/guardian/status' },
-      makeContext(), // no guardianTrustClass set
+      makeContext(), // defaults to guardianTrustClass: 'guardian'
     );
     expect(result.isError).toBe(false);
     expect(result.content).toBe('ok');

--- a/assistant/src/__tests__/headless-browser-interactions.test.ts
+++ b/assistant/src/__tests__/headless-browser-interactions.test.ts
@@ -87,6 +87,7 @@ const ctx: ToolContext = {
   sessionId: 'test-session',
   conversationId: 'test-conversation',
   workingDir: '/tmp',
+  guardianTrustClass: 'guardian',
 };
 
 function resetMockPage() {

--- a/assistant/src/__tests__/headless-browser-navigate.test.ts
+++ b/assistant/src/__tests__/headless-browser-navigate.test.ts
@@ -58,6 +58,7 @@ const ctx: ToolContext = {
   sessionId: 'test-session',
   conversationId: 'test-conversation',
   workingDir: '/tmp',
+  guardianTrustClass: 'guardian',
 };
 
 function resetMockPage() {

--- a/assistant/src/__tests__/headless-browser-read-tools.test.ts
+++ b/assistant/src/__tests__/headless-browser-read-tools.test.ts
@@ -67,6 +67,7 @@ const ctx: ToolContext = {
   sessionId: 'test-session',
   conversationId: 'test-conversation',
   workingDir: '/tmp',
+  guardianTrustClass: 'guardian',
 };
 
 function resetMockPage() {

--- a/assistant/src/__tests__/headless-browser-snapshot.test.ts
+++ b/assistant/src/__tests__/headless-browser-snapshot.test.ts
@@ -66,6 +66,7 @@ const ctx: ToolContext = {
   sessionId: 'test-session',
   conversationId: 'test-conversation',
   workingDir: '/tmp',
+  guardianTrustClass: 'guardian',
 };
 
 function resetMockPage() {

--- a/assistant/src/__tests__/host-file-edit-tool.test.ts
+++ b/assistant/src/__tests__/host-file-edit-tool.test.ts
@@ -14,6 +14,7 @@ function makeContext(): ToolContext {
     workingDir: '/tmp',
     sessionId: 'test-session',
     conversationId: 'test-conversation',
+    guardianTrustClass: 'guardian',
   };
 }
 

--- a/assistant/src/__tests__/host-file-read-tool.test.ts
+++ b/assistant/src/__tests__/host-file-read-tool.test.ts
@@ -14,6 +14,7 @@ function makeContext(): ToolContext {
     workingDir: '/tmp',
     sessionId: 'test-session',
     conversationId: 'test-conversation',
+    guardianTrustClass: 'guardian',
   };
 }
 

--- a/assistant/src/__tests__/host-file-write-tool.test.ts
+++ b/assistant/src/__tests__/host-file-write-tool.test.ts
@@ -14,6 +14,7 @@ function makeContext(): ToolContext {
     workingDir: '/tmp',
     sessionId: 'test-session',
     conversationId: 'test-conversation',
+    guardianTrustClass: 'guardian',
   };
 }
 

--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -74,6 +74,7 @@ function makeContext(): ToolContext {
     workingDir: '/tmp',
     sessionId: 'test-session',
     conversationId: 'test-conversation',
+    guardianTrustClass: 'guardian',
   };
 }
 

--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -84,6 +84,7 @@ function makeContext(): ToolContext {
     workingDir: '/tmp',
     sessionId: 'test-session',
     conversationId: 'test-conversation',
+    guardianTrustClass: 'guardian',
   };
 }
 

--- a/assistant/src/__tests__/media-reuse-story.e2e.test.ts
+++ b/assistant/src/__tests__/media-reuse-story.e2e.test.ts
@@ -235,6 +235,7 @@ describe('Story E2E: selfie yesterday -> generated image today', () => {
       workingDir: sandboxDir,
       sessionId: 'sess-story',
       conversationId: threadB.id,
+      guardianTrustClass: 'guardian',
     };
 
     const result = await assetSearchTool.execute(
@@ -253,6 +254,7 @@ describe('Story E2E: selfie yesterday -> generated image today', () => {
       workingDir: sandboxDir,
       sessionId: 'sess-story',
       conversationId: threadB.id,
+      guardianTrustClass: 'guardian',
     };
 
     const result = await assetSearchTool.execute(
@@ -269,6 +271,7 @@ describe('Story E2E: selfie yesterday -> generated image today', () => {
       workingDir: sandboxDir,
       sessionId: 'sess-story',
       conversationId: threadB.id,
+      guardianTrustClass: 'guardian',
     };
 
     const result = await assetMaterializeTool.execute(
@@ -296,6 +299,7 @@ describe('Story E2E: selfie yesterday -> generated image today', () => {
       workingDir: sandboxDir,
       sessionId: 'sess-story',
       conversationId: threadB.id,
+      guardianTrustClass: 'guardian',
     };
 
     // Step 3a: Search for the selfie
@@ -486,6 +490,7 @@ describe('Private-thread variant: cross-thread media blocking', () => {
       workingDir: sandboxDir,
       sessionId: 'sess-priv-test',
       conversationId: standardThread.id,
+      guardianTrustClass: 'guardian',
     };
 
     const result = await assetSearchTool.execute(
@@ -510,6 +515,7 @@ describe('Private-thread variant: cross-thread media blocking', () => {
       workingDir: sandboxDir,
       sessionId: 'sess-priv-test',
       conversationId: standardThread.id,
+      guardianTrustClass: 'guardian',
     };
 
     const result = await assetMaterializeTool.execute(
@@ -533,6 +539,7 @@ describe('Private-thread variant: cross-thread media blocking', () => {
       workingDir: sandboxDir,
       sessionId: 'sess-priv-test',
       conversationId: privateThread.id,
+      guardianTrustClass: 'guardian',
     };
 
     const searchResult = await assetSearchTool.execute(
@@ -563,6 +570,7 @@ describe('Private-thread variant: cross-thread media blocking', () => {
       workingDir: sandboxDir,
       sessionId: 'sess-priv-test',
       conversationId: privateThreadB.id,
+      guardianTrustClass: 'guardian',
     };
 
     const searchResult = await assetSearchTool.execute(

--- a/assistant/src/__tests__/messaging-send-tool.test.ts
+++ b/assistant/src/__tests__/messaging-send-tool.test.ts
@@ -48,6 +48,7 @@ describe('messaging-send tool', () => {
         sessionId: 'sess-1',
         conversationId: 'conv-1',
         assistantId: 'ast-alpha',
+        guardianTrustClass: 'guardian' as const,
       },
     );
 

--- a/assistant/src/__tests__/playbook-execution.test.ts
+++ b/assistant/src/__tests__/playbook-execution.test.ts
@@ -69,6 +69,7 @@ const ctx: ToolContext = {
   workingDir: '/tmp',
   sessionId: 'test-session',
   conversationId: 'test-conversation',
+  guardianTrustClass: 'guardian',
 };
 
 function insertPlaybookRow(overrides: Partial<{

--- a/assistant/src/__tests__/playbook-tools.test.ts
+++ b/assistant/src/__tests__/playbook-tools.test.ts
@@ -61,6 +61,7 @@ const ctx: ToolContext = {
   workingDir: '/tmp',
   sessionId: 'test-session',
   conversationId: 'test-conversation',
+  guardianTrustClass: 'guardian',
 };
 
 function clearPlaybooks(): void {

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -30,6 +30,7 @@ function makeContext(): ToolContext {
     workingDir: '/tmp',
     sessionId: 'test-session',
     conversationId: 'test-conversation',
+    guardianTrustClass: 'guardian',
   };
 }
 

--- a/assistant/src/__tests__/schedule-tools.test.ts
+++ b/assistant/src/__tests__/schedule-tools.test.ts
@@ -56,6 +56,7 @@ const ctx: ToolContext = {
   workingDir: '/tmp',
   sessionId: 'test-session',
   conversationId: 'test-conversation',
+  guardianTrustClass: 'guardian',
 };
 
 // ── schedule_create ─────────────────────────────────────────────────

--- a/assistant/src/__tests__/secret-onetime-send.test.ts
+++ b/assistant/src/__tests__/secret-onetime-send.test.ts
@@ -61,6 +61,7 @@ describe('one-time send override', () => {
       workingDir: '/tmp',
       sessionId: 's1',
       conversationId: 'c1',
+      guardianTrustClass: 'guardian' as const,
       requestSecret: async () => ({ value: 'v1', delivery: 'transient_send' as const }),
     };
 
@@ -80,6 +81,7 @@ describe('one-time send override', () => {
       workingDir: '/tmp',
       sessionId: 's1',
       conversationId: 'c1',
+      guardianTrustClass: 'guardian' as const,
       requestSecret: async () => ({ value: 'v1', delivery: 'transient_send' as const }),
     };
 
@@ -99,6 +101,7 @@ describe('one-time send override', () => {
       workingDir: '/tmp',
       sessionId: 's1',
       conversationId: 'c1',
+      guardianTrustClass: 'guardian' as const,
       requestSecret: async () => ({ value: 'v1', delivery: 'store' as const }),
     };
 
@@ -118,6 +121,7 @@ describe('one-time send override', () => {
       workingDir: '/tmp',
       sessionId: 's1',
       conversationId: 'c1',
+      guardianTrustClass: 'guardian' as const,
       requestSecret: async () => ({ value: secretVal, delivery: 'transient_send' as const }),
     };
 

--- a/assistant/src/__tests__/secret-scanner-executor.test.ts
+++ b/assistant/src/__tests__/secret-scanner-executor.test.ts
@@ -95,6 +95,7 @@ function makeContext(overrides?: Partial<{
     workingDir: '/tmp',
     sessionId: 'test-session',
     conversationId: 'test-conversation',
+    guardianTrustClass: 'guardian' as const,
     onToolLifecycleEvent: (event: ToolLifecycleEvent) => {
       auditListener(event);
       return overrides?.onToolLifecycleEvent?.(event);
@@ -313,6 +314,7 @@ describe('Secret scanner executor integration', () => {
       workingDir: '/tmp',
       sessionId: 'test-session',
       conversationId: 'test-conversation',
+      guardianTrustClass: 'guardian' as const,
     };
 
     const result = await executor.execute('file_read', {}, ctx);

--- a/assistant/src/__tests__/send-notification-tool.test.ts
+++ b/assistant/src/__tests__/send-notification-tool.test.ts
@@ -33,6 +33,7 @@ describe('send-notification tool', () => {
         sessionId: 'sess-1',
         conversationId: 'conv-1',
         assistantId: 'ast-alpha',
+        guardianTrustClass: 'guardian' as const,
       },
     );
 
@@ -76,6 +77,7 @@ describe('send-notification tool', () => {
         sessionId: 'sess-1',
         conversationId: 'conv-1',
         assistantId: 'ast-alpha',
+        guardianTrustClass: 'guardian' as const,
       },
     );
 

--- a/assistant/src/__tests__/shell-credential-ref.test.ts
+++ b/assistant/src/__tests__/shell-credential-ref.test.ts
@@ -77,6 +77,7 @@ const ctx: ToolContext = {
   workingDir: '/tmp',
   sessionId: 'test-session',
   conversationId: 'test-conv',
+  guardianTrustClass: 'guardian',
 };
 
 beforeEach(() => {

--- a/assistant/src/__tests__/shell-tool-proxy-mode.test.ts
+++ b/assistant/src/__tests__/shell-tool-proxy-mode.test.ts
@@ -127,6 +127,7 @@ function makeContext(overrides?: Partial<ToolContext>): ToolContext {
     workingDir: '/tmp',
     sessionId: 'test-session',
     conversationId: 'test-conv',
+    guardianTrustClass: 'guardian',
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -81,6 +81,7 @@ async function executeSkillLoad(input: Record<string, unknown>): Promise<{ conte
     workingDir: '/tmp',
     sessionId: 'session-1',
     conversationId: 'conversation-1',
+    guardianTrustClass: 'guardian',
   });
   return { content: result.content, isError: result.isError };
 }

--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -76,6 +76,7 @@ async function executeSkillLoad(input: Record<string, unknown>): Promise<{ conte
     workingDir: '/tmp',
     sessionId: 'session-1',
     conversationId: 'conversation-1',
+    guardianTrustClass: 'guardian',
   });
   return { content: result.content, isError: result.isError };
 }

--- a/assistant/src/__tests__/skill-script-runner-host.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-host.test.ts
@@ -17,6 +17,7 @@ function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
     workingDir: '/tmp',
     sessionId: 'test-session',
     conversationId: 'test-conversation',
+    guardianTrustClass: 'guardian',
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/skill-script-runner-sandbox.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-sandbox.test.ts
@@ -63,6 +63,7 @@ function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
     workingDir: '/tmp',
     sessionId: 'test-session',
     conversationId: 'test-conversation',
+    guardianTrustClass: 'guardian',
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/skill-script-runner.test.ts
+++ b/assistant/src/__tests__/skill-script-runner.test.ts
@@ -17,6 +17,7 @@ const ctx: ToolContext = {
   workingDir: '/tmp',
   sessionId: 'test-session',
   conversationId: 'test-conversation',
+  guardianTrustClass: 'guardian',
 };
 
 function makeSkillDir(name: string): string {

--- a/assistant/src/__tests__/skill-tool-factory.test.ts
+++ b/assistant/src/__tests__/skill-tool-factory.test.ts
@@ -36,6 +36,7 @@ function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
     workingDir: '/tmp',
     sessionId: 'test-session',
     conversationId: 'test-conversation',
+    guardianTrustClass: 'guardian',
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -88,7 +88,7 @@ function injectSubagent(
 }
 
 function makeContext(sessionId: string, extras: Record<string, unknown> = {}) {
-  return { workingDir: '/tmp', sessionId, conversationId: 'conv-1', ...extras };
+  return { workingDir: '/tmp', sessionId, conversationId: 'conv-1', guardianTrustClass: 'guardian' as const, ...extras } as import('../tools/types.js').ToolContext;
 }
 
 // ── Tool definitions ────────────────────────────────────────────────

--- a/assistant/src/__tests__/swarm-recursion.test.ts
+++ b/assistant/src/__tests__/swarm-recursion.test.ts
@@ -87,6 +87,7 @@ function makeContext(overrides?: Partial<ToolContext>): ToolContext {
     sessionId: 'test-session',
     conversationId: 'test-conv',
     workingDir: '/tmp/test',
+    guardianTrustClass: 'guardian',
     onOutput: () => {},
     ...overrides,
   } as ToolContext;

--- a/assistant/src/__tests__/swarm-session-integration.test.ts
+++ b/assistant/src/__tests__/swarm-session-integration.test.ts
@@ -79,6 +79,7 @@ function makeContext(overrides?: Partial<ToolContext>): ToolContext {
     sessionId: 'test-session',
     conversationId: 'test-conv',
     workingDir: '/tmp/test',
+    guardianTrustClass: 'guardian',
     onOutput: () => {},
     ...overrides,
   } as ToolContext;

--- a/assistant/src/__tests__/swarm-tool.test.ts
+++ b/assistant/src/__tests__/swarm-tool.test.ts
@@ -74,6 +74,7 @@ function makeContext(overrides?: Partial<ToolContext>): ToolContext {
   return {
     sessionId: 'test-session',
     workingDir: '/tmp/test',
+    guardianTrustClass: 'guardian',
     onOutput: () => {},
     ...overrides,
   } as ToolContext;

--- a/assistant/src/__tests__/task-management-tools.test.ts
+++ b/assistant/src/__tests__/task-management-tools.test.ts
@@ -62,6 +62,7 @@ const ctx: ToolContext = {
   workingDir: '/tmp',
   sessionId: 'test-session',
   conversationId: 'test-conversation',
+  guardianTrustClass: 'guardian',
 };
 
 function clearTables() {

--- a/assistant/src/__tests__/task-tools.test.ts
+++ b/assistant/src/__tests__/task-tools.test.ts
@@ -84,6 +84,7 @@ const stubContext: ToolContext = {
   workingDir: '/tmp',
   sessionId: 'test-session',
   conversationId: 'test-conversation',
+  guardianTrustClass: 'guardian',
 };
 
 // ── task_save ────────────────────────────────────────────────────────

--- a/assistant/src/__tests__/terminal-tools.test.ts
+++ b/assistant/src/__tests__/terminal-tools.test.ts
@@ -573,6 +573,7 @@ describe('Shell tool input validation', () => {
     workingDir: testTmpDir,
     sessionId: 'test-session-1',
     conversationId: 'test-conv-1',
+    guardianTrustClass: 'guardian' as const,
     onOutput: () => {},
   };
 

--- a/assistant/src/__tests__/tool-approval-handler.test.ts
+++ b/assistant/src/__tests__/tool-approval-handler.test.ts
@@ -286,11 +286,11 @@ describe('ToolApprovalHandler / pre-exec gate grant check', () => {
     expect(result.allowed).toBe(true);
   });
 
-  test('undefined actor role (desktop) bypasses grant check', async () => {
+  test('guardian actor role (desktop) bypasses grant check', async () => {
     const toolName = 'bash';
     const input = { command: 'deploy' };
 
-    const context = makeContext({ guardianTrustClass: undefined });
+    const context = makeContext({ guardianTrustClass: 'guardian' });
     const result = await handler.checkPreExecutionGates(
       toolName, input, context, 'host', 'high', Date.now(), emitLifecycleEvent,
     );

--- a/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
+++ b/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
@@ -101,6 +101,7 @@ function makeToolContext(workingDir: string, signal?: AbortSignal) {
     workingDir,
     sessionId: 'test-session',
     conversationId: 'test-conv',
+    guardianTrustClass: 'guardian' as const,
     signal,
   };
 }

--- a/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
+++ b/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
@@ -403,6 +403,7 @@ describe('Tool execution pipeline benchmark', () => {
       workingDir: '/tmp',
       sessionId: 'bench-session',
       conversationId: 'bench-conv',
+      guardianTrustClass: 'guardian',
     };
 
     function makeTool(name: string, sleepMs: number): Tool {

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -138,6 +138,7 @@ function makeContext(events: ToolLifecycleEvent[]) {
     workingDir: '/tmp/project',
     sessionId: 'session-1',
     conversationId: 'conversation-1',
+    guardianTrustClass: 'guardian' as const,
     onToolLifecycleEvent: (event: ToolLifecycleEvent) => {
       events.push(event);
     },
@@ -424,6 +425,7 @@ describe('ToolExecutor lifecycle events', () => {
       workingDir: '/tmp/project',
       sessionId: 'session-1',
       conversationId: 'conversation-1',
+      guardianTrustClass: 'guardian',
       onToolLifecycleEvent: () => new Promise<void>(() => {}),
     });
 

--- a/assistant/src/__tests__/tool-executor-shell-integration.test.ts
+++ b/assistant/src/__tests__/tool-executor-shell-integration.test.ts
@@ -125,6 +125,7 @@ function makeContext(overrides?: Partial<ToolContext>): ToolContext {
     workingDir: '/tmp/project',
     sessionId: 'session-integration',
     conversationId: 'conversation-integration',
+    guardianTrustClass: 'guardian',
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -106,6 +106,7 @@ function makeContext(overrides?: Partial<ToolContext>): ToolContext {
     workingDir: '/tmp/project',
     sessionId: 'session-1',
     conversationId: 'conversation-1',
+    guardianTrustClass: 'guardian',
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/view-image-tool.test.ts
+++ b/assistant/src/__tests__/view-image-tool.test.ts
@@ -50,6 +50,7 @@ function makeContext(workingDir: string = testDir): ToolContext {
     workingDir,
     sessionId: 'test-session',
     conversationId: 'test-conversation',
+    guardianTrustClass: 'guardian',
   };
 }
 

--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -499,6 +499,7 @@ export class ComputerUseSession {
         workingDir: getSandboxWorkingDir(),
         sessionId: this.sessionId,
         conversationId: this.sessionId,
+        guardianTrustClass: 'guardian',
         proxyToolResolver: proxyResolver,
         allowedToolNames,
         requestSecret: async (params) => {

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -299,7 +299,7 @@ export async function runAgentLoopImpl(
         conflictGate: ctx.conflictGate,
         scopeId: ctx.memoryPolicy.scopeId,
         includeDefaultFallback: ctx.memoryPolicy.includeDefaultFallback,
-        guardianTrustClass: ctx.guardianContext?.trustClass,
+        guardianTrustClass: ctx.guardianContext?.trustClass ?? 'guardian',
         isInteractive: options?.isInteractive ?? (!ctx.hasNoClient && !ctx.headlessLock),
       },
       content,

--- a/assistant/src/daemon/session-memory.ts
+++ b/assistant/src/daemon/session-memory.ts
@@ -34,7 +34,7 @@ export interface MemoryPrepareContext {
   conflictGate: ConflictGate;
   scopeId: string;
   includeDefaultFallback: boolean;
-  guardianTrustClass?: 'guardian' | 'trusted_contact' | 'unknown';
+  guardianTrustClass: 'guardian' | 'trusted_contact' | 'unknown';
   /** When false (e.g. scheduled tasks), skip conflict clarification prompts. */
   isInteractive?: boolean;
 }
@@ -64,7 +64,7 @@ export async function prepareMemoryContext(
   // Provenance-based trust gating: untrusted actors skip all memory operations
   // (recall, dynamic profile, conflict gate) to prevent untrusted content from
   // influencing memory-augmented responses.
-  const isTrustedActor = ctx.guardianTrustClass === 'guardian' || ctx.guardianTrustClass === undefined;
+  const isTrustedActor = ctx.guardianTrustClass === 'guardian';
 
   if (!isTrustedActor) {
     return {

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -110,7 +110,7 @@ export function createToolExecutor(
       assistantId: ctx.assistantId,
       requestId: ctx.currentRequestId,
       taskRunId: ctx.taskRunId,
-      guardianTrustClass: ctx.guardianContext?.trustClass,
+      guardianTrustClass: ctx.guardianContext?.trustClass ?? 'guardian',
       executionChannel: ctx.guardianContext?.sourceChannel,
       callSessionId: ctx.callSessionId,
       requesterExternalUserId: ctx.guardianContext?.requesterExternalUserId,

--- a/assistant/src/tools/guardian-control-plane-policy.ts
+++ b/assistant/src/tools/guardian-control-plane-policy.ts
@@ -124,13 +124,13 @@ export function isGuardianControlPlaneInvocation(
 export function enforceGuardianOnlyPolicy(
   toolName: string,
   input: Record<string, unknown>,
-  trustClass: string | undefined,
+  trustClass: string,
 ): { denied: boolean; reason?: string } {
   if (!isGuardianControlPlaneInvocation(toolName, input)) {
     return { denied: false };
   }
 
-  if (trustClass === 'guardian' || trustClass === undefined) {
+  if (trustClass === 'guardian') {
     return { denied: false };
   }
 

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -138,7 +138,7 @@ export interface ToolContext {
   /** Optional principal identifier propagated to sub-tool confirmation flows. */
   principal?: string;
   /** Inbound trust classification for the session — used by trust/policy gates. */
-  guardianTrustClass?: 'guardian' | 'trusted_contact' | 'unknown';
+  guardianTrustClass: 'guardian' | 'trusted_contact' | 'unknown';
   /** Channel through which the tool invocation originates (e.g. 'telegram', 'voice'). Used for scoped grant consumption. */
   executionChannel?: string;
   /** Voice/call session ID, if the invocation originates from a call. Used for scoped grant consumption. */


### PR DESCRIPTION
## Summary
- Makes `ToolContext.guardianTrustClass` a required field, eliminating the implicit `undefined => trusted` security fallback
- Removes permissive `undefined` handling in guardian control-plane policy and memory provenance gating
- Session entry points default to `'guardian'` for local/desktop sessions where no guardian context exists
- Updates ~45 test files to provide explicit trust class values

## Changes
**Production code:**
- `tools/types.ts`: `guardianTrustClass` is now required in `ToolContext`
- `tools/guardian-control-plane-policy.ts`: `trustClass` parameter changed from `string | undefined` to `string`; only `'guardian'` passes the gate
- `daemon/session-memory.ts`: `guardianTrustClass` required in `MemoryPrepareContext`; removed `undefined` fallback
- `daemon/session-tool-setup.ts`: Defaults to `'guardian'` when no guardian context
- `daemon/session-agent-loop.ts`: Defaults to `'guardian'` when no guardian context
- `daemon/computer-use-session.ts`: Explicit `'guardian'` trust class

**Test files (~45 files):** All test `makeContext`/`ToolContext` constructions updated with explicit `guardianTrustClass: 'guardian'`

Closes #11159
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
