### PR TITLE
M3: Enforce temporary approval modes in tool permission pipeline

### DIFF
--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -11,6 +11,7 @@ import type { PermissionPrompter } from '../permissions/prompter.js';
 import type { SecretPrompter } from '../permissions/secret-prompter.js';
 import { addRule, findHighestPriorityRule } from '../permissions/trust-store.js';
 import { isAllowDecision } from '../permissions/types.js';
+import { getEffectiveMode } from '../runtime/session-approval-overrides.js';
 import type { Message, ToolDefinition } from '../providers/types.js';
 import type { ToolExecutor } from '../tools/executor.js';
 import type { ToolExecutionResult, ToolLifecycleEventHandler } from '../tools/types.js';
@@ -162,6 +163,12 @@ export function createToolExecutor(
             decision: existingRule.decision === 'allow' ? 'allow' as const : 'deny' as const,
           };
         }
+        // Auto-approve sub-tool confirmations when a temporary approval
+        // override is active for this conversation (guardian only).
+        const guardianTrust = ctx.guardianContext?.trustClass ?? 'guardian';
+        if (guardianTrust === 'guardian' && getEffectiveMode(ctx.conversationId) !== null) {
+          return { decision: 'allow' as const };
+        }
         const allowlistOptions = [
           { label: `cc:${req.toolName}`, description: `Claude Code ${req.toolName}`, pattern: `cc:${req.toolName}` },
           { label: 'cc:*', description: 'All Claude Code sub-tools', pattern: 'cc:*' },
@@ -259,6 +266,13 @@ export function createProxyApprovalCallback(
     // blocking for the full permission timeout before auto-denying.
     if (ctx.hasNoClient) {
       return false;
+    }
+
+    // Auto-approve proxy network requests when a temporary approval
+    // override is active for this conversation (guardian only).
+    const proxyGuardianTrust = ctx.guardianContext?.trustClass ?? 'guardian';
+    if (proxyGuardianTrust === 'guardian' && getEffectiveMode(ctx.conversationId) !== null) {
+      return true;
     }
 
     const response = await prompter.prompt(

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -514,14 +514,10 @@ export class Session {
       decisionContext,
     );
 
-    // Activate conversation-scoped temporary approval override when the
-    // user picks a temporary allow mode. These do not grant persistent
-    // trust and do not mutate allowlists/denylists.
-    if (decision === 'allow_thread') {
-      approvalOverrides.setThreadMode(this.conversationId);
-    } else if (decision === 'allow_10m') {
-      approvalOverrides.setTimedMode(this.conversationId);
-    }
+    // Mode activation (setTimedMode / setThreadMode) is intentionally NOT
+    // done here. It is handled in permission-checker.ts where
+    // persistentDecisionsAllowed context is available — this prevents
+    // proxied bash commands from escalating into blanket auto-approval.
 
     // Emit authoritative confirmation state and activity transition centrally
     // so ALL callers (IPC handlers, /v1/confirm, channel bridges) get

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -16,7 +16,7 @@ export interface TrustRule {
   allowHighRisk?: boolean;
 }
 
-export type UserDecision = 'allow' | 'allow_10m' | 'allow_thread' | 'always_allow' | 'always_allow_high_risk' | 'deny' | 'always_deny';
+export type UserDecision = 'allow' | 'allow_10m' | 'allow_thread' | 'always_allow' | 'always_allow_high_risk' | 'deny' | 'always_deny' | 'temporary_override';
 
 /** Returns true for any allow-variant decision. Centralizes the check to prevent omissions when new allow variants are added. */
 export function isAllowDecision(decision: UserDecision): boolean {
@@ -24,7 +24,8 @@ export function isAllowDecision(decision: UserDecision): boolean {
     || decision === 'allow_10m'
     || decision === 'allow_thread'
     || decision === 'always_allow'
-    || decision === 'always_allow_high_risk';
+    || decision === 'always_allow_high_risk'
+    || decision === 'temporary_override';
 }
 
 export interface PermissionCheckResult {

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -3,6 +3,7 @@ import { getHookManager } from '../hooks/manager.js';
 import { check, classifyRisk, generateAllowlistOptions, generateScopeOptions } from '../permissions/checker.js';
 import type { PermissionPrompter } from '../permissions/prompter.js';
 import { addRule } from '../permissions/trust-store.js';
+import { getEffectiveMode, setThreadMode, setTimedMode } from '../runtime/session-approval-overrides.js';
 import { getLogger } from '../util/logger.js';
 import { buildPolicyContext } from './policy-context.js';
 import { isSideEffectTool } from './side-effects.js';
@@ -108,6 +109,22 @@ export class PermissionChecker {
             riskLevel,
             content: `Permission denied: tool "${name}" requires user approval but no interactive client is connected. The tool was not executed. To allow this tool in non-interactive sessions, add a trust rule via permission settings.`,
           };
+        }
+
+        // Temporary approval override: if the guardian has enabled a
+        // conversation-scoped "allow all" mode (allow_10m or allow_thread),
+        // skip the interactive prompt and auto-approve. Only applies to
+        // guardian actors — untrusted actors cannot leverage this to bypass
+        // guardian-required gates (those are enforced in pre-execution gates).
+        if (
+          context.guardianTrustClass === 'guardian'
+          && getEffectiveMode(context.conversationId) !== null
+        ) {
+          log.info(
+            { toolName: name, riskLevel, conversationId: context.conversationId },
+            'Temporary approval override active — auto-approving without prompt',
+          );
+          return { allowed: true, decision: 'temporary_override', riskLevel };
         }
 
         const allowlistOptions = await generateAllowlistOptions(name, input, context.signal);
@@ -265,6 +282,24 @@ export class PermissionChecker {
           if (effectiveScope) {
             addRule(name, response.selectedPattern, effectiveScope, 'allow', 100, hasOptions ? ruleOptions : undefined);
           }
+        }
+
+        // Activate temporary approval mode when the user chooses a
+        // time-limited or thread-scoped override. Subsequent tool
+        // invocations in this conversation will auto-approve without
+        // prompting (checked above in the temporary override block).
+        if (response.decision === 'allow_10m') {
+          setTimedMode(context.conversationId);
+          log.info(
+            { toolName: name, conversationId: context.conversationId },
+            'Activated timed (10m) temporary approval mode',
+          );
+        } else if (response.decision === 'allow_thread') {
+          setThreadMode(context.conversationId);
+          log.info(
+            { toolName: name, conversationId: context.conversationId },
+            'Activated thread-scoped temporary approval mode',
+          );
         }
 
         return { allowed: true, decision, riskLevel };

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -116,8 +116,16 @@ export class PermissionChecker {
         // skip the interactive prompt and auto-approve. Only applies to
         // guardian actors — untrusted actors cannot leverage this to bypass
         // guardian-required gates (those are enforced in pre-execution gates).
+        // Proxied bash commands require per-invocation approval and must not
+        // be auto-approved by a temporary override — they are excluded here
+        // by requiring persistent decisions to be allowed.
+        const persistentDecisionsAllowedForOverride = !(
+          name === 'bash'
+          && input.network_mode === 'proxied'
+        );
         if (
           context.guardianTrustClass === 'guardian'
+          && persistentDecisionsAllowedForOverride
           && getEffectiveMode(context.conversationId) !== null
         ) {
           log.info(

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -288,13 +288,16 @@ export class PermissionChecker {
         // time-limited or thread-scoped override. Subsequent tool
         // invocations in this conversation will auto-approve without
         // prompting (checked above in the temporary override block).
-        if (response.decision === 'allow_10m') {
+        // Gated on persistentDecisionsAllowed so that proxied bash
+        // commands (which require per-invocation approval) cannot
+        // escalate into blanket auto-approval.
+        if (persistentDecisionsAllowed && response.decision === 'allow_10m') {
           setTimedMode(context.conversationId);
           log.info(
             { toolName: name, conversationId: context.conversationId },
             'Activated timed (10m) temporary approval mode',
           );
-        } else if (response.decision === 'allow_thread') {
+        } else if (persistentDecisionsAllowed && response.decision === 'allow_thread') {
           setThreadMode(context.conversationId);
           log.info(
             { toolName: name, conversationId: context.conversationId },


### PR DESCRIPTION
Part of #11230. Integrates session-approval-overrides into permission-checker to auto-approve tool executions when a temporary approval mode (allow_10m, allow_thread) is active. Preserves deny rules, pre-execution gates, and guardian invariants. Closes #11233.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
