### PR TITLE
fix: silence Sendable closure warning in VoiceInputManager

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -89,22 +89,26 @@ final class VoiceInputManager {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            guard let self else { return }
-            self.lastAppSwitchTime = Date()
-            self.holdTask?.cancel()
-            self.holdTask = nil
-            self.otherKeyPressedDuringHold = false
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.lastAppSwitchTime = Date()
+                self.holdTask?.cancel()
+                self.holdTask = nil
+                self.otherKeyPressedDuringHold = false
+            }
         }
         let resignObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.didResignActiveNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            guard let self else { return }
-            self.lastAppSwitchTime = Date()
-            self.holdTask?.cancel()
-            self.holdTask = nil
-            self.otherKeyPressedDuringHold = false
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.lastAppSwitchTime = Date()
+                self.holdTask?.cancel()
+                self.holdTask = nil
+                self.otherKeyPressedDuringHold = false
+            }
         }
         appSwitchObservers = [workspaceObserver, resignObserver]
 


### PR DESCRIPTION
## Summary
- Wrap `didActivateApplicationNotification` and `didResignActiveNotification` observer closures in `MainActor.assumeIsolated` to silence the "main actor-isolated property cannot be mutated from a Sendable closure" warning
- Both closures already run on `queue: .main`, so `assumeIsolated` is safe and avoids unnecessary async hops

## Original prompt
fix: main actor-isolated property 'lastAppSwitchTime' can not be mutated from a Sendable closure in VoiceInputManager.swift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
