### PR TITLE
feat: add Slack guardian verification support

### DIFF
--- a/assistant/src/runtime/guardian-outbound-actions.ts
+++ b/assistant/src/runtime/guardian-outbound-actions.ts
@@ -7,17 +7,17 @@
  * IPC handler (config-channels.ts) and the HTTP route layer (integration-routes.ts).
  */
 
-import { createHash,randomBytes } from 'node:crypto';
+import { createHash, randomBytes } from "node:crypto";
 
-import { startGuardianVerificationCall } from '../calls/call-domain.js';
-import type { ChannelId } from '../channels/types.js';
-import { getGatewayInternalBaseUrl } from '../config/env.js';
-import { sendMessage as sendSms } from '../messaging/providers/sms/client.js';
-import { getCredentialMetadata } from '../tools/credentials/metadata-store.js';
-import { getLogger } from '../util/logger.js';
-import { normalizePhoneNumber } from '../util/phone.js';
-import { readHttpToken } from '../util/platform.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
+import { startGuardianVerificationCall } from "../calls/call-domain.js";
+import type { ChannelId } from "../channels/types.js";
+import { getGatewayInternalBaseUrl } from "../config/env.js";
+import { sendMessage as sendSms } from "../messaging/providers/sms/client.js";
+import { getCredentialMetadata } from "../tools/credentials/metadata-store.js";
+import { getLogger } from "../util/logger.js";
+import { normalizePhoneNumber } from "../util/phone.js";
+import { readHttpToken } from "../util/platform.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
 import {
   countRecentSendsToDestination,
   createOutboundSession,
@@ -25,14 +25,15 @@ import {
   getGuardianBinding,
   updateSessionDelivery,
   updateSessionStatus,
-} from './channel-guardian-service.js';
+} from "./channel-guardian-service.js";
 import {
+  composeVerificationSlack,
   composeVerificationSms,
   composeVerificationTelegram,
   GUARDIAN_VERIFY_TEMPLATE_KEYS,
-} from './guardian-verification-templates.js';
+} from "./guardian-verification-templates.js";
 
-const log = getLogger('guardian-outbound-actions');
+const log = getLogger("guardian-outbound-actions");
 
 // ---------------------------------------------------------------------------
 // Rate limit constants for outbound verification
@@ -73,7 +74,7 @@ function isTelegramChatId(destination: string): boolean {
  */
 export function normalizeTelegramDestination(destination: string): string {
   if (isTelegramChatId(destination)) return destination;
-  return destination.replace(/^@/, '').toLowerCase();
+  return destination.replace(/^@/, "").toLowerCase();
 }
 
 /**
@@ -81,8 +82,12 @@ export function normalizeTelegramDestination(destination: string): string {
  * Falls back to process.env.TELEGRAM_BOT_USERNAME.
  */
 function getTelegramBotUsername(): string | undefined {
-  const meta = getCredentialMetadata('telegram', 'bot_token');
-  if (meta?.accountInfo && typeof meta.accountInfo === 'string' && meta.accountInfo.trim().length > 0) {
+  const meta = getCredentialMetadata("telegram", "bot_token");
+  if (
+    meta?.accountInfo &&
+    typeof meta.accountInfo === "string" &&
+    meta.accountInfo.trim().length > 0
+  ) {
     return meta.accountInfo.trim();
   }
   return process.env.TELEGRAM_BOT_USERNAME || undefined;
@@ -150,13 +155,15 @@ function deliverVerificationSms(
       const gatewayUrl = getGatewayInternalBaseUrl();
       const bearerToken = readHttpToken();
       if (!bearerToken) {
-        log.error('Cannot deliver verification SMS: no runtime HTTP token available');
+        log.error(
+          "Cannot deliver verification SMS: no runtime HTTP token available",
+        );
         return;
       }
       await sendSms(gatewayUrl, bearerToken, to, text, assistantId);
-      log.info({ to, assistantId }, 'Verification SMS delivered');
+      log.info({ to, assistantId }, "Verification SMS delivered");
     } catch (err) {
-      log.error({ err, to, assistantId }, 'Failed to deliver verification SMS');
+      log.error({ err, to, assistantId }, "Failed to deliver verification SMS");
     }
   })();
 }
@@ -179,26 +186,37 @@ function deliverVerificationTelegram(
       const gatewayUrl = getGatewayInternalBaseUrl();
       const bearerToken = readHttpToken();
       if (!bearerToken) {
-        log.error('Cannot deliver verification Telegram message: no runtime HTTP token available');
+        log.error(
+          "Cannot deliver verification Telegram message: no runtime HTTP token available",
+        );
         return;
       }
       const url = `${gatewayUrl}/deliver/telegram`;
       const resp = await fetch(url, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
           Authorization: `Bearer ${bearerToken}`,
         },
         body: JSON.stringify({ chatId, text, assistantId }),
       });
       if (!resp.ok) {
-        const body = await resp.text().catch(() => '<unreadable>');
-        log.error({ chatId, assistantId, status: resp.status, body }, 'Gateway /deliver/telegram failed for verification');
+        const body = await resp.text().catch(() => "<unreadable>");
+        log.error(
+          { chatId, assistantId, status: resp.status, body },
+          "Gateway /deliver/telegram failed for verification",
+        );
       } else {
-        log.info({ chatId, assistantId }, 'Verification Telegram message delivered');
+        log.info(
+          { chatId, assistantId },
+          "Verification Telegram message delivered",
+        );
       }
     } catch (err) {
-      log.error({ err, chatId, assistantId }, 'Failed to deliver verification Telegram message');
+      log.error(
+        { err, chatId, assistantId },
+        "Failed to deliver verification Telegram message",
+      );
     }
   })();
 }
@@ -226,12 +244,25 @@ function initiateGuardianVoiceCall(
         originConversationId,
       });
       if (result.ok) {
-        log.info({ phoneNumber, guardianVerificationSessionId, callSid: result.callSid }, 'Guardian verification call initiated');
+        log.info(
+          {
+            phoneNumber,
+            guardianVerificationSessionId,
+            callSid: result.callSid,
+          },
+          "Guardian verification call initiated",
+        );
       } else {
-        log.error({ phoneNumber, guardianVerificationSessionId, error: result.error }, 'Failed to initiate guardian verification call');
+        log.error(
+          { phoneNumber, guardianVerificationSessionId, error: result.error },
+          "Failed to initiate guardian verification call",
+        );
       }
     } catch (err) {
-      log.error({ err, phoneNumber, guardianVerificationSessionId }, 'Failed to initiate guardian verification call');
+      log.error(
+        { err, phoneNumber, guardianVerificationSessionId },
+        "Failed to initiate guardian verification call",
+      );
     }
   })();
 }
@@ -240,23 +271,51 @@ function initiateGuardianVoiceCall(
 // Start outbound
 // ---------------------------------------------------------------------------
 
-export function startOutbound(params: StartOutboundParams): OutboundActionResult {
+export function startOutbound(
+  params: StartOutboundParams,
+): OutboundActionResult {
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const channel = params.channel;
   const originConversationId = params.originConversationId;
 
-  if (channel === 'sms') {
-    return startOutboundSms(params.destination, assistantId, channel, params.rebind, originConversationId);
-  } else if (channel === 'telegram') {
-    return startOutboundTelegram(params.destination, assistantId, channel, params.rebind, originConversationId);
-  } else if (channel === 'voice') {
-    return startOutboundVoice(params.destination, assistantId, channel, params.rebind, originConversationId);
+  if (channel === "sms") {
+    return startOutboundSms(
+      params.destination,
+      assistantId,
+      channel,
+      params.rebind,
+      originConversationId,
+    );
+  } else if (channel === "telegram") {
+    return startOutboundTelegram(
+      params.destination,
+      assistantId,
+      channel,
+      params.rebind,
+      originConversationId,
+    );
+  } else if (channel === "voice") {
+    return startOutboundVoice(
+      params.destination,
+      assistantId,
+      channel,
+      params.rebind,
+      originConversationId,
+    );
+  } else if (channel === "slack") {
+    return startOutboundSlack(
+      params.destination,
+      assistantId,
+      channel,
+      params.rebind,
+      originConversationId,
+    );
   }
 
   return {
     success: false,
-    error: 'unsupported_channel',
-    message: `Outbound verification is only supported for SMS, Telegram, and voice. Got: ${channel}`,
+    error: "unsupported_channel",
+    message: `Outbound verification is only supported for SMS, Telegram, voice, and Slack. Got: ${channel}`,
     channel,
   };
 }
@@ -271,8 +330,9 @@ function startOutboundSms(
   if (!rawDestination) {
     return {
       success: false,
-      error: 'missing_destination',
-      message: 'A destination phone number is required for outbound SMS verification.',
+      error: "missing_destination",
+      message:
+        "A destination phone number is required for outbound SMS verification.",
       channel,
     };
   }
@@ -281,8 +341,9 @@ function startOutboundSms(
   if (!destination) {
     return {
       success: false,
-      error: 'invalid_destination',
-      message: 'Could not parse phone number. Please enter a valid number (e.g. +15551234567, (555) 123-4567, or 555-123-4567).',
+      error: "invalid_destination",
+      message:
+        "Could not parse phone number. Please enter a valid number (e.g. +15551234567, (555) 123-4567, or 555-123-4567).",
       channel,
     };
   }
@@ -291,18 +352,24 @@ function startOutboundSms(
   if (existingBinding && !rebind) {
     return {
       success: false,
-      error: 'already_bound',
-      message: 'A guardian is already bound for this channel. Set rebind: true to replace.',
+      error: "already_bound",
+      message:
+        "A guardian is already bound for this channel. Set rebind: true to replace.",
       channel,
     };
   }
 
-  const recentSendCount = countRecentSendsToDestination(channel, destination, DESTINATION_RATE_WINDOW_MS);
+  const recentSendCount = countRecentSendsToDestination(
+    channel,
+    destination,
+    DESTINATION_RATE_WINDOW_MS,
+  );
   if (recentSendCount >= MAX_SENDS_PER_DESTINATION_WINDOW) {
     return {
       success: false,
-      error: 'rate_limited',
-      message: 'Too many verification attempts to this phone number. Please try again later.',
+      error: "rate_limited",
+      message:
+        "Too many verification attempts to this phone number. Please try again later.",
       channel,
     };
   }
@@ -352,8 +419,9 @@ function startOutboundTelegram(
   if (!destination) {
     return {
       success: false,
-      error: 'missing_destination',
-      message: 'A destination (Telegram handle or chat ID) is required for outbound Telegram verification.',
+      error: "missing_destination",
+      message:
+        "A destination (Telegram handle or chat ID) is required for outbound Telegram verification.",
       channel,
     };
   }
@@ -362,20 +430,26 @@ function startOutboundTelegram(
   if (existingBinding && !rebind) {
     return {
       success: false,
-      error: 'already_bound',
-      message: 'A guardian is already bound for this channel. Set rebind: true to replace.',
+      error: "already_bound",
+      message:
+        "A guardian is already bound for this channel. Set rebind: true to replace.",
       channel,
     };
   }
 
   const normalizedDestination = normalizeTelegramDestination(destination);
 
-  const recentSendCount = countRecentSendsToDestination(channel, normalizedDestination, DESTINATION_RATE_WINDOW_MS);
+  const recentSendCount = countRecentSendsToDestination(
+    channel,
+    normalizedDestination,
+    DESTINATION_RATE_WINDOW_MS,
+  );
   if (recentSendCount >= MAX_SENDS_PER_DESTINATION_WINDOW) {
     return {
       success: false,
-      error: 'rate_limited',
-      message: 'Too many verification attempts to this destination. Please try again later.',
+      error: "rate_limited",
+      message:
+        "Too many verification attempts to this destination. Please try again later.",
       channel,
     };
   }
@@ -385,8 +459,9 @@ function startOutboundTelegram(
     if (isNaN(chatIdNum) || chatIdNum < 0) {
       return {
         success: false,
-        error: 'invalid_destination',
-        message: 'Telegram group chats are not supported for verification. Use a private chat ID or @handle.',
+        error: "invalid_destination",
+        message:
+          "Telegram group chats are not supported for verification. Use a private chat ID or @handle.",
         channel,
       };
     }
@@ -395,7 +470,7 @@ function startOutboundTelegram(
       assistantId,
       channel,
       expectedChatId: destination,
-      identityBindingStatus: 'bound',
+      identityBindingStatus: "bound",
       destinationAddress: normalizedDestination,
     });
 
@@ -411,7 +486,12 @@ function startOutboundTelegram(
     const nextResendAt = now + RESEND_COOLDOWN_MS;
     const sendCount = 1;
 
-    updateSessionDelivery(sessionResult.sessionId, now, sendCount, nextResendAt);
+    updateSessionDelivery(
+      sessionResult.sessionId,
+      now,
+      sendCount,
+      nextResendAt,
+    );
     deliverVerificationTelegram(destination, telegramBody, assistantId);
 
     return {
@@ -431,19 +511,22 @@ function startOutboundTelegram(
   if (!botUsername) {
     return {
       success: false,
-      error: 'no_bot_username',
-      message: 'Telegram bot username is not configured. Set up the Telegram integration first.',
+      error: "no_bot_username",
+      message:
+        "Telegram bot username is not configured. Set up the Telegram integration first.",
       channel,
     };
   }
 
-  const bootstrapToken = randomBytes(16).toString('hex');
-  const bootstrapTokenHash = createHash('sha256').update(bootstrapToken).digest('hex');
+  const bootstrapToken = randomBytes(16).toString("hex");
+  const bootstrapTokenHash = createHash("sha256")
+    .update(bootstrapToken)
+    .digest("hex");
 
   const sessionResult = createOutboundSession({
     assistantId,
     channel,
-    identityBindingStatus: 'pending_bootstrap',
+    identityBindingStatus: "pending_bootstrap",
     destinationAddress: normalizedDestination,
     bootstrapTokenHash,
   });
@@ -470,8 +553,9 @@ function startOutboundVoice(
   if (!rawDestination) {
     return {
       success: false,
-      error: 'missing_destination',
-      message: 'A destination phone number is required for outbound voice verification.',
+      error: "missing_destination",
+      message:
+        "A destination phone number is required for outbound voice verification.",
       channel,
     };
   }
@@ -480,8 +564,9 @@ function startOutboundVoice(
   if (!destination) {
     return {
       success: false,
-      error: 'invalid_destination',
-      message: 'Could not parse phone number. Please enter a valid number (e.g. +15551234567, (555) 123-4567, or 555-123-4567).',
+      error: "invalid_destination",
+      message:
+        "Could not parse phone number. Please enter a valid number (e.g. +15551234567, (555) 123-4567, or 555-123-4567).",
       channel,
     };
   }
@@ -490,18 +575,24 @@ function startOutboundVoice(
   if (existingBinding && !rebind) {
     return {
       success: false,
-      error: 'already_bound',
-      message: 'A guardian is already bound for this channel. Set rebind: true to replace.',
+      error: "already_bound",
+      message:
+        "A guardian is already bound for this channel. Set rebind: true to replace.",
       channel,
     };
   }
 
-  const recentSendCount = countRecentSendsToDestination(channel, destination, DESTINATION_RATE_WINDOW_MS);
+  const recentSendCount = countRecentSendsToDestination(
+    channel,
+    destination,
+    DESTINATION_RATE_WINDOW_MS,
+  );
   if (recentSendCount >= MAX_SENDS_PER_DESTINATION_WINDOW) {
     return {
       success: false,
-      error: 'rate_limited',
-      message: 'Too many verification attempts to this phone number. Please try again later.',
+      error: "rate_limited",
+      message:
+        "Too many verification attempts to this phone number. Please try again later.",
       channel,
     };
   }
@@ -520,7 +611,140 @@ function startOutboundVoice(
   const sendCount = 1;
 
   updateSessionDelivery(sessionResult.sessionId, now, sendCount, nextResendAt);
-  initiateGuardianVoiceCall(destination, sessionResult.sessionId, assistantId, originConversationId);
+  initiateGuardianVoiceCall(
+    destination,
+    sessionResult.sessionId,
+    assistantId,
+    originConversationId,
+  );
+
+  return {
+    success: true,
+    verificationSessionId: sessionResult.sessionId,
+    secret: sessionResult.secret,
+    expiresAt: sessionResult.expiresAt,
+    nextResendAt,
+    sendCount,
+    channel,
+    originConversationId,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Slack delivery helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Deliver a verification Slack DM via the gateway's /deliver/slack endpoint.
+ * Fire-and-forget with error logging.
+ */
+function deliverVerificationSlack(
+  userId: string,
+  text: string,
+  assistantId: string,
+): void {
+  (async () => {
+    try {
+      const gatewayUrl = getGatewayInternalBaseUrl();
+      const bearerToken = readHttpToken();
+      if (!bearerToken) {
+        log.error(
+          "Cannot deliver verification Slack DM: no runtime HTTP token available",
+        );
+        return;
+      }
+      const url = `${gatewayUrl}/deliver/slack`;
+      const resp = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${bearerToken}`,
+        },
+        body: JSON.stringify({ chatId: userId, text, assistantId }),
+      });
+      if (!resp.ok) {
+        const body = await resp.text().catch(() => "<unreadable>");
+        log.error(
+          { userId, assistantId, status: resp.status, body },
+          "Gateway /deliver/slack failed for verification",
+        );
+      } else {
+        log.info({ userId, assistantId }, "Verification Slack DM delivered");
+      }
+    } catch (err) {
+      log.error(
+        { err, userId, assistantId },
+        "Failed to deliver verification Slack DM",
+      );
+    }
+  })();
+}
+
+function startOutboundSlack(
+  destination: string | undefined,
+  assistantId: string,
+  channel: ChannelId,
+  rebind?: boolean,
+  originConversationId?: string,
+): OutboundActionResult {
+  if (!destination) {
+    return {
+      success: false,
+      error: "missing_destination",
+      message: "A Slack user ID is required for outbound Slack verification.",
+      channel,
+    };
+  }
+
+  const existingBinding = getGuardianBinding(assistantId, channel);
+  if (existingBinding && !rebind) {
+    return {
+      success: false,
+      error: "already_bound",
+      message:
+        "A guardian is already bound for this channel. Set rebind: true to replace.",
+      channel,
+    };
+  }
+
+  const recentSendCount = countRecentSendsToDestination(
+    channel,
+    destination,
+    DESTINATION_RATE_WINDOW_MS,
+  );
+  if (recentSendCount >= MAX_SENDS_PER_DESTINATION_WINDOW) {
+    return {
+      success: false,
+      error: "rate_limited",
+      message:
+        "Too many verification attempts to this Slack user. Please try again later.",
+      channel,
+    };
+  }
+
+  const sessionResult = createOutboundSession({
+    assistantId,
+    channel,
+    expectedExternalUserId: destination,
+    expectedChatId: destination,
+    identityBindingStatus: "bound",
+    destinationAddress: destination,
+  });
+
+  const slackBody = composeVerificationSlack(
+    GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_CHALLENGE_REQUEST,
+    {
+      code: sessionResult.secret,
+      expiresInMinutes: Math.floor(SESSION_TTL_SECONDS / 60),
+    },
+  );
+
+  const now = Date.now();
+  const nextResendAt = now + RESEND_COOLDOWN_MS;
+  const sendCount = 1;
+
+  updateSessionDelivery(sessionResult.sessionId, now, sendCount, nextResendAt);
+  deliverVerificationSlack(destination, slackBody, assistantId);
 
   return {
     success: true,
@@ -538,7 +762,9 @@ function startOutboundVoice(
 // Resend outbound
 // ---------------------------------------------------------------------------
 
-export function resendOutbound(params: ResendOutboundParams): OutboundActionResult {
+export function resendOutbound(
+  params: ResendOutboundParams,
+): OutboundActionResult {
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const channel = params.channel;
   const originConversationId = params.originConversationId;
@@ -547,17 +773,18 @@ export function resendOutbound(params: ResendOutboundParams): OutboundActionResu
   if (!session) {
     return {
       success: false,
-      error: 'no_active_session',
-      message: 'No active outbound verification session found.',
+      error: "no_active_session",
+      message: "No active outbound verification session found.",
       channel,
     };
   }
 
-  if (session.identityBindingStatus === 'pending_bootstrap') {
+  if (session.identityBindingStatus === "pending_bootstrap") {
     return {
       success: false,
-      error: 'pending_bootstrap',
-      message: 'Cannot resend: waiting for bootstrap deep-link activation. The user must click the link first.',
+      error: "pending_bootstrap",
+      message:
+        "Cannot resend: waiting for bootstrap deep-link activation. The user must click the link first.",
       channel,
     };
   }
@@ -565,8 +792,8 @@ export function resendOutbound(params: ResendOutboundParams): OutboundActionResu
   if (session.nextResendAt != null && Date.now() < session.nextResendAt) {
     return {
       success: false,
-      error: 'rate_limited',
-      message: 'Please wait before requesting another verification code.',
+      error: "rate_limited",
+      message: "Please wait before requesting another verification code.",
       channel,
     };
   }
@@ -575,41 +802,52 @@ export function resendOutbound(params: ResendOutboundParams): OutboundActionResu
   if (currentSendCount >= MAX_SENDS_PER_SESSION) {
     return {
       success: false,
-      error: 'max_sends_exceeded',
-      message: 'Maximum number of verification sends reached for this session.',
+      error: "max_sends_exceeded",
+      message: "Maximum number of verification sends reached for this session.",
       channel,
     };
   }
 
-  const resendDestination = session.destinationAddress ?? session.expectedPhoneE164 ?? session.expectedChatId;
+  const resendDestination =
+    session.destinationAddress ??
+    session.expectedPhoneE164 ??
+    session.expectedChatId;
   if (resendDestination) {
-    const recentDestSends = countRecentSendsToDestination(channel, resendDestination, DESTINATION_RATE_WINDOW_MS);
+    const recentDestSends = countRecentSendsToDestination(
+      channel,
+      resendDestination,
+      DESTINATION_RATE_WINDOW_MS,
+    );
     if (recentDestSends >= MAX_SENDS_PER_DESTINATION_WINDOW) {
       return {
         success: false,
-        error: 'rate_limited',
-        message: 'Too many verification attempts to this destination. Please try again later.',
+        error: "rate_limited",
+        message:
+          "Too many verification attempts to this destination. Please try again later.",
         channel,
       };
     }
   }
 
-  const destination = session.destinationAddress ?? session.expectedPhoneE164 ?? session.expectedChatId;
+  const destination =
+    session.destinationAddress ??
+    session.expectedPhoneE164 ??
+    session.expectedChatId;
   if (!destination) {
     return {
       success: false,
-      error: 'no_destination',
-      message: 'Cannot resend: no destination address on the session.',
+      error: "no_destination",
+      message: "Cannot resend: no destination address on the session.",
       channel,
     };
   }
 
-  if (channel === 'telegram') {
+  if (channel === "telegram") {
     const newSession = createOutboundSession({
       assistantId,
       channel,
       expectedChatId: destination,
-      identityBindingStatus: 'bound',
+      identityBindingStatus: "bound",
       destinationAddress: destination,
     });
 
@@ -625,7 +863,12 @@ export function resendOutbound(params: ResendOutboundParams): OutboundActionResu
     const newSendCount = currentSendCount + 1;
     const nextResendAt = now + RESEND_COOLDOWN_MS;
 
-    updateSessionDelivery(newSession.sessionId, now, newSendCount, nextResendAt);
+    updateSessionDelivery(
+      newSession.sessionId,
+      now,
+      newSendCount,
+      nextResendAt,
+    );
     deliverVerificationTelegram(destination, telegramBody, assistantId);
 
     return {
@@ -637,7 +880,7 @@ export function resendOutbound(params: ResendOutboundParams): OutboundActionResu
       channel,
       originConversationId,
     };
-  } else if (channel === 'voice') {
+  } else if (channel === "voice") {
     const newSession = createOutboundSession({
       assistantId,
       channel,
@@ -651,8 +894,57 @@ export function resendOutbound(params: ResendOutboundParams): OutboundActionResu
     const newSendCount = currentSendCount + 1;
     const nextResendAt = now + RESEND_COOLDOWN_MS;
 
-    updateSessionDelivery(newSession.sessionId, now, newSendCount, nextResendAt);
-    initiateGuardianVoiceCall(destination, newSession.sessionId, assistantId, originConversationId);
+    updateSessionDelivery(
+      newSession.sessionId,
+      now,
+      newSendCount,
+      nextResendAt,
+    );
+    initiateGuardianVoiceCall(
+      destination,
+      newSession.sessionId,
+      assistantId,
+      originConversationId,
+    );
+
+    return {
+      success: true,
+      verificationSessionId: newSession.sessionId,
+      secret: newSession.secret,
+      nextResendAt,
+      sendCount: newSendCount,
+      channel,
+      originConversationId,
+    };
+  } else if (channel === "slack") {
+    const newSession = createOutboundSession({
+      assistantId,
+      channel,
+      expectedExternalUserId: destination,
+      expectedChatId: destination,
+      identityBindingStatus: "bound",
+      destinationAddress: destination,
+    });
+
+    const slackBody = composeVerificationSlack(
+      GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_RESEND,
+      {
+        code: newSession.secret,
+        expiresInMinutes: Math.floor(SESSION_TTL_SECONDS / 60),
+      },
+    );
+
+    const now = Date.now();
+    const newSendCount = currentSendCount + 1;
+    const nextResendAt = now + RESEND_COOLDOWN_MS;
+
+    updateSessionDelivery(
+      newSession.sessionId,
+      now,
+      newSendCount,
+      nextResendAt,
+    );
+    deliverVerificationSlack(destination, slackBody, assistantId);
 
     return {
       success: true,
@@ -674,13 +966,10 @@ export function resendOutbound(params: ResendOutboundParams): OutboundActionResu
     destinationAddress: destination,
   });
 
-  const smsBody = composeVerificationSms(
-    GUARDIAN_VERIFY_TEMPLATE_KEYS.RESEND,
-    {
-      code: newSession.secret,
-      expiresInMinutes: Math.floor(SESSION_TTL_SECONDS / 60),
-    },
-  );
+  const smsBody = composeVerificationSms(GUARDIAN_VERIFY_TEMPLATE_KEYS.RESEND, {
+    code: newSession.secret,
+    expiresInMinutes: Math.floor(SESSION_TTL_SECONDS / 60),
+  });
 
   const now = Date.now();
   const newSendCount = currentSendCount + 1;
@@ -704,7 +993,9 @@ export function resendOutbound(params: ResendOutboundParams): OutboundActionResu
 // Cancel outbound
 // ---------------------------------------------------------------------------
 
-export function cancelOutbound(params: CancelOutboundParams): OutboundActionResult {
+export function cancelOutbound(
+  params: CancelOutboundParams,
+): OutboundActionResult {
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const channel = params.channel;
 
@@ -712,13 +1003,13 @@ export function cancelOutbound(params: CancelOutboundParams): OutboundActionResu
   if (!session) {
     return {
       success: false,
-      error: 'no_active_session',
-      message: 'No active outbound verification session found.',
+      error: "no_active_session",
+      message: "No active outbound verification session found.",
       channel,
     };
   }
 
-  updateSessionStatus(session.id, 'revoked');
+  updateSessionStatus(session.id, "revoked");
 
   return {
     success: true,

--- a/assistant/src/runtime/guardian-verification-templates.ts
+++ b/assistant/src/runtime/guardian-verification-templates.ts
@@ -12,43 +12,50 @@
 
 export const GUARDIAN_VERIFY_TEMPLATE_KEYS = {
   /** Initial outbound SMS with verification code. */
-  CHALLENGE_REQUEST: 'guardian_verify.sms.challenge_request',
+  CHALLENGE_REQUEST: "guardian_verify.sms.challenge_request",
   /** Resend SMS with verification code. */
-  RESEND: 'guardian_verify.sms.resend',
+  RESEND: "guardian_verify.sms.resend",
   /** Response when the user is already verified. */
-  ALREADY_VERIFIED: 'guardian_verify.already_verified',
+  ALREADY_VERIFIED: "guardian_verify.already_verified",
   /** Initial outbound Telegram verification prompt (code is not included). */
-  TELEGRAM_CHALLENGE_REQUEST: 'guardian_verify.telegram.challenge_request',
+  TELEGRAM_CHALLENGE_REQUEST: "guardian_verify.telegram.challenge_request",
   /** Resend Telegram verification prompt (code is not included). */
-  TELEGRAM_RESEND: 'guardian_verify.telegram.resend',
+  TELEGRAM_RESEND: "guardian_verify.telegram.resend",
+  /** Initial outbound Slack DM verification prompt. */
+  SLACK_CHALLENGE_REQUEST: "guardian_verify.slack.challenge_request",
+  /** Resend Slack DM verification prompt. */
+  SLACK_RESEND: "guardian_verify.slack.resend",
   /** Outbound voice call intro prompt: asks guardian to enter verification code via keypad. */
-  VOICE_CALL_INTRO: 'guardian_verify.voice.call_intro',
+  VOICE_CALL_INTRO: "guardian_verify.voice.call_intro",
   /** Voice retry prompt after an incorrect code entry. */
-  VOICE_RETRY: 'guardian_verify.voice.retry',
+  VOICE_RETRY: "guardian_verify.voice.retry",
   /** Voice success prompt after successful verification. */
-  VOICE_SUCCESS: 'guardian_verify.voice.success',
+  VOICE_SUCCESS: "guardian_verify.voice.success",
   /** Voice failure prompt after too many incorrect attempts. */
-  VOICE_FAILURE: 'guardian_verify.voice.failure',
+  VOICE_FAILURE: "guardian_verify.voice.failure",
   /** Deterministic reply after successful channel verification command. */
-  CHANNEL_VERIFY_SUCCESS: 'guardian_verify.channel.success',
+  CHANNEL_VERIFY_SUCCESS: "guardian_verify.channel.success",
   /** Deterministic reply after failed channel verification command. */
-  CHANNEL_VERIFY_FAILED: 'guardian_verify.channel.failed',
+  CHANNEL_VERIFY_FAILED: "guardian_verify.channel.failed",
   /** Deterministic reply for bootstrap deep-link success. */
-  CHANNEL_BOOTSTRAP_BOUND: 'guardian_verify.channel.bootstrap_bound',
+  CHANNEL_BOOTSTRAP_BOUND: "guardian_verify.channel.bootstrap_bound",
   /** Deterministic reply after successful trusted contact verification. */
-  CHANNEL_TRUSTED_CONTACT_VERIFY_SUCCESS: 'guardian_verify.channel.trusted_contact_success',
+  CHANNEL_TRUSTED_CONTACT_VERIFY_SUCCESS:
+    "guardian_verify.channel.trusted_contact_success",
 } as const;
 
 export type GuardianVerifyTemplateKey =
   (typeof GUARDIAN_VERIFY_TEMPLATE_KEYS)[keyof typeof GUARDIAN_VERIFY_TEMPLATE_KEYS];
 
-/** Template keys for SMS/Telegram text-based verification messages. */
+/** Template keys for SMS/Telegram/Slack text-based verification messages. */
 type TextVerifyTemplateKey =
   | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST
   | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.RESEND
   | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.ALREADY_VERIFIED
   | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST
-  | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_RESEND;
+  | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_RESEND
+  | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_CHALLENGE_REQUEST
+  | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_RESEND;
 
 /** Template keys for deterministic channel verification reply messages. */
 export type ChannelVerifyReplyTemplateKey =
@@ -81,25 +88,36 @@ export interface ChannelVerifyReplyVars {
 // Template Composers
 // ---------------------------------------------------------------------------
 
-const templates: Record<TextVerifyTemplateKey, (vars: GuardianVerifyTemplateVars) => string> = {
+const templates: Record<
+  TextVerifyTemplateKey,
+  (vars: GuardianVerifyTemplateVars) => string
+> = {
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST]: (_vars) => {
-    return 'Vellum assistant guardian verification requested. Reply with the 6-digit code you were given.';
+    return "Vellum assistant guardian verification requested. Reply with the 6-digit code you were given.";
   },
 
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.RESEND]: (_vars) => {
-    return 'Vellum assistant guardian verification requested. Reply with the 6-digit code you were given. (resent)';
+    return "Vellum assistant guardian verification requested. Reply with the 6-digit code you were given. (resent)";
   },
 
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.ALREADY_VERIFIED]: (_vars) => {
-    return 'This channel is already verified. No further action is needed.';
+    return "This channel is already verified. No further action is needed.";
   },
 
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST]: (_vars) => {
-    return 'Vellum assistant guardian verification requested. Reply with the 6-digit code you were given.';
+    return "Vellum assistant guardian verification requested. Reply with the 6-digit code you were given.";
   },
 
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_RESEND]: (_vars) => {
-    return 'Vellum assistant guardian verification requested. Reply with the 6-digit code you were given. (resent)';
+    return "Vellum assistant guardian verification requested. Reply with the 6-digit code you were given. (resent)";
+  },
+
+  [GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_CHALLENGE_REQUEST]: (_vars) => {
+    return "Vellum assistant guardian verification requested. Reply with the 6-digit code you were given.";
+  },
+
+  [GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_RESEND]: (_vars) => {
+    return "Vellum assistant guardian verification requested. Reply with the 6-digit code you were given. (resent)";
   },
 };
 
@@ -108,6 +126,18 @@ const templates: Record<TextVerifyTemplateKey, (vars: GuardianVerifyTemplateVars
  * Returns plain string content suitable for SMS delivery.
  */
 export function composeVerificationSms(
+  templateKey: TextVerifyTemplateKey,
+  vars: GuardianVerifyTemplateVars,
+): string {
+  const composer = templates[templateKey];
+  return composer(vars);
+}
+
+/**
+ * Compose an outbound verification Slack DM from a template key and typed variables.
+ * Returns plain string content suitable for Slack delivery.
+ */
+export function composeVerificationSlack(
   templateKey: TextVerifyTemplateKey,
   vars: GuardianVerifyTemplateVars,
 ): string {
@@ -137,18 +167,21 @@ type VoiceTemplateKey =
   | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_SUCCESS
   | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_FAILURE;
 
-const voiceTemplates: Record<VoiceTemplateKey, (vars: GuardianVerifyVoiceTemplateVars) => string> = {
+const voiceTemplates: Record<
+  VoiceTemplateKey,
+  (vars: GuardianVerifyVoiceTemplateVars) => string
+> = {
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_CALL_INTRO]: (vars) =>
     `You are receiving a guardian verification call for your Vellum assistant. Please enter your ${vars.codeDigits}-digit verification code using your keypad.`,
 
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_RETRY]: (_vars) =>
-    'That code was incorrect. Please try again.',
+    "That code was incorrect. Please try again.",
 
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_SUCCESS]: (_vars) =>
-    'Verification successful. Thank you. Goodbye.',
+    "Verification successful. Thank you. Goodbye.",
 
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_FAILURE]: (_vars) =>
-    'Too many incorrect attempts. Goodbye.',
+    "Too many incorrect attempts. Goodbye.",
 };
 
 /**
@@ -167,18 +200,21 @@ export function composeVerificationVoice(
 // Channel Verification Reply Templates (deterministic, non-agent)
 // ---------------------------------------------------------------------------
 
-const channelVerifyReplyTemplates: Record<ChannelVerifyReplyTemplateKey, (vars: ChannelVerifyReplyVars) => string> = {
+const channelVerifyReplyTemplates: Record<
+  ChannelVerifyReplyTemplateKey,
+  (vars: ChannelVerifyReplyVars) => string
+> = {
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_VERIFY_SUCCESS]: () =>
-    'Verification successful. You are now set as the guardian for this channel.',
+    "Verification successful. You are now set as the guardian for this channel.",
 
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_VERIFY_FAILED]: (vars) =>
-    vars.failureReason ?? 'The verification code is invalid or has expired.',
+    vars.failureReason ?? "The verification code is invalid or has expired.",
 
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_BOOTSTRAP_BOUND]: () =>
-    'Welcome! Your identity has been linked. Please check for a verification code message.',
+    "Welcome! Your identity has been linked. Please check for a verification code message.",
 
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_TRUSTED_CONTACT_VERIFY_SUCCESS]: () =>
-    'Verification successful! You can now message the assistant.',
+    "Verification successful! You can now message the assistant.",
 };
 
 /**

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -75,6 +75,7 @@ struct SettingsChannelsTab: View {
             refreshBearerToken()
             store.refreshChannelGuardianStatus(channel: "telegram")
             store.refreshChannelGuardianStatus(channel: "voice")
+            store.refreshChannelGuardianStatus(channel: "slack")
             store.refreshTelegramApprovedMembers()
             store.fetchSlackChannelConfig()
             Task {
@@ -486,7 +487,11 @@ struct SettingsChannelsTab: View {
                     .foregroundColor(VColor.error)
             }
 
-
+            // Guardian row (only when bot token and app token are configured)
+            if store.slackChannelHasBotToken && store.slackChannelHasAppToken {
+                Divider().background(VColor.surfaceBorder)
+                guardianStatusRow(channel: "slack")
+            }
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -1041,6 +1046,15 @@ struct SettingsChannelsTab: View {
                !displayName.isEmpty {
                 return displayName
             }
+        } else if channel == "slack" {
+            if let username = store.slackGuardianUsername?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !username.isEmpty {
+                return username.hasPrefix("@") ? username : "@\(username)"
+            }
+            if let displayName = store.slackGuardianDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !displayName.isEmpty {
+                return displayName
+            }
         }
         return identity
     }
@@ -1065,6 +1079,7 @@ struct SettingsChannelsTab: View {
             case "telegram": return store.telegramGuardianIdentity
             case "sms": return store.smsGuardianIdentity
             case "voice": return store.voiceGuardianIdentity
+            case "slack": return store.slackGuardianIdentity
             default: return nil
             }
         }()
@@ -1073,6 +1088,7 @@ struct SettingsChannelsTab: View {
             case "telegram": return store.telegramGuardianVerified
             case "sms": return store.smsGuardianVerified
             case "voice": return store.voiceGuardianVerified
+            case "slack": return store.slackGuardianVerified
             default: return false
             }
         }()
@@ -1081,6 +1097,7 @@ struct SettingsChannelsTab: View {
             case "telegram": return store.telegramGuardianVerificationInProgress
             case "sms": return store.smsGuardianVerificationInProgress
             case "voice": return store.voiceGuardianVerificationInProgress
+            case "slack": return store.slackGuardianVerificationInProgress
             default: return false
             }
         }()
@@ -1089,6 +1106,7 @@ struct SettingsChannelsTab: View {
             case "telegram": return store.telegramGuardianInstruction
             case "sms": return store.smsGuardianInstruction
             case "voice": return store.voiceGuardianInstruction
+            case "slack": return store.slackGuardianInstruction
             default: return nil
             }
         }()
@@ -1097,6 +1115,7 @@ struct SettingsChannelsTab: View {
             case "telegram": return store.telegramGuardianError
             case "sms": return store.smsGuardianError
             case "voice": return store.voiceGuardianError
+            case "slack": return store.slackGuardianError
             default: return nil
             }
         }()
@@ -1105,6 +1124,7 @@ struct SettingsChannelsTab: View {
             case "telegram": return store.telegramGuardianAlreadyBound
             case "sms": return store.smsGuardianAlreadyBound
             case "voice": return store.voiceGuardianAlreadyBound
+            case "slack": return store.slackGuardianAlreadyBound
             default: return false
             }
         }()
@@ -1113,6 +1133,7 @@ struct SettingsChannelsTab: View {
             case "telegram": return store.telegramOutboundSessionId
             case "sms": return store.smsOutboundSessionId
             case "voice": return store.voiceOutboundSessionId
+            case "slack": return store.slackOutboundSessionId
             default: return nil
             }
         }()
@@ -1121,6 +1142,7 @@ struct SettingsChannelsTab: View {
             case "telegram": return store.telegramOutboundExpiresAt
             case "sms": return store.smsOutboundExpiresAt
             case "voice": return store.voiceOutboundExpiresAt
+            case "slack": return store.slackOutboundExpiresAt
             default: return nil
             }
         }()
@@ -1129,6 +1151,7 @@ struct SettingsChannelsTab: View {
             case "telegram": return store.telegramOutboundNextResendAt
             case "sms": return store.smsOutboundNextResendAt
             case "voice": return store.voiceOutboundNextResendAt
+            case "slack": return store.slackOutboundNextResendAt
             default: return nil
             }
         }()
@@ -1137,6 +1160,7 @@ struct SettingsChannelsTab: View {
             case "telegram": return store.telegramOutboundSendCount
             case "sms": return store.smsOutboundSendCount
             case "voice": return store.voiceOutboundSendCount
+            case "slack": return store.slackOutboundSendCount
             default: return 0
             }
         }()
@@ -1146,6 +1170,7 @@ struct SettingsChannelsTab: View {
             case "telegram": return store.telegramOutboundCode
             case "sms": return store.smsOutboundCode
             case "voice": return store.voiceOutboundCode
+            case "slack": return store.slackOutboundCode
             default: return nil
             }
         }()
@@ -1338,9 +1363,11 @@ struct SettingsChannelsTab: View {
                             NSPasteboard.general.clearContents()
                             NSPasteboard.general.setString(outboundCode, forType: .string)
                             outboundCodeCopiedChannel = channel
-                            Task {
-                                try? await Task.sleep(nanoseconds: 2_000_000_000)
-                                if outboundCodeCopiedChannel == channel {
+                            // Use GCD instead of Task to avoid Swift concurrency executor
+                            // tracking issues when the countdown timer rebuilds this view.
+                            let copiedChannel = channel
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                if outboundCodeCopiedChannel == copiedChannel {
                                     outboundCodeCopiedChannel = nil
                                 }
                             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1748,6 +1748,12 @@ public final class SettingsStore: ObservableObject {
                 if self.voiceGuardianError == nil {
                     self.voiceGuardianError = "Timed out waiting for verification instructions. Try again."
                 }
+            case "slack":
+                self.slackGuardianVerificationInProgress = false
+                self.slackGuardianInstruction = nil
+                if self.slackGuardianError == nil {
+                    self.slackGuardianError = "Timed out waiting for verification instructions. Try again."
+                }
             default:
                 break
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -187,6 +187,25 @@ public final class SettingsStore: ObservableObject {
     @Published var slackChannelSaveInProgress: Bool = false
     @Published var slackChannelError: String?
 
+    // MARK: - Channel Guardian State (Slack)
+
+    @Published var slackGuardianIdentity: String?
+    @Published var slackGuardianUsername: String?
+    @Published var slackGuardianDisplayName: String?
+    @Published var slackGuardianVerified: Bool = false
+    @Published var slackGuardianVerificationInProgress: Bool = false
+    @Published var slackGuardianInstruction: String?
+    @Published var slackGuardianError: String?
+    @Published var slackGuardianAlreadyBound: Bool = false
+
+    // MARK: - Outbound Guardian Session State (Slack)
+
+    @Published var slackOutboundSessionId: String?
+    @Published var slackOutboundExpiresAt: Date?
+    @Published var slackOutboundNextResendAt: Date?
+    @Published var slackOutboundSendCount: Int = 0
+    @Published var slackOutboundCode: String?
+
     // MARK: - Email Integration State
 
     @Published var assistantEmail: String?
@@ -583,6 +602,28 @@ public final class SettingsStore: ObservableObject {
                     let isAlreadyBound = response.error == "already_bound"
                     self.voiceGuardianAlreadyBound = isAlreadyBound
                     self.voiceGuardianError = isAlreadyBound
+                        ? "A guardian is already bound. Revoke it first or replace it."
+                        : response.error
+                }
+            case "slack":
+                self.slackGuardianVerificationInProgress = false
+                if response.success {
+                    self.slackGuardianIdentity = response.guardianExternalUserId
+                    self.slackGuardianUsername = Self.reflectedString(response, key: "guardianUsername")
+                    self.slackGuardianDisplayName = Self.reflectedString(response, key: "guardianDisplayName")
+                    let isVerified = response.bound ?? false
+                    self.slackGuardianVerified = isVerified
+                    if isVerified {
+                        self.slackGuardianInstruction = nil
+                    } else if let instruction = response.instruction {
+                        self.slackGuardianInstruction = instruction
+                    }
+                    self.slackGuardianError = nil
+                    self.slackGuardianAlreadyBound = false
+                } else {
+                    let isAlreadyBound = response.error == "already_bound"
+                    self.slackGuardianAlreadyBound = isAlreadyBound
+                    self.slackGuardianError = isAlreadyBound
                         ? "A guardian is already bound. Revoke it first or replace it."
                         : response.error
                 }
@@ -1242,6 +1283,11 @@ public final class SettingsStore: ObservableObject {
             voiceGuardianError = nil
             voiceGuardianAlreadyBound = false
             voiceGuardianInstruction = nil
+        case "slack":
+            slackGuardianVerificationInProgress = true
+            slackGuardianError = nil
+            slackGuardianAlreadyBound = false
+            slackGuardianInstruction = nil
         default:
             return
         }
@@ -1258,6 +1304,9 @@ public final class SettingsStore: ObservableObject {
                 case "voice":
                     voiceGuardianVerificationInProgress = false
                     voiceGuardianError = "Daemon is not connected. Reconnect and try again."
+                case "slack":
+                    slackGuardianVerificationInProgress = false
+                    slackGuardianError = "Daemon is not connected. Reconnect and try again."
                 default:
                     break
                 }
@@ -1283,6 +1332,9 @@ public final class SettingsStore: ObservableObject {
             case "voice":
                 voiceGuardianVerificationInProgress = false
                 voiceGuardianError = "Failed to start verification. Try again."
+            case "slack":
+                slackGuardianVerificationInProgress = false
+                slackGuardianError = "Failed to start verification. Try again."
             default:
                 break
             }
@@ -1302,6 +1354,9 @@ public final class SettingsStore: ObservableObject {
         case "voice":
             voiceGuardianVerificationInProgress = false
             voiceGuardianInstruction = nil
+        case "slack":
+            slackGuardianVerificationInProgress = false
+            slackGuardianInstruction = nil
         default:
             break
         }
@@ -1325,6 +1380,8 @@ public final class SettingsStore: ObservableObject {
             smsGuardianInstruction = nil
         case "voice":
             voiceGuardianInstruction = nil
+        case "slack":
+            slackGuardianInstruction = nil
         default:
             break
         }
@@ -1427,6 +1484,10 @@ public final class SettingsStore: ObservableObject {
             voiceGuardianVerificationInProgress = true
             voiceGuardianError = nil
             voiceGuardianAlreadyBound = false
+        case "slack":
+            slackGuardianVerificationInProgress = true
+            slackGuardianError = nil
+            slackGuardianAlreadyBound = false
         default:
             return
         }
@@ -1442,6 +1503,9 @@ public final class SettingsStore: ObservableObject {
                 case "voice":
                     voiceGuardianVerificationInProgress = false
                     voiceGuardianError = "Daemon is not connected. Reconnect and try again."
+                case "slack":
+                    slackGuardianVerificationInProgress = false
+                    slackGuardianError = "Daemon is not connected. Reconnect and try again."
                 default:
                     break
                 }
@@ -1464,6 +1528,9 @@ public final class SettingsStore: ObservableObject {
             case "voice":
                 voiceGuardianVerificationInProgress = false
                 voiceGuardianError = "Failed to start verification. Try again."
+            case "slack":
+                slackGuardianVerificationInProgress = false
+                slackGuardianError = "Failed to start verification. Try again."
             default:
                 break
             }
@@ -1491,6 +1558,8 @@ public final class SettingsStore: ObservableObject {
             smsGuardianVerificationInProgress = false
         case "voice":
             voiceGuardianVerificationInProgress = false
+        case "slack":
+            slackGuardianVerificationInProgress = false
         default:
             break
         }
@@ -1525,6 +1594,12 @@ public final class SettingsStore: ObservableObject {
             voiceOutboundNextResendAt = nil
             voiceOutboundSendCount = 0
             voiceOutboundCode = nil
+        case "slack":
+            slackOutboundSessionId = nil
+            slackOutboundExpiresAt = nil
+            slackOutboundNextResendAt = nil
+            slackOutboundSendCount = 0
+            slackOutboundCode = nil
         default:
             break
         }
@@ -1590,6 +1665,17 @@ public final class SettingsStore: ObservableObject {
             if let nextResendAt { voiceOutboundNextResendAt = nextResendAt }
             if let sendCount { voiceOutboundSendCount = sendCount }
             if let secret { voiceOutboundCode = secret }
+        case "slack":
+            if sessionId != slackOutboundSessionId {
+                slackOutboundNextResendAt = nil
+                slackOutboundSendCount = 0
+                slackOutboundCode = nil
+            }
+            slackOutboundSessionId = sessionId
+            if let expiresAt { slackOutboundExpiresAt = expiresAt }
+            if let nextResendAt { slackOutboundNextResendAt = nextResendAt }
+            if let sendCount { slackOutboundSendCount = sendCount }
+            if let secret { slackOutboundCode = secret }
         default:
             break
         }
@@ -1607,6 +1693,7 @@ public final class SettingsStore: ObservableObject {
             ("telegram", telegramGuardianVerificationInProgress),
             ("sms", smsGuardianVerificationInProgress),
             ("voice", voiceGuardianVerificationInProgress),
+            ("slack", slackGuardianVerificationInProgress),
         ].filter(\.1)
         if inProgressChannels.count == 1 {
             return inProgressChannels.first?.0
@@ -1629,6 +1716,8 @@ public final class SettingsStore: ObservableObject {
             smsGuardianInstruction = nil
         case "voice":
             voiceGuardianInstruction = nil
+        case "slack":
+            slackGuardianInstruction = nil
         default:
             break
         }
@@ -1668,7 +1757,7 @@ public final class SettingsStore: ObservableObject {
     }
 
     private func startGuardianStatusPolling(for channel: String) {
-        guard channel == "telegram" || channel == "sms" || channel == "voice" else { return }
+        guard channel == "telegram" || channel == "sms" || channel == "voice" || channel == "slack" else { return }
         stopGuardianStatusPolling(for: channel)
         guardianStatusPollingDeadlines[channel] = Date().addingTimeInterval(guardianStatusPollWindow)
         scheduleGuardianStatusPoll(for: channel, delay: guardianStatusPollInterval)

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -74,7 +74,16 @@ export function normalizeSlackDirectMessage(
   // user is required for routing
   if (!event.user) return null;
 
-  const routing = resolveAssistant(config, event.channel, event.user);
+  // DMs are always directed at the bot, so use the default assistant even
+  // when the DM channel ID (D...) isn't in the routing table. This ensures
+  // guardian verification replies aren't silently dropped.
+  let routing = resolveAssistant(config, event.channel, event.user);
+  if (isRejection(routing) && config.defaultAssistantId) {
+    routing = {
+      assistantId: config.defaultAssistantId,
+      routeSource: "default" as const,
+    };
+  }
   if (isRejection(routing)) {
     return null;
   }

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -18,6 +18,22 @@ export interface SlackAppMentionEvent {
 }
 
 /**
+ * Slack `message` event shape for direct messages (IMs).
+ */
+export interface SlackDirectMessageEvent {
+  type: "message";
+  subtype?: string;
+  user?: string;
+  text: string;
+  ts: string;
+  channel: string;
+  channel_type: "im";
+  thread_ts?: string;
+  client_msg_id?: string;
+  event_ts?: string;
+}
+
+/**
  * Strip leading bot-mention tokens (`<@U...>`) from the message text.
  * Slack wraps mentions as `<@UXXXXXX>`, often at the start of an
  * app_mention event's text field. We remove all leading occurrences
@@ -38,6 +54,59 @@ export type NormalizedSlackEvent = {
 };
 
 /**
+ * Normalize a Slack DM (`message` with `channel_type: "im"`) into the
+ * gateway's canonical inbound event shape. Used for guardian verification
+ * code replies and direct conversations with the bot.
+ *
+ * Returns null if the event cannot be routed or should be ignored
+ * (e.g. bot's own messages, subtypes like message_changed).
+ */
+export function normalizeSlackDirectMessage(
+  event: SlackDirectMessageEvent,
+  eventId: string,
+  config: GatewayConfig,
+  botUserId?: string,
+): NormalizedSlackEvent | null {
+  // Ignore messages from the bot itself
+  if (botUserId && event.user === botUserId) return null;
+  // Ignore message subtypes (edits, deletions, etc.) — only handle plain user messages
+  if (event.subtype) return null;
+  // user is required for routing
+  if (!event.user) return null;
+
+  const routing = resolveAssistant(config, event.channel, event.user);
+  if (isRejection(routing)) {
+    return null;
+  }
+
+  const externalMessageId =
+    event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
+
+  return {
+    event: {
+      version: "v1",
+      sourceChannel: "slack",
+      receivedAt: new Date().toISOString(),
+      message: {
+        content: event.text,
+        conversationExternalId: event.channel,
+        externalMessageId,
+      },
+      actor: {
+        actorExternalId: event.user,
+      },
+      source: {
+        updateId: eventId,
+      },
+      raw: event as unknown as Record<string, unknown>,
+    },
+    routing,
+    threadTs: event.thread_ts ?? event.ts,
+    channel: event.channel,
+  };
+}
+
+/**
  * Normalize a Slack `app_mention` event into the gateway's
  * canonical inbound event shape, matching the pattern used by
  * the Telegram normalizer.
@@ -55,7 +124,8 @@ export function normalizeSlackAppMention(
   }
 
   const content = stripBotMention(event.text);
-  const externalMessageId = event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
+  const externalMessageId =
+    event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
 
   return {
     event: {

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -1,7 +1,13 @@
 import { getLogger } from "../logger.js";
 import { fetchImpl } from "../fetch.js";
 import type { GatewayConfig } from "../config.js";
-import { normalizeSlackAppMention, type SlackAppMentionEvent, type NormalizedSlackEvent } from "./normalize.js";
+import {
+  normalizeSlackAppMention,
+  normalizeSlackDirectMessage,
+  type SlackAppMentionEvent,
+  type SlackDirectMessageEvent,
+  type NormalizedSlackEvent,
+} from "./normalize.js";
 
 const log = getLogger("slack-socket-mode");
 
@@ -14,6 +20,8 @@ export type SlackSocketModeConfig = {
   appToken: string;
   botToken: string;
   gatewayConfig: GatewayConfig;
+  /** Bot's own Slack user ID, used to ignore the bot's own DMs. */
+  botUserId?: string;
 };
 
 /**
@@ -34,7 +42,10 @@ export class SlackSocketModeClient {
   private dedupMap = new Map<string, number>();
   private dedupCleanupTimer: ReturnType<typeof setInterval> | null = null;
 
-  constructor(config: SlackSocketModeConfig, onEvent: (event: NormalizedSlackEvent) => void) {
+  constructor(
+    config: SlackSocketModeConfig,
+    onEvent: (event: NormalizedSlackEvent) => void,
+  ) {
     this.config = config;
     this.onEvent = onEvent;
   }
@@ -43,6 +54,24 @@ export class SlackSocketModeClient {
     if (this.running) return;
     this.running = true;
     this.startDedupCleanup();
+
+    // Resolve bot user ID via auth.test so we can filter the bot's own DMs
+    if (!this.config.botUserId) {
+      try {
+        const resp = await fetchImpl("https://slack.com/api/auth.test", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${this.config.botToken}` },
+        });
+        const data = (await resp.json()) as { ok: boolean; user_id?: string };
+        if (data.ok && data.user_id) {
+          this.config.botUserId = data.user_id;
+          log.info({ botUserId: data.user_id }, "Resolved Slack bot user ID");
+        }
+      } catch (err) {
+        log.warn({ err }, "Failed to resolve bot user ID via auth.test");
+      }
+    }
+
     await this.connect();
   }
 
@@ -91,13 +120,19 @@ export class SlackSocketModeClient {
       });
 
       ws.addEventListener("close", (closeEvent) => {
-        log.info({ code: closeEvent.code, reason: closeEvent.reason }, "Slack Socket Mode disconnected");
+        log.info(
+          { code: closeEvent.code, reason: closeEvent.reason },
+          "Slack Socket Mode disconnected",
+        );
         this.ws = null;
         this.scheduleReconnect();
       });
 
       ws.addEventListener("error", (errorEvent) => {
-        log.error({ error: String(errorEvent) }, "Slack Socket Mode WebSocket error");
+        log.error(
+          { error: String(errorEvent) },
+          "Slack Socket Mode WebSocket error",
+        );
       });
     } catch (err) {
       log.error({ err }, "Failed to create WebSocket connection");
@@ -107,21 +142,30 @@ export class SlackSocketModeClient {
   }
 
   private async getWebSocketUrl(): Promise<string> {
-    const resp = await fetchImpl("https://slack.com/api/apps.connections.open", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${this.config.appToken}`,
-        "Content-Type": "application/x-www-form-urlencoded",
+    const resp = await fetchImpl(
+      "https://slack.com/api/apps.connections.open",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.config.appToken}`,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
       },
-    });
+    );
 
     if (!resp.ok) {
       throw new Error(`apps.connections.open HTTP ${resp.status}`);
     }
 
-    const data = (await resp.json()) as { ok: boolean; url?: string; error?: string };
+    const data = (await resp.json()) as {
+      ok: boolean;
+      url?: string;
+      error?: string;
+    };
     if (!data.ok || !data.url) {
-      throw new Error(`apps.connections.open failed: ${data.error ?? "unknown error"}`);
+      throw new Error(
+        `apps.connections.open failed: ${data.error ?? "unknown error"}`,
+      );
     }
 
     return data.url;
@@ -133,7 +177,7 @@ export class SlackSocketModeClient {
       type?: string;
       payload?: {
         event_id?: string;
-        event?: SlackAppMentionEvent;
+        event?: SlackAppMentionEvent | SlackDirectMessageEvent;
       };
       reason?: string;
     };
@@ -146,13 +190,20 @@ export class SlackSocketModeClient {
     }
 
     // ACK every envelope immediately
-    if (envelope.envelope_id && this.ws && this.ws.readyState === WebSocket.OPEN) {
+    if (
+      envelope.envelope_id &&
+      this.ws &&
+      this.ws.readyState === WebSocket.OPEN
+    ) {
       this.ws.send(JSON.stringify({ envelope_id: envelope.envelope_id }));
     }
 
     // Handle disconnect type: Slack asks us to reconnect
     if (envelope.type === "disconnect") {
-      log.info({ reason: envelope.reason }, "Slack requested disconnect, reconnecting");
+      log.info(
+        { reason: envelope.reason },
+        "Slack requested disconnect, reconnecting",
+      );
       if (this.ws) {
         try {
           this.ws.close(1000, "server requested disconnect");
@@ -173,8 +224,16 @@ export class SlackSocketModeClient {
     const eventPayload = envelope.payload;
     if (!eventPayload?.event || !eventPayload.event_id) return;
 
-    // Only process app_mention events in MVP
-    if (eventPayload.event.type !== "app_mention") return;
+    const event = eventPayload.event;
+    const dmEvent = event as SlackDirectMessageEvent;
+
+    // Process app_mention events and DM (message with channel_type: "im") events
+    if (
+      event.type !== "app_mention" &&
+      !(event.type === "message" && dmEvent.channel_type === "im")
+    ) {
+      return;
+    }
 
     // Deduplicate on event_id
     const eventId = eventPayload.event_id;
@@ -184,14 +243,25 @@ export class SlackSocketModeClient {
     }
     this.dedupMap.set(eventId, Date.now());
 
-    const normalized = normalizeSlackAppMention(
-      eventPayload.event,
-      eventId,
-      this.config.gatewayConfig,
-    );
+    let normalized: NormalizedSlackEvent | null;
+    if (event.type === "app_mention") {
+      normalized = normalizeSlackAppMention(
+        event as SlackAppMentionEvent,
+        eventId,
+        this.config.gatewayConfig,
+      );
+    } else {
+      normalized = normalizeSlackDirectMessage(
+        event as SlackDirectMessageEvent,
+        eventId,
+        this.config.gatewayConfig,
+        this.config.botUserId,
+      );
+    }
+
     if (!normalized) {
       log.info(
-        { eventId, channel: eventPayload.event.channel },
+        { eventId, channel: event.channel, type: event.type },
         "Slack event dropped by normalization/routing",
       );
       return;
@@ -212,7 +282,10 @@ export class SlackSocketModeClient {
     const jitter = Math.random() * backoff * 0.5;
     const delay = Math.round(backoff + jitter);
 
-    log.info({ attempt: this.reconnectAttempt, delayMs: delay }, "Scheduling Socket Mode reconnect");
+    log.info(
+      { attempt: this.reconnectAttempt, delayMs: delay },
+      "Scheduling Socket Mode reconnect",
+    );
     this.reconnectAttempt++;
 
     this.reconnectTimer = setTimeout(() => {


### PR DESCRIPTION
## Summary
- Add end-to-end guardian verification for the Slack channel (macOS client, daemon, gateway)
- Support outbound verification DMs, code entry via Slack DM, and auto-polling for status updates
- Handle Slack DM (`message` with `channel_type: "im"`) events in Socket Mode alongside `app_mention`
- Resolve bot user ID on startup to prevent feedback loops from bot's own messages
- Fix copy-code button crash by replacing `Task` with `DispatchQueue.main.asyncAfter`

## Test plan
- [x] Enter Slack user ID and click Send — verification DM delivered
- [x] Reply with 6-digit code in Slack DM — "Verification successful" reply
- [x] macOS app auto-updates to show verified guardian status
- [x] Copy button works without crash
- [x] Resend works
- [x] Cancel works
- [x] No feedback loop from bot's own DMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
