### PR TITLE
M2: Enable hatching for local non-userHosted flow and prevent double gateway

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1305,23 +1305,41 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
         Task {
             if !isCurrentAssistantRemote {
-                // On first launch post-onboarding, use daemonOnly: false so the CLI
-                // creates a lockfile entry. On subsequent launches, daemonOnly: true
-                // prevents duplicates.
-                let needsLockfileEntry = isFirstLaunch && !self.lockfileHasAssistants()
-                do {
-                    try await assistantCli.hatch(daemonOnly: !needsLockfileEntry)
-                } catch {
-                    log.error("Failed to hatch assistant during daemon setup: \(error)")
-                    if needsLockfileEntry {
-                        log.info("Full hatch failed on first launch — retrying daemon-only as fallback")
-                        try? await assistantCli.hatch(daemonOnly: true)
+                // If the hatching step already started the gateway (e.g. `vellum-cli hatch --remote local`),
+                // skip the CLI hatch to avoid spawning a duplicate gateway process.
+                // Require BOTH lockfile and healthy gateway — a stale lockfile with an unhealthy
+                // gateway falls through to the normal hatch path.
+                let lockfileExists = self.lockfileHasAssistants()
+                var gatewayHealthy = false
+                if lockfileExists {
+                    for _ in 0..<3 {
+                        if await isGatewayHealthy() { gatewayHealthy = true; break }
+                        try? await Task.sleep(nanoseconds: 1_000_000_000)
                     }
                 }
-                if needsLockfileEntry {
-                    _ = self.loadAssistantFromLockfile()
+
+                if lockfileExists && gatewayHealthy {
+                    log.info("Lockfile and gateway already present — skipping CLI hatch to avoid duplicate gateway")
+                    assistantCli.startMonitoring()
+                } else {
+                    // On first launch post-onboarding, use daemonOnly: false so the CLI
+                    // creates a lockfile entry. On subsequent launches, daemonOnly: true
+                    // prevents duplicates.
+                    let needsLockfileEntry = isFirstLaunch && !lockfileExists
+                    do {
+                        try await assistantCli.hatch(daemonOnly: !needsLockfileEntry)
+                    } catch {
+                        log.error("Failed to hatch assistant during daemon setup: \(error)")
+                        if needsLockfileEntry {
+                            log.info("Full hatch failed on first launch — retrying daemon-only as fallback")
+                            try? await assistantCli.hatch(daemonOnly: true)
+                        }
+                    }
+                    if needsLockfileEntry {
+                        _ = self.loadAssistantFromLockfile()
+                    }
+                    assistantCli.startMonitoring()
                 }
-                assistantCli.startMonitoring()
             }
             // Skip connect if the bootstrap retry coordinator already connected
             // or has a connect in flight (hatch can take a long time; the
@@ -2196,6 +2214,24 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             return false
         }
         return !assistants.isEmpty
+    }
+
+    /// Check whether the local gateway is healthy by hitting its /healthz endpoint.
+    /// Reads port from GATEWAY_PORT env var (default 7830) to match local.ts runtime behavior.
+    private func isGatewayHealthy() async -> Bool {
+        let port = ProcessInfo.processInfo.environment["GATEWAY_PORT"] ?? "7830"
+        guard let url = URL(string: "http://localhost:\(port)/healthz") else { return false }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 2
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse, http.statusCode == 200 {
+                return true
+            }
+        } catch {
+            // Gateway not reachable — not healthy
+        }
+        return false
     }
 
     /// Remove a specific assistant entry from the lockfile. Used after a

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1326,8 +1326,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                     // creates a lockfile entry. On subsequent launches, daemonOnly: true
                     // prevents duplicates.
                     let needsLockfileEntry = isFirstLaunch && !lockfileExists
+                    // When lockfile exists but gateway is unhealthy, force a full hatch
+                    // (daemonOnly: false) so the CLI runs startGateway() to recover.
+                    let needsGatewayRecovery = lockfileExists && !gatewayHealthy
+                    let daemonOnly = !needsLockfileEntry && !needsGatewayRecovery
                     do {
-                        try await assistantCli.hatch(daemonOnly: !needsLockfileEntry)
+                        try await assistantCli.hatch(daemonOnly: daemonOnly)
                     } catch {
                         log.error("Failed to hatch assistant during daemon setup: \(error)")
                         if needsLockfileEntry {

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1312,9 +1312,15 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 let lockfileExists = self.lockfileHasAssistants()
                 var gatewayHealthy = false
                 if lockfileExists {
-                    for _ in 0..<3 {
-                        if await isGatewayHealthy() { gatewayHealthy = true; break }
-                        try? await Task.sleep(nanoseconds: 1_000_000_000)
+                    if isFirstLaunch {
+                        // Retry window: gateway may still be starting from onboarding hatch
+                        for _ in 0..<3 {
+                            if await isGatewayHealthy() { gatewayHealthy = true; break }
+                            try? await Task.sleep(nanoseconds: 1_000_000_000)
+                        }
+                    } else {
+                        // Non-first-launch: single check, no retry delay
+                        gatewayHealthy = await isGatewayHealthy()
                     }
                 }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1326,10 +1326,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                     // creates a lockfile entry. On subsequent launches, daemonOnly: true
                     // prevents duplicates.
                     let needsLockfileEntry = isFirstLaunch && !lockfileExists
-                    // When lockfile exists but gateway is unhealthy, force a full hatch
-                    // (daemonOnly: false) so the CLI runs startGateway() to recover.
-                    let needsGatewayRecovery = lockfileExists && !gatewayHealthy
-                    let daemonOnly = !needsLockfileEntry && !needsGatewayRecovery
+                    let daemonOnly = !needsLockfileEntry
                     do {
                         try await assistantCli.hatch(daemonOnly: daemonOnly)
                     } catch {

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -283,7 +283,8 @@ struct APIKeyStepView: View {
             } else if userHostedEnabled {
                 state.isHatching = true
             } else {
-                state.advance()
+                state.cloudProvider = "local"
+                state.isHatching = true
             }
     }
 


### PR DESCRIPTION
## Summary
- Changed non-userHosted onboarding to show HatchingStepView with `remote: local` instead of directly advancing, ensuring users see the egg animation during local setup
- Added compound guard in AppDelegate's setupDaemonClient to skip CLI hatch when lockfile exists AND gateway is healthy (with 3-poll retry window), preventing double gateway spawn
- Added isGatewayHealthy() helper that reads GATEWAY_PORT env var (default 7830) and checks /healthz endpoint

Closes #11194
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
