### PR TITLE
M6: Add regression guards and architecture docs for canonical trust model

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -2085,3 +2085,25 @@ The daemon uses a single fixed internal scope constant — `DAEMON_INTERNAL_ASSI
 |------|---------|
 | `src/runtime/assistant-scope.ts` | Exports `DAEMON_INTERNAL_ASSISTANT_ID` constant |
 | `src/__tests__/assistant-id-boundary-guard.test.ts` | Guard tests enforcing the identity boundary |
+
+### Canonical Trust-Context Model
+
+The guardian trust system uses a three-valued `TrustClass` — `'guardian'`, `'trusted_contact'`, or `'unknown'` — as the single vocabulary for actor trust classification across all channels and runtime paths. There is no legacy `actorRole` concept; all trust decisions flow through `TrustClass`.
+
+**`GuardianRuntimeContext`** (in `src/daemon/session-runtime-assembly.ts`) is the single runtime carrier for trust state on channel-originated turns. It carries `trustClass`, guardian identity fields, and requester metadata. The `guardianPrincipalId` field is typed as `?: string` (optional but non-nullable) — a principal ID is present when a guardian binding exists but is never `null`.
+
+**Explicit trust gates:** `guardianTrustClass` is a **required** field in `ToolContext` (in `src/tools/types.ts`). Every tool execution must carry a trust classification — the field is not optional. This ensures trust-gated tool policies (guardian control-plane restrictions, host-tool blocking for untrusted actors) cannot be bypassed by omitting the classification.
+
+**Guardian bindings** (in `src/memory/guardian-bindings.ts`) always carry `guardianPrincipalId: string` as a required, non-null field. A binding without a principal ID is invalid and cannot be created.
+
+**Strict retry sweep parsing:** The channel retry sweep (`src/runtime/channel-retry-sweep.ts`) uses `parseGuardianRuntimeContext()` which validates `trustClass` against the canonical three-value set. There is no fallback to a legacy `actorRole` field — stored payloads that lack a valid `trustClass` are rejected deterministically to prevent silent privilege escalation.
+
+**Key files:**
+
+| File | Purpose |
+|------|---------|
+| `src/daemon/session-runtime-assembly.ts` | `GuardianRuntimeContext` type definition |
+| `src/tools/types.ts` | `ToolContext.guardianTrustClass` (required trust gate) |
+| `src/runtime/channel-retry-sweep.ts` | Strict `trustClass` parser for retry sweep |
+| `src/memory/guardian-bindings.ts` | `GuardianBinding` with required `guardianPrincipalId` |
+| `src/__tests__/trust-context-guards.test.ts` | Guard tests enforcing trust-context type invariants |

--- a/assistant/src/__tests__/trust-context-guards.test.ts
+++ b/assistant/src/__tests__/trust-context-guards.test.ts
@@ -1,0 +1,186 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'bun:test';
+
+/**
+ * Guard tests for the canonical trust-context model.
+ *
+ * These tests prevent reintroduction of removed compatibility patterns
+ * by scanning source files for type invariants:
+ *
+ *  (a) guardianPrincipalId in GuardianRuntimeContext must be `?: string`
+ *      (optional string), NOT `string | null`.
+ *  (b) guardianTrustClass in ToolContext must be a required field (no `?`).
+ *  (c) The channel retry sweep parser must not reference `actorRole`.
+ *  (d) guardianPrincipalId in GuardianBinding must be `string` (non-null,
+ *      non-optional).
+ */
+
+const srcDir = join(import.meta.dir, '..');
+
+describe('trust-context guards', () => {
+  // -----------------------------------------------------------------------
+  // (a) No `string | null` for guardianPrincipalId in runtime types
+  // -----------------------------------------------------------------------
+
+  it('guardianPrincipalId is not typed as string | null in GuardianRuntimeContext', () => {
+    const source = readFileSync(
+      join(srcDir, 'daemon', 'session-runtime-assembly.ts'),
+      'utf-8',
+    );
+
+    // Extract the GuardianRuntimeContext interface block
+    const ifaceStart = source.indexOf('export interface GuardianRuntimeContext');
+    expect(ifaceStart).toBeGreaterThan(-1);
+
+    const blockStart = source.indexOf('{', ifaceStart);
+    let braceDepth = 0;
+    let blockEnd = blockStart;
+    for (let i = blockStart; i < source.length; i++) {
+      if (source[i] === '{') braceDepth++;
+      if (source[i] === '}') braceDepth--;
+      if (braceDepth === 0) {
+        blockEnd = i + 1;
+        break;
+      }
+    }
+    const block = source.slice(blockStart, blockEnd);
+
+    // guardianPrincipalId should NOT be typed as `string | null`
+    const principalLine = block.split('\n').find((l) =>
+      l.includes('guardianPrincipalId'),
+    );
+    expect(
+      principalLine,
+      'Expected to find guardianPrincipalId in GuardianRuntimeContext',
+    ).toBeDefined();
+
+    expect(
+      principalLine!.includes('string | null'),
+      'guardianPrincipalId must not be typed as `string | null` in GuardianRuntimeContext. ' +
+        'Use `guardianPrincipalId?: string` (optional, non-nullable) instead. ' +
+        `Found: "${principalLine!.trim()}"`,
+    ).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // (b) guardianTrustClass is required in ToolContext
+  // -----------------------------------------------------------------------
+
+  it('guardianTrustClass is a required field in ToolContext', () => {
+    const source = readFileSync(
+      join(srcDir, 'tools', 'types.ts'),
+      'utf-8',
+    );
+
+    // Extract the ToolContext interface block
+    const ifaceStart = source.indexOf('export interface ToolContext');
+    expect(ifaceStart).toBeGreaterThan(-1);
+
+    const blockStart = source.indexOf('{', ifaceStart);
+    let braceDepth = 0;
+    let blockEnd = blockStart;
+    for (let i = blockStart; i < source.length; i++) {
+      if (source[i] === '{') braceDepth++;
+      if (source[i] === '}') braceDepth--;
+      if (braceDepth === 0) {
+        blockEnd = i + 1;
+        break;
+      }
+    }
+    const block = source.slice(blockStart, blockEnd);
+
+    const trustLine = block.split('\n').find((l) =>
+      l.includes('guardianTrustClass'),
+    );
+    expect(
+      trustLine,
+      'Expected to find guardianTrustClass in ToolContext',
+    ).toBeDefined();
+
+    // The field must NOT have a `?` before the colon — it must be required.
+    expect(
+      /guardianTrustClass\s*\?/.test(trustLine!),
+      'guardianTrustClass must be a required field in ToolContext (no `?`). ' +
+        'Explicit trust gates must not be optional — every tool execution ' +
+        `must carry a trust classification. Found: "${trustLine!.trim()}"`,
+    ).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // (c) No actorRole fallback in channel retry sweep parser
+  // -----------------------------------------------------------------------
+
+  it('channel retry sweep parser does not reference actorRole', () => {
+    const source = readFileSync(
+      join(srcDir, 'runtime', 'channel-retry-sweep.ts'),
+      'utf-8',
+    );
+
+    // The parseGuardianRuntimeContext function must use strict trustClass
+    // parsing only — no legacy actorRole fallback.
+    const parserStart = source.indexOf('function parseGuardianRuntimeContext');
+    expect(parserStart).toBeGreaterThan(-1);
+
+    // Find the end of the function (next function-level declaration or EOF)
+    const parserBody = source.slice(parserStart);
+    const nextFn = parserBody.indexOf('\nexport ', 1);
+    const parserSource = nextFn > 0 ? parserBody.slice(0, nextFn) : parserBody;
+
+    expect(
+      parserSource.includes('actorRole'),
+      'parseGuardianRuntimeContext must not reference `actorRole`. ' +
+        'The retry sweep uses strict `trustClass` parsing — no legacy actorRole fallback.',
+    ).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // (d) guardianPrincipalId is non-null in GuardianBinding
+  // -----------------------------------------------------------------------
+
+  it('guardianPrincipalId is typed as string (non-null) in GuardianBinding', () => {
+    const source = readFileSync(
+      join(srcDir, 'memory', 'guardian-bindings.ts'),
+      'utf-8',
+    );
+
+    // Extract the GuardianBinding interface block
+    const ifaceStart = source.indexOf('export interface GuardianBinding');
+    expect(ifaceStart).toBeGreaterThan(-1);
+
+    const blockStart = source.indexOf('{', ifaceStart);
+    let braceDepth = 0;
+    let blockEnd = blockStart;
+    for (let i = blockStart; i < source.length; i++) {
+      if (source[i] === '{') braceDepth++;
+      if (source[i] === '}') braceDepth--;
+      if (braceDepth === 0) {
+        blockEnd = i + 1;
+        break;
+      }
+    }
+    const block = source.slice(blockStart, blockEnd);
+
+    const principalLine = block.split('\n').find((l) =>
+      l.includes('guardianPrincipalId'),
+    );
+    expect(
+      principalLine,
+      'Expected to find guardianPrincipalId in GuardianBinding',
+    ).toBeDefined();
+
+    // Must be `guardianPrincipalId: string` — not optional, not nullable
+    expect(
+      principalLine!.includes('string | null'),
+      'guardianPrincipalId must not be typed as `string | null` in GuardianBinding. ' +
+        `Found: "${principalLine!.trim()}"`,
+    ).toBe(false);
+
+    expect(
+      /guardianPrincipalId\s*\?/.test(principalLine!),
+      'guardianPrincipalId must not be optional in GuardianBinding. ' +
+        `Found: "${principalLine!.trim()}"`,
+    ).toBe(false);
+  });
+});

--- a/assistant/src/__tests__/trust-context-guards.test.ts
+++ b/assistant/src/__tests__/trust-context-guards.test.ts
@@ -57,11 +57,20 @@ describe('trust-context guards', () => {
     ).toBeDefined();
 
     expect(
-      principalLine!.includes('string | null'),
-      'guardianPrincipalId must not be typed as `string | null` in GuardianRuntimeContext. ' +
+      principalLine!.includes('string | null') || principalLine!.includes('null | string'),
+      'guardianPrincipalId must not be typed as nullable in GuardianRuntimeContext. ' +
         'Use `guardianPrincipalId?: string` (optional, non-nullable) instead. ' +
         `Found: "${principalLine!.trim()}"`,
     ).toBe(false);
+
+    // The field must remain optional (has `?`) — channels where no guardian
+    // principal exists should be able to omit it.
+    expect(
+      /guardianPrincipalId\s*\?/.test(principalLine!),
+      'guardianPrincipalId must remain optional (`?:`) in GuardianRuntimeContext. ' +
+        'Channels without a guardian principal need to omit this field. ' +
+        `Found: "${principalLine!.trim()}"`,
+    ).toBe(true);
   });
 
   // -----------------------------------------------------------------------
@@ -172,8 +181,8 @@ describe('trust-context guards', () => {
 
     // Must be `guardianPrincipalId: string` — not optional, not nullable
     expect(
-      principalLine!.includes('string | null'),
-      'guardianPrincipalId must not be typed as `string | null` in GuardianBinding. ' +
+      principalLine!.includes('string | null') || principalLine!.includes('null | string'),
+      'guardianPrincipalId must not be typed as nullable in GuardianBinding. ' +
         `Found: "${principalLine!.trim()}"`,
     ).toBe(false);
 


### PR DESCRIPTION
## Summary
- Add source-level guard tests to prevent reintroduction of removed compatibility patterns
- Update architecture docs to describe canonical trust-context model

Closes #11162

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
