### PR TITLE
Rewrite /update around vellum ps/sleep/wake with explicit freshness checks

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -18,7 +18,7 @@ Re-run `setup` after pulling updates to the claude-skills repo.
 
 These commands are specific to vellum-assistant and live in `.claude/skills/vellum-skills/` as local skill files (NOT symlinks):
 
-- **`/update`** — Pull latest from main, restart the backend daemon, verify gateway health, rebuild/launch the macOS app (`.claude/skills/vellum-skills/update/SKILL.md`)
+- **`/update`** — Pull latest from main, use `vellum ps/sleep/wake` to manage daemon/gateway lifecycle, rebuild/launch the macOS app (`.claude/skills/vellum-skills/update/SKILL.md`)
 - **`/release`** — Cut a new release by triggering the GitHub Actions release workflow (`.claude/skills/vellum-skills/release/SKILL.md`)
 
 The shared-vs-local model:

--- a/.claude/skills/vellum-skills/update/SKILL.md
+++ b/.claude/skills/vellum-skills/update/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: update
 description: >
-  Pull latest from main, restart the backend daemon, verify gateway health, rebuild/launch the macOS app, and print a startup summary.
+  Pull latest from main, use vellum ps/sleep/wake to manage daemon and gateway lifecycle, rebuild/launch the macOS app, and print a startup summary.
 ---
 
 # Update — Pull Latest and Restart Vellum
 
-Pull the latest changes from main, rebuild/launch the macOS app (which manages its own daemon and gateway lifecycle).
+Pull the latest changes from main, use `vellum` lifecycle CLI to stop and restart processes, rebuild/launch the macOS app.
 
 ## Steps
 
@@ -15,30 +15,50 @@ Pull the latest changes from main, rebuild/launch the macOS app (which manages i
    export PATH="$HOME/.bun/bin:$PATH"
    ```
 
-1. Kill app, daemon, and **all** gateway processes. The macOS app manages its own daemon and gateway — kill everything so it starts clean:
+1. Preflight snapshot — capture current state before making changes:
    ```bash
-   pkill -x "Vellum" || true
-   pkill -x "vellum-assistant" || true
-   vellum daemon stop || true
-   pkill -f "dev:proxy" || true
-   pkill -f "gateway/src/index" || true
-   lsof -ti :7830 | xargs kill -9 2>/dev/null || true
-   lsof -ti :7821 | xargs kill -9 2>/dev/null || true
+   vellum ps
    ```
 
-2. Switch to main and pull latest:
+2. Kill the macOS app first (it manages its own daemon/gateway, so it must be stopped before quiescing processes):
+   ```bash
+   pkill -x "Vellum" || true
+   ```
+
+3. Quiesce with `vellum sleep` — stop daemon and gateway processes. This is directory-agnostic and stops processes globally regardless of CWD:
+   ```bash
+   vellum sleep
+   ```
+
+   **Fallback only if sleep fails** (processes stubbornly remain):
+   ```bash
+   pkill -x "vellum-assistant" || true
+   pkill -f "gateway/src/index" || true
+   ```
+
+4. Verify stopped — run `vellum ps` and confirm no running processes. If processes remain, log a warning:
+   ```bash
+   vellum ps
+   ```
+
+5. Switch to main and pull latest:
    ```bash
    git checkout main
    git pull origin main
    ```
 
-3. Install any new dependencies:
+6. Install any new dependencies:
    ```bash
    cd assistant && bun install && cd ..
    cd gateway && bun install && cd ..
    ```
 
-4. Build the macOS app from source synchronously (wait for build to complete before launching to avoid opening a stale build), then launch with file-watching in the background:
+7. Restart with `vellum wake` — start daemon and gateway from the current checkout. `vellum wake` must be run from the checkout directory that should supply the new daemon code:
+   ```bash
+   vellum wake
+   ```
+
+8. Build the macOS app from source synchronously (wait for build to complete before launching to avoid opening a stale build), then launch with file-watching in the background:
    ```bash
    REPO_ROOT="$(pwd)"
    cd clients/macos && VELLUM_GATEWAY_DIR="$REPO_ROOT/gateway" ./build.sh
@@ -49,17 +69,18 @@ Pull the latest changes from main, rebuild/launch the macOS app (which manages i
    cd clients/macos && VELLUM_GATEWAY_DIR="$REPO_ROOT/gateway" ./build.sh run &
    ```
 
-5. Wait for the app to launch and settle, then print startup summary:
+9. Verify fresh state — run `vellum ps` to confirm processes are running, then check health endpoints:
    ```bash
    sleep 5
    echo ""
    echo "=== Startup Summary ==="
+   vellum ps
+   echo ""
    DAEMON_STATUS=$(curl -sS --max-time 2 http://127.0.0.1:7821/healthz 2>&1 || echo "NOT YET RUNNING (app will start daemon on first launch/hatch)")
    GATEWAY_STATUS=$(curl -sS --max-time 2 http://127.0.0.1:7830/healthz 2>&1 || echo "NOT YET RUNNING (app will start gateway on first launch/hatch)")
-   echo "  Daemon:   $DAEMON_STATUS"
-   echo "  Gateway:  $GATEWAY_STATUS"
+   echo "  Daemon health:  $DAEMON_STATUS"
+   echo "  Gateway health: $GATEWAY_STATUS"
    echo "======================="
-   echo ""
    ```
 
 Report:

--- a/.claude/skills/vellum-skills/update/SKILL.md
+++ b/.claude/skills/vellum-skills/update/SKILL.md
@@ -27,13 +27,15 @@ Pull the latest changes from main, use `vellum` lifecycle CLI to stop and restar
 
 3. Quiesce with `vellum sleep` — stop daemon and gateway processes. This is directory-agnostic and stops processes globally regardless of CWD:
    ```bash
-   vellum sleep
+   vellum sleep || true
    ```
 
    **Fallback only if sleep fails** (processes stubbornly remain):
    ```bash
    pkill -x "vellum-assistant" || true
    pkill -f "gateway/src/index" || true
+   lsof -ti :7830 | xargs kill -9 2>/dev/null || true
+   lsof -ti :7821 | xargs kill -9 2>/dev/null || true
    ```
 
 4. Verify stopped — run `vellum ps` and confirm no running processes. If processes remain, log a warning:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ Most commands are shared from the [`claude-skills`](https://github.com/vellum-ai
 | `/safe-check-review [file]` | Check the active plan PR for review feedback from codex/devin/humans. Addresses requested changes, waits if reviews are pending. |
 | `/resume-plan [file]` | Merge the current plan PR, implement the next one, create it, and stop again. Repeats until the plan is complete. The PR body includes the full plan content for traceability. |
 
-| `/update` | Pull latest from main, restart the backend daemon, verify gateway health (fail fast on startup failure), rebuild/launch the macOS app, and print a startup summary. The default assistant is resolved from the lockfile by selecting the most recently hatched assistant (`hatchedAt` descending). |
+| `/update` | Pull latest from main, use `vellum ps/sleep/wake` to manage daemon and gateway lifecycle, rebuild/launch the macOS app, and print a startup summary. Uses `vellum sleep` (directory-agnostic global stop) to quiesce processes, then `vellum wake` (from current checkout) to restart. |
 
 
 ## Linear Ticket Hygiene


### PR DESCRIPTION
## Summary
- Rewrote /update skill to use vellum ps/sleep/wake as primary lifecycle controls
- Replaced ad-hoc pkill/lsof process killing with vellum sleep (kept as fallback only)
- Added preflight vellum ps snapshot and post-restart verification
- Made semantics explicit: vellum sleep is directory-agnostic, vellum wake starts from current checkout
- Updated AGENTS.md /update description

Part of #11222

## Test plan
- [ ] Run /update twice consecutively — confirm no stale process residue
- [ ] Run /update from a feature branch — confirm vellum wake starts from that checkout
- [ ] After vellum sleep, confirm vellum ps shows no running processes
- [ ] Verify startup summary shows daemon/gateway health

🤖 Generated with [Claude Code](https://claude.com/claude-code)