### PR TITLE
fix: add credential-setup-for metadata to google-oauth-setup skill

### DIFF
--- a/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
@@ -2,6 +2,7 @@
 name: "Google OAuth Setup"
 description: "Set up Google Cloud OAuth credentials for Gmail and Calendar using browser automation"
 user-invocable: true
+credential-setup-for: "gmail"
 includes: ["browser", "public-ingress"]
 metadata: {"vellum": {"emoji": "\ud83d\udd11"}}
 ---


### PR DESCRIPTION
## Summary
- Adds `credential-setup-for: "gmail"` to the google-oauth-setup skill frontmatter
- Without this, the assistant doesn't know to auto-load the OAuth setup skill when Gmail credentials are missing — it improvises manual instructions instead

## Test plan
- [x] Ask the assistant to "help me manage my email" without Gmail credentials configured
- [x] Verify it loads the google-oauth-setup skill instead of giving manual instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
