### PR TITLE
M4: Remove legacy actorRole fallback in channel retry sweep

### DIFF
--- a/assistant/src/__tests__/channel-retry-sweep.test.ts
+++ b/assistant/src/__tests__/channel-retry-sweep.test.ts
@@ -61,6 +61,7 @@ function seedFailedEventWithTrustClass(
     guardianCtx: {
       trustClass,
       sourceChannel: 'telegram',
+      guardianPrincipalId: 'principal-1',
       requesterExternalUserId: 'user-1',
       requesterChatId: `chat-${trustClass}`,
       ...extra,
@@ -128,14 +129,14 @@ describe('channel-retry-sweep', () => {
       resetTables();
       const eventId = seedFailedEventWithTrustClass(c.trustClass);
       let capturedOptions: {
-        guardianContext?: { trustClass?: string };
+        guardianContext?: { trustClass?: string; guardianPrincipalId?: string };
         isInteractive?: boolean;
       } | undefined;
 
       await sweepFailedEvents(
         async (conversationId, _content, _attachmentIds, options) => {
           capturedOptions = options as {
-            guardianContext?: { trustClass?: string };
+            guardianContext?: { trustClass?: string; guardianPrincipalId?: string };
             isInteractive?: boolean;
           };
           const messageId = `message-${c.trustClass}`;
@@ -153,6 +154,7 @@ describe('channel-retry-sweep', () => {
       );
 
       expect(capturedOptions?.guardianContext?.trustClass).toBe(c.trustClass);
+      expect(capturedOptions?.guardianContext?.guardianPrincipalId).toBe('principal-1');
       expect(capturedOptions?.isInteractive).toBe(c.expectedInteractive);
 
       const db = getDb();

--- a/assistant/src/__tests__/channel-retry-sweep.test.ts
+++ b/assistant/src/__tests__/channel-retry-sweep.test.ts
@@ -161,7 +161,7 @@ describe('channel-retry-sweep', () => {
     }
   });
 
-  test('rejects legacy payloads with only actorRole (no trustClass)', async () => {
+  test('marks legacy payloads with only actorRole (no trustClass) as failed', async () => {
     const actorRoles: Array<'guardian' | 'non-guardian' | 'unverified_channel'> = [
       'guardian',
       'non-guardian',
@@ -170,18 +170,12 @@ describe('channel-retry-sweep', () => {
 
     for (const actorRole of actorRoles) {
       resetTables();
-      seedFailedEventWithActorRoleOnly(actorRole);
-      let capturedOptions: {
-        guardianContext?: { trustClass?: string } | undefined;
-        isInteractive?: boolean;
-      } | undefined;
+      const eventId = seedFailedEventWithActorRoleOnly(actorRole);
+      let processMessageCalled = false;
 
       await sweepFailedEvents(
-        async (conversationId, _content, _attachmentIds, options) => {
-          capturedOptions = options as {
-            guardianContext?: { trustClass?: string } | undefined;
-            isInteractive?: boolean;
-          };
+        async (conversationId, _content, _attachmentIds, _options) => {
+          processMessageCalled = true;
           const messageId = `message-legacy-${actorRole}`;
           const db = getDb();
           db.insert(messages).values({
@@ -196,27 +190,25 @@ describe('channel-retry-sweep', () => {
         undefined,
       );
 
-      // parseGuardianRuntimeContext rejects payloads without a valid trustClass,
-      // so guardianContext is undefined and isInteractive falls back to false
-      expect(capturedOptions?.guardianContext).toBeUndefined();
-      expect(capturedOptions?.isInteractive).toBe(false);
+      // Legacy payloads with guardianCtx that can't be parsed into canonical form
+      // must be marked as failed to prevent privilege escalation — processMessage
+      // should never be called.
+      expect(processMessageCalled).toBe(false);
+
+      const db = getDb();
+      const row = db.select().from(channelInboundEvents).where(eq(channelInboundEvents.id, eventId)).get();
+      expect(row?.processingStatus).toBe('failed');
     }
   });
 
-  test('rejects payloads with invalid trustClass values', async () => {
+  test('marks payloads with invalid trustClass values as failed', async () => {
     resetTables();
     const eventId = seedFailedEventWithTrustClass('invalid_value');
-    let capturedOptions: {
-      guardianContext?: { trustClass?: string } | undefined;
-      isInteractive?: boolean;
-    } | undefined;
+    let processMessageCalled = false;
 
     await sweepFailedEvents(
-      async (conversationId, _content, _attachmentIds, options) => {
-        capturedOptions = options as {
-          guardianContext?: { trustClass?: string } | undefined;
-          isInteractive?: boolean;
-        };
+      async (conversationId, _content, _attachmentIds, _options) => {
+        processMessageCalled = true;
         const messageId = 'message-invalid';
         const db = getDb();
         db.insert(messages).values({
@@ -231,9 +223,13 @@ describe('channel-retry-sweep', () => {
       undefined,
     );
 
-    // guardianContext should be undefined since the trustClass is invalid
-    expect(capturedOptions?.guardianContext).toBeUndefined();
-    expect(capturedOptions?.isInteractive).toBe(false);
+    // guardianCtx was present but couldn't be parsed (invalid trustClass),
+    // so the event must be failed rather than processed without trust context.
+    expect(processMessageCalled).toBe(false);
+
+    const db = getDb();
+    const row = db.select().from(channelInboundEvents).where(eq(channelInboundEvents.id, eventId)).get();
+    expect(row?.processingStatus).toBe('failed');
   });
 
   test('rejects payloads with missing guardianCtx entirely', async () => {

--- a/assistant/src/__tests__/channel-retry-sweep.test.ts
+++ b/assistant/src/__tests__/channel-retry-sweep.test.ts
@@ -49,8 +49,41 @@ function resetTables(): void {
   db.run('DELETE FROM conversations');
 }
 
-function seedFailedLegacyEvent(actorRole: 'guardian' | 'non-guardian' | 'unverified_channel'): string {
-  const inbound = channelDeliveryStore.recordInbound('telegram', 'chat-legacy', `msg-${actorRole}`);
+function seedFailedEventWithTrustClass(
+  trustClass: string,
+  extra?: Record<string, unknown>,
+): string {
+  const inbound = channelDeliveryStore.recordInbound('telegram', `chat-${trustClass}`, `msg-${trustClass}`);
+  channelDeliveryStore.storePayload(inbound.eventId, {
+    content: 'retry me',
+    sourceChannel: 'telegram',
+    interface: 'telegram',
+    guardianCtx: {
+      trustClass,
+      sourceChannel: 'telegram',
+      requesterExternalUserId: 'user-1',
+      requesterChatId: `chat-${trustClass}`,
+      ...extra,
+    },
+  });
+
+  const db = getDb();
+  db.update(channelInboundEvents)
+    .set({
+      processingStatus: 'failed',
+      processingAttempts: 1,
+      retryAfter: Date.now() - 1,
+    })
+    .where(eq(channelInboundEvents.id, inbound.eventId))
+    .run();
+
+  return inbound.eventId;
+}
+
+function seedFailedEventWithActorRoleOnly(
+  actorRole: 'guardian' | 'non-guardian' | 'unverified_channel',
+): string {
+  const inbound = channelDeliveryStore.recordInbound('telegram', `chat-legacy-${actorRole}`, `msg-legacy-${actorRole}`);
   channelDeliveryStore.storePayload(inbound.eventId, {
     content: 'retry me',
     sourceChannel: 'telegram',
@@ -59,7 +92,7 @@ function seedFailedLegacyEvent(actorRole: 'guardian' | 'non-guardian' | 'unverif
       actorRole,
       sourceChannel: 'telegram',
       requesterExternalUserId: 'legacy-user',
-      requesterChatId: 'chat-legacy',
+      requesterChatId: `chat-legacy-${actorRole}`,
     },
   });
 
@@ -81,19 +114,19 @@ describe('channel-retry-sweep', () => {
     resetTables();
   });
 
-  test('replays legacy guardianCtx.actorRole with preserved trust semantics', async () => {
+  test('replays canonical payloads with trustClass correctly', async () => {
     const cases: Array<{
-      actorRole: 'guardian' | 'non-guardian' | 'unverified_channel';
-      expectedTrustClass: 'guardian' | 'trusted_contact' | 'unknown';
+      trustClass: 'guardian' | 'trusted_contact' | 'unknown';
       expectedInteractive: boolean;
     }> = [
-      { actorRole: 'guardian', expectedTrustClass: 'guardian', expectedInteractive: true },
-      { actorRole: 'non-guardian', expectedTrustClass: 'trusted_contact', expectedInteractive: false },
-      { actorRole: 'unverified_channel', expectedTrustClass: 'unknown', expectedInteractive: false },
+      { trustClass: 'guardian', expectedInteractive: true },
+      { trustClass: 'trusted_contact', expectedInteractive: false },
+      { trustClass: 'unknown', expectedInteractive: false },
     ];
 
     for (const c of cases) {
-      const eventId = seedFailedLegacyEvent(c.actorRole);
+      resetTables();
+      const eventId = seedFailedEventWithTrustClass(c.trustClass);
       let capturedOptions: {
         guardianContext?: { trustClass?: string };
         isInteractive?: boolean;
@@ -105,7 +138,7 @@ describe('channel-retry-sweep', () => {
             guardianContext?: { trustClass?: string };
             isInteractive?: boolean;
           };
-          const messageId = `message-${c.actorRole}`;
+          const messageId = `message-${c.trustClass}`;
           const db = getDb();
           db.insert(messages).values({
             id: messageId,
@@ -119,12 +152,133 @@ describe('channel-retry-sweep', () => {
         undefined,
       );
 
-      expect(capturedOptions?.guardianContext?.trustClass).toBe(c.expectedTrustClass);
+      expect(capturedOptions?.guardianContext?.trustClass).toBe(c.trustClass);
       expect(capturedOptions?.isInteractive).toBe(c.expectedInteractive);
 
       const db = getDb();
       const row = db.select().from(channelInboundEvents).where(eq(channelInboundEvents.id, eventId)).get();
       expect(row?.processingStatus).toBe('processed');
     }
+  });
+
+  test('rejects legacy payloads with only actorRole (no trustClass)', async () => {
+    const actorRoles: Array<'guardian' | 'non-guardian' | 'unverified_channel'> = [
+      'guardian',
+      'non-guardian',
+      'unverified_channel',
+    ];
+
+    for (const actorRole of actorRoles) {
+      resetTables();
+      seedFailedEventWithActorRoleOnly(actorRole);
+      let capturedOptions: {
+        guardianContext?: { trustClass?: string } | undefined;
+        isInteractive?: boolean;
+      } | undefined;
+
+      await sweepFailedEvents(
+        async (conversationId, _content, _attachmentIds, options) => {
+          capturedOptions = options as {
+            guardianContext?: { trustClass?: string } | undefined;
+            isInteractive?: boolean;
+          };
+          const messageId = `message-legacy-${actorRole}`;
+          const db = getDb();
+          db.insert(messages).values({
+            id: messageId,
+            conversationId,
+            role: 'user',
+            content: JSON.stringify([{ type: 'text', text: 'retry me' }]),
+            createdAt: Date.now(),
+          }).run();
+          return { messageId };
+        },
+        undefined,
+      );
+
+      // parseGuardianRuntimeContext rejects payloads without a valid trustClass,
+      // so guardianContext is undefined and isInteractive falls back to false
+      expect(capturedOptions?.guardianContext).toBeUndefined();
+      expect(capturedOptions?.isInteractive).toBe(false);
+    }
+  });
+
+  test('rejects payloads with invalid trustClass values', async () => {
+    resetTables();
+    const eventId = seedFailedEventWithTrustClass('invalid_value');
+    let capturedOptions: {
+      guardianContext?: { trustClass?: string } | undefined;
+      isInteractive?: boolean;
+    } | undefined;
+
+    await sweepFailedEvents(
+      async (conversationId, _content, _attachmentIds, options) => {
+        capturedOptions = options as {
+          guardianContext?: { trustClass?: string } | undefined;
+          isInteractive?: boolean;
+        };
+        const messageId = 'message-invalid';
+        const db = getDb();
+        db.insert(messages).values({
+          id: messageId,
+          conversationId,
+          role: 'user',
+          content: JSON.stringify([{ type: 'text', text: 'retry me' }]),
+          createdAt: Date.now(),
+        }).run();
+        return { messageId };
+      },
+      undefined,
+    );
+
+    // guardianContext should be undefined since the trustClass is invalid
+    expect(capturedOptions?.guardianContext).toBeUndefined();
+    expect(capturedOptions?.isInteractive).toBe(false);
+  });
+
+  test('rejects payloads with missing guardianCtx entirely', async () => {
+    const inbound = channelDeliveryStore.recordInbound('telegram', 'chat-no-ctx', 'msg-no-ctx');
+    channelDeliveryStore.storePayload(inbound.eventId, {
+      content: 'retry me',
+      sourceChannel: 'telegram',
+      interface: 'telegram',
+    });
+
+    const db = getDb();
+    db.update(channelInboundEvents)
+      .set({
+        processingStatus: 'failed',
+        processingAttempts: 1,
+        retryAfter: Date.now() - 1,
+      })
+      .where(eq(channelInboundEvents.id, inbound.eventId))
+      .run();
+
+    let capturedOptions: {
+      guardianContext?: { trustClass?: string } | undefined;
+      isInteractive?: boolean;
+    } | undefined;
+
+    await sweepFailedEvents(
+      async (conversationId, _content, _attachmentIds, options) => {
+        capturedOptions = options as {
+          guardianContext?: { trustClass?: string } | undefined;
+          isInteractive?: boolean;
+        };
+        const messageId = 'message-no-ctx';
+        db.insert(messages).values({
+          id: messageId,
+          conversationId,
+          role: 'user',
+          content: JSON.stringify([{ type: 'text', text: 'retry me' }]),
+          createdAt: Date.now(),
+        }).run();
+        return { messageId };
+      },
+      undefined,
+    );
+
+    expect(capturedOptions?.guardianContext).toBeUndefined();
+    expect(capturedOptions?.isInteractive).toBe(false);
   });
 });

--- a/assistant/src/memory/channel-delivery-store.ts
+++ b/assistant/src/memory/channel-delivery-store.ts
@@ -33,6 +33,7 @@ export {
   getDeadLetterEvents,
   getRetryableEvents,
   markProcessed,
+  markRetryableFailure,
   recordProcessingFailure,
   replayDeadLetters,
 } from './delivery-status.js';

--- a/assistant/src/memory/delivery-status.ts
+++ b/assistant/src/memory/delivery-status.ts
@@ -107,6 +107,49 @@ export function recordProcessingFailure(eventId: string, err: unknown): void {
   }
 }
 
+/**
+ * Mark an event as failed with a specific error message, bypassing error
+ * classification. Use this when the failure reason is known and the event
+ * should remain retryable (up to max attempts).
+ */
+export function markRetryableFailure(eventId: string, errorMessage: string): void {
+  const db = getDb();
+  const now = Date.now();
+
+  const row = db
+    .select({ attempts: channelInboundEvents.processingAttempts })
+    .from(channelInboundEvents)
+    .where(eq(channelInboundEvents.id, eventId))
+    .get();
+
+  const attempts = (row?.attempts ?? 0) + 1;
+
+  if (attempts >= RETRY_MAX_ATTEMPTS) {
+    db.update(channelInboundEvents)
+      .set({
+        processingStatus: 'dead_letter',
+        processingAttempts: attempts,
+        lastProcessingError: errorMessage,
+        retryAfter: null,
+        updatedAt: now,
+      })
+      .where(eq(channelInboundEvents.id, eventId))
+      .run();
+  } else {
+    const delay = retryDelayForAttempt(attempts);
+    db.update(channelInboundEvents)
+      .set({
+        processingStatus: 'failed',
+        processingAttempts: attempts,
+        lastProcessingError: errorMessage,
+        retryAfter: now + delay,
+        updatedAt: now,
+      })
+      .where(eq(channelInboundEvents.id, eventId))
+      .run();
+  }
+}
+
 /** Fetch events eligible for automatic retry (failed + past their backoff). */
 export function getRetryableEvents(limit = 20): Array<{
   id: string;

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -100,6 +100,23 @@ export async function sweepFailedEvents(
       : undefined;
     const guardianContext = parseGuardianRuntimeContext(payload.guardianCtx);
 
+    // If the stored payload had guardian context data but it couldn't be parsed
+    // into a valid canonical shape (e.g., legacy actorRole-only payloads without
+    // trustClass), fail the event deterministically rather than processing it
+    // without guardian context. Without this check, the downstream default of
+    // `guardianTrustClass ?? 'guardian'` would silently escalate privileges.
+    if (payload.guardianCtx && !guardianContext) {
+      log.warn(
+        { eventId: event.id },
+        'Stored guardianCtx could not be parsed into canonical form; marking event as failed to prevent privilege escalation',
+      );
+      channelDeliveryStore.recordProcessingFailure(
+        event.id,
+        new Error('Unparseable guardian context in stored payload — refusing to process without trust classification'),
+      );
+      continue;
+    }
+
     const metadataHintsRaw = sourceMetadata?.hints;
     const metadataHints = Array.isArray(metadataHintsRaw)
       ? metadataHintsRaw.filter((h): h is string => typeof h === 'string' && h.trim().length > 0)

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -15,16 +15,7 @@ const log = getLogger('runtime-http');
 function parseGuardianRuntimeContext(value: unknown): GuardianRuntimeContext | undefined {
   if (!value || typeof value !== 'object') return undefined;
   const raw = value as Record<string, unknown>;
-  const trustClass = raw.trustClass
-    ?? (
-      raw.actorRole === 'guardian'
-        ? 'guardian'
-        : raw.actorRole === 'non-guardian'
-          ? 'trusted_contact'
-          : raw.actorRole === 'unverified_channel'
-            ? 'unknown'
-            : undefined
-    );
+  const trustClass = raw.trustClass;
   if (
     trustClass !== 'guardian'
     && trustClass !== 'trusted_contact'

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -37,6 +37,7 @@ function parseGuardianRuntimeContext(value: unknown): GuardianRuntimeContext | u
     trustClass,
     guardianChatId: typeof raw.guardianChatId === 'string' ? raw.guardianChatId : undefined,
     guardianExternalUserId: typeof raw.guardianExternalUserId === 'string' ? raw.guardianExternalUserId : undefined,
+    guardianPrincipalId: typeof raw.guardianPrincipalId === 'string' ? raw.guardianPrincipalId : undefined,
     requesterIdentifier: typeof raw.requesterIdentifier === 'string' ? raw.requesterIdentifier : undefined,
     requesterDisplayName: typeof raw.requesterDisplayName === 'string' ? raw.requesterDisplayName : undefined,
     requesterSenderDisplayName: typeof raw.requesterSenderDisplayName === 'string' ? raw.requesterSenderDisplayName : undefined,
@@ -110,9 +111,9 @@ export async function sweepFailedEvents(
         { eventId: event.id },
         'Stored guardianCtx could not be parsed into canonical form; marking event as failed to prevent privilege escalation',
       );
-      channelDeliveryStore.recordProcessingFailure(
+      channelDeliveryStore.markRetryableFailure(
         event.id,
-        new Error('Unparseable guardian context in stored payload — refusing to process without trust classification'),
+        'Unparseable guardian context in stored payload — refusing to process without trust classification',
       );
       continue;
     }


### PR DESCRIPTION
## Summary
- Remove actorRole -> trustClass compatibility mapping in retry sweep payload parser
- Parser now only accepts canonical trustClass payload shape
- Add tests verifying strict parsing rejects legacy actorRole-only payloads

Part of #11156

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
