### PR TITLE
Reduce duplicate keychain prompts during hatch

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -32,7 +32,10 @@ enum APIKeyManager {
 
     private static var readCache: [String: CachedKeyRead] = [:]
     private static let readCacheLock = NSLock()
-    private static let readCacheTTL: TimeInterval = 60
+    private static let readCacheHitTTL: TimeInterval = 60
+    /// Short TTL for misses so external writes (e.g. from the daemon) are picked up quickly
+    /// while still batching rapid sequential calls like hasAnyKey().
+    private static let readCacheMissTTL: TimeInterval = 5
 
     // MARK: - Anthropic (convenience wrappers for backward compatibility)
 
@@ -64,9 +67,7 @@ enum APIKeyManager {
             }
         }
         let value = cliGetKey(service: service, account: provider)
-        if value != nil {
-            setCachedValue(value, for: provider)
-        }
+        setCachedValue(value, for: provider)
         return value
     }
 
@@ -80,11 +81,8 @@ enum APIKeyManager {
     }
 
     static func deleteKey(for provider: String) {
-        if cliDeleteKey(service: service, account: provider) {
-            setCachedValue(nil, for: provider)
-        } else {
-            invalidateCachedValue(for: provider)
-        }
+        cliDeleteKey(service: service, account: provider)
+        invalidateCachedValue(for: provider)
         notifyKeyDidChange()
     }
 
@@ -96,7 +94,8 @@ enum APIKeyManager {
             return (false, nil)
         }
 
-        if Date().timeIntervalSince(entry.cachedAt) > readCacheTTL {
+        let ttl = entry.value != nil ? readCacheHitTTL : readCacheMissTTL
+        if Date().timeIntervalSince(entry.cachedAt) > ttl {
             readCache.removeValue(forKey: provider)
             return (false, nil)
         }

--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -25,6 +25,15 @@ enum APIKeyManager {
     private static let legacyService = "com.vellum-assistant.anthropic-api-key"
     private static let legacyAccount = "anthropic-api-key"
 
+    private struct CachedKeyRead {
+        let value: String?
+        let cachedAt: Date
+    }
+
+    private static var readCache: [String: CachedKeyRead] = [:]
+    private static let readCacheLock = NSLock()
+    private static let readCacheTTL: TimeInterval = 60
+
     // MARK: - Anthropic (convenience wrappers for backward compatibility)
 
     static func getKey() -> String? { getKey(for: "anthropic") }
@@ -42,23 +51,55 @@ enum APIKeyManager {
     // MARK: - Generic provider access
 
     static func getKey(for provider: String) -> String? {
+        let cached = cachedValue(for: provider)
+        if cached.hit { return cached.value }
+
         if provider == "anthropic" {
             // migrateIfNeeded returns the key if it was already read during
             // the migration check, avoiding a redundant security CLI spawn
             // (each spawn triggers a macOS keychain authorization prompt).
-            if let cached = migrateIfNeeded() { return cached }
+            if let migrated = migrateIfNeeded() {
+                setCachedValue(migrated, for: provider)
+                return migrated
+            }
         }
-        return cliGetKey(service: service, account: provider)
+        let value = cliGetKey(service: service, account: provider)
+        setCachedValue(value, for: provider)
+        return value
     }
 
     static func setKey(_ key: String, for provider: String) {
         cliSetKey(service: service, account: provider, value: key)
+        setCachedValue(key, for: provider)
         notifyKeyDidChange()
     }
 
     static func deleteKey(for provider: String) {
         cliDeleteKey(service: service, account: provider)
+        setCachedValue(nil, for: provider)
         notifyKeyDidChange()
+    }
+
+    private static func cachedValue(for provider: String) -> (hit: Bool, value: String?) {
+        readCacheLock.lock()
+        defer { readCacheLock.unlock() }
+
+        guard let entry = readCache[provider] else {
+            return (false, nil)
+        }
+
+        if Date().timeIntervalSince(entry.cachedAt) > readCacheTTL {
+            readCache.removeValue(forKey: provider)
+            return (false, nil)
+        }
+
+        return (true, entry.value)
+    }
+
+    private static func setCachedValue(_ value: String?, for provider: String) {
+        readCacheLock.lock()
+        defer { readCacheLock.unlock() }
+        readCache[provider] = CachedKeyRead(value: value, cachedAt: Date())
     }
 
     // MARK: - CLI Helpers

--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -64,7 +64,9 @@ enum APIKeyManager {
             }
         }
         let value = cliGetKey(service: service, account: provider)
-        setCachedValue(value, for: provider)
+        if value != nil {
+            setCachedValue(value, for: provider)
+        }
         return value
     }
 

--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -69,14 +69,20 @@ enum APIKeyManager {
     }
 
     static func setKey(_ key: String, for provider: String) {
-        cliSetKey(service: service, account: provider, value: key)
-        setCachedValue(key, for: provider)
+        if cliSetKey(service: service, account: provider, value: key) {
+            setCachedValue(key, for: provider)
+        } else {
+            invalidateCachedValue(for: provider)
+        }
         notifyKeyDidChange()
     }
 
     static func deleteKey(for provider: String) {
-        cliDeleteKey(service: service, account: provider)
-        setCachedValue(nil, for: provider)
+        if cliDeleteKey(service: service, account: provider) {
+            setCachedValue(nil, for: provider)
+        } else {
+            invalidateCachedValue(for: provider)
+        }
         notifyKeyDidChange()
     }
 
@@ -102,6 +108,12 @@ enum APIKeyManager {
         readCache[provider] = CachedKeyRead(value: value, cachedAt: Date())
     }
 
+    private static func invalidateCachedValue(for provider: String) {
+        readCacheLock.lock()
+        defer { readCacheLock.unlock() }
+        readCache.removeValue(forKey: provider)
+    }
+
     // MARK: - CLI Helpers
 
     /// Read a generic password via `security find-generic-password`.
@@ -124,25 +136,37 @@ enum APIKeyManager {
     }
 
     /// Write a generic password via `security add-generic-password -U` (update if exists).
-    private static func cliSetKey(service: String, account: String, value: String) {
+    @discardableResult
+    private static func cliSetKey(service: String, account: String, value: String) -> Bool {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
         process.arguments = ["add-generic-password", "-s", service, "-a", account, "-w", value, "-U"]
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
-        try? process.run()
-        process.waitUntilExit()
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            return false
+        }
     }
 
     /// Delete a generic password via `security delete-generic-password`.
-    private static func cliDeleteKey(service: String, account: String) {
+    @discardableResult
+    private static func cliDeleteKey(service: String, account: String) -> Bool {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
         process.arguments = ["delete-generic-password", "-s", service, "-a", account]
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
-        try? process.run()
-        process.waitUntilExit()
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            return false
+        }
     }
 
     // MARK: - Migration


### PR DESCRIPTION
## Summary
- add a small in-process read cache to macOS `APIKeyManager` keyed by provider
- cache both hits and misses (with TTL) so back-to-back `getKey` / `hasAnyKey` calls do not repeatedly spawn keychain reads
- keep cache coherent on `setKey` and `deleteKey` so onboarding/setup updates are reflected immediately

## Why
Hatch flow currently performs multiple immediate key lookups in the same app process (onboarding hatch step, then main-window startup checks), which can trigger repeated macOS keychain authorization prompts.

## Testing
- manual code-path verification of call sites
- no full `swift test` run (repo-wide Swift package build is very large and slow in this environment)
