### PR TITLE
M1: Auth core primitives for single-header JWT auth

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -36,7 +36,8 @@ import { rotateToolInvocations } from '../memory/tool-usage-store.js';
 import { migrateToDataLayout } from '../migrations/data-layout.js';
 import { migrateToWorkspaceLayout } from '../migrations/workspace-layout.js';
 import { emitNotificationSignal, registerBroadcastFn } from '../notifications/emit-signal.js';
-import { initSigningKey, loadOrCreateSigningKey } from '../runtime/actor-token-service.js';
+import { loadOrCreateSigningKey } from '../runtime/actor-token-service.js';
+import { initAuthSigningKey } from '../runtime/auth/token-service.js';
 import { assistantEventHub } from '../runtime/assistant-event-hub.js';
 import { ensureVellumGuardianBinding } from '../runtime/guardian-vellum-migration.js';
 import { RuntimeHttpServer } from '../runtime/http-server.js';
@@ -136,7 +137,7 @@ export async function runDaemon(): Promise<void> {
     // Load (or generate + persist) the actor-token signing key so tokens
     // survive daemon restarts. Must happen after ensureDataDir() creates
     // the protected directory.
-    initSigningKey(loadOrCreateSigningKey());
+    initAuthSigningKey(loadOrCreateSigningKey());
 
     log.info('Daemon startup: migrations complete');
 

--- a/assistant/src/runtime/auth/__tests__/context.test.ts
+++ b/assistant/src/runtime/auth/__tests__/context.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../../assistant-scope.js';
 import { buildAuthContext } from '../context.js';
 import type { TokenClaims } from '../types.js';
 
@@ -58,6 +59,48 @@ describe('buildAuthContext', () => {
       expect(result.context.assistantId).toBe('self');
       expect(result.context.sessionId).toBe('session-123');
       expect(result.context.scopes.has('ipc.all')).toBe(true);
+    }
+  });
+
+  test('daemon-audience token forces assistantId to DAEMON_INTERNAL_ASSISTANT_ID', () => {
+    // Token sub contains an external assistant ID, but audience is daemon
+    const result = buildAuthContext(validClaims({
+      aud: 'vellum-daemon',
+      sub: 'actor:external-assistant-xyz:principal-abc',
+    }));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.context.assistantId).toBe(DAEMON_INTERNAL_ASSISTANT_ID);
+      expect(result.context.assistantId).toBe('self');
+      // Other fields should still reflect the parsed sub
+      expect(result.context.principalType).toBe('actor');
+      expect(result.context.actorPrincipalId).toBe('principal-abc');
+    }
+  });
+
+  test('gateway-audience token preserves assistantId from sub', () => {
+    const result = buildAuthContext(validClaims({
+      aud: 'vellum-gateway',
+      sub: 'actor:external-assistant-xyz:principal-abc',
+    }));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.context.assistantId).toBe('external-assistant-xyz');
+      expect(result.context.principalType).toBe('actor');
+      expect(result.context.actorPrincipalId).toBe('principal-abc');
+    }
+  });
+
+  test('daemon-audience svc:gateway sub also forces assistantId to self', () => {
+    const result = buildAuthContext(validClaims({
+      aud: 'vellum-daemon',
+      sub: 'svc:gateway:external-id',
+      scope_profile: 'gateway_ingress_v1',
+    }));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.context.assistantId).toBe(DAEMON_INTERNAL_ASSISTANT_ID);
+      expect(result.context.principalType).toBe('svc_gateway');
     }
   });
 

--- a/assistant/src/runtime/auth/index.ts
+++ b/assistant/src/runtime/auth/index.ts
@@ -14,7 +14,6 @@ export type { ParseSubResult } from './subject.js';
 export {
   hashToken,
   initAuthSigningKey,
-  initSigningKey,
   loadOrCreateSigningKey,
   mintToken,
   verifyToken,

--- a/assistant/src/runtime/auth/token-service.ts
+++ b/assistant/src/runtime/auth/token-service.ts
@@ -11,9 +11,9 @@ import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypt
 import { isStaleEpoch } from './policy.js';
 import type { ScopeProfile, TokenAudience, TokenClaims } from './types.js';
 
-// Re-export signing key management from the existing actor-token-service
-// so callers don't need to import from two places during the transition.
-export { initSigningKey, loadOrCreateSigningKey } from '../actor-token-service.js';
+// Re-export loadOrCreateSigningKey so callers can load/persist the key
+// without importing from two places during the transition.
+export { loadOrCreateSigningKey } from '../actor-token-service.js';
 
 // ---------------------------------------------------------------------------
 // Internal: signing key access
@@ -31,8 +31,10 @@ function getSigningKey(): Buffer {
 let _authSigningKey: Buffer | null = null;
 
 /**
- * Initialize the auth module's signing key. This should be called at startup
- * alongside the existing initSigningKey() call, or can be used independently.
+ * Single initialization entry point for the auth signing key. Sets both
+ * the new auth module key and the legacy actor-token-service key so that
+ * both token systems share the same material. Callers should use this
+ * instead of importing initSigningKey from actor-token-service directly.
  */
 export function initAuthSigningKey(key: Buffer): void {
   _authSigningKey = key;


### PR DESCRIPTION
Add foundation types and utilities for the new single-header JWT auth system. Creates assistant/src/runtime/auth/ with types, sub parser, scope resolver, JWT token service, policy epoch, and AuthContext builder. Mirrors key types to gateway/src/auth/. Part of #11203.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
