### PR TITLE
Add lightweight checks to prevent command/runbook drift regressions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ Most commands are shared from the [`claude-skills`](https://github.com/vellum-ai
 
 | `/update` | Pull latest from main, use `vellum ps/sleep/wake` to manage daemon and gateway lifecycle, rebuild/launch the macOS app, and print a startup summary. Uses `vellum sleep` (directory-agnostic global stop) to quiesce processes, then `vellum wake` (from current checkout) to restart. |
 
+**Lifecycle docs drift guard:** A guard test (`lifecycle-docs-guard.test.ts`) enforces that repo-local commands live in `.claude/skills/vellum-skills/` (not `.claude/commands/`), key docs reference `vellum` CLI lifecycle commands, and stale daemon startup patterns (`bun run src/index.ts daemon start`) are not used as primary instructions outside dev-only contexts.
 
 ## Linear Ticket Hygiene
 

--- a/assistant/src/__tests__/lifecycle-docs-guard.test.ts
+++ b/assistant/src/__tests__/lifecycle-docs-guard.test.ts
@@ -1,0 +1,199 @@
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'bun:test';
+
+/**
+ * Guard test: prevent stale lifecycle instructions from being reintroduced
+ * into documentation. The canonical lifecycle commands are `vellum wake`,
+ * `vellum ps`, and `vellum sleep`. Repo-local slash commands live in
+ * `.claude/skills/vellum-skills/`, not `.claude/commands/`.
+ *
+ * See AGENTS.md for the conventions these tests enforce.
+ */
+
+const REPO_ROOT = join(import.meta.dir, '../../..');
+
+describe('lifecycle docs guard', () => {
+  it('repo-local commands live in skills directory, not commands directory', () => {
+    const staleLocations = [
+      '.claude/commands/update.md',
+      '.claude/commands/release.md',
+    ];
+
+    const violations = staleLocations.filter((p) =>
+      existsSync(join(REPO_ROOT, p)),
+    );
+
+    if (violations.length > 0) {
+      const message = [
+        'Found repo-local commands in .claude/commands/ — they should live in .claude/skills/vellum-skills/.',
+        '',
+        'Stale files:',
+        ...violations.map((f) => `  - ${f}`),
+        '',
+        'Move them to .claude/skills/vellum-skills/<name>/SKILL.md instead.',
+      ].join('\n');
+
+      expect(violations, message).toEqual([]);
+    }
+
+    // Verify the correct locations exist
+    const expectedLocations = [
+      '.claude/skills/vellum-skills/update/SKILL.md',
+      '.claude/skills/vellum-skills/release/SKILL.md',
+    ];
+
+    const missing = expectedLocations.filter(
+      (p) => !existsSync(join(REPO_ROOT, p)),
+    );
+
+    if (missing.length > 0) {
+      const message = [
+        'Expected repo-local skill files are missing:',
+        ...missing.map((f) => `  - ${f}`),
+      ].join('\n');
+
+      expect(missing, message).toEqual([]);
+    }
+  });
+
+  it('key docs reference vellum lifecycle commands', () => {
+    const checks: Array<{
+      file: string;
+      pattern: string;
+      description: string;
+    }> = [
+      {
+        file: 'README.md',
+        pattern: 'vellum wake\\|vellum ps\\|vellum sleep',
+        description:
+          'README.md should mention vellum wake, vellum ps, or vellum sleep',
+      },
+      {
+        file: 'assistant/README.md',
+        pattern: 'vellum wake\\|vellum ps',
+        description:
+          'assistant/README.md should mention vellum wake or vellum ps',
+      },
+      {
+        file: 'AGENTS.md',
+        pattern: 'vellum',
+        description:
+          'AGENTS.md should mention vellum in the /update command description',
+      },
+    ];
+
+    const failures: string[] = [];
+
+    for (const check of checks) {
+      try {
+        execSync(`git grep -q '${check.pattern}' -- '${check.file}'`, {
+          encoding: 'utf-8',
+          cwd: REPO_ROOT,
+        });
+      } catch {
+        failures.push(check.description);
+      }
+    }
+
+    if (failures.length > 0) {
+      const message = [
+        'Key docs are missing vellum lifecycle command references:',
+        '',
+        ...failures.map((f) => `  - ${f}`),
+        '',
+        'These docs should reference vellum CLI lifecycle commands (wake/ps/sleep).',
+      ].join('\n');
+
+      expect(failures, message).toEqual([]);
+    }
+  });
+
+  it('no docs use stale daemon startup as primary instruction', () => {
+    // Files that are allowed to contain these patterns
+    const allowedPrefixes = [
+      'cli/', // CLI source code
+      'assistant/src/', // assistant runtime source
+      'CLAUDE.md', // project instructions
+      'AGENTS.md', // agent conventions (may reference patterns for context)
+    ];
+
+    const stalePatterns = [
+      {
+        pattern: 'bun run src/index.ts daemon start',
+        label: 'bun run src/index.ts daemon start',
+      },
+    ];
+
+    const violations: string[] = [];
+
+    for (const { pattern, label } of stalePatterns) {
+      let grepOutput = '';
+      try {
+        grepOutput = execSync(
+          `git grep -n '${pattern}' -- '*.md'`,
+          { encoding: 'utf-8', cwd: REPO_ROOT },
+        ).trim();
+      } catch {
+        // No matches — happy path
+        continue;
+      }
+
+      const lines = grepOutput.split('\n').filter((l) => l.length > 0);
+
+      for (const line of lines) {
+        const filePath = line.split(':')[0];
+
+        // Skip allowed file prefixes
+        if (allowedPrefixes.some((prefix) => filePath.startsWith(prefix))) {
+          continue;
+        }
+
+        // Skip test files
+        if (filePath.includes('__tests__') || filePath.endsWith('.test.ts')) {
+          continue;
+        }
+
+        // Check if this occurrence is inside a <details> section or
+        // a "Development" / "raw bun commands" context by examining
+        // surrounding lines. We use git grep -B10 to get context.
+        try {
+          const context = execSync(
+            `git grep -B10 '${pattern}' -- '${filePath}'`,
+            { encoding: 'utf-8', cwd: REPO_ROOT },
+          );
+
+          const contextLower = context.toLowerCase();
+          const isInDetails = contextLower.includes('<details>');
+          const isDevContext =
+            contextLower.includes('development:') ||
+            contextLower.includes('low-level development') ||
+            contextLower.includes('raw bun commands');
+
+          if (isInDetails || isDevContext) {
+            continue;
+          }
+        } catch {
+          // If context grep fails, treat as a violation
+        }
+
+        violations.push(`${filePath}: contains "${label}" as primary instruction`);
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        'Found docs using stale daemon startup patterns as primary instructions.',
+        'Use `vellum wake` / `vellum sleep` instead. Raw bun commands are acceptable',
+        'only in collapsed <details> sections or dev-only contexts.',
+        '',
+        'Violations:',
+        ...violations.map((v) => `  - ${v}`),
+      ].join('\n');
+
+      expect(violations, message).toEqual([]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Added lifecycle-docs-guard.test.ts to prevent stale daemon startup instructions from being reintroduced
- Guards: repo-local commands in correct location, key docs reference vellum lifecycle CLI, no stale primary instructions
- Added AGENTS.md note about the guard test

Part of #11222

## Test plan
- [ ] Guard test passes locally
- [ ] Guard test catches intentionally stale patterns
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
