### PR TITLE
fix: prevent freeze when scrolling up during active message stream

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -396,7 +396,11 @@ struct MessageListView: View {
             .scrollDisabled(messages.isEmpty && !isSending)
             .background {
                 ScrollWheelDetector(
-                    onScrollUp: { isNearBottom = false },
+                    onScrollUp: {
+                        scrollDebounceTask?.cancel()
+                        scrollDebounceTask = nil
+                        isNearBottom = false
+                    },
                     onScrollToBottom: { isNearBottom = true }
                 )
             }
@@ -451,18 +455,15 @@ struct MessageListView: View {
                     // execute during active streaming, not only after the last token.
                     if scrollDebounceTask == nil {
                         scrollDebounceTask = Task {
-                            // Re-check after the sleep — user may have scrolled away.
-                            guard isNearBottom else {
-                                scrollDebounceTask = nil
-                                return
-                            }
+                            defer { scrollDebounceTask = nil }
+                            guard isNearBottom && !isSuppressingBottomScroll else { return }
                             withAnimation(VAnimation.fast) {
                                 proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                             }
                             try? await Task.sleep(nanoseconds: 200_000_000)
-                            scrollDebounceTask = nil
-                            // Trailing edge: content may have changed during cooldown.
-                            if isNearBottom {
+                            // If the task was cancelled during the sleep (user scrolled up), do not fire trailing-edge scroll.
+                            guard !Task.isCancelled else { return }
+                            if isNearBottom && !isSuppressingBottomScroll {
                                 withAnimation(VAnimation.fast) {
                                     proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                                 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -455,7 +455,7 @@ struct MessageListView: View {
                     // execute during active streaming, not only after the last token.
                     if scrollDebounceTask == nil {
                         scrollDebounceTask = Task {
-                            defer { scrollDebounceTask = nil }
+                            defer { if !Task.isCancelled { scrollDebounceTask = nil } }
                             guard isNearBottom && !isSuppressingBottomScroll else { return }
                             withAnimation(VAnimation.fast) {
                                 proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)


### PR DESCRIPTION
## Summary
Fixes a crash and screen freeze that occurred when the user tried to scroll up in a chat thread while a message was actively streaming. The root cause was the streaming auto-scroll task never being cancelled on manual scroll, causing competing \`withAnimation + proxy.scrollTo\` calls to overwhelm SwiftUI's layout engine.

## Changes
- Cancel \`scrollDebounceTask\` immediately in the \`onScrollUp\` callback — the sleeping task is terminated the moment the user scrolls up, preventing the trailing-edge \`proxy.scrollTo("scroll-bottom-anchor")\` from firing
- Add \`guard !Task.isCancelled else { return }\` after the 200ms sleep — belt-and-suspenders defence against race conditions between task cancellation and sleep completion
- Add \`!isSuppressingBottomScroll\` check inside the task body alongside the existing \`isNearBottom\` guard — prevents streaming auto-scroll from fighting pagination scroll-position restoration
- Use \`defer { scrollDebounceTask = nil }\` for cleaner task cleanup

## Milestone PRs (merged into feature branch)
- #11239: fix: prevent freeze when scrolling up during active message stream

## Project issue
Closes #11228

## Test plan
- [ ] Start a long streaming response and immediately try to scroll up — view should scroll freely without fighting back
- [ ] After scrolling up during streaming, wait for stream to finish — auto-scroll should NOT resume unless user manually scrolls back to bottom
- [ ] Scroll to bottom mid-stream — auto-scroll should re-engage normally
- [ ] Paginate (scroll to top of history) during streaming — no conflict between pagination restoration and streaming scroll

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
