### PR TITLE
M3: Surface specific error messages during hatching and post-hatch bootstrap

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -97,6 +97,8 @@ declare -a SAFE_LINE_PATTERNS=(
     # Swift: named argument passing a variable (e.g. `clientSecret: trimmedSecret`)
     # where the line ends with the identifier or has a trailing closing paren.
     "[Cc]lient[Ss]ecret:[[:space:]]*[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*$"
+    # Swift: named argument passing a variable for privateKey (e.g. `sshPrivateKey: state.sshPrivateKey,`)
+    "[Pp]rivate[Kk]ey:[[:space:]]*[a-zA-Z_][a-zA-Z0-9_.]*[[:space:]]*[,)][[:space:]]*$"
     # Swift/Kotlin: constant declaration whose value is a camelCase identifier
     # (e.g. `let archivedSessionsKey = "archivedSessionIds"`).
     # These are AppStorage / UserDefaults keys, not secrets.
@@ -234,6 +236,8 @@ if [ "${1:-}" = "--self-test" ]; then
     SAFE_DOTTED_PROP_SECRET='    clientSecret: options.clientSecret,'
     # Swift named argument passing a variable (false positive to whitelist)
     SAFE_SWIFT_NAMED_ARG='                clientSecret: trimmedSecret'
+    # Swift named argument passing a variable for privateKey (false positive to whitelist)
+    SAFE_SWIFT_PRIVATE_KEY_ARG='            sshPrivateKey: state.sshPrivateKey,'
     # AWS well-known example key (false positive to whitelist)
     SAFE_AWS_EXAMPLE_KEY='const EXAMPLE_KEY = "AKIAIOSFODNN7EXAMPLE";'
     # Swift storage key constant (safe — UserDefaults key, not a secret)
@@ -467,6 +471,10 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$SAFE_SWIFT_NAMED_ARG" && ! matches_safe_line_pattern "$SAFE_SWIFT_NAMED_ARG"; then
         echo -e "${RED}Self-test failed:${NC} Swift named argument clientSecret false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_SWIFT_PRIVATE_KEY_ARG" && ! matches_safe_line_pattern "$SAFE_SWIFT_PRIVATE_KEY_ARG"; then
+        echo -e "${RED}Self-test failed:${NC} Swift named argument sshPrivateKey false positive"
         exit 1
     fi
     if matches_secret_pattern "$SAFE_AWS_EXAMPLE_KEY" && ! matches_safe_line_pattern "$SAFE_AWS_EXAMPLE_KEY"; then

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -527,8 +527,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 bootstrapFailureKind = .unknown
 
                 if daemonClient.isConnected {
-                    // Daemon is connected — check gateway health before proceeding
-                    if !(await isGatewayHealthy()) {
+                    // Daemon is connected — check gateway health before proceeding.
+                    // Remote assistants don't run a local gateway, so skip the check.
+                    let gatewayOk = isCurrentAssistantRemote || (await isGatewayHealthy())
+                    if !gatewayOk {
                         bootstrapFailureKind = .gatewayUnhealthy
                     } else {
                         log.info("Daemon connected during bootstrap retry — proceeding to wake-up send")
@@ -556,8 +558,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                     try? await assistantCli.hatch(daemonOnly: true)
                 }
 
-                // Attempt a connection if not already in progress
-                if !daemonClient.isConnecting {
+                // Attempt a connection if not already connected or in progress.
+                // The gateway-unhealthy fallthrough above should not trigger a
+                // reconnect — tearing down a healthy daemon connection just
+                // because the gateway isn't ready yet causes unnecessary churn.
+                if !daemonClient.isConnected && !daemonClient.isConnecting {
                     do {
                         try await daemonClient.connect()
                     } catch {
@@ -569,8 +574,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 }
 
                 if daemonClient.isConnected {
-                    // Connected — verify gateway health before proceeding
-                    if !(await isGatewayHealthy()) {
+                    // Connected — verify gateway health before proceeding.
+                    // Remote assistants don't run a local gateway, so skip the check.
+                    let gatewayOk = isCurrentAssistantRemote || (await isGatewayHealthy())
+                    if !gatewayOk {
                         bootstrapFailureKind = .gatewayUnhealthy
                     } else {
                         log.info("Daemon connected after bootstrap retry connect — proceeding to wake-up send")

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -66,6 +66,17 @@ enum BootstrapState: String {
     case complete = "complete"
 }
 
+/// Categorises the most recent bootstrap failure so diagnostic messages
+/// can be specific rather than generic escalating text.
+private enum BootstrapFailureKind {
+    case socketMissing
+    case daemonNotRunning
+    case connectionRefused
+    case gatewayUnhealthy
+    case authFailed
+    case unknown
+}
+
 /// Carbon event handler for the Quick Input hotkey (Cmd+Shift+/).
 /// Must be a free function because Carbon callbacks are C function pointers.
 private func quickInputHotKeyHandler(
@@ -156,6 +167,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     private var bootstrapInterstitialWindow: NSWindow?
     /// Active task for the bootstrap retry coordinator. Cancelled on dismiss.
     private var bootstrapRetryTask: Task<Void, Never>?
+    /// Tracks the most recent failure kind during bootstrap retries so that
+    /// diagnostic messages reflect the actual problem, not generic escalating text.
+    private var bootstrapFailureKind: BootstrapFailureKind = .unknown
     /// Background task that retries actor-token bootstrap until success.
     private var actorTokenBootstrapTask: Task<Void, Never>?
     /// Tracks file paths of .vellumapp bundles awaiting daemon responses (FIFO).
@@ -508,26 +522,24 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
         bootstrapRetryTask = Task {
             while !Task.isCancelled {
-                if daemonClient.isConnected {
-                    log.info("Daemon connected during bootstrap retry — proceeding to wake-up send")
-                    transitionBootstrap(to: .pendingWakeupSend)
-                    dismissBootstrapInterstitialWindow()
-                    await performRetriableWakeUpSend()
-                    // Only nil out if we're still the active task (no new coordinator was started)
-                    if !Task.isCancelled {
-                        bootstrapRetryTask = nil
-                    }
-                    return
-                }
+                // Reset so the displayed message always reflects the most
+                // recent failure, not a stale one from a previous iteration.
+                bootstrapFailureKind = .unknown
 
-                // Surface escalating diagnostics so the user isn't staring
-                // at a spinner with no context.
-                let elapsed = CFAbsoluteTimeGetCurrent() - retryStart
-                if elapsed > 30 {
-                    updateBootstrapInterstitial(
-                        errorMessage: bootstrapDiagnosticMessage(elapsed: elapsed),
-                        isRetrying: true
-                    )
+                if daemonClient.isConnected {
+                    // Daemon is connected — check gateway health before proceeding
+                    if !(await isGatewayHealthy()) {
+                        bootstrapFailureKind = .gatewayUnhealthy
+                    } else {
+                        log.info("Daemon connected during bootstrap retry — proceeding to wake-up send")
+                        transitionBootstrap(to: .pendingWakeupSend)
+                        dismissBootstrapInterstitialWindow()
+                        await performRetriableWakeUpSend()
+                        if !Task.isCancelled {
+                            bootstrapRetryTask = nil
+                        }
+                        return
+                    }
                 }
 
                 // If the daemon socket doesn't exist, the daemon process
@@ -535,7 +547,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 // so we don't loop forever on connect-only retries.
                 let socketPath = DaemonClient.resolveSocketPath()
                 if !FileManager.default.fileExists(atPath: socketPath) {
+                    bootstrapFailureKind = .socketMissing
                     log.info("Daemon socket missing during bootstrap retry — re-attempting hatch")
+                    try? await assistantCli.hatch(daemonOnly: true)
+                } else if !DaemonClient.isDaemonProcessAlive() {
+                    bootstrapFailureKind = .daemonNotRunning
+                    log.info("Daemon process not alive during bootstrap retry — re-attempting hatch")
                     try? await assistantCli.hatch(daemonOnly: true)
                 }
 
@@ -544,20 +561,37 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                     do {
                         try await daemonClient.connect()
                     } catch {
+                        if bootstrapFailureKind == .unknown {
+                            bootstrapFailureKind = .connectionRefused
+                        }
                         log.error("Bootstrap retry connect attempt failed: \(error)")
                     }
                 }
 
                 if daemonClient.isConnected {
-                    log.info("Daemon connected after bootstrap retry connect — proceeding to wake-up send")
-                    transitionBootstrap(to: .pendingWakeupSend)
-                    dismissBootstrapInterstitialWindow()
-                    await performRetriableWakeUpSend()
-                    // Only nil out if we're still the active task (no new coordinator was started)
-                    if !Task.isCancelled {
-                        bootstrapRetryTask = nil
+                    // Connected — verify gateway health before proceeding
+                    if !(await isGatewayHealthy()) {
+                        bootstrapFailureKind = .gatewayUnhealthy
+                    } else {
+                        log.info("Daemon connected after bootstrap retry connect — proceeding to wake-up send")
+                        transitionBootstrap(to: .pendingWakeupSend)
+                        dismissBootstrapInterstitialWindow()
+                        await performRetriableWakeUpSend()
+                        if !Task.isCancelled {
+                            bootstrapRetryTask = nil
+                        }
+                        return
                     }
-                    return
+                }
+
+                // Surface diagnostics so the user isn't staring at a
+                // spinner with no context.
+                let elapsed = CFAbsoluteTimeGetCurrent() - retryStart
+                if elapsed > 30 {
+                    updateBootstrapInterstitial(
+                        errorMessage: bootstrapDiagnosticMessage(elapsed: elapsed),
+                        isRetrying: true
+                    )
                 }
 
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
@@ -565,19 +599,52 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         }
     }
 
-    /// Returns a user-facing diagnostic message based on how long the bootstrap
-    /// retry has been running. Messages escalate in specificity over time.
+    /// Returns a user-facing diagnostic message based on the current failure
+    /// kind and how long the bootstrap retry has been running.
     private func bootstrapDiagnosticMessage(elapsed: CFAbsoluteTime) -> String {
-        if elapsed > 120 {
-            return "Your assistant is taking unusually long to start. "
-                + "Try quitting the app (\u{2318}Q) and reopening it. "
-                + "If the issue persists, retire and re-hatch your assistant."
-        } else if elapsed > 60 {
-            return "This is taking longer than expected. "
-                + "A background process may have crashed. "
-                + "The app will keep retrying automatically."
-        } else {
-            return "Still working on it \u{2014} this can take a minute on first launch."
+        switch bootstrapFailureKind {
+        case .socketMissing:
+            if elapsed > 60 {
+                return "Assistant files are missing. Try quitting (\u{2318}Q) and reopening."
+            }
+            return "Restarting your assistant\u{2026}"
+
+        case .daemonNotRunning:
+            if elapsed > 60 {
+                return "Unable to restart assistant. Try quitting (\u{2318}Q) and reopening."
+            }
+            return "Assistant process stopped \u{2014} restarting\u{2026}"
+
+        case .connectionRefused:
+            if elapsed > 60 {
+                return "Connection keeps failing. Try quitting (\u{2318}Q) and reopening."
+            }
+            return "Connecting to your assistant\u{2026}"
+
+        case .gatewayUnhealthy:
+            if elapsed > 60 {
+                return "Network services are not responding. Try quitting (\u{2318}Q) and reopening."
+            }
+            return "Waiting for network services\u{2026}"
+
+        case .authFailed:
+            if elapsed > 30 {
+                return "Authentication issue. You may need to re-pair your assistant."
+            }
+            return "Authenticating\u{2026}"
+
+        case .unknown:
+            if elapsed > 120 {
+                return "Your assistant is taking unusually long to start. "
+                    + "Try quitting the app (\u{2318}Q) and reopening it. "
+                    + "If the issue persists, retire and re-hatch your assistant."
+            } else if elapsed > 60 {
+                return "This is taking longer than expected. "
+                    + "A background process may have crashed. "
+                    + "The app will keep retrying automatically."
+            } else {
+                return "Still working on it \u{2014} this can take a minute on first launch."
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -567,7 +567,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                         try await daemonClient.connect()
                     } catch {
                         if bootstrapFailureKind == .unknown {
-                            bootstrapFailureKind = .connectionRefused
+                            if error is DaemonClient.AuthError {
+                                bootstrapFailureKind = .authFailed
+                            } else {
+                                bootstrapFailureKind = .connectionRefused
+                            }
                         }
                         log.error("Bootstrap retry connect attempt failed: \(error)")
                     }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -639,7 +639,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             return "Waiting for network services\u{2026}"
 
         case .authFailed:
-            if elapsed > 30 {
+            if elapsed > 60 {
                 return "Authentication issue. You may need to re-pair your assistant."
             }
             return "Authenticating\u{2026}"

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -22,6 +22,7 @@ struct HatchingStepView: View {
     @State private var progressMessageTimer: Timer?
     @State private var showTimeEstimate = false
     @State private var cliFinished = false
+    @State private var failureReason: String?
 
     private static let progressMessages = [
         "Getting things ready\u{2026}",
@@ -155,6 +156,11 @@ struct HatchingStepView: View {
                 Text("Something went wrong")
                     .font(.system(size: 24, weight: .regular, design: .serif))
                     .foregroundColor(VColor.textPrimary)
+                if let reason = failureReason {
+                    Text(reason)
+                        .font(.system(size: 14))
+                        .foregroundColor(VColor.textSecondary)
+                }
             } else if state.hatchCompleted {
                 Text(isCustomHardware ? "Your assistant is paired!" : "Your assistant has hatched!")
                     .font(.system(size: 24, weight: .regular, design: .serif))
@@ -233,11 +239,13 @@ struct HatchingStepView: View {
         state.hatchFailed = false
         state.hatchLogLines = []
         hatchStarted = false
+        failureReason = nil
     }
 
     private func retryHatch() {
         state.hatchFailed = false
         state.hatchLogLines = []
+        failureReason = nil
         eggCracked = false
         crackTime = nil
         cliFinished = false
@@ -374,6 +382,7 @@ struct HatchingStepView: View {
                 handleHatchSuccess()
             } catch {
                 state.hatchLogLines.append("Error: \(error.localizedDescription)")
+                failureReason = friendlyErrorMessage(from: error)
                 state.hatchFailed = true
             }
         }
@@ -390,8 +399,28 @@ struct HatchingStepView: View {
                 handleHatchSuccess()
             } catch {
                 state.hatchLogLines.append("Error: \(error.localizedDescription)")
+                failureReason = friendlyErrorMessage(from: error)
                 state.hatchFailed = true
             }
+        }
+    }
+
+    // MARK: - Error Mapping
+
+    private func friendlyErrorMessage(from error: Error) -> String {
+        let desc = error.localizedDescription.lowercased()
+        if desc.contains("connection refused") || desc.contains("econnrefused") {
+            return "Could not connect to your assistant"
+        } else if desc.contains("timed out") || desc.contains("timeout") {
+            return "Setup timed out \u{2014} please try again"
+        } else if desc.contains("no such file") || desc.contains("enoent") {
+            return "Assistant files could not be found"
+        } else if desc.contains("network") || desc.contains("internet") {
+            return "Network connection issue"
+        } else if desc.contains("permission") || desc.contains("eacces") {
+            return "Permission denied"
+        } else {
+            return error.localizedDescription
         }
     }
 }


### PR DESCRIPTION
## Summary
- HatchingStepView now shows a user-friendly error reason below 'Something went wrong' when hatching fails (maps CLI errors to friendly messages via `friendlyErrorMessage(from:)`)
- BootstrapInterstitialView now shows specific diagnostic messages based on failure type (socket missing, daemon not running, connection refused, gateway unhealthy, auth failed) instead of generic escalating text
- Added `BootstrapFailureKind` enum to track failure context in the retry coordinator
- Reset `bootstrapFailureKind` at the top of each retry loop iteration so displayed messages always reflect the most recent failure
- Fixed pre-commit hook false positive for Swift named argument `sshPrivateKey: state.sshPrivateKey`

Closes #11241
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
