### PR TITLE
fix(macos): wake word voice activation — wrong thread and failed mic handoff

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -230,7 +230,8 @@ final class VoiceModeManager: ObservableObject {
         errorMessage = ""
         state = .listening
         guard voiceService.startRecording() else {
-            errorMessage = "Speech recognition unavailable"
+            log.error("Voice mode: startRecording() failed — mic may not be available yet")
+            errorMessage = "Microphone not ready. Try again."
             state = .idle
             return
         }

--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
@@ -32,6 +32,10 @@ final class WakeWordCoordinator: ObservableObject {
     /// The in-flight activation task — stored so it can be cancelled if voice mode
     /// is toggled off before the mic handoff completes.
     private var activationTask: Task<Void, Never>?
+    /// True while the retry loop is calling deactivate() between attempts.
+    /// Prevents the `.off` state observer from cancelling the activation task
+    /// when the retry loop itself triggers the `.off` transition.
+    private var isRetryingActivation = false
 
     /// Cooldown after activation to prevent re-triggering from leftover audio.
     private var lastActivationTime: Date?
@@ -148,9 +152,12 @@ final class WakeWordCoordinator: ObservableObject {
                     return
                 }
 
-                // startListening() failed — tear down and retry
+                // startListening() failed — tear down and retry. Set the flag so
+                // the .off state observer doesn't cancel this activation task.
                 log.warning("startListening() failed on attempt \(attempt + 1) — mic not ready yet")
+                self.isRetryingActivation = true
                 self.voiceModeManager.deactivate()
+                self.isRetryingActivation = false
             }
 
             // All attempts failed
@@ -208,9 +215,12 @@ final class WakeWordCoordinator: ObservableObject {
             .sink { [weak self] newState in
                 guard let self else { return }
                 if newState == .off {
-                    // Cancel any in-flight activation attempts
-                    self.activationTask?.cancel()
-                    self.activationTask = nil
+                    // Cancel in-flight activation — but not when the retry loop
+                    // itself called deactivate() between attempts.
+                    if !self.isRetryingActivation {
+                        self.activationTask?.cancel()
+                        self.activationTask = nil
+                    }
                     // Only resume monitoring if wake word is enabled in settings
                     if UserDefaults.standard.bool(forKey: "wakeWordEnabled") {
                         log.info("Voice mode deactivated — resuming wake word listening after delay")

--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
@@ -29,6 +29,9 @@ final class WakeWordCoordinator: ObservableObject {
     /// Stored so it can be cancelled on rapid voice mode toggles, preventing
     /// stacked restart callbacks from queuing up via the old asyncAfter pattern.
     private var restartMonitorTask: Task<Void, Never>?
+    /// The in-flight activation task — stored so it can be cancelled if voice mode
+    /// is toggled off before the mic handoff completes.
+    private var activationTask: Task<Void, Never>?
 
     /// Cooldown after activation to prevent re-triggering from leftover audio.
     private var lastActivationTime: Date?
@@ -110,25 +113,51 @@ final class WakeWordCoordinator: ObservableObject {
         WakeWordFeedback.playActivationChime()
         activationWindow.show(state: .activated)
 
-        // 2. Pause the audio monitor (stop keyword listening to free the mic)
+        // 2. Capture the ChatViewModel NOW (before any async delay) so it matches
+        // the thread the user is currently looking at.
+        guard let chatViewModel = ensureChatViewModel() else {
+            log.error("Wake word activation failed — no ChatViewModel available")
+            return
+        }
+
+        // 3. Pause the audio monitor (stop keyword listening to free the mic)
         audioMonitor.stopMonitoring()
 
-        // 3. Ensure we have an active ChatViewModel (create a new thread if needed)
-        guard let chatViewModel = ensureChatViewModel() else {
-            log.error("Wake word activation failed — no ChatViewModel available, resuming wake word listening")
-            audioMonitor.startMonitoring()
-            return
-        }
+        // 4. Wait for the wake word engine's SFSpeechRecognitionTask to fully
+        // release, then activate voice mode. macOS only allows one recognition
+        // task per process, so we retry with backoff if the first attempt fails.
+        activationTask?.cancel()
+        activationTask = Task { @MainActor [weak self] in
+            let delays: [Duration] = [.milliseconds(200), .milliseconds(300), .milliseconds(500)]
+            for (attempt, delay) in delays.enumerated() {
+                try? await Task.sleep(for: delay)
+                guard let self, !Task.isCancelled else { return }
+                guard self.voiceModeManager.state == .off else { return }
 
-        // 4. Activate voice mode (voice bar appears automatically via ComposerSection)
-        voiceModeManager.activate(chatViewModel: chatViewModel)
-        guard voiceModeManager.state != .off else {
-            log.warning("Voice mode activation failed — resuming wake word listening")
-            audioMonitor.startMonitoring()
-            return
+                self.voiceModeManager.activate(chatViewModel: chatViewModel)
+                guard self.voiceModeManager.state != .off else {
+                    log.warning("Voice mode activation failed on attempt \(attempt + 1)")
+                    continue
+                }
+                self.activatedViaWakeWord = true
+                self.voiceModeManager.startListening()
+
+                // Verify recording actually started
+                if self.voiceModeManager.state == .listening {
+                    log.info("Voice mode activated via wake word (attempt \(attempt + 1))")
+                    return
+                }
+
+                // startListening() failed — tear down and retry
+                log.warning("startListening() failed on attempt \(attempt + 1) — mic not ready yet")
+                self.voiceModeManager.deactivate()
+            }
+
+            // All attempts failed
+            guard let self else { return }
+            log.error("Voice mode activation failed after \(delays.count) attempts — resuming wake word listening")
+            self.audioMonitor.startMonitoring()
         }
-        activatedViaWakeWord = true
-        voiceModeManager.startListening()
     }
 
     /// Returns the active ChatViewModel, creating a new thread if none exists.
@@ -179,6 +208,9 @@ final class WakeWordCoordinator: ObservableObject {
             .sink { [weak self] newState in
                 guard let self else { return }
                 if newState == .off {
+                    // Cancel any in-flight activation attempts
+                    self.activationTask?.cancel()
+                    self.activationTask = nil
                     // Only resume monitoring if wake word is enabled in settings
                     if UserDefaults.standard.bool(forKey: "wakeWordEnabled") {
                         log.info("Voice mode deactivated — resuming wake word listening after delay")


### PR DESCRIPTION
## Summary
- **Capture ChatViewModel before async delay** so voice messages go to the thread the user is looking at, not whatever thread becomes active during the mic handoff delay
- **Retry with backoff** (200/300/500ms) when `startRecording()` fails because the wake word engine's `SFSpeechRecognitionTask` hasn't fully released yet — macOS only allows one per process
- **Better error feedback** when mic acquisition fails: logs explicitly and shows "Microphone not ready" instead of the misleading "Speech recognition unavailable"
- **Cancellable activation task** so rapid voice mode toggles don't stack up stale retries

## Test plan
- [ ] Open app → click "New Chat" → say wake word → verify voice bar appears in composer, transcription shows, message sent to new thread (not a previous one)
- [ ] Open an existing thread → say wake word → speak → verify silence detection triggers and message auto-submits
- [ ] Say wake word while app is already in voice mode → verify it's ignored (no double activation)
- [ ] Toggle voice mode off during activation retry window → verify clean teardown, wake word resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
