### PR TITLE
Add pre-commit warning for new .claude/commands/ files

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -803,4 +803,44 @@ if git diff --cached --name-only | grep -q 'assistant/src/config/system-prompt.t
     sleep 3
 fi
 
+# --- .claude/commands/ skill migration nudge ---
+# Non-blocking reminder when someone adds a new non-symlink .md file to
+# .claude/commands/. These should be created as skills instead.
+
+COMMAND_VIOLATIONS=0
+while IFS= read -r -d '' FILE; do
+    case "$FILE" in
+        .claude/commands/*.md)
+            # Skip symlinks — those are managed by claude-skills/setup
+            if [ -L "$FILE" ]; then
+                continue
+            fi
+            if [ $COMMAND_VIOLATIONS -eq 0 ]; then
+                echo ""
+                echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+                echo -e "${YELLOW}⚠️  New command file detected in .claude/commands/${NC}"
+                echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+                echo ""
+                echo "Repo-local commands should be created as skills, not command files."
+                echo "The .claude/commands/ directory is for symlinks managed by claude-skills/setup."
+                echo ""
+                echo "Instead of:  .claude/commands/<name>.md"
+                echo "Create:      .claude/skills/<name>/SKILL.md"
+                echo ""
+                echo "See the Agent Skills spec: https://agentskills.io/specification"
+                echo ""
+                echo "Files:"
+            fi
+            echo "  - $FILE"
+            COMMAND_VIOLATIONS=$((COMMAND_VIOLATIONS + 1))
+            ;;
+    esac
+done < <(git diff --cached --name-only --diff-filter=ACM -z)
+
+if [ $COMMAND_VIOLATIONS -gt 0 ]; then
+    echo ""
+    echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+fi
+
 exit 0


### PR DESCRIPTION
## Summary
- Adds a non-blocking pre-commit warning when someone stages a new non-symlink `.md` file in `.claude/commands/`
- The warning suggests creating a skill at `.claude/skills/<name>/SKILL.md` instead, per the Agent Skills spec
- Follows the same pattern as the existing `system-prompt.ts` modification warning — informational, does not block the commit
- Symlinks (managed by `claude-skills/setup`) are explicitly skipped

## Test plan
- [x] `pre-commit --self-test` passes
- [x] Hook correctly identifies non-symlink `.md` files in `.claude/commands/`
- [x] Symlinks in `.claude/commands/` are not flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)