### PR TITLE
M7: Finalize tests, architecture docs, and rollout safeguards

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -138,7 +138,7 @@ In addition to persistent trust rules (`always_allow` / `always_deny`), the appr
 | `src/runtime/session-approval-overrides.ts` | In-memory store: `setThreadMode`, `setTimedMode`, `getEffectiveMode`, `clearMode`, `hasActiveOverride`, `clearAll` |
 | `src/permissions/types.ts` | `UserDecision` type (includes `allow_10m`, `allow_thread`, `temporary_override`), `isAllowDecision()` helper |
 | `src/runtime/guardian-decision-types.ts` | `buildDecisionActions()` — controls which temporary options appear in approval prompts |
-| `src/tools/tool-approval-handler.ts` | Permission pipeline integration — checks temporary overrides before prompting |
+| `src/tools/permission-checker.ts` | Permission pipeline integration — checks temporary overrides before prompting |
 
 ### Canonical Guardian Request System
 

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -116,6 +116,30 @@ All guardian approval decisions — regardless of how they arrive — route thro
 | `src/daemon/ipc-contract/guardian-actions.ts` | IPC message type definitions for guardian action requests/responses |
 | `src/runtime/channel-approval-types.ts` | Channel-facing approval action types and `toApprovalActionOptions` bridge |
 
+### Temporary Approval Modes (Session-Scoped Overrides)
+
+In addition to persistent trust rules (`always_allow` / `always_deny`), the approval system supports two **temporary** approval modes that auto-approve tool confirmations for the duration of a conversation or a fixed time window. These exist to reduce prompt fatigue during intensive sessions without permanently altering the trust configuration.
+
+**Two modes:**
+
+1. **`allow_thread`** — Auto-approve all tool confirmations for the remainder of the current conversation. The override persists until the session ends, the conversation is closed, or the mode is explicitly cleared.
+2. **`allow_10m`** — Auto-approve all tool confirmations for 10 minutes (configurable). The override expires lazily on the next read after the TTL elapses — no background sweep runs.
+
+**Session-scoped, in-memory only:** Overrides are keyed by `conversationId` and stored in an in-memory `Map` inside `session-approval-overrides.ts`. They do not survive daemon restarts, which is intentional — temporary approvals should not outlive the session that created them.
+
+**Integration with the permission pipeline:** The tool-approval handler (`src/tools/tool-approval-handler.ts`) checks for an active temporary override via `getEffectiveMode()` before prompting the user. If an active override exists for the current conversation, the confirmation is auto-approved without surfacing a prompt. This check runs after persistent trust rules, so a persistent `deny` rule still takes precedence.
+
+**No persistent side effects:** Temporary modes do not write to `trust.json` or create persistent trust rules. They are purely ephemeral. The `buildDecisionActions()` function in `guardian-decision-types.ts` controls whether temporary options (`allow_10m`, `allow_thread`) are surfaced in the approval prompt UI, gated by the `temporaryOptionsAvailable` flag.
+
+**Key source files:**
+
+| File | Purpose |
+|------|---------|
+| `src/runtime/session-approval-overrides.ts` | In-memory store: `setThreadMode`, `setTimedMode`, `getEffectiveMode`, `clearMode`, `hasActiveOverride`, `clearAll` |
+| `src/permissions/types.ts` | `UserDecision` type (includes `allow_10m`, `allow_thread`, `temporary_override`), `isAllowDecision()` helper |
+| `src/runtime/guardian-decision-types.ts` | `buildDecisionActions()` — controls which temporary options appear in approval prompts |
+| `src/tools/tool-approval-handler.ts` | Permission pipeline integration — checks temporary overrides before prompting |
+
 ### Canonical Guardian Request System
 
 The canonical guardian request system provides a channel-agnostic, unified domain for all guardian approval and question flows. It replaces the fragmented per-channel storage with a single source of truth that works identically for voice calls, Telegram/SMS/WhatsApp, and desktop UI.

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -127,7 +127,7 @@ In addition to persistent trust rules (`always_allow` / `always_deny`), the appr
 
 **Session-scoped, in-memory only:** Overrides are keyed by `conversationId` and stored in an in-memory `Map` inside `session-approval-overrides.ts`. They do not survive daemon restarts, which is intentional — temporary approvals should not outlive the session that created them.
 
-**Integration with the permission pipeline:** The tool-approval handler (`src/tools/tool-approval-handler.ts`) checks for an active temporary override via `getEffectiveMode()` before prompting the user. If an active override exists for the current conversation, the confirmation is auto-approved without surfacing a prompt. This check runs after persistent trust rules, so a persistent `deny` rule still takes precedence.
+**Integration with the permission pipeline:** The permission checker (`src/tools/permission-checker.ts`) checks for an active temporary override via `getEffectiveMode()` before prompting the user. If an active override exists for the current conversation, the confirmation is auto-approved without surfacing a prompt. This check runs after persistent trust rules, so a persistent `deny` rule still takes precedence.
 
 **No persistent side effects:** Temporary modes do not write to `trust.json` or create persistent trust rules. They are purely ephemeral. The `buildDecisionActions()` function in `guardian-decision-types.ts` controls whether temporary options (`allow_10m`, `allow_thread`) are surfaced in the approval prompt UI, gated by the `temporaryOptionsAvailable` flag.
 

--- a/assistant/src/__tests__/permission-types.test.ts
+++ b/assistant/src/__tests__/permission-types.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isAllowDecision } from '../permissions/types.js';
+import type { UserDecision } from '../permissions/types.js';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('isAllowDecision', () => {
+  const allowDecisions: UserDecision[] = [
+    'allow',
+    'allow_10m',
+    'allow_thread',
+    'always_allow',
+    'always_allow_high_risk',
+    'temporary_override',
+  ];
+
+  for (const decision of allowDecisions) {
+    test(`returns true for '${decision}'`, () => {
+      expect(isAllowDecision(decision)).toBe(true);
+    });
+  }
+
+  test("returns false for 'deny'", () => {
+    expect(isAllowDecision('deny')).toBe(false);
+  });
+
+  test("returns false for 'always_deny'", () => {
+    expect(isAllowDecision('always_deny')).toBe(false);
+  });
+});

--- a/assistant/src/__tests__/session-approval-overrides.test.ts
+++ b/assistant/src/__tests__/session-approval-overrides.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import {
+  clearAll,
+  clearMode,
+  getEffectiveMode,
+  hasActiveOverride,
+  setThreadMode,
+  setTimedMode,
+} from '../runtime/session-approval-overrides.js';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('session-approval-overrides', () => {
+  afterEach(() => {
+    clearAll();
+  });
+
+  // -----------------------------------------------------------------------
+  // setThreadMode / getEffectiveMode
+  // -----------------------------------------------------------------------
+  describe('thread mode', () => {
+    test('setThreadMode stores a thread override', () => {
+      setThreadMode('conv-1');
+      const mode = getEffectiveMode('conv-1');
+      expect(mode).not.toBeNull();
+      expect(mode!.kind).toBe('thread');
+    });
+
+    test('thread mode persists across multiple reads', () => {
+      setThreadMode('conv-1');
+      expect(getEffectiveMode('conv-1')).not.toBeNull();
+      expect(getEffectiveMode('conv-1')).not.toBeNull();
+    });
+
+    test('thread mode is scoped to a specific conversationId', () => {
+      setThreadMode('conv-1');
+      expect(getEffectiveMode('conv-1')).not.toBeNull();
+      expect(getEffectiveMode('conv-2')).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // setTimedMode / getEffectiveMode
+  // -----------------------------------------------------------------------
+  describe('timed mode', () => {
+    test('setTimedMode stores a timed override with default 10-minute TTL', () => {
+      const before = Date.now();
+      setTimedMode('conv-1');
+      const after = Date.now();
+
+      const mode = getEffectiveMode('conv-1');
+      expect(mode).not.toBeNull();
+      expect(mode!.kind).toBe('timed');
+
+      const timed = mode!;
+      if (timed.kind === 'timed') {
+        const expectedMin = before + 10 * 60 * 1000;
+        const expectedMax = after + 10 * 60 * 1000;
+        expect(timed.expiresAt).toBeGreaterThanOrEqual(expectedMin);
+        expect(timed.expiresAt).toBeLessThanOrEqual(expectedMax);
+      }
+    });
+
+    test('setTimedMode accepts a custom duration', () => {
+      const before = Date.now();
+      setTimedMode('conv-1', 5000);
+      const after = Date.now();
+
+      const mode = getEffectiveMode('conv-1');
+      expect(mode).not.toBeNull();
+      const timed = mode!;
+      if (timed.kind === 'timed') {
+        expect(timed.expiresAt).toBeGreaterThanOrEqual(before + 5000);
+        expect(timed.expiresAt).toBeLessThanOrEqual(after + 5000);
+      }
+    });
+
+    test('timed mode expires after TTL elapses', async () => {
+      setTimedMode('conv-1', 1); // 1ms TTL
+      // Small delay to ensure expiry
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      expect(getEffectiveMode('conv-1')).toBeNull();
+    });
+
+    test('expired timed mode is lazily cleaned up on read', async () => {
+      setTimedMode('conv-1', 1);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+
+      // First read triggers cleanup and returns null
+      expect(getEffectiveMode('conv-1')).toBeNull();
+      // Subsequent read also returns null (entry was removed)
+      expect(getEffectiveMode('conv-1')).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Mode replacement
+  // -----------------------------------------------------------------------
+  describe('mode replacement', () => {
+    test('setTimedMode replaces an existing thread mode', () => {
+      setThreadMode('conv-1');
+      setTimedMode('conv-1', 60_000);
+
+      const mode = getEffectiveMode('conv-1');
+      expect(mode).not.toBeNull();
+      expect(mode!.kind).toBe('timed');
+    });
+
+    test('setThreadMode replaces an existing timed mode', () => {
+      setTimedMode('conv-1', 60_000);
+      setThreadMode('conv-1');
+
+      const mode = getEffectiveMode('conv-1');
+      expect(mode).not.toBeNull();
+      expect(mode!.kind).toBe('thread');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // clearMode
+  // -----------------------------------------------------------------------
+  describe('clearMode', () => {
+    test('clearMode removes a thread override', () => {
+      setThreadMode('conv-1');
+      clearMode('conv-1');
+      expect(getEffectiveMode('conv-1')).toBeNull();
+    });
+
+    test('clearMode removes a timed override', () => {
+      setTimedMode('conv-1', 60_000);
+      clearMode('conv-1');
+      expect(getEffectiveMode('conv-1')).toBeNull();
+    });
+
+    test('clearMode is a no-op for unknown conversationId', () => {
+      // Should not throw
+      clearMode('nonexistent');
+      expect(getEffectiveMode('nonexistent')).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // hasActiveOverride
+  // -----------------------------------------------------------------------
+  describe('hasActiveOverride', () => {
+    test('returns false when no override is set', () => {
+      expect(hasActiveOverride('conv-1')).toBe(false);
+    });
+
+    test('returns true for active thread override', () => {
+      setThreadMode('conv-1');
+      expect(hasActiveOverride('conv-1')).toBe(true);
+    });
+
+    test('returns true for active timed override', () => {
+      setTimedMode('conv-1', 60_000);
+      expect(hasActiveOverride('conv-1')).toBe(true);
+    });
+
+    test('returns false after timed override expires', async () => {
+      setTimedMode('conv-1', 1);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      expect(hasActiveOverride('conv-1')).toBe(false);
+    });
+
+    test('returns false after clearMode', () => {
+      setThreadMode('conv-1');
+      clearMode('conv-1');
+      expect(hasActiveOverride('conv-1')).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // clearAll
+  // -----------------------------------------------------------------------
+  describe('clearAll', () => {
+    test('clearAll removes all overrides', () => {
+      setThreadMode('conv-1');
+      setTimedMode('conv-2', 60_000);
+      setThreadMode('conv-3');
+
+      clearAll();
+
+      expect(getEffectiveMode('conv-1')).toBeNull();
+      expect(getEffectiveMode('conv-2')).toBeNull();
+      expect(getEffectiveMode('conv-3')).toBeNull();
+    });
+
+    test('clearAll is safe to call on empty store', () => {
+      // Should not throw
+      clearAll();
+      expect(hasActiveOverride('anything')).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getEffectiveMode with no override
+  // -----------------------------------------------------------------------
+  test('getEffectiveMode returns null for unknown conversationId', () => {
+    expect(getEffectiveMode('nonexistent')).toBeNull();
+  });
+});


### PR DESCRIPTION
Adds unit tests for session-approval-overrides and isAllowDecision, updates architecture docs. Closes #11237.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
