### PR TITLE
test: add dictation routing tests for VoiceInputManager

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -24,7 +24,7 @@ final class VoiceInputManager {
     var currentMode: VoiceInputMode = .dictation
 
     /// Daemon client used to send dictation requests in `.dictation` mode.
-    var daemonClient: DaemonClient?
+    var daemonClient: (any DaemonClientProtocol)?
 
     /// Called when the daemon returns a dictation response (cleaned-up text + action plan).
     var onDictationResponse: ((IPCDictationResponse) -> Void)?
@@ -34,7 +34,7 @@ final class VoiceInputManager {
     var onActionModeTriggered: ((String) -> Void)?
 
     /// Context captured at activation time, describing the frontmost app state.
-    private var currentDictationContext: DictationContext?
+    var currentDictationContext: DictationContext?
 
     /// Floating overlay showing dictation state (recording/processing/done).
     private let overlayWindow = DictationOverlayWindow()
@@ -44,7 +44,7 @@ final class VoiceInputManager {
 
     /// True after a dictation request has been sent to the daemon and we're awaiting a response.
     /// Used by `stopRecording()` to decide whether the overlay should stay visible.
-    private var awaitingDaemonResponse = false
+    private(set) var awaitingDaemonResponse = false
 
     /// Whether the microphone is currently recording for PTT/dictation.
     private(set) var isRecording = false
@@ -239,9 +239,12 @@ final class VoiceInputManager {
                 try? await Task.sleep(nanoseconds: Self.holdDelay)
                 guard !Task.isCancelled else { return }
                 guard let self = self else { return }
-                // Don't start recording if any key was pressed during hold (Control+C, etc.)
-                guard !self.otherKeyPressedDuringHold else { return }
-                guard Date().timeIntervalSince(self.lastAppSwitchTime) > 0.5 else { return }
+                guard self.shouldStartRecording(
+                    activationKeyPressed: true,
+                    otherKeyPressed: self.otherKeyPressedDuringHold,
+                    timeSinceAppSwitch: Date().timeIntervalSince(self.lastAppSwitchTime),
+                    isAlreadyRecording: self.isRecording
+                ) else { return }
                 // Capture frontmost app context before recording starts so the daemon
                 // knows where to insert the cleaned-up text after dictation completes.
                 if self.currentMode == .dictation {
@@ -500,7 +503,7 @@ final class VoiceInputManager {
     }
 
     /// Routes a final transcription based on the current mode.
-    private func handleFinalTranscription(_ text: String) {
+    func handleFinalTranscription(_ text: String) {
         switch currentMode {
         case .conversation:
             onTranscription?(text)

--- a/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import VellumAssistantShared
 @testable import VellumAssistantLib
 
 @MainActor
@@ -76,5 +77,181 @@ final class VoiceInputManagerTests: XCTestCase {
             isAlreadyRecording: false
         )
         XCTAssertFalse(result, "Should not start recording when activation key is not pressed")
+    }
+
+    // MARK: - Dictation Routing (handleFinalTranscription)
+
+    /// Helper: creates a DictationContext with sensible defaults for test use.
+    private func makeDictationContext(
+        bundleIdentifier: String = "com.example.TestApp",
+        appName: String = "TestApp",
+        windowTitle: String = "Untitled",
+        selectedText: String? = nil,
+        cursorInTextField: Bool = true
+    ) -> DictationContext {
+        DictationContext(
+            bundleIdentifier: bundleIdentifier,
+            appName: appName,
+            windowTitle: windowTitle,
+            selectedText: selectedText,
+            cursorInTextField: cursorInTextField
+        )
+    }
+
+    func testConversationModeRoutesToOnTranscription() {
+        manager.currentMode = .conversation
+        var receivedText: String?
+        manager.onTranscription = { receivedText = $0 }
+
+        manager.handleFinalTranscription("hello world")
+
+        XCTAssertEqual(receivedText, "hello world")
+    }
+
+    func testDictationModeWithoutContextFallsBackToConversation() {
+        manager.currentMode = .dictation
+        manager.currentDictationContext = nil
+        var receivedText: String?
+        manager.onTranscription = { receivedText = $0 }
+
+        manager.handleFinalTranscription("fallback text")
+
+        XCTAssertEqual(receivedText, "fallback text")
+    }
+
+    func testDictationModeSendsRequestToDaemon() {
+        let mockDaemon = MockDaemonClient()
+        manager.currentMode = .dictation
+        manager.daemonClient = mockDaemon
+        manager.currentDictationContext = makeDictationContext(appName: "Notes")
+
+        manager.handleFinalTranscription("take a note")
+
+        XCTAssertEqual(mockDaemon.sentMessages.count, 1)
+        let sent = mockDaemon.sentMessages.first as? IPCDictationRequest
+        XCTAssertNotNil(sent)
+        XCTAssertEqual(sent?.transcription, "take a note")
+        XCTAssertEqual(sent?.context.appName, "Notes")
+        XCTAssertEqual(sent?.type, "dictation_request")
+    }
+
+    func testDictationModeSetsAwaitingDaemonResponse() {
+        let mockDaemon = MockDaemonClient()
+        manager.currentMode = .dictation
+        manager.daemonClient = mockDaemon
+        manager.currentDictationContext = makeDictationContext()
+
+        manager.handleFinalTranscription("some text")
+
+        XCTAssertTrue(manager.awaitingDaemonResponse)
+    }
+
+    func testDictationModeIncludesSelectedTextInContext() {
+        let mockDaemon = MockDaemonClient()
+        manager.currentMode = .dictation
+        manager.daemonClient = mockDaemon
+        manager.currentDictationContext = makeDictationContext(selectedText: "selected snippet")
+
+        manager.handleFinalTranscription("replace this")
+
+        let sent = mockDaemon.sentMessages.first as? IPCDictationRequest
+        XCTAssertEqual(sent?.context.selectedText, "selected snippet")
+    }
+
+    func testDictationModeWithNoDaemonFallsBackToConversation() {
+        manager.currentMode = .dictation
+        manager.daemonClient = nil
+        manager.currentDictationContext = makeDictationContext()
+        var receivedText: String?
+        manager.onTranscription = { receivedText = $0 }
+
+        manager.handleFinalTranscription("no daemon available")
+
+        XCTAssertEqual(receivedText, "no daemon available")
+    }
+
+    func testDictationRequestIncludesBundleIdentifier() {
+        let mockDaemon = MockDaemonClient()
+        manager.currentMode = .dictation
+        manager.daemonClient = mockDaemon
+        manager.currentDictationContext = makeDictationContext(bundleIdentifier: "com.apple.Safari")
+
+        manager.handleFinalTranscription("search for this")
+
+        let sent = mockDaemon.sentMessages.first as? IPCDictationRequest
+        XCTAssertEqual(sent?.context.bundleIdentifier, "com.apple.Safari")
+    }
+
+    func testDictationRequestIncludesCursorInTextFieldFlag() {
+        let mockDaemon = MockDaemonClient()
+        manager.currentMode = .dictation
+        manager.daemonClient = mockDaemon
+        manager.currentDictationContext = makeDictationContext(cursorInTextField: false)
+
+        manager.handleFinalTranscription("type something")
+
+        let sent = mockDaemon.sentMessages.first as? IPCDictationRequest
+        XCTAssertEqual(sent?.context.cursorInTextField, false)
+    }
+
+    // MARK: - handleDictationResponse (mode detection)
+
+    func testDictationResponseDictationModeClearsAwaitingFlag() {
+        manager.handleDictationResponse(text: "cleaned text", mode: "dictation")
+
+        XCTAssertFalse(manager.awaitingDaemonResponse)
+    }
+
+    func testDictationResponseCommandModeClearsAwaitingFlag() {
+        manager.handleDictationResponse(text: "open terminal", mode: "command")
+
+        XCTAssertFalse(manager.awaitingDaemonResponse)
+    }
+
+    func testDictationResponseActionModeTriggersCallback() {
+        var actionText: String?
+        manager.onActionModeTriggered = { actionText = $0 }
+
+        manager.handleDictationResponse(text: "Slack Alex about the standup", mode: "action")
+
+        XCTAssertEqual(actionText, "Slack Alex about the standup")
+    }
+
+    func testDictationResponseActionModeClearsAwaitingFlag() {
+        manager.onActionModeTriggered = { _ in }
+
+        manager.handleDictationResponse(text: "do something", mode: "action")
+
+        XCTAssertFalse(manager.awaitingDaemonResponse)
+    }
+
+    func testDictationResponseDictationModeDoesNotTriggerActionCallback() {
+        var actionTriggered = false
+        manager.onActionModeTriggered = { _ in actionTriggered = true }
+
+        manager.handleDictationResponse(text: "just text", mode: "dictation")
+
+        XCTAssertFalse(actionTriggered)
+    }
+
+    func testDictationResponseCommandModeDoesNotTriggerActionCallback() {
+        var actionTriggered = false
+        manager.onActionModeTriggered = { _ in actionTriggered = true }
+
+        manager.handleDictationResponse(text: "open app", mode: "command")
+
+        XCTAssertFalse(actionTriggered)
+    }
+
+    // MARK: - Mode property
+
+    func testDefaultModeIsDictation() {
+        let fresh = VoiceInputManager()
+        XCTAssertEqual(fresh.currentMode, .dictation)
+    }
+
+    func testModeCanBeSwitchedToConversation() {
+        manager.currentMode = .conversation
+        XCTAssertEqual(manager.currentMode, .conversation)
     }
 }


### PR DESCRIPTION
## Summary
- Add 16 dictation routing tests for `VoiceInputManager` covering mode detection (dictation/command/action) and daemon request/response via `MockDaemonClient`
- Wire `shouldStartRecording()` into the production hold-timer path so tests validate real code (addresses [review feedback](https://github.com/vellum-ai/vellum-assistant/pull/11274#discussion_r2874368503) from #11274)
- Change `daemonClient` from `DaemonClient?` to `(any DaemonClientProtocol)?` for dependency injection in tests

## Test plan
- [x] All 22 `VoiceInputManagerTests` pass (6 existing + 16 new)
- [ ] CI green
- [ ] Verify hold-to-record still works in manual QA (production path now routes through `shouldStartRecording()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
