### PR TITLE
fix: redesign Voice Settings view to match other settings tabs

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -3,7 +3,7 @@ import VellumAssistantShared
 
 /// Voice settings tab — configure push-to-talk activation key,
 /// enable/disable wake word listening, configure keyword phrase,
-/// and conversation timeout.
+/// conversation timeout, and text-to-speech.
 struct VoiceSettingsView: View {
     @ObservedObject var store: SettingsStore
 
@@ -14,359 +14,9 @@ struct VoiceSettingsView: View {
 
     @State private var elevenLabsKeyText: String = ""
 
-    private let suggestedKeywords = ["computer", "jarvis", "hey vellum", "assistant"]
-
     private var selectedActivationKey: ActivationKey {
         ActivationKey(rawValue: activationKey) ?? .fn
     }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xl) {
-            // Push to Talk
-            pttDivider
-            pttStatusSection
-            pttKeyPicker
-            pttPrivacyNote
-
-            // Wake Word
-            wakeWordDivider
-            statusSection
-            educationHero
-            howItWorksSteps
-            tryItPrompt
-            settingsDivider
-            enableSection
-            keywordSection
-            timeoutSection
-            privacyNote
-
-            // Text-to-Speech
-            ttsDivider
-            ttsStatusSection
-            ttsKeySection
-            ttsPrivacyNote
-        }
-    }
-
-    // MARK: - PTT Section Divider
-
-    private var pttDivider: some View {
-        HStack(spacing: VSpacing.md) {
-            Text("PUSH TO TALK")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(VColor.textMuted)
-                .tracking(1)
-
-            Rectangle()
-                .fill(VColor.surfaceBorder)
-                .frame(height: 1)
-        }
-    }
-
-    // MARK: - PTT Status
-
-    private var pttStatusSection: some View {
-        HStack(spacing: VSpacing.sm) {
-            Circle()
-                .fill(selectedActivationKey != .none ? VColor.success : VColor.textMuted)
-                .frame(width: 8, height: 8)
-
-            Text(selectedActivationKey != .none ? "Activation key: \(selectedActivationKey.displayName)" : "Push to talk disabled")
-                .font(VFont.body)
-                .foregroundColor(selectedActivationKey != .none ? VColor.success : VColor.textSecondary)
-
-            Spacer()
-        }
-        .padding(VSpacing.lg)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(selectedActivationKey != .none ? VColor.success.opacity(0.08) : VColor.surfaceSubtle)
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
-                        .strokeBorder(selectedActivationKey != .none ? VColor.success.opacity(0.2) : VColor.surfaceBorder, lineWidth: 1)
-                )
-        )
-    }
-
-    // MARK: - PTT Key Picker
-
-    private var pttKeyPicker: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Activation key")
-                .font(VFont.bodyMedium)
-                .foregroundColor(VColor.textPrimary)
-
-            HStack(spacing: VSpacing.sm) {
-                ForEach(ActivationKey.allCases, id: \.rawValue) { key in
-                    Button(key.displayName) {
-                        activationKey = key.rawValue
-                    }
-                    .buttonStyle(.plain)
-                    .font(VFont.caption)
-                    .foregroundColor(selectedActivationKey == key ? .white : VColor.textMuted)
-                    .padding(.horizontal, VSpacing.sm)
-                    .padding(.vertical, VSpacing.xs)
-                    .background(
-                        Capsule()
-                            .fill(selectedActivationKey == key ? Forest._700 : VColor.surface)
-                    )
-                    .overlay(
-                        Capsule()
-                            .strokeBorder(selectedActivationKey == key ? Color.clear : VColor.surfaceBorder, lineWidth: 1)
-                    )
-                }
-            }
-        }
-        .padding(VSpacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceSubtle)
-    }
-
-    // MARK: - PTT Privacy Note
-
-    private var pttPrivacyNote: some View {
-        HStack(alignment: .top, spacing: VSpacing.sm) {
-            Image(systemName: "lock.fill")
-                .font(.system(size: 10))
-                .foregroundColor(VColor.textMuted)
-
-            Text("Hold the activation key to dictate text or start a voice conversation. Uses on-device speech recognition.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
-                .lineSpacing(2)
-        }
-    }
-
-    // MARK: - Wake Word Section Divider
-
-    private var wakeWordDivider: some View {
-        HStack(spacing: VSpacing.md) {
-            Text("WAKE WORD")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(VColor.textMuted)
-                .tracking(1)
-
-            Rectangle()
-                .fill(VColor.surfaceBorder)
-                .frame(height: 1)
-        }
-    }
-
-    // MARK: - Status
-
-    private var statusSection: some View {
-        HStack(spacing: VSpacing.sm) {
-            Circle()
-                .fill(wakeWordEnabled ? VColor.success : VColor.textMuted)
-                .frame(width: 8, height: 8)
-
-            Text(wakeWordEnabled ? "Listening for \"\(wakeWordKeyword)\"" : "Wake word disabled")
-                .font(VFont.body)
-                .foregroundColor(wakeWordEnabled ? VColor.success : VColor.textSecondary)
-
-            Spacer()
-        }
-        .padding(VSpacing.lg)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(wakeWordEnabled ? VColor.success.opacity(0.08) : VColor.surfaceSubtle)
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
-                        .strokeBorder(wakeWordEnabled ? VColor.success.opacity(0.2) : VColor.surfaceBorder, lineWidth: 1)
-                )
-        )
-    }
-
-    // MARK: - Education Hero
-
-    private var educationHero: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            Text("Talk to Vellum, hands-free")
-                .font(VFont.cardTitle)
-                .foregroundColor(VColor.textPrimary)
-
-            Text("Wake word lets you start a conversation by speaking a keyword aloud \u{2014} no need to click or press anything. It uses on-device speech recognition, so nothing you say ever leaves your Mac.")
-                .font(VFont.body)
-                .foregroundColor(VColor.textSecondary)
-                .lineSpacing(2)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(VSpacing.xl)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.xl)
-                .fill(VColor.surfaceSubtle)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.xl)
-                .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
-        )
-    }
-
-    // MARK: - How It Works
-
-    private var howItWorksSteps: some View {
-        HStack(alignment: .top, spacing: VSpacing.md) {
-            stepCard(number: "1", title: "Say the keyword", description: "Speak your wake word when you're ready to talk.", showConnector: true)
-            stepCard(number: "2", title: "Vellum starts listening", description: "A chime plays and your microphone activates.", showConnector: true)
-            stepCard(number: "3", title: "Ask anything", description: "Speak naturally. Vellum responds when you pause.", showConnector: false)
-        }
-    }
-
-    private func stepCard(number: String, title: String, description: String, showConnector: Bool) -> some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text(number)
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundColor(VColor.success)
-                .frame(width: 24, height: 24)
-                .background(
-                    Circle()
-                        .fill(VColor.success.opacity(0.15))
-                )
-
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text(title)
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.textPrimary)
-
-                Text(description)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
-                    .lineSpacing(1)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(VSpacing.lg)
-        .vCard(background: VColor.surfaceSubtle)
-    }
-
-    // MARK: - Try It
-
-    private var tryItPrompt: some View {
-        HStack(spacing: VSpacing.md) {
-            Image(systemName: "mic.fill")
-                .font(.system(size: 14))
-                .foregroundColor(VColor.textSecondary)
-
-            HStack(spacing: VSpacing.xs) {
-                Text("Try it now")
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.textPrimary)
-
-                Text("\u{2014} say")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textSecondary)
-
-                Text(wakeWordKeyword)
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(.white)
-                    .padding(.horizontal, VSpacing.sm)
-                    .padding(.vertical, VSpacing.xxs)
-                    .background(
-                        Capsule()
-                            .fill(Forest._700)
-                    )
-
-                Text("followed by a question")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textSecondary)
-            }
-        }
-        .padding(VSpacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(VColor.success.opacity(0.08))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
-                        .strokeBorder(VColor.success.opacity(0.2), style: StrokeStyle(lineWidth: 1, dash: [6, 4]))
-                )
-        )
-    }
-
-    // MARK: - Section Divider
-
-    private var settingsDivider: some View {
-        HStack(spacing: VSpacing.md) {
-            Text("SETTINGS")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(VColor.textMuted)
-                .tracking(1)
-
-            Rectangle()
-                .fill(VColor.surfaceBorder)
-                .frame(height: 1)
-        }
-    }
-
-    // MARK: - Enable/Disable
-
-    private var enableSection: some View {
-        HStack {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text("Enable wake word listening")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textPrimary)
-                Text("Activate the assistant by speaking instead of using a keyboard shortcut.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
-            }
-            Spacer()
-            VToggle(isOn: $wakeWordEnabled)
-                .accessibilityLabel("Enable wake word listening")
-        }
-        .padding(VSpacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceSubtle)
-    }
-
-    // MARK: - Keyword
-
-    private var keywordSection: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Keyword")
-                .font(VFont.bodyMedium)
-                .foregroundColor(VColor.textPrimary)
-
-            TextField("Enter wake word or phrase", text: $wakeWordKeyword)
-                .vInputStyle()
-                .accessibilityLabel("Wake word keyword")
-
-            HStack(spacing: VSpacing.sm) {
-                ForEach(suggestedKeywords, id: \.self) { suggestion in
-                    Button(suggestion) {
-                        wakeWordKeyword = suggestion
-                    }
-                    .buttonStyle(.plain)
-                    .font(VFont.caption)
-                    .foregroundColor(wakeWordKeyword == suggestion ? .white : VColor.textMuted)
-                    .padding(.horizontal, VSpacing.sm)
-                    .padding(.vertical, VSpacing.xs)
-                    .background(
-                        Capsule()
-                            .fill(wakeWordKeyword == suggestion ? Forest._700 : VColor.surface)
-                    )
-                    .overlay(
-                        Capsule()
-                            .strokeBorder(wakeWordKeyword == suggestion ? Color.clear : VColor.surfaceBorder, lineWidth: 1)
-                    )
-                }
-            }
-
-            HStack(spacing: VSpacing.xs) {
-                Image(systemName: "lock.fill")
-                    .font(.system(size: 10))
-                    .foregroundColor(VColor.textMuted)
-                Text("Type any word or phrase. Uses on-device speech recognition \u{2014} no data leaves your Mac.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
-            }
-        }
-        .padding(VSpacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceSubtle)
-    }
-
-    // MARK: - Timeout
 
     private let timeoutOptions: [(label: String, value: Int)] = [
         (label: "5 seconds", value: 5),
@@ -376,104 +26,162 @@ struct VoiceSettingsView: View {
         (label: "60 seconds", value: 60),
     ]
 
-    private var timeoutSection: some View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xl) {
+            pushToTalkCard
+            wakeWordCard
+            textToSpeechCard
+        }
+    }
+
+    // MARK: - Push to Talk Card
+
+    private var pushToTalkCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text("Conversation timeout")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textPrimary)
-                Text("How long to wait for follow-up speech before ending the conversation.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
+            Text("Push to Talk")
+                .font(VFont.sectionTitle)
+                .foregroundColor(VColor.textPrimary)
+
+            HStack {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Activation key")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Text("Hold this key to dictate text or start a voice conversation.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+                Spacer()
+                VDropdown(
+                    placeholder: "Select key\u{2026}",
+                    selection: Binding(
+                        get: { selectedActivationKey },
+                        set: { activationKey = $0.rawValue }
+                    ),
+                    options: ActivationKey.allCases.map { (label: $0.displayName, value: $0) }
+                )
+                .frame(width: 140)
+                .accessibilityLabel("Push to talk activation key")
             }
-            VDropdown(
-                placeholder: "Select timeout\u{2026}",
-                selection: $wakeWordTimeoutSeconds,
-                options: timeoutOptions
-            )
-            .frame(width: 160)
-            .accessibilityLabel("Conversation timeout duration")
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: selectedActivationKey != .none ? "checkmark.circle.fill" : "xmark.circle")
+                    .foregroundColor(selectedActivationKey != .none ? VColor.success : VColor.textMuted)
+                    .font(.system(size: 14))
+                Text(selectedActivationKey != .none
+                     ? "Active — activation key: \(selectedActivationKey.displayName)"
+                     : "Push to talk disabled")
+                    .font(VFont.body)
+                    .foregroundColor(selectedActivationKey != .none ? VColor.success : VColor.textSecondary)
+                Spacer()
+            }
+
+            Text("Uses on-device speech recognition — audio never leaves your Mac.")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
     }
 
-    // MARK: - Privacy Note
+    // MARK: - Wake Word Card
 
-    private var privacyNote: some View {
-        HStack(alignment: .top, spacing: VSpacing.sm) {
-            Image(systemName: "shield.fill")
-                .font(.system(size: 12))
-                .foregroundColor(VColor.textMuted)
-
-            Text("Wake word detection runs entirely on your device using Apple's Speech framework. Audio is only processed when the wake word is detected, and no recordings are stored or sent anywhere.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
-                .lineSpacing(2)
-        }
-        .padding(VSpacing.lg)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.md)
-                .fill(Color.white.opacity(0.02))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
-                )
-        )
-    }
-
-    // MARK: - TTS Section Divider
-
-    private var ttsDivider: some View {
-        HStack(spacing: VSpacing.md) {
-            Text("TEXT-TO-SPEECH")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(VColor.textMuted)
-                .tracking(1)
-
-            Rectangle()
-                .fill(VColor.surfaceBorder)
-                .frame(height: 1)
-        }
-    }
-
-    // MARK: - TTS Status
-
-    private var ttsStatusSection: some View {
-        HStack(spacing: VSpacing.sm) {
-            Circle()
-                .fill(store.hasElevenLabsKey ? VColor.success : VColor.textMuted)
-                .frame(width: 8, height: 8)
-
-            Text(store.hasElevenLabsKey ? "ElevenLabs API key saved" : "ElevenLabs not configured")
-                .font(VFont.body)
-                .foregroundColor(store.hasElevenLabsKey ? VColor.success : VColor.textSecondary)
-
-            Spacer()
-        }
-        .padding(VSpacing.lg)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(store.hasElevenLabsKey ? VColor.success.opacity(0.08) : VColor.surfaceSubtle)
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
-                        .strokeBorder(store.hasElevenLabsKey ? VColor.success.opacity(0.2) : VColor.surfaceBorder, lineWidth: 1)
-                )
-        )
-    }
-
-    // MARK: - TTS Key Section
-
-    private var ttsKeySection: some View {
+    private var wakeWordCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("ElevenLabs API Key")
-                .font(VFont.bodyMedium)
+            Text("Wake Word")
+                .font(VFont.sectionTitle)
                 .foregroundColor(VColor.textPrimary)
 
-            Text("ElevenLabs provides high-quality voice responses during voice conversations. An API key is required.")
+            HStack {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Enable wake word listening")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Text("Activate the assistant by speaking instead of using a keyboard shortcut.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+                Spacer()
+                VToggle(isOn: $wakeWordEnabled)
+                    .accessibilityLabel("Enable wake word listening")
+            }
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            HStack {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Keyword")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Text("The word or phrase that triggers listening.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+                Spacer()
+                TextField("Enter wake word", text: $wakeWordKeyword)
+                    .vInputStyle()
+                    .frame(width: 180)
+                    .accessibilityLabel("Wake word keyword")
+            }
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            HStack {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Conversation timeout")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Text("How long to wait for follow-up speech before ending the conversation.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+                Spacer()
+                VDropdown(
+                    placeholder: "Select timeout\u{2026}",
+                    selection: $wakeWordTimeoutSeconds,
+                    options: timeoutOptions
+                )
+                .frame(width: 140)
+                .accessibilityLabel("Conversation timeout duration")
+            }
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: wakeWordEnabled ? "checkmark.circle.fill" : "xmark.circle")
+                    .foregroundColor(wakeWordEnabled ? VColor.success : VColor.textMuted)
+                    .font(.system(size: 14))
+                Text(wakeWordEnabled
+                     ? "Listening for \"\(wakeWordKeyword)\""
+                     : "Wake word disabled")
+                    .font(VFont.body)
+                    .foregroundColor(wakeWordEnabled ? VColor.success : VColor.textSecondary)
+                Spacer()
+            }
+
+            Text("Wake word detection runs entirely on your device using Apple\u{2019}s Speech framework. No audio is stored or transmitted.")
                 .font(VFont.caption)
                 .foregroundColor(VColor.textMuted)
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard(background: VColor.surfaceSubtle)
+    }
+
+    // MARK: - Text-to-Speech Card
+
+    private var textToSpeechCard: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("Text-to-Speech")
+                .font(VFont.sectionTitle)
+                .foregroundColor(VColor.textPrimary)
 
             if store.hasElevenLabsKey {
                 HStack(spacing: VSpacing.sm) {
@@ -490,29 +198,43 @@ struct VoiceSettingsView: View {
                     }
                 }
             } else {
+                HStack {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("ElevenLabs API Key")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                        Text("Required for high-quality voice responses during voice conversations.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    Spacer()
+                }
+
                 VInlineActionField(text: $elevenLabsKeyText, placeholder: "Your ElevenLabs API key", isSecure: true) {
                     store.saveElevenLabsKey(elevenLabsKeyText)
                     elevenLabsKeyText = ""
                 }
             }
-        }
-        .padding(VSpacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceSubtle)
-    }
 
-    // MARK: - TTS Privacy Note
+            Divider()
+                .background(VColor.surfaceBorder)
 
-    private var ttsPrivacyNote: some View {
-        HStack(alignment: .top, spacing: VSpacing.sm) {
-            Image(systemName: "lock.fill")
-                .font(.system(size: 10))
-                .foregroundColor(VColor.textMuted)
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: store.hasElevenLabsKey ? "checkmark.circle.fill" : "xmark.circle")
+                    .foregroundColor(store.hasElevenLabsKey ? VColor.success : VColor.textMuted)
+                    .font(.system(size: 14))
+                Text(store.hasElevenLabsKey ? "ElevenLabs API key saved" : "ElevenLabs not configured")
+                    .font(VFont.body)
+                    .foregroundColor(store.hasElevenLabsKey ? VColor.success : VColor.textSecondary)
+                Spacer()
+            }
 
             Text("Your API key is stored securely in the macOS Keychain and is only used to generate voice responses.")
                 .font(VFont.caption)
                 .foregroundColor(VColor.textMuted)
-                .lineSpacing(2)
         }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard(background: VColor.surfaceSubtle)
     }
 }


### PR DESCRIPTION
Rewrites VoiceSettingsView.swift to align with the visual language used across all other settings tabs (Privacy, Appearance, Account, Advanced, Automation).

**Changes:**
- Remove custom caps-text + horizontal-line section dividers; replace with card-grouped sections using VFont.sectionTitle headers
- Replace custom Circle-dot status indicators with standard checkmark.circle.fill icon pattern
- Replace custom Capsule button rows for activation key picker with VDropdown
- Remove promotional education hero, how-it-works step cards, and try-it prompt
- Replace keyword suggestion capsule buttons with simplified TextField-only approach
- Convert floating privacy notes into inline caption text within cards
- Apply standard HStack row pattern (label+description left, control right) with Divider() between rows
- All three sections (PTT, Wake Word, TTS) now use consistent .vCard(background: VColor.surfaceSubtle) wrappers

Closes #11278. Part of #11277.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
