### PR TITLE
M2: Add conversation-scoped temporary approval state with TTL support

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -500,6 +500,12 @@ export class Session {
       decisionText?: string;
     },
   ): void {
+    // Guard: only proceed if the confirmation is still pending. Stale or
+    // already-resolved requests must not activate overrides or emit events.
+    if (!this.prompter.hasPendingRequest(requestId)) {
+      return;
+    }
+
     this.prompter.resolveConfirmation(
       requestId,
       decision,

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -34,6 +34,7 @@ import { SecretPrompter } from '../permissions/secret-prompter.js';
 import type { UserDecision } from '../permissions/types.js';
 import type { Message } from '../providers/types.js';
 import type { Provider } from '../providers/types.js';
+import * as approvalOverrides from '../runtime/session-approval-overrides.js';
 import { ToolExecutor } from '../tools/executor.js';
 import type { AssistantAttachmentDraft } from './assistant-attachments.js';
 import type { AssistantActivityState, ConfirmationStateChanged } from './ipc-contract/messages.js';
@@ -505,6 +506,15 @@ export class Session {
       selectedScope,
       decisionContext,
     );
+
+    // Activate conversation-scoped temporary approval override when the
+    // user picks a temporary allow mode. These do not grant persistent
+    // trust and do not mutate allowlists/denylists.
+    if (decision === 'allow_thread') {
+      approvalOverrides.setThreadMode(this.conversationId);
+    } else if (decision === 'allow_10m') {
+      approvalOverrides.setTimedMode(this.conversationId);
+    }
 
     // Emit authoritative confirmation state and activity transition centrally
     // so ALL callers (IPC handlers, /v1/confirm, channel bridges) get

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -428,6 +428,7 @@ export class Session {
   }
 
   dispose(): void {
+    approvalOverrides.clearMode(this.conversationId);
     disposeSession(this);
   }
 

--- a/assistant/src/runtime/session-approval-overrides.ts
+++ b/assistant/src/runtime/session-approval-overrides.ts
@@ -1,0 +1,84 @@
+/**
+ * Per-conversation temporary approval overrides.
+ *
+ * When a user chooses `allow_thread` or `allow_10m`, the session records a
+ * temporary approval mode scoped to the conversation. Subsequent tool-use
+ * confirmations within the same conversation can check this state to
+ * auto-approve without prompting.
+ *
+ * State is in-memory only -- it does not survive daemon restarts, which is
+ * the desired behavior for temporary approvals. Thread-scoped overrides
+ * persist until the session ends or the mode is explicitly cleared. Timed
+ * overrides expire after their TTL (checked at read time, no background sweep).
+ */
+
+export type TemporaryApprovalMode =
+  | { kind: 'thread' }
+  | { kind: 'timed'; expiresAt: number };
+
+const DEFAULT_TIMED_DURATION_MS = 10 * 60 * 1000; // 10 minutes
+
+const store = new Map<string, TemporaryApprovalMode>();
+
+/**
+ * Set thread-scoped temporary approval for a conversation.
+ * Remains active until explicitly cleared or session ends.
+ * Replaces any existing mode for the conversation.
+ */
+export function setThreadMode(conversationId: string): void {
+  store.set(conversationId, { kind: 'thread' });
+}
+
+/**
+ * Set time-limited temporary approval for a conversation.
+ * Replaces any existing mode for the conversation.
+ *
+ * @param conversationId - The conversation to scope the override to
+ * @param durationMs - How long the override lasts (defaults to 10 minutes)
+ */
+export function setTimedMode(
+  conversationId: string,
+  durationMs: number = DEFAULT_TIMED_DURATION_MS,
+): void {
+  store.set(conversationId, {
+    kind: 'timed',
+    expiresAt: Date.now() + durationMs,
+  });
+}
+
+/**
+ * Clear any temporary approval mode for a conversation.
+ */
+export function clearMode(conversationId: string): void {
+  store.delete(conversationId);
+}
+
+/**
+ * Get the effective temporary approval mode for a conversation.
+ *
+ * Returns null if no mode is set or if a timed mode has expired.
+ * Expired timed modes are cleaned up lazily on read.
+ */
+export function getEffectiveMode(conversationId: string): TemporaryApprovalMode | null {
+  const mode = store.get(conversationId);
+  if (!mode) return null;
+
+  if (mode.kind === 'timed' && Date.now() >= mode.expiresAt) {
+    store.delete(conversationId);
+    return null;
+  }
+
+  return mode;
+}
+
+/**
+ * Check whether a conversation has an active (non-expired) temporary approval.
+ */
+export function hasActiveOverride(conversationId: string): boolean {
+  return getEffectiveMode(conversationId) !== null;
+}
+
+/** Clear all overrides. Useful for testing. */
+export function clearAll(): void {
+  store.clear();
+}


### PR DESCRIPTION
Part of #11230. Adds a session-approval-overrides module for per-conversation temporary approval modes (thread and timed). Wires handleConfirmationResponse to set/clear state for allow_10m and allow_thread decisions. Closes #11232.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
