### PR TITLE
fix: polish Channels settings UI — remove redundant labels and simplify Mobile section

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -178,12 +178,10 @@ struct SettingsChannelsTab: View {
                     .accessibilityLabel("Copy bearer token")
                     .help("Copy token")
 
-                    // Regenerate button
-                    Button("Regenerate") {
-                        showingRegenerateConfirmation = true
-                    }
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.accent)
+                }
+
+                VButton(label: "Regenerate", style: .tertiary, size: .large) {
+                    showingRegenerateConfirmation = true
                 }
             }
         }
@@ -292,18 +290,8 @@ struct SettingsChannelsTab: View {
             } else if telegramSetupExpanded {
                 telegramCredentialEntry
             } else {
-                VStack(alignment: .leading, spacing: VSpacing.lg) {
-                    HStack(spacing: VSpacing.sm) {
-                        Image(systemName: "exclamationmark.triangle")
-                            .foregroundColor(VColor.warning)
-                            .font(.system(size: 12))
-                        Text("Not configured")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-                    }
-                    VButton(label: "Set Up", style: .secondary, size: .large) {
-                        telegramSetupExpanded = true
-                    }
+                VButton(label: "Set Up", style: .secondary, size: .large) {
+                    telegramSetupExpanded = true
                 }
             }
 
@@ -466,18 +454,8 @@ struct SettingsChannelsTab: View {
             } else if slackChannelSetupExpanded {
                 slackChannelCredentialEntry
             } else {
-                VStack(alignment: .leading, spacing: VSpacing.lg) {
-                    HStack(spacing: VSpacing.sm) {
-                        Image(systemName: "exclamationmark.triangle")
-                            .foregroundColor(VColor.warning)
-                            .font(.system(size: 12))
-                        Text("Not configured")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-                    }
-                    VButton(label: "Set Up", style: .secondary, size: .large) {
-                        slackChannelSetupExpanded = true
-                    }
+                VButton(label: "Set Up", style: .secondary, size: .large) {
+                    slackChannelSetupExpanded = true
                 }
             }
 
@@ -1630,16 +1608,6 @@ struct SettingsChannelsTab: View {
 
     // MARK: - Mobile Card (Pairing + Approved Devices)
 
-    private var mobilePairingLabel: some View {
-        HStack(spacing: VSpacing.xs) {
-            Text("Device Pairing")
-            VInfoTooltip("Scan a QR code with the iOS app to pair your phone with this Mac.")
-        }
-        .font(VFont.caption)
-        .foregroundColor(VColor.textSecondary)
-        .frame(width: labelColumnWidth, alignment: .leading)
-    }
-
     private var mobileCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
@@ -1652,15 +1620,7 @@ struct SettingsChannelsTab: View {
             }
 
             // Connected devices — shown as status rows (mirrors Telegram bot / Twilio phone rows)
-            if store.approvedDevices.isEmpty {
-                channelStatusRow(
-                    label: "Device",
-                    icon: "iphone",
-                    iconColor: VColor.textMuted,
-                    value: "No devices paired",
-                    valueColor: VColor.textMuted
-                )
-            } else {
+            if !store.approvedDevices.isEmpty {
                 ForEach(store.approvedDevices, id: \.hashedDeviceId) { device in
                     channelStatusRow(
                         label: "Device",
@@ -1672,9 +1632,8 @@ struct SettingsChannelsTab: View {
                         }
                     )
                 }
+                Divider().background(VColor.surfaceBorder)
             }
-
-            Divider().background(VColor.surfaceBorder)
 
             // Device pairing row — mirrors Guardian Verification row layout
             mobilePairingRow
@@ -1722,7 +1681,6 @@ struct SettingsChannelsTab: View {
 
         if store.isRegeneratingToken {
             HStack(spacing: VSpacing.sm) {
-                mobilePairingLabel
                 ProgressView()
                     .controlSize(.small)
                 Text("Restarting daemon\u{2026}")
@@ -1731,7 +1689,6 @@ struct SettingsChannelsTab: View {
             }
         } else if !hasGateway {
             HStack(spacing: VSpacing.sm) {
-                mobilePairingLabel
                 Image(systemName: "exclamationmark.triangle.fill")
                     .foregroundColor(VColor.warning)
                     .font(.system(size: 12))
@@ -1742,7 +1699,6 @@ struct SettingsChannelsTab: View {
         } else if !hasToken {
             VStack(alignment: .leading, spacing: VSpacing.sm) {
                 HStack(spacing: VSpacing.sm) {
-                    mobilePairingLabel
                     Image(systemName: "exclamationmark.triangle.fill")
                         .foregroundColor(VColor.warning)
                         .font(.system(size: 12))
@@ -1755,13 +1711,8 @@ struct SettingsChannelsTab: View {
                 }
             }
         } else {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
-                HStack(spacing: VSpacing.sm) {
-                    mobilePairingLabel
-                }
-                VButton(label: "Pair Device", leftIcon: "qrcode", style: .primary, size: .large) {
-                    showingPairingQR = true
-                }
+            VButton(label: "Pair Device", leftIcon: "qrcode", style: .primary, size: .large) {
+                showingPairingQR = true
             }
         }
     }


### PR DESCRIPTION
UI polish for the Settings → Channels tab.

**Change 1 — Remove redundant 'Not configured' labels:**
- Telegram and Slack: remove the warning icon + 'Not configured' text shown alongside the Set Up button. The button itself communicates the unconfigured state; the warning label is redundant noise.

**Change 2 — Simplify Mobile (iOS) section:**
- Remove the 'No devices paired' status row when no devices are paired — unpaired state now goes straight to the Pair Device button
- Remove the 'Device Pairing' label (+ tooltip) shown above the pairing button row — it was a redundant column label not used by any other card section
- Move the Regenerate token button out of the bearer token HStack and onto its own row as `VButton(style: .tertiary, size: .large)`, left-aligned

Closes #11286. Part of #11285.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
