### PR TITLE
test: voice input QA test infrastructure (69 tests)

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -277,6 +277,23 @@ final class VoiceInputManager {
         holdTask = nil
     }
 
+    // MARK: - Hold Detection Logic (extracted for testability)
+
+    /// Pure decision function: should recording begin after the hold timer fires?
+    /// Extracted from the hold detection closure so it can be unit-tested without NSEvent mocking.
+    func shouldStartRecording(
+        activationKeyPressed: Bool,
+        otherKeyPressed: Bool,
+        timeSinceAppSwitch: TimeInterval,
+        isAlreadyRecording: Bool
+    ) -> Bool {
+        guard activationKeyPressed else { return false }
+        guard !otherKeyPressed else { return false }
+        guard timeSinceAppSwitch > 0.5 else { return false }
+        guard !isAlreadyRecording else { return false }
+        return true
+    }
+
     // MARK: - Recording
 
     private func beginRecording() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -414,7 +414,7 @@ extension MainWindowView {
                     onMicrophoneToggle: onMicrophoneToggle,
                     isTemporaryChat: activeThread?.kind == .private,
                     voiceModeManager: voiceModeManager,
-                    voiceService: voiceModeManager.voiceService,
+                    voiceService: voiceModeManager.openAIVoiceService,
                     onEndVoiceMode: {
                         voiceModeManager.deactivate()
                     },

--- a/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
@@ -30,7 +30,7 @@ enum VoiceServiceError: Error, LocalizedError {
 /// Voice service: SFSpeechRecognizer STT (on-device) + TTS (ElevenLabs REST API).
 /// Records audio, detects silence, transcribes via SFSpeechRecognizer, speaks via ElevenLabs.
 @MainActor
-final class OpenAIVoiceService: ObservableObject {
+final class OpenAIVoiceService: ObservableObject, VoiceServiceProtocol {
     @Published var amplitude: Float = 0
     @Published var speakingAmplitude: Float = 0
     @Published var livePartialText: String = ""

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -25,9 +25,14 @@ final class VoiceModeManager: ObservableObject {
     /// How long to wait in `.idle` before auto-deactivating voice mode.
     var conversationTimeoutInterval: TimeInterval = 30
 
-    let voiceService: OpenAIVoiceService
+    let voiceService: any VoiceServiceProtocol
 
-    private weak var chatViewModel: ChatViewModel?
+    /// Typed accessor for UI views that need @Published properties (amplitude, speakingAmplitude).
+    var openAIVoiceService: OpenAIVoiceService? {
+        voiceService as? OpenAIVoiceService
+    }
+
+    weak var chatViewModel: ChatViewModel?
     private weak var settingsStore: SettingsStore?
     private var previousOnVoiceResponseComplete: ((String) -> Void)?
     private var previousOnVoiceTextDelta: ((String) -> Void)?
@@ -51,8 +56,8 @@ final class VoiceModeManager: ObservableObject {
     /// Combine subscription forwarding live partial transcription from the voice service.
     private var liveTranscriptionCancellable: AnyCancellable?
 
-    nonisolated init() {
-        self.voiceService = OpenAIVoiceService()
+    nonisolated init(voiceService: any VoiceServiceProtocol = OpenAIVoiceService()) {
+        self.voiceService = voiceService
     }
 
     var stateLabel: String {
@@ -136,12 +141,14 @@ final class VoiceModeManager: ObservableObject {
             }
 
         // Forward live partial transcription when listening
-        liveTranscriptionCancellable = voiceService.$livePartialText
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] text in
-                guard let self, self.state == .listening else { return }
-                self.liveTranscription = text
-            }
+        if let openAI = voiceService as? OpenAIVoiceService {
+            liveTranscriptionCancellable = openAI.$livePartialText
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] text in
+                    guard let self, self.state == .listening else { return }
+                    self.liveTranscription = text
+                }
+        }
 
         // Pre-warm audio engine so first recording starts instantly
         voiceService.prewarmEngine()
@@ -427,7 +434,7 @@ final class VoiceModeManager: ObservableObject {
     }
 
     /// Produce a short, non-technical voice description for a single tool action.
-    private func describeAction(_ confirmation: ToolConfirmationData) -> String {
+    func describeAction(_ confirmation: ToolConfirmationData) -> String {
         let reason = (confirmation.input["reason"]?.value as? String) ?? ""
 
         // If the model provided a reason, use it directly — it's already high-level.
@@ -467,7 +474,12 @@ final class VoiceModeManager: ObservableObject {
         }
     }
 
-    private func handlePermissionResponse(_ text: String) {
+    /// Classify a voice response as approved, denied, or ambiguous.
+    enum PermissionDecision {
+        case approved, denied, ambiguous
+    }
+
+    static func classifyPermissionResponse(_ text: String) -> PermissionDecision {
         let lower = text.lowercased()
         let affirmative = ["yes", "yeah", "yep", "go ahead", "allow", "approve",
                            "sure", "okay", "ok", "do it", "proceed"]
@@ -478,8 +490,15 @@ final class VoiceModeManager: ObservableObject {
 
         // If both affirmative and negative substrings match (e.g. "no, don't do it"
         // contains "do it" + "no"/"don't"), treat as denial for safety.
-        let isApproved = hasAffirmative && !hasNegative
-        let isDenied = hasNegative
+        if hasAffirmative && !hasNegative { return .approved }
+        if hasNegative { return .denied }
+        return .ambiguous
+    }
+
+    private func handlePermissionResponse(_ text: String) {
+        let decision = Self.classifyPermissionResponse(text)
+        let isApproved = decision == .approved
+        let isDenied = decision == .denied
 
         guard let chatViewModel else {
             pendingPermissionIds = []

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceServiceProtocol.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceServiceProtocol.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Protocol abstracting voice service capabilities for testability.
+/// `OpenAIVoiceService` is the production implementation; tests use `MockVoiceService`.
+@MainActor
+protocol VoiceServiceProtocol: AnyObject {
+    var onSilenceDetected: (() -> Void)? { get set }
+    var onMicrophoneAuthorized: (() -> Void)? { get set }
+    var onBargeInDetected: (() -> Void)? { get set }
+    var livePartialText: String { get }
+    var hasElevenLabsKey: Bool { get }
+
+    func prewarmEngine()
+    @discardableResult func startRecording() -> Bool
+    func stopRecordingAndGetTranscription() async -> String?
+    func cancelRecording()
+    func shutdown()
+    func feedTextDelta(_ delta: String)
+    func finishTextStream(onComplete: @escaping () -> Void)
+    func resetStreamingTTS()
+    func stopSpeaking()
+    func startBargeInMonitor()
+    func stopBargeInMonitor()
+}

--- a/clients/macos/vellum-assistantTests/MockVoiceService.swift
+++ b/clients/macos/vellum-assistantTests/MockVoiceService.swift
@@ -1,0 +1,106 @@
+import Foundation
+@testable import VellumAssistantLib
+
+@MainActor
+final class MockVoiceService: VoiceServiceProtocol {
+    var onSilenceDetected: (() -> Void)?
+    var onMicrophoneAuthorized: (() -> Void)?
+    var onBargeInDetected: (() -> Void)?
+    var livePartialText: String = ""
+    var hasElevenLabsKey: Bool = false
+
+    // MARK: - Spy Flags
+
+    var prewarmEngineCalled = false
+    var startRecordingCalled = false
+    var stopRecordingCalled = false
+    var cancelRecordingCalled = false
+    var shutdownCalled = false
+    var feedTextDeltaCalled = false
+    var finishTextStreamCalled = false
+    var resetStreamingTTSCalled = false
+    var stopSpeakingCalled = false
+    var startBargeInMonitorCalled = false
+    var stopBargeInMonitorCalled = false
+
+    var fedTextDeltas: [String] = []
+
+    // MARK: - Configurable Return Values
+
+    var startRecordingResult: Bool = true
+    var transcriptionToReturn: String? = "test transcription"
+
+    // MARK: - Stored Completions
+
+    /// Stored completion from `finishTextStream` — call this in tests to simulate TTS completing.
+    var finishTextStreamCompletion: (() -> Void)?
+
+    // MARK: - Protocol Methods
+
+    func prewarmEngine() {
+        prewarmEngineCalled = true
+    }
+
+    @discardableResult
+    func startRecording() -> Bool {
+        startRecordingCalled = true
+        return startRecordingResult
+    }
+
+    func stopRecordingAndGetTranscription() async -> String? {
+        stopRecordingCalled = true
+        return transcriptionToReturn
+    }
+
+    func cancelRecording() {
+        cancelRecordingCalled = true
+    }
+
+    func shutdown() {
+        shutdownCalled = true
+    }
+
+    func feedTextDelta(_ delta: String) {
+        feedTextDeltaCalled = true
+        fedTextDeltas.append(delta)
+    }
+
+    func finishTextStream(onComplete: @escaping () -> Void) {
+        finishTextStreamCalled = true
+        finishTextStreamCompletion = onComplete
+    }
+
+    func resetStreamingTTS() {
+        resetStreamingTTSCalled = true
+    }
+
+    func stopSpeaking() {
+        stopSpeakingCalled = true
+    }
+
+    func startBargeInMonitor() {
+        startBargeInMonitorCalled = true
+    }
+
+    func stopBargeInMonitor() {
+        stopBargeInMonitorCalled = true
+    }
+
+    // MARK: - Test Helpers
+
+    func reset() {
+        prewarmEngineCalled = false
+        startRecordingCalled = false
+        stopRecordingCalled = false
+        cancelRecordingCalled = false
+        shutdownCalled = false
+        feedTextDeltaCalled = false
+        finishTextStreamCalled = false
+        resetStreamingTTSCalled = false
+        stopSpeakingCalled = false
+        startBargeInMonitorCalled = false
+        stopBargeInMonitorCalled = false
+        fedTextDeltas = []
+        finishTextStreamCompletion = nil
+    }
+}

--- a/clients/macos/vellum-assistantTests/TTSRedactorTests.swift
+++ b/clients/macos/vellum-assistantTests/TTSRedactorTests.swift
@@ -1,0 +1,151 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class TTSRedactorTests: XCTestCase {
+
+    // MARK: - Anthropic API Keys
+
+    func testRedactsAnthropicKey() {
+        let input = "Your key is sk-ant-api03-abcdefghijklmnopqrstuvwxyz"
+        let result = TTSRedactor.redact(input)
+        XCTAssertEqual(result, "Your key is a redacted Anthropic key")
+    }
+
+    // MARK: - OpenAI Project Keys
+
+    func testRedactsOpenAIProjectKey() {
+        let input = "Use sk-proj-abcdefghijklmnopqrstuvwxyz to authenticate"
+        let result = TTSRedactor.redact(input)
+        XCTAssertEqual(result, "Use a redacted API key to authenticate")
+    }
+
+    // MARK: - Generic OpenAI Keys
+
+    func testRedactsGenericOpenAIKey() {
+        let input = "sk-abcdefghijklmnopqrstuvwxyz1234"
+        let result = TTSRedactor.redact(input)
+        XCTAssertEqual(result, "a redacted API key")
+    }
+
+    // MARK: - GitHub Fine-Grained PATs
+
+    func testRedactsGitHubFinegrainedPAT() {
+        let pat = "github_pat_" + String(repeating: "A", count: 82)
+        let input = "Token: \(pat)"
+        let result = TTSRedactor.redact(input)
+        XCTAssertEqual(result, "Token: a redacted GitHub token")
+    }
+
+    // MARK: - GitHub Classic Tokens
+
+    func testRedactsGitHubClassicPAT() {
+        let token = "ghp_" + String(repeating: "A", count: 36)
+        let result = TTSRedactor.redact(token)
+        XCTAssertEqual(result, "a redacted GitHub token")
+    }
+
+    func testRedactsGitHubServerToken() {
+        let token = "ghs_" + String(repeating: "B", count: 36)
+        let result = TTSRedactor.redact(token)
+        XCTAssertEqual(result, "a redacted GitHub token")
+    }
+
+    func testRedactsGitHubOAuthToken() {
+        let token = "gho_" + String(repeating: "C", count: 36)
+        let result = TTSRedactor.redact(token)
+        XCTAssertEqual(result, "a redacted GitHub token")
+    }
+
+    func testRedactsGitHubRefreshToken() {
+        let token = "ghr_" + String(repeating: "D", count: 36)
+        let result = TTSRedactor.redact(token)
+        XCTAssertEqual(result, "a redacted GitHub token")
+    }
+
+    // MARK: - JWT Tokens
+
+    func testRedactsJWTToken() {
+        let jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
+        let result = TTSRedactor.redact(jwt)
+        XCTAssertEqual(result, "a redacted token")
+    }
+
+    // MARK: - Bearer Tokens
+
+    func testRedactsBearerToken() {
+        let token = "Bearer " + String(repeating: "x", count: 20)
+        let input = "Authorization: \(token)"
+        let result = TTSRedactor.redact(input)
+        XCTAssertEqual(result, "Authorization: a redacted bearer token")
+    }
+
+    func testRedactsAuthTokenCaseInsensitive() {
+        // Uppercase variant of "Bearer" prefix
+        let prefix = "BEARER"
+        let token = prefix + " " + String(repeating: "y", count: 20)
+        let result = TTSRedactor.redact(token)
+        XCTAssertEqual(result, "a redacted bearer token")
+    }
+
+    // MARK: - 32-char Alphanumeric Keys
+
+    func testRedacts32CharAlphanumericKey() {
+        let key = String(repeating: "Ab1", count: 10) + "Xy"  // 32 chars
+        let input = "ElevenLabs key: \(key) is set"
+        let result = TTSRedactor.redact(input)
+        XCTAssertEqual(result, "ElevenLabs key: a redacted key is set")
+    }
+
+    // MARK: - Long Hex Strings
+
+    func testRedacts40CharHexString() {
+        let hex = String(repeating: "a1b2c3d4e5", count: 4)  // 40 chars
+        let input = "SHA1: \(hex)"
+        let result = TTSRedactor.redact(input)
+        XCTAssertEqual(result, "SHA1: a redacted hash")
+    }
+
+    func testRedacts64CharHexString() {
+        let hex = String(repeating: "abcdef01", count: 8)  // 64 chars
+        let input = "Hash: \(hex)"
+        let result = TTSRedactor.redact(input)
+        XCTAssertEqual(result, "Hash: a redacted hash")
+    }
+
+    // MARK: - Passthrough (No Credentials)
+
+    func testPassesThroughNormalText() {
+        let input = "Hello, how are you today?"
+        let result = TTSRedactor.redact(input)
+        XCTAssertEqual(result, input)
+    }
+
+    func testPassesThroughEmptyString() {
+        XCTAssertEqual(TTSRedactor.redact(""), "")
+    }
+
+    func testPassesThroughShortAlphanumeric() {
+        let input = "The code is ABC123"
+        let result = TTSRedactor.redact(input)
+        XCTAssertEqual(result, input)
+    }
+
+    // MARK: - Multiple Credentials
+
+    func testRedactsMultipleCredentials() {
+        let key1 = "sk-ant-api03-" + String(repeating: "x", count: 20)
+        let key2 = "ghp_" + String(repeating: "Y", count: 36)
+        let input = "Found \(key1) and \(key2) in the config"
+        let result = TTSRedactor.redact(input)
+        XCTAssertEqual(result, "Found a redacted Anthropic key and a redacted GitHub token in the config")
+    }
+
+    // MARK: - Credential Embedded in Sentence
+
+    func testRedactsCredentialEmbeddedInSentence() {
+        let key = "sk-ant-api03-" + String(repeating: "z", count: 20)
+        let input = "I found the key \(key) in your .env file"
+        let result = TTSRedactor.redact(input)
+        XCTAssertEqual(result, "I found the key a redacted Anthropic key in your .env file")
+    }
+}

--- a/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class VoiceInputManagerTests: XCTestCase {
+
+    private var manager: VoiceInputManager!
+
+    override func setUp() {
+        super.setUp()
+        manager = VoiceInputManager()
+    }
+
+    override func tearDown() {
+        manager = nil
+        super.tearDown()
+    }
+
+    // MARK: - shouldStartRecording
+
+    func testActivationKeyAloneAfterAppSwitch() {
+        let result = manager.shouldStartRecording(
+            activationKeyPressed: true,
+            otherKeyPressed: false,
+            timeSinceAppSwitch: 1.0,
+            isAlreadyRecording: false
+        )
+        XCTAssertTrue(result)
+    }
+
+    func testOtherKeyPressedDuringHold() {
+        let result = manager.shouldStartRecording(
+            activationKeyPressed: true,
+            otherKeyPressed: true,
+            timeSinceAppSwitch: 1.0,
+            isAlreadyRecording: false
+        )
+        XCTAssertFalse(result, "Should not start recording when another key is pressed during hold")
+    }
+
+    func testRecentAppSwitch() {
+        let result = manager.shouldStartRecording(
+            activationKeyPressed: true,
+            otherKeyPressed: false,
+            timeSinceAppSwitch: 0.3,
+            isAlreadyRecording: false
+        )
+        XCTAssertFalse(result, "Should not start recording within 0.5s of app switch")
+    }
+
+    func testAppSwitchExactlyAtThreshold() {
+        let result = manager.shouldStartRecording(
+            activationKeyPressed: true,
+            otherKeyPressed: false,
+            timeSinceAppSwitch: 0.5,
+            isAlreadyRecording: false
+        )
+        XCTAssertFalse(result, "Should not start recording at exactly 0.5s (not >)")
+    }
+
+    func testAlreadyRecording() {
+        let result = manager.shouldStartRecording(
+            activationKeyPressed: true,
+            otherKeyPressed: false,
+            timeSinceAppSwitch: 1.0,
+            isAlreadyRecording: true
+        )
+        XCTAssertFalse(result, "Should not start recording when already recording")
+    }
+
+    func testActivationKeyNotPressed() {
+        let result = manager.shouldStartRecording(
+            activationKeyPressed: false,
+            otherKeyPressed: false,
+            timeSinceAppSwitch: 1.0,
+            isAlreadyRecording: false
+        )
+        XCTAssertFalse(result, "Should not start recording when activation key is not pressed")
+    }
+}

--- a/clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift
@@ -1,0 +1,382 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class VoiceModeManagerTests: XCTestCase {
+
+    private var mockVoiceService: MockVoiceService!
+    private var manager: VoiceModeManager!
+    private var chatViewModel: ChatViewModel!
+    private var daemonClient: DaemonClient!
+
+    override func setUp() {
+        super.setUp()
+        mockVoiceService = MockVoiceService()
+        manager = VoiceModeManager(voiceService: mockVoiceService)
+        daemonClient = DaemonClient()
+        daemonClient.isConnected = true
+        daemonClient.sendOverride = { _ in }
+        chatViewModel = ChatViewModel(daemonClient: daemonClient)
+    }
+
+    override func tearDown() {
+        manager.deactivate()
+        manager = nil
+        mockVoiceService = nil
+        chatViewModel = nil
+        daemonClient = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Activate voice mode, bypassing the speech recognition auth check.
+    /// Tests use MockVoiceService so we call activate then manually set state.
+    private func activateManager() {
+        // Directly set state to idle since we bypass auth checks
+        // by not calling activate() which checks SFSpeechRecognizer.
+        manager.activate(chatViewModel: chatViewModel)
+        // If activation didn't go through (no speech auth in test env),
+        // force the state for testing.
+        if manager.state == .off {
+            // We need to simulate activation manually
+            forceActivate()
+        }
+    }
+
+    /// Force the manager into an activated state for testing.
+    /// Sets chatViewModel and wires up voice service callbacks like `activate()` would.
+    private func forceActivate() {
+        manager.chatViewModel = chatViewModel
+        manager.state = .idle
+
+        // Wire up callbacks that activate() would set
+        mockVoiceService.onSilenceDetected = { [weak self] in
+            // Mirror activate()'s handleSilenceDetected
+            _ = self
+        }
+        mockVoiceService.onBargeInDetected = { [weak self] in
+            guard let self, self.manager.state == .speaking else { return }
+            self.manager.toggleListening()
+        }
+    }
+
+    // MARK: - State Transitions
+
+    func testInitialStateIsOff() {
+        XCTAssertEqual(manager.state, .off)
+    }
+
+    func testStartListeningFromIdle() {
+        forceActivate()
+        XCTAssertEqual(manager.state, .idle)
+
+        manager.startListening()
+
+        if mockVoiceService.startRecordingResult {
+            XCTAssertEqual(manager.state, .listening)
+            XCTAssertTrue(mockVoiceService.startRecordingCalled)
+        }
+    }
+
+    func testStartListeningWhenNotIdle() {
+        forceActivate()
+        manager.state = .processing
+
+        manager.startListening()
+        // Should be a no-op — state shouldn't change
+        XCTAssertEqual(manager.state, .processing)
+    }
+
+    func testStartRecordingFailure() {
+        forceActivate()
+        mockVoiceService.startRecordingResult = false
+
+        manager.startListening()
+
+        XCTAssertEqual(manager.state, .idle, "Should return to idle on recording failure")
+        XCTAssertEqual(manager.errorMessage, "Microphone not ready. Try again.")
+    }
+
+    func testDeactivateFromIdle() {
+        forceActivate()
+        XCTAssertEqual(manager.state, .idle)
+
+        manager.deactivate()
+        XCTAssertEqual(manager.state, .off)
+        XCTAssertTrue(mockVoiceService.shutdownCalled)
+    }
+
+    func testDeactivateWhenAlreadyOff() {
+        manager.deactivate()
+        XCTAssertEqual(manager.state, .off)
+        XCTAssertFalse(mockVoiceService.shutdownCalled, "Should not call shutdown when already off")
+    }
+
+    func testToggleListeningFromIdle() {
+        forceActivate()
+        manager.toggleListening()
+        XCTAssertEqual(manager.state, .listening)
+    }
+
+    func testToggleListeningFromListening() {
+        forceActivate()
+        manager.state = .listening
+        manager.toggleListening()
+        XCTAssertEqual(manager.state, .idle)
+        XCTAssertTrue(mockVoiceService.cancelRecordingCalled)
+    }
+
+    // MARK: - Barge-in
+
+    func testBargeInFromSpeaking() {
+        forceActivate()
+        manager.state = .speaking
+
+        // toggleListening from .speaking triggers handleBargeIn
+        manager.toggleListening()
+
+        // After barge-in: stops speaking, goes idle, then starts listening
+        XCTAssertTrue(mockVoiceService.stopSpeakingCalled)
+        // State should transition to listening (idle → startListening)
+        XCTAssertEqual(manager.state, .listening)
+    }
+
+    func testToggleListeningFromSpeaking() {
+        forceActivate()
+        manager.state = .speaking
+
+        manager.toggleListening()
+
+        // Should trigger barge-in behavior
+        XCTAssertTrue(mockVoiceService.stopSpeakingCalled)
+    }
+
+    // MARK: - State Labels
+
+    func testStateLabelOff() {
+        XCTAssertEqual(manager.stateLabel, "")
+    }
+
+    func testStateLabelIdle() {
+        forceActivate()
+        XCTAssertEqual(manager.stateLabel, "Ready")
+    }
+
+    func testStateLabelListening() {
+        forceActivate()
+        manager.state = .listening
+        XCTAssertEqual(manager.stateLabel, "Listening...")
+    }
+
+    func testStateLabelProcessing() {
+        forceActivate()
+        manager.state = .processing
+        XCTAssertEqual(manager.stateLabel, "Thinking...")
+    }
+
+    func testStateLabelSpeaking() {
+        forceActivate()
+        manager.state = .speaking
+        XCTAssertEqual(manager.stateLabel, "Speaking...")
+    }
+
+    // MARK: - Conversation Timeout
+
+    func testConversationTimeoutAutoDeactivates() async {
+        forceActivate()
+        // Note: startConversationTimeout clamps to min 1.0s
+        manager.conversationTimeoutInterval = 1.0
+        // Trigger the timeout by transitioning to idle
+        manager.state = .processing
+        manager.state = .idle
+
+        // Wait for timeout to fire (1s timeout + margin)
+        try? await Task.sleep(nanoseconds: 1_500_000_000)
+
+        XCTAssertEqual(manager.state, .off, "Should auto-deactivate after timeout")
+        XCTAssertTrue(manager.wasAutoDeactivated)
+    }
+
+    func testPauseConversationTimeoutPreventsDeactivation() async {
+        forceActivate()
+        manager.conversationTimeoutInterval = 1.0
+        manager.state = .processing
+        manager.state = .idle
+        manager.pauseConversationTimeout()
+
+        try? await Task.sleep(nanoseconds: 1_500_000_000)
+
+        XCTAssertEqual(manager.state, .idle, "Should NOT auto-deactivate when timeout is paused")
+        XCTAssertFalse(manager.wasAutoDeactivated)
+    }
+
+    func testResumeConversationTimeoutRestartsTimer() async {
+        forceActivate()
+        manager.conversationTimeoutInterval = 1.0
+        manager.pauseConversationTimeout()
+
+        // Move to idle with timeout paused
+        manager.state = .processing
+        manager.state = .idle
+
+        // Resume — should start the timer
+        manager.resumeConversationTimeout()
+
+        try? await Task.sleep(nanoseconds: 1_500_000_000)
+
+        XCTAssertEqual(manager.state, .off, "Should auto-deactivate after resumed timeout")
+        XCTAssertTrue(manager.wasAutoDeactivated)
+    }
+
+    // MARK: - Permission Keyword Classification
+
+    func testClassifyYes() {
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("yes"), .approved)
+    }
+
+    func testClassifyNo() {
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("no"), .denied)
+    }
+
+    func testClassifyYeahSure() {
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("yeah sure"), .approved)
+    }
+
+    func testClassifyGoAhead() {
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("go ahead"), .approved)
+    }
+
+    func testClassifyNoDontDoIt() {
+        // Contains both "do it" (affirmative) and "no"/"don't" (negative) → deny wins
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("no don't do it"), .denied)
+    }
+
+    func testClassifyMaybe() {
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("maybe"), .ambiguous)
+    }
+
+    func testClassifyReject() {
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("reject that"), .denied)
+    }
+
+    func testClassifyProceed() {
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("please proceed"), .approved)
+    }
+
+    func testClassifyStopCancel() {
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("stop cancel"), .denied)
+    }
+
+    func testClassifyRandomText() {
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("I think the weather is nice"), .ambiguous)
+    }
+
+    // MARK: - describeAction
+
+    func testDescribeActionBashOpen() {
+        let confirmation = makeConfirmation(toolName: "bash", input: ["command": AnyCodable("open -a Safari")])
+        XCTAssertEqual(manager.describeAction(confirmation), "open an app for you")
+    }
+
+    func testDescribeActionBashOsascript() {
+        let confirmation = makeConfirmation(toolName: "bash", input: ["command": AnyCodable("osascript -e 'tell app \"Finder\" to open'")])
+        XCTAssertEqual(manager.describeAction(confirmation), "run a quick script on your Mac")
+    }
+
+    func testDescribeActionBashGeneric() {
+        let confirmation = makeConfirmation(toolName: "bash", input: ["command": AnyCodable("ls -la")])
+        XCTAssertEqual(manager.describeAction(confirmation), "run something on your Mac")
+    }
+
+    func testDescribeActionHostBash() {
+        let confirmation = makeConfirmation(toolName: "host_bash", input: ["command": AnyCodable("echo hello")])
+        XCTAssertEqual(manager.describeAction(confirmation), "run something on your Mac")
+    }
+
+    func testDescribeActionFileWriteWithPath() {
+        let confirmation = makeConfirmation(toolName: "file_write", input: ["path": AnyCodable("/tmp/test.txt")])
+        XCTAssertEqual(manager.describeAction(confirmation), "create a file called test.txt")
+    }
+
+    func testDescribeActionFileWriteNoPath() {
+        let confirmation = makeConfirmation(toolName: "file_write", input: [:])
+        XCTAssertEqual(manager.describeAction(confirmation), "create a file for you")
+    }
+
+    func testDescribeActionFileEdit() {
+        let confirmation = makeConfirmation(toolName: "file_edit", input: ["path": AnyCodable("/Users/test/doc.md")])
+        XCTAssertEqual(manager.describeAction(confirmation), "make some changes to doc.md")
+    }
+
+    func testDescribeActionFileEditNoPath() {
+        let confirmation = makeConfirmation(toolName: "file_edit", input: [:])
+        XCTAssertEqual(manager.describeAction(confirmation), "make some changes to a file")
+    }
+
+    func testDescribeActionFileRead() {
+        let confirmation = makeConfirmation(toolName: "file_read", input: ["path": AnyCodable("/etc/hosts")])
+        XCTAssertEqual(manager.describeAction(confirmation), "take a look at hosts")
+    }
+
+    func testDescribeActionFileReadNoPath() {
+        let confirmation = makeConfirmation(toolName: "file_read", input: [:])
+        XCTAssertEqual(manager.describeAction(confirmation), "take a look at a file")
+    }
+
+    func testDescribeActionWebFetch() {
+        let confirmation = makeConfirmation(toolName: "web_fetch", input: ["url": AnyCodable("https://example.com/api")])
+        XCTAssertEqual(manager.describeAction(confirmation), "grab some info from example.com")
+    }
+
+    func testDescribeActionWebFetchNoURL() {
+        let confirmation = makeConfirmation(toolName: "web_fetch", input: [:])
+        XCTAssertEqual(manager.describeAction(confirmation), "look something up online")
+    }
+
+    func testDescribeActionBrowserNavigate() {
+        let confirmation = makeConfirmation(toolName: "browser_navigate", input: ["url": AnyCodable("https://github.com/page")])
+        XCTAssertEqual(manager.describeAction(confirmation), "open up github.com")
+    }
+
+    func testDescribeActionBrowserNavigateNoURL() {
+        let confirmation = makeConfirmation(toolName: "browser_navigate", input: [:])
+        XCTAssertEqual(manager.describeAction(confirmation), "open up a webpage")
+    }
+
+    func testDescribeActionWithReason() {
+        let confirmation = makeConfirmation(toolName: "bash", input: [
+            "command": AnyCodable("some-cmd"),
+            "reason": AnyCodable("Install the package")
+        ])
+        XCTAssertEqual(manager.describeAction(confirmation), "install the package")
+    }
+
+    func testDescribeActionUnknownTool() {
+        let confirmation = makeConfirmation(toolName: "custom_tool", input: [:])
+        // Falls back to toolCategory which returns a category label based on toolName
+        let result = manager.describeAction(confirmation)
+        XCTAssertFalse(result.isEmpty, "Should return a non-empty string for unknown tools")
+    }
+
+    // MARK: - Helpers
+
+    private func makeConfirmation(
+        toolName: String,
+        input: [String: AnyCodable]
+    ) -> ToolConfirmationData {
+        ToolConfirmationData(
+            requestId: "test-\(UUID().uuidString)",
+            toolName: toolName,
+            input: input,
+            riskLevel: "low",
+            diff: nil,
+            allowlistOptions: [],
+            scopeOptions: [],
+            executionTarget: nil,
+            persistentDecisionsAllowed: true,
+            state: .pending
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `VoiceServiceProtocol` from `OpenAIVoiceService` for dependency injection in tests
- Add `MockVoiceService` with spy flags and configurable return values
- Add **TTSRedactorTests** (19 tests) — all 9 regex patterns, passthrough, multi-credential, embedded
- Add **VoiceModeManagerTests** (44 tests) — state machine transitions, conversation timeout, permission keyword classification, `describeAction` for every tool type, barge-in
- Add **VoiceInputManagerTests** (6 tests) — extracted `shouldStartRecording` hold detection logic
- Minor refactors for testability: `classifyPermissionResponse()` extracted as static, `describeAction()` made internal

Voice components previously had **zero unit tests**. This PR brings them up to the same DI/mock standard as the rest of the codebase (76 existing test files).

## Test plan
- [x] All 69 new tests pass (`swift test --filter TTSRedactorTests|VoiceModeManagerTests|VoiceInputManagerTests`)
- [x] Full test suite passes (no regressions)
- [x] `swift build` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
