### PR TITLE
feat: add health check to vellum mcp list

### DIFF
--- a/assistant/src/cli/mcp.ts
+++ b/assistant/src/cli/mcp.ts
@@ -6,10 +6,40 @@ import type { Command } from 'commander';
 
 import { loadRawConfig, saveRawConfig } from '../config/loader.js';
 import type { McpConfig, McpServerConfig } from '../config/mcp-schema.js';
+import { McpClient } from '../mcp/client.js';
 import { deleteMcpOAuthCredentials, McpOAuthProvider } from '../mcp/mcp-oauth-provider.js';
 import { getCliLogger } from '../util/logger.js';
 
 const log = getCliLogger('cli');
+
+const HEALTH_CHECK_TIMEOUT_MS = 10_000;
+
+async function checkServerHealth(serverId: string, config: McpServerConfig): Promise<string> {
+  const client = new McpClient(serverId, { quiet: true });
+  try {
+    await Promise.race([
+      client.connect(config.transport),
+      new Promise<never>((_, reject) => {
+        const t = setTimeout(() => reject(new Error('timeout')), HEALTH_CHECK_TIMEOUT_MS);
+        if (typeof t === 'object' && 'unref' in t) t.unref();
+      }),
+    ]);
+
+    if (!client.isConnected) {
+      return '! Needs authentication';
+    }
+
+    await client.disconnect();
+    return '\u2713 Connected';
+  } catch (err) {
+    try { await client.disconnect(); } catch { /* ignore */ }
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes('timeout')) {
+      return '\u2717 Timed out';
+    }
+    return `\u2717 Error: ${message}`;
+  }
+}
 
 export function registerMcpCommand(program: Command): void {
   const mcp = program.command('mcp').description('Manage MCP (Model Context Protocol) servers');
@@ -18,7 +48,7 @@ export function registerMcpCommand(program: Command): void {
     .command('list')
     .description('List configured MCP servers and their status')
     .option('--json', 'Output as JSON')
-    .action((opts: { json?: boolean }) => {
+    .action(async (opts: { json?: boolean }) => {
       const raw = loadRawConfig();
       const mcpConfig = raw.mcp as Partial<McpConfig> | undefined;
       const servers = mcpConfig?.servers ?? {};
@@ -42,6 +72,8 @@ export function registerMcpCommand(program: Command): void {
       }
 
       log.info(`${entries.length} MCP server(s) configured:\n`);
+
+      let didHealthCheck = false;
       for (const [id, cfg] of entries) {
         if (!cfg || typeof cfg !== 'object') {
           log.info(`  ${id} (invalid config — skipped)\n`);
@@ -50,7 +82,14 @@ export function registerMcpCommand(program: Command): void {
         const enabled = cfg.enabled !== false;
         const transport = cfg.transport;
         const risk = cfg.defaultRiskLevel ?? 'high';
-        const status = enabled ? '✓ enabled' : '✗ disabled';
+
+        let status: string;
+        if (!enabled) {
+          status = '✗ disabled';
+        } else {
+          status = await checkServerHealth(id, cfg);
+          didHealthCheck = true;
+        }
 
         log.info(`  ${id}`);
         log.info(`    Status:    ${status}`);
@@ -65,6 +104,9 @@ export function registerMcpCommand(program: Command): void {
         if (cfg.blockedTools) log.info(`    Blocked:   ${cfg.blockedTools.join(', ')}`);
         log.info('');
       }
+
+      // Health checks may leave MCP transports alive — force exit
+      if (didHealthCheck) process.exit(0);
     });
 
   mcp

--- a/assistant/src/mcp/client.ts
+++ b/assistant/src/mcp/client.ts
@@ -30,13 +30,15 @@ export class McpClient {
   private transport: StdioClientTransport | SSEClientTransport | StreamableHTTPClientTransport | null = null;
   private connected = false;
   private oauthProvider: McpOAuthProvider | null = null;
+  private quiet: boolean;
 
   get isConnected(): boolean {
     return this.connected;
   }
 
-  constructor(serverId: string) {
+  constructor(serverId: string, opts?: { quiet?: boolean }) {
     this.serverId = serverId;
+    this.quiet = opts?.quiet ?? false;
     this.client = new Client({
       name: 'vellum-assistant',
       version: '1.0.0',
@@ -59,7 +61,7 @@ export class McpClient {
       }
     }
 
-    console.log(`[MCP] Connecting to server "${this.serverId}"...`);
+    if (!this.quiet) console.log(`[MCP] Connecting to server "${this.serverId}"...`);
     this.transport = this.createTransport(transportConfig);
 
     try {
@@ -80,13 +82,13 @@ export class McpClient {
         if (isAuthError) {
           // Auth-related — user can run `vellum mcp auth <name>` to authenticate.
           log.info({ serverId: this.serverId, err }, 'MCP server requires authentication');
-          console.log(`[MCP] Server "${this.serverId}" requires authentication. Run "vellum mcp auth ${this.serverId}" to authenticate.`);
+          if (!this.quiet) console.log(`[MCP] Server "${this.serverId}" requires authentication. Run "vellum mcp auth ${this.serverId}" to authenticate.`);
           return;
         }
 
         // Non-auth error (DNS, TLS, timeout, etc.) — log and re-throw
         log.error({ serverId: this.serverId, err }, 'MCP server connection failed');
-        console.error(`[MCP] Server "${this.serverId}" connection failed: ${err instanceof Error ? err.message : err}`);
+        if (!this.quiet) console.error(`[MCP] Server "${this.serverId}" connection failed: ${err instanceof Error ? err.message : err}`);
         throw err;
       }
 
@@ -94,7 +96,7 @@ export class McpClient {
     }
 
     this.connected = true;
-    console.log(`[MCP] Server "${this.serverId}" connected successfully`);
+    if (!this.quiet) console.log(`[MCP] Server "${this.serverId}" connected successfully`);
     log.info({ serverId: this.serverId }, 'MCP client connected');
   }
 


### PR DESCRIPTION
## Summary
- `vellum mcp list` now attempts a quick connection to each enabled server and shows live status instead of static "enabled/disabled"
- Status results: `✓ Connected`, `! Needs authentication`, `✗ Timed out`, `✗ Error: <message>`
- Adds `quiet` option to `McpClient` to suppress console output during health checks

## Test plan
- [ ] Run `vellum mcp list` with a connected server — verify `✓ Connected`
- [ ] Run `vellum mcp list` with an unauthenticated OAuth server — verify `! Needs authentication`
- [ ] Run `vellum mcp list` with a disabled server — verify `✗ disabled`
- [ ] Run `vellum mcp list --json` — verify JSON output unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
