### PR TITLE
fix: add CFBundleIconFile to Info.plist for dock icon

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -579,6 +579,8 @@ cat > "$CONTENTS/Info.plist" <<PLIST
     <true/>
     <key>CFBundleIconName</key>
     <string>AppIcon</string>
+    <key>CFBundleIconFile</key>
+    <string>AppIcon</string>
     <key>NSAppTransportSecurity</key>
     <dict>
         <!-- Allow HTTP on the local network only -->


### PR DESCRIPTION
## Summary
- Added `CFBundleIconFile` key pointing to `AppIcon` in the generated Info.plist
- macOS needs this key to find the `.icns` file in Resources — `CFBundleIconName` alone (for asset catalog lookup) wasn't sufficient

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
