### PR TITLE
fix: prevent freeze when scrolling up during active message stream

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -396,7 +396,11 @@ struct MessageListView: View {
             .scrollDisabled(messages.isEmpty && !isSending)
             .background {
                 ScrollWheelDetector(
-                    onScrollUp: { isNearBottom = false },
+                    onScrollUp: {
+                        scrollDebounceTask?.cancel()
+                        scrollDebounceTask = nil
+                        isNearBottom = false
+                    },
                     onScrollToBottom: { isNearBottom = true }
                 )
             }
@@ -451,18 +455,15 @@ struct MessageListView: View {
                     // execute during active streaming, not only after the last token.
                     if scrollDebounceTask == nil {
                         scrollDebounceTask = Task {
-                            // Re-check after the sleep — user may have scrolled away.
-                            guard isNearBottom else {
-                                scrollDebounceTask = nil
-                                return
-                            }
+                            defer { scrollDebounceTask = nil }
+                            guard isNearBottom && !isSuppressingBottomScroll else { return }
                             withAnimation(VAnimation.fast) {
                                 proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                             }
                             try? await Task.sleep(nanoseconds: 200_000_000)
-                            scrollDebounceTask = nil
-                            // Trailing edge: content may have changed during cooldown.
-                            if isNearBottom {
+                            // If the task was cancelled during the sleep (user scrolled up), do not fire trailing-edge scroll.
+                            guard !Task.isCancelled else { return }
+                            if isNearBottom && !isSuppressingBottomScroll {
                                 withAnimation(VAnimation.fast) {
                                     proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                                 }


### PR DESCRIPTION
Cancel scrollDebounceTask (the streaming auto-scroll throttle) immediately when the user manually scrolls up, and add Task.isCancelled guard after the 200ms sleep window. Previously, the sleeping task would fire a trailing-edge proxy.scrollTo() even after isNearBottom was set to false by the user scrolling up — causing competing withAnimation+scrollTo calls that overwhelmed SwiftUI's layout engine during high-frequency streaming (100ms token flush), leading to freeze and crash.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
