### PR TITLE
fix: reduce onboarding icon-to-title spacing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -49,7 +49,7 @@ struct OnboardingFlowView: View {
                             .aspectRatio(contentMode: .fit)
                             .frame(width: 96, height: 96)
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-                            .padding(.bottom, VSpacing.xxl)
+                            .padding(.bottom, VSpacing.lg)
                     }
 
                     // Step content — Group flattens into parent VStack so


### PR DESCRIPTION
## Summary
- Reduced bottom padding on the app icon in the onboarding flow from `VSpacing.xxl` (32pt) to `VSpacing.lg` (16pt) to fix excessive gap between the icon and "Create your Assistant" title

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
