### PR TITLE
feat: add OAuth support for MCP servers

### DIFF
--- a/assistant/src/cli/mcp.ts
+++ b/assistant/src/cli/mcp.ts
@@ -1,7 +1,12 @@
+import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { Command } from 'commander';
 
 import { loadRawConfig, saveRawConfig } from '../config/loader.js';
 import type { McpConfig, McpServerConfig } from '../config/mcp-schema.js';
+import { deleteMcpOAuthCredentials, McpOAuthProvider } from '../mcp/mcp-oauth-provider.js';
 import { getCliLogger } from '../util/logger.js';
 
 const log = getCliLogger('cli');
@@ -134,9 +139,115 @@ export function registerMcpCommand(program: Command): void {
     });
 
   mcp
+    .command('auth <name>')
+    .description('Authenticate with an MCP server via OAuth')
+    .action(async (name: string) => {
+      const raw = loadRawConfig();
+      const mcpConfig = raw.mcp as Partial<McpConfig> | undefined;
+      const servers = mcpConfig?.servers ?? {};
+      const serverConfig = (servers as Record<string, McpServerConfig>)[name];
+
+      if (!serverConfig) {
+        log.error(`MCP server "${name}" not found. Add it first with: vellum mcp add`);
+        process.exitCode = 1;
+        return;
+      }
+
+      const transport = serverConfig.transport;
+      if (transport.type !== 'sse' && transport.type !== 'streamable-http') {
+        log.error(`OAuth is only supported for sse/streamable-http transports (server "${name}" uses ${transport.type})`);
+        process.exitCode = 1;
+        return;
+      }
+
+      const provider = new McpOAuthProvider(name, transport.url, /* interactive */ true);
+      // Clear all stale credentials — the callback server uses a random port,
+      // so any previously cached client_info/tokens have a mismatched redirect_uri.
+      await provider.invalidateCredentials('all');
+      const { codePromise } = await provider.startCallbackServer();
+
+      const OAUTH_TIMEOUT_MS = 150_000; // 2.5 min for browser interaction
+      const TransportClass = transport.type === 'sse' ? SSEClientTransport : StreamableHTTPClientTransport;
+      const mcpTransport = new TransportClass(
+        new URL(transport.url),
+        {
+          authProvider: provider,
+          requestInit: transport.headers ? { headers: transport.headers } : undefined,
+        },
+      );
+
+      const client = new Client({ name: 'vellum-assistant', version: '1.0.0' });
+
+      try {
+        // Try connecting — if tokens are already cached, this succeeds immediately
+        await client.connect(mcpTransport);
+        provider.stopCallbackServer();
+        await client.close();
+        log.info(`Server "${name}" is already authenticated.`);
+        return;
+      } catch (err) {
+        if (!(err instanceof UnauthorizedError)) {
+          provider.stopCallbackServer();
+          try { await client.close(); } catch { /* ignore */ }
+          log.error(`Failed to connect to "${name}": ${err}`);
+          process.exitCode = 1;
+          return;
+        }
+      }
+
+      // UnauthorizedError — browser was opened by redirectToAuthorization().
+      // Wait for the user to complete the OAuth flow.
+      log.info('Waiting for authorization in browser... (press Ctrl+C to cancel)');
+
+      let code: string;
+      try {
+        code = await Promise.race([
+          codePromise,
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error('OAuth authorization timed out after 2.5 minutes')), OAUTH_TIMEOUT_MS),
+          ),
+        ]);
+      } catch (err) {
+        provider.stopCallbackServer();
+        try { await client.close(); } catch { /* ignore */ }
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.includes('denied') || message.includes('cancelled')) {
+          log.error(`Authorization cancelled for "${name}".`);
+        } else if (message.includes('timed out')) {
+          log.error(`Authorization timed out for "${name}". Try again with: vellum mcp auth ${name}`);
+        } else {
+          log.error(`Authorization failed for "${name}": ${message}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      log.info('Authorization received. Exchanging token...');
+
+      // Exchange auth code for tokens
+      try {
+        await mcpTransport.finishAuth(code);
+      } catch (err) {
+        provider.stopCallbackServer();
+        try { await client.close(); } catch { /* ignore */ }
+        log.error(`Token exchange failed for "${name}": ${err}`);
+        process.exitCode = 1;
+        return;
+      }
+
+      // Clean up transport/client so the process can exit
+      try { await client.close(); } catch { /* ignore */ }
+      provider.stopCallbackServer();
+
+      log.info(`Authentication successful for "${name}".`);
+      log.info('Restart the daemon for changes to take effect: vellum daemon restart');
+      process.exit(0);
+    });
+
+  mcp
     .command('remove <name>')
     .description('Remove an MCP server configuration')
-    .action((name: string) => {
+    .action(async (name: string) => {
       const raw = loadRawConfig();
       const mcpConfig = raw.mcp as Record<string, unknown> | undefined;
       const servers = mcpConfig?.servers as Record<string, unknown> | undefined;
@@ -145,6 +256,17 @@ export function registerMcpCommand(program: Command): void {
         log.error(`MCP server "${name}" not found.`);
         process.exitCode = 1;
         return;
+      }
+
+      // Best-effort cleanup of any OAuth credentials stored for this server
+      const serverConfig = servers[name] as Record<string, unknown>;
+      const transport = serverConfig?.transport as Record<string, unknown> | undefined;
+      if (transport?.type === 'sse' || transport?.type === 'streamable-http') {
+        try {
+          await deleteMcpOAuthCredentials(name);
+        } catch {
+          // Ignore — credentials may not exist
+        }
       }
 
       delete servers[name];

--- a/assistant/src/cli/mcp.ts
+++ b/assistant/src/cli/mcp.ts
@@ -161,9 +161,11 @@ export function registerMcpCommand(program: Command): void {
       }
 
       const provider = new McpOAuthProvider(name, transport.url, /* interactive */ true);
-      // Clear all stale credentials — the callback server uses a random port,
-      // so any previously cached client_info/tokens have a mismatched redirect_uri.
-      await provider.invalidateCredentials('all');
+      // Clear stale client_info and discovery — the callback server uses a random port,
+      // so any previously cached client_info has a mismatched redirect_uri.
+      // Preserve tokens so they survive if this auth attempt fails.
+      await provider.invalidateCredentials('client');
+      await provider.invalidateCredentials('discovery');
       const { codePromise } = await provider.startCallbackServer();
 
       const OAUTH_TIMEOUT_MS = 150_000; // 2.5 min for browser interaction
@@ -200,14 +202,18 @@ export function registerMcpCommand(program: Command): void {
       log.info('Waiting for authorization in browser... (press Ctrl+C to cancel)');
 
       let code: string;
+      let oauthTimer: ReturnType<typeof setTimeout> | undefined;
       try {
         code = await Promise.race([
           codePromise,
-          new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error('OAuth authorization timed out after 2.5 minutes')), OAUTH_TIMEOUT_MS),
-          ),
+          new Promise<never>((_, reject) => {
+            oauthTimer = setTimeout(() => reject(new Error('OAuth authorization timed out after 2.5 minutes')), OAUTH_TIMEOUT_MS);
+            if (typeof oauthTimer === 'object' && 'unref' in oauthTimer) oauthTimer.unref();
+          }),
         ]);
+        clearTimeout(oauthTimer);
       } catch (err) {
+        clearTimeout(oauthTimer);
         provider.stopCallbackServer();
         try { await client.close(); } catch { /* ignore */ }
         const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/mcp/client.ts
+++ b/assistant/src/mcp/client.ts
@@ -1,3 +1,4 @@
+import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
@@ -73,11 +74,20 @@ export class McpClient {
       this.transport = null;
 
       if (isHttpTransport) {
-        // For HTTP transports, any connection failure may be auth-related.
-        // Skip silently — user can run `vellum mcp auth <name>` to authenticate.
-        log.info({ serverId: this.serverId, err }, 'MCP server connection failed — may need authentication');
-        console.log(`[MCP] Server "${this.serverId}" is not available. Run "vellum mcp auth ${this.serverId}" if it requires authentication.`);
-        return;
+        const isAuthError = err instanceof UnauthorizedError
+          || (err instanceof Error && /\b(401|403|unauthorized|forbidden)\b/i.test(err.message));
+
+        if (isAuthError) {
+          // Auth-related — user can run `vellum mcp auth <name>` to authenticate.
+          log.info({ serverId: this.serverId, err }, 'MCP server requires authentication');
+          console.log(`[MCP] Server "${this.serverId}" requires authentication. Run "vellum mcp auth ${this.serverId}" to authenticate.`);
+          return;
+        }
+
+        // Non-auth error (DNS, TLS, timeout, etc.) — log and re-throw
+        log.error({ serverId: this.serverId, err }, 'MCP server connection failed');
+        console.error(`[MCP] Server "${this.serverId}" connection failed: ${err instanceof Error ? err.message : err}`);
+        throw err;
       }
 
       throw err;

--- a/assistant/src/mcp/client.ts
+++ b/assistant/src/mcp/client.ts
@@ -4,7 +4,9 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
 import type { McpTransport } from '../config/mcp-schema.js';
+import { getSecureKeyAsync } from '../security/secure-keys.js';
 import { getLogger } from '../util/logger.js';
+import { McpOAuthProvider } from './mcp-oauth-provider.js';
 
 const log = getLogger('mcp-client');
 
@@ -26,6 +28,11 @@ export class McpClient {
   private client: Client;
   private transport: StdioClientTransport | SSEClientTransport | StreamableHTTPClientTransport | null = null;
   private connected = false;
+  private oauthProvider: McpOAuthProvider | null = null;
+
+  get isConnected(): boolean {
+    return this.connected;
+  }
 
   constructor(serverId: string) {
     this.serverId = serverId;
@@ -38,8 +45,22 @@ export class McpClient {
   async connect(transportConfig: McpTransport): Promise<void> {
     if (this.connected) return;
 
+    const isHttpTransport = transportConfig.type === 'sse' || transportConfig.type === 'streamable-http';
+
+    // For HTTP transports, only attach an OAuth provider if cached tokens exist.
+    // This avoids triggering client registration (which binds to a random port)
+    // during daemon startup. If no tokens, try without auth — if the server
+    // requires it, skip silently.
+    if (isHttpTransport) {
+      const cachedTokens = await getSecureKeyAsync(`mcp:${this.serverId}:tokens`);
+      if (cachedTokens) {
+        this.oauthProvider = new McpOAuthProvider(this.serverId, transportConfig.url);
+      }
+    }
+
     console.log(`[MCP] Connecting to server "${this.serverId}"...`);
     this.transport = this.createTransport(transportConfig);
+
     try {
       await Promise.race([
         this.client.connect(this.transport),
@@ -48,11 +69,20 @@ export class McpClient {
         ),
       ]);
     } catch (err) {
-      // Clean up the transport on failure (e.g., kill spawned stdio process)
       try { await this.client.close(); } catch { /* ignore cleanup errors */ }
       this.transport = null;
+
+      if (isHttpTransport) {
+        // For HTTP transports, any connection failure may be auth-related.
+        // Skip silently — user can run `vellum mcp auth <name>` to authenticate.
+        log.info({ serverId: this.serverId, err }, 'MCP server connection failed — may need authentication');
+        console.log(`[MCP] Server "${this.serverId}" is not available. Run "vellum mcp auth ${this.serverId}" if it requires authentication.`);
+        return;
+      }
+
       throw err;
     }
+
     this.connected = true;
     console.log(`[MCP] Server "${this.serverId}" connected successfully`);
     log.info({ serverId: this.serverId }, 'MCP client connected');
@@ -140,13 +170,20 @@ export class McpClient {
       case 'sse':
         return new SSEClientTransport(
           new URL(config.url),
-          { requestInit: config.headers ? { headers: config.headers } : undefined },
+          {
+            authProvider: this.oauthProvider ?? undefined,
+            requestInit: config.headers ? { headers: config.headers } : undefined,
+          },
         );
       case 'streamable-http':
         return new StreamableHTTPClientTransport(
           new URL(config.url),
-          { requestInit: config.headers ? { headers: config.headers } : undefined },
+          {
+            authProvider: this.oauthProvider ?? undefined,
+            requestInit: config.headers ? { headers: config.headers } : undefined,
+          },
         );
     }
   }
 }
+

--- a/assistant/src/mcp/manager.ts
+++ b/assistant/src/mcp/manager.ts
@@ -27,8 +27,17 @@ export class McpServerManager {
 
       try {
         console.log(`[MCP] Starting server "${serverId}" (transport: ${serverConfig.transport.type})`);
+        if (serverConfig.transport.type === 'sse' || serverConfig.transport.type === 'streamable-http') {
+          log.debug({ serverId }, 'HTTP transport — OAuth provider will be available if server requires authentication');
+        }
         const client = new McpClient(serverId);
         await client.connect(serverConfig.transport);
+
+        if (!client.isConnected) {
+          // Server requires authentication — connect() logged guidance
+          continue;
+        }
+
         this.clients.set(serverId, client);
         this.serverConfigs.set(serverId, serverConfig);
 

--- a/assistant/src/mcp/mcp-oauth-provider.ts
+++ b/assistant/src/mcp/mcp-oauth-provider.ts
@@ -152,10 +152,16 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
     try {
       const { execFile } = await import('node:child_process');
+      const onError = (err: Error | null) => {
+        if (err) {
+          log.warn({ err }, 'Failed to open browser');
+          console.log(`[MCP] Please open this URL in your browser:\n${url}`);
+        }
+      };
       if (isMacOS()) {
-        execFile('open', [url]);
+        execFile('open', [url], onError);
       } else if (isLinux()) {
-        execFile('xdg-open', [url]);
+        execFile('xdg-open', [url], onError);
       } else {
         log.warn('Unsupported platform for browser open — please visit the URL manually');
         console.log(`[MCP] Please open this URL in your browser:\n${url}`);

--- a/assistant/src/mcp/mcp-oauth-provider.ts
+++ b/assistant/src/mcp/mcp-oauth-provider.ts
@@ -1,0 +1,341 @@
+/**
+ * OAuthClientProvider implementation for MCP servers.
+ *
+ * Uses secure-keys (OS keychain / encrypted file store) for persistent
+ * credential storage and a loopback HTTP server for the browser callback.
+ */
+
+import { createServer, type Server } from 'node:http';
+
+import type { OAuthClientProvider, OAuthDiscoveryState } from '@modelcontextprotocol/sdk/client/auth.js';
+import type { OAuthClientInformationMixed, OAuthClientMetadata, OAuthTokens } from '@modelcontextprotocol/sdk/shared/auth.js';
+
+import {
+  deleteSecureKeyAsync,
+  getSecureKeyAsync,
+  setSecureKeyAsync,
+} from '../security/secure-keys.js';
+import { getLogger } from '../util/logger.js';
+import { isLinux, isMacOS } from '../util/platform.js';
+
+const log = getLogger('mcp-oauth');
+
+const CALLBACK_PATH = '/oauth/callback';
+const CALLBACK_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
+
+// Keychain key helpers
+function tokensKey(serverId: string): string { return `mcp:${serverId}:tokens`; }
+function clientInfoKey(serverId: string): string { return `mcp:${serverId}:client_info`; }
+function discoveryKey(serverId: string): string { return `mcp:${serverId}:discovery`; }
+
+export interface McpOAuthCallbackResult {
+  /** Resolves with the authorization code when the callback is received. */
+  codePromise: Promise<string>;
+}
+
+export class McpOAuthProvider implements OAuthClientProvider {
+  private readonly serverId: string;
+  private readonly serverUrl: string;
+  private readonly interactive: boolean;
+  private _codeVerifier: string | undefined;
+  private _redirectUrl: string | undefined;
+  private _codePromise: Promise<string> | null = null;
+  private callbackServer: Server | null = null;
+  private callbackTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * @param interactive When true (e.g. `mcp auth` CLI), opens browser for OAuth.
+   *                    When false (daemon), logs a message instead.
+   */
+  constructor(serverId: string, serverUrl: string, interactive = false) {
+    this.serverId = serverId;
+    this.serverUrl = serverUrl;
+    this.interactive = interactive;
+  }
+
+  // --- redirectUrl ---
+
+  get redirectUrl(): string | undefined {
+    return this._redirectUrl;
+  }
+
+  // --- clientMetadata ---
+
+  get clientMetadata(): OAuthClientMetadata {
+    return {
+      client_name: 'Vellum Assistant',
+      redirect_uris: this._redirectUrl ? [this._redirectUrl] : [],
+      token_endpoint_auth_method: 'none',
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+    };
+  }
+
+  // --- Tokens ---
+
+  async tokens(): Promise<OAuthTokens | undefined> {
+    const raw = await getSecureKeyAsync(tokensKey(this.serverId));
+    if (!raw) return undefined;
+    try {
+      return JSON.parse(raw) as OAuthTokens;
+    } catch {
+      log.warn({ serverId: this.serverId }, 'Failed to parse stored OAuth tokens');
+      return undefined;
+    }
+  }
+
+  async saveTokens(tokens: OAuthTokens): Promise<void> {
+    await setSecureKeyAsync(tokensKey(this.serverId), JSON.stringify(tokens));
+    log.info({ serverId: this.serverId }, 'OAuth tokens saved');
+  }
+
+  // --- Client Information ---
+
+  async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
+    const raw = await getSecureKeyAsync(clientInfoKey(this.serverId));
+    if (!raw) return undefined;
+    try {
+      return JSON.parse(raw) as OAuthClientInformationMixed;
+    } catch {
+      log.warn({ serverId: this.serverId }, 'Failed to parse stored client information');
+      return undefined;
+    }
+  }
+
+  async saveClientInformation(info: OAuthClientInformationMixed): Promise<void> {
+    await setSecureKeyAsync(clientInfoKey(this.serverId), JSON.stringify(info));
+    log.info({ serverId: this.serverId }, 'OAuth client information saved');
+  }
+
+  // --- Code Verifier (in-memory, ephemeral) ---
+
+  async saveCodeVerifier(verifier: string): Promise<void> {
+    this._codeVerifier = verifier;
+  }
+
+  async codeVerifier(): Promise<string> {
+    if (!this._codeVerifier) {
+      throw new Error('No code verifier available — OAuth flow not started');
+    }
+    return this._codeVerifier;
+  }
+
+  // --- Discovery State ---
+
+  async discoveryState(): Promise<OAuthDiscoveryState | undefined> {
+    const raw = await getSecureKeyAsync(discoveryKey(this.serverId));
+    if (!raw) return undefined;
+    try {
+      return JSON.parse(raw) as OAuthDiscoveryState;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async saveDiscoveryState(state: OAuthDiscoveryState): Promise<void> {
+    await setSecureKeyAsync(discoveryKey(this.serverId), JSON.stringify(state));
+  }
+
+  // --- Redirect to Authorization ---
+
+  async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+    const url = authorizationUrl.toString();
+
+    if (!this.interactive) {
+      // Daemon mode — don't open browser, just log guidance
+      log.info({ serverId: this.serverId }, 'OAuth required but running in non-interactive mode');
+      return;
+    }
+
+    log.info({ serverId: this.serverId }, 'Opening browser for OAuth authorization');
+    console.log(`[MCP] Opening browser for OAuth authorization of "${this.serverId}"...`);
+
+    try {
+      const { execFile } = await import('node:child_process');
+      if (isMacOS()) {
+        execFile('open', [url]);
+      } else if (isLinux()) {
+        execFile('xdg-open', [url]);
+      } else {
+        log.warn('Unsupported platform for browser open — please visit the URL manually');
+        console.log(`[MCP] Please open this URL in your browser:\n${url}`);
+      }
+    } catch (err) {
+      log.warn({ err }, 'Failed to open browser');
+      console.log(`[MCP] Please open this URL in your browser:\n${url}`);
+    }
+  }
+
+  // --- Invalidate Credentials ---
+
+  async invalidateCredentials(scope: 'all' | 'client' | 'tokens' | 'verifier' | 'discovery'): Promise<void> {
+    log.info({ serverId: this.serverId, scope }, 'Invalidating OAuth credentials');
+
+    if (scope === 'all' || scope === 'tokens') {
+      await deleteSecureKeyAsync(tokensKey(this.serverId));
+    }
+    if (scope === 'all' || scope === 'client') {
+      await deleteSecureKeyAsync(clientInfoKey(this.serverId));
+    }
+    if (scope === 'all' || scope === 'verifier') {
+      this._codeVerifier = undefined;
+    }
+    if (scope === 'all' || scope === 'discovery') {
+      await deleteSecureKeyAsync(discoveryKey(this.serverId));
+    }
+  }
+
+  // --- Callback Server ---
+
+  /**
+   * Start a loopback HTTP server to receive the OAuth callback.
+   * Returns a promise that resolves with the authorization code.
+   */
+  startCallbackServer(): Promise<McpOAuthCallbackResult> {
+    return new Promise((resolveSetup, rejectSetup) => {
+      let settled = false;
+      let listening = false;
+      let codeResolve: (code: string) => void;
+      let codeReject: (err: Error) => void;
+
+      const codePromise = new Promise<string>((resolve, reject) => {
+        codeResolve = resolve;
+        codeReject = reject;
+      });
+      this._codePromise = codePromise;
+
+      const server = createServer((req, res) => {
+        if (settled) {
+          res.writeHead(400, { 'Content-Type': 'text/html' });
+          res.end(renderPage('Authorization already completed', false));
+          return;
+        }
+
+        const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+        if (url.pathname !== CALLBACK_PATH) {
+          res.writeHead(404, { 'Content-Type': 'text/plain' });
+          res.end('Not found');
+          return;
+        }
+
+        const code = url.searchParams.get('code');
+        const error = url.searchParams.get('error');
+
+        settled = true;
+
+        if (error) {
+          const errorDesc = url.searchParams.get('error_description') ?? error;
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.end(renderPage(`Authorization failed: ${errorDesc}`, false));
+          cleanup();
+          codeReject(new Error(`MCP OAuth authorization denied: ${error}`));
+          return;
+        }
+
+        if (!code) {
+          res.writeHead(400, { 'Content-Type': 'text/html' });
+          res.end(renderPage('Missing authorization code', false));
+          cleanup();
+          codeReject(new Error('MCP OAuth callback missing authorization code'));
+          return;
+        }
+
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(renderPage('Authorization successful! You can close this tab.', true));
+        cleanup();
+        codeResolve(code);
+      });
+
+      this.callbackServer = server;
+
+      const timeout = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          cleanup();
+          codeReject(new Error('MCP OAuth callback timed out'));
+        }
+      }, CALLBACK_TIMEOUT_MS);
+      if (typeof timeout === 'object' && 'unref' in timeout) timeout.unref();
+      this.callbackTimeout = timeout;
+
+      const cleanup = () => {
+        if (this.callbackTimeout) {
+          clearTimeout(this.callbackTimeout);
+          this.callbackTimeout = null;
+        }
+        if (this.callbackServer) {
+          this.callbackServer.close();
+          this.callbackServer = null;
+        }
+      };
+
+      server.listen(0, '127.0.0.1', () => {
+        const addr = server.address() as { port: number };
+        this._redirectUrl = `http://127.0.0.1:${addr.port}${CALLBACK_PATH}`;
+        listening = true;
+        log.info({ serverId: this.serverId, redirectUrl: this._redirectUrl }, 'OAuth callback server started');
+        resolveSetup({ codePromise });
+      });
+
+      server.on('error', (err) => {
+        const message = `MCP OAuth callback server error: ${err.message}`;
+        if (!listening) {
+          settled = true;
+          cleanup();
+          rejectSetup(new Error(message));
+        } else if (!settled) {
+          settled = true;
+          cleanup();
+          codeReject(new Error(message));
+        }
+      });
+    });
+  }
+
+  /** Returns the code promise from the running callback server. */
+  waitForCode(): Promise<string> {
+    if (!this._codePromise) {
+      throw new Error('Callback server not started — call startCallbackServer() first');
+    }
+    return this._codePromise;
+  }
+
+  /** Stop the callback server if it's still running. */
+  stopCallbackServer(): void {
+    if (this.callbackTimeout) {
+      clearTimeout(this.callbackTimeout);
+      this.callbackTimeout = null;
+    }
+    if (this.callbackServer) {
+      this.callbackServer.close();
+      this.callbackServer = null;
+    }
+  }
+}
+
+// --- Static helpers ---
+
+/**
+ * Delete all OAuth credentials for a given MCP server.
+ * Used by `mcp remove` for cleanup.
+ */
+export async function deleteMcpOAuthCredentials(serverId: string): Promise<void> {
+  await Promise.all([
+    deleteSecureKeyAsync(tokensKey(serverId)),
+    deleteSecureKeyAsync(clientInfoKey(serverId)),
+    deleteSecureKeyAsync(discoveryKey(serverId)),
+  ]);
+  log.info({ serverId }, 'OAuth credentials deleted');
+}
+
+// --- HTML rendering ---
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
+function renderPage(message: string, success: boolean): string {
+  const title = success ? 'Authorization Successful' : 'Authorization Failed';
+  const color = success ? '#4CAF50' : '#f44336';
+  return `<!DOCTYPE html><html><head><title>${escapeHtml(title)}</title><style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0;background:#f5f5f5}div{text-align:center;padding:2rem;background:white;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,0.1)}h1{color:${color}}</style></head><body><div><h1>${escapeHtml(title)}</h1><p>${escapeHtml(message)}</p></div></body></html>`;
+}


### PR DESCRIPTION
## Summary
- Add `vellum mcp auth <name>` CLI command that opens a browser for OAuth, stores tokens in keychain, and exits cleanly
- Daemon connects using cached tokens when available; if a server needs auth, it skips gracefully and logs `Run "vellum mcp auth <name>"`
- `vellum mcp remove` cleans up stored OAuth credentials from keychain
- New `McpOAuthProvider` implementing the MCP SDK's `OAuthClientProvider` interface with secure-keys storage and loopback callback server

## Test plan
- [ ] `vellum mcp add linear -t streamable-http -u https://mcp.linear.app/mcp` — adds server
- [ ] `vellum mcp auth linear` — opens browser, completes OAuth, stores tokens, exits
- [ ] Restart daemon — Linear connects using cached tokens (no browser)
- [ ] `vellum mcp remove linear` — removes config and cleans up keychain credentials
- [ ] Daemon with unauthenticated server — skips gracefully, shows guidance message
- [ ] Non-OAuth servers (e.g. context7) — still connect normally without any auth overhead

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
