### PR TITLE
Unify app/daemon run instructions around vellum lifecycle CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,18 @@ See [.githooks/README.md](./.githooks/README.md) for more details about availabl
 <details>
 <summary><b>Assistant Runtime</b></summary>
 
-The assistant runtime lives in `/assistant`.
+The assistant runtime lives in `/assistant`. The recommended way to start it is via the `vellum` CLI:
+
+```bash
+vellum wake    # starts daemon + gateway from current checkout
+vellum ps      # check process status
+vellum sleep   # stop daemon + gateway
+```
+
+<details>
+<summary>Development: raw bun commands</summary>
+
+For low-level development (e.g., working on the daemon itself):
 
 ```bash
 cd assistant
@@ -103,6 +114,8 @@ bun run src/index.ts daemon start
 ```
 
 > **Note:** Some dependencies (`agentmail`, `@pydantic/logfire-node`) are optional at runtime but required for full `tsc --noEmit` type-checking to pass. They are installed automatically by `bun install`.
+
+</details>
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ vellum ps      # check process status
 vellum sleep   # stop daemon + gateway
 ```
 
-> **Note:** `vellum wake` requires a hatched assistant. Run `vellum hatch local` first, or launch the macOS app which handles hatching automatically.
+> **Note:** `vellum wake` requires a hatched assistant. Run `vellum hatch` first, or launch the macOS app which handles hatching automatically.
 
 <details>
 <summary>Development: raw bun commands</summary>

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ vellum ps      # check process status
 vellum sleep   # stop daemon + gateway
 ```
 
+> **Note:** `vellum wake` requires a hatched assistant. Run `vellum hatch local` first, or launch the macOS app which handles hatching automatically.
+
 <details>
 <summary>Development: raw bun commands</summary>
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -68,6 +68,8 @@ vellum ps      # list assistants and per-assistant process status
 vellum sleep   # stop daemon + gateway (directory-agnostic)
 ```
 
+> **Note:** `vellum wake` requires a hatched assistant. Run `vellum hatch local` first, or launch the macOS app which handles hatching automatically.
+
 ### Development: raw bun commands
 
 For low-level development (e.g., working on the daemon itself):

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -58,30 +58,35 @@ When a release includes relevant updates, the daemon materializes release notes 
 
 ## Usage
 
-### Start the daemon
+### Lifecycle management (recommended)
+
+Use the `vellum` CLI to manage daemon and gateway processes:
 
 ```bash
-bun run src/index.ts daemon start
+vellum wake    # start daemon + gateway from current checkout
+vellum ps      # list assistants and per-assistant process status
+vellum sleep   # stop daemon + gateway (directory-agnostic)
 ```
 
-### Interactive CLI
+### Development: raw bun commands
+
+For low-level development (e.g., working on the daemon itself):
 
 ```bash
-bun run src/index.ts
-```
-
-### Dev mode (auto-restart on file changes)
-
-```bash
-bun run src/index.ts dev
+bun run src/index.ts daemon start   # start daemon only
+bun run src/index.ts                # interactive CLI session
+bun run src/index.ts dev            # dev mode (auto-restart on file changes)
 ```
 
 ### CLI commands
 
 | Command | Description |
 |---------|-------------|
+| `vellum wake` | Start daemon + gateway from current checkout |
+| `vellum sleep` | Stop daemon + gateway processes |
+| `vellum ps` | List assistants and per-assistant process status |
 | `vellum` | Launch interactive CLI session |
-| `vellum daemon start\|stop\|restart\|status` | Manage the daemon process |
+| `vellum daemon start\|stop\|restart\|status` | Manage the daemon process (low-level) |
 | `vellum dev` | Run daemon with auto-restart on file changes |
 | `vellum sessions list\|new\|export\|clear` | Manage conversation sessions |
 | `vellum config set\|get\|list` | Manage configuration |

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -68,7 +68,7 @@ vellum ps      # list assistants and per-assistant process status
 vellum sleep   # stop daemon + gateway (directory-agnostic)
 ```
 
-> **Note:** `vellum wake` requires a hatched assistant. Run `vellum hatch local` first, or launch the macOS app which handles hatching automatically.
+> **Note:** `vellum wake` requires a hatched assistant. Run `vellum hatch` first, or launch the macOS app which handles hatching automatically.
 
 ### Development: raw bun commands
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -35,6 +35,8 @@ vellum ps
 vellum sleep
 ```
 
+> **Note:** `vellum wake` requires a hatched assistant. Run `vellum hatch local` first, or launch the macOS app which handles hatching automatically.
+
 ### `hatch`
 
 Provision a new assistant instance and bootstrap the Vellum runtime on it.

--- a/cli/README.md
+++ b/cli/README.md
@@ -35,7 +35,7 @@ vellum ps
 vellum sleep
 ```
 
-> **Note:** `vellum wake` requires a hatched assistant. Run `vellum hatch local` first, or launch the macOS app which handles hatching automatically.
+> **Note:** `vellum wake` requires a hatched assistant. Run `vellum hatch` first, or launch the macOS app which handles hatching automatically.
 
 ### `hatch`
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -14,6 +14,27 @@ bun run ./src/index.ts <command> [options]
 
 ## Commands
 
+### Lifecycle: `ps`, `sleep`, `wake`
+
+Day-to-day process management for the daemon and gateway.
+
+| Command | Description |
+|---------|-------------|
+| `vellum ps` | List assistants and per-assistant process status (daemon, gateway PIDs and health). |
+| `vellum sleep` | Stop daemon and gateway processes. Directory-agnostic — works from anywhere. |
+| `vellum wake` | Start the daemon and gateway from the current checkout. |
+
+```bash
+# Start everything
+vellum wake
+
+# Check what's running
+vellum ps
+
+# Stop everything
+vellum sleep
+```
+
 ### `hatch`
 
 Provision a new assistant instance and bootstrap the Vellum runtime on it.

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -75,7 +75,7 @@ cd clients/ios
 
 ### Connected to Mac Mode
 
-Requires the Vellum daemon running on your Mac (via the macOS desktop app or `cd assistant && bun run src/index.ts daemon start` from the repo root). The iOS app connects to the daemon through an HTTP gateway using a bearer token for authentication.
+Requires the Vellum daemon running on your Mac (via the macOS desktop app or `vellum wake` from the CLI). The iOS app connects to the daemon through an HTTP gateway using a bearer token for authentication.
 
 **QR Code Pairing:**
 

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -194,7 +194,19 @@ The macOS app is a frontend — all inference (chat, computer-use sessions, ambi
 **You must start the daemon before using the app.** Without it, the app will connect but get no responses.
 
 ```bash
-# Start the daemon (from the repo root)
+# Recommended: use the vellum CLI (starts daemon + gateway)
+vellum wake
+
+# Check process status
+vellum ps
+
+# Stop everything
+vellum sleep
+```
+
+For low-level development, you can also start the daemon directly:
+
+```bash
 cd assistant && bun run src/index.ts daemon start
 ```
 


### PR DESCRIPTION
## Summary
- Updated docs to recommend vellum ps/sleep/wake as primary lifecycle management
- Distinguished between day-to-day usage (vellum CLI) and advanced development (raw bun commands)
- Removed/updated stale daemon startup instructions across READMEs

Part of #11222

## Test plan
- [ ] Grep for stale startup patterns (bun run src/index.ts daemon start as default path)
- [ ] Manual doc sanity pass from fresh-clone perspective
- [ ] All major docs agree on lifecycle management approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
