### PR TITLE
ci: add NGROK_AUTH_TOKEN secret to playwright pipeline

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -265,12 +265,14 @@ jobs:
           secrets: |-
             ANTHROPIC_API_KEY:vellum-nonprod/ANTHROPIC_API_KEY
             TWILIO_AUTH_TOKEN:vellum-nonprod/TWILIO_AUTH_TOKEN
+            NGROK_AUTH_TOKEN:vellum-nonprod/NGROK_AUTH_TOKEN
 
       - name: Set API keys in env
         run: |
           echo "ANTHROPIC_API_KEY=${{ steps.secrets.outputs.ANTHROPIC_API_KEY }}" >> "$GITHUB_ENV"
           echo "TWILIO_AUTH_TOKEN=${{ steps.secrets.outputs.TWILIO_AUTH_TOKEN }}" >> "$GITHUB_ENV"
           echo "TWILIO_ACCOUNT_SID=${{ vars.TWILIO_ACCOUNT_SID }}" >> "$GITHUB_ENV"
+          echo "NGROK_AUTH_TOKEN=${{ steps.secrets.outputs.NGROK_AUTH_TOKEN }}" >> "$GITHUB_ENV"
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary
- Fetch NGROK_AUTH_TOKEN from GCP Secret Manager in the playwright CI workflow
- Inject it into the environment alongside existing secrets (ANTHROPIC_API_KEY, TWILIO_AUTH_TOKEN)

## Original prompt
❯ Help me add NGROK_AUTH_TOKEN as a secret that gets injected into our playwright ci pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
