### PR TITLE
Hatching View Refactor: Progress UX, Local Flow, Error Surfacing

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -97,6 +97,8 @@ declare -a SAFE_LINE_PATTERNS=(
     # Swift: named argument passing a variable (e.g. `clientSecret: trimmedSecret`)
     # where the line ends with the identifier or has a trailing closing paren.
     "[Cc]lient[Ss]ecret:[[:space:]]*[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*$"
+    # Swift: named argument passing a variable for privateKey (e.g. `sshPrivateKey: state.sshPrivateKey,`)
+    "[Pp]rivate[Kk]ey:[[:space:]]*[a-zA-Z_][a-zA-Z0-9_.]*[[:space:]]*[,)][[:space:]]*$"
     # Swift/Kotlin: constant declaration whose value is a camelCase identifier
     # (e.g. `let archivedSessionsKey = "archivedSessionIds"`).
     # These are AppStorage / UserDefaults keys, not secrets.
@@ -234,6 +236,8 @@ if [ "${1:-}" = "--self-test" ]; then
     SAFE_DOTTED_PROP_SECRET='    clientSecret: options.clientSecret,'
     # Swift named argument passing a variable (false positive to whitelist)
     SAFE_SWIFT_NAMED_ARG='                clientSecret: trimmedSecret'
+    # Swift named argument passing a variable for privateKey (false positive to whitelist)
+    SAFE_SWIFT_PRIVATE_KEY_ARG='            sshPrivateKey: state.sshPrivateKey,'
     # AWS well-known example key (false positive to whitelist)
     SAFE_AWS_EXAMPLE_KEY='const EXAMPLE_KEY = "AKIAIOSFODNN7EXAMPLE";'
     # Swift storage key constant (safe — UserDefaults key, not a secret)
@@ -467,6 +471,10 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$SAFE_SWIFT_NAMED_ARG" && ! matches_safe_line_pattern "$SAFE_SWIFT_NAMED_ARG"; then
         echo -e "${RED}Self-test failed:${NC} Swift named argument clientSecret false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_SWIFT_PRIVATE_KEY_ARG" && ! matches_safe_line_pattern "$SAFE_SWIFT_PRIVATE_KEY_ARG"; then
+        echo -e "${RED}Self-test failed:${NC} Swift named argument sshPrivateKey false positive"
         exit 1
     fi
     if matches_secret_pattern "$SAFE_AWS_EXAMPLE_KEY" && ! matches_safe_line_pattern "$SAFE_AWS_EXAMPLE_KEY"; then

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -531,17 +531,23 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                     // Remote assistants don't run a local gateway, so skip the check.
                     let gatewayOk = isCurrentAssistantRemote || (await isGatewayHealthy())
                     if !gatewayOk {
+                        // Gateway is unhealthy but daemon is connected. Record for
+                        // diagnostics but proceed anyway — the gateway being down
+                        // only affects external ingress (Twilio, OAuth), not core
+                        // assistant functionality. Blocking here causes a deadlock
+                        // when the lockfile-exists fallback hatches with daemonOnly.
                         bootstrapFailureKind = .gatewayUnhealthy
+                        log.warning("Gateway unhealthy during bootstrap retry but daemon is connected — proceeding anyway (some features like Twilio/OAuth ingress may be unavailable)")
                     } else {
                         log.info("Daemon connected during bootstrap retry — proceeding to wake-up send")
-                        transitionBootstrap(to: .pendingWakeupSend)
-                        dismissBootstrapInterstitialWindow()
-                        await performRetriableWakeUpSend()
-                        if !Task.isCancelled {
-                            bootstrapRetryTask = nil
-                        }
-                        return
                     }
+                    transitionBootstrap(to: .pendingWakeupSend)
+                    dismissBootstrapInterstitialWindow()
+                    await performRetriableWakeUpSend()
+                    if !Task.isCancelled {
+                        bootstrapRetryTask = nil
+                    }
+                    return
                 }
 
                 // If the daemon socket doesn't exist, the daemon process
@@ -559,9 +565,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 }
 
                 // Attempt a connection if not already connected or in progress.
-                // The gateway-unhealthy fallthrough above should not trigger a
-                // reconnect — tearing down a healthy daemon connection just
-                // because the gateway isn't ready yet causes unnecessary churn.
                 if !daemonClient.isConnected && !daemonClient.isConnecting {
                     do {
                         try await daemonClient.connect()
@@ -582,17 +585,21 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                     // Remote assistants don't run a local gateway, so skip the check.
                     let gatewayOk = isCurrentAssistantRemote || (await isGatewayHealthy())
                     if !gatewayOk {
+                        // Same rationale as the check above: gateway health is a
+                        // warning, not a gate. Blocking here deadlocks when hatch
+                        // ran with daemonOnly (lockfile-exists fallback).
                         bootstrapFailureKind = .gatewayUnhealthy
+                        log.warning("Gateway unhealthy after bootstrap retry connect but daemon is connected — proceeding anyway (some features like Twilio/OAuth ingress may be unavailable)")
                     } else {
                         log.info("Daemon connected after bootstrap retry connect — proceeding to wake-up send")
-                        transitionBootstrap(to: .pendingWakeupSend)
-                        dismissBootstrapInterstitialWindow()
-                        await performRetriableWakeUpSend()
-                        if !Task.isCancelled {
-                            bootstrapRetryTask = nil
-                        }
-                        return
                     }
+                    transitionBootstrap(to: .pendingWakeupSend)
+                    dismissBootstrapInterstitialWindow()
+                    await performRetriableWakeUpSend()
+                    if !Task.isCancelled {
+                        bootstrapRetryTask = nil
+                    }
+                    return
                 }
 
                 // Surface diagnostics so the user isn't staring at a

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -66,6 +66,17 @@ enum BootstrapState: String {
     case complete = "complete"
 }
 
+/// Categorises the most recent bootstrap failure so diagnostic messages
+/// can be specific rather than generic escalating text.
+private enum BootstrapFailureKind {
+    case socketMissing
+    case daemonNotRunning
+    case connectionRefused
+    case gatewayUnhealthy
+    case authFailed
+    case unknown
+}
+
 /// Carbon event handler for the Quick Input hotkey (Cmd+Shift+/).
 /// Must be a free function because Carbon callbacks are C function pointers.
 private func quickInputHotKeyHandler(
@@ -156,6 +167,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     private var bootstrapInterstitialWindow: NSWindow?
     /// Active task for the bootstrap retry coordinator. Cancelled on dismiss.
     private var bootstrapRetryTask: Task<Void, Never>?
+    /// Tracks the most recent failure kind during bootstrap retries so that
+    /// diagnostic messages reflect the actual problem, not generic escalating text.
+    private var bootstrapFailureKind: BootstrapFailureKind = .unknown
     /// Background task that retries actor-token bootstrap until success.
     private var actorTokenBootstrapTask: Task<Void, Never>?
     /// Tracks file paths of .vellumapp bundles awaiting daemon responses (FIFO).
@@ -508,20 +522,81 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
         bootstrapRetryTask = Task {
             while !Task.isCancelled {
+                // Reset so the displayed message always reflects the most
+                // recent failure, not a stale one from a previous iteration.
+                bootstrapFailureKind = .unknown
+
                 if daemonClient.isConnected {
-                    log.info("Daemon connected during bootstrap retry — proceeding to wake-up send")
-                    transitionBootstrap(to: .pendingWakeupSend)
-                    dismissBootstrapInterstitialWindow()
-                    await performRetriableWakeUpSend()
-                    // Only nil out if we're still the active task (no new coordinator was started)
-                    if !Task.isCancelled {
-                        bootstrapRetryTask = nil
+                    // Daemon is connected — check gateway health before proceeding.
+                    // Remote assistants don't run a local gateway, so skip the check.
+                    let gatewayOk = isCurrentAssistantRemote || (await isGatewayHealthy())
+                    if !gatewayOk {
+                        bootstrapFailureKind = .gatewayUnhealthy
+                    } else {
+                        log.info("Daemon connected during bootstrap retry — proceeding to wake-up send")
+                        transitionBootstrap(to: .pendingWakeupSend)
+                        dismissBootstrapInterstitialWindow()
+                        await performRetriableWakeUpSend()
+                        if !Task.isCancelled {
+                            bootstrapRetryTask = nil
+                        }
+                        return
                     }
-                    return
                 }
 
-                // Surface escalating diagnostics so the user isn't staring
-                // at a spinner with no context.
+                // If the daemon socket doesn't exist, the daemon process
+                // likely isn't running (e.g. hatch failed). Re-attempt hatch
+                // so we don't loop forever on connect-only retries.
+                let socketPath = DaemonClient.resolveSocketPath()
+                if !FileManager.default.fileExists(atPath: socketPath) {
+                    bootstrapFailureKind = .socketMissing
+                    log.info("Daemon socket missing during bootstrap retry — re-attempting hatch")
+                    try? await assistantCli.hatch(daemonOnly: true)
+                } else if !DaemonClient.isDaemonProcessAlive() {
+                    bootstrapFailureKind = .daemonNotRunning
+                    log.info("Daemon process not alive during bootstrap retry — re-attempting hatch")
+                    try? await assistantCli.hatch(daemonOnly: true)
+                }
+
+                // Attempt a connection if not already connected or in progress.
+                // The gateway-unhealthy fallthrough above should not trigger a
+                // reconnect — tearing down a healthy daemon connection just
+                // because the gateway isn't ready yet causes unnecessary churn.
+                if !daemonClient.isConnected && !daemonClient.isConnecting {
+                    do {
+                        try await daemonClient.connect()
+                    } catch {
+                        if bootstrapFailureKind == .unknown {
+                            if error is DaemonClient.AuthError {
+                                bootstrapFailureKind = .authFailed
+                            } else {
+                                bootstrapFailureKind = .connectionRefused
+                            }
+                        }
+                        log.error("Bootstrap retry connect attempt failed: \(error)")
+                    }
+                }
+
+                if daemonClient.isConnected {
+                    // Connected — verify gateway health before proceeding.
+                    // Remote assistants don't run a local gateway, so skip the check.
+                    let gatewayOk = isCurrentAssistantRemote || (await isGatewayHealthy())
+                    if !gatewayOk {
+                        bootstrapFailureKind = .gatewayUnhealthy
+                    } else {
+                        log.info("Daemon connected after bootstrap retry connect — proceeding to wake-up send")
+                        transitionBootstrap(to: .pendingWakeupSend)
+                        dismissBootstrapInterstitialWindow()
+                        await performRetriableWakeUpSend()
+                        if !Task.isCancelled {
+                            bootstrapRetryTask = nil
+                        }
+                        return
+                    }
+                }
+
+                // Surface diagnostics so the user isn't staring at a
+                // spinner with no context.
                 let elapsed = CFAbsoluteTimeGetCurrent() - retryStart
                 if elapsed > 30 {
                     updateBootstrapInterstitial(
@@ -530,54 +605,57 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                     )
                 }
 
-                // If the daemon socket doesn't exist, the daemon process
-                // likely isn't running (e.g. hatch failed). Re-attempt hatch
-                // so we don't loop forever on connect-only retries.
-                let socketPath = DaemonClient.resolveSocketPath()
-                if !FileManager.default.fileExists(atPath: socketPath) {
-                    log.info("Daemon socket missing during bootstrap retry — re-attempting hatch")
-                    try? await assistantCli.hatch(daemonOnly: true)
-                }
-
-                // Attempt a connection if not already in progress
-                if !daemonClient.isConnecting {
-                    do {
-                        try await daemonClient.connect()
-                    } catch {
-                        log.error("Bootstrap retry connect attempt failed: \(error)")
-                    }
-                }
-
-                if daemonClient.isConnected {
-                    log.info("Daemon connected after bootstrap retry connect — proceeding to wake-up send")
-                    transitionBootstrap(to: .pendingWakeupSend)
-                    dismissBootstrapInterstitialWindow()
-                    await performRetriableWakeUpSend()
-                    // Only nil out if we're still the active task (no new coordinator was started)
-                    if !Task.isCancelled {
-                        bootstrapRetryTask = nil
-                    }
-                    return
-                }
-
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
             }
         }
     }
 
-    /// Returns a user-facing diagnostic message based on how long the bootstrap
-    /// retry has been running. Messages escalate in specificity over time.
+    /// Returns a user-facing diagnostic message based on the current failure
+    /// kind and how long the bootstrap retry has been running.
     private func bootstrapDiagnosticMessage(elapsed: CFAbsoluteTime) -> String {
-        if elapsed > 120 {
-            return "Your assistant is taking unusually long to start. "
-                + "Try quitting the app (\u{2318}Q) and reopening it. "
-                + "If the issue persists, retire and re-hatch your assistant."
-        } else if elapsed > 60 {
-            return "This is taking longer than expected. "
-                + "A background process may have crashed. "
-                + "The app will keep retrying automatically."
-        } else {
-            return "Still working on it \u{2014} this can take a minute on first launch."
+        switch bootstrapFailureKind {
+        case .socketMissing:
+            if elapsed > 60 {
+                return "Assistant files are missing. Try quitting (\u{2318}Q) and reopening."
+            }
+            return "Restarting your assistant\u{2026}"
+
+        case .daemonNotRunning:
+            if elapsed > 60 {
+                return "Unable to restart assistant. Try quitting (\u{2318}Q) and reopening."
+            }
+            return "Assistant process stopped \u{2014} restarting\u{2026}"
+
+        case .connectionRefused:
+            if elapsed > 60 {
+                return "Connection keeps failing. Try quitting (\u{2318}Q) and reopening."
+            }
+            return "Connecting to your assistant\u{2026}"
+
+        case .gatewayUnhealthy:
+            if elapsed > 60 {
+                return "Network services are not responding. Try quitting (\u{2318}Q) and reopening."
+            }
+            return "Waiting for network services\u{2026}"
+
+        case .authFailed:
+            if elapsed > 60 {
+                return "Authentication issue. You may need to re-pair your assistant."
+            }
+            return "Authenticating\u{2026}"
+
+        case .unknown:
+            if elapsed > 120 {
+                return "Your assistant is taking unusually long to start. "
+                    + "Try quitting the app (\u{2318}Q) and reopening it. "
+                    + "If the issue persists, retire and re-hatch your assistant."
+            } else if elapsed > 60 {
+                return "This is taking longer than expected. "
+                    + "A background process may have crashed. "
+                    + "The app will keep retrying automatically."
+            } else {
+                return "Still working on it \u{2014} this can take a minute on first launch."
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -529,7 +529,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 if daemonClient.isConnected {
                     // Daemon is connected — check gateway health before proceeding.
                     // Remote assistants don't run a local gateway, so skip the check.
-                    let gatewayOk = isCurrentAssistantRemote || (await isGatewayHealthy())
+                    let gatewayHealthy = await isGatewayHealthy()
+                    let gatewayOk = isCurrentAssistantRemote || gatewayHealthy
                     if !gatewayOk {
                         // Gateway is unhealthy but daemon is connected. Record for
                         // diagnostics but proceed anyway — the gateway being down
@@ -583,7 +584,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 if daemonClient.isConnected {
                     // Connected — verify gateway health before proceeding.
                     // Remote assistants don't run a local gateway, so skip the check.
-                    let gatewayOk = isCurrentAssistantRemote || (await isGatewayHealthy())
+                    let gatewayHealthy = await isGatewayHealthy()
+                    let gatewayOk = isCurrentAssistantRemote || gatewayHealthy
                     if !gatewayOk {
                         // Same rationale as the check above: gateway health is a
                         // warning, not a gate. Blocking here deadlocks when hatch

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1305,23 +1305,48 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
         Task {
             if !isCurrentAssistantRemote {
-                // On first launch post-onboarding, use daemonOnly: false so the CLI
-                // creates a lockfile entry. On subsequent launches, daemonOnly: true
-                // prevents duplicates.
-                let needsLockfileEntry = isFirstLaunch && !self.lockfileHasAssistants()
-                do {
-                    try await assistantCli.hatch(daemonOnly: !needsLockfileEntry)
-                } catch {
-                    log.error("Failed to hatch assistant during daemon setup: \(error)")
-                    if needsLockfileEntry {
-                        log.info("Full hatch failed on first launch — retrying daemon-only as fallback")
-                        try? await assistantCli.hatch(daemonOnly: true)
+                // If the hatching step already started the gateway (e.g. `vellum-cli hatch --remote local`),
+                // skip the CLI hatch to avoid spawning a duplicate gateway process.
+                // Require BOTH lockfile and healthy gateway — a stale lockfile with an unhealthy
+                // gateway falls through to the normal hatch path.
+                let lockfileExists = self.lockfileHasAssistants()
+                var gatewayHealthy = false
+                if lockfileExists {
+                    if isFirstLaunch {
+                        // Retry window: gateway may still be starting from onboarding hatch
+                        for _ in 0..<3 {
+                            if await isGatewayHealthy() { gatewayHealthy = true; break }
+                            try? await Task.sleep(nanoseconds: 1_000_000_000)
+                        }
+                    } else {
+                        // Non-first-launch: single check, no retry delay
+                        gatewayHealthy = await isGatewayHealthy()
                     }
                 }
-                if needsLockfileEntry {
-                    _ = self.loadAssistantFromLockfile()
+
+                if lockfileExists && gatewayHealthy {
+                    log.info("Lockfile and gateway already present — skipping CLI hatch to avoid duplicate gateway")
+                    assistantCli.startMonitoring()
+                } else {
+                    // On first launch post-onboarding, use daemonOnly: false so the CLI
+                    // creates a lockfile entry. On subsequent launches, daemonOnly: true
+                    // prevents duplicates.
+                    let needsLockfileEntry = isFirstLaunch && !lockfileExists
+                    let daemonOnly = !needsLockfileEntry
+                    do {
+                        try await assistantCli.hatch(daemonOnly: daemonOnly)
+                    } catch {
+                        log.error("Failed to hatch assistant during daemon setup: \(error)")
+                        if needsLockfileEntry {
+                            log.info("Full hatch failed on first launch — retrying daemon-only as fallback")
+                            try? await assistantCli.hatch(daemonOnly: true)
+                        }
+                    }
+                    if needsLockfileEntry {
+                        _ = self.loadAssistantFromLockfile()
+                    }
+                    assistantCli.startMonitoring()
                 }
-                assistantCli.startMonitoring()
             }
             // Skip connect if the bootstrap retry coordinator already connected
             // or has a connect in flight (hatch can take a long time; the
@@ -2197,6 +2222,24 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             return false
         }
         return !assistants.isEmpty
+    }
+
+    /// Check whether the local gateway is healthy by hitting its /healthz endpoint.
+    /// Reads port from GATEWAY_PORT env var (default 7830) to match local.ts runtime behavior.
+    private func isGatewayHealthy() async -> Bool {
+        let port = ProcessInfo.processInfo.environment["GATEWAY_PORT"] ?? "7830"
+        guard let url = URL(string: "http://localhost:\(port)/healthz") else { return false }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 2
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse, http.statusCode == 200 {
+                return true
+            }
+        } catch {
+            // Gateway not reachable — not healthy
+        }
+        return false
     }
 
     /// Remove a specific assistant entry from the lockfile. Used after a

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -283,7 +283,8 @@ struct APIKeyStepView: View {
             } else if userHostedEnabled {
                 state.isHatching = true
             } else {
-                state.advance()
+                state.cloudProvider = "local"
+                state.isHatching = true
             }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -131,7 +131,7 @@ struct HatchingStepView: View {
     }
 
     private var wobbleEgg: some View {
-        Text(state.hatchFailed ? "\u{1F480}" : eggCracked ? "\u{1F423}" : "\u{1F95A}")
+        Text(state.hatchFailed ? "\u{1FAE0}" : eggCracked ? "\u{1F423}" : "\u{1F95A}")
             .font(.system(size: 72))
             .rotationEffect(.degrees(wobbleAngle))
             .scaleEffect(eggCracked ? 1.1 : 1.0)
@@ -197,26 +197,15 @@ struct HatchingStepView: View {
 
     private var failureButtons: some View {
         VStack(spacing: VSpacing.sm) {
-            Button(action: { retryHatch() }) {
-                Text("Try Again")
-                    .font(.system(size: 13))
-                    .foregroundColor(VColor.textSecondary)
-            }
-            .buttonStyle(.plain)
-            .onHover { hovering in
-                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            OnboardingButton(title: "Try Again", style: .primary) {
+                retryHatch()
             }
 
-            Button(action: { goBack() }) {
-                Text("Go Back")
-                    .font(.system(size: 13))
-                    .foregroundColor(VColor.textMuted)
-            }
-            .buttonStyle(.plain)
-            .onHover { hovering in
-                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            OnboardingButton(title: "Go Back", style: .tertiary) {
+                goBack()
             }
         }
+        .frame(maxWidth: 280)
         .padding(.top, VSpacing.xs)
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -22,6 +22,7 @@ struct HatchingStepView: View {
     @State private var progressMessageTimer: Timer?
     @State private var showTimeEstimate = false
     @State private var cliFinished = false
+    @State private var failureReason: String?
 
     private static let progressMessages = [
         "Getting things ready\u{2026}",
@@ -155,6 +156,11 @@ struct HatchingStepView: View {
                 Text("Something went wrong")
                     .font(.system(size: 24, weight: .regular, design: .serif))
                     .foregroundColor(VColor.textPrimary)
+                if let reason = failureReason {
+                    Text(reason)
+                        .font(.system(size: 14))
+                        .foregroundColor(VColor.textSecondary)
+                }
             } else if state.hatchCompleted {
                 Text(isCustomHardware ? "Your assistant is paired!" : "Your assistant has hatched!")
                     .font(.system(size: 24, weight: .regular, design: .serif))
@@ -233,11 +239,13 @@ struct HatchingStepView: View {
         state.hatchFailed = false
         state.hatchLogLines = []
         hatchStarted = false
+        failureReason = nil
     }
 
     private func retryHatch() {
         state.hatchFailed = false
         state.hatchLogLines = []
+        failureReason = nil
         eggCracked = false
         crackTime = nil
         cliFinished = false
@@ -374,6 +382,7 @@ struct HatchingStepView: View {
                 handleHatchSuccess()
             } catch {
                 state.hatchLogLines.append("Error: \(error.localizedDescription)")
+                failureReason = friendlyErrorMessage(from: error)
                 state.hatchFailed = true
             }
         }
@@ -390,8 +399,28 @@ struct HatchingStepView: View {
                 handleHatchSuccess()
             } catch {
                 state.hatchLogLines.append("Error: \(error.localizedDescription)")
+                failureReason = friendlyErrorMessage(from: error)
                 state.hatchFailed = true
             }
+        }
+    }
+
+    // MARK: - Error Mapping
+
+    private func friendlyErrorMessage(from error: Error) -> String {
+        let desc = error.localizedDescription.lowercased()
+        if desc.contains("connection refused") || desc.contains("econnrefused") {
+            return "Could not connect to your assistant"
+        } else if desc.contains("timed out") || desc.contains("timeout") {
+            return "Setup timed out \u{2014} please try again"
+        } else if desc.contains("no such file") || desc.contains("enoent") {
+            return "Assistant files could not be found"
+        } else if desc.contains("network") || desc.contains("internet") {
+            return "Network connection issue"
+        } else if desc.contains("permission") || desc.contains("eacces") {
+            return "Permission denied"
+        } else {
+            return error.localizedDescription
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -14,9 +14,38 @@ struct HatchingStepView: View {
     @State private var wobbleAngle: Double = 0
     @State private var wobbleTimer: Timer?
     @State private var hatchStarted = false
+    @State private var crackTime: Date?
+    @State private var hatchStartTime: Date?
+    @State private var elapsedTime: TimeInterval = 0
+    @State private var elapsedTimer: Timer?
+    @State private var progressMessageIndex: Int = 0
+    @State private var progressMessageTimer: Timer?
+    @State private var showTimeEstimate = false
+    @State private var cliFinished = false
 
-    private var latestLogLine: String {
-        state.hatchLogLines.last ?? ""
+    private static let progressMessages = [
+        "Getting things ready\u{2026}",
+        "Making things cozy\u{2026}",
+        "Almost there\u{2026}",
+        "Just a moment longer\u{2026}",
+    ]
+
+    private var isLocalFlow: Bool {
+        state.cloudProvider == "local" || state.cloudProvider.isEmpty
+    }
+
+    /// Expected duration in seconds: local flows are fast, cloud flows take longer.
+    private var expectedDuration: TimeInterval {
+        isLocalFlow ? 45.0 : 180.0
+    }
+
+    private var timeEstimateText: String {
+        if elapsedTime > expectedDuration * 1.5 {
+            return "Taking a bit longer than usual\u{2026}"
+        }
+        return isLocalFlow
+            ? "This usually takes less than a minute"
+            : "This usually takes a few minutes"
     }
 
     var body: some View {
@@ -28,10 +57,13 @@ struct HatchingStepView: View {
 
             statusText
 
-            logOutput
+            if !state.hatchFailed && !state.hatchCompleted {
+                progressMessageView
+                timeEstimateView
+            }
 
             if state.hatchFailed {
-                backButton
+                failureButtons
             }
 
             Spacer()
@@ -43,6 +75,15 @@ struct HatchingStepView: View {
                 showContent = true
             }
             startWobble()
+            hatchStartTime = Date()
+            startElapsedTimer()
+            startProgressMessageRotation()
+            // Fade in time estimate after 2 seconds
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                withAnimation(.easeIn(duration: 0.5)) {
+                    showTimeEstimate = true
+                }
+            }
             if !hatchStarted {
                 hatchStarted = true
                 startHatching()
@@ -50,10 +91,14 @@ struct HatchingStepView: View {
         }
         .onDisappear {
             wobbleTimer?.invalidate()
+            elapsedTimer?.invalidate()
+            progressMessageTimer?.invalidate()
         }
         .onChange(of: state.hatchCompleted) { _, completed in
             if completed {
                 wobbleTimer?.invalidate()
+                elapsedTimer?.invalidate()
+                progressMessageTimer?.invalidate()
                 withAnimation(.spring(duration: 0.6, bounce: 0.3)) {
                     eggHatched = true
                 }
@@ -62,6 +107,8 @@ struct HatchingStepView: View {
         .onChange(of: state.hatchFailed) { _, failed in
             if failed {
                 wobbleTimer?.invalidate()
+                elapsedTimer?.invalidate()
+                progressMessageTimer?.invalidate()
             }
         }
     }
@@ -105,7 +152,7 @@ struct HatchingStepView: View {
     private var statusText: some View {
         VStack(spacing: VSpacing.sm) {
             if state.hatchFailed {
-                Text(isCustomHardware ? "Pairing failed" : "Hatching failed")
+                Text("Something went wrong")
                     .font(.system(size: 24, weight: .regular, design: .serif))
                     .foregroundColor(VColor.textPrimary)
             } else if state.hatchCompleted {
@@ -117,26 +164,66 @@ struct HatchingStepView: View {
                     .font(.system(size: 24, weight: .regular, design: .serif))
                     .foregroundColor(VColor.textPrimary)
 
-                Text(state.cloudProvider == "local"
-                     ? "Setting up your local assistant"
-                     : "Setting up your assistant on \(state.cloudProvider.uppercased())")
-                    .font(.system(size: 14))
-                    .foregroundColor(VColor.textSecondary)
+                if isLocalFlow {
+                    Text("Setting up your assistant")
+                        .font(.system(size: 14))
+                        .foregroundColor(VColor.textSecondary)
+                } else if isCustomHardware {
+                    Text("Setting up your assistant")
+                        .font(.system(size: 14))
+                        .foregroundColor(VColor.textSecondary)
+                } else {
+                    Text("Setting up your assistant on \(state.cloudProvider.uppercased())")
+                        .font(.system(size: 14))
+                        .foregroundColor(VColor.textSecondary)
+                }
             }
         }
     }
 
-    // MARK: - Back Button
+    // MARK: - Progress Message
 
-    private var backButton: some View {
-        Button(action: { goBack() }) {
-            Text("Back")
-                .font(.system(size: 13))
-                .foregroundColor(VColor.textMuted)
-        }
-        .buttonStyle(.plain)
-        .onHover { hovering in
-            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+    private var progressMessageView: some View {
+        Text(Self.progressMessages[progressMessageIndex])
+            .font(.system(size: 14))
+            .foregroundColor(VColor.textSecondary)
+            .id(progressMessageIndex)
+            .transition(.opacity)
+            .animation(.easeInOut(duration: 0.6), value: progressMessageIndex)
+    }
+
+    // MARK: - Time Estimate
+
+    private var timeEstimateView: some View {
+        Text(timeEstimateText)
+            .font(.system(size: 13))
+            .foregroundColor(VColor.textMuted)
+            .opacity(showTimeEstimate ? 1 : 0)
+    }
+
+    // MARK: - Failure Buttons
+
+    private var failureButtons: some View {
+        VStack(spacing: VSpacing.sm) {
+            Button(action: { retryHatch() }) {
+                Text("Try Again")
+                    .font(.system(size: 13))
+                    .foregroundColor(VColor.textSecondary)
+            }
+            .buttonStyle(.plain)
+            .onHover { hovering in
+                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            }
+
+            Button(action: { goBack() }) {
+                Text("Go Back")
+                    .font(.system(size: 13))
+                    .foregroundColor(VColor.textMuted)
+            }
+            .buttonStyle(.plain)
+            .onHover { hovering in
+                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            }
         }
         .padding(.top, VSpacing.xs)
     }
@@ -148,51 +235,97 @@ struct HatchingStepView: View {
         hatchStarted = false
     }
 
-    // MARK: - Log Output
+    private func retryHatch() {
+        state.hatchFailed = false
+        state.hatchLogLines = []
+        eggCracked = false
+        crackTime = nil
+        cliFinished = false
+        elapsedTime = 0
+        progressMessageIndex = 0
+        showTimeEstimate = false
+        hatchStartTime = Date()
+        startWobble()
+        startElapsedTimer()
+        startProgressMessageRotation()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            withAnimation(.easeIn(duration: 0.5)) {
+                showTimeEstimate = true
+            }
+        }
+        startHatching()
+    }
 
-    private var logOutput: some View {
-        VStack(spacing: VSpacing.xs) {
-            ScrollViewReader { proxy in
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 2) {
-                        ForEach(Array(state.hatchLogLines.enumerated()), id: \.offset) { index, line in
-                            Text(line)
-                                .font(.system(size: 11, design: .monospaced))
-                                .foregroundColor(VColor.textMuted)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .id(index)
-                        }
-                    }
-                    .padding(VSpacing.sm)
-                }
-                .frame(maxWidth: 380, maxHeight: 140)
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
-                        .fill(adaptiveColor(
-                            light: Color(nsColor: NSColor(red: 0.95, green: 0.95, blue: 0.97, alpha: 1)),
-                            dark: VColor.surface.opacity(0.3)
-                        ))
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
-                .onChange(of: state.hatchLogLines.count) { _, _ in
-                    if let last = state.hatchLogLines.indices.last {
-                        withAnimation(.easeOut(duration: 0.2)) {
-                            proxy.scrollTo(last, anchor: .bottom)
-                        }
-                    }
+    // MARK: - Timers
+
+    private func startElapsedTimer() {
+        elapsedTimer?.invalidate()
+        elapsedTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+            Task { @MainActor in
+                guard let start = hatchStartTime else { return }
+                elapsedTime = Date().timeIntervalSince(start)
+                // Time-based egg crack: crack at 50% of expected duration
+                if !eggCracked && elapsedTime >= expectedDuration * 0.5 {
+                    triggerCrack()
                 }
             }
         }
-        .padding(.horizontal, VSpacing.xxl)
-        .padding(.top, VSpacing.md)
+    }
+
+    private func startProgressMessageRotation() {
+        progressMessageTimer?.invalidate()
+        progressMessageTimer = Timer.scheduledTimer(withTimeInterval: 8.0, repeats: true) { _ in
+            Task { @MainActor in
+                withAnimation(.easeInOut(duration: 0.6)) {
+                    progressMessageIndex = (progressMessageIndex + 1) % Self.progressMessages.count
+                }
+            }
+        }
+    }
+
+    // MARK: - Crack Logic
+
+    private func triggerCrack() {
+        guard !eggCracked else { return }
+        withAnimation(.spring(duration: 0.4)) {
+            eggCracked = true
+        }
+        crackTime = Date()
+    }
+
+    /// Called when the CLI process finishes successfully. Applies the post-crack
+    /// minimum delay before signaling completion to OnboardingFlowView.
+    private func handleHatchSuccess() {
+        cliFinished = true
+
+        if !eggCracked {
+            // Fast-path: CLI finished before time-based crack fired.
+            // Force crack immediately, then wait 2s before completing.
+            triggerCrack()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                state.hatchCompleted = true
+            }
+        } else if let crack = crackTime {
+            let elapsed = Date().timeIntervalSince(crack)
+            if elapsed < 2.0 {
+                // Crack happened less than 2s ago; wait the remaining time.
+                let remaining = 2.0 - elapsed
+                DispatchQueue.main.asyncAfter(deadline: .now() + remaining) {
+                    state.hatchCompleted = true
+                }
+            } else {
+                // Crack happened 2s+ ago; complete immediately.
+                state.hatchCompleted = true
+            }
+        } else {
+            state.hatchCompleted = true
+        }
     }
 
     // MARK: - Wobble
 
     private func startWobble() {
+        wobbleTimer?.invalidate()
         wobbleTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
             Task { @MainActor in
                 withAnimation(.easeInOut(duration: 0.25)) {
@@ -236,14 +369,9 @@ struct HatchingStepView: View {
                 try await cliLauncher.runRemoteHatch(config: config) { line in
                     Task { @MainActor in
                         state.hatchLogLines.append(line)
-                        if !eggCracked && state.hatchLogLines.count > 3 {
-                            withAnimation(.spring(duration: 0.4)) {
-                                eggCracked = true
-                            }
-                        }
                     }
                 }
-                state.hatchCompleted = true
+                handleHatchSuccess()
             } catch {
                 state.hatchLogLines.append("Error: \(error.localizedDescription)")
                 state.hatchFailed = true
@@ -257,14 +385,9 @@ struct HatchingStepView: View {
                 try await cliLauncher.runPair(qrCodeImageData: state.customQRCodeImageData) { line in
                     Task { @MainActor in
                         state.hatchLogLines.append(line)
-                        if !eggCracked && state.hatchLogLines.count > 3 {
-                            withAnimation(.spring(duration: 0.4)) {
-                                eggCracked = true
-                            }
-                        }
                     }
                 }
-                state.hatchCompleted = true
+                handleHatchSuccess()
             } catch {
                 state.hatchLogLines.append("Error: \(error.localizedDescription)")
                 state.hatchFailed = true
@@ -280,14 +403,6 @@ struct HatchingStepView: View {
             let s = OnboardingState()
             s.isHatching = true
             s.cloudProvider = "gcp"
-            s.hatchLogLines = [
-                "Creating new assistant: vellum-abc123",
-                "Species: vellum",
-                "Cloud: GCP",
-                "Project: my-project",
-                "Zone: us-central1-a",
-                "Creating instance with startup script...",
-            ]
             return s
         }())
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -169,20 +169,6 @@ struct HatchingStepView: View {
                 Text(isCustomHardware ? "Pairing\u{2026}" : "Hatching\u{2026}")
                     .font(.system(size: 24, weight: .regular, design: .serif))
                     .foregroundColor(VColor.textPrimary)
-
-                if isLocalFlow {
-                    Text("Setting up your assistant")
-                        .font(.system(size: 14))
-                        .foregroundColor(VColor.textSecondary)
-                } else if isCustomHardware {
-                    Text("Setting up your assistant")
-                        .font(.system(size: 14))
-                        .foregroundColor(VColor.textSecondary)
-                } else {
-                    Text("Setting up your assistant on \(state.cloudProvider.uppercased())")
-                        .font(.system(size: 14))
-                        .foregroundColor(VColor.textSecondary)
-                }
             }
         }
     }


### PR DESCRIPTION
## Summary
Refactors the HatchingStepView and post-hatch bootstrap flow in the macOS app to provide better UX during initial setup:
- Removes raw CLI log output from the hatching view and replaces it with friendly progress messages, time estimates, and time-based egg crack animation
- Enables the hatching interstitial for local (non-userHosted) onboarding flows, not just remote/cloud
- Prevents double gateway process spawning with a compound guard (lockfile + gateway health check)
- Surfaces specific error messages during hatching failures and in the bootstrap interstitial (daemon down, gateway unhealthy, auth failed, socket missing, connection refused)

## Changes
- **HatchingStepView**: Rotating progress messages, time-based crack progression, friendly error display with `failureReason` state and `friendlyErrorMessage(from:)` helper
- **APIKeyStepView**: Non-userHosted branch now triggers local hatching flow instead of advancing directly
- **AppDelegate**: Compound guard (lockfile + gateway health) with first-launch retry polling, `BootstrapFailureKind` enum for diagnostic tracking, specific failure-type messages in bootstrap interstitial, remote-assistant-aware gateway checks, auth error detection via `DaemonClient.AuthError`

## Milestone PRs (merged into feature branch)
- #11195: M1 — Rewrite HatchingStepView with friendly progress UX
- #11196: M2 — Show hatching interstitial during local onboarding and prevent double gateway
- #11263: M3 — Surface specific error messages during hatching and post-hatch bootstrap

## Project issue
Closes #11192

## Test plan
- [ ] First launch with local assistant — verify hatching shows progress messages and egg animation
- [ ] First launch with remote assistant — verify hatching works without gateway health check blocking
- [ ] Simulate hatching failure — verify specific error message is displayed (not just "Something went wrong")
- [ ] Verify no duplicate gateway processes after onboarding completes
- [ ] Verify bootstrap interstitial shows failure-specific diagnostics (socket missing, daemon not running, etc.)
- [ ] Verify "Try Again" and "Go Back" buttons work on hatch failure

Generated with [Claude Code](https://claude.com/claude-code)

<img width="464" height="624" alt="image" src="https://github.com/user-attachments/assets/f13e30a7-2a53-4df8-afe3-ea50ebc0829a" />

```
Subtitle: One of these failureReason strings depending on the error:                                                                                                                                         
    - "Could not connect to your assistant" (connection refused)                                                                                                                                                  
    - "Setup timed out — please try again" (timeout)                                                                                                                                                            
    - "Assistant files could not be found" (file not found)
    - "Network connection issue" (network errors)
    - "Permission denied" (permission errors)
    - Or the raw error.localizedDescription as fallback
```
