### PR TITLE
refactor: migrate /e2e from command to skill

### DIFF
--- a/.claude/skills/e2e/SKILL.md
+++ b/.claude/skills/e2e/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: e2e
+description: Run end-to-end tests via the CI workflow.
+user_invocable: true
+---
+
 Run end-to-end tests via the CI workflow.
 
 The user may pass `$ARGUMENTS` to filter to a specific test case by name (e.g., `hello-world`, `phone-setup`). If not provided, infer options from context (see below).

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ dist
 .claude/skills/*
 !.claude/skills/update/
 !.claude/skills/release/
+!.claude/skills/e2e/
 
 # Shared claude-skills symlinks (managed by claude-skills/setup)
 # These are gitignored because they're symlinks to the shared repo.


### PR DESCRIPTION
## Summary
- Move `.claude/commands/e2e.md` to `.claude/skills/e2e/SKILL.md` with proper frontmatter so Claude Code discovers it as a skill
- Add `!.claude/skills/e2e/` to `.gitignore` to track the new skill directory
- This follows the same pattern as `/update` and `/release` which were migrated in #11306

## Test plan
- [x] Verify `/e2e` appears in Claude Code's skill list after migration
- [x] Pre-commit hook no longer flags this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
