### PR TITLE
Migrate local /update + /release to skill-backed local commands

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -16,10 +16,14 @@ Re-run `setup` after pulling updates to the claude-skills repo.
 
 ### Repo-local commands
 
-These commands are specific to vellum-assistant and live directly in `.claude/commands/`:
+These commands are specific to vellum-assistant and live in `.claude/skills/vellum-skills/` as local skill files (NOT symlinks):
 
-- **`/update`** — Pull latest from main, restart the backend daemon, verify gateway health, rebuild/launch the macOS app
-- **`/release`** — Cut a new release by triggering the GitHub Actions release workflow
+- **`/update`** — Pull latest from main, restart the backend daemon, verify gateway health, rebuild/launch the macOS app (`.claude/skills/vellum-skills/update/SKILL.md`)
+- **`/release`** — Cut a new release by triggering the GitHub Actions release workflow (`.claude/skills/vellum-skills/release/SKILL.md`)
+
+The shared-vs-local model:
+- **Shared commands**: maintained in the `claude-skills` repo, symlinked by `setup` to `.claude/skills/<name>` and `.claude/commands/<name>.md`
+- **Local commands**: maintained directly in `.claude/skills/vellum-skills/<name>/SKILL.md` — these are NOT symlinks and are tracked in this repo's git
 
 ## Utility Scripts
 

--- a/.claude/skills/vellum-skills/release/SKILL.md
+++ b/.claude/skills/vellum-skills/release/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: release
+description: >
+  Cut a new release by triggering the Release workflow via GitHub Actions workflow dispatch.
+---
+
 Cut a new release by triggering the Release workflow via GitHub Actions workflow dispatch.
 
 The user may pass `$ARGUMENTS` as the bump type: `patch`, `minor`, or `major`. If not provided, default to `patch`.

--- a/.claude/skills/vellum-skills/update/SKILL.md
+++ b/.claude/skills/vellum-skills/update/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: update
+description: >
+  Pull latest from main, restart the backend daemon, verify gateway health, rebuild/launch the macOS app, and print a startup summary.
+---
+
 # Update — Pull Latest and Restart Vellum
 
 Pull the latest changes from main, rebuild/launch the macOS app (which manages its own daemon and gateway lifecycle).

--- a/.gitignore
+++ b/.gitignore
@@ -28,14 +28,17 @@ dist
 .claude/*
 !.claude/commands/
 !.claude/phases/
+!.claude/skills/
 !.claude/README.md
+
+# Shared claude-skills symlinks are gitignored; only repo-local skills are tracked.
+.claude/skills/*
+!.claude/skills/vellum-skills/
 
 # Shared claude-skills symlinks (managed by claude-skills/setup)
 # These are gitignored because they're symlinks to the shared repo.
-# Repo-local commands (update.md, release.md) are preserved via negation.
+# Repo-local commands now live in .claude/skills/vellum-skills/.
 .claude/commands/*.md
-!.claude/commands/update.md
-!.claude/commands/release.md
 .claude/phases/
 .private/
 temp.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Bun + TypeScript monorepo with multiple packages:
 - `gateway/` — Channel ingress gateway (Bun + TypeScript)
 - `clients/` — Client apps (macOS/iOS/etc). See `clients/AGENTS.md` and platform docs like `clients/macos/CLAUDE.md`.
 - `scripts/` — Utility scripts
-- `.claude/` — Claude Code slash commands and helper scripts (see `.claude/README.md`). Most commands are shared from [`claude-skills`](https://github.com/vellum-ai/claude-skills) via symlinks; repo-local commands (`update.md`, `release.md`) live here directly.
+- `.claude/` — Claude Code slash commands and helper scripts (see `.claude/README.md`). Most commands are shared from [`claude-skills`](https://github.com/vellum-ai/claude-skills) via symlinks; repo-local commands live in `.claude/skills/vellum-skills/` as local skill files.
 
 ## Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ When your PR establishes a new mandatory pattern, convention, or architectural c
 
 ## Slash Commands — TLDR
 
-Most commands are shared from the [`claude-skills`](https://github.com/vellum-ai/claude-skills) repo via symlinks. Repo-local commands (`/update`, `/release`) live in `.claude/commands/` directly. After cloning, run `path/to/claude-skills/setup` to create the symlinks.
+Most commands are shared from the [`claude-skills`](https://github.com/vellum-ai/claude-skills) repo via symlinks. Repo-local commands (`/update`, `/release`) live in `.claude/skills/vellum-skills/` as local skill files. After cloning, run `path/to/claude-skills/setup` to create the symlinks.
 
 | Command | What it does |
 |---|---|

--- a/assistant/src/__tests__/gateway-only-guard.test.ts
+++ b/assistant/src/__tests__/gateway-only-guard.test.ts
@@ -26,7 +26,7 @@ const ALLOWLIST = new Set([
   'clients/shared/IPC/DaemonClient.swift',
   'clients/macos/vellum-assistant/App/AppDelegate.swift',
   'clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift',
-  '.claude/commands/update.md', // daemon health check script
+  '.claude/skills/vellum-skills/update/SKILL.md', // daemon health check script
 
   // --- Documentation and comments that mention the port for explanatory purposes ---
   'AGENTS.md', // documents the gateway-only rule itself


### PR DESCRIPTION
## Summary
- Moved /update command from .claude/commands/update.md to .claude/skills/vellum-skills/update/SKILL.md
- Moved /release command from .claude/commands/release.md to .claude/skills/vellum-skills/release/SKILL.md
- Updated .gitignore to track local skill files instead of local command files
- Updated docs (.claude/README.md, AGENTS.md) to reflect new local skill-backed command model
- No behavior changes — pure migration

Part of #11222

## Test plan
- [ ] Verify /update and /release commands still resolve correctly from local skills
- [ ] Verify .claude/commands/update.md and release.md are deleted
- [ ] Verify .gitignore tracks local skill files correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
