### PR TITLE
M4: Add temporary approval modes to channel decision actions and parsing

### DIFF
--- a/assistant/src/__tests__/channel-approval.test.ts
+++ b/assistant/src/__tests__/channel-approval.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import { parseApprovalDecision } from '../runtime/channel-approval-parser.js';
+import { parseCallbackData } from '../runtime/routes/channel-route-shared.js';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Plain-text approval decision parser
@@ -29,6 +30,48 @@ describe('parseApprovalDecision', () => {
     const result = parseApprovalDecision(input);
     expect(result).not.toBeNull();
     expect(result!.action).toBe('approve_once');
+    expect(result!.source).toBe('plain_text');
+  });
+
+  // ── Approve for 10 minutes ────────────────────────────────────────
+
+  test.each([
+    'approve for 10 minutes',
+    'Approve for 10 minutes',
+    'APPROVE FOR 10 MINUTES',
+    'allow for 10 minutes',
+    'Allow for 10 minutes',
+    'ALLOW FOR 10 MINUTES',
+    'approve 10m',
+    'Approve 10m',
+    'APPROVE 10M',
+    'allow 10m',
+    'approve 10 min',
+    'allow 10 min',
+  ])('recognises "%s" as approve_10m', (input) => {
+    const result = parseApprovalDecision(input);
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe('approve_10m');
+    expect(result!.source).toBe('plain_text');
+  });
+
+  // ── Approve for thread ────────────────────────────────────────────
+
+  test.each([
+    'approve for thread',
+    'Approve for thread',
+    'APPROVE FOR THREAD',
+    'allow for thread',
+    'Allow for thread',
+    'ALLOW FOR THREAD',
+    'approve thread',
+    'Approve thread',
+    'APPROVE THREAD',
+    'allow thread',
+  ])('recognises "%s" as approve_thread', (input) => {
+    const result = parseApprovalDecision(input);
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe('approve_thread');
     expect(result!.source).toBe('plain_text');
   });
 
@@ -130,6 +173,20 @@ describe('parseApprovalDecision', () => {
     expect(result!.requestId).toBe('req-789');
   });
 
+  test('extracts requestId from [ref:...] tag with approve_10m decision', () => {
+    const result = parseApprovalDecision('approve for 10 minutes [ref:req-timer]');
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe('approve_10m');
+    expect(result!.requestId).toBe('req-timer');
+  });
+
+  test('extracts requestId from [ref:...] tag with approve_thread decision', () => {
+    const result = parseApprovalDecision('approve for thread [ref:req-thread]');
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe('approve_thread');
+    expect(result!.requestId).toBe('req-thread');
+  });
+
   test('handles ref tag on separate line', () => {
     const result = parseApprovalDecision('yes\n[ref:req-abc-123]');
     expect(result).not.toBeNull();
@@ -141,5 +198,48 @@ describe('parseApprovalDecision', () => {
     const result = parseApprovalDecision('yes');
     expect(result).not.toBeNull();
     expect(result!.requestId).toBeUndefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Callback data parser
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('parseCallbackData', () => {
+  test.each([
+    ['apr:req-123:approve_once', 'approve_once'],
+    ['apr:req-123:approve_10m', 'approve_10m'],
+    ['apr:req-123:approve_thread', 'approve_thread'],
+    ['apr:req-123:approve_always', 'approve_always'],
+    ['apr:req-123:reject', 'reject'],
+  ] as const)('parses "%s" as action "%s"', (data, expectedAction) => {
+    const result = parseCallbackData(data);
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe(expectedAction);
+    expect(result!.requestId).toBe('req-123');
+    expect(result!.source).toBe('telegram_button');
+  });
+
+  test('parses whatsapp source channel', () => {
+    const result = parseCallbackData('apr:req-456:approve_10m', 'whatsapp');
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe('approve_10m');
+    expect(result!.source).toBe('whatsapp_button');
+  });
+
+  test('returns null for unknown action', () => {
+    expect(parseCallbackData('apr:req-123:unknown_action')).toBeNull();
+  });
+
+  test('returns null for missing prefix', () => {
+    expect(parseCallbackData('xyz:req-123:approve_once')).toBeNull();
+  });
+
+  test('returns null for incomplete data', () => {
+    expect(parseCallbackData('apr:req-123')).toBeNull();
+  });
+
+  test('returns null for empty requestId', () => {
+    expect(parseCallbackData('apr::approve_once')).toBeNull();
   });
 });

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -283,6 +283,8 @@ export function mintCanonicalRequestGrant(params: {
 /** Valid actions for canonical guardian decisions. */
 const VALID_CANONICAL_ACTIONS: ReadonlySet<ApprovalAction> = new Set([
   'approve_once',
+  'approve_10m',
+  'approve_thread',
   'approve_always',
   'reject',
 ]);

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -162,10 +162,11 @@ export interface ApplyGuardianDecisionParams {
 export function applyGuardianDecision(params: ApplyGuardianDecisionParams): ApplyGuardianDecisionResult {
   const { approval, decision, actorExternalUserId, actorChannel, decisionContext } = params;
 
-  // Guardians cannot approve_always on behalf of requesters -- downgrade.
-  const effectiveDecision: ApprovalDecisionResult = decision.action === 'approve_always'
-    ? { ...decision, action: 'approve_once' }
-    : decision;
+  // Guardians cannot grant broad allow modes on behalf of requesters -- downgrade.
+  const effectiveDecision: ApprovalDecisionResult =
+    decision.action === 'approve_always' || decision.action === 'approve_10m' || decision.action === 'approve_thread'
+      ? { ...decision, action: 'approve_once' }
+      : decision;
 
   // Capture pending approval info before handleChannelDecision resolves
   // (and removes) the pending interaction. Needed for grant minting.
@@ -404,11 +405,13 @@ export async function applyCanonicalGuardianDecision(
     return { applied: false, reason: 'expired' };
   }
 
-  // 3. Downgrade approve_always to approve_once for guardian-on-behalf requests.
-  // Guardians cannot permanently allowlist tools on behalf of requesters.
-  const effectiveAction: ApprovalAction = action === 'approve_always'
-    ? 'approve_once'
-    : action;
+  // 3. Downgrade approve_always and temporary modes to approve_once for
+  // guardian-on-behalf requests. Guardians cannot grant broad allow modes
+  // (permanent, timed, or thread-scoped) on behalf of requesters.
+  const effectiveAction: ApprovalAction =
+    action === 'approve_always' || action === 'approve_10m' || action === 'approve_thread'
+      ? 'approve_once'
+      : action;
 
   // 4. CAS resolve: atomically transition from 'pending' to terminal status
   const targetStatus: CanonicalRequestStatus = effectiveAction === 'reject'

--- a/assistant/src/daemon/approval-generators.ts
+++ b/assistant/src/daemon/approval-generators.ts
@@ -62,6 +62,8 @@ const APPROVAL_CONVERSATION_TOOL_SCHEMA = {
 const VALID_DISPOSITIONS: ReadonlySet<string> = new Set([
   'keep_pending',
   'approve_once',
+  'approve_10m',
+  'approve_thread',
   'approve_always',
   'reject',
 ]);

--- a/assistant/src/daemon/approval-generators.ts
+++ b/assistant/src/daemon/approval-generators.ts
@@ -37,11 +37,12 @@ const APPROVAL_CONVERSATION_TOOL_SCHEMA = {
     properties: {
       disposition: {
         type: 'string',
-        enum: ['keep_pending', 'approve_once', 'approve_always', 'reject'],
+        enum: ['keep_pending', 'approve_once', 'approve_10m', 'approve_thread', 'approve_always', 'reject'],
         description:
           'The decision: keep_pending if the user is asking questions or unclear, '
-          + 'approve_once to approve this single request, approve_always to approve '
-          + 'this tool permanently, reject to deny the request.',
+          + 'approve_once to approve this single request, approve_10m to approve all '
+          + 'requests for 10 minutes, approve_thread to approve all requests in this '
+          + 'thread, approve_always to approve this tool permanently, reject to deny the request.',
       },
       replyText: {
         type: 'string',

--- a/assistant/src/daemon/handlers/guardian-actions.ts
+++ b/assistant/src/daemon/handlers/guardian-actions.ts
@@ -8,7 +8,7 @@ import { listGuardianDecisionPrompts } from '../../runtime/routes/guardian-actio
 import type { GuardianActionDecision, GuardianActionsPendingRequest } from '../ipc-protocol.js';
 import { defineHandlers, log } from './shared.js';
 
-const VALID_ACTIONS = new Set<string>(['approve_once', 'approve_always', 'reject']);
+const VALID_ACTIONS = new Set<string>(['approve_once', 'approve_10m', 'approve_thread', 'approve_always', 'reject']);
 
 export const guardianActionsHandlers = defineHandlers({
   guardian_actions_pending_request: (msg: GuardianActionsPendingRequest, socket, ctx) => {

--- a/assistant/src/runtime/approval-conversation-turn.ts
+++ b/assistant/src/runtime/approval-conversation-turn.ts
@@ -21,6 +21,8 @@ import type {
 const VALID_DISPOSITIONS: ReadonlySet<ApprovalConversationDisposition> = new Set([
   'keep_pending',
   'approve_once',
+  'approve_10m',
+  'approve_thread',
   'approve_always',
   'reject',
 ]);
@@ -28,6 +30,8 @@ const VALID_DISPOSITIONS: ReadonlySet<ApprovalConversationDisposition> = new Set
 /** Dispositions that represent an actual decision (not just "keep waiting"). */
 const DECISION_BEARING_DISPOSITIONS: ReadonlySet<ApprovalConversationDisposition> = new Set([
   'approve_once',
+  'approve_10m',
+  'approve_thread',
   'approve_always',
   'reject',
 ]);

--- a/assistant/src/runtime/channel-approval-parser.ts
+++ b/assistant/src/runtime/channel-approval-parser.ts
@@ -18,21 +18,27 @@ import type { ApprovalAction, ApprovalDecisionResult } from './channel-approval-
 // ---------------------------------------------------------------------------
 
 const APPROVE_ONCE_PHRASES = ['yes', 'approve', 'approve once', 'allow', 'go ahead'];
+const APPROVE_10M_PHRASES = ['approve for 10 minutes', 'allow for 10 minutes', 'approve 10m', 'allow 10m', 'approve 10 min', 'allow 10 min'];
+const APPROVE_THREAD_PHRASES = ['approve for thread', 'allow for thread', 'approve thread', 'allow thread'];
 const APPROVE_ALWAYS_PHRASES = ['always', 'approve always', 'allow always'];
 const REJECT_PHRASES = ['no', 'reject', 'deny', 'cancel'];
 
 /**
- * Build a Map from lowercased phrase to action. "Approve always" phrases
- * are checked first (longest-match-wins) because "approve" is a prefix
- * of "approve always".
+ * Build a Map from lowercased phrase to action. Longer phrases are
+ * inserted first so iteration order does not matter — we match on
+ * exact equality after normalising, not prefix matching.
  */
 function buildPhraseMap(): Map<string, ApprovalAction> {
   const map = new Map<string, ApprovalAction>();
 
-  // Insert longer phrases first so iteration order does not matter —
-  // we match on exact equality after normalising, not prefix matching.
   for (const phrase of APPROVE_ALWAYS_PHRASES) {
     map.set(phrase, 'approve_always');
+  }
+  for (const phrase of APPROVE_10M_PHRASES) {
+    map.set(phrase, 'approve_10m');
+  }
+  for (const phrase of APPROVE_THREAD_PHRASES) {
+    map.set(phrase, 'approve_thread');
   }
   for (const phrase of APPROVE_ONCE_PHRASES) {
     map.set(phrase, 'approve_once');

--- a/assistant/src/runtime/channel-approval-types.ts
+++ b/assistant/src/runtime/channel-approval-types.ts
@@ -14,7 +14,7 @@ import type { GuardianDecisionAction } from './guardian-decision-types.js';
 // ---------------------------------------------------------------------------
 
 /** The set of actions a user can take on an approval prompt. */
-export type ApprovalAction = 'approve_once' | 'approve_always' | 'reject';
+export type ApprovalAction = 'approve_once' | 'approve_10m' | 'approve_thread' | 'approve_always' | 'reject';
 
 /** An action presented to the user as a tappable button or text option. */
 export interface ApprovalActionOption {

--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -10,9 +10,11 @@
  */
 
 import { addRule } from '../permissions/trust-store.js';
+import type { UserDecision } from '../permissions/types.js';
 import { getTool } from '../tools/registry.js';
 import { composeApprovalMessage } from './approval-message-composer.js';
 import type {
+  ApprovalAction,
   ApprovalDecisionResult,
   ApprovalUIMetadata,
   ChannelApprovalPrompt,
@@ -111,6 +113,25 @@ export function buildApprovalUIMetadata(
 }
 
 // ---------------------------------------------------------------------------
+// 2.5. Action → UserDecision mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a channel-level `ApprovalAction` to the permission system's
+ * `UserDecision` type. Temporary approval modes (`approve_10m`,
+ * `approve_thread`) map directly to their `allow_*` counterparts so
+ * the permission pipeline can activate the appropriate override.
+ */
+function mapApprovalActionToUserDecision(action: ApprovalAction): UserDecision {
+  switch (action) {
+    case 'reject': return 'deny';
+    case 'approve_10m': return 'allow_10m';
+    case 'approve_thread': return 'allow_thread';
+    default: return 'allow';
+  }
+}
+
+// ---------------------------------------------------------------------------
 // 3. Consume a user decision and apply it to the session
 // ---------------------------------------------------------------------------
 
@@ -176,7 +197,7 @@ export function handleChannelDecision(
   if (!resolved) return { applied: false };
 
   // Map channel-level action to the permission system's UserDecision type.
-  const userDecision = decision.action === 'reject' ? 'deny' as const : 'allow' as const;
+  const userDecision = mapApprovalActionToUserDecision(decision.action);
   if (decisionContext === undefined) {
     resolved.session.handleConfirmationResponse(info.requestId, userDecision);
   } else {

--- a/assistant/src/runtime/guardian-decision-types.ts
+++ b/assistant/src/runtime/guardian-decision-types.ts
@@ -44,6 +44,8 @@ export interface GuardianDecisionAction {
 /** Canonical set of all guardian decision actions with their labels. */
 export const GUARDIAN_DECISION_ACTIONS = {
   approve_once:   { action: 'approve_once',   label: 'Approve once' },
+  approve_10m:    { action: 'approve_10m',    label: 'Allow 10 min' },
+  approve_thread: { action: 'approve_thread', label: 'Allow thread' },
   approve_always: { action: 'approve_always', label: 'Approve always' },
   reject:         { action: 'reject',         label: 'Reject' },
 } as const satisfies Record<string, GuardianDecisionAction>;
@@ -54,16 +56,21 @@ export const GUARDIAN_DECISION_ACTIONS = {
  *
  * When `persistentDecisionsAllowed` is `false`, the `approve_always` action
  * is excluded. When `forGuardianOnBehalf` is `true` (guardian acting on behalf
- * of a requester), `approve_always` is also excluded since guardians cannot
- * permanently allowlist tools on behalf of others.
+ * of a requester), both `approve_always` and the temporary modes are excluded
+ * since guardians cannot grant broad delegated allow modes on behalf of others.
+ *
+ * Temporary modes (`approve_10m`, `approve_thread`) are included for
+ * requester-side standard approval flows when persistent decisions are allowed.
  */
 export function buildDecisionActions(opts?: {
   persistentDecisionsAllowed?: boolean;
   forGuardianOnBehalf?: boolean;
 }): GuardianDecisionAction[] {
   const showAlways = opts?.persistentDecisionsAllowed !== false && !opts?.forGuardianOnBehalf;
+  const showTemporary = opts?.persistentDecisionsAllowed !== false && !opts?.forGuardianOnBehalf;
   return [
     GUARDIAN_DECISION_ACTIONS.approve_once,
+    ...(showTemporary ? [GUARDIAN_DECISION_ACTIONS.approve_10m, GUARDIAN_DECISION_ACTIONS.approve_thread] : []),
     ...(showAlways ? [GUARDIAN_DECISION_ACTIONS.approve_always] : []),
     GUARDIAN_DECISION_ACTIONS.reject,
   ];
@@ -72,16 +79,26 @@ export function buildDecisionActions(opts?: {
 /**
  * Build the plain-text fallback instruction string that matches the given
  * set of decision actions. Ensures the text always includes parser-compatible
- * keywords (yes/always/no) so text-based fallback remains actionable.
+ * keywords so text-based fallback remains actionable.
  */
 export function buildPlainTextFallback(
   promptText: string,
   actions: GuardianDecisionAction[],
 ): string {
   const hasAlways = actions.some(a => a.action === 'approve_always');
-  return hasAlways
-    ? `${promptText}\n\nReply "yes" to approve once, "always" to approve always, or "no" to reject.`
-    : `${promptText}\n\nReply "yes" to approve or "no" to reject.`;
+  const has10m = actions.some(a => a.action === 'approve_10m');
+  const hasThread = actions.some(a => a.action === 'approve_thread');
+
+  if (hasAlways && has10m && hasThread) {
+    return `${promptText}\n\nReply "yes" to approve once, "approve for 10 minutes", "approve for thread", "always" to approve always, or "no" to reject.`;
+  }
+  if (hasAlways) {
+    return `${promptText}\n\nReply "yes" to approve once, "always" to approve always, or "no" to reject.`;
+  }
+  if (has10m && hasThread) {
+    return `${promptText}\n\nReply "yes" to approve once, "approve for 10 minutes", "approve for thread", or "no" to reject.`;
+  }
+  return `${promptText}\n\nReply "yes" to approve or "no" to reject.`;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -108,6 +108,8 @@ export interface GuardianReplyResult {
 
 const VALID_ACTIONS: ReadonlySet<string> = new Set([
   'approve_once',
+  'approve_10m',
+  'approve_thread',
   'approve_always',
   'reject',
 ]);
@@ -476,9 +478,9 @@ export async function routeGuardianReply(
     // Decision-bearing disposition from the engine
     let decisionAction = engineResult.disposition as ApprovalAction;
 
-    // Guardians cannot approve_always — the canonical primitive enforces
-    // this too, but enforce it here for clarity.
-    if (decisionAction === 'approve_always') {
+    // Guardians cannot use broad allow modes — the canonical primitive
+    // enforces this too, but enforce it here for clarity.
+    if (decisionAction === 'approve_always' || decisionAction === 'approve_10m' || decisionAction === 'approve_thread') {
       decisionAction = 'approve_once';
     }
 

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -27,6 +27,8 @@ export type ApprovalCopyGenerator = (
 export type ApprovalConversationDisposition =
   | 'keep_pending'
   | 'approve_once'
+  | 'approve_10m'
+  | 'approve_thread'
   | 'approve_always'
   | 'reject';
 

--- a/assistant/src/runtime/routes/channel-route-shared.ts
+++ b/assistant/src/runtime/routes/channel-route-shared.ts
@@ -69,7 +69,13 @@ export const GUARDIAN_APPROVAL_TTL_MS = 30 * 60 * 1000;
  */
 export function requiredDecisionKeywords(actions: ApprovalUIMetadata['actions']): string[] {
   const hasAlways = actions.some((action) => action.id === 'approve_always');
-  return hasAlways ? ['yes', 'always', 'no'] : ['yes', 'no'];
+  const has10m = actions.some((action) => action.id === 'approve_10m');
+  const hasThread = actions.some((action) => action.id === 'approve_thread');
+  const keywords = ['yes', 'no'];
+  if (has10m) keywords.push('approve for 10 minutes');
+  if (hasThread) keywords.push('approve for thread');
+  if (hasAlways) keywords.push('always');
+  return keywords;
 }
 
 // ---------------------------------------------------------------------------
@@ -78,6 +84,8 @@ export function requiredDecisionKeywords(actions: ApprovalUIMetadata['actions'])
 
 const VALID_ACTIONS: ReadonlySet<string> = new Set<string>([
   'approve_once',
+  'approve_10m',
+  'approve_thread',
   'approve_always',
   'reject',
 ]);

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -104,9 +104,9 @@ export async function handleGuardianActionDecision(req: Request, server: ServerW
     return httpError('BAD_REQUEST', 'action is required', 400);
   }
 
-  const VALID_ACTIONS = new Set<string>(['approve_once', 'approve_always', 'reject']);
+  const VALID_ACTIONS = new Set<string>(['approve_once', 'approve_10m', 'approve_thread', 'approve_always', 'reject']);
   if (!VALID_ACTIONS.has(action)) {
-    return httpError('BAD_REQUEST', `Invalid action: ${action}. Must be one of: approve_once, approve_always, reject`, 400);
+    return httpError('BAD_REQUEST', `Invalid action: ${action}. Must be one of: approve_once, approve_10m, approve_thread, approve_always, reject`, 400);
   }
 
   // Verify conversationId scoping before applying the canonical decision.

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -18,6 +18,7 @@ import { runApprovalConversationTurn } from '../approval-conversation-turn.js';
 import { composeApprovalMessageGenerative } from '../approval-message-composer.js';
 import { parseApprovalDecision } from '../channel-approval-parser.js';
 import type {
+  ApprovalAction,
   ApprovalDecisionResult,
 } from '../channel-approval-types.js';
 import {
@@ -275,12 +276,12 @@ export async function handleApprovalInterception(
         }
 
         // Decision-bearing disposition from the engine
-        let decisionAction = engineResult.disposition as 'approve_once' | 'approve_always' | 'reject';
+        let decisionAction = engineResult.disposition as ApprovalAction;
 
-        // Belt-and-suspenders: guardians cannot approve_always even if the
-        // engine returns it (the engine's allowedActions validation should
+        // Belt-and-suspenders: guardians cannot use broad allow modes even if
+        // the engine returns them (the engine's allowedActions validation should
         // already prevent this, but enforce it here too).
-        if (decisionAction === 'approve_always') {
+        if (decisionAction === 'approve_always' || decisionAction === 'approve_10m' || decisionAction === 'approve_thread') {
           decisionAction = 'approve_once';
         }
 
@@ -838,7 +839,7 @@ export async function handleApprovalInterception(
     }
 
     // Decision-bearing disposition — map to ApprovalDecisionResult and apply
-    const decisionAction = engineResult.disposition as 'approve_once' | 'approve_always' | 'reject';
+    const decisionAction = engineResult.disposition as ApprovalAction;
     const engineDecision: ApprovalDecisionResult = {
       action: decisionAction,
       source: 'plain_text',

--- a/gateway/src/whatsapp/send.ts
+++ b/gateway/src/whatsapp/send.ts
@@ -30,16 +30,18 @@ const WHATSAPP_MAX_BUTTONS = 3;
 
 /**
  * Select up to WHATSAPP_MAX_BUTTONS actions for WhatsApp interactive buttons.
- * When there are more actions than the cap allows, this ensures the reject
- * action is always included alongside the highest-priority approve variants.
+ * When there are more actions than the cap allows, this ensures that `reject`
+ * and `approve_always` are always preserved (they are the most important
+ * decisions), with remaining slots filled by other approve variants in order.
  */
 function selectWhatsAppButtons(actions: Array<{ id: string; label: string }>): Array<{ id: string; label: string }> {
   if (actions.length <= WHATSAPP_MAX_BUTTONS) return actions;
-  const reject = actions.find(a => a.id === 'reject');
-  const nonReject = actions.filter(a => a.id !== 'reject');
-  const slotsForApprove = reject ? WHATSAPP_MAX_BUTTONS - 1 : WHATSAPP_MAX_BUTTONS;
-  const selected = nonReject.slice(0, slotsForApprove);
-  if (reject) selected.push(reject);
+
+  // Always preserve reject and approve_always when present
+  const pinned = actions.filter(a => a.id === 'reject' || a.id === 'approve_always');
+  const rest = actions.filter(a => a.id !== 'reject' && a.id !== 'approve_always');
+  const slotsForRest = WHATSAPP_MAX_BUTTONS - pinned.length;
+  const selected = [...rest.slice(0, slotsForRest), ...pinned];
   return selected;
 }
 

--- a/gateway/src/whatsapp/send.ts
+++ b/gateway/src/whatsapp/send.ts
@@ -28,6 +28,21 @@ const WHATSAPP_BUTTON_TITLE_MAX_LEN = 20;
 // WhatsApp supports a maximum of 3 reply buttons
 const WHATSAPP_MAX_BUTTONS = 3;
 
+/**
+ * Select up to WHATSAPP_MAX_BUTTONS actions for WhatsApp interactive buttons.
+ * When there are more actions than the cap allows, this ensures the reject
+ * action is always included alongside the highest-priority approve variants.
+ */
+function selectWhatsAppButtons(actions: Array<{ id: string; label: string }>): Array<{ id: string; label: string }> {
+  if (actions.length <= WHATSAPP_MAX_BUTTONS) return actions;
+  const reject = actions.find(a => a.id === 'reject');
+  const nonReject = actions.filter(a => a.id !== 'reject');
+  const slotsForApprove = reject ? WHATSAPP_MAX_BUTTONS - 1 : WHATSAPP_MAX_BUTTONS;
+  const selected = nonReject.slice(0, slotsForApprove);
+  if (reject) selected.push(reject);
+  return selected;
+}
+
 export async function sendWhatsAppReply(
   config: GatewayConfig,
   to: string,
@@ -35,8 +50,11 @@ export async function sendWhatsAppReply(
   approval?: ApprovalPayload,
 ): Promise<void> {
   if (approval) {
-    // WhatsApp interactive buttons: up to 3 buttons, 20-char titles, 1024-char body
-    const buttons = approval.actions.slice(0, WHATSAPP_MAX_BUTTONS).map((action) => ({
+    // WhatsApp interactive buttons: up to 3 buttons, 20-char titles, 1024-char body.
+    // When there are more actions than the button cap allows, prioritize keeping
+    // the reject action visible alongside the most important approve variants.
+    const selectedActions = selectWhatsAppButtons(approval.actions);
+    const buttons = selectedActions.map((action) => ({
       id: `apr:${approval.runId}:${action.id}`,
       title: action.label.slice(0, WHATSAPP_BUTTON_TITLE_MAX_LEN),
     }));


### PR DESCRIPTION
Part of #11230. Extends channel approval actions and parser for approve_10m and approve_thread. Adds Telegram inline buttons for temporary modes. Handles WhatsApp 3-button cap via plain-text fallback. Guardian-on-behalf flows remain restricted. Closes #11234.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
