### PR TITLE
fix: prevent scroll position conflict during thread pagination

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -60,6 +60,9 @@ struct MessageListView: View {
     /// Guards the pagination sentinel against re-entry during the brief window
     /// between Task launch and the first `await` (before isLoadingMoreMessages is set).
     @State private var isPaginationInFlight: Bool = false
+    /// Suppresses bottom auto-scroll for the ~32ms layout window after pagination
+    /// restores scroll position, preventing a jump back to the bottom.
+    @State private var isSuppressingBottomScroll: Bool = false
 
     /// The subset of messages actually shown, honoring the pagination window.
     private var visibleMessages: [ChatMessage] {
@@ -198,9 +201,13 @@ struct MessageListView: View {
                                     defer { isPaginationInFlight = false }
                                     let hadMore = await loadPreviousMessagePage?() ?? false
                                     if hadMore, let id = anchorId {
+                                        // Suppress bottom auto-scroll for the brief layout window so the
+                                        // restored anchor position is not immediately overridden.
+                                        isSuppressingBottomScroll = true
                                         // Wait ~2 frames for SwiftUI to complete layout before restoring position.
                                         try? await Task.sleep(nanoseconds: 32_000_000)
                                         proxy.scrollTo(id, anchor: .top)
+                                        isSuppressingBottomScroll = false
                                     }
                                 }
                             }
@@ -430,7 +437,7 @@ struct MessageListView: View {
                 }
             }
             .onChange(of: streamingScrollTrigger) {
-                if isNearBottom && !isLoadingMoreMessages {
+                if isNearBottom && !isSuppressingBottomScroll {
                     // Throttle pattern: fire immediately then suppress for 200ms.
                     // Unlike debounce (cancel+recreate), this guarantees scrolls
                     // execute during active streaming, not only after the last token.
@@ -457,7 +464,7 @@ struct MessageListView: View {
                 }
             }
             .onChange(of: messages.count) {
-                if isNearBottom && !isLoadingMoreMessages {
+                if isNearBottom && !isSuppressingBottomScroll {
                     withAnimation(VAnimation.fast) {
                         proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -57,6 +57,9 @@ struct MessageListView: View {
     /// Observing the full TaskProgressOverlayManager would cause the entire
     /// message list to re-render on every frequent `data` progress tick.
     @State private var activeSurfaceId: String?
+    /// Guards the pagination sentinel against re-entry during the brief window
+    /// between Task launch and the first `await` (before isLoadingMoreMessages is set).
+    @State private var isPaginationInFlight: Bool = false
 
     /// The subset of messages actually shown, honoring the pagination window.
     private var visibleMessages: [ChatMessage] {
@@ -188,10 +191,15 @@ struct MessageListView: View {
                             .frame(height: 1)
                             .id("page-load-trigger")
                             .onAppear {
+                                guard !isPaginationInFlight else { return }
+                                isPaginationInFlight = true
                                 let anchorId = visibleMessages.first?.id
                                 Task {
+                                    defer { isPaginationInFlight = false }
                                     let hadMore = await loadPreviousMessagePage?() ?? false
                                     if hadMore, let id = anchorId {
+                                        // Wait ~2 frames for SwiftUI to complete layout before restoring position.
+                                        try? await Task.sleep(nanoseconds: 32_000_000)
                                         proxy.scrollTo(id, anchor: .top)
                                     }
                                 }
@@ -422,7 +430,7 @@ struct MessageListView: View {
                 }
             }
             .onChange(of: streamingScrollTrigger) {
-                if isNearBottom {
+                if isNearBottom && !isLoadingMoreMessages {
                     // Throttle pattern: fire immediately then suppress for 200ms.
                     // Unlike debounce (cancel+recreate), this guarantees scrolls
                     // execute during active streaming, not only after the last token.
@@ -449,7 +457,7 @@ struct MessageListView: View {
                 }
             }
             .onChange(of: messages.count) {
-                if isNearBottom {
+                if isNearBottom && !isLoadingMoreMessages {
                     withAnimation(VAnimation.fast) {
                         proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                     }


### PR DESCRIPTION
Fixes a freeze/crash when scrolling up through threads with pagination.

Root cause: onChange(of: messages.count) unconditionally scrolled to bottom while pagination was simultaneously trying to scroll to the anchor message, causing SwiftUI layout to enter a bad state.

Changes:
- Guard onChange(of: messages.count) with !isLoadingMoreMessages
- Guard onChange(of: streamingScrollTrigger) with !isLoadingMoreMessages  
- Add isPaginationInFlight @State guard to prevent sentinel re-entry before ViewModel sets isLoadingMoreMessages
- Add 32ms delay before scroll restoration to let SwiftUI complete layout

Closes #11182
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
