### PR TITLE
fix: validate MCP server URL before starting OAuth callback server

### DIFF
--- a/assistant/src/cli/mcp.ts
+++ b/assistant/src/cli/mcp.ts
@@ -202,6 +202,16 @@ export function registerMcpCommand(program: Command): void {
         return;
       }
 
+      // Validate URL early so we fail fast before starting the callback server
+      let serverUrl: URL;
+      try {
+        serverUrl = new URL(transport.url);
+      } catch {
+        log.error(`Invalid URL for MCP server "${name}": ${transport.url}`);
+        process.exitCode = 1;
+        return;
+      }
+
       const provider = new McpOAuthProvider(name, transport.url, /* interactive */ true);
       // Clear stale client_info and discovery — the callback server uses a random port,
       // so any previously cached client_info has a mismatched redirect_uri.
@@ -213,7 +223,7 @@ export function registerMcpCommand(program: Command): void {
       const OAUTH_TIMEOUT_MS = 150_000; // 2.5 min for browser interaction
       const TransportClass = transport.type === 'sse' ? SSEClientTransport : StreamableHTTPClientTransport;
       const mcpTransport = new TransportClass(
-        new URL(transport.url),
+        serverUrl,
         {
           authProvider: provider,
           requestInit: transport.headers ? { headers: transport.headers } : undefined,


### PR DESCRIPTION
## Summary
- Validate the MCP server URL with `new URL()` before starting the OAuth callback server in `vellum mcp auth`
- Reuse the parsed URL object when constructing the transport, avoiding redundant parsing
- Addresses review feedback from #11197: if the URL is malformed, the CLI now fails fast with a clear error instead of leaving a callback server running until timeout

## Test plan
- [ ] `vellum mcp auth <name>` with a valid URL still works normally
- [ ] `vellum mcp auth <name>` with a malformed URL in config shows error and exits immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
