### PR TITLE
fix: replace curl health checks with vellum ps in /update skill

### DIFF
--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -72,17 +72,12 @@ Pull the latest changes from main, use `vellum` lifecycle CLI to stop and restar
    cd clients/macos && VELLUM_GATEWAY_DIR="$REPO_ROOT/gateway" ./build.sh run &
    ```
 
-9. Verify fresh state — run `vellum ps` to confirm processes are running, then check health endpoints:
+9. Verify fresh state — run `vellum ps` to confirm processes are running:
    ```bash
    sleep 5
    echo ""
    echo "=== Startup Summary ==="
    vellum ps
-   echo ""
-   DAEMON_STATUS=$(curl -sS --max-time 2 http://127.0.0.1:7821/healthz 2>&1 || echo "NOT YET RUNNING (app will start daemon on first launch/hatch)")
-   GATEWAY_STATUS=$(curl -sS --max-time 2 http://127.0.0.1:7830/healthz 2>&1 || echo "NOT YET RUNNING (app will start gateway on first launch/hatch)")
-   echo "  Daemon health:  $DAEMON_STATUS"
-   echo "  Gateway health: $GATEWAY_STATUS"
    echo "======================="
    ```
 


### PR DESCRIPTION
## Summary
- Remove direct `curl` calls to `127.0.0.1:7821/healthz` and `127.0.0.1:7830/healthz` in the startup summary step
- Use `vellum ps` instead, which already reports process status without hardcoded ports
- Addresses feedback from @awlevin on #11284

## Test plan
- [x] `/update` skill still shows startup summary via `vellum ps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
