### PR TITLE
fix: update guardian test for Slack channel support

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -636,7 +636,7 @@ for DIR in "${DIRS_TO_CHECK[@]}"; do
         for F in "${PRETTIER_FILES[@]}"; do
             REL_FILES+=("${F#$DIR/}")
         done
-        if ! (cd "$DIR" && "$BUN" run format:check "${REL_FILES[@]}") 2>&1; then
+        if ! (cd "$DIR" && "$BUN" x prettier --check "${REL_FILES[@]}") 2>&1; then
             echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
             echo -e "${RED}Prettier formatting issues found in ${DIR}/!${NC}"
             echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -1,85 +1,125 @@
-import { createHash } from 'node:crypto';
-import { mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { afterAll, beforeEach, describe, expect, mock,test } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ---------------------------------------------------------------------------
 // Test isolation: in-memory SQLite via temp directory
 // ---------------------------------------------------------------------------
 
-const testDir = mkdtempSync(join(tmpdir(), 'channel-guardian-test-'));
+const testDir = mkdtempSync(join(tmpdir(), "channel-guardian-test-"));
 
-mock.module('../util/platform.js', () => ({
+mock.module("../util/platform.js", () => ({
   getRootDir: () => testDir,
   getDataDir: () => testDir,
-  isMacOS: () => process.platform === 'darwin',
-  isLinux: () => process.platform === 'linux',
-  isWindows: () => process.platform === 'win32',
-  getSocketPath: () => join(testDir, 'test.sock'),
-  getPidPath: () => join(testDir, 'test.pid'),
-  getDbPath: () => join(testDir, 'test.db'),
-  getLogPath: () => join(testDir, 'test.log'),
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getSocketPath: () => join(testDir, "test.sock"),
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
   ensureDataDir: () => {},
-  readHttpToken: () => 'test-bearer-token',
+  readHttpToken: () => "test-bearer-token",
 }));
 
-mock.module('../util/logger.js', () => ({
-  getLogger: () => new Proxy({} as Record<string, unknown>, {
-    get: () => () => {},
-  }),
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
 }));
 
-import type * as net from 'node:net';
+import type * as net from "node:net";
 
 // SMS client mock — outbound SMS delivery is fire-and-forget, so we just track calls.
-const smsSendCalls: Array<{ to: string; text: string; assistantId?: string }> = [];
-mock.module('../messaging/providers/sms/client.js', () => ({
-  sendMessage: async (_gatewayUrl: string, _bearerToken: string, to: string, text: string, assistantId?: string) => {
+const smsSendCalls: Array<{ to: string; text: string; assistantId?: string }> =
+  [];
+mock.module("../messaging/providers/sms/client.js", () => ({
+  sendMessage: async (
+    _gatewayUrl: string,
+    _bearerToken: string,
+    to: string,
+    text: string,
+    assistantId?: string,
+  ) => {
     smsSendCalls.push({ to, text, assistantId });
-    return { messageSid: 'SM-mock', status: 'queued' };
+    return { messageSid: "SM-mock", status: "queued" };
   },
 }));
 
-mock.module('../config/env.js', () => ({
-  getGatewayInternalBaseUrl: () => 'http://127.0.0.1:7830',
+mock.module("../config/env.js", () => ({
+  getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
 }));
 
 // Telegram credential metadata mock — provides the bot username for deep-link construction
-let mockBotUsername: string | undefined = 'test_bot';
-mock.module('../tools/credentials/metadata-store.js', () => ({
-  getCredentialMetadata: (_service: string, _key: string) => mockBotUsername ? { accountInfo: mockBotUsername } : null,
+let mockBotUsername: string | undefined = "test_bot";
+mock.module("../tools/credentials/metadata-store.js", () => ({
+  getCredentialMetadata: (_service: string, _key: string) =>
+    mockBotUsername ? { accountInfo: mockBotUsername } : null,
   upsertCredentialMetadata: () => {},
   deleteCredentialMetadata: () => {},
 }));
 
 // Call domain mock — outbound voice verification calls are fire-and-forget.
-const voiceCallInitCalls: Array<{ phoneNumber: string; guardianVerificationSessionId: string; assistantId?: string }> = [];
-mock.module('../calls/call-domain.js', () => ({
-  startGuardianVerificationCall: async (input: { phoneNumber: string; guardianVerificationSessionId: string; assistantId?: string }) => {
+const voiceCallInitCalls: Array<{
+  phoneNumber: string;
+  guardianVerificationSessionId: string;
+  assistantId?: string;
+}> = [];
+mock.module("../calls/call-domain.js", () => ({
+  startGuardianVerificationCall: async (input: {
+    phoneNumber: string;
+    guardianVerificationSessionId: string;
+    assistantId?: string;
+  }) => {
     voiceCallInitCalls.push(input);
-    return { ok: true, callSessionId: 'mock-call-session', callSid: 'CA-mock' };
+    return { ok: true, callSessionId: "mock-call-session", callSid: "CA-mock" };
   },
 }));
 
 // Track Telegram deliveries via fetch mock
-const telegramDeliverCalls: Array<{ chatId: string; text: string; assistantId?: string }> = [];
+const telegramDeliverCalls: Array<{
+  chatId: string;
+  text: string;
+  assistantId?: string;
+}> = [];
 const originalFetch = globalThis.fetch;
-globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-  const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
-  if (url.includes('/deliver/telegram') && init?.method === 'POST') {
-    const body = JSON.parse(init.body as string) as { chatId: string; text: string; assistantId?: string };
+globalThis.fetch = (async (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => {
+  const url =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+  if (url.includes("/deliver/telegram") && init?.method === "POST") {
+    const body = JSON.parse(init.body as string) as {
+      chatId: string;
+      text: string;
+      assistantId?: string;
+    };
     telegramDeliverCalls.push(body);
     return new Response(JSON.stringify({ ok: true }), { status: 200 });
   }
   return originalFetch(input, init as never);
 }) as typeof fetch;
-import { eq } from 'drizzle-orm';
+import { eq } from "drizzle-orm";
 
-import { handleGuardianVerification, MAX_SENDS_PER_SESSION, RESEND_COOLDOWN_MS } from '../daemon/handlers/config-channels.js';
-import type { HandlerContext } from '../daemon/handlers/shared.js';
-import type { GuardianVerificationRequest, GuardianVerificationResponse } from '../daemon/ipc-contract.js';
+import {
+  handleGuardianVerification,
+  MAX_SENDS_PER_SESSION,
+  RESEND_COOLDOWN_MS,
+} from "../daemon/handlers/config-channels.js";
+import type { HandlerContext } from "../daemon/handlers/shared.js";
+import type {
+  GuardianVerificationRequest,
+  GuardianVerificationResponse,
+} from "../daemon/ipc-contract.js";
 import {
   bindSessionIdentity as _storeBindSessionIdentity,
   consumeChallenge,
@@ -102,9 +142,9 @@ import {
   updateApprovalDecision,
   updateSessionDelivery as storeUpdateSessionDelivery,
   updateSessionStatus as _storeUpdateSessionStatus,
-} from '../memory/channel-guardian-store.js';
-import { getDb, initializeDb, resetDb } from '../memory/db.js';
-import { channelGuardianVerificationChallenges } from '../memory/schema.js';
+} from "../memory/channel-guardian-store.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { channelGuardianVerificationChallenges } from "../memory/schema.js";
 import {
   bindSessionIdentity as serviceBindSessionIdentity,
   createOutboundSession,
@@ -118,142 +158,146 @@ import {
   revokeBinding as serviceRevokeBinding,
   updateSessionStatus as serviceUpdateSessionStatus,
   validateAndConsumeChallenge,
-} from '../runtime/channel-guardian-service.js';
+} from "../runtime/channel-guardian-service.js";
 import {
   composeVerificationSms,
   composeVerificationTelegram,
   GUARDIAN_VERIFY_TEMPLATE_KEYS,
-} from '../runtime/guardian-verification-templates.js';
+} from "../runtime/guardian-verification-templates.js";
 
 initializeDb();
 
 afterAll(() => {
   globalThis.fetch = originalFetch;
   resetDb();
-  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
 });
 
 function resetTables(): void {
   const db = getDb();
-  db.run('DELETE FROM channel_guardian_bindings');
-  db.run('DELETE FROM channel_guardian_verification_challenges');
-  db.run('DELETE FROM channel_guardian_approval_requests');
-  db.run('DELETE FROM channel_guardian_rate_limits');
+  db.run("DELETE FROM channel_guardian_bindings");
+  db.run("DELETE FROM channel_guardian_verification_challenges");
+  db.run("DELETE FROM channel_guardian_approval_requests");
+  db.run("DELETE FROM channel_guardian_rate_limits");
   smsSendCalls.length = 0;
   telegramDeliverCalls.length = 0;
   voiceCallInitCalls.length = 0;
-  mockBotUsername = 'test_bot';
+  mockBotUsername = "test_bot";
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
 // 1. Guardian Binding CRUD (Store)
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('guardian binding CRUD', () => {
+describe("guardian binding CRUD", () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('createBinding creates an active binding with correct fields', () => {
+  test("createBinding creates an active binding with correct fields", () => {
     const binding = createBinding({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      guardianExternalUserId: 'user-42',
-      guardianDeliveryChatId: 'chat-42',
+      assistantId: "asst-1",
+      channel: "telegram",
+      guardianExternalUserId: "user-42",
+      guardianDeliveryChatId: "chat-42",
     });
 
     expect(binding.id).toBeDefined();
-    expect(binding.assistantId).toBe('asst-1');
-    expect(binding.channel).toBe('telegram');
-    expect(binding.guardianExternalUserId).toBe('user-42');
-    expect(binding.guardianDeliveryChatId).toBe('chat-42');
-    expect(binding.status).toBe('active');
-    expect(binding.verifiedVia).toBe('challenge');
+    expect(binding.assistantId).toBe("asst-1");
+    expect(binding.channel).toBe("telegram");
+    expect(binding.guardianExternalUserId).toBe("user-42");
+    expect(binding.guardianDeliveryChatId).toBe("chat-42");
+    expect(binding.status).toBe("active");
+    expect(binding.verifiedVia).toBe("challenge");
     expect(binding.verifiedAt).toBeGreaterThan(0);
     expect(binding.createdAt).toBeGreaterThan(0);
     expect(binding.updatedAt).toBeGreaterThan(0);
   });
 
-  test('getActiveBinding returns the active binding', () => {
+  test("getActiveBinding returns the active binding", () => {
     createBinding({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      guardianExternalUserId: 'user-42',
-      guardianDeliveryChatId: 'chat-42',
+      assistantId: "asst-1",
+      channel: "telegram",
+      guardianExternalUserId: "user-42",
+      guardianDeliveryChatId: "chat-42",
     });
 
-    const found = getActiveBinding('asst-1', 'telegram');
+    const found = getActiveBinding("asst-1", "telegram");
     expect(found).not.toBeNull();
-    expect(found!.guardianExternalUserId).toBe('user-42');
+    expect(found!.guardianExternalUserId).toBe("user-42");
   });
 
-  test('getActiveBinding returns null when no binding exists', () => {
-    const found = getActiveBinding('asst-1', 'telegram');
+  test("getActiveBinding returns null when no binding exists", () => {
+    const found = getActiveBinding("asst-1", "telegram");
     expect(found).toBeNull();
   });
 
-  test('getActiveBinding returns null for different assistant', () => {
+  test("getActiveBinding returns null for different assistant", () => {
     createBinding({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      guardianExternalUserId: 'user-42',
-      guardianDeliveryChatId: 'chat-42',
+      assistantId: "asst-1",
+      channel: "telegram",
+      guardianExternalUserId: "user-42",
+      guardianDeliveryChatId: "chat-42",
     });
 
-    const found = getActiveBinding('asst-2', 'telegram');
+    const found = getActiveBinding("asst-2", "telegram");
     expect(found).toBeNull();
   });
 
-  test('getActiveBinding returns null for different channel', () => {
+  test("getActiveBinding returns null for different channel", () => {
     createBinding({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      guardianExternalUserId: 'user-42',
-      guardianDeliveryChatId: 'chat-42',
+      assistantId: "asst-1",
+      channel: "telegram",
+      guardianExternalUserId: "user-42",
+      guardianDeliveryChatId: "chat-42",
     });
 
-    const found = getActiveBinding('asst-1', 'slack');
+    const found = getActiveBinding("asst-1", "slack");
     expect(found).toBeNull();
   });
 
-  test('revokeBinding transitions active binding to revoked', () => {
+  test("revokeBinding transitions active binding to revoked", () => {
     createBinding({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      guardianExternalUserId: 'user-42',
-      guardianDeliveryChatId: 'chat-42',
+      assistantId: "asst-1",
+      channel: "telegram",
+      guardianExternalUserId: "user-42",
+      guardianDeliveryChatId: "chat-42",
     });
 
-    const result = revokeBinding('asst-1', 'telegram');
+    const result = revokeBinding("asst-1", "telegram");
     expect(result).toBe(true);
 
-    const found = getActiveBinding('asst-1', 'telegram');
+    const found = getActiveBinding("asst-1", "telegram");
     expect(found).toBeNull();
   });
 
-  test('revokeBinding returns false when no active binding exists', () => {
-    const result = revokeBinding('asst-1', 'telegram');
+  test("revokeBinding returns false when no active binding exists", () => {
+    const result = revokeBinding("asst-1", "telegram");
     expect(result).toBe(false);
   });
 
-  test('revokeBinding does not affect bindings on other channels', () => {
+  test("revokeBinding does not affect bindings on other channels", () => {
     createBinding({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      guardianExternalUserId: 'user-42',
-      guardianDeliveryChatId: 'chat-42',
+      assistantId: "asst-1",
+      channel: "telegram",
+      guardianExternalUserId: "user-42",
+      guardianDeliveryChatId: "chat-42",
     });
     createBinding({
-      assistantId: 'asst-1',
-      channel: 'slack',
-      guardianExternalUserId: 'user-99',
-      guardianDeliveryChatId: 'chat-99',
+      assistantId: "asst-1",
+      channel: "slack",
+      guardianExternalUserId: "user-99",
+      guardianDeliveryChatId: "chat-99",
     });
 
-    revokeBinding('asst-1', 'telegram');
+    revokeBinding("asst-1", "telegram");
 
-    expect(getActiveBinding('asst-1', 'telegram')).toBeNull();
-    expect(getActiveBinding('asst-1', 'slack')).not.toBeNull();
+    expect(getActiveBinding("asst-1", "telegram")).toBeNull();
+    expect(getActiveBinding("asst-1", "slack")).not.toBeNull();
   });
 });
 
@@ -261,117 +305,147 @@ describe('guardian binding CRUD', () => {
 // 2. Verification Challenge Lifecycle (Store)
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('verification challenge lifecycle', () => {
+describe("verification challenge lifecycle", () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('createChallenge creates a pending challenge', () => {
+  test("createChallenge creates a pending challenge", () => {
     const challenge = createChallenge({
-      id: 'chal-1',
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      challengeHash: 'abc123hash',
+      id: "chal-1",
+      assistantId: "asst-1",
+      channel: "telegram",
+      challengeHash: "abc123hash",
       expiresAt: Date.now() + 600_000,
     });
 
-    expect(challenge.id).toBe('chal-1');
-    expect(challenge.status).toBe('pending');
-    expect(challenge.challengeHash).toBe('abc123hash');
+    expect(challenge.id).toBe("chal-1");
+    expect(challenge.status).toBe("pending");
+    expect(challenge.challengeHash).toBe("abc123hash");
     expect(challenge.consumedByExternalUserId).toBeNull();
     expect(challenge.consumedByChatId).toBeNull();
   });
 
-  test('findPendingChallengeByHash finds a matching pending challenge', () => {
+  test("findPendingChallengeByHash finds a matching pending challenge", () => {
     createChallenge({
-      id: 'chal-1',
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      challengeHash: 'abc123hash',
+      id: "chal-1",
+      assistantId: "asst-1",
+      channel: "telegram",
+      challengeHash: "abc123hash",
       expiresAt: Date.now() + 600_000,
     });
 
-    const found = findPendingChallengeByHash('asst-1', 'telegram', 'abc123hash');
+    const found = findPendingChallengeByHash(
+      "asst-1",
+      "telegram",
+      "abc123hash",
+    );
     expect(found).not.toBeNull();
-    expect(found!.id).toBe('chal-1');
+    expect(found!.id).toBe("chal-1");
   });
 
-  test('findPendingChallengeByHash returns null for wrong hash', () => {
+  test("findPendingChallengeByHash returns null for wrong hash", () => {
     createChallenge({
-      id: 'chal-1',
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      challengeHash: 'abc123hash',
+      id: "chal-1",
+      assistantId: "asst-1",
+      channel: "telegram",
+      challengeHash: "abc123hash",
       expiresAt: Date.now() + 600_000,
     });
 
-    const found = findPendingChallengeByHash('asst-1', 'telegram', 'wrong-hash');
+    const found = findPendingChallengeByHash(
+      "asst-1",
+      "telegram",
+      "wrong-hash",
+    );
     expect(found).toBeNull();
   });
 
-  test('findPendingChallengeByHash returns null for expired challenge', () => {
+  test("findPendingChallengeByHash returns null for expired challenge", () => {
     createChallenge({
-      id: 'chal-1',
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      challengeHash: 'abc123hash',
+      id: "chal-1",
+      assistantId: "asst-1",
+      channel: "telegram",
+      challengeHash: "abc123hash",
       expiresAt: Date.now() - 1000, // already expired
     });
 
-    const found = findPendingChallengeByHash('asst-1', 'telegram', 'abc123hash');
+    const found = findPendingChallengeByHash(
+      "asst-1",
+      "telegram",
+      "abc123hash",
+    );
     expect(found).toBeNull();
   });
 
-  test('consumeChallenge marks challenge as consumed', () => {
+  test("consumeChallenge marks challenge as consumed", () => {
     createChallenge({
-      id: 'chal-1',
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      challengeHash: 'abc123hash',
+      id: "chal-1",
+      assistantId: "asst-1",
+      channel: "telegram",
+      challengeHash: "abc123hash",
       expiresAt: Date.now() + 600_000,
     });
 
-    consumeChallenge('chal-1', 'user-42', 'chat-42');
+    consumeChallenge("chal-1", "user-42", "chat-42");
 
     // After consumption, findPendingChallengeByHash should return null
-    const found = findPendingChallengeByHash('asst-1', 'telegram', 'abc123hash');
+    const found = findPendingChallengeByHash(
+      "asst-1",
+      "telegram",
+      "abc123hash",
+    );
     expect(found).toBeNull();
   });
 
-  test('consumed challenge cannot be found again (replay prevention)', () => {
+  test("consumed challenge cannot be found again (replay prevention)", () => {
     createChallenge({
-      id: 'chal-1',
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      challengeHash: 'abc123hash',
+      id: "chal-1",
+      assistantId: "asst-1",
+      channel: "telegram",
+      challengeHash: "abc123hash",
       expiresAt: Date.now() + 600_000,
     });
 
     // First consumption succeeds
-    const found1 = findPendingChallengeByHash('asst-1', 'telegram', 'abc123hash');
+    const found1 = findPendingChallengeByHash(
+      "asst-1",
+      "telegram",
+      "abc123hash",
+    );
     expect(found1).not.toBeNull();
-    consumeChallenge('chal-1', 'user-42', 'chat-42');
+    consumeChallenge("chal-1", "user-42", "chat-42");
 
     // Second lookup returns null because challenge is consumed
-    const found2 = findPendingChallengeByHash('asst-1', 'telegram', 'abc123hash');
+    const found2 = findPendingChallengeByHash(
+      "asst-1",
+      "telegram",
+      "abc123hash",
+    );
     expect(found2).toBeNull();
   });
 
-  test('findPendingChallengeByHash scoped to assistant and channel', () => {
+  test("findPendingChallengeByHash scoped to assistant and channel", () => {
     createChallenge({
-      id: 'chal-1',
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      challengeHash: 'abc123hash',
+      id: "chal-1",
+      assistantId: "asst-1",
+      channel: "telegram",
+      challengeHash: "abc123hash",
       expiresAt: Date.now() + 600_000,
     });
 
     // Different assistant
-    expect(findPendingChallengeByHash('asst-2', 'telegram', 'abc123hash')).toBeNull();
+    expect(
+      findPendingChallengeByHash("asst-2", "telegram", "abc123hash"),
+    ).toBeNull();
     // Different channel
-    expect(findPendingChallengeByHash('asst-1', 'slack', 'abc123hash')).toBeNull();
+    expect(
+      findPendingChallengeByHash("asst-1", "slack", "abc123hash"),
+    ).toBeNull();
     // Correct match
-    expect(findPendingChallengeByHash('asst-1', 'telegram', 'abc123hash')).not.toBeNull();
+    expect(
+      findPendingChallengeByHash("asst-1", "telegram", "abc123hash"),
+    ).not.toBeNull();
   });
 });
 
@@ -379,13 +453,13 @@ describe('verification challenge lifecycle', () => {
 // 3. Guardian Service — Challenge Validation
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('guardian service challenge validation', () => {
+describe("guardian service challenge validation", () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('createVerificationChallenge returns a secret, verifyCommand, ttlSeconds, and instruction', () => {
-    const result = createVerificationChallenge('asst-1', 'telegram');
+  test("createVerificationChallenge returns a secret, verifyCommand, ttlSeconds, and instruction", () => {
+    const result = createVerificationChallenge("asst-1", "telegram");
 
     expect(result.challengeId).toBeDefined();
     expect(result.secret).toBeDefined();
@@ -399,58 +473,64 @@ describe('guardian service challenge validation', () => {
     expect(result.instruction).toContain(`the code: ${result.secret}`);
   });
 
-  test('createVerificationChallenge produces a non-empty instruction for telegram channel', () => {
-    const result = createVerificationChallenge('asst-1', 'telegram');
+  test("createVerificationChallenge produces a non-empty instruction for telegram channel", () => {
+    const result = createVerificationChallenge("asst-1", "telegram");
     expect(result.instruction).toBeDefined();
     expect(result.instruction.length).toBeGreaterThan(0);
     expect(result.instruction).toContain(`the code: ${result.secret}`);
   });
 
-  test('createVerificationChallenge produces a non-empty instruction for sms channel', () => {
-    const result = createVerificationChallenge('asst-1', 'sms');
+  test("createVerificationChallenge produces a non-empty instruction for sms channel", () => {
+    const result = createVerificationChallenge("asst-1", "sms");
     expect(result.instruction).toBeDefined();
     expect(result.instruction.length).toBeGreaterThan(0);
     expect(result.instruction).toContain(`the code: ${result.secret}`);
   });
 
-  test('validateAndConsumeChallenge succeeds with correct secret', () => {
-    const { secret } = createVerificationChallenge('asst-1', 'telegram');
+  test("validateAndConsumeChallenge succeeds with correct secret", () => {
+    const { secret } = createVerificationChallenge("asst-1", "telegram");
 
     const result = validateAndConsumeChallenge(
-      'asst-1',
-      'telegram',
+      "asst-1",
+      "telegram",
       secret,
-      'user-42',
-      'chat-42',
+      "user-42",
+      "chat-42",
     );
 
     expect(result.success).toBe(true);
-    if (result.success && result.verificationType === 'guardian') {
+    if (result.success && result.verificationType === "guardian") {
       expect(result.bindingId).toBeDefined();
     }
   });
 
-  test('validateAndConsumeChallenge creates a guardian binding', () => {
-    const { secret } = createVerificationChallenge('asst-1', 'telegram');
+  test("validateAndConsumeChallenge creates a guardian binding", () => {
+    const { secret } = createVerificationChallenge("asst-1", "telegram");
 
-    validateAndConsumeChallenge('asst-1', 'telegram', secret, 'user-42', 'chat-42');
+    validateAndConsumeChallenge(
+      "asst-1",
+      "telegram",
+      secret,
+      "user-42",
+      "chat-42",
+    );
 
-    const binding = getActiveBinding('asst-1', 'telegram');
+    const binding = getActiveBinding("asst-1", "telegram");
     expect(binding).not.toBeNull();
-    expect(binding!.guardianExternalUserId).toBe('user-42');
-    expect(binding!.guardianDeliveryChatId).toBe('chat-42');
-    expect(binding!.verifiedVia).toBe('challenge');
+    expect(binding!.guardianExternalUserId).toBe("user-42");
+    expect(binding!.guardianDeliveryChatId).toBe("chat-42");
+    expect(binding!.verifiedVia).toBe("challenge");
   });
 
-  test('validateAndConsumeChallenge fails with wrong secret', () => {
-    createVerificationChallenge('asst-1', 'telegram');
+  test("validateAndConsumeChallenge fails with wrong secret", () => {
+    createVerificationChallenge("asst-1", "telegram");
 
     const result = validateAndConsumeChallenge(
-      'asst-1',
-      'telegram',
-      'wrong-secret',
-      'user-42',
-      'chat-42',
+      "asst-1",
+      "telegram",
+      "wrong-secret",
+      "user-42",
+      "chat-42",
     );
 
     expect(result.success).toBe(false);
@@ -458,28 +538,28 @@ describe('guardian service challenge validation', () => {
       // Composed failure message — check it is non-empty and contains "failed"
       expect(result.reason).toBeDefined();
       expect(result.reason.length).toBeGreaterThan(0);
-      expect(result.reason.toLowerCase()).toContain('failed');
+      expect(result.reason.toLowerCase()).toContain("failed");
     }
   });
 
-  test('validateAndConsumeChallenge fails with expired challenge', () => {
+  test("validateAndConsumeChallenge fails with expired challenge", () => {
     // Create a challenge that is already expired by inserting directly
-    const secret = 'test-secret-expired';
-    const challengeHash = createHash('sha256').update(secret).digest('hex');
+    const secret = "test-secret-expired";
+    const challengeHash = createHash("sha256").update(secret).digest("hex");
     createChallenge({
-      id: 'chal-expired',
-      assistantId: 'asst-1',
-      channel: 'telegram',
+      id: "chal-expired",
+      assistantId: "asst-1",
+      channel: "telegram",
       challengeHash,
       expiresAt: Date.now() - 1000, // already expired
     });
 
     const result = validateAndConsumeChallenge(
-      'asst-1',
-      'telegram',
+      "asst-1",
+      "telegram",
       secret,
-      'user-42',
-      'chat-42',
+      "user-42",
+      "chat-42",
     );
 
     expect(result.success).toBe(false);
@@ -487,118 +567,124 @@ describe('guardian service challenge validation', () => {
       // Composed failure message — check it is non-empty and contains "failed"
       expect(result.reason).toBeDefined();
       expect(result.reason.length).toBeGreaterThan(0);
-      expect(result.reason.toLowerCase()).toContain('failed');
+      expect(result.reason.toLowerCase()).toContain("failed");
     }
   });
 
-  test('consumed challenge cannot be reused', () => {
-    const { secret } = createVerificationChallenge('asst-1', 'telegram');
+  test("consumed challenge cannot be reused", () => {
+    const { secret } = createVerificationChallenge("asst-1", "telegram");
 
     // First use succeeds
     const result1 = validateAndConsumeChallenge(
-      'asst-1',
-      'telegram',
+      "asst-1",
+      "telegram",
       secret,
-      'user-42',
-      'chat-42',
+      "user-42",
+      "chat-42",
     );
     expect(result1.success).toBe(true);
 
     // Second use with same secret fails (replay prevention)
     const result2 = validateAndConsumeChallenge(
-      'asst-1',
-      'telegram',
+      "asst-1",
+      "telegram",
       secret,
-      'user-99',
-      'chat-99',
+      "user-99",
+      "chat-99",
     );
     expect(result2.success).toBe(false);
   });
 
-  test('validateAndConsumeChallenge succeeds with sms channel', () => {
-    const { secret } = createVerificationChallenge('asst-1', 'sms');
+  test("validateAndConsumeChallenge succeeds with sms channel", () => {
+    const { secret } = createVerificationChallenge("asst-1", "sms");
 
     const result = validateAndConsumeChallenge(
-      'asst-1',
-      'sms',
+      "asst-1",
+      "sms",
       secret,
-      'phone-user-1',
-      'sms-chat-1',
+      "phone-user-1",
+      "sms-chat-1",
     );
 
     expect(result.success).toBe(true);
-    if (result.success && result.verificationType === 'guardian') {
+    if (result.success && result.verificationType === "guardian") {
       expect(result.bindingId).toBeDefined();
     }
 
     // Verify the binding was created for the sms channel
-    const binding = getActiveBinding('asst-1', 'sms');
+    const binding = getActiveBinding("asst-1", "sms");
     expect(binding).not.toBeNull();
-    expect(binding!.guardianExternalUserId).toBe('phone-user-1');
-    expect(binding!.guardianDeliveryChatId).toBe('sms-chat-1');
-    expect(binding!.channel).toBe('sms');
+    expect(binding!.guardianExternalUserId).toBe("phone-user-1");
+    expect(binding!.guardianDeliveryChatId).toBe("sms-chat-1");
+    expect(binding!.channel).toBe("sms");
   });
 
-  test('sms and telegram guardian challenges are independent', () => {
-    const telegramChallenge = createVerificationChallenge('asst-1', 'telegram');
-    const smsChallenge = createVerificationChallenge('asst-1', 'sms');
+  test("sms and telegram guardian challenges are independent", () => {
+    const telegramChallenge = createVerificationChallenge("asst-1", "telegram");
+    const smsChallenge = createVerificationChallenge("asst-1", "sms");
 
     // Validate SMS challenge against telegram channel should fail
     const crossResult = validateAndConsumeChallenge(
-      'asst-1',
-      'telegram',
+      "asst-1",
+      "telegram",
       smsChallenge.secret,
-      'user-1',
-      'chat-1',
+      "user-1",
+      "chat-1",
     );
     expect(crossResult.success).toBe(false);
 
     // Validate SMS challenge against correct channel should succeed
     const smsResult = validateAndConsumeChallenge(
-      'asst-1',
-      'sms',
+      "asst-1",
+      "sms",
       smsChallenge.secret,
-      'user-1',
-      'chat-1',
+      "user-1",
+      "chat-1",
     );
     expect(smsResult.success).toBe(true);
 
     // Telegram challenge should still be valid
     const telegramResult = validateAndConsumeChallenge(
-      'asst-1',
-      'telegram',
+      "asst-1",
+      "telegram",
       telegramChallenge.secret,
-      'user-2',
-      'chat-2',
+      "user-2",
+      "chat-2",
     );
     expect(telegramResult.success).toBe(true);
   });
 
-  test('validateAndConsumeChallenge revokes existing binding before creating new one', () => {
+  test("validateAndConsumeChallenge revokes existing binding before creating new one", () => {
     // Create initial guardian binding
     createBinding({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      guardianExternalUserId: 'old-user',
-      guardianDeliveryChatId: 'old-chat',
+      assistantId: "asst-1",
+      channel: "telegram",
+      guardianExternalUserId: "old-user",
+      guardianDeliveryChatId: "old-chat",
     });
 
-    const oldBinding = getActiveBinding('asst-1', 'telegram');
+    const oldBinding = getActiveBinding("asst-1", "telegram");
     expect(oldBinding).not.toBeNull();
-    expect(oldBinding!.guardianExternalUserId).toBe('old-user');
+    expect(oldBinding!.guardianExternalUserId).toBe("old-user");
 
     // Attempt verification with a different user — should be rejected
     // because a different guardian is already bound for this channel.
-    const { secret } = createVerificationChallenge('asst-1', 'telegram');
-    const result = validateAndConsumeChallenge('asst-1', 'telegram', secret, 'new-user', 'new-chat');
+    const { secret } = createVerificationChallenge("asst-1", "telegram");
+    const result = validateAndConsumeChallenge(
+      "asst-1",
+      "telegram",
+      secret,
+      "new-user",
+      "new-chat",
+    );
 
     // The different-user takeover should be blocked
     expect(result.success).toBe(false);
 
     // The original binding should remain active
-    const binding = getActiveBinding('asst-1', 'telegram');
+    const binding = getActiveBinding("asst-1", "telegram");
     expect(binding).not.toBeNull();
-    expect(binding!.guardianExternalUserId).toBe('old-user');
+    expect(binding!.guardianExternalUserId).toBe("old-user");
   });
 });
 
@@ -606,93 +692,93 @@ describe('guardian service challenge validation', () => {
 // 4. Guardian Identity Check (Service)
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('guardian identity check', () => {
+describe("guardian identity check", () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('isGuardian returns true for matching user', () => {
+  test("isGuardian returns true for matching user", () => {
     createBinding({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      guardianExternalUserId: 'user-42',
-      guardianDeliveryChatId: 'chat-42',
+      assistantId: "asst-1",
+      channel: "telegram",
+      guardianExternalUserId: "user-42",
+      guardianDeliveryChatId: "chat-42",
     });
 
-    expect(isGuardian('asst-1', 'telegram', 'user-42')).toBe(true);
+    expect(isGuardian("asst-1", "telegram", "user-42")).toBe(true);
   });
 
-  test('isGuardian returns false for non-matching user', () => {
+  test("isGuardian returns false for non-matching user", () => {
     createBinding({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      guardianExternalUserId: 'user-42',
-      guardianDeliveryChatId: 'chat-42',
+      assistantId: "asst-1",
+      channel: "telegram",
+      guardianExternalUserId: "user-42",
+      guardianDeliveryChatId: "chat-42",
     });
 
-    expect(isGuardian('asst-1', 'telegram', 'user-99')).toBe(false);
+    expect(isGuardian("asst-1", "telegram", "user-99")).toBe(false);
   });
 
-  test('isGuardian returns false when no binding exists', () => {
-    expect(isGuardian('asst-1', 'telegram', 'user-42')).toBe(false);
+  test("isGuardian returns false when no binding exists", () => {
+    expect(isGuardian("asst-1", "telegram", "user-42")).toBe(false);
   });
 
-  test('isGuardian returns false after binding is revoked', () => {
+  test("isGuardian returns false after binding is revoked", () => {
     createBinding({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      guardianExternalUserId: 'user-42',
-      guardianDeliveryChatId: 'chat-42',
+      assistantId: "asst-1",
+      channel: "telegram",
+      guardianExternalUserId: "user-42",
+      guardianDeliveryChatId: "chat-42",
     });
 
-    revokeBinding('asst-1', 'telegram');
+    revokeBinding("asst-1", "telegram");
 
-    expect(isGuardian('asst-1', 'telegram', 'user-42')).toBe(false);
+    expect(isGuardian("asst-1", "telegram", "user-42")).toBe(false);
   });
 
-  test('getGuardianBinding returns the active binding', () => {
+  test("getGuardianBinding returns the active binding", () => {
     createBinding({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      guardianExternalUserId: 'user-42',
-      guardianDeliveryChatId: 'chat-42',
+      assistantId: "asst-1",
+      channel: "telegram",
+      guardianExternalUserId: "user-42",
+      guardianDeliveryChatId: "chat-42",
     });
 
-    const binding = getGuardianBinding('asst-1', 'telegram');
+    const binding = getGuardianBinding("asst-1", "telegram");
     expect(binding).not.toBeNull();
-    expect(binding!.guardianExternalUserId).toBe('user-42');
+    expect(binding!.guardianExternalUserId).toBe("user-42");
   });
 
-  test('getGuardianBinding returns null when no binding exists', () => {
-    const binding = getGuardianBinding('asst-1', 'telegram');
+  test("getGuardianBinding returns null when no binding exists", () => {
+    const binding = getGuardianBinding("asst-1", "telegram");
     expect(binding).toBeNull();
   });
 
-  test('isGuardian works for sms channel', () => {
+  test("isGuardian works for sms channel", () => {
     createBinding({
-      assistantId: 'asst-1',
-      channel: 'sms',
-      guardianExternalUserId: 'phone-user-1',
-      guardianDeliveryChatId: 'sms-chat-1',
+      assistantId: "asst-1",
+      channel: "sms",
+      guardianExternalUserId: "phone-user-1",
+      guardianDeliveryChatId: "sms-chat-1",
     });
 
-    expect(isGuardian('asst-1', 'sms', 'phone-user-1')).toBe(true);
-    expect(isGuardian('asst-1', 'sms', 'phone-user-2')).toBe(false);
+    expect(isGuardian("asst-1", "sms", "phone-user-1")).toBe(true);
+    expect(isGuardian("asst-1", "sms", "phone-user-2")).toBe(false);
     // Telegram guardian should not match sms channel
-    expect(isGuardian('asst-1', 'telegram', 'phone-user-1')).toBe(false);
+    expect(isGuardian("asst-1", "telegram", "phone-user-1")).toBe(false);
   });
 
-  test('serviceRevokeBinding revokes the active binding', () => {
+  test("serviceRevokeBinding revokes the active binding", () => {
     createBinding({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      guardianExternalUserId: 'user-42',
-      guardianDeliveryChatId: 'chat-42',
+      assistantId: "asst-1",
+      channel: "telegram",
+      guardianExternalUserId: "user-42",
+      guardianDeliveryChatId: "chat-42",
     });
 
-    const result = serviceRevokeBinding('asst-1', 'telegram');
+    const result = serviceRevokeBinding("asst-1", "telegram");
     expect(result).toBe(true);
-    expect(getGuardianBinding('asst-1', 'telegram')).toBeNull();
+    expect(getGuardianBinding("asst-1", "telegram")).toBeNull();
   });
 });
 
@@ -700,227 +786,230 @@ describe('guardian identity check', () => {
 // 5. Approval Request CRUD (Store)
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('guardian approval request CRUD', () => {
+describe("guardian approval request CRUD", () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('createApprovalRequest creates a pending request', () => {
+  test("createApprovalRequest creates a pending request", () => {
     const request = createApprovalRequest({
-      runId: 'run-1',
-      conversationId: 'conv-1',
-      channel: 'telegram',
-      requesterExternalUserId: 'user-99',
-      requesterChatId: 'chat-99',
-      guardianExternalUserId: 'user-42',
-      guardianChatId: 'chat-42',
-      toolName: 'shell',
-      riskLevel: 'high',
-      reason: 'Executing rm command',
+      runId: "run-1",
+      conversationId: "conv-1",
+      channel: "telegram",
+      requesterExternalUserId: "user-99",
+      requesterChatId: "chat-99",
+      guardianExternalUserId: "user-42",
+      guardianChatId: "chat-42",
+      toolName: "shell",
+      riskLevel: "high",
+      reason: "Executing rm command",
       expiresAt: Date.now() + 300_000,
     });
 
     expect(request.id).toBeDefined();
-    expect(request.runId).toBe('run-1');
-    expect(request.status).toBe('pending');
-    expect(request.toolName).toBe('shell');
-    expect(request.riskLevel).toBe('high');
-    expect(request.reason).toBe('Executing rm command');
+    expect(request.runId).toBe("run-1");
+    expect(request.status).toBe("pending");
+    expect(request.toolName).toBe("shell");
+    expect(request.riskLevel).toBe("high");
+    expect(request.reason).toBe("Executing rm command");
     expect(request.decidedByExternalUserId).toBeNull();
   });
 
-  test('getPendingApprovalForRun returns the pending request', () => {
+  test("getPendingApprovalForRun returns the pending request", () => {
     createApprovalRequest({
-      runId: 'run-1',
-      conversationId: 'conv-1',
-      channel: 'telegram',
-      requesterExternalUserId: 'user-99',
-      requesterChatId: 'chat-99',
-      guardianExternalUserId: 'user-42',
-      guardianChatId: 'chat-42',
-      toolName: 'shell',
+      runId: "run-1",
+      conversationId: "conv-1",
+      channel: "telegram",
+      requesterExternalUserId: "user-99",
+      requesterChatId: "chat-99",
+      guardianExternalUserId: "user-42",
+      guardianChatId: "chat-42",
+      toolName: "shell",
       expiresAt: Date.now() + 300_000,
     });
 
-    const found = getPendingApprovalForRun('run-1');
+    const found = getPendingApprovalForRun("run-1");
     expect(found).not.toBeNull();
-    expect(found!.runId).toBe('run-1');
-    expect(found!.status).toBe('pending');
+    expect(found!.runId).toBe("run-1");
+    expect(found!.status).toBe("pending");
   });
 
-  test('getPendingApprovalForRun returns null when no pending request exists', () => {
-    const found = getPendingApprovalForRun('run-nonexistent');
+  test("getPendingApprovalForRun returns null when no pending request exists", () => {
+    const found = getPendingApprovalForRun("run-nonexistent");
     expect(found).toBeNull();
   });
 
-  test('getPendingApprovalByGuardianChat returns pending request for guardian chat', () => {
+  test("getPendingApprovalByGuardianChat returns pending request for guardian chat", () => {
     createApprovalRequest({
-      runId: 'run-1',
-      conversationId: 'conv-1',
-      channel: 'telegram',
-      requesterExternalUserId: 'user-99',
-      requesterChatId: 'chat-99',
-      guardianExternalUserId: 'user-42',
-      guardianChatId: 'chat-42',
-      toolName: 'shell',
+      runId: "run-1",
+      conversationId: "conv-1",
+      channel: "telegram",
+      requesterExternalUserId: "user-99",
+      requesterChatId: "chat-99",
+      guardianExternalUserId: "user-42",
+      guardianChatId: "chat-42",
+      toolName: "shell",
       expiresAt: Date.now() + 300_000,
     });
 
-    const found = getPendingApprovalByGuardianChat('telegram', 'chat-42');
+    const found = getPendingApprovalByGuardianChat("telegram", "chat-42");
     expect(found).not.toBeNull();
-    expect(found!.guardianChatId).toBe('chat-42');
+    expect(found!.guardianChatId).toBe("chat-42");
   });
 
-  test('getPendingApprovalByGuardianChat returns null for wrong channel', () => {
+  test("getPendingApprovalByGuardianChat returns null for wrong channel", () => {
     createApprovalRequest({
-      runId: 'run-1',
-      conversationId: 'conv-1',
-      channel: 'telegram',
-      requesterExternalUserId: 'user-99',
-      requesterChatId: 'chat-99',
-      guardianExternalUserId: 'user-42',
-      guardianChatId: 'chat-42',
-      toolName: 'shell',
+      runId: "run-1",
+      conversationId: "conv-1",
+      channel: "telegram",
+      requesterExternalUserId: "user-99",
+      requesterChatId: "chat-99",
+      guardianExternalUserId: "user-42",
+      guardianChatId: "chat-42",
+      toolName: "shell",
       expiresAt: Date.now() + 300_000,
     });
 
-    const found = getPendingApprovalByGuardianChat('slack', 'chat-42');
+    const found = getPendingApprovalByGuardianChat("slack", "chat-42");
     expect(found).toBeNull();
   });
 
-  test('updateApprovalDecision updates status to approved', () => {
+  test("updateApprovalDecision updates status to approved", () => {
     const request = createApprovalRequest({
-      runId: 'run-1',
-      conversationId: 'conv-1',
-      channel: 'telegram',
-      requesterExternalUserId: 'user-99',
-      requesterChatId: 'chat-99',
-      guardianExternalUserId: 'user-42',
-      guardianChatId: 'chat-42',
-      toolName: 'shell',
+      runId: "run-1",
+      conversationId: "conv-1",
+      channel: "telegram",
+      requesterExternalUserId: "user-99",
+      requesterChatId: "chat-99",
+      guardianExternalUserId: "user-42",
+      guardianChatId: "chat-42",
+      toolName: "shell",
       expiresAt: Date.now() + 300_000,
     });
 
     updateApprovalDecision(request.id, {
-      status: 'approved',
-      decidedByExternalUserId: 'user-42',
+      status: "approved",
+      decidedByExternalUserId: "user-42",
     });
 
     // After approval, getPendingApprovalForRun should return null
-    const found = getPendingApprovalForRun('run-1');
+    const found = getPendingApprovalForRun("run-1");
     expect(found).toBeNull();
   });
 
-  test('updateApprovalDecision updates status to denied', () => {
+  test("updateApprovalDecision updates status to denied", () => {
     const request = createApprovalRequest({
-      runId: 'run-1',
-      conversationId: 'conv-1',
-      channel: 'telegram',
-      requesterExternalUserId: 'user-99',
-      requesterChatId: 'chat-99',
-      guardianExternalUserId: 'user-42',
-      guardianChatId: 'chat-42',
-      toolName: 'shell',
+      runId: "run-1",
+      conversationId: "conv-1",
+      channel: "telegram",
+      requesterExternalUserId: "user-99",
+      requesterChatId: "chat-99",
+      guardianExternalUserId: "user-42",
+      guardianChatId: "chat-42",
+      toolName: "shell",
       expiresAt: Date.now() + 300_000,
     });
 
     updateApprovalDecision(request.id, {
-      status: 'denied',
-      decidedByExternalUserId: 'user-42',
+      status: "denied",
+      decidedByExternalUserId: "user-42",
     });
 
-    const found = getPendingApprovalForRun('run-1');
+    const found = getPendingApprovalForRun("run-1");
     expect(found).toBeNull();
   });
 
-  test('multiple approval requests for different runs are independent', () => {
+  test("multiple approval requests for different runs are independent", () => {
     createApprovalRequest({
-      runId: 'run-1',
-      conversationId: 'conv-1',
-      channel: 'telegram',
-      requesterExternalUserId: 'user-99',
-      requesterChatId: 'chat-99',
-      guardianExternalUserId: 'user-42',
-      guardianChatId: 'chat-42',
-      toolName: 'shell',
+      runId: "run-1",
+      conversationId: "conv-1",
+      channel: "telegram",
+      requesterExternalUserId: "user-99",
+      requesterChatId: "chat-99",
+      guardianExternalUserId: "user-42",
+      guardianChatId: "chat-42",
+      toolName: "shell",
       expiresAt: Date.now() + 300_000,
     });
 
     createApprovalRequest({
-      runId: 'run-2',
-      conversationId: 'conv-2',
-      channel: 'telegram',
-      requesterExternalUserId: 'user-88',
-      requesterChatId: 'chat-88',
-      guardianExternalUserId: 'user-42',
-      guardianChatId: 'chat-42',
-      toolName: 'browser',
+      runId: "run-2",
+      conversationId: "conv-2",
+      channel: "telegram",
+      requesterExternalUserId: "user-88",
+      requesterChatId: "chat-88",
+      guardianExternalUserId: "user-42",
+      guardianChatId: "chat-42",
+      toolName: "browser",
       expiresAt: Date.now() + 300_000,
     });
 
-    const found1 = getPendingApprovalForRun('run-1');
-    const found2 = getPendingApprovalForRun('run-2');
+    const found1 = getPendingApprovalForRun("run-1");
+    const found2 = getPendingApprovalForRun("run-2");
     expect(found1).not.toBeNull();
     expect(found2).not.toBeNull();
-    expect(found1!.toolName).toBe('shell');
-    expect(found2!.toolName).toBe('browser');
+    expect(found1!.toolName).toBe("shell");
+    expect(found2!.toolName).toBe("browser");
   });
 
-  test('createApprovalRequest works for sms channel', () => {
+  test("createApprovalRequest works for sms channel", () => {
     const request = createApprovalRequest({
-      runId: 'run-sms-1',
-      conversationId: 'conv-sms-1',
-      channel: 'sms',
-      requesterExternalUserId: 'phone-user-99',
-      requesterChatId: 'sms-chat-99',
-      guardianExternalUserId: 'phone-user-42',
-      guardianChatId: 'sms-chat-42',
-      toolName: 'shell',
+      runId: "run-sms-1",
+      conversationId: "conv-sms-1",
+      channel: "sms",
+      requesterExternalUserId: "phone-user-99",
+      requesterChatId: "sms-chat-99",
+      guardianExternalUserId: "phone-user-42",
+      guardianChatId: "sms-chat-42",
+      toolName: "shell",
       expiresAt: Date.now() + 300_000,
     });
 
     expect(request.id).toBeDefined();
-    expect(request.runId).toBe('run-sms-1');
-    expect(request.channel).toBe('sms');
-    expect(request.status).toBe('pending');
+    expect(request.runId).toBe("run-sms-1");
+    expect(request.channel).toBe("sms");
+    expect(request.status).toBe("pending");
 
-    const found = getPendingApprovalForRun('run-sms-1');
+    const found = getPendingApprovalForRun("run-sms-1");
     expect(found).not.toBeNull();
-    expect(found!.channel).toBe('sms');
+    expect(found!.channel).toBe("sms");
   });
 
-  test('getPendingApprovalByGuardianChat works for sms channel', () => {
+  test("getPendingApprovalByGuardianChat works for sms channel", () => {
     createApprovalRequest({
-      runId: 'run-sms-2',
-      conversationId: 'conv-sms-2',
-      channel: 'sms',
-      requesterExternalUserId: 'phone-user-99',
-      requesterChatId: 'sms-chat-99',
-      guardianExternalUserId: 'phone-user-42',
-      guardianChatId: 'sms-chat-42',
-      toolName: 'shell',
+      runId: "run-sms-2",
+      conversationId: "conv-sms-2",
+      channel: "sms",
+      requesterExternalUserId: "phone-user-99",
+      requesterChatId: "sms-chat-99",
+      guardianExternalUserId: "phone-user-42",
+      guardianChatId: "sms-chat-42",
+      toolName: "shell",
       expiresAt: Date.now() + 300_000,
     });
 
-    const found = getPendingApprovalByGuardianChat('sms', 'sms-chat-42');
+    const found = getPendingApprovalByGuardianChat("sms", "sms-chat-42");
     expect(found).not.toBeNull();
-    expect(found!.channel).toBe('sms');
+    expect(found!.channel).toBe("sms");
 
     // Should not find it under a different channel
-    const notFound = getPendingApprovalByGuardianChat('telegram', 'sms-chat-42');
+    const notFound = getPendingApprovalByGuardianChat(
+      "telegram",
+      "sms-chat-42",
+    );
     expect(notFound).toBeNull();
   });
 
-  test('createApprovalRequest with optional fields omitted defaults to null', () => {
+  test("createApprovalRequest with optional fields omitted defaults to null", () => {
     const request = createApprovalRequest({
-      runId: 'run-1',
-      conversationId: 'conv-1',
-      channel: 'telegram',
-      requesterExternalUserId: 'user-99',
-      requesterChatId: 'chat-99',
-      guardianExternalUserId: 'user-42',
-      guardianChatId: 'chat-42',
-      toolName: 'shell',
+      runId: "run-1",
+      conversationId: "conv-1",
+      channel: "telegram",
+      requesterExternalUserId: "user-99",
+      requesterChatId: "chat-99",
+      guardianExternalUserId: "user-42",
+      guardianChatId: "chat-42",
+      toolName: "shell",
       expiresAt: Date.now() + 300_000,
     });
 
@@ -933,66 +1022,138 @@ describe('guardian approval request CRUD', () => {
 // 6. Verification Rate Limiting (Store)
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('verification rate limiting store', () => {
+describe("verification rate limiting store", () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('getRateLimit returns null when no record exists', () => {
-    const rl = getRateLimit('asst-1', 'telegram', 'user-42', 'chat-42');
+  test("getRateLimit returns null when no record exists", () => {
+    const rl = getRateLimit("asst-1", "telegram", "user-42", "chat-42");
     expect(rl).toBeNull();
   });
 
-  test('recordInvalidAttempt creates a new record on first failure', () => {
-    const rl = recordInvalidAttempt('asst-1', 'telegram', 'user-42', 'chat-42', 900_000, 5, 1_800_000);
+  test("recordInvalidAttempt creates a new record on first failure", () => {
+    const rl = recordInvalidAttempt(
+      "asst-1",
+      "telegram",
+      "user-42",
+      "chat-42",
+      900_000,
+      5,
+      1_800_000,
+    );
     expect(rl.invalidAttempts).toBe(1);
     expect(rl.lockedUntil).toBeNull();
-    expect(rl.assistantId).toBe('asst-1');
-    expect(rl.channel).toBe('telegram');
-    expect(rl.actorExternalUserId).toBe('user-42');
+    expect(rl.assistantId).toBe("asst-1");
+    expect(rl.channel).toBe("telegram");
+    expect(rl.actorExternalUserId).toBe("user-42");
   });
 
-  test('recordInvalidAttempt increments counter on subsequent failures', () => {
-    recordInvalidAttempt('asst-1', 'telegram', 'user-42', 'chat-42', 900_000, 5, 1_800_000);
-    recordInvalidAttempt('asst-1', 'telegram', 'user-42', 'chat-42', 900_000, 5, 1_800_000);
-    const rl = recordInvalidAttempt('asst-1', 'telegram', 'user-42', 'chat-42', 900_000, 5, 1_800_000);
+  test("recordInvalidAttempt increments counter on subsequent failures", () => {
+    recordInvalidAttempt(
+      "asst-1",
+      "telegram",
+      "user-42",
+      "chat-42",
+      900_000,
+      5,
+      1_800_000,
+    );
+    recordInvalidAttempt(
+      "asst-1",
+      "telegram",
+      "user-42",
+      "chat-42",
+      900_000,
+      5,
+      1_800_000,
+    );
+    const rl = recordInvalidAttempt(
+      "asst-1",
+      "telegram",
+      "user-42",
+      "chat-42",
+      900_000,
+      5,
+      1_800_000,
+    );
     expect(rl.invalidAttempts).toBe(3);
     expect(rl.lockedUntil).toBeNull();
   });
 
-  test('recordInvalidAttempt sets lockedUntil when max attempts reached', () => {
+  test("recordInvalidAttempt sets lockedUntil when max attempts reached", () => {
     for (let i = 0; i < 4; i++) {
-      recordInvalidAttempt('asst-1', 'telegram', 'user-42', 'chat-42', 900_000, 5, 1_800_000);
+      recordInvalidAttempt(
+        "asst-1",
+        "telegram",
+        "user-42",
+        "chat-42",
+        900_000,
+        5,
+        1_800_000,
+      );
     }
-    const rl = recordInvalidAttempt('asst-1', 'telegram', 'user-42', 'chat-42', 900_000, 5, 1_800_000);
+    const rl = recordInvalidAttempt(
+      "asst-1",
+      "telegram",
+      "user-42",
+      "chat-42",
+      900_000,
+      5,
+      1_800_000,
+    );
     expect(rl.invalidAttempts).toBe(5);
     expect(rl.lockedUntil).not.toBeNull();
     expect(rl.lockedUntil!).toBeGreaterThan(Date.now());
   });
 
-  test('resetRateLimit clears the counter and lockout', () => {
+  test("resetRateLimit clears the counter and lockout", () => {
     for (let i = 0; i < 5; i++) {
-      recordInvalidAttempt('asst-1', 'telegram', 'user-42', 'chat-42', 900_000, 5, 1_800_000);
+      recordInvalidAttempt(
+        "asst-1",
+        "telegram",
+        "user-42",
+        "chat-42",
+        900_000,
+        5,
+        1_800_000,
+      );
     }
-    const locked = getRateLimit('asst-1', 'telegram', 'user-42', 'chat-42');
+    const locked = getRateLimit("asst-1", "telegram", "user-42", "chat-42");
     expect(locked).not.toBeNull();
     expect(locked!.lockedUntil).not.toBeNull();
 
-    resetRateLimit('asst-1', 'telegram', 'user-42', 'chat-42');
+    resetRateLimit("asst-1", "telegram", "user-42", "chat-42");
 
-    const after = getRateLimit('asst-1', 'telegram', 'user-42', 'chat-42');
+    const after = getRateLimit("asst-1", "telegram", "user-42", "chat-42");
     expect(after).not.toBeNull();
     expect(after!.invalidAttempts).toBe(0);
     expect(after!.lockedUntil).toBeNull();
   });
 
-  test('rate limits are scoped per actor and channel', () => {
-    recordInvalidAttempt('asst-1', 'telegram', 'user-42', 'chat-42', 900_000, 5, 1_800_000);
-    recordInvalidAttempt('asst-1', 'telegram', 'user-99', 'chat-99', 900_000, 5, 1_800_000);
+  test("rate limits are scoped per actor and channel", () => {
+    recordInvalidAttempt(
+      "asst-1",
+      "telegram",
+      "user-42",
+      "chat-42",
+      900_000,
+      5,
+      1_800_000,
+    );
+    recordInvalidAttempt(
+      "asst-1",
+      "telegram",
+      "user-99",
+      "chat-99",
+      900_000,
+      5,
+      1_800_000,
+    );
 
-    const rl42 = getRateLimit('asst-1', 'telegram', 'user-42', 'chat-42');
-    const rl99 = getRateLimit('asst-1', 'telegram', 'user-99', 'chat-99');
-    const rlSms = getRateLimit('asst-1', 'sms', 'user-42', 'chat-42');
+    const rl42 = getRateLimit("asst-1", "telegram", "user-42", "chat-42");
+    const rl99 = getRateLimit("asst-1", "telegram", "user-99", "chat-99");
+    const rlSms = getRateLimit("asst-1", "sms", "user-42", "chat-42");
 
     expect(rl42).not.toBeNull();
     expect(rl42!.invalidAttempts).toBe(1);
@@ -1006,65 +1167,101 @@ describe('verification rate limiting store', () => {
 // 7. Verification Rate Limiting (Service — end-to-end)
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('guardian service rate limiting', () => {
+describe("guardian service rate limiting", () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('repeated invalid submissions hit rate limit', () => {
+  test("repeated invalid submissions hit rate limit", () => {
     // Create a valid challenge so there is a pending challenge
-    createVerificationChallenge('asst-1', 'telegram');
+    createVerificationChallenge("asst-1", "telegram");
 
     // Submit wrong codes repeatedly
     for (let i = 0; i < 5; i++) {
       const result = validateAndConsumeChallenge(
-        'asst-1', 'telegram', `wrong-secret-${i}`, 'user-42', 'chat-42',
+        "asst-1",
+        "telegram",
+        `wrong-secret-${i}`,
+        "user-42",
+        "chat-42",
       );
       expect(result.success).toBe(false);
     }
 
     // The 6th attempt should be rate-limited even without a new challenge
     const result = validateAndConsumeChallenge(
-      'asst-1', 'telegram', 'another-wrong', 'user-42', 'chat-42',
+      "asst-1",
+      "telegram",
+      "another-wrong",
+      "user-42",
+      "chat-42",
     );
     expect(result.success).toBe(false);
     expect((result as { reason: string }).reason).toBeDefined();
     expect((result as { reason: string }).reason.length).toBeGreaterThan(0);
-    expect((result as { reason: string }).reason.toLowerCase()).toContain('failed');
+    expect((result as { reason: string }).reason.toLowerCase()).toContain(
+      "failed",
+    );
 
     // Verify the rate limit record
-    const rl = getRateLimit('asst-1', 'telegram', 'user-42', 'chat-42');
+    const rl = getRateLimit("asst-1", "telegram", "user-42", "chat-42");
     expect(rl).not.toBeNull();
     expect(rl!.lockedUntil).not.toBeNull();
   });
 
-  test('valid challenge still succeeds when under threshold', () => {
+  test("valid challenge still succeeds when under threshold", () => {
     // Record a couple invalid attempts
-    const { secret: _secret } = createVerificationChallenge('asst-1', 'telegram');
-    validateAndConsumeChallenge('asst-1', 'telegram', 'wrong-1', 'user-42', 'chat-42');
-    validateAndConsumeChallenge('asst-1', 'telegram', 'wrong-2', 'user-42', 'chat-42');
+    const { secret: _secret } = createVerificationChallenge(
+      "asst-1",
+      "telegram",
+    );
+    validateAndConsumeChallenge(
+      "asst-1",
+      "telegram",
+      "wrong-1",
+      "user-42",
+      "chat-42",
+    );
+    validateAndConsumeChallenge(
+      "asst-1",
+      "telegram",
+      "wrong-2",
+      "user-42",
+      "chat-42",
+    );
 
     // Valid attempt should still succeed (under the 5-attempt threshold)
     // Need a new challenge since the old one is still pending but the secret was never consumed
-    const { secret: secret2 } = createVerificationChallenge('asst-1', 'telegram');
+    const { secret: secret2 } = createVerificationChallenge(
+      "asst-1",
+      "telegram",
+    );
     const result = validateAndConsumeChallenge(
-      'asst-1', 'telegram', secret2, 'user-42', 'chat-42',
+      "asst-1",
+      "telegram",
+      secret2,
+      "user-42",
+      "chat-42",
     );
     expect(result.success).toBe(true);
 
     // Rate limit should be reset after success
-    const rl = getRateLimit('asst-1', 'telegram', 'user-42', 'chat-42');
+    const rl = getRateLimit("asst-1", "telegram", "user-42", "chat-42");
     expect(rl).not.toBeNull();
     expect(rl!.invalidAttempts).toBe(0);
     expect(rl!.lockedUntil).toBeNull();
   });
 
-  test('rate-limit uses generic failure message (no oracle leakage)', () => {
-    createVerificationChallenge('asst-1', 'telegram');
+  test("rate-limit uses generic failure message (no oracle leakage)", () => {
+    createVerificationChallenge("asst-1", "telegram");
 
     // Capture a normal invalid-code failure response
     const normalFailure = validateAndConsumeChallenge(
-      'asst-1', 'telegram', 'wrong-first', 'user-42', 'chat-42',
+      "asst-1",
+      "telegram",
+      "wrong-first",
+      "user-42",
+      "chat-42",
     );
     expect(normalFailure.success).toBe(false);
     const normalReason = (normalFailure as { reason: string }).reason;
@@ -1072,18 +1269,26 @@ describe('guardian service rate limiting', () => {
     // Trigger rate limit (4 more attempts to reach 5 total)
     for (let i = 0; i < 4; i++) {
       validateAndConsumeChallenge(
-        'asst-1', 'telegram', `wrong-${i}`, 'user-42', 'chat-42',
+        "asst-1",
+        "telegram",
+        `wrong-${i}`,
+        "user-42",
+        "chat-42",
       );
     }
 
     // Verify lockout is actually active before testing the rate-limited response
-    const rl = getRateLimit('asst-1', 'telegram', 'user-42', 'chat-42');
+    const rl = getRateLimit("asst-1", "telegram", "user-42", "chat-42");
     expect(rl).not.toBeNull();
     expect(rl!.lockedUntil).toBeGreaterThan(Date.now());
 
     // The rate-limited response should be indistinguishable from normal failure
     const rateLimitedResult = validateAndConsumeChallenge(
-      'asst-1', 'telegram', 'anything', 'user-42', 'chat-42',
+      "asst-1",
+      "telegram",
+      "anything",
+      "user-42",
+      "chat-42",
     );
     expect(rateLimitedResult.success).toBe(false);
     const rateLimitedReason = (rateLimitedResult as { reason: string }).reason;
@@ -1092,21 +1297,31 @@ describe('guardian service rate limiting', () => {
     expect(rateLimitedReason).toBe(normalReason);
 
     // Neither should reveal rate-limiting info
-    expect(rateLimitedReason).not.toContain('rate limit');
-    expect(normalReason).not.toContain('rate limit');
+    expect(rateLimitedReason).not.toContain("rate limit");
+    expect(normalReason).not.toContain("rate limit");
   });
 
-  test('rate limit does not affect different actors', () => {
+  test("rate limit does not affect different actors", () => {
     // Rate-limit user-42
-    createVerificationChallenge('asst-1', 'telegram');
+    createVerificationChallenge("asst-1", "telegram");
     for (let i = 0; i < 5; i++) {
-      validateAndConsumeChallenge('asst-1', 'telegram', `wrong-${i}`, 'user-42', 'chat-42');
+      validateAndConsumeChallenge(
+        "asst-1",
+        "telegram",
+        `wrong-${i}`,
+        "user-42",
+        "chat-42",
+      );
     }
 
     // user-99 should still be able to verify
-    const { secret } = createVerificationChallenge('asst-1', 'telegram');
+    const { secret } = createVerificationChallenge("asst-1", "telegram");
     const result = validateAndConsumeChallenge(
-      'asst-1', 'telegram', secret, 'user-99', 'chat-99',
+      "asst-1",
+      "telegram",
+      secret,
+      "user-99",
+      "chat-99",
     );
     expect(result.success).toBe(true);
   });
@@ -1116,107 +1331,125 @@ describe('guardian service rate limiting', () => {
 // 8. Assistant-scoped guardian resolution
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('assistant-scoped guardian resolution', () => {
+describe("assistant-scoped guardian resolution", () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('isGuardian resolves independently per assistantId', () => {
+  test("isGuardian resolves independently per assistantId", () => {
     // Create guardian binding for asst-A on telegram
     createBinding({
-      assistantId: 'asst-A',
-      channel: 'telegram',
-      guardianExternalUserId: 'user-alpha',
-      guardianDeliveryChatId: 'chat-alpha',
+      assistantId: "asst-A",
+      channel: "telegram",
+      guardianExternalUserId: "user-alpha",
+      guardianDeliveryChatId: "chat-alpha",
     });
     // Create guardian binding for asst-B on telegram with a different user
     createBinding({
-      assistantId: 'asst-B',
-      channel: 'telegram',
-      guardianExternalUserId: 'user-beta',
-      guardianDeliveryChatId: 'chat-beta',
+      assistantId: "asst-B",
+      channel: "telegram",
+      guardianExternalUserId: "user-beta",
+      guardianDeliveryChatId: "chat-beta",
     });
 
     // user-alpha is guardian for asst-A but not asst-B
-    expect(isGuardian('asst-A', 'telegram', 'user-alpha')).toBe(true);
-    expect(isGuardian('asst-B', 'telegram', 'user-alpha')).toBe(false);
+    expect(isGuardian("asst-A", "telegram", "user-alpha")).toBe(true);
+    expect(isGuardian("asst-B", "telegram", "user-alpha")).toBe(false);
 
     // user-beta is guardian for asst-B but not asst-A
-    expect(isGuardian('asst-B', 'telegram', 'user-beta')).toBe(true);
-    expect(isGuardian('asst-A', 'telegram', 'user-beta')).toBe(false);
+    expect(isGuardian("asst-B", "telegram", "user-beta")).toBe(true);
+    expect(isGuardian("asst-A", "telegram", "user-beta")).toBe(false);
   });
 
-  test('getGuardianBinding returns different bindings for different assistants', () => {
+  test("getGuardianBinding returns different bindings for different assistants", () => {
     createBinding({
-      assistantId: 'asst-A',
-      channel: 'telegram',
-      guardianExternalUserId: 'user-alpha',
-      guardianDeliveryChatId: 'chat-alpha',
+      assistantId: "asst-A",
+      channel: "telegram",
+      guardianExternalUserId: "user-alpha",
+      guardianDeliveryChatId: "chat-alpha",
     });
     createBinding({
-      assistantId: 'asst-B',
-      channel: 'telegram',
-      guardianExternalUserId: 'user-beta',
-      guardianDeliveryChatId: 'chat-beta',
+      assistantId: "asst-B",
+      channel: "telegram",
+      guardianExternalUserId: "user-beta",
+      guardianDeliveryChatId: "chat-beta",
     });
 
-    const bindingA = getGuardianBinding('asst-A', 'telegram');
-    const bindingB = getGuardianBinding('asst-B', 'telegram');
+    const bindingA = getGuardianBinding("asst-A", "telegram");
+    const bindingB = getGuardianBinding("asst-B", "telegram");
 
     expect(bindingA).not.toBeNull();
     expect(bindingB).not.toBeNull();
-    expect(bindingA!.guardianExternalUserId).toBe('user-alpha');
-    expect(bindingB!.guardianExternalUserId).toBe('user-beta');
+    expect(bindingA!.guardianExternalUserId).toBe("user-alpha");
+    expect(bindingB!.guardianExternalUserId).toBe("user-beta");
   });
 
-  test('revoking binding for one assistant does not affect another', () => {
+  test("revoking binding for one assistant does not affect another", () => {
     createBinding({
-      assistantId: 'asst-A',
-      channel: 'telegram',
-      guardianExternalUserId: 'user-alpha',
-      guardianDeliveryChatId: 'chat-alpha',
+      assistantId: "asst-A",
+      channel: "telegram",
+      guardianExternalUserId: "user-alpha",
+      guardianDeliveryChatId: "chat-alpha",
     });
     createBinding({
-      assistantId: 'asst-B',
-      channel: 'telegram',
-      guardianExternalUserId: 'user-beta',
-      guardianDeliveryChatId: 'chat-beta',
+      assistantId: "asst-B",
+      channel: "telegram",
+      guardianExternalUserId: "user-beta",
+      guardianDeliveryChatId: "chat-beta",
     });
 
-    serviceRevokeBinding('asst-A', 'telegram');
+    serviceRevokeBinding("asst-A", "telegram");
 
-    expect(getGuardianBinding('asst-A', 'telegram')).toBeNull();
-    expect(getGuardianBinding('asst-B', 'telegram')).not.toBeNull();
+    expect(getGuardianBinding("asst-A", "telegram")).toBeNull();
+    expect(getGuardianBinding("asst-B", "telegram")).not.toBeNull();
   });
 
-  test('validateAndConsumeChallenge scoped to assistantId', () => {
+  test("validateAndConsumeChallenge scoped to assistantId", () => {
     // Create challenge for asst-A
-    const { secret: secretA } = createVerificationChallenge('asst-A', 'telegram');
+    const { secret: secretA } = createVerificationChallenge(
+      "asst-A",
+      "telegram",
+    );
     // Create challenge for asst-B
-    const { secret: secretB } = createVerificationChallenge('asst-B', 'telegram');
+    const { secret: secretB } = createVerificationChallenge(
+      "asst-B",
+      "telegram",
+    );
 
     // Attempting to consume asst-A challenge with asst-B should fail
     const crossResult = validateAndConsumeChallenge(
-      'asst-B', 'telegram', secretA, 'user-1', 'chat-1',
+      "asst-B",
+      "telegram",
+      secretA,
+      "user-1",
+      "chat-1",
     );
     expect(crossResult.success).toBe(false);
 
     // Consuming with correct assistantId should succeed
     const resultA = validateAndConsumeChallenge(
-      'asst-A', 'telegram', secretA, 'user-1', 'chat-1',
+      "asst-A",
+      "telegram",
+      secretA,
+      "user-1",
+      "chat-1",
     );
     expect(resultA.success).toBe(true);
 
     const resultB = validateAndConsumeChallenge(
-      'asst-B', 'telegram', secretB, 'user-2', 'chat-2',
+      "asst-B",
+      "telegram",
+      secretB,
+      "user-2",
+      "chat-2",
     );
     expect(resultB.success).toBe(true);
 
     // Verify bindings are scoped correctly
-    const bindingA = getGuardianBinding('asst-A', 'telegram');
-    const bindingB = getGuardianBinding('asst-B', 'telegram');
-    expect(bindingA!.guardianExternalUserId).toBe('user-1');
-    expect(bindingB!.guardianExternalUserId).toBe('user-2');
+    const bindingA = getGuardianBinding("asst-A", "telegram");
+    const bindingB = getGuardianBinding("asst-B", "telegram");
+    expect(bindingA!.guardianExternalUserId).toBe("user-1");
+    expect(bindingB!.guardianExternalUserId).toBe("user-2");
   });
 });
 
@@ -1224,74 +1457,74 @@ describe('assistant-scoped guardian resolution', () => {
 // 9. Assistant-scoped approval request lookups
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('assistant-scoped approval request lookups', () => {
+describe("assistant-scoped approval request lookups", () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('createApprovalRequest stores assistantId and defaults to self', () => {
+  test("createApprovalRequest stores assistantId and defaults to self", () => {
     const reqWithoutId = createApprovalRequest({
-      runId: 'run-1',
-      conversationId: 'conv-1',
-      channel: 'telegram',
-      requesterExternalUserId: 'user-99',
-      requesterChatId: 'chat-99',
-      guardianExternalUserId: 'user-42',
-      guardianChatId: 'chat-42',
-      toolName: 'shell',
+      runId: "run-1",
+      conversationId: "conv-1",
+      channel: "telegram",
+      requesterExternalUserId: "user-99",
+      requesterChatId: "chat-99",
+      guardianExternalUserId: "user-42",
+      guardianChatId: "chat-42",
+      toolName: "shell",
       expiresAt: Date.now() + 300_000,
     });
-    expect(reqWithoutId.assistantId).toBe('self');
+    expect(reqWithoutId.assistantId).toBe("self");
 
     const reqWithId = createApprovalRequest({
-      runId: 'run-2',
-      conversationId: 'conv-2',
-      assistantId: 'asst-A',
-      channel: 'telegram',
-      requesterExternalUserId: 'user-99',
-      requesterChatId: 'chat-99',
-      guardianExternalUserId: 'user-42',
-      guardianChatId: 'chat-42',
-      toolName: 'browser',
+      runId: "run-2",
+      conversationId: "conv-2",
+      assistantId: "asst-A",
+      channel: "telegram",
+      requesterExternalUserId: "user-99",
+      requesterChatId: "chat-99",
+      guardianExternalUserId: "user-42",
+      guardianChatId: "chat-42",
+      toolName: "browser",
       expiresAt: Date.now() + 300_000,
     });
-    expect(reqWithId.assistantId).toBe('asst-A');
+    expect(reqWithId.assistantId).toBe("asst-A");
   });
 
-  test('approval requests from different assistants are independent', () => {
+  test("approval requests from different assistants are independent", () => {
     createApprovalRequest({
-      runId: 'run-A',
-      conversationId: 'conv-A',
-      assistantId: 'asst-A',
-      channel: 'telegram',
-      requesterExternalUserId: 'user-99',
-      requesterChatId: 'chat-99',
-      guardianExternalUserId: 'user-42',
-      guardianChatId: 'chat-42',
-      toolName: 'shell',
+      runId: "run-A",
+      conversationId: "conv-A",
+      assistantId: "asst-A",
+      channel: "telegram",
+      requesterExternalUserId: "user-99",
+      requesterChatId: "chat-99",
+      guardianExternalUserId: "user-42",
+      guardianChatId: "chat-42",
+      toolName: "shell",
       expiresAt: Date.now() + 300_000,
     });
     createApprovalRequest({
-      runId: 'run-B',
-      conversationId: 'conv-B',
-      assistantId: 'asst-B',
-      channel: 'telegram',
-      requesterExternalUserId: 'user-88',
-      requesterChatId: 'chat-88',
-      guardianExternalUserId: 'user-42',
-      guardianChatId: 'chat-42',
-      toolName: 'browser',
+      runId: "run-B",
+      conversationId: "conv-B",
+      assistantId: "asst-B",
+      channel: "telegram",
+      requesterExternalUserId: "user-88",
+      requesterChatId: "chat-88",
+      guardianExternalUserId: "user-42",
+      guardianChatId: "chat-42",
+      toolName: "browser",
       expiresAt: Date.now() + 300_000,
     });
 
-    const foundA = getPendingApprovalForRun('run-A');
-    const foundB = getPendingApprovalForRun('run-B');
+    const foundA = getPendingApprovalForRun("run-A");
+    const foundB = getPendingApprovalForRun("run-B");
     expect(foundA).not.toBeNull();
     expect(foundB).not.toBeNull();
-    expect(foundA!.assistantId).toBe('asst-A');
-    expect(foundB!.assistantId).toBe('asst-B');
-    expect(foundA!.toolName).toBe('shell');
-    expect(foundB!.toolName).toBe('browser');
+    expect(foundA!.assistantId).toBe("asst-A");
+    expect(foundB!.assistantId).toBe("asst-B");
+    expect(foundA!.toolName).toBe("shell");
+    expect(foundB!.toolName).toBe("browser");
   });
 });
 
@@ -1302,7 +1535,10 @@ describe('assistant-scoped approval request lookups', () => {
 /**
  * Creates a minimal mock HandlerContext that captures the response sent via ctx.send().
  */
-function createMockCtx(): { ctx: HandlerContext; lastResponse: () => GuardianVerificationResponse | null } {
+function createMockCtx(): {
+  ctx: HandlerContext;
+  lastResponse: () => GuardianVerificationResponse | null;
+} {
   let captured: GuardianVerificationResponse | null = null;
   const ctx = {
     sessions: new Map(),
@@ -1312,11 +1548,16 @@ function createMockCtx(): { ctx: HandlerContext; lastResponse: () => GuardianVer
     cuObservationParseSequence: new Map(),
     socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],
-    debounceTimers: { schedule: () => {}, cancel: () => {} } as unknown as HandlerContext['debounceTimers'],
+    debounceTimers: {
+      schedule: () => {},
+      cancel: () => {},
+    } as unknown as HandlerContext["debounceTimers"],
     suppressConfigReload: false,
     setSuppressConfigReload: () => {},
     updateConfigFingerprint: () => {},
-    send: (_socket: net.Socket, msg: unknown) => { captured = msg as GuardianVerificationResponse; },
+    send: (_socket: net.Socket, msg: unknown) => {
+      captured = msg as GuardianVerificationResponse;
+    },
     broadcast: () => {},
     clearAllSessions: () => 0,
     getOrCreateSession: () => Promise.resolve({} as never),
@@ -1327,17 +1568,17 @@ function createMockCtx(): { ctx: HandlerContext; lastResponse: () => GuardianVer
 
 const mockSocket = {} as net.Socket;
 
-describe('IPC handler channel-aware guardian status', () => {
+describe("IPC handler channel-aware guardian status", () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('status action for telegram returns channel and assistantId fields', () => {
+  test("status action for telegram returns channel and assistantId fields", () => {
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
-      type: 'guardian_verification',
-      action: 'status',
-      channel: 'telegram',
+      type: "guardian_verification",
+      action: "status",
+      channel: "telegram",
     };
 
     handleGuardianVerification(msg, mockSocket, ctx);
@@ -1345,18 +1586,18 @@ describe('IPC handler channel-aware guardian status', () => {
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(true);
-    expect(resp!.channel).toBe('telegram');
-    expect(resp!.assistantId).toBe('self');
+    expect(resp!.channel).toBe("telegram");
+    expect(resp!.assistantId).toBe("self");
     expect(resp!.bound).toBe(false);
     expect(resp!.guardianDeliveryChatId).toBeUndefined();
   });
 
-  test('status action for sms returns channel: sms and assistantId: self', () => {
+  test("status action for sms returns channel: sms and assistantId: self", () => {
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
-      type: 'guardian_verification',
-      action: 'status',
-      channel: 'sms',
+      type: "guardian_verification",
+      action: "status",
+      channel: "sms",
     };
 
     handleGuardianVerification(msg, mockSocket, ctx);
@@ -1364,24 +1605,24 @@ describe('IPC handler channel-aware guardian status', () => {
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(true);
-    expect(resp!.channel).toBe('sms');
-    expect(resp!.assistantId).toBe('self');
+    expect(resp!.channel).toBe("sms");
+    expect(resp!.assistantId).toBe("self");
     expect(resp!.bound).toBe(false);
   });
 
-  test('status action returns guardianDeliveryChatId when bound', () => {
+  test("status action returns guardianDeliveryChatId when bound", () => {
     createBinding({
-      assistantId: 'self',
-      channel: 'telegram',
-      guardianExternalUserId: 'user-42',
-      guardianDeliveryChatId: 'chat-42',
+      assistantId: "self",
+      channel: "telegram",
+      guardianExternalUserId: "user-42",
+      guardianDeliveryChatId: "chat-42",
     });
 
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
-      type: 'guardian_verification',
-      action: 'status',
-      channel: 'telegram',
+      type: "guardian_verification",
+      action: "status",
+      channel: "telegram",
     };
 
     handleGuardianVerification(msg, mockSocket, ctx);
@@ -1390,41 +1631,44 @@ describe('IPC handler channel-aware guardian status', () => {
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(true);
     expect(resp!.bound).toBe(true);
-    expect(resp!.guardianExternalUserId).toBe('user-42');
-    expect(resp!.guardianDeliveryChatId).toBe('chat-42');
-    expect(resp!.channel).toBe('telegram');
-    expect(resp!.assistantId).toBe('self');
+    expect(resp!.guardianExternalUserId).toBe("user-42");
+    expect(resp!.guardianDeliveryChatId).toBe("chat-42");
+    expect(resp!.channel).toBe("telegram");
+    expect(resp!.assistantId).toBe("self");
   });
 
-  test('status action returns guardian username/displayName from binding metadata', () => {
+  test("status action returns guardian username/displayName from binding metadata", () => {
     createBinding({
-      assistantId: 'self',
-      channel: 'telegram',
-      guardianExternalUserId: 'user-43',
-      guardianDeliveryChatId: 'chat-43',
-      metadataJson: JSON.stringify({ username: 'guardian_handle', displayName: 'Guardian Name' }),
+      assistantId: "self",
+      channel: "telegram",
+      guardianExternalUserId: "user-43",
+      guardianDeliveryChatId: "chat-43",
+      metadataJson: JSON.stringify({
+        username: "guardian_handle",
+        displayName: "Guardian Name",
+      }),
     });
 
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
-      type: 'guardian_verification',
-      action: 'status',
-      channel: 'telegram',
+      type: "guardian_verification",
+      action: "status",
+      channel: "telegram",
     };
 
     handleGuardianVerification(msg, mockSocket, ctx);
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
-    expect(resp!.guardianUsername).toBe('guardian_handle');
-    expect(resp!.guardianDisplayName).toBe('Guardian Name');
+    expect(resp!.guardianUsername).toBe("guardian_handle");
+    expect(resp!.guardianDisplayName).toBe("Guardian Name");
   });
 
-  test('status action defaults channel to telegram when omitted (backward compat)', () => {
+  test("status action defaults channel to telegram when omitted (backward compat)", () => {
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
-      type: 'guardian_verification',
-      action: 'status',
+      type: "guardian_verification",
+      action: "status",
       // channel omitted — should default to 'telegram'
     };
 
@@ -1432,16 +1676,16 @@ describe('IPC handler channel-aware guardian status', () => {
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
-    expect(resp!.channel).toBe('telegram');
-    expect(resp!.assistantId).toBe('self');
+    expect(resp!.channel).toBe("telegram");
+    expect(resp!.assistantId).toBe("self");
   });
 
-  test('status action defaults assistantId to self when omitted (backward compat)', () => {
+  test("status action defaults assistantId to self when omitted (backward compat)", () => {
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
-      type: 'guardian_verification',
-      action: 'status',
-      channel: 'sms',
+      type: "guardian_verification",
+      action: "status",
+      channel: "sms",
       // assistantId omitted — should default to 'self'
     };
 
@@ -1449,16 +1693,16 @@ describe('IPC handler channel-aware guardian status', () => {
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
-    expect(resp!.assistantId).toBe('self');
-    expect(resp!.channel).toBe('sms');
+    expect(resp!.assistantId).toBe("self");
+    expect(resp!.channel).toBe("sms");
   });
 
-  test('status action for unbound sms does not return guardianDeliveryChatId', () => {
+  test("status action for unbound sms does not return guardianDeliveryChatId", () => {
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
-      type: 'guardian_verification',
-      action: 'status',
-      channel: 'sms',
+      type: "guardian_verification",
+      action: "status",
+      channel: "sms",
     };
 
     handleGuardianVerification(msg, mockSocket, ctx);
@@ -1470,14 +1714,14 @@ describe('IPC handler channel-aware guardian status', () => {
     expect(resp!.guardianExternalUserId).toBeUndefined();
   });
 
-  test('status action includes hasPendingChallenge when challenge exists', () => {
-    createVerificationChallenge('self', 'voice');
+  test("status action includes hasPendingChallenge when challenge exists", () => {
+    createVerificationChallenge("self", "voice");
 
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
-      type: 'guardian_verification',
-      action: 'status',
-      channel: 'voice',
+      type: "guardian_verification",
+      action: "status",
+      channel: "voice",
     };
 
     handleGuardianVerification(msg, mockSocket, ctx);
@@ -1488,12 +1732,12 @@ describe('IPC handler channel-aware guardian status', () => {
     expect(resp!.hasPendingChallenge).toBe(true);
   });
 
-  test('status action hasPendingChallenge is false when no challenge exists', () => {
+  test("status action hasPendingChallenge is false when no challenge exists", () => {
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
-      type: 'guardian_verification',
-      action: 'status',
-      channel: 'voice',
+      type: "guardian_verification",
+      action: "status",
+      channel: "voice",
     };
 
     handleGuardianVerification(msg, mockSocket, ctx);
@@ -1509,13 +1753,13 @@ describe('IPC handler channel-aware guardian status', () => {
 // 11. Voice Guardian Challenge — Six-Digit Secret Generation
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('voice guardian challenge generation', () => {
+describe("voice guardian challenge generation", () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('createVerificationChallenge for voice returns a high-entropy hex secret', () => {
-    const result = createVerificationChallenge('asst-1', 'voice');
+  test("createVerificationChallenge for voice returns a high-entropy hex secret", () => {
+    const result = createVerificationChallenge("asst-1", "voice");
 
     expect(result.challengeId).toBeDefined();
     expect(result.secret).toBeDefined();
@@ -1523,39 +1767,39 @@ describe('voice guardian challenge generation', () => {
     expect(result.secret.length).toBe(64);
   });
 
-  test('createVerificationChallenge for non-voice returns high-entropy hex secret', () => {
-    const result = createVerificationChallenge('asst-1', 'telegram');
+  test("createVerificationChallenge for non-voice returns high-entropy hex secret", () => {
+    const result = createVerificationChallenge("asst-1", "telegram");
 
     expect(result.secret.length).toBe(64);
     expect(result.secret).toMatch(/^[0-9a-f]{64}$/);
   });
 
-  test('voice challenge verifyCommand contains the hex secret', () => {
-    const result = createVerificationChallenge('asst-1', 'voice');
+  test("voice challenge verifyCommand contains the hex secret", () => {
+    const result = createVerificationChallenge("asst-1", "voice");
 
     expect(result.verifyCommand).toBe(result.secret);
   });
 
-  test('voice challenge instruction contains voice-specific copy', () => {
-    const result = createVerificationChallenge('asst-1', 'voice');
+  test("voice challenge instruction contains voice-specific copy", () => {
+    const result = createVerificationChallenge("asst-1", "voice");
 
     // Inbound challenges use high-entropy hex, so the voice template says
     // "enter the code" rather than "six-digit code".
-    expect(result.instruction).toContain('enter the code');
+    expect(result.instruction).toContain("enter the code");
     expect(result.instruction).toContain(result.secret);
   });
 
-  test('voice challenge secrets are different across calls', () => {
-    const result1 = createVerificationChallenge('asst-1', 'voice');
-    const result2 = createVerificationChallenge('asst-2', 'voice');
+  test("voice challenge secrets are different across calls", () => {
+    const result1 = createVerificationChallenge("asst-1", "voice");
+    const result2 = createVerificationChallenge("asst-2", "voice");
 
     // High-entropy hex secrets: collision probability is negligible
     expect(result1.secret).toMatch(/^[0-9a-f]{64}$/);
     expect(result2.secret).toMatch(/^[0-9a-f]{64}$/);
   });
 
-  test('voice ttlSeconds is 600 (10 minutes)', () => {
-    const result = createVerificationChallenge('asst-1', 'voice');
+  test("voice ttlSeconds is 600 (10 minutes)", () => {
+    const result = createVerificationChallenge("asst-1", "voice");
     expect(result.ttlSeconds).toBe(600);
   });
 });
@@ -1564,132 +1808,152 @@ describe('voice guardian challenge generation', () => {
 // 12. Voice Guardian Challenge Validation
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('voice guardian challenge validation', () => {
+describe("voice guardian challenge validation", () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('validateAndConsumeChallenge succeeds with correct voice secret', () => {
-    const { secret } = createVerificationChallenge('asst-1', 'voice');
+  test("validateAndConsumeChallenge succeeds with correct voice secret", () => {
+    const { secret } = createVerificationChallenge("asst-1", "voice");
 
     const result = validateAndConsumeChallenge(
-      'asst-1',
-      'voice',
+      "asst-1",
+      "voice",
       secret,
-      'voice-user-1',
-      'voice-chat-1',
+      "voice-user-1",
+      "voice-chat-1",
     );
 
     expect(result.success).toBe(true);
-    if (result.success && result.verificationType === 'guardian') {
+    if (result.success && result.verificationType === "guardian") {
       expect(result.bindingId).toBeDefined();
     }
   });
 
-  test('validateAndConsumeChallenge creates a guardian binding for voice', () => {
-    const { secret } = createVerificationChallenge('asst-1', 'voice');
+  test("validateAndConsumeChallenge creates a guardian binding for voice", () => {
+    const { secret } = createVerificationChallenge("asst-1", "voice");
 
-    validateAndConsumeChallenge('asst-1', 'voice', secret, 'voice-user-1', 'voice-chat-1');
+    validateAndConsumeChallenge(
+      "asst-1",
+      "voice",
+      secret,
+      "voice-user-1",
+      "voice-chat-1",
+    );
 
-    const binding = getActiveBinding('asst-1', 'voice');
+    const binding = getActiveBinding("asst-1", "voice");
     expect(binding).not.toBeNull();
-    expect(binding!.guardianExternalUserId).toBe('voice-user-1');
-    expect(binding!.guardianDeliveryChatId).toBe('voice-chat-1');
-    expect(binding!.channel).toBe('voice');
-    expect(binding!.verifiedVia).toBe('challenge');
+    expect(binding!.guardianExternalUserId).toBe("voice-user-1");
+    expect(binding!.guardianDeliveryChatId).toBe("voice-chat-1");
+    expect(binding!.channel).toBe("voice");
+    expect(binding!.verifiedVia).toBe("challenge");
   });
 
-  test('validateAndConsumeChallenge fails with wrong voice secret', () => {
-    createVerificationChallenge('asst-1', 'voice');
+  test("validateAndConsumeChallenge fails with wrong voice secret", () => {
+    createVerificationChallenge("asst-1", "voice");
 
     const result = validateAndConsumeChallenge(
-      'asst-1',
-      'voice',
-      '000000',
-      'voice-user-1',
-      'voice-chat-1',
+      "asst-1",
+      "voice",
+      "000000",
+      "voice-user-1",
+      "voice-chat-1",
     );
 
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.reason).toBeDefined();
       expect(result.reason.length).toBeGreaterThan(0);
-      expect(result.reason.toLowerCase()).toContain('failed');
+      expect(result.reason.toLowerCase()).toContain("failed");
     }
   });
 
-  test('voice and telegram guardian challenges are independent', () => {
-    const voiceChallenge = createVerificationChallenge('asst-1', 'voice');
-    const telegramChallenge = createVerificationChallenge('asst-1', 'telegram');
+  test("voice and telegram guardian challenges are independent", () => {
+    const voiceChallenge = createVerificationChallenge("asst-1", "voice");
+    const telegramChallenge = createVerificationChallenge("asst-1", "telegram");
 
     // Voice secret against telegram channel should fail
     const crossResult = validateAndConsumeChallenge(
-      'asst-1',
-      'telegram',
+      "asst-1",
+      "telegram",
       voiceChallenge.secret,
-      'user-1',
-      'chat-1',
+      "user-1",
+      "chat-1",
     );
     expect(crossResult.success).toBe(false);
 
     // Voice secret against correct channel should succeed
     const voiceResult = validateAndConsumeChallenge(
-      'asst-1',
-      'voice',
+      "asst-1",
+      "voice",
       voiceChallenge.secret,
-      'voice-user-1',
-      'voice-chat-1',
+      "voice-user-1",
+      "voice-chat-1",
     );
     expect(voiceResult.success).toBe(true);
 
     // Telegram challenge should still be valid
     const telegramResult = validateAndConsumeChallenge(
-      'asst-1',
-      'telegram',
+      "asst-1",
+      "telegram",
       telegramChallenge.secret,
-      'user-2',
-      'chat-2',
+      "user-2",
+      "chat-2",
     );
     expect(telegramResult.success).toBe(true);
   });
 
-  test('consumed voice challenge cannot be reused', () => {
-    const { secret } = createVerificationChallenge('asst-1', 'voice');
+  test("consumed voice challenge cannot be reused", () => {
+    const { secret } = createVerificationChallenge("asst-1", "voice");
 
     const result1 = validateAndConsumeChallenge(
-      'asst-1', 'voice', secret, 'voice-user-1', 'voice-chat-1',
+      "asst-1",
+      "voice",
+      secret,
+      "voice-user-1",
+      "voice-chat-1",
     );
     expect(result1.success).toBe(true);
 
     const result2 = validateAndConsumeChallenge(
-      'asst-1', 'voice', secret, 'voice-user-2', 'voice-chat-2',
+      "asst-1",
+      "voice",
+      secret,
+      "voice-user-2",
+      "voice-chat-2",
     );
     expect(result2.success).toBe(false);
   });
 
-  test('validateAndConsumeChallenge revokes existing voice binding before creating new one', () => {
+  test("validateAndConsumeChallenge revokes existing voice binding before creating new one", () => {
     createBinding({
-      assistantId: 'asst-1',
-      channel: 'voice',
-      guardianExternalUserId: 'old-voice-user',
-      guardianDeliveryChatId: 'old-voice-chat',
+      assistantId: "asst-1",
+      channel: "voice",
+      guardianExternalUserId: "old-voice-user",
+      guardianDeliveryChatId: "old-voice-chat",
     });
 
-    const oldBinding = getActiveBinding('asst-1', 'voice');
+    const oldBinding = getActiveBinding("asst-1", "voice");
     expect(oldBinding).not.toBeNull();
-    expect(oldBinding!.guardianExternalUserId).toBe('old-voice-user');
+    expect(oldBinding!.guardianExternalUserId).toBe("old-voice-user");
 
     // Attempt verification with a different user — should be rejected
-    const { secret } = createVerificationChallenge('asst-1', 'voice');
-    const result = validateAndConsumeChallenge('asst-1', 'voice', secret, 'new-voice-user', 'new-voice-chat');
+    const { secret } = createVerificationChallenge("asst-1", "voice");
+    const result = validateAndConsumeChallenge(
+      "asst-1",
+      "voice",
+      secret,
+      "new-voice-user",
+      "new-voice-chat",
+    );
 
     // The different-user takeover should be blocked
     expect(result.success).toBe(false);
 
     // The original binding should remain active
-    const binding = getActiveBinding('asst-1', 'voice');
+    const binding = getActiveBinding("asst-1", "voice");
     expect(binding).not.toBeNull();
-    expect(binding!.guardianExternalUserId).toBe('old-voice-user');
+    expect(binding!.guardianExternalUserId).toBe("old-voice-user");
   });
 });
 
@@ -1697,70 +1961,70 @@ describe('voice guardian challenge validation', () => {
 // 13. Voice Guardian Identity and Revocation
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('voice guardian identity and revocation', () => {
+describe("voice guardian identity and revocation", () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('isGuardian works for voice channel', () => {
+  test("isGuardian works for voice channel", () => {
     createBinding({
-      assistantId: 'asst-1',
-      channel: 'voice',
-      guardianExternalUserId: 'voice-user-1',
-      guardianDeliveryChatId: 'voice-chat-1',
+      assistantId: "asst-1",
+      channel: "voice",
+      guardianExternalUserId: "voice-user-1",
+      guardianDeliveryChatId: "voice-chat-1",
     });
 
-    expect(isGuardian('asst-1', 'voice', 'voice-user-1')).toBe(true);
-    expect(isGuardian('asst-1', 'voice', 'voice-user-2')).toBe(false);
+    expect(isGuardian("asst-1", "voice", "voice-user-1")).toBe(true);
+    expect(isGuardian("asst-1", "voice", "voice-user-2")).toBe(false);
     // Voice guardian should not match telegram channel
-    expect(isGuardian('asst-1', 'telegram', 'voice-user-1')).toBe(false);
+    expect(isGuardian("asst-1", "telegram", "voice-user-1")).toBe(false);
   });
 
-  test('getGuardianBinding returns voice binding', () => {
+  test("getGuardianBinding returns voice binding", () => {
     createBinding({
-      assistantId: 'asst-1',
-      channel: 'voice',
-      guardianExternalUserId: 'voice-user-1',
-      guardianDeliveryChatId: 'voice-chat-1',
+      assistantId: "asst-1",
+      channel: "voice",
+      guardianExternalUserId: "voice-user-1",
+      guardianDeliveryChatId: "voice-chat-1",
     });
 
-    const binding = getGuardianBinding('asst-1', 'voice');
+    const binding = getGuardianBinding("asst-1", "voice");
     expect(binding).not.toBeNull();
-    expect(binding!.channel).toBe('voice');
-    expect(binding!.guardianExternalUserId).toBe('voice-user-1');
+    expect(binding!.channel).toBe("voice");
+    expect(binding!.guardianExternalUserId).toBe("voice-user-1");
   });
 
-  test('revokeBinding clears active voice guardian binding', () => {
+  test("revokeBinding clears active voice guardian binding", () => {
     createBinding({
-      assistantId: 'asst-1',
-      channel: 'voice',
-      guardianExternalUserId: 'voice-user-1',
-      guardianDeliveryChatId: 'voice-chat-1',
+      assistantId: "asst-1",
+      channel: "voice",
+      guardianExternalUserId: "voice-user-1",
+      guardianDeliveryChatId: "voice-chat-1",
     });
 
-    const result = serviceRevokeBinding('asst-1', 'voice');
+    const result = serviceRevokeBinding("asst-1", "voice");
     expect(result).toBe(true);
-    expect(getGuardianBinding('asst-1', 'voice')).toBeNull();
+    expect(getGuardianBinding("asst-1", "voice")).toBeNull();
   });
 
-  test('revokeBinding for voice does not affect telegram binding', () => {
+  test("revokeBinding for voice does not affect telegram binding", () => {
     createBinding({
-      assistantId: 'asst-1',
-      channel: 'voice',
-      guardianExternalUserId: 'voice-user-1',
-      guardianDeliveryChatId: 'voice-chat-1',
+      assistantId: "asst-1",
+      channel: "voice",
+      guardianExternalUserId: "voice-user-1",
+      guardianDeliveryChatId: "voice-chat-1",
     });
     createBinding({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      guardianExternalUserId: 'tg-user-1',
-      guardianDeliveryChatId: 'tg-chat-1',
+      assistantId: "asst-1",
+      channel: "telegram",
+      guardianExternalUserId: "tg-user-1",
+      guardianDeliveryChatId: "tg-chat-1",
     });
 
-    serviceRevokeBinding('asst-1', 'voice');
+    serviceRevokeBinding("asst-1", "voice");
 
-    expect(getGuardianBinding('asst-1', 'voice')).toBeNull();
-    expect(getGuardianBinding('asst-1', 'telegram')).not.toBeNull();
+    expect(getGuardianBinding("asst-1", "voice")).toBeNull();
+    expect(getGuardianBinding("asst-1", "telegram")).not.toBeNull();
   });
 });
 
@@ -1768,60 +2032,90 @@ describe('voice guardian identity and revocation', () => {
 // 14. Voice Guardian Rate Limiting
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('voice guardian rate limiting', () => {
+describe("voice guardian rate limiting", () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('repeated invalid voice submissions hit rate limit', () => {
-    createVerificationChallenge('asst-1', 'voice');
+  test("repeated invalid voice submissions hit rate limit", () => {
+    createVerificationChallenge("asst-1", "voice");
 
     for (let i = 0; i < 5; i++) {
       const result = validateAndConsumeChallenge(
-        'asst-1', 'voice', `${100000 + i}`, 'voice-user-1', 'voice-chat-1',
+        "asst-1",
+        "voice",
+        `${100000 + i}`,
+        "voice-user-1",
+        "voice-chat-1",
       );
       expect(result.success).toBe(false);
     }
 
     // The 6th attempt should be rate-limited
     const result = validateAndConsumeChallenge(
-      'asst-1', 'voice', '999999', 'voice-user-1', 'voice-chat-1',
+      "asst-1",
+      "voice",
+      "999999",
+      "voice-user-1",
+      "voice-chat-1",
     );
     expect(result.success).toBe(false);
 
-    const rl = getRateLimit('asst-1', 'voice', 'voice-user-1', 'voice-chat-1');
+    const rl = getRateLimit("asst-1", "voice", "voice-user-1", "voice-chat-1");
     expect(rl).not.toBeNull();
     expect(rl!.lockedUntil).not.toBeNull();
   });
 
-  test('voice rate limit does not affect telegram rate limit', () => {
-    createVerificationChallenge('asst-1', 'voice');
+  test("voice rate limit does not affect telegram rate limit", () => {
+    createVerificationChallenge("asst-1", "voice");
     for (let i = 0; i < 5; i++) {
-      validateAndConsumeChallenge('asst-1', 'voice', `${100000 + i}`, 'user-1', 'chat-1');
+      validateAndConsumeChallenge(
+        "asst-1",
+        "voice",
+        `${100000 + i}`,
+        "user-1",
+        "chat-1",
+      );
     }
 
-    const voiceRl = getRateLimit('asst-1', 'voice', 'user-1', 'chat-1');
+    const voiceRl = getRateLimit("asst-1", "voice", "user-1", "chat-1");
     expect(voiceRl).not.toBeNull();
     expect(voiceRl!.lockedUntil).not.toBeNull();
 
     // Telegram should be unaffected
-    const telegramRl = getRateLimit('asst-1', 'telegram', 'user-1', 'chat-1');
+    const telegramRl = getRateLimit("asst-1", "telegram", "user-1", "chat-1");
     expect(telegramRl).toBeNull();
   });
 
-  test('successful voice verification resets rate limit', () => {
-    const { secret: _s } = createVerificationChallenge('asst-1', 'voice');
-    validateAndConsumeChallenge('asst-1', 'voice', '000000', 'voice-user-1', 'voice-chat-1');
-    validateAndConsumeChallenge('asst-1', 'voice', '111111', 'voice-user-1', 'voice-chat-1');
+  test("successful voice verification resets rate limit", () => {
+    const { secret: _s } = createVerificationChallenge("asst-1", "voice");
+    validateAndConsumeChallenge(
+      "asst-1",
+      "voice",
+      "000000",
+      "voice-user-1",
+      "voice-chat-1",
+    );
+    validateAndConsumeChallenge(
+      "asst-1",
+      "voice",
+      "111111",
+      "voice-user-1",
+      "voice-chat-1",
+    );
 
     // Valid attempt should succeed (under the 5-attempt threshold)
-    const { secret } = createVerificationChallenge('asst-1', 'voice');
+    const { secret } = createVerificationChallenge("asst-1", "voice");
     const result = validateAndConsumeChallenge(
-      'asst-1', 'voice', secret, 'voice-user-1', 'voice-chat-1',
+      "asst-1",
+      "voice",
+      secret,
+      "voice-user-1",
+      "voice-chat-1",
     );
     expect(result.success).toBe(true);
 
-    const rl = getRateLimit('asst-1', 'voice', 'voice-user-1', 'voice-chat-1');
+    const rl = getRateLimit("asst-1", "voice", "voice-user-1", "voice-chat-1");
     expect(rl).not.toBeNull();
     expect(rl!.invalidAttempts).toBe(0);
     expect(rl!.lockedUntil).toBeNull();
@@ -1832,62 +2126,68 @@ describe('voice guardian rate limiting', () => {
 // 15. Pending Challenge Lookup (Store + Service)
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('pending challenge lookup', () => {
+describe("pending challenge lookup", () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('findPendingChallengeForChannel returns pending challenge', () => {
-    createVerificationChallenge('asst-1', 'voice');
+  test("findPendingChallengeForChannel returns pending challenge", () => {
+    createVerificationChallenge("asst-1", "voice");
 
-    const pending = findPendingChallengeForChannel('asst-1', 'voice');
+    const pending = findPendingChallengeForChannel("asst-1", "voice");
     expect(pending).not.toBeNull();
-    expect(pending!.channel).toBe('voice');
-    expect(pending!.status).toBe('pending');
+    expect(pending!.channel).toBe("voice");
+    expect(pending!.status).toBe("pending");
   });
 
-  test('findPendingChallengeForChannel returns null when no challenge exists', () => {
-    const pending = findPendingChallengeForChannel('asst-1', 'voice');
+  test("findPendingChallengeForChannel returns null when no challenge exists", () => {
+    const pending = findPendingChallengeForChannel("asst-1", "voice");
     expect(pending).toBeNull();
   });
 
-  test('findPendingChallengeForChannel returns null for different channel', () => {
-    createVerificationChallenge('asst-1', 'telegram');
+  test("findPendingChallengeForChannel returns null for different channel", () => {
+    createVerificationChallenge("asst-1", "telegram");
 
-    const pending = findPendingChallengeForChannel('asst-1', 'voice');
+    const pending = findPendingChallengeForChannel("asst-1", "voice");
     expect(pending).toBeNull();
   });
 
-  test('findPendingChallengeForChannel returns null after challenge is consumed', () => {
-    const { secret } = createVerificationChallenge('asst-1', 'voice');
-    validateAndConsumeChallenge('asst-1', 'voice', secret, 'voice-user-1', 'voice-chat-1');
+  test("findPendingChallengeForChannel returns null after challenge is consumed", () => {
+    const { secret } = createVerificationChallenge("asst-1", "voice");
+    validateAndConsumeChallenge(
+      "asst-1",
+      "voice",
+      secret,
+      "voice-user-1",
+      "voice-chat-1",
+    );
 
-    const pending = findPendingChallengeForChannel('asst-1', 'voice');
+    const pending = findPendingChallengeForChannel("asst-1", "voice");
     expect(pending).toBeNull();
   });
 
-  test('getPendingChallenge service helper returns pending voice challenge', () => {
-    createVerificationChallenge('asst-1', 'voice');
+  test("getPendingChallenge service helper returns pending voice challenge", () => {
+    createVerificationChallenge("asst-1", "voice");
 
-    const pending = getPendingChallenge('asst-1', 'voice');
+    const pending = getPendingChallenge("asst-1", "voice");
     expect(pending).not.toBeNull();
-    expect(pending!.channel).toBe('voice');
+    expect(pending!.channel).toBe("voice");
   });
 
-  test('getPendingChallenge returns null when no challenge exists', () => {
-    const pending = getPendingChallenge('asst-1', 'voice');
+  test("getPendingChallenge returns null when no challenge exists", () => {
+    const pending = getPendingChallenge("asst-1", "voice");
     expect(pending).toBeNull();
   });
 
-  test('creating a new challenge revokes prior pending challenges', () => {
-    createVerificationChallenge('asst-1', 'voice');
-    const pending1 = findPendingChallengeForChannel('asst-1', 'voice');
+  test("creating a new challenge revokes prior pending challenges", () => {
+    createVerificationChallenge("asst-1", "voice");
+    const pending1 = findPendingChallengeForChannel("asst-1", "voice");
     expect(pending1).not.toBeNull();
     const firstId = pending1!.id;
 
     // Creating a second challenge should revoke the first
-    createVerificationChallenge('asst-1', 'voice');
-    const pending2 = findPendingChallengeForChannel('asst-1', 'voice');
+    createVerificationChallenge("asst-1", "voice");
+    const pending2 = findPendingChallengeForChannel("asst-1", "voice");
     expect(pending2).not.toBeNull();
     expect(pending2!.id).not.toBe(firstId);
   });
@@ -1897,17 +2197,17 @@ describe('pending challenge lookup', () => {
 // 16. IPC handler — voice guardian verification
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('IPC handler voice guardian verification', () => {
+describe("IPC handler voice guardian verification", () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('create_challenge for voice returns a high-entropy hex secret', () => {
+  test("create_challenge for voice returns a high-entropy hex secret", () => {
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
-      type: 'guardian_verification',
-      action: 'create_challenge',
-      channel: 'voice',
+      type: "guardian_verification",
+      action: "create_challenge",
+      channel: "voice",
     };
 
     handleGuardianVerification(msg, mockSocket, ctx);
@@ -1918,16 +2218,16 @@ describe('IPC handler voice guardian verification', () => {
     expect(resp!.secret).toBeDefined();
     expect(resp!.secret).toMatch(/^[0-9a-f]{64}$/);
     expect(resp!.instruction).toBeDefined();
-    expect(resp!.instruction).toContain('enter the code');
-    expect(resp!.channel).toBe('voice');
+    expect(resp!.instruction).toContain("enter the code");
+    expect(resp!.channel).toBe("voice");
   });
 
-  test('status for voice reflects unbound state', () => {
+  test("status for voice reflects unbound state", () => {
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
-      type: 'guardian_verification',
-      action: 'status',
-      channel: 'voice',
+      type: "guardian_verification",
+      action: "status",
+      channel: "voice",
     };
 
     handleGuardianVerification(msg, mockSocket, ctx);
@@ -1935,24 +2235,24 @@ describe('IPC handler voice guardian verification', () => {
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(true);
-    expect(resp!.channel).toBe('voice');
+    expect(resp!.channel).toBe("voice");
     expect(resp!.bound).toBe(false);
     expect(resp!.guardianExternalUserId).toBeUndefined();
   });
 
-  test('status for voice reflects bound state', () => {
+  test("status for voice reflects bound state", () => {
     createBinding({
-      assistantId: 'self',
-      channel: 'voice',
-      guardianExternalUserId: 'voice-user-1',
-      guardianDeliveryChatId: 'voice-chat-1',
+      assistantId: "self",
+      channel: "voice",
+      guardianExternalUserId: "voice-user-1",
+      guardianDeliveryChatId: "voice-chat-1",
     });
 
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
-      type: 'guardian_verification',
-      action: 'status',
-      channel: 'voice',
+      type: "guardian_verification",
+      action: "status",
+      channel: "voice",
     };
 
     handleGuardianVerification(msg, mockSocket, ctx);
@@ -1961,24 +2261,24 @@ describe('IPC handler voice guardian verification', () => {
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(true);
     expect(resp!.bound).toBe(true);
-    expect(resp!.guardianExternalUserId).toBe('voice-user-1');
-    expect(resp!.guardianDeliveryChatId).toBe('voice-chat-1');
-    expect(resp!.channel).toBe('voice');
+    expect(resp!.guardianExternalUserId).toBe("voice-user-1");
+    expect(resp!.guardianDeliveryChatId).toBe("voice-chat-1");
+    expect(resp!.channel).toBe("voice");
   });
 
-  test('revoke for voice clears active binding', () => {
+  test("revoke for voice clears active binding", () => {
     createBinding({
-      assistantId: 'self',
-      channel: 'voice',
-      guardianExternalUserId: 'voice-user-1',
-      guardianDeliveryChatId: 'voice-chat-1',
+      assistantId: "self",
+      channel: "voice",
+      guardianExternalUserId: "voice-user-1",
+      guardianDeliveryChatId: "voice-chat-1",
     });
 
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
-      type: 'guardian_verification',
-      action: 'revoke',
-      channel: 'voice',
+      type: "guardian_verification",
+      action: "revoke",
+      channel: "voice",
     };
 
     handleGuardianVerification(msg, mockSocket, ctx);
@@ -1989,34 +2289,34 @@ describe('IPC handler voice guardian verification', () => {
     expect(resp!.bound).toBe(false);
 
     // Verify binding is actually revoked
-    expect(getGuardianBinding('self', 'voice')).toBeNull();
+    expect(getGuardianBinding("self", "voice")).toBeNull();
   });
 
-  test('revoke for voice does not affect telegram binding', () => {
+  test("revoke for voice does not affect telegram binding", () => {
     createBinding({
-      assistantId: 'self',
-      channel: 'voice',
-      guardianExternalUserId: 'voice-user-1',
-      guardianDeliveryChatId: 'voice-chat-1',
+      assistantId: "self",
+      channel: "voice",
+      guardianExternalUserId: "voice-user-1",
+      guardianDeliveryChatId: "voice-chat-1",
     });
     createBinding({
-      assistantId: 'self',
-      channel: 'telegram',
-      guardianExternalUserId: 'tg-user-1',
-      guardianDeliveryChatId: 'tg-chat-1',
+      assistantId: "self",
+      channel: "telegram",
+      guardianExternalUserId: "tg-user-1",
+      guardianDeliveryChatId: "tg-chat-1",
     });
 
     const { ctx } = createMockCtx();
     const msg: GuardianVerificationRequest = {
-      type: 'guardian_verification',
-      action: 'revoke',
-      channel: 'voice',
+      type: "guardian_verification",
+      action: "revoke",
+      channel: "voice",
     };
 
     handleGuardianVerification(msg, mockSocket, ctx);
 
-    expect(getGuardianBinding('self', 'voice')).toBeNull();
-    expect(getGuardianBinding('self', 'telegram')).not.toBeNull();
+    expect(getGuardianBinding("self", "voice")).toBeNull();
+    expect(getGuardianBinding("self", "telegram")).not.toBeNull();
   });
 });
 
@@ -2024,19 +2324,19 @@ describe('IPC handler voice guardian verification', () => {
 // 17. Outbound Verification Sessions
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('outbound verification sessions', () => {
+describe("outbound verification sessions", () => {
   beforeEach(() => {
     resetTables();
   });
 
   // ── Session creation with expected identity fields ──
 
-  test('createOutboundSession creates a session with expected identity fields', () => {
+  test("createOutboundSession creates a session with expected identity fields", () => {
     const result = createOutboundSession({
-      assistantId: 'asst-1',
-      channel: 'sms',
-      expectedPhoneE164: '+15551234567',
-      destinationAddress: '+15551234567',
+      assistantId: "asst-1",
+      channel: "sms",
+      expectedPhoneE164: "+15551234567",
+      destinationAddress: "+15551234567",
     });
 
     expect(result.sessionId).toBeDefined();
@@ -2045,61 +2345,69 @@ describe('outbound verification sessions', () => {
     expect(result.expiresAt).toBeGreaterThan(Date.now());
     expect(result.ttlSeconds).toBe(600);
 
-    const session = serviceFindActiveSession('asst-1', 'sms');
+    const session = serviceFindActiveSession("asst-1", "sms");
     expect(session).not.toBeNull();
-    expect(session!.expectedPhoneE164).toBe('+15551234567');
-    expect(session!.destinationAddress).toBe('+15551234567');
-    expect(session!.identityBindingStatus).toBe('bound');
-    expect(session!.status).toBe('awaiting_response');
+    expect(session!.expectedPhoneE164).toBe("+15551234567");
+    expect(session!.destinationAddress).toBe("+15551234567");
+    expect(session!.identityBindingStatus).toBe("bound");
+    expect(session!.status).toBe("awaiting_response");
   });
 
-  test('createOutboundSession for telegram with pending_bootstrap status', () => {
+  test("createOutboundSession for telegram with pending_bootstrap status", () => {
     const result = createOutboundSession({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      identityBindingStatus: 'pending_bootstrap',
-      destinationAddress: '@some_handle',
+      assistantId: "asst-1",
+      channel: "telegram",
+      identityBindingStatus: "pending_bootstrap",
+      destinationAddress: "@some_handle",
     });
 
     expect(result.sessionId).toBeDefined();
 
-    const session = serviceFindActiveSession('asst-1', 'telegram');
+    const session = serviceFindActiveSession("asst-1", "telegram");
     expect(session).not.toBeNull();
-    expect(session!.identityBindingStatus).toBe('pending_bootstrap');
-    expect(session!.status).toBe('pending_bootstrap');
+    expect(session!.identityBindingStatus).toBe("pending_bootstrap");
+    expect(session!.status).toBe("pending_bootstrap");
     expect(session!.expectedExternalUserId).toBeNull();
     expect(session!.expectedChatId).toBeNull();
   });
 
   // ── Identity match: right code + right identity → success ──
 
-  test('validateAndConsumeChallenge succeeds with correct secret and matching identity (SMS)', () => {
+  test("validateAndConsumeChallenge succeeds with correct secret and matching identity (SMS)", () => {
     const { secret } = createOutboundSession({
-      assistantId: 'asst-1',
-      channel: 'sms',
-      expectedPhoneE164: '+15551234567',
-      expectedExternalUserId: '+15551234567',
-      destinationAddress: '+15551234567',
+      assistantId: "asst-1",
+      channel: "sms",
+      expectedPhoneE164: "+15551234567",
+      expectedExternalUserId: "+15551234567",
+      destinationAddress: "+15551234567",
     });
 
     const result = validateAndConsumeChallenge(
-      'asst-1', 'sms', secret, '+15551234567', 'sms-chat-1',
+      "asst-1",
+      "sms",
+      secret,
+      "+15551234567",
+      "sms-chat-1",
     );
 
     expect(result.success).toBe(true);
   });
 
-  test('validateAndConsumeChallenge succeeds with correct secret and matching identity (Telegram)', () => {
+  test("validateAndConsumeChallenge succeeds with correct secret and matching identity (Telegram)", () => {
     const { secret } = createOutboundSession({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      expectedExternalUserId: 'tg-user-42',
-      expectedChatId: 'tg-chat-42',
-      destinationAddress: 'tg-chat-42',
+      assistantId: "asst-1",
+      channel: "telegram",
+      expectedExternalUserId: "tg-user-42",
+      expectedChatId: "tg-chat-42",
+      destinationAddress: "tg-chat-42",
     });
 
     const result = validateAndConsumeChallenge(
-      'asst-1', 'telegram', secret, 'tg-user-42', 'tg-chat-42',
+      "asst-1",
+      "telegram",
+      secret,
+      "tg-user-42",
+      "tg-chat-42",
     );
 
     expect(result.success).toBe(true);
@@ -2107,39 +2415,47 @@ describe('outbound verification sessions', () => {
 
   // ── Identity mismatch: right code + wrong identity → reject ──
 
-  test('validateAndConsumeChallenge rejects correct secret with wrong identity (anti-oracle)', () => {
+  test("validateAndConsumeChallenge rejects correct secret with wrong identity (anti-oracle)", () => {
     const { secret } = createOutboundSession({
-      assistantId: 'asst-1',
-      channel: 'sms',
-      expectedPhoneE164: '+15551234567',
-      expectedExternalUserId: '+15551234567',
-      destinationAddress: '+15551234567',
+      assistantId: "asst-1",
+      channel: "sms",
+      expectedPhoneE164: "+15551234567",
+      expectedExternalUserId: "+15551234567",
+      destinationAddress: "+15551234567",
     });
 
     const result = validateAndConsumeChallenge(
-      'asst-1', 'sms', secret, '+15559999999', 'sms-chat-wrong',
+      "asst-1",
+      "sms",
+      secret,
+      "+15559999999",
+      "sms-chat-wrong",
     );
 
     expect(result.success).toBe(false);
     if (!result.success) {
       // Anti-oracle: same generic "invalid or expired" message
-      expect(result.reason.toLowerCase()).toContain('failed');
-      expect(result.reason).not.toContain('identity');
-      expect(result.reason).not.toContain('mismatch');
+      expect(result.reason.toLowerCase()).toContain("failed");
+      expect(result.reason).not.toContain("identity");
+      expect(result.reason).not.toContain("mismatch");
     }
   });
 
-  test('validateAndConsumeChallenge rejects correct secret with wrong Telegram identity', () => {
+  test("validateAndConsumeChallenge rejects correct secret with wrong Telegram identity", () => {
     const { secret } = createOutboundSession({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      expectedExternalUserId: 'tg-user-42',
-      expectedChatId: 'tg-chat-42',
-      destinationAddress: 'tg-chat-42',
+      assistantId: "asst-1",
+      channel: "telegram",
+      expectedExternalUserId: "tg-user-42",
+      expectedChatId: "tg-chat-42",
+      destinationAddress: "tg-chat-42",
     });
 
     const result = validateAndConsumeChallenge(
-      'asst-1', 'telegram', secret, 'tg-user-WRONG', 'tg-chat-WRONG',
+      "asst-1",
+      "telegram",
+      secret,
+      "tg-user-WRONG",
+      "tg-chat-WRONG",
     );
 
     expect(result.success).toBe(false);
@@ -2147,23 +2463,27 @@ describe('outbound verification sessions', () => {
 
   // ── Expired session → reject ──
 
-  test('expired outbound session is rejected', () => {
+  test("expired outbound session is rejected", () => {
     // Create a session directly via the store with an already-expired expiresAt
-    const secret = 'test-expired-session-secret';
-    const challengeHash = createHash('sha256').update(secret).digest('hex');
+    const secret = "test-expired-session-secret";
+    const challengeHash = createHash("sha256").update(secret).digest("hex");
     createVerificationSession({
-      id: 'session-expired',
-      assistantId: 'asst-1',
-      channel: 'sms',
+      id: "session-expired",
+      assistantId: "asst-1",
+      channel: "sms",
       challengeHash,
       expiresAt: Date.now() - 1000,
-      status: 'awaiting_response',
-      expectedPhoneE164: '+15551234567',
-      identityBindingStatus: 'bound',
+      status: "awaiting_response",
+      expectedPhoneE164: "+15551234567",
+      identityBindingStatus: "bound",
     });
 
     const result = validateAndConsumeChallenge(
-      'asst-1', 'sms', secret, '+15551234567', 'sms-chat-1',
+      "asst-1",
+      "sms",
+      secret,
+      "+15551234567",
+      "sms-chat-1",
     );
 
     expect(result.success).toBe(false);
@@ -2171,19 +2491,23 @@ describe('outbound verification sessions', () => {
 
   // ── Revoked session → reject ──
 
-  test('revoked outbound session is rejected', () => {
+  test("revoked outbound session is rejected", () => {
     const { secret, sessionId } = createOutboundSession({
-      assistantId: 'asst-1',
-      channel: 'sms',
-      expectedPhoneE164: '+15551234567',
-      destinationAddress: '+15551234567',
+      assistantId: "asst-1",
+      channel: "sms",
+      expectedPhoneE164: "+15551234567",
+      destinationAddress: "+15551234567",
     });
 
     // Revoke the session
-    serviceUpdateSessionStatus(sessionId, 'revoked');
+    serviceUpdateSessionStatus(sessionId, "revoked");
 
     const result = validateAndConsumeChallenge(
-      'asst-1', 'sms', secret, '+15551234567', 'sms-chat-1',
+      "asst-1",
+      "sms",
+      secret,
+      "+15551234567",
+      "sms-chat-1",
     );
 
     expect(result.success).toBe(false);
@@ -2191,91 +2515,103 @@ describe('outbound verification sessions', () => {
 
   // ── One-time consumption (replay prevention) ──
 
-  test('outbound session cannot be consumed twice (replay prevention)', () => {
+  test("outbound session cannot be consumed twice (replay prevention)", () => {
     const { secret } = createOutboundSession({
-      assistantId: 'asst-1',
-      channel: 'sms',
-      expectedPhoneE164: '+15551234567',
-      expectedExternalUserId: '+15551234567',
-      destinationAddress: '+15551234567',
+      assistantId: "asst-1",
+      channel: "sms",
+      expectedPhoneE164: "+15551234567",
+      expectedExternalUserId: "+15551234567",
+      destinationAddress: "+15551234567",
     });
 
     const result1 = validateAndConsumeChallenge(
-      'asst-1', 'sms', secret, '+15551234567', 'sms-chat-1',
+      "asst-1",
+      "sms",
+      secret,
+      "+15551234567",
+      "sms-chat-1",
     );
     expect(result1.success).toBe(true);
 
     const result2 = validateAndConsumeChallenge(
-      'asst-1', 'sms', secret, '+15551234567', 'sms-chat-1',
+      "asst-1",
+      "sms",
+      secret,
+      "+15551234567",
+      "sms-chat-1",
     );
     expect(result2.success).toBe(false);
   });
 
   // ── Backward compat: existing inbound-only flow still works ──
 
-  test('backward compat: inbound-only challenge without expected identity still works', () => {
-    const { secret } = createVerificationChallenge('asst-1', 'telegram');
+  test("backward compat: inbound-only challenge without expected identity still works", () => {
+    const { secret } = createVerificationChallenge("asst-1", "telegram");
 
     const result = validateAndConsumeChallenge(
-      'asst-1', 'telegram', secret, 'user-42', 'chat-42',
+      "asst-1",
+      "telegram",
+      secret,
+      "user-42",
+      "chat-42",
     );
 
     expect(result.success).toBe(true);
-    if (result.success && result.verificationType === 'guardian') {
+    if (result.success && result.verificationType === "guardian") {
       expect(result.bindingId).toBeDefined();
     }
   });
 
   // ── Session state transitions ──
 
-  test('session state transitions (pending_bootstrap → awaiting_response → verified)', () => {
+  test("session state transitions (pending_bootstrap → awaiting_response → verified)", () => {
     const { sessionId } = createOutboundSession({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      identityBindingStatus: 'pending_bootstrap',
-      destinationAddress: '@some_handle',
+      assistantId: "asst-1",
+      channel: "telegram",
+      identityBindingStatus: "pending_bootstrap",
+      destinationAddress: "@some_handle",
     });
 
-    const initial = serviceFindActiveSession('asst-1', 'telegram');
+    const initial = serviceFindActiveSession("asst-1", "telegram");
     expect(initial).not.toBeNull();
-    expect(initial!.status).toBe('pending_bootstrap');
+    expect(initial!.status).toBe("pending_bootstrap");
 
     // Transition to awaiting_response
-    serviceUpdateSessionStatus(sessionId, 'awaiting_response');
-    const awaiting = storeFindActiveSession('asst-1', 'telegram');
+    serviceUpdateSessionStatus(sessionId, "awaiting_response");
+    const awaiting = storeFindActiveSession("asst-1", "telegram");
     expect(awaiting).not.toBeNull();
-    expect(awaiting!.status).toBe('awaiting_response');
+    expect(awaiting!.status).toBe("awaiting_response");
 
     // Transition to verified
-    serviceUpdateSessionStatus(sessionId, 'verified');
+    serviceUpdateSessionStatus(sessionId, "verified");
     // verified is not an "active" status, so findActiveSession returns null
-    const active = storeFindActiveSession('asst-1', 'telegram');
+    const active = storeFindActiveSession("asst-1", "telegram");
     expect(active).toBeNull();
   });
 
   // ── Auto-revoke of prior sessions ──
 
-  test('creating a new outbound session auto-revokes prior pending/awaiting sessions', () => {
+  test("creating a new outbound session auto-revokes prior pending/awaiting sessions", () => {
     const { sessionId: firstId } = createOutboundSession({
-      assistantId: 'asst-1',
-      channel: 'sms',
-      expectedPhoneE164: '+15551234567',
-      destinationAddress: '+15551234567',
+      assistantId: "asst-1",
+      channel: "sms",
+      expectedPhoneE164: "+15551234567",
+      destinationAddress: "+15551234567",
     });
 
-    const first = serviceFindActiveSession('asst-1', 'sms');
+    const first = serviceFindActiveSession("asst-1", "sms");
     expect(first).not.toBeNull();
     expect(first!.id).toBe(firstId);
 
     // Create a second session — first should be revoked
     const { sessionId: secondId } = createOutboundSession({
-      assistantId: 'asst-1',
-      channel: 'sms',
-      expectedPhoneE164: '+15559876543',
-      destinationAddress: '+15559876543',
+      assistantId: "asst-1",
+      channel: "sms",
+      expectedPhoneE164: "+15559876543",
+      destinationAddress: "+15559876543",
     });
 
-    const second = serviceFindActiveSession('asst-1', 'sms');
+    const second = serviceFindActiveSession("asst-1", "sms");
     expect(second).not.toBeNull();
     expect(second!.id).toBe(secondId);
 
@@ -2287,116 +2623,130 @@ describe('outbound verification sessions', () => {
       .where(eq(channelGuardianVerificationChallenges.id, firstId))
       .get();
     expect(firstRow).toBeDefined();
-    expect(firstRow!.status).toBe('revoked');
+    expect(firstRow!.status).toBe("revoked");
   });
 
   // ── findActiveSession returns correct session ──
 
-  test('findActiveSession returns the most recent active session', () => {
+  test("findActiveSession returns the most recent active session", () => {
     createOutboundSession({
-      assistantId: 'asst-1',
-      channel: 'sms',
-      expectedPhoneE164: '+15551234567',
-      destinationAddress: '+15551234567',
+      assistantId: "asst-1",
+      channel: "sms",
+      expectedPhoneE164: "+15551234567",
+      destinationAddress: "+15551234567",
     });
 
-    const session = serviceFindActiveSession('asst-1', 'sms');
+    const session = serviceFindActiveSession("asst-1", "sms");
     expect(session).not.toBeNull();
-    expect(session!.status).toBe('awaiting_response');
-    expect(session!.expectedPhoneE164).toBe('+15551234567');
+    expect(session!.status).toBe("awaiting_response");
+    expect(session!.expectedPhoneE164).toBe("+15551234567");
   });
 
-  test('findActiveSession returns null when no active session exists', () => {
-    const session = serviceFindActiveSession('asst-1', 'sms');
+  test("findActiveSession returns null when no active session exists", () => {
+    const session = serviceFindActiveSession("asst-1", "sms");
     expect(session).toBeNull();
   });
 
   // ── findSessionByIdentity returns identity-bound session ──
 
-  test('findSessionByIdentity returns session matching phone E164', () => {
+  test("findSessionByIdentity returns session matching phone E164", () => {
     createOutboundSession({
-      assistantId: 'asst-1',
-      channel: 'sms',
-      expectedPhoneE164: '+15551234567',
-      destinationAddress: '+15551234567',
+      assistantId: "asst-1",
+      channel: "sms",
+      expectedPhoneE164: "+15551234567",
+      destinationAddress: "+15551234567",
     });
 
     const session = serviceFindSessionByIdentity(
-      'asst-1', 'sms', undefined, undefined, '+15551234567',
+      "asst-1",
+      "sms",
+      undefined,
+      undefined,
+      "+15551234567",
     );
     expect(session).not.toBeNull();
-    expect(session!.expectedPhoneE164).toBe('+15551234567');
+    expect(session!.expectedPhoneE164).toBe("+15551234567");
   });
 
-  test('findSessionByIdentity returns session matching external user ID', () => {
+  test("findSessionByIdentity returns session matching external user ID", () => {
     createOutboundSession({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      expectedExternalUserId: 'tg-user-42',
-      expectedChatId: 'tg-chat-42',
-      destinationAddress: 'tg-chat-42',
+      assistantId: "asst-1",
+      channel: "telegram",
+      expectedExternalUserId: "tg-user-42",
+      expectedChatId: "tg-chat-42",
+      destinationAddress: "tg-chat-42",
     });
 
     const session = serviceFindSessionByIdentity(
-      'asst-1', 'telegram', 'tg-user-42',
+      "asst-1",
+      "telegram",
+      "tg-user-42",
     );
     expect(session).not.toBeNull();
-    expect(session!.expectedExternalUserId).toBe('tg-user-42');
+    expect(session!.expectedExternalUserId).toBe("tg-user-42");
   });
 
-  test('findSessionByIdentity returns null for non-matching identity', () => {
+  test("findSessionByIdentity returns null for non-matching identity", () => {
     createOutboundSession({
-      assistantId: 'asst-1',
-      channel: 'sms',
-      expectedPhoneE164: '+15551234567',
-      destinationAddress: '+15551234567',
+      assistantId: "asst-1",
+      channel: "sms",
+      expectedPhoneE164: "+15551234567",
+      destinationAddress: "+15551234567",
     });
 
     const session = serviceFindSessionByIdentity(
-      'asst-1', 'sms', undefined, undefined, '+15559999999',
+      "asst-1",
+      "sms",
+      undefined,
+      undefined,
+      "+15559999999",
     );
     expect(session).toBeNull();
   });
 
   // ── bindSessionIdentity transitions from pending_bootstrap to bound ──
 
-  test('bindSessionIdentity transitions from pending_bootstrap to bound', () => {
+  test("bindSessionIdentity transitions from pending_bootstrap to bound", () => {
     const { sessionId } = createOutboundSession({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      identityBindingStatus: 'pending_bootstrap',
-      destinationAddress: '@some_handle',
+      assistantId: "asst-1",
+      channel: "telegram",
+      identityBindingStatus: "pending_bootstrap",
+      destinationAddress: "@some_handle",
     });
 
-    const before = serviceFindActiveSession('asst-1', 'telegram');
+    const before = serviceFindActiveSession("asst-1", "telegram");
     expect(before).not.toBeNull();
-    expect(before!.identityBindingStatus).toBe('pending_bootstrap');
+    expect(before!.identityBindingStatus).toBe("pending_bootstrap");
     expect(before!.expectedExternalUserId).toBeNull();
     expect(before!.expectedChatId).toBeNull();
 
     // Bind the identity
-    serviceBindSessionIdentity(sessionId, 'tg-user-42', 'tg-chat-42');
+    serviceBindSessionIdentity(sessionId, "tg-user-42", "tg-chat-42");
 
-    const after = storeFindActiveSession('asst-1', 'telegram');
+    const after = storeFindActiveSession("asst-1", "telegram");
     expect(after).not.toBeNull();
-    expect(after!.identityBindingStatus).toBe('bound');
-    expect(after!.expectedExternalUserId).toBe('tg-user-42');
-    expect(after!.expectedChatId).toBe('tg-chat-42');
+    expect(after!.identityBindingStatus).toBe("bound");
+    expect(after!.expectedExternalUserId).toBe("tg-user-42");
+    expect(after!.expectedChatId).toBe("tg-chat-42");
   });
 
   // ── pending_bootstrap allows consumption without identity check ──
 
-  test('pending_bootstrap session allows consumption without identity check', () => {
+  test("pending_bootstrap session allows consumption without identity check", () => {
     const { secret } = createOutboundSession({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      identityBindingStatus: 'pending_bootstrap',
-      destinationAddress: '@some_handle',
+      assistantId: "asst-1",
+      channel: "telegram",
+      identityBindingStatus: "pending_bootstrap",
+      destinationAddress: "@some_handle",
     });
 
     // Any actor can consume during pending_bootstrap
     const result = validateAndConsumeChallenge(
-      'asst-1', 'telegram', secret, 'any-user', 'any-chat',
+      "asst-1",
+      "telegram",
+      secret,
+      "any-user",
+      "any-chat",
     );
 
     expect(result.success).toBe(true);
@@ -2404,18 +2754,18 @@ describe('outbound verification sessions', () => {
 
   // ── Delivery tracking ──
 
-  test('updateSessionDelivery updates delivery tracking fields', () => {
+  test("updateSessionDelivery updates delivery tracking fields", () => {
     const { sessionId } = createOutboundSession({
-      assistantId: 'asst-1',
-      channel: 'sms',
-      expectedPhoneE164: '+15551234567',
-      destinationAddress: '+15551234567',
+      assistantId: "asst-1",
+      channel: "sms",
+      expectedPhoneE164: "+15551234567",
+      destinationAddress: "+15551234567",
     });
 
     const now = Date.now();
     storeUpdateSessionDelivery(sessionId, now, 1, now + 30_000);
 
-    const session = serviceFindActiveSession('asst-1', 'sms');
+    const session = serviceFindActiveSession("asst-1", "sms");
     expect(session).not.toBeNull();
     expect(session!.lastSentAt).toBe(now);
     expect(session!.sendCount).toBe(1);
@@ -2424,17 +2774,21 @@ describe('outbound verification sessions', () => {
 
   // ── Telegram identity match via chatId ──
 
-  test('Telegram identity match succeeds via chatId alone', () => {
+  test("Telegram identity match succeeds via chatId alone", () => {
     const { secret } = createOutboundSession({
-      assistantId: 'asst-1',
-      channel: 'telegram',
-      expectedChatId: 'tg-chat-42',
-      destinationAddress: 'tg-chat-42',
+      assistantId: "asst-1",
+      channel: "telegram",
+      expectedChatId: "tg-chat-42",
+      destinationAddress: "tg-chat-42",
     });
 
     // Actor has a different external user ID but matching chat ID
     const result = validateAndConsumeChallenge(
-      'asst-1', 'telegram', secret, 'tg-user-DIFFERENT', 'tg-chat-42',
+      "asst-1",
+      "telegram",
+      secret,
+      "tg-user-DIFFERENT",
+      "tg-chat-42",
     );
 
     expect(result.success).toBe(true);
@@ -2442,18 +2796,22 @@ describe('outbound verification sessions', () => {
 
   // ── SMS identity match via expectedExternalUserId ──
 
-  test('SMS identity match succeeds via expectedExternalUserId', () => {
+  test("SMS identity match succeeds via expectedExternalUserId", () => {
     const { secret } = createOutboundSession({
-      assistantId: 'asst-1',
-      channel: 'sms',
-      expectedExternalUserId: 'sms-user-42',
-      expectedPhoneE164: '+15551234567',
-      destinationAddress: '+15551234567',
+      assistantId: "asst-1",
+      channel: "sms",
+      expectedExternalUserId: "sms-user-42",
+      expectedPhoneE164: "+15551234567",
+      destinationAddress: "+15551234567",
     });
 
     // Actor matches expectedExternalUserId
     const result = validateAndConsumeChallenge(
-      'asst-1', 'sms', secret, 'sms-user-42', 'sms-chat-1',
+      "asst-1",
+      "sms",
+      secret,
+      "sms-user-42",
+      "sms-chat-1",
     );
 
     expect(result.success).toBe(true);
@@ -2464,18 +2822,18 @@ describe('outbound verification sessions', () => {
 // 18. Outbound SMS Verification (IPC Handlers)
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('outbound SMS verification', () => {
+describe("outbound SMS verification", () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('start_outbound creates session with expected E.164 identity and returns code', () => {
+  test("start_outbound creates session with expected E.164 identity and returns code", () => {
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'sms',
-      destination: '+15551234567',
+      type: "guardian_verification",
+      action: "start_outbound",
+      channel: "sms",
+      destination: "+15551234567",
     };
 
     handleGuardianVerification(msg, mockSocket, ctx);
@@ -2488,30 +2846,30 @@ describe('outbound SMS verification', () => {
     expect(resp!.expiresAt).toBeGreaterThan(Date.now());
     expect(resp!.nextResendAt).toBeGreaterThan(Date.now());
     expect(resp!.sendCount).toBe(1);
-    expect(resp!.channel).toBe('sms');
+    expect(resp!.channel).toBe("sms");
 
     // Verify the session was created with expected identity
-    const session = serviceFindActiveSession('self', 'sms');
+    const session = serviceFindActiveSession("self", "sms");
     expect(session).not.toBeNull();
-    expect(session!.expectedPhoneE164).toBe('+15551234567');
-    expect(session!.destinationAddress).toBe('+15551234567');
+    expect(session!.expectedPhoneE164).toBe("+15551234567");
+    expect(session!.destinationAddress).toBe("+15551234567");
   });
 
-  test('start_outbound rejects when active binding exists (rebind=false)', () => {
+  test("start_outbound rejects when active binding exists (rebind=false)", () => {
     // Create an existing guardian binding
     createBinding({
-      assistantId: 'self',
-      channel: 'sms',
-      guardianExternalUserId: '+15551234567',
-      guardianDeliveryChatId: 'sms-chat-1',
+      assistantId: "self",
+      channel: "sms",
+      guardianExternalUserId: "+15551234567",
+      guardianDeliveryChatId: "sms-chat-1",
     });
 
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'sms',
-      destination: '+15559876543',
+      type: "guardian_verification",
+      action: "start_outbound",
+      channel: "sms",
+      destination: "+15559876543",
       rebind: false,
     };
 
@@ -2520,24 +2878,24 @@ describe('outbound SMS verification', () => {
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe('already_bound');
+    expect(resp!.error).toBe("already_bound");
   });
 
-  test('start_outbound allows rebind when rebind=true', () => {
+  test("start_outbound allows rebind when rebind=true", () => {
     // Create an existing guardian binding
     createBinding({
-      assistantId: 'self',
-      channel: 'sms',
-      guardianExternalUserId: '+15551234567',
-      guardianDeliveryChatId: 'sms-chat-1',
+      assistantId: "self",
+      channel: "sms",
+      guardianExternalUserId: "+15551234567",
+      guardianDeliveryChatId: "sms-chat-1",
     });
 
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'sms',
-      destination: '+15559876543',
+      type: "guardian_verification",
+      action: "start_outbound",
+      channel: "sms",
+      destination: "+15559876543",
       rebind: true,
     };
 
@@ -2549,55 +2907,76 @@ describe('outbound SMS verification', () => {
     expect(resp!.verificationSessionId).toBeDefined();
   });
 
-  test('resend_outbound before cooldown is rejected', () => {
+  test("resend_outbound before cooldown is rejected", () => {
     // Start an outbound session first
     const { ctx: startCtx } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'sms',
-      destination: '+15551234567',
-    }, mockSocket, startCtx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "sms",
+        destination: "+15551234567",
+      },
+      mockSocket,
+      startCtx,
+    );
 
     // Immediately try to resend (before cooldown)
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'resend_outbound',
-      channel: 'sms',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "resend_outbound",
+        channel: "sms",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe('rate_limited');
+    expect(resp!.error).toBe("rate_limited");
   });
 
-  test('resend_outbound after cooldown succeeds and increments sendCount', () => {
+  test("resend_outbound after cooldown succeeds and increments sendCount", () => {
     // Start an outbound session
     const { ctx: startCtx, lastResponse: startResp } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'sms',
-      destination: '+15551234567',
-    }, mockSocket, startCtx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "sms",
+        destination: "+15551234567",
+      },
+      mockSocket,
+      startCtx,
+    );
 
     const startResponse = startResp();
     expect(startResponse!.success).toBe(true);
 
     // Manually update the session's nextResendAt to the past to simulate cooldown elapsed
-    const session = serviceFindActiveSession('self', 'sms');
+    const session = serviceFindActiveSession("self", "sms");
     expect(session).not.toBeNull();
-    storeUpdateSessionDelivery(session!.id, Date.now() - RESEND_COOLDOWN_MS - 1000, 1, Date.now() - 1000);
+    storeUpdateSessionDelivery(
+      session!.id,
+      Date.now() - RESEND_COOLDOWN_MS - 1000,
+      1,
+      Date.now() - 1000,
+    );
 
     // Now resend should succeed
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'resend_outbound',
-      channel: 'sms',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "resend_outbound",
+        channel: "sms",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -2606,18 +2985,22 @@ describe('outbound SMS verification', () => {
     expect(resp!.nextResendAt).toBeGreaterThan(Date.now());
   });
 
-  test('resend_outbound exceeding max sends is rejected', () => {
+  test("resend_outbound exceeding max sends is rejected", () => {
     // Start an outbound session
     const { ctx: startCtx } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'sms',
-      destination: '+15551234567',
-    }, mockSocket, startCtx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "sms",
+        destination: "+15551234567",
+      },
+      mockSocket,
+      startCtx,
+    );
 
     // Set the send count to MAX_SENDS_PER_SESSION and nextResendAt to the past
-    const session = serviceFindActiveSession('self', 'sms');
+    const session = serviceFindActiveSession("self", "sms");
     expect(session).not.toBeNull();
     storeUpdateSessionDelivery(
       session!.id,
@@ -2628,176 +3011,212 @@ describe('outbound SMS verification', () => {
 
     // Resend should be rejected due to max sends
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'resend_outbound',
-      channel: 'sms',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "resend_outbound",
+        channel: "sms",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe('max_sends_exceeded');
+    expect(resp!.error).toBe("max_sends_exceeded");
   });
 
-  test('cancel_outbound revokes active session', () => {
+  test("cancel_outbound revokes active session", () => {
     // Start an outbound session
     const { ctx: startCtx } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'sms',
-      destination: '+15551234567',
-    }, mockSocket, startCtx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "sms",
+        destination: "+15551234567",
+      },
+      mockSocket,
+      startCtx,
+    );
 
     // Verify session exists
-    const sessionBefore = serviceFindActiveSession('self', 'sms');
+    const sessionBefore = serviceFindActiveSession("self", "sms");
     expect(sessionBefore).not.toBeNull();
 
     // Cancel it
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'cancel_outbound',
-      channel: 'sms',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "cancel_outbound",
+        channel: "sms",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(true);
-    expect(resp!.channel).toBe('sms');
+    expect(resp!.channel).toBe("sms");
 
     // Verify session is no longer active
-    const sessionAfter = serviceFindActiveSession('self', 'sms');
+    const sessionAfter = serviceFindActiveSession("self", "sms");
     expect(sessionAfter).toBeNull();
   });
 
-  test('inbound SMS from expected identity + correct code succeeds', () => {
+  test("inbound SMS from expected identity + correct code succeeds", () => {
     // Create an outbound session
     const { secret } = createOutboundSession({
-      assistantId: 'self',
-      channel: 'sms',
-      expectedPhoneE164: '+15551234567',
-      expectedExternalUserId: '+15551234567',
-      destinationAddress: '+15551234567',
+      assistantId: "self",
+      channel: "sms",
+      expectedPhoneE164: "+15551234567",
+      expectedExternalUserId: "+15551234567",
+      destinationAddress: "+15551234567",
     });
 
     // Validate with matching identity
     const result = validateAndConsumeChallenge(
-      'self', 'sms', secret, '+15551234567', 'sms-chat-1',
+      "self",
+      "sms",
+      secret,
+      "+15551234567",
+      "sms-chat-1",
     );
 
     expect(result.success).toBe(true);
     if (result.success) {
       // Guardian outbound sessions (no verificationPurpose override) create
       // guardian bindings on success
-      expect(result.verificationType).toBe('guardian');
-      if (result.verificationType === 'guardian') {
+      expect(result.verificationType).toBe("guardian");
+      if (result.verificationType === "guardian") {
         expect(result.bindingId).toBeDefined();
       }
     }
   });
 
-  test('inbound SMS from wrong identity + correct code is rejected', () => {
+  test("inbound SMS from wrong identity + correct code is rejected", () => {
     // Create an outbound session with expected identity +15551234567
     const { secret } = createOutboundSession({
-      assistantId: 'self',
-      channel: 'sms',
-      expectedPhoneE164: '+15551234567',
-      expectedExternalUserId: '+15551234567',
-      destinationAddress: '+15551234567',
+      assistantId: "self",
+      channel: "sms",
+      expectedPhoneE164: "+15551234567",
+      expectedExternalUserId: "+15551234567",
+      destinationAddress: "+15551234567",
     });
 
     // Try to validate with a different phone number (anti-oracle: same generic error)
     const result = validateAndConsumeChallenge(
-      'self', 'sms', secret, '+15559999999', 'sms-chat-wrong',
+      "self",
+      "sms",
+      secret,
+      "+15559999999",
+      "sms-chat-wrong",
     );
 
     expect(result.success).toBe(false);
     if (!result.success) {
       // Anti-oracle: generic failure message, no identity-specific info leaked
-      expect(result.reason.toLowerCase()).toContain('failed');
-      expect(result.reason).not.toContain('identity');
-      expect(result.reason).not.toContain('mismatch');
+      expect(result.reason.toLowerCase()).toContain("failed");
+      expect(result.reason).not.toContain("identity");
+      expect(result.reason).not.toContain("mismatch");
     }
   });
 
-  test('template composer returns expected SMS format', () => {
+  test("template composer returns expected SMS format", () => {
     const challengeSms = composeVerificationSms(
       GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST,
-      { code: '123456', expiresInMinutes: 10 },
+      { code: "123456", expiresInMinutes: 10 },
     );
     // Code should NOT appear in the message — user sees it in the app
-    expect(challengeSms).not.toContain('123456');
-    expect(challengeSms).toContain('code you were given');
+    expect(challengeSms).not.toContain("123456");
+    expect(challengeSms).toContain("code you were given");
 
     const resendSms = composeVerificationSms(
       GUARDIAN_VERIFY_TEMPLATE_KEYS.RESEND,
-      { code: 'ABCDEF', expiresInMinutes: 5 },
+      { code: "ABCDEF", expiresInMinutes: 5 },
     );
-    expect(resendSms).not.toContain('ABCDEF');
-    expect(resendSms).toContain('resent');
+    expect(resendSms).not.toContain("ABCDEF");
+    expect(resendSms).toContain("resent");
 
     const alreadySms = composeVerificationSms(
       GUARDIAN_VERIFY_TEMPLATE_KEYS.ALREADY_VERIFIED,
-      { code: 'unused', expiresInMinutes: 0 },
+      { code: "unused", expiresInMinutes: 0 },
     );
-    expect(alreadySms).toContain('already verified');
+    expect(alreadySms).toContain("already verified");
   });
 
-  test('start_outbound rejects unsupported channels', () => {
+  test("start_outbound rejects unsupported channels", () => {
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'slack',
-      destination: '@some_user',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "email",
+        destination: "user@example.com",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe('unsupported_channel');
+    expect(resp!.error).toBe("unsupported_channel");
   });
 
-  test('start_outbound rejects missing destination', () => {
+  test("start_outbound rejects missing destination", () => {
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'sms',
-      // no destination
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "sms",
+        // no destination
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe('missing_destination');
+    expect(resp!.error).toBe("missing_destination");
   });
 
-  test('start_outbound rejects unparseable phone number', () => {
+  test("start_outbound rejects unparseable phone number", () => {
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'sms',
-      destination: 'not-a-phone',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "sms",
+        destination: "not-a-phone",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe('invalid_destination');
+    expect(resp!.error).toBe("invalid_destination");
   });
 
-  test('start_outbound normalizes formatted phone number for SMS', async () => {
+  test("start_outbound normalizes formatted phone number for SMS", async () => {
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'sms',
-      destination: '(555) 123-4567',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "sms",
+        destination: "(555) 123-4567",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -2806,10 +3225,10 @@ describe('outbound SMS verification', () => {
     expect(resp!.secret).toBeDefined();
 
     // Verify the session was created with the normalized E.164 number
-    const session = serviceFindActiveSession('self', 'sms');
+    const session = serviceFindActiveSession("self", "sms");
     expect(session).not.toBeNull();
-    expect(session!.expectedPhoneE164).toBe('+15551234567');
-    expect(session!.destinationAddress).toBe('+15551234567');
+    expect(session!.expectedPhoneE164).toBe("+15551234567");
+    expect(session!.destinationAddress).toBe("+15551234567");
 
     // Allow fire-and-forget SMS delivery to complete
     await new Promise((resolve) => setTimeout(resolve, 50));
@@ -2817,31 +3236,35 @@ describe('outbound SMS verification', () => {
     // Verify SMS was sent to the normalized number
     expect(smsSendCalls.length).toBeGreaterThanOrEqual(1);
     const lastSms = smsSendCalls[smsSendCalls.length - 1];
-    expect(lastSms.to).toBe('+15551234567');
+    expect(lastSms.to).toBe("+15551234567");
   });
 
-  test('template composer includes Vellum assistant prefix', () => {
+  test("template composer includes Vellum assistant prefix", () => {
     const sms = composeVerificationSms(
       GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST,
-      { code: '999999', expiresInMinutes: 10, assistantName: 'MyBot' },
+      { code: "999999", expiresInMinutes: 10, assistantName: "MyBot" },
     );
-    expect(sms).toContain('Vellum assistant');
+    expect(sms).toContain("Vellum assistant");
     // Code should NOT appear in the message
-    expect(sms).not.toContain('999999');
+    expect(sms).not.toContain("999999");
   });
 
-  test('cancel_outbound returns error when no active session', () => {
+  test("cancel_outbound returns error when no active session", () => {
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'cancel_outbound',
-      channel: 'sms',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "cancel_outbound",
+        channel: "sms",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe('no_active_session');
+    expect(resp!.error).toBe("no_active_session");
   });
 });
 
@@ -2849,64 +3272,80 @@ describe('outbound SMS verification', () => {
 // 19. Outbound Telegram Verification
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('outbound Telegram verification', () => {
+describe("outbound Telegram verification", () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('start_outbound for telegram with handle returns deep link URL, no outbound message', () => {
+  test("start_outbound for telegram with handle returns deep link URL, no outbound message", () => {
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'telegram',
-      destination: '@someuser',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "telegram",
+        destination: "@someuser",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(true);
     expect(resp!.verificationSessionId).toBeDefined();
     expect(resp!.telegramBootstrapUrl).toBeDefined();
-    expect(resp!.telegramBootstrapUrl).toContain('https://t.me/test_bot?start=gv_');
-    expect(resp!.channel).toBe('telegram');
+    expect(resp!.telegramBootstrapUrl).toContain(
+      "https://t.me/test_bot?start=gv_",
+    );
+    expect(resp!.channel).toBe("telegram");
     // No outbound message should be sent yet (pending bootstrap)
     expect(telegramDeliverCalls.length).toBe(0);
 
     // Verify the session is in pending_bootstrap state
-    const session = serviceFindActiveSession('self', 'telegram');
+    const session = serviceFindActiveSession("self", "telegram");
     expect(session).not.toBeNull();
-    expect(session!.identityBindingStatus).toBe('pending_bootstrap');
+    expect(session!.identityBindingStatus).toBe("pending_bootstrap");
     // destinationAddress is normalized: '@' stripped and lowercased
-    expect(session!.destinationAddress).toBe('someuser');
+    expect(session!.destinationAddress).toBe("someuser");
     expect(session!.bootstrapTokenHash).toBeDefined();
     expect(session!.bootstrapTokenHash).not.toBeNull();
   });
 
-  test('start_outbound for telegram with handle (no @ prefix) returns deep link', () => {
+  test("start_outbound for telegram with handle (no @ prefix) returns deep link", () => {
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'telegram',
-      destination: 'someuser',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "telegram",
+        destination: "someuser",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(true);
-    expect(resp!.telegramBootstrapUrl).toContain('https://t.me/test_bot?start=gv_');
+    expect(resp!.telegramBootstrapUrl).toContain(
+      "https://t.me/test_bot?start=gv_",
+    );
     expect(telegramDeliverCalls.length).toBe(0);
   });
 
-  test('start_outbound for telegram with known chat ID sends message, no deep link', async () => {
+  test("start_outbound for telegram with known chat ID sends message, no deep link", async () => {
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'telegram',
-      destination: '123456789',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "telegram",
+        destination: "123456789",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -2916,238 +3355,259 @@ describe('outbound Telegram verification', () => {
     expect(resp!.expiresAt).toBeGreaterThan(Date.now());
     expect(resp!.nextResendAt).toBeGreaterThan(Date.now());
     expect(resp!.sendCount).toBe(1);
-    expect(resp!.channel).toBe('telegram');
+    expect(resp!.channel).toBe("telegram");
     // No bootstrap URL since this is a direct chat ID
     expect(resp!.telegramBootstrapUrl).toBeUndefined();
 
     // Verify the session was created with expected identity
-    const session = serviceFindActiveSession('self', 'telegram');
+    const session = serviceFindActiveSession("self", "telegram");
     expect(session).not.toBeNull();
-    expect(session!.expectedChatId).toBe('123456789');
-    expect(session!.identityBindingStatus).toBe('bound');
-    expect(session!.destinationAddress).toBe('123456789');
+    expect(session!.expectedChatId).toBe("123456789");
+    expect(session!.identityBindingStatus).toBe("bound");
+    expect(session!.destinationAddress).toBe("123456789");
 
     // Allow async telegram delivery to settle
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(telegramDeliverCalls.length).toBe(1);
-    expect(telegramDeliverCalls[0].chatId).toBe('123456789');
-    expect(telegramDeliverCalls[0].text).toContain('code you were given');
+    expect(telegramDeliverCalls[0].chatId).toBe("123456789");
+    expect(telegramDeliverCalls[0].text).toContain("code you were given");
   });
 
-  test('start_outbound for telegram without bot username fails', () => {
+  test("start_outbound for telegram without bot username fails", () => {
     mockBotUsername = undefined;
 
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'telegram',
-      destination: '@someuser',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "telegram",
+        destination: "@someuser",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe('no_bot_username');
+    expect(resp!.error).toBe("no_bot_username");
   });
 
-  test('start_outbound for telegram rejects when active binding exists (rebind=false)', () => {
+  test("start_outbound for telegram rejects when active binding exists (rebind=false)", () => {
     createBinding({
-      assistantId: 'self',
-      channel: 'telegram',
-      guardianExternalUserId: 'user-42',
-      guardianDeliveryChatId: 'chat-42',
+      assistantId: "self",
+      channel: "telegram",
+      guardianExternalUserId: "user-42",
+      guardianDeliveryChatId: "chat-42",
     });
 
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'telegram',
-      destination: '@newuser',
-      rebind: false,
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "telegram",
+        destination: "@newuser",
+        rebind: false,
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe('already_bound');
+    expect(resp!.error).toBe("already_bound");
   });
 
-  test('bootstrap: resolveBootstrapToken finds pending_bootstrap session by token', async () => {
-    const { createHash } = await import('node:crypto');
-    const token = 'test_bootstrap_token_hex';
-    const tokenHash = createHash('sha256').update(token).digest('hex');
+  test("bootstrap: resolveBootstrapToken finds pending_bootstrap session by token", async () => {
+    const { createHash } = await import("node:crypto");
+    const token = "test_bootstrap_token_hex";
+    const tokenHash = createHash("sha256").update(token).digest("hex");
 
     createVerificationSession({
-      id: 'session-bootstrap-1',
-      assistantId: 'self',
-      channel: 'telegram',
-      challengeHash: 'some-challenge-hash',
+      id: "session-bootstrap-1",
+      assistantId: "self",
+      channel: "telegram",
+      challengeHash: "some-challenge-hash",
       expiresAt: Date.now() + 600_000,
-      status: 'pending_bootstrap',
-      identityBindingStatus: 'pending_bootstrap',
-      destinationAddress: '@targetuser',
+      status: "pending_bootstrap",
+      identityBindingStatus: "pending_bootstrap",
+      destinationAddress: "@targetuser",
       bootstrapTokenHash: tokenHash,
     });
 
-    const found = resolveBootstrapToken('self', 'telegram', token);
+    const found = resolveBootstrapToken("self", "telegram", token);
     expect(found).not.toBeNull();
-    expect(found!.id).toBe('session-bootstrap-1');
-    expect(found!.status).toBe('pending_bootstrap');
+    expect(found!.id).toBe("session-bootstrap-1");
+    expect(found!.status).toBe("pending_bootstrap");
   });
 
-  test('bootstrap: resolveBootstrapToken returns null for wrong token', async () => {
-    const { createHash } = await import('node:crypto');
-    const token = 'test_bootstrap_token_hex';
-    const tokenHash = createHash('sha256').update(token).digest('hex');
+  test("bootstrap: resolveBootstrapToken returns null for wrong token", async () => {
+    const { createHash } = await import("node:crypto");
+    const token = "test_bootstrap_token_hex";
+    const tokenHash = createHash("sha256").update(token).digest("hex");
 
     createVerificationSession({
-      id: 'session-bootstrap-2',
-      assistantId: 'self',
-      channel: 'telegram',
-      challengeHash: 'some-challenge-hash',
+      id: "session-bootstrap-2",
+      assistantId: "self",
+      channel: "telegram",
+      challengeHash: "some-challenge-hash",
       expiresAt: Date.now() + 600_000,
-      status: 'pending_bootstrap',
-      identityBindingStatus: 'pending_bootstrap',
-      destinationAddress: '@targetuser',
+      status: "pending_bootstrap",
+      identityBindingStatus: "pending_bootstrap",
+      destinationAddress: "@targetuser",
       bootstrapTokenHash: tokenHash,
     });
 
-    const found = resolveBootstrapToken('self', 'telegram', 'wrong_token');
+    const found = resolveBootstrapToken("self", "telegram", "wrong_token");
     expect(found).toBeNull();
   });
 
-  test('bootstrap: resolveBootstrapToken returns null for expired session', async () => {
-    const { createHash } = await import('node:crypto');
-    const token = 'test_bootstrap_token_hex';
-    const tokenHash = createHash('sha256').update(token).digest('hex');
+  test("bootstrap: resolveBootstrapToken returns null for expired session", async () => {
+    const { createHash } = await import("node:crypto");
+    const token = "test_bootstrap_token_hex";
+    const tokenHash = createHash("sha256").update(token).digest("hex");
 
     createVerificationSession({
-      id: 'session-bootstrap-3',
-      assistantId: 'self',
-      channel: 'telegram',
-      challengeHash: 'some-challenge-hash',
+      id: "session-bootstrap-3",
+      assistantId: "self",
+      channel: "telegram",
+      challengeHash: "some-challenge-hash",
       expiresAt: Date.now() - 1000, // already expired
-      status: 'pending_bootstrap',
-      identityBindingStatus: 'pending_bootstrap',
-      destinationAddress: '@targetuser',
+      status: "pending_bootstrap",
+      identityBindingStatus: "pending_bootstrap",
+      destinationAddress: "@targetuser",
       bootstrapTokenHash: tokenHash,
     });
 
-    const found = resolveBootstrapToken('self', 'telegram', token);
+    const found = resolveBootstrapToken("self", "telegram", token);
     expect(found).toBeNull();
   });
 
-  test('identity-bound consume: right chat_id + right code succeeds', () => {
+  test("identity-bound consume: right chat_id + right code succeeds", () => {
     // Create an awaiting_response session with expected identity
     const sessionResult = createOutboundSession({
-      assistantId: 'self',
-      channel: 'telegram',
-      expectedExternalUserId: 'user-42',
-      expectedChatId: 'chat-42',
-      identityBindingStatus: 'bound',
-      destinationAddress: 'chat-42',
+      assistantId: "self",
+      channel: "telegram",
+      expectedExternalUserId: "user-42",
+      expectedChatId: "chat-42",
+      identityBindingStatus: "bound",
+      destinationAddress: "chat-42",
     });
 
     const result = validateAndConsumeChallenge(
-      'self',
-      'telegram',
+      "self",
+      "telegram",
       sessionResult.secret,
-      'user-42',
-      'chat-42',
-      'testuser',
-      'Test User',
+      "user-42",
+      "chat-42",
+      "testuser",
+      "Test User",
     );
 
     expect(result.success).toBe(true);
   });
 
-  test('identity mismatch: wrong chat_id + right code rejects', () => {
+  test("identity mismatch: wrong chat_id + right code rejects", () => {
     const sessionResult = createOutboundSession({
-      assistantId: 'self',
-      channel: 'telegram',
-      expectedExternalUserId: 'user-42',
-      expectedChatId: 'chat-42',
-      identityBindingStatus: 'bound',
-      destinationAddress: 'chat-42',
+      assistantId: "self",
+      channel: "telegram",
+      expectedExternalUserId: "user-42",
+      expectedChatId: "chat-42",
+      identityBindingStatus: "bound",
+      destinationAddress: "chat-42",
     });
 
     const result = validateAndConsumeChallenge(
-      'self',
-      'telegram',
+      "self",
+      "telegram",
       sessionResult.secret,
-      'attacker-99',
-      'attacker-chat-99',
-      'attacker',
-      'Attacker',
+      "attacker-99",
+      "attacker-chat-99",
+      "attacker",
+      "Attacker",
     );
 
     expect(result.success).toBe(false);
   });
 
-  test('revoked session rejects verification', () => {
+  test("revoked session rejects verification", () => {
     const sessionResult = createOutboundSession({
-      assistantId: 'self',
-      channel: 'telegram',
-      expectedExternalUserId: 'user-42',
-      expectedChatId: 'chat-42',
-      identityBindingStatus: 'bound',
-      destinationAddress: 'chat-42',
+      assistantId: "self",
+      channel: "telegram",
+      expectedExternalUserId: "user-42",
+      expectedChatId: "chat-42",
+      identityBindingStatus: "bound",
+      destinationAddress: "chat-42",
     });
 
     // Revoke the session
-    serviceUpdateSessionStatus(sessionResult.sessionId, 'revoked');
+    serviceUpdateSessionStatus(sessionResult.sessionId, "revoked");
 
     const result = validateAndConsumeChallenge(
-      'self',
-      'telegram',
+      "self",
+      "telegram",
       sessionResult.secret,
-      'user-42',
-      'chat-42',
+      "user-42",
+      "chat-42",
     );
 
     expect(result.success).toBe(false);
   });
 
-  test('inbound-only Telegram verification flow still works with bare code', () => {
+  test("inbound-only Telegram verification flow still works with bare code", () => {
     // Create an inbound-only challenge (no outbound session, no expected identity)
-    const challengeResult = createVerificationChallenge('self', 'telegram');
+    const challengeResult = createVerificationChallenge("self", "telegram");
 
     const result = validateAndConsumeChallenge(
-      'self',
-      'telegram',
+      "self",
+      "telegram",
       challengeResult.secret,
-      'user-42',
-      'chat-42',
-      'testuser',
-      'Test User',
+      "user-42",
+      "chat-42",
+      "testuser",
+      "Test User",
     );
 
     expect(result.success).toBe(true);
   });
 
-  test('resend_outbound for telegram works with known chat ID', async () => {
+  test("resend_outbound for telegram works with known chat ID", async () => {
     // Start an outbound session with a known chat ID
     const { ctx: startCtx } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'telegram',
-      destination: '123456789',
-    }, mockSocket, startCtx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "telegram",
+        destination: "123456789",
+      },
+      mockSocket,
+      startCtx,
+    );
 
     // Fast-forward the cooldown
-    const session = serviceFindActiveSession('self', 'telegram');
+    const session = serviceFindActiveSession("self", "telegram");
     expect(session).not.toBeNull();
-    storeUpdateSessionDelivery(session!.id, Date.now() - RESEND_COOLDOWN_MS - 1000, 1, Date.now() - 1000);
+    storeUpdateSessionDelivery(
+      session!.id,
+      Date.now() - RESEND_COOLDOWN_MS - 1000,
+      1,
+      Date.now() - 1000,
+    );
 
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'resend_outbound',
-      channel: 'telegram',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "resend_outbound",
+        channel: "telegram",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -3160,112 +3620,136 @@ describe('outbound Telegram verification', () => {
     expect(telegramDeliverCalls.length).toBeGreaterThanOrEqual(2);
   });
 
-  test('resend_outbound for pending_bootstrap session is rejected', () => {
+  test("resend_outbound for pending_bootstrap session is rejected", () => {
     // Start an outbound session with a handle (pending_bootstrap)
     const { ctx: startCtx } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'telegram',
-      destination: '@someuser',
-    }, mockSocket, startCtx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "telegram",
+        destination: "@someuser",
+      },
+      mockSocket,
+      startCtx,
+    );
 
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'resend_outbound',
-      channel: 'telegram',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "resend_outbound",
+        channel: "telegram",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe('pending_bootstrap');
+    expect(resp!.error).toBe("pending_bootstrap");
   });
 
-  test('cancel_outbound for telegram revokes session', () => {
+  test("cancel_outbound for telegram revokes session", () => {
     // Start an outbound session
     const { ctx: startCtx } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'telegram',
-      destination: '123456789',
-    }, mockSocket, startCtx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "telegram",
+        destination: "123456789",
+      },
+      mockSocket,
+      startCtx,
+    );
 
-    const session = serviceFindActiveSession('self', 'telegram');
+    const session = serviceFindActiveSession("self", "telegram");
     expect(session).not.toBeNull();
 
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'cancel_outbound',
-      channel: 'telegram',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "cancel_outbound",
+        channel: "telegram",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(true);
 
     // Session should be revoked
-    const revoked = serviceFindActiveSession('self', 'telegram');
+    const revoked = serviceFindActiveSession("self", "telegram");
     expect(revoked).toBeNull();
   });
 
-  test('telegram template does not include verification code in message', () => {
+  test("telegram template does not include verification code in message", () => {
     const msg = composeVerificationTelegram(
       GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST,
-      { code: 'abc123', expiresInMinutes: 10 },
+      { code: "abc123", expiresInMinutes: 10 },
     );
-    expect(msg).not.toContain('abc123');
-    expect(msg).not.toContain('guardian_verify');
+    expect(msg).not.toContain("abc123");
+    expect(msg).not.toContain("guardian_verify");
   });
 
-  test('telegram resend template does not include code and includes (resent) suffix', () => {
+  test("telegram resend template does not include code and includes (resent) suffix", () => {
     const msg = composeVerificationTelegram(
       GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_RESEND,
-      { code: 'xyz789', expiresInMinutes: 5 },
+      { code: "xyz789", expiresInMinutes: 5 },
     );
-    expect(msg).not.toContain('xyz789');
-    expect(msg).not.toContain('guardian_verify');
-    expect(msg).toContain('(resent)');
+    expect(msg).not.toContain("xyz789");
+    expect(msg).not.toContain("guardian_verify");
+    expect(msg).toContain("(resent)");
   });
 
-  test('telegram template includes Vellum assistant prefix', () => {
+  test("telegram template includes Vellum assistant prefix", () => {
     const msg = composeVerificationTelegram(
       GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST,
-      { code: '999999', expiresInMinutes: 10, assistantName: 'MyBot' },
+      { code: "999999", expiresInMinutes: 10, assistantName: "MyBot" },
     );
-    expect(msg).toContain('Vellum assistant');
-    expect(msg).not.toContain('999999');
+    expect(msg).toContain("Vellum assistant");
+    expect(msg).not.toContain("999999");
   });
 
-  test('start_outbound for telegram with missing destination fails', () => {
+  test("start_outbound for telegram with missing destination fails", () => {
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'telegram',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "telegram",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe('missing_destination');
+    expect(resp!.error).toBe("missing_destination");
   });
 
-  test('rate limits apply to telegram outbound (per-session send cap)', () => {
+  test("rate limits apply to telegram outbound (per-session send cap)", () => {
     // Start an outbound session with a known chat ID
     const { ctx: startCtx } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'telegram',
-      destination: '123456789',
-    }, mockSocket, startCtx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "telegram",
+        destination: "123456789",
+      },
+      mockSocket,
+      startCtx,
+    );
 
     // Set the send count to MAX_SENDS_PER_SESSION and nextResendAt to the past
-    const session = serviceFindActiveSession('self', 'telegram');
+    const session = serviceFindActiveSession("self", "telegram");
     expect(session).not.toBeNull();
     storeUpdateSessionDelivery(
       session!.id,
@@ -3276,40 +3760,52 @@ describe('outbound Telegram verification', () => {
 
     // Resend should be rejected due to max sends
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'resend_outbound',
-      channel: 'telegram',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "resend_outbound",
+        channel: "telegram",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe('max_sends_exceeded');
+    expect(resp!.error).toBe("max_sends_exceeded");
   });
 
-  test('rate limits apply to telegram outbound (cooldown)', () => {
+  test("rate limits apply to telegram outbound (cooldown)", () => {
     // Start an outbound session with a known chat ID
     const { ctx: startCtx } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'telegram',
-      destination: '123456789',
-    }, mockSocket, startCtx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "telegram",
+        destination: "123456789",
+      },
+      mockSocket,
+      startCtx,
+    );
 
     // Immediately try to resend (before cooldown)
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'resend_outbound',
-      channel: 'telegram',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "resend_outbound",
+        channel: "telegram",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe('rate_limited');
+    expect(resp!.error).toBe("rate_limited");
   });
 });
 
@@ -3317,19 +3813,23 @@ describe('outbound Telegram verification', () => {
 // 20. Outbound Voice Verification
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('outbound voice verification', () => {
+describe("outbound voice verification", () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('start_outbound for voice creates session with 6-digit code and initiates call', async () => {
+  test("start_outbound for voice creates session with 6-digit code and initiates call", async () => {
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'voice',
-      destination: '+15551234567',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "voice",
+        destination: "+15551234567",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -3342,13 +3842,13 @@ describe('outbound voice verification', () => {
     expect(resp!.expiresAt).toBeGreaterThan(Date.now());
     expect(resp!.nextResendAt).toBeGreaterThan(Date.now());
     expect(resp!.sendCount).toBe(1);
-    expect(resp!.channel).toBe('voice');
+    expect(resp!.channel).toBe("voice");
 
     // Verify the session was created with expected identity
-    const session = serviceFindActiveSession('self', 'voice');
+    const session = serviceFindActiveSession("self", "voice");
     expect(session).not.toBeNull();
-    expect(session!.expectedPhoneE164).toBe('+15551234567');
-    expect(session!.destinationAddress).toBe('+15551234567');
+    expect(session!.expectedPhoneE164).toBe("+15551234567");
+    expect(session!.destinationAddress).toBe("+15551234567");
 
     // Allow the fire-and-forget call initiation to complete
     await new Promise((resolve) => setTimeout(resolve, 50));
@@ -3356,33 +3856,43 @@ describe('outbound voice verification', () => {
     // Verify the call was initiated
     expect(voiceCallInitCalls.length).toBeGreaterThanOrEqual(1);
     const lastCall = voiceCallInitCalls[voiceCallInitCalls.length - 1];
-    expect(lastCall.phoneNumber).toBe('+15551234567');
-    expect(lastCall.guardianVerificationSessionId).toBe(resp!.verificationSessionId!);
+    expect(lastCall.phoneNumber).toBe("+15551234567");
+    expect(lastCall.guardianVerificationSessionId).toBe(
+      resp!.verificationSessionId!,
+    );
   });
 
-  test('start_outbound for voice rejects unparseable phone number', () => {
+  test("start_outbound for voice rejects unparseable phone number", () => {
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'voice',
-      destination: 'not-a-phone',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "voice",
+        destination: "not-a-phone",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe('invalid_destination');
+    expect(resp!.error).toBe("invalid_destination");
   });
 
-  test('start_outbound for voice normalizes formatted phone number', async () => {
+  test("start_outbound for voice normalizes formatted phone number", async () => {
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'voice',
-      destination: '555-123-4567',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "voice",
+        destination: "555-123-4567",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -3393,10 +3903,10 @@ describe('outbound voice verification', () => {
     expect(resp!.secret!.length).toBe(6);
 
     // Verify the session was created with the normalized E.164 number
-    const session = serviceFindActiveSession('self', 'voice');
+    const session = serviceFindActiveSession("self", "voice");
     expect(session).not.toBeNull();
-    expect(session!.expectedPhoneE164).toBe('+15551234567');
-    expect(session!.destinationAddress).toBe('+15551234567');
+    expect(session!.expectedPhoneE164).toBe("+15551234567");
+    expect(session!.destinationAddress).toBe("+15551234567");
 
     // Allow fire-and-forget call initiation to complete
     await new Promise((resolve) => setTimeout(resolve, 50));
@@ -3404,130 +3914,160 @@ describe('outbound voice verification', () => {
     // Verify the call was initiated with the normalized number
     expect(voiceCallInitCalls.length).toBeGreaterThanOrEqual(1);
     const lastCall = voiceCallInitCalls[voiceCallInitCalls.length - 1];
-    expect(lastCall.phoneNumber).toBe('+15551234567');
+    expect(lastCall.phoneNumber).toBe("+15551234567");
   });
 
-  test('start_outbound for voice rejects when binding exists (rebind=false)', () => {
+  test("start_outbound for voice rejects when binding exists (rebind=false)", () => {
     createBinding({
-      assistantId: 'self',
-      channel: 'voice',
-      guardianExternalUserId: '+15551234567',
-      guardianDeliveryChatId: '+15551234567',
+      assistantId: "self",
+      channel: "voice",
+      guardianExternalUserId: "+15551234567",
+      guardianDeliveryChatId: "+15551234567",
     });
 
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'voice',
-      destination: '+15559876543',
-      rebind: false,
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "voice",
+        destination: "+15559876543",
+        rebind: false,
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe('already_bound');
+    expect(resp!.error).toBe("already_bound");
   });
 
-  test('resend_outbound for voice initiates a new call with cooldown check', async () => {
+  test("resend_outbound for voice initiates a new call with cooldown check", async () => {
     // Start an outbound session first
     const { ctx: startCtx } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'voice',
-      destination: '+15551234567',
-    }, mockSocket, startCtx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "voice",
+        destination: "+15551234567",
+      },
+      mockSocket,
+      startCtx,
+    );
 
     // Immediately try to resend (before cooldown)
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'resend_outbound',
-      channel: 'voice',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "resend_outbound",
+        channel: "voice",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe('rate_limited');
+    expect(resp!.error).toBe("rate_limited");
   });
 
-  test('cancel_outbound for voice cancels session', () => {
+  test("cancel_outbound for voice cancels session", () => {
     // Start an outbound session first
     const { ctx: startCtx } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'voice',
-      destination: '+15551234567',
-    }, mockSocket, startCtx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "voice",
+        destination: "+15551234567",
+      },
+      mockSocket,
+      startCtx,
+    );
 
     // Cancel the session
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'cancel_outbound',
-      channel: 'voice',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "cancel_outbound",
+        channel: "voice",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(true);
 
     // Session should no longer be active
-    const session = serviceFindActiveSession('self', 'voice');
+    const session = serviceFindActiveSession("self", "voice");
     expect(session).toBeNull();
   });
 
-  test('rate limit enforcement: destination rate limit applies to voice', () => {
+  test("rate limit enforcement: destination rate limit applies to voice", () => {
     // Exhaust the per-destination rate limit by creating many sessions
     const db = getDb();
     const now = Date.now();
     for (let i = 0; i < 10; i++) {
       // Insert sessions with recent lastSentAt to simulate sends
-      db.insert(channelGuardianVerificationChallenges).values({
-        id: `rate-limit-voice-${i}`,
-        assistantId: 'self',
-        channel: 'voice',
-        challengeHash: `hash-${i}`,
-        expiresAt: now + 600_000,
-        status: 'awaiting_response',
-        destinationAddress: '+15551234567',
-        lastSentAt: now - 1000,
-        sendCount: 1,
-        createdAt: now,
-        updatedAt: now,
-      }).run();
+      db.insert(channelGuardianVerificationChallenges)
+        .values({
+          id: `rate-limit-voice-${i}`,
+          assistantId: "self",
+          channel: "voice",
+          challengeHash: `hash-${i}`,
+          expiresAt: now + 600_000,
+          status: "awaiting_response",
+          destinationAddress: "+15551234567",
+          lastSentAt: now - 1000,
+          sendCount: 1,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
     }
 
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'voice',
-      destination: '+15551234567',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "voice",
+        destination: "+15551234567",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe('rate_limited');
+    expect(resp!.error).toBe("rate_limited");
   });
 
-  test('start_outbound for voice requires destination', () => {
+  test("start_outbound for voice requires destination", () => {
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'voice',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "voice",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe('missing_destination');
+    expect(resp!.error).toBe("missing_destination");
   });
 });
 
@@ -3535,79 +4075,100 @@ describe('outbound voice verification', () => {
 // 22. M1–M4 Hardening: constant values, secret presence, and entropy
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('M1–M4 hardening coverage', () => {
+describe("M1–M4 hardening coverage", () => {
   beforeEach(() => {
     resetTables();
   });
 
   // ── M2: RESEND_COOLDOWN_MS is 15 000 ms (was 60 000) ──
 
-  test('RESEND_COOLDOWN_MS is 15 000 ms', () => {
+  test("RESEND_COOLDOWN_MS is 15 000 ms", () => {
     expect(RESEND_COOLDOWN_MS).toBe(15_000);
   });
 
   // ── M2: start_outbound for SMS returns secret in response ──
 
-  test('start_outbound for SMS response includes secret', () => {
+  test("start_outbound for SMS response includes secret", () => {
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'sms',
-      destination: '+15551234567',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "sms",
+        destination: "+15551234567",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(true);
     expect(resp!.secret).toBeDefined();
-    expect(typeof resp!.secret).toBe('string');
+    expect(typeof resp!.secret).toBe("string");
     expect(resp!.secret!.length).toBeGreaterThan(0);
   });
 
   // ── M2: resend_outbound for SMS returns secret in response ──
 
-  test('resend_outbound for SMS response includes secret', () => {
+  test("resend_outbound for SMS response includes secret", () => {
     // Start a session first
     const { ctx: startCtx } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'sms',
-      destination: '+15551234567',
-    }, mockSocket, startCtx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "sms",
+        destination: "+15551234567",
+      },
+      mockSocket,
+      startCtx,
+    );
 
     // Move past cooldown
-    const session = serviceFindActiveSession('self', 'sms');
+    const session = serviceFindActiveSession("self", "sms");
     expect(session).not.toBeNull();
-    storeUpdateSessionDelivery(session!.id, Date.now() - RESEND_COOLDOWN_MS - 1000, 1, Date.now() - 1000);
+    storeUpdateSessionDelivery(
+      session!.id,
+      Date.now() - RESEND_COOLDOWN_MS - 1000,
+      1,
+      Date.now() - 1000,
+    );
 
     // Resend
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'resend_outbound',
-      channel: 'sms',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "resend_outbound",
+        channel: "sms",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(true);
     expect(resp!.secret).toBeDefined();
-    expect(typeof resp!.secret).toBe('string');
+    expect(typeof resp!.secret).toBe("string");
     expect(resp!.secret!.length).toBeGreaterThan(0);
   });
 
   // ── M2: start_outbound for Telegram bootstrap does NOT return secret ──
 
-  test('start_outbound for Telegram bootstrap (handle) does NOT return secret', () => {
+  test("start_outbound for Telegram bootstrap (handle) does NOT return secret", () => {
     const { ctx, lastResponse } = createMockCtx();
-    handleGuardianVerification({
-      type: 'guardian_verification',
-      action: 'start_outbound',
-      channel: 'telegram',
-      destination: '@someuser',
-    }, mockSocket, ctx);
+    handleGuardianVerification(
+      {
+        type: "guardian_verification",
+        action: "start_outbound",
+        channel: "telegram",
+        destination: "@someuser",
+      },
+      mockSocket,
+      ctx,
+    );
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -3620,12 +4181,12 @@ describe('M1–M4 hardening coverage', () => {
 
   // ── M2: bootstrap sessions use high-entropy hex secrets ──
 
-  test('bootstrap (pending_bootstrap) sessions use high-entropy hex secrets, identity-bound use 6-digit numeric', () => {
+  test("bootstrap (pending_bootstrap) sessions use high-entropy hex secrets, identity-bound use 6-digit numeric", () => {
     const bootstrapResult = createOutboundSession({
-      assistantId: 'asst-entropy',
-      channel: 'telegram',
-      identityBindingStatus: 'pending_bootstrap',
-      destinationAddress: '@testuser',
+      assistantId: "asst-entropy",
+      channel: "telegram",
+      identityBindingStatus: "pending_bootstrap",
+      destinationAddress: "@testuser",
     });
     // Pending bootstrap: high-entropy hex (32 bytes = 64 hex chars)
     expect(bootstrapResult.secret.length).toBe(64);
@@ -3635,11 +4196,11 @@ describe('M1–M4 hardening coverage', () => {
 
     // Identity-bound: 6-digit numeric code
     const boundResult = createOutboundSession({
-      assistantId: 'asst-entropy',
-      channel: 'sms',
-      expectedPhoneE164: '+15551234567',
-      destinationAddress: '+15551234567',
-      identityBindingStatus: 'bound',
+      assistantId: "asst-entropy",
+      channel: "sms",
+      expectedPhoneE164: "+15551234567",
+      destinationAddress: "+15551234567",
+      identityBindingStatus: "bound",
     });
     expect(boundResult.secret.length).toBe(6);
     expect(boundResult.secret).toMatch(/^\d{6}$/);
@@ -3647,13 +4208,13 @@ describe('M1–M4 hardening coverage', () => {
 
   // ── M2: all identity-bound channels use 6-digit numeric codes ──
 
-  test('all identity-bound channels (SMS, Telegram chat ID, voice) use 6-digit numeric codes', () => {
+  test("all identity-bound channels (SMS, Telegram chat ID, voice) use 6-digit numeric codes", () => {
     // SMS
     const smsResult = createOutboundSession({
-      assistantId: 'asst-codes',
-      channel: 'sms',
-      expectedPhoneE164: '+15551234567',
-      destinationAddress: '+15551234567',
+      assistantId: "asst-codes",
+      channel: "sms",
+      expectedPhoneE164: "+15551234567",
+      destinationAddress: "+15551234567",
     });
     expect(smsResult.secret).toMatch(/^\d{6}$/);
 
@@ -3661,11 +4222,11 @@ describe('M1–M4 hardening coverage', () => {
 
     // Telegram (bound via chat ID)
     const tgResult = createOutboundSession({
-      assistantId: 'asst-codes',
-      channel: 'telegram',
-      expectedChatId: '123456789',
-      identityBindingStatus: 'bound',
-      destinationAddress: '123456789',
+      assistantId: "asst-codes",
+      channel: "telegram",
+      expectedChatId: "123456789",
+      identityBindingStatus: "bound",
+      destinationAddress: "123456789",
     });
     expect(tgResult.secret).toMatch(/^\d{6}$/);
 
@@ -3673,10 +4234,10 @@ describe('M1–M4 hardening coverage', () => {
 
     // Voice
     const voiceResult = createOutboundSession({
-      assistantId: 'asst-codes',
-      channel: 'voice',
-      expectedPhoneE164: '+15551234567',
-      destinationAddress: '+15551234567',
+      assistantId: "asst-codes",
+      channel: "voice",
+      expectedPhoneE164: "+15551234567",
+      destinationAddress: "+15551234567",
       codeDigits: 6,
     });
     expect(voiceResult.secret).toMatch(/^\d{6}$/);


### PR DESCRIPTION
## Summary
- The Slack guardian verification PR (#11187) added Slack as a supported channel, but the `start_outbound rejects unsupported channels` test still used `'slack'` as its example unsupported channel, causing CI failure.
- Updated the test to use `'email'` instead (not supported for outbound verification).
- Fixed pre-commit hook's prettier check to only check staged files instead of running `prettier --check .` on the entire codebase.

## Test plan
- [x] `bun test src/__tests__/channel-guardian.test.ts` passes (174/174 tests)
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)