### PR TITLE
M1: Auth core primitives

### DIFF
--- a/assistant/src/runtime/auth/__tests__/context.test.ts
+++ b/assistant/src/runtime/auth/__tests__/context.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'bun:test';
+
+import { buildAuthContext } from '../context.js';
+import type { TokenClaims } from '../types.js';
+
+function validClaims(overrides?: Partial<TokenClaims>): TokenClaims {
+  return {
+    iss: 'vellum-auth',
+    aud: 'vellum-daemon',
+    sub: 'actor:self:principal-abc',
+    scope_profile: 'actor_client_v1',
+    exp: Math.floor(Date.now() / 1000) + 300,
+    policy_epoch: 1,
+    iat: Math.floor(Date.now() / 1000),
+    jti: 'test-jti',
+    ...overrides,
+  };
+}
+
+describe('buildAuthContext', () => {
+  test('builds context from valid actor claims', () => {
+    const result = buildAuthContext(validClaims());
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.context.subject).toBe('actor:self:principal-abc');
+      expect(result.context.principalType).toBe('actor');
+      expect(result.context.assistantId).toBe('self');
+      expect(result.context.actorPrincipalId).toBe('principal-abc');
+      expect(result.context.sessionId).toBeUndefined();
+      expect(result.context.scopeProfile).toBe('actor_client_v1');
+      expect(result.context.policyEpoch).toBe(1);
+      expect(result.context.scopes.has('chat.read')).toBe(true);
+      expect(result.context.scopes.has('chat.write')).toBe(true);
+    }
+  });
+
+  test('builds context from valid svc:gateway claims', () => {
+    const result = buildAuthContext(validClaims({
+      sub: 'svc:gateway:self',
+      scope_profile: 'gateway_ingress_v1',
+    }));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.context.principalType).toBe('svc_gateway');
+      expect(result.context.assistantId).toBe('self');
+      expect(result.context.scopes.has('ingress.write')).toBe(true);
+    }
+  });
+
+  test('builds context from valid ipc claims', () => {
+    const result = buildAuthContext(validClaims({
+      sub: 'ipc:self:session-123',
+      scope_profile: 'ipc_v1',
+    }));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.context.principalType).toBe('ipc');
+      expect(result.context.assistantId).toBe('self');
+      expect(result.context.sessionId).toBe('session-123');
+      expect(result.context.scopes.has('ipc.all')).toBe(true);
+    }
+  });
+
+  test('fails with invalid sub pattern', () => {
+    const result = buildAuthContext(validClaims({ sub: 'bad:format' }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('unrecognized');
+    }
+  });
+
+  test('fails with empty sub', () => {
+    const result = buildAuthContext(validClaims({ sub: '' }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('empty');
+    }
+  });
+
+  test('preserves policy epoch from claims', () => {
+    const result = buildAuthContext(validClaims({ policy_epoch: 42 }));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.context.policyEpoch).toBe(42);
+    }
+  });
+});

--- a/assistant/src/runtime/auth/__tests__/policy.test.ts
+++ b/assistant/src/runtime/auth/__tests__/policy.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+
+import { CURRENT_POLICY_EPOCH, isStaleEpoch } from '../policy.js';
+
+describe('policy epoch', () => {
+  test('CURRENT_POLICY_EPOCH is 1', () => {
+    expect(CURRENT_POLICY_EPOCH).toBe(1);
+  });
+
+  test('epoch equal to current is not stale', () => {
+    expect(isStaleEpoch(CURRENT_POLICY_EPOCH)).toBe(false);
+  });
+
+  test('epoch greater than current is not stale', () => {
+    expect(isStaleEpoch(CURRENT_POLICY_EPOCH + 1)).toBe(false);
+  });
+
+  test('epoch less than current is stale', () => {
+    expect(isStaleEpoch(CURRENT_POLICY_EPOCH - 1)).toBe(true);
+  });
+
+  test('epoch 0 is stale', () => {
+    expect(isStaleEpoch(0)).toBe(true);
+  });
+
+  test('negative epoch is stale', () => {
+    expect(isStaleEpoch(-1)).toBe(true);
+  });
+});

--- a/assistant/src/runtime/auth/__tests__/scopes.test.ts
+++ b/assistant/src/runtime/auth/__tests__/scopes.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'bun:test';
+
+import { hasAllScopes, hasScope, resolveScopeProfile } from '../scopes.js';
+import type { AuthContext, Scope, ScopeProfile } from '../types.js';
+
+/** Utility to create a minimal AuthContext with a given scope profile. */
+function makeCtx(profile: ScopeProfile): AuthContext {
+  return {
+    subject: 'test:self:id',
+    principalType: 'actor',
+    assistantId: 'self',
+    scopeProfile: profile,
+    scopes: resolveScopeProfile(profile),
+    policyEpoch: 1,
+  };
+}
+
+describe('resolveScopeProfile', () => {
+  test('actor_client_v1 includes all client scopes', () => {
+    const scopes = resolveScopeProfile('actor_client_v1');
+    const expected: Scope[] = [
+      'chat.read', 'chat.write',
+      'approval.read', 'approval.write',
+      'settings.read', 'settings.write',
+      'attachments.read', 'attachments.write',
+      'calls.read', 'calls.write',
+      'feature_flags.read', 'feature_flags.write',
+    ];
+    for (const s of expected) {
+      expect(scopes.has(s)).toBe(true);
+    }
+    expect(scopes.size).toBe(expected.length);
+  });
+
+  test('actor_client_v1 does not include server-only scopes', () => {
+    const scopes = resolveScopeProfile('actor_client_v1');
+    expect(scopes.has('ingress.write')).toBe(false);
+    expect(scopes.has('internal.write')).toBe(false);
+    expect(scopes.has('ipc.all')).toBe(false);
+  });
+
+  test('gateway_ingress_v1 includes ingress and internal scopes', () => {
+    const scopes = resolveScopeProfile('gateway_ingress_v1');
+    expect(scopes.has('ingress.write')).toBe(true);
+    expect(scopes.has('internal.write')).toBe(true);
+    expect(scopes.size).toBe(2);
+  });
+
+  test('gateway_service_v1 includes settings and internal scopes', () => {
+    const scopes = resolveScopeProfile('gateway_service_v1');
+    expect(scopes.has('settings.read')).toBe(true);
+    expect(scopes.has('settings.write')).toBe(true);
+    expect(scopes.has('internal.write')).toBe(true);
+    expect(scopes.size).toBe(3);
+  });
+
+  test('ipc_v1 includes only ipc.all', () => {
+    const scopes = resolveScopeProfile('ipc_v1');
+    expect(scopes.has('ipc.all')).toBe(true);
+    expect(scopes.size).toBe(1);
+  });
+});
+
+describe('hasScope', () => {
+  test('returns true for a scope the profile includes', () => {
+    const ctx = makeCtx('actor_client_v1');
+    expect(hasScope(ctx, 'chat.read')).toBe(true);
+  });
+
+  test('returns false for a scope the profile excludes', () => {
+    const ctx = makeCtx('actor_client_v1');
+    expect(hasScope(ctx, 'ingress.write')).toBe(false);
+  });
+
+  test('returns true for ipc.all on ipc_v1 profile', () => {
+    const ctx = makeCtx('ipc_v1');
+    expect(hasScope(ctx, 'ipc.all')).toBe(true);
+  });
+});
+
+describe('hasAllScopes', () => {
+  test('returns true when all requested scopes are present', () => {
+    const ctx = makeCtx('actor_client_v1');
+    expect(hasAllScopes(ctx, 'chat.read', 'chat.write', 'approval.read')).toBe(true);
+  });
+
+  test('returns false when any requested scope is missing', () => {
+    const ctx = makeCtx('actor_client_v1');
+    expect(hasAllScopes(ctx, 'chat.read', 'ingress.write')).toBe(false);
+  });
+
+  test('returns true for empty scope list', () => {
+    const ctx = makeCtx('actor_client_v1');
+    expect(hasAllScopes(ctx)).toBe(true);
+  });
+
+  test('returns true for single present scope', () => {
+    const ctx = makeCtx('gateway_ingress_v1');
+    expect(hasAllScopes(ctx, 'ingress.write')).toBe(true);
+  });
+
+  test('returns false for single absent scope', () => {
+    const ctx = makeCtx('gateway_ingress_v1');
+    expect(hasAllScopes(ctx, 'chat.read')).toBe(false);
+  });
+});

--- a/assistant/src/runtime/auth/__tests__/subject.test.ts
+++ b/assistant/src/runtime/auth/__tests__/subject.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from 'bun:test';
+
+import { parseSub } from '../subject.js';
+
+describe('parseSub', () => {
+  // -------------------------------------------------------------------------
+  // actor pattern
+  // -------------------------------------------------------------------------
+
+  test('parses actor:<assistantId>:<actorPrincipalId>', () => {
+    const result = parseSub('actor:self:principal-abc');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.principalType).toBe('actor');
+      expect(result.assistantId).toBe('self');
+      expect(result.actorPrincipalId).toBe('principal-abc');
+      expect(result.sessionId).toBeUndefined();
+    }
+  });
+
+  test('parses actor pattern with complex ids', () => {
+    const result = parseSub('actor:asst-uuid-123:principal-uuid-456');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.principalType).toBe('actor');
+      expect(result.assistantId).toBe('asst-uuid-123');
+      expect(result.actorPrincipalId).toBe('principal-uuid-456');
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // svc:gateway pattern
+  // -------------------------------------------------------------------------
+
+  test('parses svc:gateway:<assistantId>', () => {
+    const result = parseSub('svc:gateway:self');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.principalType).toBe('svc_gateway');
+      expect(result.assistantId).toBe('self');
+      expect(result.actorPrincipalId).toBeUndefined();
+      expect(result.sessionId).toBeUndefined();
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // ipc pattern
+  // -------------------------------------------------------------------------
+
+  test('parses ipc:<assistantId>:<sessionId>', () => {
+    const result = parseSub('ipc:self:session-xyz');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.principalType).toBe('ipc');
+      expect(result.assistantId).toBe('self');
+      expect(result.sessionId).toBe('session-xyz');
+      expect(result.actorPrincipalId).toBeUndefined();
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Malformed input
+  // -------------------------------------------------------------------------
+
+  test('fails on empty string', () => {
+    const result = parseSub('');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('empty');
+    }
+  });
+
+  test('fails on unrecognized prefix', () => {
+    const result = parseSub('unknown:self:id');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('unrecognized');
+    }
+  });
+
+  test('fails on actor with too few parts', () => {
+    const result = parseSub('actor:self');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('unrecognized');
+    }
+  });
+
+  test('fails on actor with too many parts', () => {
+    const result = parseSub('actor:self:principal:extra');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('unrecognized');
+    }
+  });
+
+  test('fails on actor with empty assistantId', () => {
+    const result = parseSub('actor::principal-abc');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('empty');
+    }
+  });
+
+  test('fails on actor with empty actorPrincipalId', () => {
+    const result = parseSub('actor:self:');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('empty');
+    }
+  });
+
+  test('fails on svc:gateway with empty assistantId', () => {
+    const result = parseSub('svc:gateway:');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('empty');
+    }
+  });
+
+  test('fails on svc with wrong second part', () => {
+    const result = parseSub('svc:other:self');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('unrecognized');
+    }
+  });
+
+  test('fails on ipc with empty sessionId', () => {
+    const result = parseSub('ipc:self:');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('empty');
+    }
+  });
+
+  test('fails on ipc with empty assistantId', () => {
+    const result = parseSub('ipc::session-abc');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('empty');
+    }
+  });
+
+  test('fails on bare prefix with no colons', () => {
+    const result = parseSub('actor');
+    expect(result.ok).toBe(false);
+  });
+});

--- a/assistant/src/runtime/auth/__tests__/token-service.test.ts
+++ b/assistant/src/runtime/auth/__tests__/token-service.test.ts
@@ -1,0 +1,263 @@
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = realpathSync(mkdtempSync(join(tmpdir(), 'auth-token-test-')));
+
+mock.module('../../../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  getDbPath: () => join(testDir, 'test.db'),
+  normalizeAssistantId: (id: string) => id === 'self' ? 'self' : id,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../../../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { CURRENT_POLICY_EPOCH } from '../policy.js';
+import { hashToken, initAuthSigningKey, mintToken, verifyToken } from '../token-service.js';
+
+const TEST_KEY = Buffer.from('test-signing-key-32-bytes-long!!');
+
+beforeEach(() => {
+  initAuthSigningKey(TEST_KEY);
+});
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true, force: true }); } catch {}
+});
+
+describe('mintToken / verifyToken round-trip', () => {
+  test('mint + verify succeeds for valid token targeting vellum-daemon', () => {
+    const token = mintToken({
+      aud: 'vellum-daemon',
+      sub: 'actor:self:principal-abc',
+      scope_profile: 'actor_client_v1',
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 300,
+    });
+
+    expect(token).toBeTruthy();
+    expect(token.split('.').length).toBe(3);
+
+    const result = verifyToken(token, 'vellum-daemon');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.claims.iss).toBe('vellum-auth');
+      expect(result.claims.aud).toBe('vellum-daemon');
+      expect(result.claims.sub).toBe('actor:self:principal-abc');
+      expect(result.claims.scope_profile).toBe('actor_client_v1');
+      expect(result.claims.policy_epoch).toBe(CURRENT_POLICY_EPOCH);
+      expect(result.claims.iat).toBeDefined();
+      expect(result.claims.jti).toBeDefined();
+    }
+  });
+
+  test('mint + verify succeeds for gateway audience', () => {
+    const token = mintToken({
+      aud: 'vellum-gateway',
+      sub: 'svc:gateway:self',
+      scope_profile: 'gateway_ingress_v1',
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 60,
+    });
+
+    const result = verifyToken(token, 'vellum-gateway');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.claims.aud).toBe('vellum-gateway');
+      expect(result.claims.sub).toBe('svc:gateway:self');
+    }
+  });
+
+  test('each mint produces a unique jti', () => {
+    const params = {
+      aud: 'vellum-daemon' as const,
+      sub: 'actor:self:p1',
+      scope_profile: 'actor_client_v1' as const,
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 300,
+    };
+
+    const t1 = mintToken(params);
+    const t2 = mintToken(params);
+
+    const r1 = verifyToken(t1, 'vellum-daemon');
+    const r2 = verifyToken(t2, 'vellum-daemon');
+
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+    if (r1.ok && r2.ok) {
+      expect(r1.claims.jti).not.toBe(r2.claims.jti);
+    }
+  });
+});
+
+describe('verifyToken failure cases', () => {
+  test('rejects expired token', () => {
+    const token = mintToken({
+      aud: 'vellum-daemon',
+      sub: 'actor:self:p1',
+      scope_profile: 'actor_client_v1',
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: -10, // already expired
+    });
+
+    const result = verifyToken(token, 'vellum-daemon');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('token_expired');
+    }
+  });
+
+  test('rejects wrong audience', () => {
+    const token = mintToken({
+      aud: 'vellum-daemon',
+      sub: 'actor:self:p1',
+      scope_profile: 'actor_client_v1',
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 300,
+    });
+
+    const result = verifyToken(token, 'vellum-gateway');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('audience_mismatch');
+    }
+  });
+
+  test('rejects malformed token (no dots)', () => {
+    const result = verifyToken('not-a-jwt', 'vellum-daemon');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('malformed_token');
+    }
+  });
+
+  test('rejects malformed token (only 2 parts)', () => {
+    const result = verifyToken('part1.part2', 'vellum-daemon');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('malformed_token');
+    }
+  });
+
+  test('rejects tampered payload', () => {
+    const token = mintToken({
+      aud: 'vellum-daemon',
+      sub: 'actor:self:p1',
+      scope_profile: 'actor_client_v1',
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 300,
+    });
+
+    const parts = token.split('.');
+    // Tamper with the payload
+    parts[1] = parts[1] + 'X';
+    const tampered = parts.join('.');
+
+    const result = verifyToken(tampered, 'vellum-daemon');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('invalid_signature');
+    }
+  });
+
+  test('rejects tampered signature', () => {
+    const token = mintToken({
+      aud: 'vellum-daemon',
+      sub: 'actor:self:p1',
+      scope_profile: 'actor_client_v1',
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 300,
+    });
+
+    const parts = token.split('.');
+    parts[2] = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    const tampered = parts.join('.');
+
+    const result = verifyToken(tampered, 'vellum-daemon');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('invalid_signature');
+    }
+  });
+
+  test('rejects token with stale policy epoch', () => {
+    const token = mintToken({
+      aud: 'vellum-daemon',
+      sub: 'actor:self:p1',
+      scope_profile: 'actor_client_v1',
+      policy_epoch: 0, // stale
+      ttlSeconds: 300,
+    });
+
+    const result = verifyToken(token, 'vellum-daemon');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('stale_policy_epoch');
+    }
+  });
+
+  test('rejects token signed with a different key', () => {
+    // Mint with current key
+    const token = mintToken({
+      aud: 'vellum-daemon',
+      sub: 'actor:self:p1',
+      scope_profile: 'actor_client_v1',
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 300,
+    });
+
+    // Switch to a different key
+    initAuthSigningKey(Buffer.from('different-key-32-bytes-longXXXX'));
+
+    const result = verifyToken(token, 'vellum-daemon');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('invalid_signature');
+    }
+
+    // Restore original key for remaining tests
+    initAuthSigningKey(TEST_KEY);
+  });
+});
+
+describe('hashToken', () => {
+  test('produces consistent SHA-256 hex digest', () => {
+    const hash1 = hashToken('test-token');
+    const hash2 = hashToken('test-token');
+    expect(hash1).toBe(hash2);
+    expect(hash1.length).toBe(64);
+  });
+
+  test('different tokens produce different hashes', () => {
+    const t1 = mintToken({
+      aud: 'vellum-daemon',
+      sub: 'actor:self:p1',
+      scope_profile: 'actor_client_v1',
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 300,
+    });
+    const t2 = mintToken({
+      aud: 'vellum-daemon',
+      sub: 'actor:self:p2',
+      scope_profile: 'actor_client_v1',
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 300,
+    });
+    expect(hashToken(t1)).not.toBe(hashToken(t2));
+  });
+});

--- a/assistant/src/runtime/auth/context.ts
+++ b/assistant/src/runtime/auth/context.ts
@@ -4,6 +4,7 @@
  * knowing about JWT internals.
  */
 
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import { resolveScopeProfile } from './scopes.js';
 import { parseSub } from './subject.js';
 import type { AuthContext, TokenClaims } from './types.js';
@@ -25,6 +26,11 @@ export type BuildAuthContextResult =
  *
  * Parses the sub claim and resolves the scope profile into a concrete
  * set of scopes. Returns a failure result if the sub is malformed.
+ *
+ * When the token audience is `vellum-daemon`, the assistantId is forced
+ * to DAEMON_INTERNAL_ASSISTANT_ID ('self') regardless of what the JWT
+ * sub encodes. Daemon code must never derive internal scoping from
+ * externally-provided assistant IDs.
  */
 export function buildAuthContext(claims: TokenClaims): BuildAuthContextResult {
   const subResult = parseSub(claims.sub);
@@ -34,10 +40,17 @@ export function buildAuthContext(claims: TokenClaims): BuildAuthContextResult {
 
   const scopes = resolveScopeProfile(claims.scope_profile);
 
+  // Daemon-audience tokens always scope to the internal assistant ID,
+  // preventing external assistant IDs from leaking into daemon-side
+  // storage and routing.
+  const assistantId = claims.aud === 'vellum-daemon'
+    ? DAEMON_INTERNAL_ASSISTANT_ID
+    : subResult.assistantId;
+
   const context: AuthContext = {
     subject: claims.sub,
     principalType: subResult.principalType,
-    assistantId: subResult.assistantId,
+    assistantId,
     actorPrincipalId: subResult.actorPrincipalId,
     sessionId: subResult.sessionId,
     scopeProfile: claims.scope_profile,

--- a/assistant/src/runtime/auth/context.ts
+++ b/assistant/src/runtime/auth/context.ts
@@ -1,0 +1,49 @@
+/**
+ * AuthContext builder — combines sub parsing and scope resolution into
+ * a normalized AuthContext that downstream code can consume without
+ * knowing about JWT internals.
+ */
+
+import { resolveScopeProfile } from './scopes.js';
+import { parseSub } from './subject.js';
+import type { AuthContext, TokenClaims } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Result type
+// ---------------------------------------------------------------------------
+
+export type BuildAuthContextResult =
+  | { ok: true; context: AuthContext }
+  | { ok: false; reason: string };
+
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a normalized AuthContext from verified JWT claims.
+ *
+ * Parses the sub claim and resolves the scope profile into a concrete
+ * set of scopes. Returns a failure result if the sub is malformed.
+ */
+export function buildAuthContext(claims: TokenClaims): BuildAuthContextResult {
+  const subResult = parseSub(claims.sub);
+  if (!subResult.ok) {
+    return { ok: false, reason: subResult.reason };
+  }
+
+  const scopes = resolveScopeProfile(claims.scope_profile);
+
+  const context: AuthContext = {
+    subject: claims.sub,
+    principalType: subResult.principalType,
+    assistantId: subResult.assistantId,
+    actorPrincipalId: subResult.actorPrincipalId,
+    sessionId: subResult.sessionId,
+    scopeProfile: claims.scope_profile,
+    scopes,
+    policyEpoch: claims.policy_epoch,
+  };
+
+  return { ok: true, context };
+}

--- a/assistant/src/runtime/auth/index.ts
+++ b/assistant/src/runtime/auth/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Auth module barrel export.
+ *
+ * Re-exports all public types and functions from the auth subsystem
+ * so consumers can import from a single path.
+ */
+
+export { buildAuthContext } from './context.js';
+export type { BuildAuthContextResult } from './context.js';
+export { CURRENT_POLICY_EPOCH, isStaleEpoch } from './policy.js';
+export { hasAllScopes, hasScope, resolveScopeProfile } from './scopes.js';
+export { parseSub } from './subject.js';
+export type { ParseSubResult } from './subject.js';
+export {
+  hashToken,
+  initAuthSigningKey,
+  initSigningKey,
+  loadOrCreateSigningKey,
+  mintToken,
+  verifyToken,
+} from './token-service.js';
+export type { VerifyResult } from './token-service.js';
+export type {
+  AuthContext,
+  PrincipalType,
+  Scope,
+  ScopeProfile,
+  TokenAudience,
+  TokenClaims,
+} from './types.js';

--- a/assistant/src/runtime/auth/policy.ts
+++ b/assistant/src/runtime/auth/policy.ts
@@ -1,0 +1,17 @@
+/**
+ * Policy epoch management.
+ *
+ * The policy epoch is a monotonic counter embedded in every JWT. When
+ * the auth policy changes (e.g., scope profiles are redefined), the
+ * epoch is bumped, and tokens carrying a stale epoch are rejected.
+ * This gives us a hard revocation mechanism without maintaining a
+ * per-token blocklist.
+ */
+
+/** Current policy epoch — bump this when auth policy changes. */
+export const CURRENT_POLICY_EPOCH = 1;
+
+/** Returns true if the given epoch is older than the current policy. */
+export function isStaleEpoch(epoch: number): boolean {
+  return epoch < CURRENT_POLICY_EPOCH;
+}

--- a/assistant/src/runtime/auth/scopes.ts
+++ b/assistant/src/runtime/auth/scopes.ts
@@ -1,0 +1,61 @@
+/**
+ * Scope profile resolver and scope-check utilities.
+ *
+ * Each scope profile maps to a fixed set of permission scopes. The
+ * mapping is intentionally hard-coded — profile definitions are a
+ * policy decision, not a runtime configuration.
+ */
+
+import type { AuthContext, Scope, ScopeProfile } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Profile -> scope mapping
+// ---------------------------------------------------------------------------
+
+const PROFILE_SCOPES: Record<ScopeProfile, ReadonlySet<Scope>> = {
+  actor_client_v1: new Set<Scope>([
+    'chat.read',
+    'chat.write',
+    'approval.read',
+    'approval.write',
+    'settings.read',
+    'settings.write',
+    'attachments.read',
+    'attachments.write',
+    'calls.read',
+    'calls.write',
+    'feature_flags.read',
+    'feature_flags.write',
+  ]),
+  gateway_ingress_v1: new Set<Scope>([
+    'ingress.write',
+    'internal.write',
+  ]),
+  gateway_service_v1: new Set<Scope>([
+    'settings.read',
+    'settings.write',
+    'internal.write',
+  ]),
+  ipc_v1: new Set<Scope>([
+    'ipc.all',
+  ]),
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Resolve a scope profile name to its set of granted scopes. */
+export function resolveScopeProfile(profile: ScopeProfile): ReadonlySet<Scope> {
+  return PROFILE_SCOPES[profile];
+}
+
+/** Check whether the auth context includes a specific scope. */
+export function hasScope(ctx: AuthContext, scope: Scope): boolean {
+  return ctx.scopes.has(scope);
+}
+
+/** Check whether the auth context includes all of the given scopes. */
+export function hasAllScopes(ctx: AuthContext, ...scopes: Scope[]): boolean {
+  return scopes.every((s) => ctx.scopes.has(s));
+}

--- a/assistant/src/runtime/auth/subject.ts
+++ b/assistant/src/runtime/auth/subject.ts
@@ -1,0 +1,68 @@
+/**
+ * Sub (subject) pattern parser for JWT tokens.
+ *
+ * The sub claim encodes principal type, assistant scope, and optional
+ * actor/session identifiers in a colon-delimited string.
+ */
+
+import type { PrincipalType } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+export type ParseSubResult =
+  | {
+      ok: true;
+      principalType: PrincipalType;
+      assistantId: string;
+      actorPrincipalId?: string;
+      sessionId?: string;
+    }
+  | { ok: false; reason: string };
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a JWT sub claim into its constituent parts.
+ *
+ * Supported patterns:
+ *   actor:<assistantId>:<actorPrincipalId>
+ *   svc:gateway:<assistantId>
+ *   ipc:<assistantId>:<sessionId>
+ */
+export function parseSub(sub: string): ParseSubResult {
+  if (!sub || typeof sub !== 'string') {
+    return { ok: false, reason: 'sub is empty or not a string' };
+  }
+
+  const parts = sub.split(':');
+
+  if (parts[0] === 'actor' && parts.length === 3) {
+    const [, assistantId, actorPrincipalId] = parts;
+    if (!assistantId || !actorPrincipalId) {
+      return { ok: false, reason: 'actor sub has empty assistantId or actorPrincipalId' };
+    }
+    return { ok: true, principalType: 'actor', assistantId, actorPrincipalId };
+  }
+
+  if (parts[0] === 'svc' && parts[1] === 'gateway' && parts.length === 3) {
+    const assistantId = parts[2];
+    if (!assistantId) {
+      return { ok: false, reason: 'svc:gateway sub has empty assistantId' };
+    }
+    return { ok: true, principalType: 'svc_gateway', assistantId };
+  }
+
+  if (parts[0] === 'ipc' && parts.length === 3) {
+    const [, assistantId, sessionId] = parts;
+    if (!assistantId || !sessionId) {
+      return { ok: false, reason: 'ipc sub has empty assistantId or sessionId' };
+    }
+    return { ok: true, principalType: 'ipc', assistantId, sessionId };
+  }
+
+  return { ok: false, reason: `unrecognized sub pattern: ${sub}` };
+}

--- a/assistant/src/runtime/auth/token-service.ts
+++ b/assistant/src/runtime/auth/token-service.ts
@@ -1,0 +1,176 @@
+/**
+ * JWT token service for the single-header auth system.
+ *
+ * Mints and verifies standard JWTs (header.payload.signature) using
+ * HMAC-SHA256. Reuses signing key infrastructure from the existing
+ * actor-token-service to avoid duplication during the transition period.
+ */
+
+import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+
+import { isStaleEpoch } from './policy.js';
+import type { ScopeProfile, TokenAudience, TokenClaims } from './types.js';
+
+// Re-export signing key management from the existing actor-token-service
+// so callers don't need to import from two places during the transition.
+export { initSigningKey, loadOrCreateSigningKey } from '../actor-token-service.js';
+
+// ---------------------------------------------------------------------------
+// Internal: signing key access
+// ---------------------------------------------------------------------------
+
+import { initSigningKey as _initLegacyKey } from '../actor-token-service.js';
+
+function getSigningKey(): Buffer {
+  if (!_authSigningKey) {
+    throw new Error('Auth signing key not initialized — call initAuthSigningKey() during startup');
+  }
+  return _authSigningKey;
+}
+
+let _authSigningKey: Buffer | null = null;
+
+/**
+ * Initialize the auth module's signing key. This should be called at startup
+ * alongside the existing initSigningKey() call, or can be used independently.
+ */
+export function initAuthSigningKey(key: Buffer): void {
+  _authSigningKey = key;
+  // Keep the legacy actor-token-service key in sync during the transition
+  _initLegacyKey(key);
+}
+
+// ---------------------------------------------------------------------------
+// Base64url helpers
+// ---------------------------------------------------------------------------
+
+function base64urlEncode(data: Buffer | string): string {
+  const buf = typeof data === 'string' ? Buffer.from(data, 'utf-8') : data;
+  return buf.toString('base64url');
+}
+
+function base64urlDecode(str: string): Buffer {
+  return Buffer.from(str, 'base64url');
+}
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+export type VerifyResult =
+  | { ok: true; claims: TokenClaims }
+  | { ok: false; reason: string };
+
+// ---------------------------------------------------------------------------
+// JWT header — static for HMAC-SHA256
+// ---------------------------------------------------------------------------
+
+const JWT_HEADER = base64urlEncode(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+
+// ---------------------------------------------------------------------------
+// Mint
+// ---------------------------------------------------------------------------
+
+/**
+ * Mint a new JWT token with the given parameters.
+ *
+ * Returns the complete JWT string (header.payload.signature).
+ */
+export function mintToken(params: {
+  aud: TokenAudience;
+  sub: string;
+  scope_profile: ScopeProfile;
+  policy_epoch: number;
+  ttlSeconds: number;
+}): string {
+  const now = Math.floor(Date.now() / 1000);
+  const claims: TokenClaims = {
+    iss: 'vellum-auth',
+    aud: params.aud,
+    sub: params.sub,
+    scope_profile: params.scope_profile,
+    exp: now + params.ttlSeconds,
+    policy_epoch: params.policy_epoch,
+    iat: now,
+    jti: randomBytes(16).toString('hex'),
+  };
+
+  const payload = base64urlEncode(JSON.stringify(claims));
+  const sigInput = JWT_HEADER + '.' + payload;
+  const sig = createHmac('sha256', getSigningKey())
+    .update(sigInput)
+    .digest();
+
+  return sigInput + '.' + base64urlEncode(sig);
+}
+
+// ---------------------------------------------------------------------------
+// Verify
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify a JWT token's structural integrity, signature, expiration,
+ * audience, and policy epoch.
+ *
+ * Does NOT check revocation — callers must additionally verify the
+ * token hash against a revocation store if needed.
+ */
+export function verifyToken(token: string, expectedAud: TokenAudience): VerifyResult {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return { ok: false, reason: 'malformed_token: expected 3 dot-separated parts' };
+  }
+
+  const [headerPart, payloadPart, sigPart] = parts;
+
+  // Recompute HMAC over header.payload
+  const sigInput = headerPart + '.' + payloadPart;
+  const expectedSig = createHmac('sha256', getSigningKey())
+    .update(sigInput)
+    .digest();
+  const actualSig = base64urlDecode(sigPart);
+
+  if (expectedSig.length !== actualSig.length) {
+    return { ok: false, reason: 'invalid_signature' };
+  }
+
+  if (!timingSafeEqual(expectedSig, actualSig)) {
+    return { ok: false, reason: 'invalid_signature' };
+  }
+
+  // Decode and parse claims
+  let claims: TokenClaims;
+  try {
+    const decoded = base64urlDecode(payloadPart).toString('utf-8');
+    claims = JSON.parse(decoded) as TokenClaims;
+  } catch {
+    return { ok: false, reason: 'malformed_claims' };
+  }
+
+  // Audience check
+  if (claims.aud !== expectedAud) {
+    return { ok: false, reason: `audience_mismatch: expected ${expectedAud}, got ${claims.aud}` };
+  }
+
+  // Expiration check (claims.exp is in seconds)
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (claims.exp <= nowSeconds) {
+    return { ok: false, reason: 'token_expired' };
+  }
+
+  // Policy epoch check
+  if (isStaleEpoch(claims.policy_epoch)) {
+    return { ok: false, reason: 'stale_policy_epoch' };
+  }
+
+  return { ok: true, claims };
+}
+
+// ---------------------------------------------------------------------------
+// Hash
+// ---------------------------------------------------------------------------
+
+/** SHA-256 hex digest of a raw token string (for revocation store lookups). */
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}

--- a/assistant/src/runtime/auth/types.ts
+++ b/assistant/src/runtime/auth/types.ts
@@ -1,0 +1,79 @@
+/**
+ * Core auth types for the single-header JWT auth system.
+ *
+ * These types define the token claims, scope profiles, principal types,
+ * and the normalized AuthContext that downstream code consumes.
+ */
+
+// ---------------------------------------------------------------------------
+// Scope profiles — named bundles of permissions
+// ---------------------------------------------------------------------------
+
+export type ScopeProfile =
+  | 'actor_client_v1'
+  | 'gateway_ingress_v1'
+  | 'gateway_service_v1'
+  | 'ipc_v1';
+
+// ---------------------------------------------------------------------------
+// Individual scope strings
+// ---------------------------------------------------------------------------
+
+export type Scope =
+  | 'chat.read'
+  | 'chat.write'
+  | 'approval.read'
+  | 'approval.write'
+  | 'settings.read'
+  | 'settings.write'
+  | 'attachments.read'
+  | 'attachments.write'
+  | 'calls.read'
+  | 'calls.write'
+  | 'ingress.write'
+  | 'internal.write'
+  | 'feature_flags.read'
+  | 'feature_flags.write'
+  | 'ipc.all';
+
+// ---------------------------------------------------------------------------
+// Principal types — derived from the sub pattern
+// ---------------------------------------------------------------------------
+
+export type PrincipalType = 'actor' | 'svc_gateway' | 'ipc';
+
+// ---------------------------------------------------------------------------
+// Token audience — which service the JWT is intended for
+// ---------------------------------------------------------------------------
+
+export type TokenAudience = 'vellum-gateway' | 'vellum-daemon';
+
+// ---------------------------------------------------------------------------
+// JWT claims — the payload inside the token
+// ---------------------------------------------------------------------------
+
+export interface TokenClaims {
+  iss: 'vellum-auth';
+  aud: TokenAudience;
+  sub: string;
+  scope_profile: ScopeProfile;
+  exp: number;
+  policy_epoch: number;
+  iat?: number;
+  jti?: string;
+}
+
+// ---------------------------------------------------------------------------
+// AuthContext — normalized auth state for downstream consumers
+// ---------------------------------------------------------------------------
+
+export interface AuthContext {
+  subject: string;
+  principalType: PrincipalType;
+  assistantId: string;
+  actorPrincipalId?: string;
+  sessionId?: string;
+  scopeProfile: ScopeProfile;
+  scopes: ReadonlySet<Scope>;
+  policyEpoch: number;
+}

--- a/gateway/src/auth/policy.ts
+++ b/gateway/src/auth/policy.ts
@@ -1,0 +1,17 @@
+/**
+ * Policy epoch management.
+ *
+ * The policy epoch is a monotonic counter embedded in every JWT. When
+ * the auth policy changes (e.g., scope profiles are redefined), the
+ * epoch is bumped, and tokens carrying a stale epoch are rejected.
+ * This gives us a hard revocation mechanism without maintaining a
+ * per-token blocklist.
+ */
+
+/** Current policy epoch — bump this when auth policy changes. */
+export const CURRENT_POLICY_EPOCH = 1;
+
+/** Returns true if the given epoch is older than the current policy. */
+export function isStaleEpoch(epoch: number): boolean {
+  return epoch < CURRENT_POLICY_EPOCH;
+}

--- a/gateway/src/auth/scopes.ts
+++ b/gateway/src/auth/scopes.ts
@@ -1,0 +1,61 @@
+/**
+ * Scope profile resolver and scope-check utilities.
+ *
+ * Each scope profile maps to a fixed set of permission scopes. The
+ * mapping is intentionally hard-coded — profile definitions are a
+ * policy decision, not a runtime configuration.
+ */
+
+import type { AuthContext, Scope, ScopeProfile } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Profile -> scope mapping
+// ---------------------------------------------------------------------------
+
+const PROFILE_SCOPES: Record<ScopeProfile, ReadonlySet<Scope>> = {
+  actor_client_v1: new Set<Scope>([
+    'chat.read',
+    'chat.write',
+    'approval.read',
+    'approval.write',
+    'settings.read',
+    'settings.write',
+    'attachments.read',
+    'attachments.write',
+    'calls.read',
+    'calls.write',
+    'feature_flags.read',
+    'feature_flags.write',
+  ]),
+  gateway_ingress_v1: new Set<Scope>([
+    'ingress.write',
+    'internal.write',
+  ]),
+  gateway_service_v1: new Set<Scope>([
+    'settings.read',
+    'settings.write',
+    'internal.write',
+  ]),
+  ipc_v1: new Set<Scope>([
+    'ipc.all',
+  ]),
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Resolve a scope profile name to its set of granted scopes. */
+export function resolveScopeProfile(profile: ScopeProfile): ReadonlySet<Scope> {
+  return PROFILE_SCOPES[profile];
+}
+
+/** Check whether the auth context includes a specific scope. */
+export function hasScope(ctx: AuthContext, scope: Scope): boolean {
+  return ctx.scopes.has(scope);
+}
+
+/** Check whether the auth context includes all of the given scopes. */
+export function hasAllScopes(ctx: AuthContext, ...scopes: Scope[]): boolean {
+  return scopes.every((s) => ctx.scopes.has(s));
+}

--- a/gateway/src/auth/subject.ts
+++ b/gateway/src/auth/subject.ts
@@ -1,0 +1,68 @@
+/**
+ * Sub (subject) pattern parser for JWT tokens.
+ *
+ * The sub claim encodes principal type, assistant scope, and optional
+ * actor/session identifiers in a colon-delimited string.
+ */
+
+import type { PrincipalType } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+export type ParseSubResult =
+  | {
+      ok: true;
+      principalType: PrincipalType;
+      assistantId: string;
+      actorPrincipalId?: string;
+      sessionId?: string;
+    }
+  | { ok: false; reason: string };
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a JWT sub claim into its constituent parts.
+ *
+ * Supported patterns:
+ *   actor:<assistantId>:<actorPrincipalId>
+ *   svc:gateway:<assistantId>
+ *   ipc:<assistantId>:<sessionId>
+ */
+export function parseSub(sub: string): ParseSubResult {
+  if (!sub || typeof sub !== 'string') {
+    return { ok: false, reason: 'sub is empty or not a string' };
+  }
+
+  const parts = sub.split(':');
+
+  if (parts[0] === 'actor' && parts.length === 3) {
+    const [, assistantId, actorPrincipalId] = parts;
+    if (!assistantId || !actorPrincipalId) {
+      return { ok: false, reason: 'actor sub has empty assistantId or actorPrincipalId' };
+    }
+    return { ok: true, principalType: 'actor', assistantId, actorPrincipalId };
+  }
+
+  if (parts[0] === 'svc' && parts[1] === 'gateway' && parts.length === 3) {
+    const assistantId = parts[2];
+    if (!assistantId) {
+      return { ok: false, reason: 'svc:gateway sub has empty assistantId' };
+    }
+    return { ok: true, principalType: 'svc_gateway', assistantId };
+  }
+
+  if (parts[0] === 'ipc' && parts.length === 3) {
+    const [, assistantId, sessionId] = parts;
+    if (!assistantId || !sessionId) {
+      return { ok: false, reason: 'ipc sub has empty assistantId or sessionId' };
+    }
+    return { ok: true, principalType: 'ipc', assistantId, sessionId };
+  }
+
+  return { ok: false, reason: `unrecognized sub pattern: ${sub}` };
+}

--- a/gateway/src/auth/token-service.ts
+++ b/gateway/src/auth/token-service.ts
@@ -1,0 +1,194 @@
+/**
+ * JWT token service for the gateway's auth system.
+ *
+ * Mirrors the assistant's token-service but manages its own signing key
+ * using the same loadOrCreateSigningKey pattern, reading from
+ * ~/.vellum/protected/actor-token-signing-key.
+ */
+
+import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { getLogger } from '../logger.js';
+import { getRootDir } from '../credential-reader.js';
+
+import { isStaleEpoch } from './policy.js';
+import type { ScopeProfile, TokenAudience, TokenClaims } from './types.js';
+
+const log = getLogger('auth-token-service');
+
+// ---------------------------------------------------------------------------
+// Signing key management
+// ---------------------------------------------------------------------------
+
+let signingKey: Buffer | null = null;
+
+function getSigningKeyPath(): string {
+  return join(getRootDir(), 'protected', 'actor-token-signing-key');
+}
+
+/**
+ * Load a signing key from disk or generate and persist a new one.
+ * Uses atomic-write + chmod 0o600 for safe secret storage.
+ */
+export function loadOrCreateSigningKey(): Buffer {
+  const keyPath = getSigningKeyPath();
+
+  if (existsSync(keyPath)) {
+    try {
+      const raw = readFileSync(keyPath);
+      if (raw.length === 32) {
+        log.info('Auth signing key loaded from disk');
+        return raw;
+      }
+      log.warn('Signing key file has unexpected length, regenerating');
+    } catch (err) {
+      log.warn({ err }, 'Failed to read signing key file, regenerating');
+    }
+  }
+
+  const newKey = randomBytes(32);
+  const dir = dirname(keyPath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const tmpPath = keyPath + '.tmp.' + process.pid;
+  writeFileSync(tmpPath, newKey, { mode: 0o600 });
+  renameSync(tmpPath, keyPath);
+  chmodSync(keyPath, 0o600);
+
+  log.info('Auth signing key generated and persisted');
+  return newKey;
+}
+
+/**
+ * Initialize (or reinitialize) the signing key. Called at gateway startup.
+ */
+export function initSigningKey(key: Buffer): void {
+  signingKey = key;
+}
+
+function getSigningKey(): Buffer {
+  if (!signingKey) {
+    throw new Error('Auth signing key not initialized — call initSigningKey() during startup');
+  }
+  return signingKey;
+}
+
+// ---------------------------------------------------------------------------
+// Base64url helpers
+// ---------------------------------------------------------------------------
+
+function base64urlEncode(data: Buffer | string): string {
+  const buf = typeof data === 'string' ? Buffer.from(data, 'utf-8') : data;
+  return buf.toString('base64url');
+}
+
+function base64urlDecode(str: string): Buffer {
+  return Buffer.from(str, 'base64url');
+}
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+export type VerifyResult =
+  | { ok: true; claims: TokenClaims }
+  | { ok: false; reason: string };
+
+// ---------------------------------------------------------------------------
+// JWT header
+// ---------------------------------------------------------------------------
+
+const JWT_HEADER = base64urlEncode(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+
+// ---------------------------------------------------------------------------
+// Mint
+// ---------------------------------------------------------------------------
+
+export function mintToken(params: {
+  aud: TokenAudience;
+  sub: string;
+  scope_profile: ScopeProfile;
+  policy_epoch: number;
+  ttlSeconds: number;
+}): string {
+  const now = Math.floor(Date.now() / 1000);
+  const claims: TokenClaims = {
+    iss: 'vellum-auth',
+    aud: params.aud,
+    sub: params.sub,
+    scope_profile: params.scope_profile,
+    exp: now + params.ttlSeconds,
+    policy_epoch: params.policy_epoch,
+    iat: now,
+    jti: randomBytes(16).toString('hex'),
+  };
+
+  const payload = base64urlEncode(JSON.stringify(claims));
+  const sigInput = JWT_HEADER + '.' + payload;
+  const sig = createHmac('sha256', getSigningKey())
+    .update(sigInput)
+    .digest();
+
+  return sigInput + '.' + base64urlEncode(sig);
+}
+
+// ---------------------------------------------------------------------------
+// Verify
+// ---------------------------------------------------------------------------
+
+export function verifyToken(token: string, expectedAud: TokenAudience): VerifyResult {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return { ok: false, reason: 'malformed_token: expected 3 dot-separated parts' };
+  }
+
+  const [headerPart, payloadPart, sigPart] = parts;
+
+  const sigInput = headerPart + '.' + payloadPart;
+  const expectedSig = createHmac('sha256', getSigningKey())
+    .update(sigInput)
+    .digest();
+  const actualSig = base64urlDecode(sigPart);
+
+  if (expectedSig.length !== actualSig.length) {
+    return { ok: false, reason: 'invalid_signature' };
+  }
+
+  if (!timingSafeEqual(expectedSig, actualSig)) {
+    return { ok: false, reason: 'invalid_signature' };
+  }
+
+  let claims: TokenClaims;
+  try {
+    const decoded = base64urlDecode(payloadPart).toString('utf-8');
+    claims = JSON.parse(decoded) as TokenClaims;
+  } catch {
+    return { ok: false, reason: 'malformed_claims' };
+  }
+
+  if (claims.aud !== expectedAud) {
+    return { ok: false, reason: `audience_mismatch: expected ${expectedAud}, got ${claims.aud}` };
+  }
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (claims.exp <= nowSeconds) {
+    return { ok: false, reason: 'token_expired' };
+  }
+
+  if (isStaleEpoch(claims.policy_epoch)) {
+    return { ok: false, reason: 'stale_policy_epoch' };
+  }
+
+  return { ok: true, claims };
+}
+
+// ---------------------------------------------------------------------------
+// Hash
+// ---------------------------------------------------------------------------
+
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}

--- a/gateway/src/auth/types.ts
+++ b/gateway/src/auth/types.ts
@@ -1,0 +1,79 @@
+/**
+ * Core auth types for the single-header JWT auth system.
+ *
+ * These types define the token claims, scope profiles, principal types,
+ * and the normalized AuthContext that downstream code consumes.
+ */
+
+// ---------------------------------------------------------------------------
+// Scope profiles — named bundles of permissions
+// ---------------------------------------------------------------------------
+
+export type ScopeProfile =
+  | 'actor_client_v1'
+  | 'gateway_ingress_v1'
+  | 'gateway_service_v1'
+  | 'ipc_v1';
+
+// ---------------------------------------------------------------------------
+// Individual scope strings
+// ---------------------------------------------------------------------------
+
+export type Scope =
+  | 'chat.read'
+  | 'chat.write'
+  | 'approval.read'
+  | 'approval.write'
+  | 'settings.read'
+  | 'settings.write'
+  | 'attachments.read'
+  | 'attachments.write'
+  | 'calls.read'
+  | 'calls.write'
+  | 'ingress.write'
+  | 'internal.write'
+  | 'feature_flags.read'
+  | 'feature_flags.write'
+  | 'ipc.all';
+
+// ---------------------------------------------------------------------------
+// Principal types — derived from the sub pattern
+// ---------------------------------------------------------------------------
+
+export type PrincipalType = 'actor' | 'svc_gateway' | 'ipc';
+
+// ---------------------------------------------------------------------------
+// Token audience — which service the JWT is intended for
+// ---------------------------------------------------------------------------
+
+export type TokenAudience = 'vellum-gateway' | 'vellum-daemon';
+
+// ---------------------------------------------------------------------------
+// JWT claims — the payload inside the token
+// ---------------------------------------------------------------------------
+
+export interface TokenClaims {
+  iss: 'vellum-auth';
+  aud: TokenAudience;
+  sub: string;
+  scope_profile: ScopeProfile;
+  exp: number;
+  policy_epoch: number;
+  iat?: number;
+  jti?: string;
+}
+
+// ---------------------------------------------------------------------------
+// AuthContext — normalized auth state for downstream consumers
+// ---------------------------------------------------------------------------
+
+export interface AuthContext {
+  subject: string;
+  principalType: PrincipalType;
+  assistantId: string;
+  actorPrincipalId?: string;
+  sessionId?: string;
+  scopeProfile: ScopeProfile;
+  scopes: ReadonlySet<Scope>;
+  policyEpoch: number;
+}


### PR DESCRIPTION
## Summary
- New `assistant/src/runtime/auth/` module: JWT token types, HMAC-SHA256 mint/verify, subject parser, scope profile resolver, policy epoch, AuthContext builder
- Mirror auth types/utilities to `gateway/src/auth/` (types, subject, scopes, policy, token-service)
- Comprehensive unit tests (53 tests) for all primitives

Closes #11204
Part of #11203

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
