### PR TITLE
Fix chat thread scrollbar visibility and switch flicker

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Combine
 import os
 import SwiftUI
@@ -66,6 +67,11 @@ struct MessageListView: View {
     /// Suppresses bottom auto-scroll for the ~32ms layout window after pagination
     /// restores scroll position, preventing a jump back to the bottom.
     @State private var isSuppressingBottomScroll: Bool = false
+    @State private var isThreadContentHovered: Bool = false
+    @State private var isAppActive: Bool = NSApp.isActive
+    @State private var hoverExitDebounceTask: Task<Void, Never>?
+    @State private var threadSwitchSuppressionTask: Task<Void, Never>?
+    @State private var suppressScrollbarDuringThreadSwitch: Bool = false
 
     /// The subset of messages actually shown, honoring the pagination window.
     private var visibleMessages: [ChatMessage] {
@@ -117,6 +123,28 @@ struct MessageListView: View {
 
     private func modelListView(for message: ChatMessage) -> some View {
         ModelListBubble(currentModel: selectedModel, configuredProviders: configuredProviders)
+    }
+
+    private var shouldShowThreadScrollbar: Bool {
+        isAppActive && isThreadContentHovered && !suppressScrollbarDuringThreadSwitch
+    }
+
+    private func handleThreadContentHover(_ hovering: Bool) {
+        if hovering {
+            hoverExitDebounceTask?.cancel()
+            hoverExitDebounceTask = nil
+            isThreadContentHovered = true
+            return
+        }
+
+        // SwiftUI/AppKit can emit rapid hover false/true transitions while moving
+        // across nested subviews; delay hide slightly to avoid visible flicker.
+        hoverExitDebounceTask?.cancel()
+        hoverExitDebounceTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 120_000_000)
+            isThreadContentHovered = false
+            hoverExitDebounceTask = nil
+        }
     }
 
     private var shouldAnchorThinkingToConfirmationChip: Bool {
@@ -394,11 +422,15 @@ struct MessageListView: View {
             }
             .scrollContentBackground(.hidden)
             .scrollDisabled(messages.isEmpty && !isSending)
+            .onHover { hovering in
+                handleThreadContentHover(hovering)
+            }
             .background {
                 ScrollWheelDetector(
                     onScrollUp: { isNearBottom = false },
                     onScrollToBottom: { isNearBottom = true }
                 )
+                ThreadScrollbarVisibilityController(shouldShow: shouldShowThreadScrollbar)
             }
             .overlay(alignment: .bottom) {
                 if !isNearBottom {
@@ -427,7 +459,14 @@ struct MessageListView: View {
                 }
             }
             .onAppear {
+                isAppActive = NSApp.isActive
                 proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+            }
+            .onDisappear {
+                hoverExitDebounceTask?.cancel()
+                hoverExitDebounceTask = nil
+                threadSwitchSuppressionTask?.cancel()
+                threadSwitchSuppressionTask = nil
             }
             .onChange(of: isSending) {
                 if isSending {
@@ -486,10 +525,122 @@ struct MessageListView: View {
                 }
                 // When mid-scroll, do nothing — let SwiftUI handle the text reflow naturally.
             }
+            .onChange(of: threadId) {
+                // Keep the underlying NSScrollView instance stable across thread
+                // switches (prevents default-scroller flash), and reset view-local
+                // scroll state explicitly instead of remounting the whole view.
+                scrollDebounceTask?.cancel()
+                scrollDebounceTask = nil
+                isPaginationInFlight = false
+                isSuppressingBottomScroll = false
+                isNearBottom = true
+                hoverExitDebounceTask?.cancel()
+                hoverExitDebounceTask = nil
+                threadSwitchSuppressionTask?.cancel()
+                suppressScrollbarDuringThreadSwitch = true
+                threadSwitchSuppressionTask = Task { @MainActor in
+                    // Let the newly-selected thread finish its first layout pass so
+                    // the scroller style/metrics settle before allowing re-show.
+                    try? await Task.sleep(nanoseconds: 150_000_000)
+                    suppressScrollbarDuringThreadSwitch = false
+                    threadSwitchSuppressionTask = nil
+                }
+                isThreadContentHovered = false
+                DispatchQueue.main.async {
+                    proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                }
+            }
             .onReceive(TaskProgressOverlayManager.shared.$activeSurfaceId) { newId in
                 activeSurfaceId = newId
             }
+            .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+                isAppActive = true
+            }
+            .onReceive(NotificationCenter.default.publisher(for: NSApplication.didResignActiveNotification)) { _ in
+                isAppActive = false
+                hoverExitDebounceTask?.cancel()
+                hoverExitDebounceTask = nil
+                threadSwitchSuppressionTask?.cancel()
+                threadSwitchSuppressionTask = nil
+                suppressScrollbarDuringThreadSwitch = false
+                isThreadContentHovered = false
+            }
         }
-        .id(threadId)
+    }
+}
+
+private struct ThreadScrollbarVisibilityController: NSViewRepresentable {
+    let shouldShow: Bool
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async {
+            context.coordinator.update(from: view, shouldShow: shouldShow)
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async {
+            context.coordinator.update(from: nsView, shouldShow: shouldShow)
+        }
+    }
+
+    final class Coordinator {
+        weak var lastResolvedScrollView: NSScrollView?
+
+        func update(from markerView: NSView, shouldShow: Bool) {
+            guard let scrollView = findEnclosingScrollView(from: markerView) ?? lastResolvedScrollView else { return }
+            lastResolvedScrollView = scrollView
+            // Keep the scroller instantiated and styled consistently; only toggle
+            // visibility. Toggling `hasVerticalScroller` can recreate scroller
+            // internals, which causes visible flicker and brief legacy-style flashes.
+            scrollView.hasVerticalScroller = true
+            scrollView.hasHorizontalScroller = false
+            scrollView.autohidesScrollers = false
+            scrollView.scrollerStyle = .overlay
+            scrollView.verticalScroller?.controlSize = .small
+            scrollView.verticalScroller?.isEnabled = shouldShow
+            scrollView.verticalScroller?.isHidden = !shouldShow
+            scrollView.verticalScroller?.alphaValue = shouldShow ? 1 : 0
+            scrollView.reflectScrolledClipView(scrollView.contentView)
+        }
+
+        private func findEnclosingScrollView(from view: NSView) -> NSScrollView? {
+            if let scrollView = view.enclosingScrollView { return scrollView }
+            var current: NSView? = view.superview
+            while let ancestor = current {
+                if let scrollView = ancestor as? NSScrollView {
+                    return scrollView
+                }
+                current = ancestor.superview
+            }
+            guard let window = view.window, let contentView = window.contentView else { return nil }
+            let probeInWindow = view.convert(
+                NSPoint(x: view.bounds.midX, y: view.bounds.midY),
+                to: nil
+            )
+            return deepestScrollView(in: contentView, containing: probeInWindow)
+        }
+
+        private func deepestScrollView(in view: NSView, containing windowPoint: NSPoint) -> NSScrollView? {
+            let localPoint = view.convert(windowPoint, from: nil)
+            guard view.bounds.contains(localPoint) else { return nil }
+
+            for subview in view.subviews.reversed() {
+                if let nested = deepestScrollView(in: subview, containing: windowPoint) {
+                    return nested
+                }
+            }
+
+            if let scrollView = view as? NSScrollView {
+                return scrollView
+            }
+            return nil
+        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -141,7 +141,12 @@ struct MessageListView: View {
         // across nested subviews; delay hide slightly to avoid visible flicker.
         hoverExitDebounceTask?.cancel()
         hoverExitDebounceTask = Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 120_000_000)
+            do {
+                try await Task.sleep(nanoseconds: 120_000_000)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
             isThreadContentHovered = false
             hoverExitDebounceTask = nil
         }
@@ -541,7 +546,12 @@ struct MessageListView: View {
                 threadSwitchSuppressionTask = Task { @MainActor in
                     // Let the newly-selected thread finish its first layout pass so
                     // the scroller style/metrics settle before allowing re-show.
-                    try? await Task.sleep(nanoseconds: 150_000_000)
+                    do {
+                        try await Task.sleep(nanoseconds: 150_000_000)
+                    } catch {
+                        return
+                    }
+                    guard !Task.isCancelled else { return }
                     suppressScrollbarDuringThreadSwitch = false
                     threadSwitchSuppressionTask = nil
                 }


### PR DESCRIPTION
## Summary
- show chat thread vertical scrollbar only when the app is active and the pointer is over thread content
- control the underlying `NSScrollView` directly (overlay/small scroller, visibility toggled without recreating the scroller)
- keep the scroll view instance stable across thread switches by removing remount-by-id and resetting state explicitly on `threadId` changes
- add short hover-exit and thread-switch suppression windows to prevent transient flicker/flash
- remove temporary scrollbar debug logging used during diagnosis

## Validation
- `cd clients/macos && ./build.sh`
- manual verification in app: hover/frontmost gating works and thread-switch flash is reduced

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
