### PR TITLE
test: add unit tests for MCP health check

### DIFF
--- a/assistant/src/__tests__/mcp-health-check.test.ts
+++ b/assistant/src/__tests__/mcp-health-check.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, jest, mock, test } from 'bun:test';
+
+const mockConnect = jest.fn();
+const mockDisconnect = jest.fn();
+let mockIsConnected = true;
+
+mock.module('../mcp/client.js', () => ({
+  McpClient: class {
+    get isConnected() { return mockIsConnected; }
+    connect = mockConnect;
+    disconnect = mockDisconnect;
+  },
+}));
+
+const { checkServerHealth } = await import('../cli/mcp.js');
+
+const serverConfig = (overrides = {}) => ({
+  transport: { type: 'streamable-http' as const, url: 'https://example.com/mcp' },
+  enabled: true,
+  defaultRiskLevel: 'high' as const,
+  maxTools: 20,
+  ...overrides,
+});
+
+describe('checkServerHealth', () => {
+  beforeEach(() => {
+    mockConnect.mockReset();
+    mockDisconnect.mockReset();
+    mockIsConnected = true;
+  });
+
+  test('returns Connected when server connects successfully', async () => {
+    mockConnect.mockResolvedValue(undefined);
+    mockDisconnect.mockResolvedValue(undefined);
+
+    const result = await checkServerHealth('test', serverConfig());
+    expect(result).toContain('Connected');
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  test('returns Needs authentication when isConnected is false', async () => {
+    mockConnect.mockResolvedValue(undefined);
+    mockIsConnected = false;
+
+    const result = await checkServerHealth('test', serverConfig());
+    expect(result).toContain('Needs authentication');
+  });
+
+  test('returns Error when connect throws', async () => {
+    mockConnect.mockRejectedValue(new Error('Connection refused'));
+    mockDisconnect.mockResolvedValue(undefined);
+
+    const result = await checkServerHealth('test', serverConfig());
+    expect(result).toContain('Error');
+    expect(result).toContain('Connection refused');
+  });
+
+  test('returns Timed out when connect hangs', async () => {
+    mockConnect.mockImplementation(() => new Promise(() => {}));
+    mockDisconnect.mockResolvedValue(undefined);
+
+    const result = await checkServerHealth('test', serverConfig(), 100);
+    expect(result).toContain('Timed out');
+  });
+});

--- a/assistant/src/cli/mcp.ts
+++ b/assistant/src/cli/mcp.ts
@@ -12,15 +12,15 @@ import { getCliLogger } from '../util/logger.js';
 
 const log = getCliLogger('cli');
 
-const HEALTH_CHECK_TIMEOUT_MS = 10_000;
+export const HEALTH_CHECK_TIMEOUT_MS = 10_000;
 
-async function checkServerHealth(serverId: string, config: McpServerConfig): Promise<string> {
+export async function checkServerHealth(serverId: string, config: McpServerConfig, timeoutMs = HEALTH_CHECK_TIMEOUT_MS): Promise<string> {
   const client = new McpClient(serverId, { quiet: true });
   try {
     await Promise.race([
       client.connect(config.transport),
       new Promise<never>((_, reject) => {
-        const t = setTimeout(() => reject(new Error('timeout')), HEALTH_CHECK_TIMEOUT_MS);
+        const t = setTimeout(() => reject(new Error('timeout')), timeoutMs);
         if (typeof t === 'object' && 'unref' in t) t.unref();
       }),
     ]);


### PR DESCRIPTION
## Summary
- Export `checkServerHealth` with configurable timeout parameter for testability
- Add `mcp-health-check.test.ts` with mocked `McpClient` covering all 4 status paths: connected, needs authentication, error, and timeout
- Tests run in ~275ms (no real network connections)

## Test plan
- [x] `bun test src/__tests__/mcp-health-check.test.ts` — 4 pass in ~275ms
- [x] `bun test src/__tests__/mcp-cli.test.ts` — 16 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
