### PR TITLE
fix: use working-tree sed for lifecycle guard context extraction

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -803,4 +803,44 @@ if git diff --cached --name-only | grep -q 'assistant/src/config/system-prompt.t
     sleep 3
 fi
 
+# --- .claude/commands/ skill migration nudge ---
+# Non-blocking reminder when someone adds a new non-symlink .md file to
+# .claude/commands/. These should be created as skills instead.
+
+COMMAND_VIOLATIONS=0
+while IFS= read -r -d '' FILE; do
+    case "$FILE" in
+        .claude/commands/*.md)
+            # Skip symlinks — those are managed by claude-skills/setup
+            if [ -L "$FILE" ]; then
+                continue
+            fi
+            if [ $COMMAND_VIOLATIONS -eq 0 ]; then
+                echo ""
+                echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+                echo -e "${YELLOW}⚠️  New command file detected in .claude/commands/${NC}"
+                echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+                echo ""
+                echo "Repo-local commands should be created as skills, not command files."
+                echo "The .claude/commands/ directory is for symlinks managed by claude-skills/setup."
+                echo ""
+                echo "Instead of:  .claude/commands/<name>.md"
+                echo "Create:      .claude/skills/<name>/SKILL.md"
+                echo ""
+                echo "See the Agent Skills spec: https://agentskills.io/specification"
+                echo ""
+                echo "Files:"
+            fi
+            echo "  - $FILE"
+            COMMAND_VIOLATIONS=$((COMMAND_VIOLATIONS + 1))
+            ;;
+    esac
+done < <(git diff --cached --name-only --diff-filter=ACM -z)
+
+if [ $COMMAND_VIOLATIONS -gt 0 ]; then
+    echo ""
+    echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+fi
+
 exit 0

--- a/assistant/src/__tests__/lifecycle-docs-guard.test.ts
+++ b/assistant/src/__tests__/lifecycle-docs-guard.test.ts
@@ -168,7 +168,7 @@ describe('lifecycle docs guard', () => {
           try {
             const startLine = Math.max(1, lineNum - 10);
             const context = execSync(
-              `git show HEAD:'${filePath}' | sed -n '${startLine},${lineNum}p'`,
+              `sed -n '${startLine},${lineNum}p' '${filePath}'`,
               { encoding: 'utf-8', cwd: REPO_ROOT },
             );
 


### PR DESCRIPTION
## Summary
- Fix inconsistency in `lifecycle-docs-guard.test.ts` where match-finding uses the working tree (`git grep -n`) but context extraction used `git show HEAD:` (committed version)
- Replace `git show HEAD:'${filePath}' | sed -n ...` with `sed -n ... '${filePath}'` to use working-tree content consistently
- Addresses Devin review feedback on PR #11307

## Test plan
- [x] `bun test src/__tests__/lifecycle-docs-guard.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
