### PR TITLE
Add codeowners for default identity/personality files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,12 @@ assistant/src/config/system-prompt.ts @awlevin @siddseethepalli @alex-nork
 assistant/src/config/computer-use-prompt.ts @awlevin @siddseethepalli @alex-nork
 assistant/src/config/templates/ @awlevin @siddseethepalli @alex-nork
 
+# Default identity/personality files
+assistant/src/config/templates/IDENTITY.md @awlevin @AnitaKirkovska
+assistant/src/config/templates/USER.md @awlevin @AnitaKirkovska
+assistant/src/config/templates/SOUL.md @awlevin @AnitaKirkovska
+assistant/src/config/templates/BOOTSTRAP.md @awlevin @AnitaKirkovska
+
 # Tool definitions and infrastructure
 assistant/src/tools/ @siddseethepalli
 


### PR DESCRIPTION
## Summary
- Adds `@awlevin` and `@AnitaKirkovska` as explicit codeowners for `IDENTITY.md`, `USER.md`, `SOUL.md`, and `BOOTSTRAP.md` in `assistant/src/config/templates/`
- These files define the assistant's default personality, onboarding, and identity — changes should be reviewed by Aaron and Anita

## Test plan
- [x] Verify CODEOWNERS syntax is valid
- [x] Confirm file paths match existing template files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
