### PR TITLE
feat(cli): add conversations command for managing conversation data

### DIFF
--- a/cli/src/commands/conversations.ts
+++ b/cli/src/commands/conversations.ts
@@ -1,0 +1,281 @@
+import { existsSync, readFileSync } from "node:fs";
+
+import {
+  findConversationKey,
+  importConversations,
+  listConversationKeys,
+  listConversations,
+  type ImportableConversation,
+} from "../lib/conversation-store.js";
+
+// ---------------------------------------------------------------------------
+// Arg helpers
+// ---------------------------------------------------------------------------
+
+function hasFlag(args: string[], flag: string): boolean {
+  return args.includes(flag);
+}
+
+function getFlagValue(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  if (idx === -1 || idx + 1 >= args.length) return undefined;
+  return args[idx + 1];
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+function formatDate(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Usage
+// ---------------------------------------------------------------------------
+
+function printUsage(): void {
+  console.log("Usage: vellum conversations <subcommand> [options]");
+  console.log("");
+  console.log("Subcommands:");
+  console.log(
+    "  list [--limit N]               List conversations (default limit 50)",
+  );
+  console.log(
+    "  import <file.json>             Import conversations from a JSON file",
+  );
+  console.log("  keys list [--limit N]          List conversation keys");
+  console.log("  keys check <key>               Check whether a key exists");
+  console.log("");
+  console.log("Options:");
+  console.log("  --json    Machine-readable JSON output");
+  console.log("");
+  console.log("Import file format (JSON array of conversation objects):");
+  console.log('  [{ "sourceKey": "...", "title": "...", "createdAt": <ms>,');
+  console.log(
+    '     "updatedAt": <ms>, "messages": [{ "role": "user"|"assistant",',
+  );
+  console.log('     "content": "...", "createdAt": <ms> }] }]');
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: list
+// ---------------------------------------------------------------------------
+
+async function handleList(args: string[]): Promise<void> {
+  const json = hasFlag(args, "--json");
+  const limit = parseInt(getFlagValue(args, "--limit") ?? "50", 10);
+
+  const rows = listConversations(limit);
+
+  if (json) {
+    console.log(JSON.stringify({ ok: true, conversations: rows }));
+    return;
+  }
+
+  if (rows.length === 0) {
+    console.log("No conversations found.");
+    return;
+  }
+
+  console.log(`Conversations (${rows.length}):\n`);
+  for (const c of rows) {
+    console.log(`  ID:      ${c.id}`);
+    console.log(`  Title:   ${c.title ?? "(untitled)"}`);
+    console.log(`  Created: ${formatDate(c.createdAt)}`);
+    console.log(`  Updated: ${formatDate(c.updatedAt)}`);
+    console.log("");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: import
+// ---------------------------------------------------------------------------
+
+async function handleImport(args: string[]): Promise<void> {
+  const json = hasFlag(args, "--json");
+  const filePath = args.find((a) => !a.startsWith("--"));
+
+  if (!filePath) {
+    console.error(
+      "Usage: vellum conversations import <file.json> [--json]",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!existsSync(filePath)) {
+    const msg = `File not found: ${filePath}`;
+    if (json) {
+      console.log(JSON.stringify({ ok: false, error: msg }));
+    } else {
+      console.error(`Error: ${msg}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(readFileSync(filePath, "utf-8"));
+  } catch (err) {
+    const msg = `Failed to parse JSON: ${err instanceof Error ? err.message : String(err)}`;
+    if (json) {
+      console.log(JSON.stringify({ ok: false, error: msg }));
+    } else {
+      console.error(`Error: ${msg}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!Array.isArray(data)) {
+    const msg = "Import file must contain a JSON array of conversation objects.";
+    if (json) {
+      console.log(JSON.stringify({ ok: false, error: msg }));
+    } else {
+      console.error(`Error: ${msg}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  let result;
+  try {
+    result = importConversations(data as ImportableConversation[]);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (json) {
+      console.log(JSON.stringify({ ok: false, error: msg }));
+    } else {
+      console.error(`Error: ${msg}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  if (json) {
+    console.log(JSON.stringify({ ok: true, ...result }));
+    return;
+  }
+
+  console.log(
+    `Imported ${result.importedCount} conversation(s) with ${result.messageCount} message(s).`,
+  );
+  if (result.skippedCount > 0) {
+    console.log(
+      `Skipped ${result.skippedCount} already-imported conversation(s).`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: keys
+// ---------------------------------------------------------------------------
+
+async function handleKeys(args: string[]): Promise<void> {
+  const json = hasFlag(args, "--json");
+  const keysSubcommand = args[0];
+
+  if (!keysSubcommand || keysSubcommand === "--help" || keysSubcommand === "-h") {
+    console.log("Usage: vellum conversations keys <subcommand> [options]");
+    console.log("");
+    console.log("Subcommands:");
+    console.log("  list [--limit N]   List all conversation keys");
+    console.log("  check <key>        Check whether a key exists");
+    return;
+  }
+
+  switch (keysSubcommand) {
+    case "list": {
+      const limit = parseInt(getFlagValue(args, "--limit") ?? "100", 10);
+      const rows = listConversationKeys(limit);
+
+      if (json) {
+        console.log(JSON.stringify({ ok: true, keys: rows }));
+        return;
+      }
+
+      if (rows.length === 0) {
+        console.log("No conversation keys found.");
+        return;
+      }
+
+      console.log(`Conversation keys (${rows.length}):\n`);
+      for (const k of rows) {
+        console.log(`  Key:            ${k.conversationKey}`);
+        console.log(`  Conversation:   ${k.conversationId}`);
+        console.log(`  Recorded:       ${formatDate(k.createdAt)}`);
+        console.log("");
+      }
+      break;
+    }
+
+    case "check": {
+      const key = args[1];
+      if (!key || key.startsWith("--")) {
+        console.error("Usage: vellum conversations keys check <key>");
+        process.exitCode = 1;
+        return;
+      }
+
+      const row = findConversationKey(key);
+
+      if (json) {
+        if (row) {
+          console.log(JSON.stringify({ ok: true, exists: true, key: row }));
+        } else {
+          console.log(JSON.stringify({ ok: true, exists: false }));
+        }
+        return;
+      }
+
+      if (row) {
+        console.log(`Key "${key}" exists.`);
+        console.log(`  Conversation: ${row.conversationId}`);
+        console.log(`  Recorded:     ${formatDate(row.createdAt)}`);
+      } else {
+        console.log(`Key "${key}" not found.`);
+      }
+      break;
+    }
+
+    default: {
+      console.error(`Unknown keys subcommand: ${keysSubcommand}`);
+      process.exitCode = 1;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command entry point
+// ---------------------------------------------------------------------------
+
+export async function conversations(): Promise<void> {
+  const args = process.argv.slice(3);
+  const subcommand = args[0];
+
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    printUsage();
+    return;
+  }
+
+  switch (subcommand) {
+    case "list":
+      await handleList(args.slice(1));
+      break;
+
+    case "import":
+      await handleImport(args.slice(1));
+      break;
+
+    case "keys":
+      await handleKeys(args.slice(1));
+      break;
+
+    default:
+      console.error(`Unknown conversations subcommand: ${subcommand}`);
+      printUsage();
+      process.exitCode = 1;
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -11,6 +11,7 @@ import { autonomy } from "./commands/autonomy";
 import { client } from "./commands/client";
 import { config } from "./commands/config";
 import { contacts } from "./commands/contacts";
+import { conversations } from "./commands/conversations";
 import { email } from "./commands/email";
 import { hatch } from "./commands/hatch";
 import { login, logout, whoami } from "./commands/login";
@@ -29,6 +30,7 @@ const commands = {
   client,
   config,
   contacts,
+  conversations,
   email,
   hatch,
   login,
@@ -89,8 +91,9 @@ async function main() {
     console.log("  autonomy View and configure autonomy tiers");
     console.log("  client   Connect to a hatched assistant");
     console.log("  config   Manage configuration");
-    console.log("  contacts Manage the contact graph");
-    console.log("  email    Email operations (status, create inbox)");
+    console.log("  contacts      Manage the contact graph");
+    console.log("  conversations Manage conversations (list, import, keys)");
+    console.log("  email         Email operations (status, create inbox)");
     console.log("  hatch    Create a new assistant instance");
     console.log("  login    Log in to the Vellum platform");
     console.log("  logout   Log out of the Vellum platform");

--- a/cli/src/lib/conversation-store.ts
+++ b/cli/src/lib/conversation-store.ts
@@ -1,0 +1,298 @@
+import { randomUUID } from "node:crypto";
+
+import { getDb } from "./db.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ConversationRow {
+  id: string;
+  title: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface MessageRow {
+  id: string;
+  conversationId: string;
+  role: string;
+  content: string;
+  createdAt: number;
+}
+
+export interface ConversationKeyRow {
+  id: string;
+  conversationKey: string;
+  conversationId: string;
+  createdAt: number;
+}
+
+/**
+ * A normalized conversation ready for import.
+ *
+ * `sourceKey` is an optional deduplication identifier (e.g. `"chatgpt:abc123"`).
+ * When provided, importing a conversation with an already-recorded key is a no-op.
+ */
+export interface ImportableConversation {
+  /** Deduplication key, e.g. `"chatgpt:abc123"`. Optional. */
+  sourceKey?: string;
+  title: string;
+  /** Unix epoch milliseconds */
+  createdAt: number;
+  /** Unix epoch milliseconds */
+  updatedAt: number;
+  messages: ImportableMessage[];
+}
+
+/**
+ * A single message within an importable conversation.
+ *
+ * `content` may be a plain string or a structured content array
+ * (e.g. `[{ type: "text", text: "Hello" }]`). Arrays are JSON-serialised
+ * before storage to match the format produced by the assistant runtime.
+ */
+export interface ImportableMessage {
+  role: string;
+  content: string | Array<{ type: string; text: string }>;
+  /** Unix epoch milliseconds */
+  createdAt: number;
+}
+
+export interface ImportResult {
+  importedCount: number;
+  skippedCount: number;
+  messageCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Low-level helpers
+// ---------------------------------------------------------------------------
+
+let lastTimestamp = 0;
+
+function monotonicNow(): number {
+  const now = Date.now();
+  lastTimestamp = Math.max(now, lastTimestamp + 1);
+  return lastTimestamp;
+}
+
+// ---------------------------------------------------------------------------
+// Conversation CRUD
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a new conversation record and return it.
+ */
+export function createConversation(
+  title: string,
+  createdAt?: number,
+  updatedAt?: number,
+): ConversationRow {
+  const db = getDb();
+  const now = Date.now();
+  const row: ConversationRow = {
+    id: randomUUID(),
+    title,
+    createdAt: createdAt ?? now,
+    updatedAt: updatedAt ?? now,
+  };
+  db.prepare(
+    `INSERT INTO conversations (
+       id, title, created_at, updated_at,
+       total_input_tokens, total_output_tokens, total_estimated_cost,
+       context_compacted_message_count, thread_type, memory_scope_id
+     ) VALUES (?, ?, ?, ?, 0, 0, 0, 0, 'standard', 'default')`,
+  ).run(row.id, row.title, row.createdAt, row.updatedAt);
+  return row;
+}
+
+/**
+ * Add a message to an existing conversation.
+ * When `createdAt` is omitted a monotonically-increasing timestamp is used.
+ */
+export function addMessage(
+  conversationId: string,
+  role: string,
+  content: string,
+  createdAt?: number,
+): MessageRow {
+  const db = getDb();
+  const ts = createdAt ?? monotonicNow();
+  const row: MessageRow = {
+    id: randomUUID(),
+    conversationId,
+    role,
+    content,
+    createdAt: ts,
+  };
+  db.prepare(
+    `INSERT INTO messages (id, conversation_id, role, content, created_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(row.id, row.conversationId, row.role, row.content, row.createdAt);
+  db.prepare(
+    `UPDATE conversations SET updated_at = ? WHERE id = ?`,
+  ).run(ts, conversationId);
+  return row;
+}
+
+// ---------------------------------------------------------------------------
+// Conversation-key helpers (deduplication)
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up a conversation key record. Returns `null` when not found.
+ */
+export function findConversationKey(key: string): ConversationKeyRow | null {
+  const db = getDb();
+  const row = db
+    .prepare(
+      `SELECT id, conversation_key, conversation_id, created_at
+       FROM conversation_keys WHERE conversation_key = ?`,
+    )
+    .get(key) as
+    | {
+        id: string;
+        conversation_key: string;
+        conversation_id: string;
+        created_at: number;
+      }
+    | undefined;
+  if (!row) return null;
+  return {
+    id: row.id,
+    conversationKey: row.conversation_key,
+    conversationId: row.conversation_id,
+    createdAt: row.created_at,
+  };
+}
+
+/**
+ * Record a deduplication key that maps to an existing conversation.
+ */
+export function createConversationKey(
+  key: string,
+  conversationId: string,
+): ConversationKeyRow {
+  const db = getDb();
+  const now = Date.now();
+  const row: ConversationKeyRow = {
+    id: randomUUID(),
+    conversationKey: key,
+    conversationId,
+    createdAt: now,
+  };
+  db.prepare(
+    `INSERT INTO conversation_keys (id, conversation_key, conversation_id, created_at)
+     VALUES (?, ?, ?, ?)`,
+  ).run(row.id, row.conversationKey, row.conversationId, row.createdAt);
+  return row;
+}
+
+/**
+ * List all recorded conversation keys, newest first.
+ */
+export function listConversationKeys(limit = 100): ConversationKeyRow[] {
+  const db = getDb();
+  const rows = db
+    .prepare(
+      `SELECT id, conversation_key, conversation_id, created_at
+       FROM conversation_keys
+       ORDER BY created_at DESC
+       LIMIT ?`,
+    )
+    .all(limit) as Array<{
+    id: string;
+    conversation_key: string;
+    conversation_id: string;
+    created_at: number;
+  }>;
+  return rows.map((r) => ({
+    id: r.id,
+    conversationKey: r.conversation_key,
+    conversationId: r.conversation_id,
+    createdAt: r.created_at,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Listing
+// ---------------------------------------------------------------------------
+
+/**
+ * List conversations ordered by most recently updated.
+ */
+export function listConversations(limit = 50): ConversationRow[] {
+  const db = getDb();
+  const rows = db
+    .prepare(
+      `SELECT id, title, created_at, updated_at
+       FROM conversations
+       ORDER BY updated_at DESC
+       LIMIT ?`,
+    )
+    .all(limit) as Array<{
+    id: string;
+    title: string | null;
+    created_at: number;
+    updated_at: number;
+  }>;
+  return rows.map((r) => ({
+    id: r.id,
+    title: r.title,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// High-level import
+// ---------------------------------------------------------------------------
+
+/**
+ * Import an array of conversations into the database.
+ *
+ * Conversations with a `sourceKey` that already exists in `conversation_keys`
+ * are silently skipped (idempotent re-import).
+ */
+export function importConversations(
+  conversations: ImportableConversation[],
+): ImportResult {
+  let importedCount = 0;
+  let skippedCount = 0;
+  let messageCount = 0;
+
+  for (const conv of conversations) {
+    // Deduplication check
+    if (conv.sourceKey) {
+      const existing = findConversationKey(conv.sourceKey);
+      if (existing) {
+        skippedCount++;
+        continue;
+      }
+    }
+
+    const conversation = createConversation(
+      conv.title,
+      conv.createdAt,
+      conv.updatedAt,
+    );
+
+    for (const msg of conv.messages) {
+      const content =
+        typeof msg.content === "string"
+          ? msg.content
+          : JSON.stringify(msg.content);
+      addMessage(conversation.id, msg.role, content, msg.createdAt);
+    }
+
+    if (conv.sourceKey) {
+      createConversationKey(conv.sourceKey, conversation.id);
+    }
+
+    importedCount++;
+    messageCount += conv.messages.length;
+  }
+
+  return { importedCount, skippedCount, messageCount };
+}

--- a/cli/src/lib/conversation-store.ts
+++ b/cli/src/lib/conversation-store.ts
@@ -254,21 +254,25 @@ export function listConversations(limit = 50): ConversationRow[] {
  *
  * Conversations with a `sourceKey` that already exists in `conversation_keys`
  * are silently skipped (idempotent re-import).
+ *
+ * Each conversation is imported atomically: if any write fails the entire
+ * conversation is rolled back, preventing partial data and duplicate-key
+ * collisions on retry.
  */
 export function importConversations(
   conversations: ImportableConversation[],
 ): ImportResult {
+  const db = getDb();
   let importedCount = 0;
   let skippedCount = 0;
   let messageCount = 0;
 
-  for (const conv of conversations) {
-    // Deduplication check
+  const importOne = db.transaction((conv: ImportableConversation) => {
+    // Deduplication check (inside the transaction for isolation)
     if (conv.sourceKey) {
       const existing = findConversationKey(conv.sourceKey);
       if (existing) {
-        skippedCount++;
-        continue;
+        return false;
       }
     }
 
@@ -286,12 +290,29 @@ export function importConversations(
       addMessage(conversation.id, msg.role, content, msg.createdAt);
     }
 
+    // Restore the intended updatedAt — addMessage overwrites it with each
+    // message's timestamp, which may not reflect the conversation's true
+    // last-updated time.
+    db.prepare(`UPDATE conversations SET updated_at = ? WHERE id = ?`).run(
+      conv.updatedAt,
+      conversation.id,
+    );
+
     if (conv.sourceKey) {
       createConversationKey(conv.sourceKey, conversation.id);
     }
 
-    importedCount++;
-    messageCount += conv.messages.length;
+    return conv.messages.length;
+  });
+
+  for (const conv of conversations) {
+    const result = importOne(conv);
+    if (result === false) {
+      skippedCount++;
+    } else {
+      importedCount++;
+      messageCount += result;
+    }
   }
 
   return { importedCount, skippedCount, messageCount };

--- a/cli/src/lib/db.ts
+++ b/cli/src/lib/db.ts
@@ -1,0 +1,23 @@
+import { Database } from "bun:sqlite";
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export function getDbPath(): string {
+  const baseDir = process.env.BASE_DATA_DIR?.trim() || homedir();
+  return join(baseDir, ".vellum", "workspace", "data", "db", "assistant.db");
+}
+
+let db: Database | null = null;
+
+export function getDb(): Database {
+  if (!db) {
+    const dbPath = getDbPath();
+    mkdirSync(join(dbPath, ".."), { recursive: true });
+    db = new Database(dbPath);
+    db.exec("PRAGMA journal_mode=WAL");
+    db.exec("PRAGMA busy_timeout=5000");
+    db.exec("PRAGMA foreign_keys = ON");
+  }
+  return db;
+}


### PR DESCRIPTION
## Summary
- Add `vellum conversations` CLI command with subcommands: `list`, `import`, and `keys` (list/check)
- Extract SQLite database access into `cli/src/lib/db.ts` (shared connection helper)
- Add `cli/src/lib/conversation-store.ts` with abstracted CRUD for conversations, messages, and conversation keys — no Drizzle ORM dependency, uses `bun:sqlite` directly
- The `import` subcommand accepts a normalized JSON format (array of conversation objects) and handles deduplication via `sourceKey`; the chatgpt-import skill is unchanged and will adopt these helpers in a follow-up PR

## Original prompt
add vellum cli commandfs to replace what chatgpt-import does with the sqllitetables and make it so they are not a part of a skill and are abstracted. don't update the gpt import skill yet though lets leave that to another PR to adopt the new functions you create

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
