### PR TITLE
fix: remove unused DenialReason import

### DIFF
--- a/assistant/src/runtime/guardian-context-resolver.ts
+++ b/assistant/src/runtime/guardian-context-resolver.ts
@@ -12,7 +12,6 @@
  */
 import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
 import {
-  type DenialReason,
   resolveActorTrust,
   type ResolveActorTrustInput,
   toGuardianRuntimeContextFromTrust,


### PR DESCRIPTION
## Summary
- Remove unused `DenialReason` type import from `guardian-context-resolver.ts` (the type is re-exported on a separate line, so the import was redundant and triggered ESLint `no-unused-vars`)

## Original prompt
fix the CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22590965420

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
