### PR TITLE
M5: Expose temporary approval actions in shared clients and CLI

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -232,6 +232,12 @@ export async function startCli(): Promise<void> {
     }
     process.stdout.write(`\u2502\n`);
     process.stdout.write(`\u2502 [a] Allow once\n`);
+    if (req.temporaryOptionsAvailable?.includes('allow_10m')) {
+      process.stdout.write(`\u2502 [t] Allow 10m\n`);
+    }
+    if (req.temporaryOptionsAvailable?.includes('allow_thread')) {
+      process.stdout.write(`\u2502 [T] Allow Thread\n`);
+    }
     process.stdout.write(`\u2502 [d] Deny once\n`);
     if (req.allowlistOptions.length > 0 && req.scopeOptions.length > 0) {
       process.stdout.write(`\u2502 [A] Allowlist...\n`);
@@ -273,6 +279,24 @@ export async function startCli(): Promise<void> {
           type: 'confirmation_response',
           requestId: req.requestId,
           decision: 'allow',
+        });
+        return;
+      }
+
+      if (choice === 't' && trimmed === 't' && req.temporaryOptionsAvailable?.includes('allow_10m')) {
+        send({
+          type: 'confirmation_response',
+          requestId: req.requestId,
+          decision: 'allow_10m',
+        });
+        return;
+      }
+
+      if (trimmed === 'T' && req.temporaryOptionsAvailable?.includes('allow_thread')) {
+        send({
+          type: 'confirmation_response',
+          requestId: req.requestId,
+          decision: 'allow_thread',
         });
         return;
       }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -40,6 +40,8 @@ struct ChatView: View {
     let onConfirmationAllow: (String) -> Void
     let onConfirmationDeny: (String) -> Void
     let onAlwaysAllow: (String, String, String, String) -> Void
+    /// Called when a temporary approval option is selected: (requestId, decision).
+    var onTemporaryAllow: ((String, String) -> Void)?
     var onGuardianAction: ((String, String) -> Void)?
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
     let sessionError: SessionError?
@@ -191,6 +193,7 @@ struct ChatView: View {
                             onConfirmationAllow: onConfirmationAllow,
                             onConfirmationDeny: onConfirmationDeny,
                             onAlwaysAllow: onAlwaysAllow,
+                            onTemporaryAllow: onTemporaryAllow,
                             onSurfaceAction: onSurfaceAction,
                             onGuardianAction: onGuardianAction,
                             onDismissDocumentWidget: onDismissDocumentWidget,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -19,6 +19,8 @@ struct MessageListView: View {
     let onConfirmationAllow: (String) -> Void
     let onConfirmationDeny: (String) -> Void
     let onAlwaysAllow: (String, String, String, String) -> Void
+    /// Called when a temporary approval option is selected: (requestId, decision).
+    var onTemporaryAllow: ((String, String) -> Void)?
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
     /// Called when a guardian decision action button is clicked: (requestId, action).
     var onGuardianAction: ((String, String) -> Void)?
@@ -269,7 +271,8 @@ struct MessageListView: View {
                                     isKeyboardActive: confirmation.requestId == activePendingRequestId,
                                     onAllow: { onConfirmationAllow(confirmation.requestId) },
                                     onDeny: { onConfirmationDeny(confirmation.requestId) },
-                                    onAlwaysAllow: onAlwaysAllow
+                                    onAlwaysAllow: onAlwaysAllow,
+                                    onTemporaryAllow: onTemporaryAllow
                                 )
                                 .id(message.id)
                                 .transition(.opacity)
@@ -284,7 +287,8 @@ struct MessageListView: View {
                                         confirmation: confirmation,
                                         onAllow: { onConfirmationAllow(confirmation.requestId) },
                                         onDeny: { onConfirmationDeny(confirmation.requestId) },
-                                        onAlwaysAllow: onAlwaysAllow
+                                        onAlwaysAllow: onAlwaysAllow,
+                                        onTemporaryAllow: onTemporaryAllow
                                     )
                                     .id(message.id)
                                     .transition(.opacity)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -670,6 +670,7 @@ struct ActiveChatViewWrapper: View {
             onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
             onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") },
             onAlwaysAllow: { requestId, selectedPattern, selectedScope, decision in viewModel.respondToAlwaysAllow(requestId: requestId, selectedPattern: selectedPattern, selectedScope: selectedScope, decision: decision) },
+            onTemporaryAllow: { requestId, decision in viewModel.respondToConfirmation(requestId: requestId, decision: decision) },
             onGuardianAction: { requestId, action in viewModel.submitGuardianDecision(requestId: requestId, action: action) },
             onSurfaceAction: { surfaceId, actionId, data in viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data) },
             sessionError: viewModel.sessionError,

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -40,6 +40,8 @@ public struct ToolConfirmationData: Equatable {
     public let executionTarget: String?
     /// When false, hide "Always Allow" and trust-rule persistence controls.
     public let persistentDecisionsAllowed: Bool
+    /// Which temporary approval options the daemon supports for this request (e.g. "allow_10m", "allow_thread").
+    public let temporaryOptionsAvailable: [String]
     public var state: ToolConfirmationState = .pending
 
     /// Normalized target label shown in confirmation UIs.
@@ -637,7 +639,7 @@ public struct ToolConfirmationData: Equatable {
         }
     }
 
-    public init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, diff: ConfirmationRequestMessage.ConfirmationDiffInfo? = nil, allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption] = [], scopeOptions: [ConfirmationRequestMessage.ConfirmationScopeOption] = [], executionTarget: String? = nil, persistentDecisionsAllowed: Bool = true, state: ToolConfirmationState = .pending) {
+    public init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, diff: ConfirmationRequestMessage.ConfirmationDiffInfo? = nil, allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption] = [], scopeOptions: [ConfirmationRequestMessage.ConfirmationScopeOption] = [], executionTarget: String? = nil, persistentDecisionsAllowed: Bool = true, temporaryOptionsAvailable: [String] = [], state: ToolConfirmationState = .pending) {
         self.requestId = requestId
         self.toolName = toolName
         self.input = input
@@ -647,6 +649,7 @@ public struct ToolConfirmationData: Equatable {
         self.scopeOptions = scopeOptions
         self.executionTarget = executionTarget
         self.persistentDecisionsAllowed = persistentDecisionsAllowed
+        self.temporaryOptionsAvailable = temporaryOptionsAvailable
         self.state = state
     }
 

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1069,7 +1069,8 @@ extension ChatViewModel {
                 allowlistOptions: msg.allowlistOptions,
                 scopeOptions: msg.scopeOptions,
                 executionTarget: msg.executionTarget,
-                persistentDecisionsAllowed: msg.persistentDecisionsAllowed ?? true
+                persistentDecisionsAllowed: msg.persistentDecisionsAllowed ?? true,
+                temporaryOptionsAvailable: msg.temporaryOptionsAvailable ?? []
             )
             let confirmMsg = ChatMessage(
                 role: .assistant,

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1885,7 +1885,8 @@ public final class ChatViewModel: ObservableObject {
         }
         // IPC send succeeded — update the message state
         if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
-            messages[index].confirmation?.state = decision == "allow" ? .approved : .denied
+            let isApproval = decision == "allow" || decision == "allow_10m" || decision == "allow_thread"
+            messages[index].confirmation?.state = isApproval ? .approved : .denied
         }
         // Dismiss the corresponding floating panel / native notification if one exists
         onInlineConfirmationResponse?(requestId, decision)

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1929,7 +1929,7 @@ public final class ChatViewModel: ObservableObject {
     public func updateConfirmationState(requestId: String, decision: String) {
         if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
             switch decision {
-            case "allow":
+            case "allow", "allow_10m", "allow_thread":
                 messages[index].confirmation?.state = .approved
             case "deny":
                 messages[index].confirmation?.state = .denied

--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -52,6 +52,9 @@ public struct MessageBubbleView: View {
                         },
                         onAlwaysAllow: { requestId, pattern, scope, decision in
                             onAlwaysAllow?(requestId, pattern, scope, decision)
+                        },
+                        onTemporaryAllow: { requestId, decision in
+                            onConfirmationResponse?(requestId, decision)
                         }
                     )
                 } else if let guardianDecision = message.guardianDecision {

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -8,6 +8,8 @@ public struct ToolConfirmationBubble: View {
     public let onAllow: () -> Void
     public let onDeny: () -> Void
     public let onAlwaysAllow: (String, String, String, String) -> Void
+    /// Called when a temporary approval option is selected: (requestId, decision).
+    public let onTemporaryAllow: ((String, String) -> Void)?
     /// When `true` this bubble owns the keyboard monitor and shows selection
     /// highlights. When `false` the monitor is removed and keyboard-only state
     /// is cleared so a lower stacked bubble doesn't steal input.
@@ -26,12 +28,13 @@ public struct ToolConfirmationBubble: View {
     @State private var keyMonitor: Any?
     #endif
 
-    public init(confirmation: ToolConfirmationData, isKeyboardActive: Bool = true, onAllow: @escaping () -> Void, onDeny: @escaping () -> Void, onAlwaysAllow: @escaping (String, String, String, String) -> Void) {
+    public init(confirmation: ToolConfirmationData, isKeyboardActive: Bool = true, onAllow: @escaping () -> Void, onDeny: @escaping () -> Void, onAlwaysAllow: @escaping (String, String, String, String) -> Void, onTemporaryAllow: ((String, String) -> Void)? = nil) {
         self.confirmation = confirmation
         self.isKeyboardActive = isKeyboardActive
         self.onAllow = onAllow
         self.onDeny = onDeny
         self.onAlwaysAllow = onAlwaysAllow
+        self.onTemporaryAllow = onTemporaryAllow
     }
 
     private var hasRuleOptions: Bool {
@@ -48,6 +51,14 @@ public struct ToolConfirmationBubble: View {
 
     private var isDecided: Bool {
         confirmation.state != .pending
+    }
+
+    private var hasAllow10m: Bool {
+        confirmation.temporaryOptionsAvailable.contains("allow_10m")
+    }
+
+    private var hasAllowThread: Bool {
+        confirmation.temporaryOptionsAvailable.contains("allow_thread")
     }
 
     /// The decision value to send when "Always Allow" is clicked.
@@ -373,6 +384,8 @@ public struct ToolConfirmationBubble: View {
     /// Build the ordered list of top-level actions based on current confirmation state.
     private var topLevelActions: [ToolConfirmationKeyboardModel.Action] {
         var actions: [ToolConfirmationKeyboardModel.Action] = [.allowOnce]
+        if hasAllow10m { actions.append(.allow10m) }
+        if hasAllowThread { actions.append(.allowThread) }
         if hasRuleOptions && confirmation.persistentDecisionsAllowed {
             actions.append(.alwaysAllow)
         }
@@ -390,6 +403,24 @@ public struct ToolConfirmationBubble: View {
                 isDanger: false,
                 isKeyboardSelected: keyboardModel?.selectedAction == .allowOnce
             ) { markCommandExplanationSeen(); onAllow() }
+            if hasAllow10m {
+                confirmationButton(
+                    "Allow 10m",
+                    isPrimary: false,
+                    isDanger: false,
+                    isKeyboardSelected: keyboardModel?.selectedAction == .allow10m
+                ) { markCommandExplanationSeen(); onTemporaryAllow?(confirmation.requestId, "allow_10m") }
+                .help("Allow this action for 10 minutes")
+            }
+            if hasAllowThread {
+                confirmationButton(
+                    "Allow Thread",
+                    isPrimary: false,
+                    isDanger: false,
+                    isKeyboardSelected: keyboardModel?.selectedAction == .allowThread
+                ) { markCommandExplanationSeen(); onTemporaryAllow?(confirmation.requestId, "allow_thread") }
+                .help("Allow this action for the current thread")
+            }
             if hasRuleOptions && confirmation.persistentDecisionsAllowed { alwaysAllowInlineButton }
             confirmationButton(
                 "Don\u{2019}t Allow",
@@ -614,6 +645,10 @@ public struct ToolConfirmationBubble: View {
         switch action {
         case .allowOnce:
             onAllow()
+        case .allow10m:
+            onTemporaryAllow?(confirmation.requestId, "allow_10m")
+        case .allowThread:
+            onTemporaryAllow?(confirmation.requestId, "allow_thread")
         case .alwaysAllow:
             if confirmation.allowlistOptions.count > 1 {
                 withAnimation(VAnimation.fast) {

--- a/clients/shared/Features/Chat/ToolConfirmationKeyboardModel.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationKeyboardModel.swift
@@ -10,6 +10,8 @@ struct ToolConfirmationKeyboardModel {
     /// The logical actions that can appear in the button row.
     enum Action: Equatable {
         case allowOnce
+        case allow10m
+        case allowThread
         case alwaysAllow
         case dontAllow
     }


### PR DESCRIPTION
Adds Allow 10m and Allow Thread options to the CLI confirmation prompt and shared Swift client confirmation UI. Closes #11235.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
