### PR TITLE
M1: Extend approval decision contracts for allow_10m and allow_thread

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -119,6 +119,7 @@ function makeIpcEventSender(params: {
           allowlistOptions: event.allowlistOptions,
           scopeOptions: event.scopeOptions,
           persistentDecisionsAllowed: event.persistentDecisionsAllowed,
+          temporaryOptionsAvailable: event.temporaryOptionsAvailable,
         },
       });
 

--- a/assistant/src/daemon/ipc-contract/messages.ts
+++ b/assistant/src/daemon/ipc-contract/messages.ts
@@ -30,7 +30,7 @@ export interface UserMessage {
 export interface ConfirmationResponse {
   type: 'confirmation_response';
   requestId: string;
-  decision: 'allow' | 'always_allow' | 'always_allow_high_risk' | 'deny' | 'always_deny';
+  decision: 'allow' | 'allow_10m' | 'allow_thread' | 'always_allow' | 'always_allow_high_risk' | 'deny' | 'always_deny';
   selectedPattern?: string;
   selectedScope?: string;
 }
@@ -119,6 +119,8 @@ export interface ConfirmationRequest {
   sessionId?: string;
   /** When false, the client should hide "always allow" / trust-rule persistence affordances. */
   persistentDecisionsAllowed?: boolean;
+  /** Which temporary approval options the client should render (e.g. "Allow for 10 minutes", "Allow for this thread"). */
+  temporaryOptionsAvailable?: Array<'allow_10m' | 'allow_thread'>;
 }
 
 export interface SecretRequest {

--- a/assistant/src/daemon/ipc-validate.ts
+++ b/assistant/src/daemon/ipc-validate.ts
@@ -137,7 +137,7 @@ const HIGH_RISK_VALIDATORS: Record<string, PropertyValidator> = {
     if (typeof obj.requestId !== 'string' || obj.requestId === '') {
       return 'confirmation_response requires a non-empty string "requestId"';
     }
-    const validDecisions = ['allow', 'always_allow', 'always_allow_high_risk', 'deny', 'always_deny'];
+    const validDecisions = ['allow', 'allow_10m', 'allow_thread', 'always_allow', 'always_allow_high_risk', 'deny', 'always_deny'];
     if (typeof obj.decision !== 'string' || !validDecisions.includes(obj.decision)) {
       return `confirmation_response "decision" must be one of: ${validDecisions.join(', ')}`;
     }

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -128,6 +128,7 @@ function makePendingInteractionRegistrar(
           allowlistOptions: msg.allowlistOptions,
           scopeOptions: msg.scopeOptions,
           persistentDecisionsAllowed: msg.persistentDecisionsAllowed,
+          temporaryOptionsAvailable: msg.temporaryOptionsAvailable,
         },
       });
 

--- a/assistant/src/daemon/session-attachments.ts
+++ b/assistant/src/daemon/session-attachments.ts
@@ -2,6 +2,7 @@ import { AttachmentUploadError,linkAttachmentToMessage, setAttachmentThumbnail, 
 import { check, classifyRisk, generateAllowlistOptions, generateScopeOptions } from '../permissions/checker.js';
 import type { PermissionPrompter } from '../permissions/prompter.js';
 import { addRule } from '../permissions/trust-store.js';
+import { isAllowDecision } from '../permissions/types.js';
 import type { ContentBlock } from '../providers/types.js';
 import { getLogger } from '../util/logger.js';
 import {
@@ -67,7 +68,7 @@ export async function approveHostAttachmentRead(
     addRule(toolName, response.selectedPattern, response.selectedScope, 'deny');
   }
 
-  return response.decision === 'allow' || response.decision === 'always_allow' || response.decision === 'always_allow_high_risk';
+  return isAllowDecision(response.decision);
 }
 
 export function formatAttachmentWarnings(warnings: string[]): string | null {

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -10,6 +10,7 @@ import { generateAllowlistOptions, generateScopeOptions, normalizeWebFetchUrl } 
 import type { PermissionPrompter } from '../permissions/prompter.js';
 import type { SecretPrompter } from '../permissions/secret-prompter.js';
 import { addRule, findHighestPriorityRule } from '../permissions/trust-store.js';
+import { isAllowDecision } from '../permissions/types.js';
 import type { Message, ToolDefinition } from '../providers/types.js';
 import type { ToolExecutor } from '../tools/executor.js';
 import type { ToolExecutionResult, ToolLifecycleEventHandler } from '../tools/types.js';
@@ -186,7 +187,7 @@ export function createToolExecutor(
           addRule('cc:' + req.toolName, response.selectedPattern, response.selectedScope, 'deny');
         }
         return {
-          decision: (response.decision === 'allow' || response.decision === 'always_allow' || response.decision === 'always_allow_high_risk') ? 'allow' as const : 'deny' as const,
+          decision: isAllowDecision(response.decision) ? 'allow' as const : 'deny' as const,
         };
       },
     });
@@ -282,9 +283,7 @@ export function createProxyApprovalCallback(
       addRule(toolName, response.selectedPattern, response.selectedScope, 'deny');
     }
 
-    return response.decision === 'allow'
-      || response.decision === 'always_allow'
-      || response.decision === 'always_allow_high_risk';
+    return isAllowDecision(response.decision);
   };
 }
 

--- a/assistant/src/events/tool-domain-event-publisher.ts
+++ b/assistant/src/events/tool-domain-event-publisher.ts
@@ -1,12 +1,7 @@
+import { isAllowDecision, type UserDecision } from '../permissions/types.js';
 import type { ToolLifecycleEventHandler } from '../tools/types.js';
 import type { EventBus } from './bus.js';
 import type { AssistantDomainEvents } from './domain-events.js';
-
-const allowDecisions = new Set(['allow', 'always_allow']);
-
-function isAllowDecision(decision: string): decision is 'allow' | 'always_allow' {
-  return allowDecisions.has(decision);
-}
 
 export function createToolDomainEventPublisher(
   eventBus: EventBus<AssistantDomainEvents>,
@@ -45,7 +40,7 @@ export function createToolDomainEventPublisher(
         });
         break;
       case 'executed':
-        if (isAllowDecision(event.decision)) {
+        if (isAllowDecision(event.decision as UserDecision)) {
           await eventBus.emit('tool.permission.decided', {
             conversationId: event.conversationId,
             sessionId: event.sessionId,
@@ -69,7 +64,7 @@ export function createToolDomainEventPublisher(
         });
         break;
       case 'error':
-        if (isAllowDecision(event.decision)) {
+        if (isAllowDecision(event.decision as UserDecision)) {
           await eventBus.emit('tool.permission.decided', {
             conversationId: event.conversationId,
             sessionId: event.sessionId,

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -56,6 +56,7 @@ export class PermissionPrompter {
     executionTarget?: ExecutionTarget,
     persistentDecisionsAllowed?: boolean,
     signal?: AbortSignal,
+    temporaryOptionsAvailable?: Array<'allow_10m' | 'allow_thread'>,
   ): Promise<{
     decision: UserDecision;
     selectedPattern?: string;
@@ -101,6 +102,7 @@ export class PermissionPrompter {
         sessionId,
         executionTarget,
         persistentDecisionsAllowed: persistentDecisionsAllowed ?? true,
+        temporaryOptionsAvailable,
       });
 
       this.onStateChanged?.(requestId, 'pending', 'system');

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -16,7 +16,7 @@ export interface TrustRule {
   allowHighRisk?: boolean;
 }
 
-export type UserDecision = 'allow' | 'always_allow' | 'always_allow_high_risk' | 'deny' | 'always_deny';
+export type UserDecision = 'allow' | 'allow_10m' | 'allow_thread' | 'always_allow' | 'always_allow_high_risk' | 'deny' | 'always_deny';
 
 export interface PermissionCheckResult {
   decision: 'allow' | 'deny' | 'prompt';

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -18,6 +18,15 @@ export interface TrustRule {
 
 export type UserDecision = 'allow' | 'allow_10m' | 'allow_thread' | 'always_allow' | 'always_allow_high_risk' | 'deny' | 'always_deny';
 
+/** Returns true for any allow-variant decision. Centralizes the check to prevent omissions when new allow variants are added. */
+export function isAllowDecision(decision: UserDecision): boolean {
+  return decision === 'allow'
+    || decision === 'allow_10m'
+    || decision === 'allow_thread'
+    || decision === 'always_allow'
+    || decision === 'always_allow_high_risk';
+}
+
 export interface PermissionCheckResult {
   decision: 'allow' | 'deny' | 'prompt';
   reason: string;

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -18,6 +18,7 @@ export interface ConfirmationDetails {
   allowlistOptions: Array<{ label: string; description: string; pattern: string }>;
   scopeOptions: Array<{ label: string; scope: string }>;
   persistentDecisionsAllowed?: boolean;
+  temporaryOptionsAvailable?: Array<'allow_10m' | 'allow_thread'>;
 }
 
 export interface PendingInteraction {

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -10,6 +10,7 @@
  */
 import { getConversationByKey } from '../../memory/conversation-key-store.js';
 import { addRule } from '../../permissions/trust-store.js';
+import type { UserDecision } from '../../permissions/types.js';
 import { getTool } from '../../tools/registry.js';
 import { getLogger } from '../../util/logger.js';
 import { httpError } from '../http-errors.js';
@@ -85,8 +86,9 @@ export async function handleConfirm(req: Request, server: ServerWithRequestIP): 
     return httpError('BAD_REQUEST', 'requestId is required', 400);
   }
 
-  if (decision !== 'allow' && decision !== 'deny') {
-    return httpError('BAD_REQUEST', 'decision must be "allow" or "deny"', 400);
+  const validConfirmDecisions = ['allow', 'allow_10m', 'allow_thread', 'deny'];
+  if (typeof decision !== 'string' || !validConfirmDecisions.includes(decision)) {
+    return httpError('BAD_REQUEST', `decision must be one of: ${validConfirmDecisions.join(', ')}`, 400);
   }
 
   const interaction = pendingInteractions.resolve(requestId);
@@ -94,7 +96,7 @@ export async function handleConfirm(req: Request, server: ServerWithRequestIP): 
     return httpError('NOT_FOUND', 'No pending interaction found for this requestId', 404);
   }
 
-  interaction.session.handleConfirmationResponse(requestId, decision, undefined, undefined, undefined, {
+  interaction.session.handleConfirmationResponse(requestId, decision as UserDecision, undefined, undefined, undefined, {
     source: 'button',
   });
   return Response.json({ accepted: true });
@@ -273,6 +275,7 @@ export function handleListPendingInteractions(url: URL, req: Request, server: Se
           })),
           scopeOptions: confirmation.confirmationDetails?.scopeOptions,
           persistentDecisionsAllowed: confirmation.confirmationDetails?.persistentDecisionsAllowed,
+          temporaryOptionsAvailable: confirmation.confirmationDetails?.temporaryOptionsAvailable,
         }
       : null,
     pendingSecret: secret

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -338,6 +338,7 @@ function makeHubPublisher(
           allowlistOptions: msg.allowlistOptions,
           scopeOptions: msg.scopeOptions,
           persistentDecisionsAllowed: msg.persistentDecisionsAllowed,
+          temporaryOptionsAvailable: msg.temporaryOptionsAvailable,
         },
       });
 

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -907,8 +907,10 @@ public struct IPCConfirmationRequest: Codable, Sendable {
     public let sessionId: String?
     /// When false, the client should hide "always allow" / trust-rule persistence affordances.
     public let persistentDecisionsAllowed: Bool?
+    /// Which temporary approval options the client should render (e.g. "Allow for 10 minutes", "Allow for this thread").
+    public let temporaryOptionsAvailable: [String]?
 
-    public init(type: String, requestId: String, toolName: String, input: [String: AnyCodable], riskLevel: String, executionTarget: String? = nil, allowlistOptions: [IPCConfirmationRequestAllowlistOption], scopeOptions: [IPCConfirmationRequestScopeOption], diff: IPCConfirmationRequestDiff? = nil, sandboxed: Bool? = nil, sessionId: String? = nil, persistentDecisionsAllowed: Bool? = nil) {
+    public init(type: String, requestId: String, toolName: String, input: [String: AnyCodable], riskLevel: String, executionTarget: String? = nil, allowlistOptions: [IPCConfirmationRequestAllowlistOption], scopeOptions: [IPCConfirmationRequestScopeOption], diff: IPCConfirmationRequestDiff? = nil, sandboxed: Bool? = nil, sessionId: String? = nil, persistentDecisionsAllowed: Bool? = nil, temporaryOptionsAvailable: [String]? = nil) {
         self.type = type
         self.requestId = requestId
         self.toolName = toolName
@@ -921,6 +923,7 @@ public struct IPCConfirmationRequest: Codable, Sendable {
         self.sandboxed = sandboxed
         self.sessionId = sessionId
         self.persistentDecisionsAllowed = persistentDecisionsAllowed
+        self.temporaryOptionsAvailable = temporaryOptionsAvailable
     }
 }
 


### PR DESCRIPTION
Part of #11230. Adds allow_10m and allow_thread decision literals to UserDecision, IPC contract, HTTP /v1/confirm, and Swift types. Backward-compatible with existing allow/deny decisions. Closes #11231.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
