### PR TITLE
move /e2e from commands to skills

### DIFF
--- a/.claude/skills/vellum-skills/e2e/SKILL.md
+++ b/.claude/skills/vellum-skills/e2e/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: e2e
+description: >
+  Run end-to-end tests via the CI workflow.
+---
+
 Run end-to-end tests via the CI workflow.
 
 The user may pass `$ARGUMENTS` to filter to a specific test case by name (e.g., `hello-world`, `phone-setup`). If not provided, infer options from context (see below).


### PR DESCRIPTION
## Summary
- Moves `/e2e` from `.claude/commands/e2e.md` to `.claude/skills/vellum-skills/e2e/SKILL.md` with proper frontmatter

## Test plan
- [ ] Verify `/e2e` is available as a skill after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
