### PR TITLE
fix: resolve VoiceModeManager actor isolation warning

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -56,7 +56,7 @@ final class VoiceModeManager: ObservableObject {
     /// Combine subscription forwarding live partial transcription from the voice service.
     private var liveTranscriptionCancellable: AnyCancellable?
 
-    nonisolated init(voiceService: any VoiceServiceProtocol = OpenAIVoiceService()) {
+    init(voiceService: any VoiceServiceProtocol = OpenAIVoiceService()) {
         self.voiceService = voiceService
     }
 


### PR DESCRIPTION
## Summary
- Removed `nonisolated` from `VoiceModeManager.init` so it inherits the class's `@MainActor` isolation, fixing the Swift 6 warning about mutating a main-actor-isolated property from a nonisolated context.

## Original prompt
fix these warnings: /Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift:60:14: warning: main actor-isolated property 'voiceService' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
