### PR TITLE
fix: redesign Voice Settings view to match settings tab style conventions

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -3,7 +3,7 @@ import VellumAssistantShared
 
 /// Voice settings tab — configure push-to-talk activation key,
 /// enable/disable wake word listening, configure keyword phrase,
-/// and conversation timeout.
+/// conversation timeout, and text-to-speech.
 struct VoiceSettingsView: View {
     @ObservedObject var store: SettingsStore
 
@@ -14,359 +14,9 @@ struct VoiceSettingsView: View {
 
     @State private var elevenLabsKeyText: String = ""
 
-    private let suggestedKeywords = ["computer", "jarvis", "hey vellum", "assistant"]
-
     private var selectedActivationKey: ActivationKey {
         ActivationKey(rawValue: activationKey) ?? .fn
     }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xl) {
-            // Push to Talk
-            pttDivider
-            pttStatusSection
-            pttKeyPicker
-            pttPrivacyNote
-
-            // Wake Word
-            wakeWordDivider
-            statusSection
-            educationHero
-            howItWorksSteps
-            tryItPrompt
-            settingsDivider
-            enableSection
-            keywordSection
-            timeoutSection
-            privacyNote
-
-            // Text-to-Speech
-            ttsDivider
-            ttsStatusSection
-            ttsKeySection
-            ttsPrivacyNote
-        }
-    }
-
-    // MARK: - PTT Section Divider
-
-    private var pttDivider: some View {
-        HStack(spacing: VSpacing.md) {
-            Text("PUSH TO TALK")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(VColor.textMuted)
-                .tracking(1)
-
-            Rectangle()
-                .fill(VColor.surfaceBorder)
-                .frame(height: 1)
-        }
-    }
-
-    // MARK: - PTT Status
-
-    private var pttStatusSection: some View {
-        HStack(spacing: VSpacing.sm) {
-            Circle()
-                .fill(selectedActivationKey != .none ? VColor.success : VColor.textMuted)
-                .frame(width: 8, height: 8)
-
-            Text(selectedActivationKey != .none ? "Activation key: \(selectedActivationKey.displayName)" : "Push to talk disabled")
-                .font(VFont.body)
-                .foregroundColor(selectedActivationKey != .none ? VColor.success : VColor.textSecondary)
-
-            Spacer()
-        }
-        .padding(VSpacing.lg)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(selectedActivationKey != .none ? VColor.success.opacity(0.08) : VColor.surfaceSubtle)
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
-                        .strokeBorder(selectedActivationKey != .none ? VColor.success.opacity(0.2) : VColor.surfaceBorder, lineWidth: 1)
-                )
-        )
-    }
-
-    // MARK: - PTT Key Picker
-
-    private var pttKeyPicker: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Activation key")
-                .font(VFont.bodyMedium)
-                .foregroundColor(VColor.textPrimary)
-
-            HStack(spacing: VSpacing.sm) {
-                ForEach(ActivationKey.allCases, id: \.rawValue) { key in
-                    Button(key.displayName) {
-                        activationKey = key.rawValue
-                    }
-                    .buttonStyle(.plain)
-                    .font(VFont.caption)
-                    .foregroundColor(selectedActivationKey == key ? .white : VColor.textMuted)
-                    .padding(.horizontal, VSpacing.sm)
-                    .padding(.vertical, VSpacing.xs)
-                    .background(
-                        Capsule()
-                            .fill(selectedActivationKey == key ? Forest._700 : VColor.surface)
-                    )
-                    .overlay(
-                        Capsule()
-                            .strokeBorder(selectedActivationKey == key ? Color.clear : VColor.surfaceBorder, lineWidth: 1)
-                    )
-                }
-            }
-        }
-        .padding(VSpacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceSubtle)
-    }
-
-    // MARK: - PTT Privacy Note
-
-    private var pttPrivacyNote: some View {
-        HStack(alignment: .top, spacing: VSpacing.sm) {
-            Image(systemName: "lock.fill")
-                .font(.system(size: 10))
-                .foregroundColor(VColor.textMuted)
-
-            Text("Hold the activation key to dictate text or start a voice conversation. Uses on-device speech recognition.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
-                .lineSpacing(2)
-        }
-    }
-
-    // MARK: - Wake Word Section Divider
-
-    private var wakeWordDivider: some View {
-        HStack(spacing: VSpacing.md) {
-            Text("WAKE WORD")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(VColor.textMuted)
-                .tracking(1)
-
-            Rectangle()
-                .fill(VColor.surfaceBorder)
-                .frame(height: 1)
-        }
-    }
-
-    // MARK: - Status
-
-    private var statusSection: some View {
-        HStack(spacing: VSpacing.sm) {
-            Circle()
-                .fill(wakeWordEnabled ? VColor.success : VColor.textMuted)
-                .frame(width: 8, height: 8)
-
-            Text(wakeWordEnabled ? "Listening for \"\(wakeWordKeyword)\"" : "Wake word disabled")
-                .font(VFont.body)
-                .foregroundColor(wakeWordEnabled ? VColor.success : VColor.textSecondary)
-
-            Spacer()
-        }
-        .padding(VSpacing.lg)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(wakeWordEnabled ? VColor.success.opacity(0.08) : VColor.surfaceSubtle)
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
-                        .strokeBorder(wakeWordEnabled ? VColor.success.opacity(0.2) : VColor.surfaceBorder, lineWidth: 1)
-                )
-        )
-    }
-
-    // MARK: - Education Hero
-
-    private var educationHero: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            Text("Talk to Vellum, hands-free")
-                .font(VFont.cardTitle)
-                .foregroundColor(VColor.textPrimary)
-
-            Text("Wake word lets you start a conversation by speaking a keyword aloud \u{2014} no need to click or press anything. It uses on-device speech recognition, so nothing you say ever leaves your Mac.")
-                .font(VFont.body)
-                .foregroundColor(VColor.textSecondary)
-                .lineSpacing(2)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(VSpacing.xl)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.xl)
-                .fill(VColor.surfaceSubtle)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.xl)
-                .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
-        )
-    }
-
-    // MARK: - How It Works
-
-    private var howItWorksSteps: some View {
-        HStack(alignment: .top, spacing: VSpacing.md) {
-            stepCard(number: "1", title: "Say the keyword", description: "Speak your wake word when you're ready to talk.", showConnector: true)
-            stepCard(number: "2", title: "Vellum starts listening", description: "A chime plays and your microphone activates.", showConnector: true)
-            stepCard(number: "3", title: "Ask anything", description: "Speak naturally. Vellum responds when you pause.", showConnector: false)
-        }
-    }
-
-    private func stepCard(number: String, title: String, description: String, showConnector: Bool) -> some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text(number)
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundColor(VColor.success)
-                .frame(width: 24, height: 24)
-                .background(
-                    Circle()
-                        .fill(VColor.success.opacity(0.15))
-                )
-
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text(title)
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.textPrimary)
-
-                Text(description)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
-                    .lineSpacing(1)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(VSpacing.lg)
-        .vCard(background: VColor.surfaceSubtle)
-    }
-
-    // MARK: - Try It
-
-    private var tryItPrompt: some View {
-        HStack(spacing: VSpacing.md) {
-            Image(systemName: "mic.fill")
-                .font(.system(size: 14))
-                .foregroundColor(VColor.textSecondary)
-
-            HStack(spacing: VSpacing.xs) {
-                Text("Try it now")
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.textPrimary)
-
-                Text("\u{2014} say")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textSecondary)
-
-                Text(wakeWordKeyword)
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(.white)
-                    .padding(.horizontal, VSpacing.sm)
-                    .padding(.vertical, VSpacing.xxs)
-                    .background(
-                        Capsule()
-                            .fill(Forest._700)
-                    )
-
-                Text("followed by a question")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textSecondary)
-            }
-        }
-        .padding(VSpacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(VColor.success.opacity(0.08))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
-                        .strokeBorder(VColor.success.opacity(0.2), style: StrokeStyle(lineWidth: 1, dash: [6, 4]))
-                )
-        )
-    }
-
-    // MARK: - Section Divider
-
-    private var settingsDivider: some View {
-        HStack(spacing: VSpacing.md) {
-            Text("SETTINGS")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(VColor.textMuted)
-                .tracking(1)
-
-            Rectangle()
-                .fill(VColor.surfaceBorder)
-                .frame(height: 1)
-        }
-    }
-
-    // MARK: - Enable/Disable
-
-    private var enableSection: some View {
-        HStack {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text("Enable wake word listening")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textPrimary)
-                Text("Activate the assistant by speaking instead of using a keyboard shortcut.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
-            }
-            Spacer()
-            VToggle(isOn: $wakeWordEnabled)
-                .accessibilityLabel("Enable wake word listening")
-        }
-        .padding(VSpacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceSubtle)
-    }
-
-    // MARK: - Keyword
-
-    private var keywordSection: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Keyword")
-                .font(VFont.bodyMedium)
-                .foregroundColor(VColor.textPrimary)
-
-            TextField("Enter wake word or phrase", text: $wakeWordKeyword)
-                .vInputStyle()
-                .accessibilityLabel("Wake word keyword")
-
-            HStack(spacing: VSpacing.sm) {
-                ForEach(suggestedKeywords, id: \.self) { suggestion in
-                    Button(suggestion) {
-                        wakeWordKeyword = suggestion
-                    }
-                    .buttonStyle(.plain)
-                    .font(VFont.caption)
-                    .foregroundColor(wakeWordKeyword == suggestion ? .white : VColor.textMuted)
-                    .padding(.horizontal, VSpacing.sm)
-                    .padding(.vertical, VSpacing.xs)
-                    .background(
-                        Capsule()
-                            .fill(wakeWordKeyword == suggestion ? Forest._700 : VColor.surface)
-                    )
-                    .overlay(
-                        Capsule()
-                            .strokeBorder(wakeWordKeyword == suggestion ? Color.clear : VColor.surfaceBorder, lineWidth: 1)
-                    )
-                }
-            }
-
-            HStack(spacing: VSpacing.xs) {
-                Image(systemName: "lock.fill")
-                    .font(.system(size: 10))
-                    .foregroundColor(VColor.textMuted)
-                Text("Type any word or phrase. Uses on-device speech recognition \u{2014} no data leaves your Mac.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
-            }
-        }
-        .padding(VSpacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceSubtle)
-    }
-
-    // MARK: - Timeout
 
     private let timeoutOptions: [(label: String, value: Int)] = [
         (label: "5 seconds", value: 5),
@@ -376,104 +26,162 @@ struct VoiceSettingsView: View {
         (label: "60 seconds", value: 60),
     ]
 
-    private var timeoutSection: some View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xl) {
+            pushToTalkCard
+            wakeWordCard
+            textToSpeechCard
+        }
+    }
+
+    // MARK: - Push to Talk Card
+
+    private var pushToTalkCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text("Conversation timeout")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textPrimary)
-                Text("How long to wait for follow-up speech before ending the conversation.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
+            Text("Push to Talk")
+                .font(VFont.sectionTitle)
+                .foregroundColor(VColor.textPrimary)
+
+            HStack {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Activation key")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Text("Hold this key to dictate text or start a voice conversation.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+                Spacer()
+                VDropdown(
+                    placeholder: "Select key\u{2026}",
+                    selection: Binding(
+                        get: { selectedActivationKey },
+                        set: { activationKey = $0.rawValue }
+                    ),
+                    options: ActivationKey.allCases.map { (label: $0.displayName, value: $0) }
+                )
+                .frame(width: 140)
+                .accessibilityLabel("Push to talk activation key")
             }
-            VDropdown(
-                placeholder: "Select timeout\u{2026}",
-                selection: $wakeWordTimeoutSeconds,
-                options: timeoutOptions
-            )
-            .frame(width: 160)
-            .accessibilityLabel("Conversation timeout duration")
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: selectedActivationKey != .none ? "checkmark.circle.fill" : "xmark.circle")
+                    .foregroundColor(selectedActivationKey != .none ? VColor.success : VColor.textMuted)
+                    .font(.system(size: 14))
+                Text(selectedActivationKey != .none
+                     ? "Active — activation key: \(selectedActivationKey.displayName)"
+                     : "Push to talk disabled")
+                    .font(VFont.body)
+                    .foregroundColor(selectedActivationKey != .none ? VColor.success : VColor.textSecondary)
+                Spacer()
+            }
+
+            Text("Uses on-device speech recognition — audio never leaves your Mac.")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
     }
 
-    // MARK: - Privacy Note
+    // MARK: - Wake Word Card
 
-    private var privacyNote: some View {
-        HStack(alignment: .top, spacing: VSpacing.sm) {
-            Image(systemName: "shield.fill")
-                .font(.system(size: 12))
-                .foregroundColor(VColor.textMuted)
-
-            Text("Wake word detection runs entirely on your device using Apple's Speech framework. Audio is only processed when the wake word is detected, and no recordings are stored or sent anywhere.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
-                .lineSpacing(2)
-        }
-        .padding(VSpacing.lg)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.md)
-                .fill(Color.white.opacity(0.02))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
-                )
-        )
-    }
-
-    // MARK: - TTS Section Divider
-
-    private var ttsDivider: some View {
-        HStack(spacing: VSpacing.md) {
-            Text("TEXT-TO-SPEECH")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(VColor.textMuted)
-                .tracking(1)
-
-            Rectangle()
-                .fill(VColor.surfaceBorder)
-                .frame(height: 1)
-        }
-    }
-
-    // MARK: - TTS Status
-
-    private var ttsStatusSection: some View {
-        HStack(spacing: VSpacing.sm) {
-            Circle()
-                .fill(store.hasElevenLabsKey ? VColor.success : VColor.textMuted)
-                .frame(width: 8, height: 8)
-
-            Text(store.hasElevenLabsKey ? "ElevenLabs API key saved" : "ElevenLabs not configured")
-                .font(VFont.body)
-                .foregroundColor(store.hasElevenLabsKey ? VColor.success : VColor.textSecondary)
-
-            Spacer()
-        }
-        .padding(VSpacing.lg)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(store.hasElevenLabsKey ? VColor.success.opacity(0.08) : VColor.surfaceSubtle)
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
-                        .strokeBorder(store.hasElevenLabsKey ? VColor.success.opacity(0.2) : VColor.surfaceBorder, lineWidth: 1)
-                )
-        )
-    }
-
-    // MARK: - TTS Key Section
-
-    private var ttsKeySection: some View {
+    private var wakeWordCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("ElevenLabs API Key")
-                .font(VFont.bodyMedium)
+            Text("Wake Word")
+                .font(VFont.sectionTitle)
                 .foregroundColor(VColor.textPrimary)
 
-            Text("ElevenLabs provides high-quality voice responses during voice conversations. An API key is required.")
+            HStack {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Enable wake word listening")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Text("Activate the assistant by speaking instead of using a keyboard shortcut.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+                Spacer()
+                VToggle(isOn: $wakeWordEnabled)
+                    .accessibilityLabel("Enable wake word listening")
+            }
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            HStack {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Keyword")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Text("The word or phrase that triggers listening.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+                Spacer()
+                TextField("Enter wake word", text: $wakeWordKeyword)
+                    .vInputStyle()
+                    .frame(width: 180)
+                    .accessibilityLabel("Wake word keyword")
+            }
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            HStack {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Conversation timeout")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Text("How long to wait for follow-up speech before ending the conversation.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+                Spacer()
+                VDropdown(
+                    placeholder: "Select timeout\u{2026}",
+                    selection: $wakeWordTimeoutSeconds,
+                    options: timeoutOptions
+                )
+                .frame(width: 140)
+                .accessibilityLabel("Conversation timeout duration")
+            }
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: wakeWordEnabled ? "checkmark.circle.fill" : "xmark.circle")
+                    .foregroundColor(wakeWordEnabled ? VColor.success : VColor.textMuted)
+                    .font(.system(size: 14))
+                Text(wakeWordEnabled
+                     ? "Listening for \"\(wakeWordKeyword)\""
+                     : "Wake word disabled")
+                    .font(VFont.body)
+                    .foregroundColor(wakeWordEnabled ? VColor.success : VColor.textSecondary)
+                Spacer()
+            }
+
+            Text("Wake word detection runs entirely on your device using Apple\u{2019}s Speech framework. No audio is stored or transmitted.")
                 .font(VFont.caption)
                 .foregroundColor(VColor.textMuted)
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard(background: VColor.surfaceSubtle)
+    }
+
+    // MARK: - Text-to-Speech Card
+
+    private var textToSpeechCard: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("Text-to-Speech")
+                .font(VFont.sectionTitle)
+                .foregroundColor(VColor.textPrimary)
 
             if store.hasElevenLabsKey {
                 HStack(spacing: VSpacing.sm) {
@@ -490,29 +198,43 @@ struct VoiceSettingsView: View {
                     }
                 }
             } else {
+                HStack {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("ElevenLabs API Key")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                        Text("Required for high-quality voice responses during voice conversations.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    Spacer()
+                }
+
                 VInlineActionField(text: $elevenLabsKeyText, placeholder: "Your ElevenLabs API key", isSecure: true) {
                     store.saveElevenLabsKey(elevenLabsKeyText)
                     elevenLabsKeyText = ""
                 }
             }
-        }
-        .padding(VSpacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceSubtle)
-    }
 
-    // MARK: - TTS Privacy Note
+            Divider()
+                .background(VColor.surfaceBorder)
 
-    private var ttsPrivacyNote: some View {
-        HStack(alignment: .top, spacing: VSpacing.sm) {
-            Image(systemName: "lock.fill")
-                .font(.system(size: 10))
-                .foregroundColor(VColor.textMuted)
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: store.hasElevenLabsKey ? "checkmark.circle.fill" : "xmark.circle")
+                    .foregroundColor(store.hasElevenLabsKey ? VColor.success : VColor.textMuted)
+                    .font(.system(size: 14))
+                Text(store.hasElevenLabsKey ? "ElevenLabs API key saved" : "ElevenLabs not configured")
+                    .font(VFont.body)
+                    .foregroundColor(store.hasElevenLabsKey ? VColor.success : VColor.textSecondary)
+                Spacer()
+            }
 
             Text("Your API key is stored securely in the macOS Keychain and is only used to generate voice responses.")
                 .font(VFont.caption)
                 .foregroundColor(VColor.textMuted)
-                .lineSpacing(2)
         }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard(background: VColor.surfaceSubtle)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -21,8 +21,12 @@ struct VoiceSettingsView: View {
         ActivationKey(rawValue: activationKey) ?? .fn
     }
 
+    private var pttEnabled: Bool {
+        selectedActivationKey != .none
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xl) {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
             pttCard
             wakeWordCard
             ttsCard
@@ -42,26 +46,43 @@ struct VoiceSettingsView: View {
                     .foregroundColor(VColor.textMuted)
             }
 
-            Divider().background(VColor.surfaceBorder)
-
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
-                Text("Activation key")
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.textPrimary)
-
-                HStack(spacing: VSpacing.sm) {
-                    ForEach(ActivationKey.allCases, id: \.rawValue) { key in
-                        Button(key.displayName) {
-                            activationKey = key.rawValue
+            HStack {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Enable Push to Talk")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                }
+                Spacer()
+                VToggle(isOn: Binding(
+                    get: { pttEnabled },
+                    set: { enabled in
+                        if enabled {
+                            if activationKey == ActivationKey.none.rawValue {
+                                activationKey = ActivationKey.fn.rawValue
+                            }
+                        } else {
+                            activationKey = ActivationKey.none.rawValue
                         }
-                        .buttonStyle(.plain)
-                        .font(VFont.caption)
-                        .foregroundColor(selectedActivationKey == key ? .white : VColor.textMuted)
-                        .padding(.horizontal, VSpacing.sm)
-                        .padding(.vertical, VSpacing.xs)
-                        .background(Capsule().fill(selectedActivationKey == key ? Forest._700 : VColor.surface))
-                        .overlay(Capsule().strokeBorder(selectedActivationKey == key ? Color.clear : VColor.surfaceBorder, lineWidth: 1))
                     }
+                ))
+                .accessibilityLabel("Enable Push to Talk")
+            }
+
+            if pttEnabled {
+                Divider().background(VColor.surfaceBorder)
+
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    Text("Activation key")
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(VColor.textPrimary)
+
+                    VSegmentedControl(
+                        items: ActivationKey.allCases.filter { $0 != .none }.map {
+                            (label: $0.displayName, tag: $0.rawValue)
+                        },
+                        selection: $activationKey,
+                        style: .pill
+                    )
                 }
             }
         }
@@ -83,8 +104,6 @@ struct VoiceSettingsView: View {
                     .foregroundColor(VColor.textMuted)
                     .lineSpacing(2)
             }
-
-            Divider().background(VColor.surfaceBorder)
 
             HStack {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
@@ -127,15 +146,6 @@ struct VoiceSettingsView: View {
                             .overlay(Capsule().strokeBorder(wakeWordKeyword == suggestion ? Color.clear : VColor.surfaceBorder, lineWidth: 1))
                         }
                     }
-
-                    HStack(spacing: VSpacing.xs) {
-                        Image(systemName: "lock.fill")
-                            .font(.system(size: 10))
-                            .foregroundColor(VColor.textMuted)
-                        Text("Type any word or phrase. Uses on-device speech recognition \u{2014} no data leaves your Mac.")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-                    }
                 }
 
                 Divider().background(VColor.surfaceBorder)
@@ -159,10 +169,51 @@ struct VoiceSettingsView: View {
                     .accessibilityLabel("Conversation timeout duration")
                 }
             }
+
+            Divider().background(VColor.surfaceBorder)
+
+            // How it works steps
+            HStack(alignment: .top, spacing: VSpacing.md) {
+                wakeWordStepCard(number: "1", title: "Say the keyword", description: "Speak your wake word when you\u{2019}re ready to talk.")
+                wakeWordStepCard(number: "2", title: "Vellum starts listening", description: "A chime plays and your microphone activates.")
+                wakeWordStepCard(number: "3", title: "Ask anything", description: "Speak naturally. Vellum responds when you pause.")
+            }
+
+            // Privacy note
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 10))
+                    .foregroundColor(VColor.textMuted)
+                Text("Uses on-device speech recognition \u{2014} no data leaves your Mac.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            }
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
+    }
+
+    private func wakeWordStepCard(number: String, title: String, description: String) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text(number)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(VColor.success)
+                .frame(width: 24, height: 24)
+                .background(Circle().fill(VColor.success.opacity(0.15)))
+
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text(title)
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.textPrimary)
+                Text(description)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .lineSpacing(1)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private let timeoutOptions: [(label: String, value: Int)] = [
@@ -185,8 +236,6 @@ struct VoiceSettingsView: View {
                     .font(VFont.caption)
                     .foregroundColor(VColor.textMuted)
             }
-
-            Divider().background(VColor.surfaceBorder)
 
             if store.hasElevenLabsKey {
                 HStack(spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -69,8 +69,6 @@ struct VoiceSettingsView: View {
             }
 
             if pttEnabled {
-                Divider().background(VColor.surfaceBorder)
-
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("Activation key")
                         .font(VFont.bodyMedium)
@@ -83,6 +81,7 @@ struct VoiceSettingsView: View {
                         selection: $activationKey,
                         style: .pill
                     )
+                    .frame(width: 360)
                 }
             }
         }
@@ -120,8 +119,6 @@ struct VoiceSettingsView: View {
             }
 
             if wakeWordEnabled {
-                Divider().background(VColor.surfaceBorder)
-
                 // Keyword
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("Keyword")
@@ -148,8 +145,6 @@ struct VoiceSettingsView: View {
                     }
                 }
 
-                Divider().background(VColor.surfaceBorder)
-
                 // Conversation timeout
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
@@ -168,25 +163,23 @@ struct VoiceSettingsView: View {
                     .frame(width: 160)
                     .accessibilityLabel("Conversation timeout duration")
                 }
-            }
 
-            Divider().background(VColor.surfaceBorder)
+                // How it works steps
+                HStack(alignment: .top, spacing: VSpacing.md) {
+                    wakeWordStepCard(number: "1", title: "Say the keyword", description: "Speak your wake word when you\u{2019}re ready to talk.")
+                    wakeWordStepCard(number: "2", title: "Vellum starts listening", description: "A chime plays and your microphone activates.")
+                    wakeWordStepCard(number: "3", title: "Ask anything", description: "Speak naturally. Vellum responds when you pause.")
+                }
 
-            // How it works steps
-            HStack(alignment: .top, spacing: VSpacing.md) {
-                wakeWordStepCard(number: "1", title: "Say the keyword", description: "Speak your wake word when you\u{2019}re ready to talk.")
-                wakeWordStepCard(number: "2", title: "Vellum starts listening", description: "A chime plays and your microphone activates.")
-                wakeWordStepCard(number: "3", title: "Ask anything", description: "Speak naturally. Vellum responds when you pause.")
-            }
-
-            // Privacy note
-            HStack(spacing: VSpacing.xs) {
-                Image(systemName: "lock.fill")
-                    .font(.system(size: 10))
-                    .foregroundColor(VColor.textMuted)
-                Text("Uses on-device speech recognition \u{2014} no data leaves your Mac.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
+                // Privacy note
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "lock.fill")
+                        .font(.system(size: 10))
+                        .foregroundColor(VColor.textMuted)
+                    Text("Uses on-device speech recognition \u{2014} no data leaves your Mac.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
             }
         }
         .padding(VSpacing.lg)

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -119,6 +119,13 @@ struct VoiceSettingsView: View {
             }
 
             if wakeWordEnabled {
+                // How it works steps
+                HStack(alignment: .top, spacing: VSpacing.md) {
+                    wakeWordStepCard(number: "1", title: "Say the keyword", description: "Speak your wake word when you\u{2019}re ready to talk.")
+                    wakeWordStepCard(number: "2", title: "Vellum starts listening", description: "A chime plays and your microphone activates.")
+                    wakeWordStepCard(number: "3", title: "Ask anything", description: "Speak naturally. Vellum responds when you pause.")
+                }
+
                 // Keyword
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("Keyword")
@@ -164,13 +171,6 @@ struct VoiceSettingsView: View {
                     .accessibilityLabel("Conversation timeout duration")
                 }
 
-                // How it works steps
-                HStack(alignment: .top, spacing: VSpacing.md) {
-                    wakeWordStepCard(number: "1", title: "Say the keyword", description: "Speak your wake word when you\u{2019}re ready to talk.")
-                    wakeWordStepCard(number: "2", title: "Vellum starts listening", description: "A chime plays and your microphone activates.")
-                    wakeWordStepCard(number: "3", title: "Ask anything", description: "Speak naturally. Vellum responds when you pause.")
-                }
-
                 // Privacy note
                 HStack(spacing: VSpacing.xs) {
                     Image(systemName: "lock.fill")
@@ -188,7 +188,7 @@ struct VoiceSettingsView: View {
     }
 
     private func wakeWordStepCard(number: String, title: String, description: String) -> some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
             Text(number)
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundColor(VColor.success)
@@ -203,10 +203,11 @@ struct VoiceSettingsView: View {
                     .font(VFont.caption)
                     .foregroundColor(VColor.textMuted)
                     .lineSpacing(1)
-                    .fixedSize(horizontal: false, vertical: true)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(VSpacing.lg)
+        .vCard(background: VColor.surfaceSubtle)
     }
 
     private let timeoutOptions: [(label: String, value: Int)] = [

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -129,7 +129,7 @@ struct VoiceSettingsView: View {
                 // Keyword
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("Keyword")
-                        .font(VFont.bodyMedium)
+                        .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
 
                     TextField("Enter wake word or phrase", text: $wakeWordKeyword)

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -261,12 +261,11 @@ struct VoiceSettingsView: View {
                     }
 
                     HStack(spacing: VSpacing.sm) {
-                        VButton(label: "Connect", style: .secondary, size: .large) {
+                        VButton(label: "Connect", style: .secondary, size: .large, isDisabled: elevenLabsKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
                             store.saveElevenLabsKey(elevenLabsKeyText)
                             elevenLabsKeyText = ""
                             ttsSetupExpanded = false
                         }
-                        .disabled(elevenLabsKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                         VButton(label: "Cancel", style: .tertiary, size: .large) {
                             ttsSetupExpanded = false
                             elevenLabsKeyText = ""

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -3,7 +3,7 @@ import VellumAssistantShared
 
 /// Voice settings tab — configure push-to-talk activation key,
 /// enable/disable wake word listening, configure keyword phrase,
-/// conversation timeout, and text-to-speech.
+/// and conversation timeout.
 struct VoiceSettingsView: View {
     @ObservedObject var store: SettingsStore
 
@@ -13,75 +13,57 @@ struct VoiceSettingsView: View {
     @AppStorage("wakeWordKeyword") private var wakeWordKeyword: String = "computer"
 
     @State private var elevenLabsKeyText: String = ""
+    @State private var ttsSetupExpanded: Bool = false
+
+    private let suggestedKeywords = ["computer", "jarvis", "hey vellum", "assistant"]
 
     private var selectedActivationKey: ActivationKey {
         ActivationKey(rawValue: activationKey) ?? .fn
     }
 
-    private let timeoutOptions: [(label: String, value: Int)] = [
-        (label: "5 seconds", value: 5),
-        (label: "10 seconds", value: 10),
-        (label: "15 seconds", value: 15),
-        (label: "30 seconds", value: 30),
-        (label: "60 seconds", value: 60),
-    ]
-
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
-            pushToTalkCard
+            pttCard
             wakeWordCard
-            textToSpeechCard
+            ttsCard
         }
     }
 
     // MARK: - Push to Talk Card
 
-    private var pushToTalkCard: some View {
+    private var pttCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Push to Talk")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.textPrimary)
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Push to Talk")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+                Text("Hold the activation key to dictate text or start a voice conversation. Uses on-device speech recognition.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            }
 
-            HStack {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Activation key")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textSecondary)
-                    Text("Hold this key to dictate text or start a voice conversation.")
+            Divider().background(VColor.surfaceBorder)
+
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Text("Activation key")
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.textPrimary)
+
+                HStack(spacing: VSpacing.sm) {
+                    ForEach(ActivationKey.allCases, id: \.rawValue) { key in
+                        Button(key.displayName) {
+                            activationKey = key.rawValue
+                        }
+                        .buttonStyle(.plain)
                         .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
+                        .foregroundColor(selectedActivationKey == key ? .white : VColor.textMuted)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(Capsule().fill(selectedActivationKey == key ? Forest._700 : VColor.surface))
+                        .overlay(Capsule().strokeBorder(selectedActivationKey == key ? Color.clear : VColor.surfaceBorder, lineWidth: 1))
+                    }
                 }
-                Spacer()
-                VDropdown(
-                    placeholder: "Select key\u{2026}",
-                    selection: Binding(
-                        get: { selectedActivationKey },
-                        set: { activationKey = $0.rawValue }
-                    ),
-                    options: ActivationKey.allCases.map { (label: $0.displayName, value: $0) }
-                )
-                .frame(width: 140)
-                .accessibilityLabel("Push to talk activation key")
             }
-
-            Divider()
-                .background(VColor.surfaceBorder)
-
-            HStack(spacing: VSpacing.sm) {
-                Image(systemName: selectedActivationKey != .none ? "checkmark.circle.fill" : "xmark.circle")
-                    .foregroundColor(selectedActivationKey != .none ? VColor.success : VColor.textMuted)
-                    .font(.system(size: 14))
-                Text(selectedActivationKey != .none
-                     ? "Active — activation key: \(selectedActivationKey.displayName)"
-                     : "Push to talk disabled")
-                    .font(VFont.body)
-                    .foregroundColor(selectedActivationKey != .none ? VColor.success : VColor.textSecondary)
-                Spacer()
-            }
-
-            Text("Uses on-device speech recognition — audio never leaves your Mac.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -92,15 +74,23 @@ struct VoiceSettingsView: View {
 
     private var wakeWordCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Wake Word")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.textPrimary)
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Talk to Vellum, hands free")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+                Text("Wake word lets you start a conversation by speaking a keyword aloud \u{2014} no need to click or press anything. It uses on-device speech recognition, so nothing you say ever leaves your Mac.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .lineSpacing(2)
+            }
+
+            Divider().background(VColor.surfaceBorder)
 
             HStack {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text("Enable wake word listening")
                         .font(VFont.body)
-                        .foregroundColor(VColor.textSecondary)
+                        .foregroundColor(VColor.textPrimary)
                     Text("Activate the assistant by speaking instead of using a keyboard shortcut.")
                         .font(VFont.caption)
                         .foregroundColor(VColor.textMuted)
@@ -110,128 +100,141 @@ struct VoiceSettingsView: View {
                     .accessibilityLabel("Enable wake word listening")
             }
 
-            Divider()
-                .background(VColor.surfaceBorder)
+            if wakeWordEnabled {
+                Divider().background(VColor.surfaceBorder)
 
-            HStack {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                // Keyword
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("Keyword")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textSecondary)
-                    Text("The word or phrase that triggers listening.")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(VColor.textPrimary)
+
+                    TextField("Enter wake word or phrase", text: $wakeWordKeyword)
+                        .vInputStyle()
+                        .accessibilityLabel("Wake word keyword")
+
+                    HStack(spacing: VSpacing.sm) {
+                        ForEach(suggestedKeywords, id: \.self) { suggestion in
+                            Button(suggestion) {
+                                wakeWordKeyword = suggestion
+                            }
+                            .buttonStyle(.plain)
+                            .font(VFont.caption)
+                            .foregroundColor(wakeWordKeyword == suggestion ? .white : VColor.textMuted)
+                            .padding(.horizontal, VSpacing.sm)
+                            .padding(.vertical, VSpacing.xs)
+                            .background(Capsule().fill(wakeWordKeyword == suggestion ? Forest._700 : VColor.surface))
+                            .overlay(Capsule().strokeBorder(wakeWordKeyword == suggestion ? Color.clear : VColor.surfaceBorder, lineWidth: 1))
+                        }
+                    }
+
+                    HStack(spacing: VSpacing.xs) {
+                        Image(systemName: "lock.fill")
+                            .font(.system(size: 10))
+                            .foregroundColor(VColor.textMuted)
+                        Text("Type any word or phrase. Uses on-device speech recognition \u{2014} no data leaves your Mac.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
                 }
-                Spacer()
-                TextField("Enter wake word", text: $wakeWordKeyword)
-                    .vInputStyle()
-                    .frame(width: 180)
-                    .accessibilityLabel("Wake word keyword")
-            }
 
-            Divider()
-                .background(VColor.surfaceBorder)
+                Divider().background(VColor.surfaceBorder)
 
-            HStack {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Conversation timeout")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textSecondary)
-                    Text("How long to wait for follow-up speech before ending the conversation.")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
+                // Conversation timeout
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Conversation timeout")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                        Text("How long to wait for follow-up speech before ending the conversation.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    VDropdown(
+                        placeholder: "Select timeout\u{2026}",
+                        selection: $wakeWordTimeoutSeconds,
+                        options: timeoutOptions
+                    )
+                    .frame(width: 160)
+                    .accessibilityLabel("Conversation timeout duration")
                 }
-                Spacer()
-                VDropdown(
-                    placeholder: "Select timeout\u{2026}",
-                    selection: $wakeWordTimeoutSeconds,
-                    options: timeoutOptions
-                )
-                .frame(width: 140)
-                .accessibilityLabel("Conversation timeout duration")
             }
-
-            Divider()
-                .background(VColor.surfaceBorder)
-
-            HStack(spacing: VSpacing.sm) {
-                Image(systemName: wakeWordEnabled ? "checkmark.circle.fill" : "xmark.circle")
-                    .foregroundColor(wakeWordEnabled ? VColor.success : VColor.textMuted)
-                    .font(.system(size: 14))
-                Text(wakeWordEnabled
-                     ? "Listening for \"\(wakeWordKeyword)\""
-                     : "Wake word disabled")
-                    .font(VFont.body)
-                    .foregroundColor(wakeWordEnabled ? VColor.success : VColor.textSecondary)
-                Spacer()
-            }
-
-            Text("Wake word detection runs entirely on your device using Apple\u{2019}s Speech framework. No audio is stored or transmitted.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
     }
 
+    private let timeoutOptions: [(label: String, value: Int)] = [
+        (label: "5 seconds", value: 5),
+        (label: "10 seconds", value: 10),
+        (label: "15 seconds", value: 15),
+        (label: "30 seconds", value: 30),
+        (label: "60 seconds", value: 60),
+    ]
+
     // MARK: - Text-to-Speech Card
 
-    private var textToSpeechCard: some View {
+    private var ttsCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Text-to-Speech")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.textPrimary)
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Text-to-Speech")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+                Text("ElevenLabs provides high-quality voice responses during voice conversations. An API key is required.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            }
+
+            Divider().background(VColor.surfaceBorder)
 
             if store.hasElevenLabsKey {
                 HStack(spacing: VSpacing.sm) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(VColor.success)
-                        .font(.system(size: 14))
-                    Text(store.maskedElevenLabsKey)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textSecondary)
-                    Spacer()
-                    VButton(label: "Remove", style: .danger) {
+                    VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success, size: .large) {}
+                    VButton(label: "Disconnect", style: .danger, size: .large) {
                         store.clearElevenLabsKey()
                         elevenLabsKeyText = ""
+                        ttsSetupExpanded = false
                     }
                 }
-            } else {
-                HStack {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        Text("ElevenLabs API Key")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textSecondary)
-                        Text("Required for high-quality voice responses during voice conversations.")
+            } else if ttsSetupExpanded {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    Text("ElevenLabs API Key")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+
+                    SecureField("Your ElevenLabs API key", text: $elevenLabsKeyText)
+                        .vInputStyle()
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+
+                    HStack(spacing: VSpacing.xs) {
+                        Image(systemName: "lock.fill")
+                            .font(.system(size: 10))
+                            .foregroundColor(VColor.textMuted)
+                        Text("Your API key is stored securely in the macOS Keychain.")
                             .font(VFont.caption)
                             .foregroundColor(VColor.textMuted)
                     }
-                    Spacer()
-                }
 
-                VInlineActionField(text: $elevenLabsKeyText, placeholder: "Your ElevenLabs API key", isSecure: true) {
-                    store.saveElevenLabsKey(elevenLabsKeyText)
-                    elevenLabsKeyText = ""
+                    HStack(spacing: VSpacing.sm) {
+                        VButton(label: "Connect", style: .secondary, size: .large) {
+                            store.saveElevenLabsKey(elevenLabsKeyText)
+                            elevenLabsKeyText = ""
+                            ttsSetupExpanded = false
+                        }
+                        .disabled(elevenLabsKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        VButton(label: "Cancel", style: .tertiary, size: .large) {
+                            ttsSetupExpanded = false
+                            elevenLabsKeyText = ""
+                        }
+                    }
+                }
+            } else {
+                VButton(label: "Set Up", style: .secondary, size: .large) {
+                    ttsSetupExpanded = true
                 }
             }
-
-            Divider()
-                .background(VColor.surfaceBorder)
-
-            HStack(spacing: VSpacing.sm) {
-                Image(systemName: store.hasElevenLabsKey ? "checkmark.circle.fill" : "xmark.circle")
-                    .foregroundColor(store.hasElevenLabsKey ? VColor.success : VColor.textMuted)
-                    .font(.system(size: 14))
-                Text(store.hasElevenLabsKey ? "ElevenLabs API key saved" : "ElevenLabs not configured")
-                    .font(VFont.body)
-                    .foregroundColor(store.hasElevenLabsKey ? VColor.success : VColor.textSecondary)
-                Spacer()
-            }
-
-            Text("Your API key is stored securely in the macOS Keychain and is only used to generate voice responses.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
Redesigns the Voice Settings tab (`VoiceSettingsView.swift`) to match the visual language used across all other settings tabs (Privacy, Appearance, Account, Advanced, Automation). The view was using one-off styling that was inconsistent with the rest of the settings UI.

## Changes
- Remove custom caps-text + horizontal-line section dividers; replace with card-grouped sections using `VFont.sectionTitle` headers
- Replace custom `Circle`-dot status indicators with the standard `checkmark.circle.fill` icon pattern
- Replace custom `Capsule` button rows for activation key picker with `VDropdown`
- Remove promotional education hero, how-it-works step cards, and try-it prompt (marketing content, not settings UI)
- Replace keyword suggestion capsule buttons with a plain `TextField`
- Convert floating privacy notes into inline caption text inside cards
- Apply standard `HStack` row pattern (label+description left, control right) with `Divider()` between rows
- All three sections (PTT, Wake Word, TTS) now use consistent `.vCard(background: VColor.surfaceSubtle)` wrappers
- View reduced from 519 → 241 lines

## Milestone PRs (merged into feature branch)
- #11280: fix: redesign Voice Settings view to match other settings tabs

## Project issue
Closes #11277

## Test plan
- [ ] Open Settings → Voice tab and verify 3 clean card sections (Push to Talk, Wake Word, Text-to-Speech)
- [ ] Verify activation key picker shows as VDropdown, changes persist
- [ ] Verify wake word toggle and keyword field work correctly
- [ ] Verify ElevenLabs API key save/remove works
- [ ] Verify visual consistency with Privacy, Appearance, and Account tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
