### PR TITLE
fix: harden scroll detection threshold and add observability

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -458,7 +458,7 @@ struct ScrollWheelDetector: NSViewRepresentable {
                     if let scrollView = coordinator.findEnclosingScrollView() {
                         let clipBounds = scrollView.contentView.bounds
                         let docHeight = scrollView.documentView?.frame.height ?? 0
-                        if docHeight - clipBounds.maxY >= 50 {
+                        if docHeight - clipBounds.maxY >= 20 {
                             coordinator.onScrollUp?()
                         }
                     } else {
@@ -473,7 +473,7 @@ struct ScrollWheelDetector: NSViewRepresentable {
                     if let scrollView = coordinator.findEnclosingScrollView() {
                         let clipBounds = scrollView.contentView.bounds
                         let docHeight = scrollView.documentView?.frame.height ?? 0
-                        if docHeight - clipBounds.maxY < 50 {
+                        if docHeight - clipBounds.maxY < 20 {
                             coordinator.onScrollToBottom?()
                         }
                     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1,6 +1,9 @@
 import Combine
+import os
 import SwiftUI
 import VellumAssistantShared
+
+private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "MessageListView")
 
 struct MessageListView: View {
     let messages: [ChatMessage]
@@ -197,9 +200,11 @@ struct MessageListView: View {
                                 guard !isPaginationInFlight else { return }
                                 isPaginationInFlight = true
                                 let anchorId = visibleMessages.first?.id
+                                log.debug("Pagination triggered — anchorId: \(String(describing: anchorId))")
                                 Task {
                                     defer { isPaginationInFlight = false }
                                     let hadMore = await loadPreviousMessagePage?() ?? false
+                                    log.debug("loadPreviousMessagePage returned hadMore=\(hadMore)")
                                     if hadMore, let id = anchorId {
                                         // Suppress bottom auto-scroll for the brief layout window so the
                                         // restored anchor position is not immediately overridden.
@@ -207,6 +212,7 @@ struct MessageListView: View {
                                         // Wait ~2 frames for SwiftUI to complete layout before restoring position.
                                         try? await Task.sleep(nanoseconds: 32_000_000)
                                         proxy.scrollTo(id, anchor: .top)
+                                        log.debug("Scroll restored to anchor \(id)")
                                         isSuppressingBottomScroll = false
                                     }
                                 }
@@ -468,6 +474,8 @@ struct MessageListView: View {
                     withAnimation(VAnimation.fast) {
                         proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                     }
+                } else if isSuppressingBottomScroll {
+                    log.debug("Auto-scroll suppressed (bottom-scroll suppression active)")
                 }
             }
             .onChange(of: conversationZoomScale) {


### PR DESCRIPTION
Two hardening improvements for the scroll/pagination system:

1. Lower ScrollWheelDetector untether/retether threshold from 50pt → 20pt.
   The old 50pt gap allowed the pagination sentinel to become visible before
   isNearBottom reset, which could still cause a scroll conflict even after M1.

2. Add os.Logger diagnostics to MessageListView pagination path so future
   scroll issues are easier to trace via Console.app.

Part of #11183, #11181
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
