### PR TITLE
feat(auth): align IPC sessions with AuthContext shape (#11208)

### DIFF
--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -50,7 +50,7 @@ import {
   revokeByTokenHash,
 } from '../runtime/actor-token-store.js';
 import { ensureVellumGuardianBinding } from '../runtime/guardian-vellum-migration.js';
-import { resolveLocalIpcGuardianContext } from '../runtime/local-actor-identity.js';
+import { resolveLocalIpcAuthContext, resolveLocalIpcGuardianContext } from '../runtime/local-actor-identity.js';
 
 // ---------------------------------------------------------------------------
 // Test signing key
@@ -351,6 +351,57 @@ describe('resolveLocalIpcGuardianContext', () => {
     ensureVellumGuardianBinding('self');
     const ctx = resolveLocalIpcGuardianContext('vellum');
     expect(ctx.sourceChannel).toBe('vellum');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Local IPC AuthContext resolution
+// ---------------------------------------------------------------------------
+
+describe('resolveLocalIpcAuthContext', () => {
+  test('returns AuthContext with ipc principal type', () => {
+    const ctx = resolveLocalIpcAuthContext('session-123');
+    expect(ctx.principalType).toBe('ipc');
+  });
+
+  test('subject follows ipc:self:<sessionId> pattern', () => {
+    const ctx = resolveLocalIpcAuthContext('session-abc');
+    expect(ctx.subject).toBe('ipc:self:session-abc');
+  });
+
+  test('assistantId is always self', () => {
+    const ctx = resolveLocalIpcAuthContext('session-123');
+    expect(ctx.assistantId).toBe('self');
+  });
+
+  test('uses ipc_v1 scope profile with ipc.all scope', () => {
+    const ctx = resolveLocalIpcAuthContext('session-123');
+    expect(ctx.scopeProfile).toBe('ipc_v1');
+    expect(ctx.scopes.has('ipc.all')).toBe(true);
+  });
+
+  test('enriches actorPrincipalId from vellum guardian binding when present', () => {
+    ensureVellumGuardianBinding('self');
+    const binding = getActiveBinding('self', 'vellum');
+    expect(binding).toBeTruthy();
+
+    const ctx = resolveLocalIpcAuthContext('session-123');
+    expect(ctx.actorPrincipalId).toBe(binding!.guardianExternalUserId);
+  });
+
+  test('actorPrincipalId is undefined when no vellum binding exists', () => {
+    // Reset DB to ensure no binding
+    resetDb();
+    initializeDb();
+
+    const ctx = resolveLocalIpcAuthContext('session-123');
+    // When no binding exists, actorPrincipalId is not set
+    expect(ctx.actorPrincipalId).toBeUndefined();
+  });
+
+  test('sessionId matches the provided argument', () => {
+    const ctx = resolveLocalIpcAuthContext('my-session');
+    expect(ctx.sessionId).toBe('my-session');
   });
 });
 

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -19,7 +19,7 @@ import { GENERATING_TITLE, queueGenerateConversationTitle, UNTITLED_FALLBACK } f
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../../runtime/assistant-scope.js';
 import { routeGuardianReply } from '../../runtime/guardian-reply-router.js';
-import { resolveLocalIpcGuardianContext } from '../../runtime/local-actor-identity.js';
+import { resolveLocalIpcAuthContext, resolveLocalIpcGuardianContext } from '../../runtime/local-actor-identity.js';
 import * as pendingInteractions from '../../runtime/pending-interactions.js';
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { compileCustomPatterns, redactSecrets } from '../../security/secret-scanner.js';
@@ -286,6 +286,8 @@ export async function handleUserMessage(
       // the guardianPrincipalId, and resolveGuardianContext classifies the
       // local user as 'guardian' via binding match.
       session.setGuardianContext(resolveLocalIpcGuardianContext(ipcChannel));
+      // Align IPC sessions with the same AuthContext shape as HTTP sessions.
+      session.setAuthContext(resolveLocalIpcAuthContext(msg.sessionId));
       session.setCommandIntent(null);
       // Fire-and-forget: don't block the IPC handler so the connection can
       // continue receiving messages (e.g. cancel, confirmations, or

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -12,6 +12,7 @@ import { estimateBase64Bytes } from '../assistant-attachments.js';
 import { ComputerUseSession } from '../computer-use-session.js';
 import type { ClientMessage, CuSessionCreate, ServerMessage, SessionTransportMetadata } from '../ipc-protocol.js';
 import { Session } from '../session.js';
+import type { AuthContext } from '../../runtime/auth/types.js';
 import type { GuardianRuntimeContext } from '../session-runtime-assembly.js';
 
 const log = getLogger('handlers');
@@ -105,6 +106,8 @@ export interface SessionCreateOptions {
   transport?: SessionTransportMetadata;
   assistantId?: string;
   guardianContext?: GuardianRuntimeContext;
+  /** Normalized auth context for the session (IPC or HTTP-derived). */
+  authContext?: AuthContext;
   /** Whether this turn can block on interactive approval prompts. */
   isInteractive?: boolean;
   memoryScopeId?: string;

--- a/assistant/src/daemon/ipc-handler.ts
+++ b/assistant/src/daemon/ipc-handler.ts
@@ -5,8 +5,12 @@
  */
 import * as net from 'node:net';
 
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { buildAssistantEvent } from '../runtime/assistant-event.js';
 import { assistantEventHub } from '../runtime/assistant-event-hub.js';
+import { CURRENT_POLICY_EPOCH } from '../runtime/auth/policy.js';
+import { resolveScopeProfile } from '../runtime/auth/scopes.js';
+import type { AuthContext } from '../runtime/auth/types.js';
 import { getLogger } from '../util/logger.js';
 import { serialize, type ServerMessage } from './ipc-protocol.js';
 
@@ -76,6 +80,26 @@ export class IpcSender {
         log.warn({ err }, 'assistant-events hub subscriber threw during IPC send');
       });
   }
+}
+
+/**
+ * Build a synthetic AuthContext for an IPC session.
+ *
+ * IPC connections are local-only (Unix domain socket) and pre-authenticated
+ * via the daemon's file-system permission model. This produces the same
+ * AuthContext shape that HTTP routes receive from JWT verification, keeping
+ * downstream code transport-agnostic.
+ */
+export function buildIpcAuthContext(sessionId: string): AuthContext {
+  return {
+    subject: `ipc:self:${sessionId}`,
+    principalType: 'ipc',
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+    sessionId,
+    scopeProfile: 'ipc_v1',
+    scopes: resolveScopeProfile('ipc_v1'),
+    policyEpoch: CURRENT_POLICY_EPOCH,
+  };
 }
 
 /** Extract sessionId from a ServerMessage if present. */

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -850,6 +850,7 @@ export class DaemonServer {
     const resolvedInterface = resolveTurnInterface(sourceInterface);
     session.setAssistantId(options?.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID);
     session.setGuardianContext(options?.guardianContext ?? null);
+    session.setAuthContext(options?.authContext ?? null);
     await session.ensureActorScopedHistory();
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel, sourceInterface));
     session.setCommandIntent(options?.commandIntent ?? null);

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -73,6 +73,7 @@ import {
 } from './session-process.js';
 import type { QueueDrainReason, QueueMetrics } from './session-queue-manager.js';
 import { MessageQueue } from './session-queue-manager.js';
+import type { AuthContext } from '../runtime/auth/types.js';
 import type { ChannelCapabilities, GuardianRuntimeContext } from './session-runtime-assembly.js';
 import type { SkillProjectionCache } from './session-skill-tools.js';
 import {
@@ -142,6 +143,7 @@ export class Session {
   /** @internal */ currentPage?: string;
   /** @internal */ channelCapabilities?: ChannelCapabilities;
   /** @internal */ guardianContext?: GuardianRuntimeContext;
+  /** @internal */ authContext?: AuthContext;
   /** @internal */ loadedHistoryTrustClass?: GuardianRuntimeContext['trustClass'];
   /** @internal */ voiceCallControlPrompt?: string;
   /** @internal */ assistantId?: string;
@@ -561,6 +563,14 @@ export class Session {
 
   setGuardianContext(ctx: GuardianRuntimeContext | null): void {
     this.guardianContext = ctx ?? undefined;
+  }
+
+  setAuthContext(ctx: AuthContext | null): void {
+    this.authContext = ctx ?? undefined;
+  }
+
+  getAuthContext(): AuthContext | undefined {
+    return this.authContext;
   }
 
   setVoiceCallControlPrompt(prompt: string | null): void {

--- a/assistant/src/runtime/auth/__tests__/ipc-auth-context.test.ts
+++ b/assistant/src/runtime/auth/__tests__/ipc-auth-context.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test';
+
+import { buildIpcAuthContext } from '../../../daemon/ipc-handler.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../../assistant-scope.js';
+import { CURRENT_POLICY_EPOCH } from '../policy.js';
+import { resolveScopeProfile } from '../scopes.js';
+
+describe('buildIpcAuthContext', () => {
+  test('produces correct subject pattern', () => {
+    const ctx = buildIpcAuthContext('session-abc');
+    expect(ctx.subject).toBe('ipc:self:session-abc');
+  });
+
+  test('sets principalType to ipc', () => {
+    const ctx = buildIpcAuthContext('session-abc');
+    expect(ctx.principalType).toBe('ipc');
+  });
+
+  test('uses DAEMON_INTERNAL_ASSISTANT_ID for assistantId', () => {
+    const ctx = buildIpcAuthContext('session-abc');
+    expect(ctx.assistantId).toBe(DAEMON_INTERNAL_ASSISTANT_ID);
+    expect(ctx.assistantId).toBe('self');
+  });
+
+  test('includes sessionId from argument', () => {
+    const ctx = buildIpcAuthContext('my-session-123');
+    expect(ctx.sessionId).toBe('my-session-123');
+  });
+
+  test('uses ipc_v1 scope profile', () => {
+    const ctx = buildIpcAuthContext('session-abc');
+    expect(ctx.scopeProfile).toBe('ipc_v1');
+  });
+
+  test('resolves scopes from ipc_v1 profile', () => {
+    const ctx = buildIpcAuthContext('session-abc');
+    const expectedScopes = resolveScopeProfile('ipc_v1');
+    expect(ctx.scopes).toBe(expectedScopes);
+    expect(ctx.scopes.has('ipc.all')).toBe(true);
+  });
+
+  test('uses current policy epoch', () => {
+    const ctx = buildIpcAuthContext('session-abc');
+    expect(ctx.policyEpoch).toBe(CURRENT_POLICY_EPOCH);
+  });
+
+  test('does not set actorPrincipalId', () => {
+    const ctx = buildIpcAuthContext('session-abc');
+    expect(ctx.actorPrincipalId).toBeUndefined();
+  });
+
+  test('matches AuthContext shape from HTTP JWT-derived contexts', () => {
+    const ctx = buildIpcAuthContext('session-xyz');
+
+    // Verify all required AuthContext fields are present
+    expect(typeof ctx.subject).toBe('string');
+    expect(typeof ctx.principalType).toBe('string');
+    expect(typeof ctx.assistantId).toBe('string');
+    expect(typeof ctx.scopeProfile).toBe('string');
+    expect(typeof ctx.policyEpoch).toBe('number');
+    expect(ctx.scopes).toBeDefined();
+    expect(typeof ctx.scopes.has).toBe('function');
+  });
+
+  test('different session IDs produce different subjects', () => {
+    const ctx1 = buildIpcAuthContext('session-1');
+    const ctx2 = buildIpcAuthContext('session-2');
+    expect(ctx1.subject).not.toBe(ctx2.subject);
+    expect(ctx1.sessionId).not.toBe(ctx2.sessionId);
+  });
+});

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -12,10 +12,12 @@
  */
 
 import type { ChannelId } from '../channels/types.js';
+import { buildIpcAuthContext } from '../daemon/ipc-handler.js';
 import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
 import { getActiveBinding } from '../memory/guardian-bindings.js';
 import { getLogger } from '../util/logger.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
+import type { AuthContext } from './auth/types.js';
 import { resolveGuardianContext } from './guardian-context-resolver.js';
 import { ensureVellumGuardianBinding } from './guardian-vellum-migration.js';
 
@@ -77,4 +79,27 @@ export function resolveLocalIpcGuardianContext(
   // Overlay the caller's actual sourceChannel onto the resolved context
   // so downstream consumers see the correct channel provenance.
   return { ...guardianCtx, sourceChannel };
+}
+
+/**
+ * Build an AuthContext for a local IPC connection.
+ *
+ * Produces the same AuthContext shape that HTTP routes receive from JWT
+ * verification, using the `ipc_v1` scope profile. The `actorPrincipalId`
+ * is populated from the vellum guardian binding when available, enabling
+ * downstream code to resolve guardian context using the same
+ * `authContext.actorPrincipalId` path as HTTP sessions.
+ */
+export function resolveLocalIpcAuthContext(sessionId: string): AuthContext {
+  const authContext = buildIpcAuthContext(sessionId);
+
+  // Enrich with the guardian principal ID when a vellum binding exists,
+  // so downstream guardian resolution can use authContext.actorPrincipalId.
+  const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
+  const binding = getActiveBinding(assistantId, 'vellum');
+  if (binding) {
+    return { ...authContext, actorPrincipalId: binding.guardianExternalUserId };
+  }
+
+  return authContext;
 }


### PR DESCRIPTION
## Summary
- IPC sessions now produce the same AuthContext shape as HTTP sessions
- Synthetic AuthContext constructed on IPC connection (subject: ipc:self:<sessionId>)
- Session types updated to optionally accept AuthContext
- local-actor-identity updated to produce AuthContext for local connections
- Type-level alignment only — no behavioral changes

Closes #11208
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
