### PR TITLE
fix: key update fallback cleanup on vellum ps output instead of sleep exit code

### DIFF
--- a/.claude/skills/vellum-skills/update/SKILL.md
+++ b/.claude/skills/vellum-skills/update/SKILL.md
@@ -30,18 +30,19 @@ Pull the latest changes from main, use `vellum` lifecycle CLI to stop and restar
    vellum sleep || true
    ```
 
-   **Fallback only if sleep fails** (processes stubbornly remain):
+4. Verify stopped — run `vellum ps` and confirm no running processes. If `vellum ps` shows processes still running, run fallback cleanup to force-kill them:
+   ```bash
+   vellum ps
+   ```
+
+   **Fallback cleanup if `vellum ps` confirms processes are still running:**
    ```bash
    pkill -x "vellum-assistant" || true
    pkill -f "gateway/src/index" || true
    lsof -ti :7830 | xargs kill -9 2>/dev/null || true
    lsof -ti :7821 | xargs kill -9 2>/dev/null || true
    ```
-
-4. Verify stopped — run `vellum ps` and confirm no running processes. If processes remain, log a warning:
-   ```bash
-   vellum ps
-   ```
+   After fallback cleanup, run `vellum ps` again to confirm all processes are stopped.
 
 5. Switch to main and pull latest:
    ```bash


### PR DESCRIPTION
Address Codex review feedback on #11284: restructure /update skill so fallback process cleanup is triggered by vellum ps verification (processes still running) rather than vellum sleep exit code. Since sleep uses || true, it never fails, so the fallback was effectively unreachable.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
