### PR TITLE
Allow All Commands: Temporary Approval Modes (10m + Thread)

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -116,6 +116,30 @@ All guardian approval decisions — regardless of how they arrive — route thro
 | `src/daemon/ipc-contract/guardian-actions.ts`  | IPC message type definitions for guardian action requests/responses                                                                               |
 | `src/runtime/channel-approval-types.ts`        | Channel-facing approval action types and `toApprovalActionOptions` bridge                                                                         |
 
+### Temporary Approval Modes (Session-Scoped Overrides)
+
+In addition to persistent trust rules (`always_allow` / `always_deny`), the approval system supports two **temporary** approval modes that auto-approve tool confirmations for the duration of a conversation or a fixed time window. These exist to reduce prompt fatigue during intensive sessions without permanently altering the trust configuration.
+
+**Two modes:**
+
+1. **`allow_thread`** — Auto-approve all tool confirmations for the remainder of the current conversation. The override persists until the session ends, the conversation is closed, or the mode is explicitly cleared.
+2. **`allow_10m`** — Auto-approve all tool confirmations for 10 minutes (configurable). The override expires lazily on the next read after the TTL elapses — no background sweep runs.
+
+**Session-scoped, in-memory only:** Overrides are keyed by `conversationId` and stored in an in-memory `Map` inside `session-approval-overrides.ts`. They do not survive daemon restarts, which is intentional — temporary approvals should not outlive the session that created them.
+
+**Integration with the permission pipeline:** The permission checker (`src/tools/permission-checker.ts`) checks for an active temporary override via `getEffectiveMode()` before prompting the user. If an active override exists for the current conversation, the confirmation is auto-approved without surfacing a prompt. This check runs after persistent trust rules, so a persistent `deny` rule still takes precedence.
+
+**No persistent side effects:** Temporary modes do not write to `trust.json` or create persistent trust rules. They are purely ephemeral. The `buildDecisionActions()` function in `guardian-decision-types.ts` controls whether temporary options (`allow_10m`, `allow_thread`) are surfaced in the approval prompt UI, gated by the `temporaryOptionsAvailable` flag.
+
+**Key source files:**
+
+| File | Purpose |
+|------|---------|
+| `src/runtime/session-approval-overrides.ts` | In-memory store: `setThreadMode`, `setTimedMode`, `getEffectiveMode`, `clearMode`, `hasActiveOverride`, `clearAll` |
+| `src/permissions/types.ts` | `UserDecision` type (includes `allow_10m`, `allow_thread`, `temporary_override`), `isAllowDecision()` helper |
+| `src/runtime/guardian-decision-types.ts` | `buildDecisionActions()` — controls which temporary options appear in approval prompts |
+| `src/tools/permission-checker.ts` | Permission pipeline integration — checks temporary overrides before prompting |
+
 ### Canonical Guardian Request System
 
 The canonical guardian request system provides a channel-agnostic, unified domain for all guardian approval and question flows. It replaces the fragmented per-channel storage with a single source of truth that works identically for voice calls, Telegram/SMS/WhatsApp, and desktop UI.

--- a/assistant/src/__tests__/channel-approval.test.ts
+++ b/assistant/src/__tests__/channel-approval.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import { parseApprovalDecision } from '../runtime/channel-approval-parser.js';
+import { parseCallbackData } from '../runtime/routes/channel-route-shared.js';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Plain-text approval decision parser
@@ -29,6 +30,48 @@ describe('parseApprovalDecision', () => {
     const result = parseApprovalDecision(input);
     expect(result).not.toBeNull();
     expect(result!.action).toBe('approve_once');
+    expect(result!.source).toBe('plain_text');
+  });
+
+  // ── Approve for 10 minutes ────────────────────────────────────────
+
+  test.each([
+    'approve for 10 minutes',
+    'Approve for 10 minutes',
+    'APPROVE FOR 10 MINUTES',
+    'allow for 10 minutes',
+    'Allow for 10 minutes',
+    'ALLOW FOR 10 MINUTES',
+    'approve 10m',
+    'Approve 10m',
+    'APPROVE 10M',
+    'allow 10m',
+    'approve 10 min',
+    'allow 10 min',
+  ])('recognises "%s" as approve_10m', (input) => {
+    const result = parseApprovalDecision(input);
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe('approve_10m');
+    expect(result!.source).toBe('plain_text');
+  });
+
+  // ── Approve for thread ────────────────────────────────────────────
+
+  test.each([
+    'approve for thread',
+    'Approve for thread',
+    'APPROVE FOR THREAD',
+    'allow for thread',
+    'Allow for thread',
+    'ALLOW FOR THREAD',
+    'approve thread',
+    'Approve thread',
+    'APPROVE THREAD',
+    'allow thread',
+  ])('recognises "%s" as approve_thread', (input) => {
+    const result = parseApprovalDecision(input);
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe('approve_thread');
     expect(result!.source).toBe('plain_text');
   });
 
@@ -130,6 +173,20 @@ describe('parseApprovalDecision', () => {
     expect(result!.requestId).toBe('req-789');
   });
 
+  test('extracts requestId from [ref:...] tag with approve_10m decision', () => {
+    const result = parseApprovalDecision('approve for 10 minutes [ref:req-timer]');
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe('approve_10m');
+    expect(result!.requestId).toBe('req-timer');
+  });
+
+  test('extracts requestId from [ref:...] tag with approve_thread decision', () => {
+    const result = parseApprovalDecision('approve for thread [ref:req-thread]');
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe('approve_thread');
+    expect(result!.requestId).toBe('req-thread');
+  });
+
   test('handles ref tag on separate line', () => {
     const result = parseApprovalDecision('yes\n[ref:req-abc-123]');
     expect(result).not.toBeNull();
@@ -141,5 +198,48 @@ describe('parseApprovalDecision', () => {
     const result = parseApprovalDecision('yes');
     expect(result).not.toBeNull();
     expect(result!.requestId).toBeUndefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Callback data parser
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('parseCallbackData', () => {
+  test.each([
+    ['apr:req-123:approve_once', 'approve_once'],
+    ['apr:req-123:approve_10m', 'approve_10m'],
+    ['apr:req-123:approve_thread', 'approve_thread'],
+    ['apr:req-123:approve_always', 'approve_always'],
+    ['apr:req-123:reject', 'reject'],
+  ] as const)('parses "%s" as action "%s"', (data, expectedAction) => {
+    const result = parseCallbackData(data);
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe(expectedAction);
+    expect(result!.requestId).toBe('req-123');
+    expect(result!.source).toBe('telegram_button');
+  });
+
+  test('parses whatsapp source channel', () => {
+    const result = parseCallbackData('apr:req-456:approve_10m', 'whatsapp');
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe('approve_10m');
+    expect(result!.source).toBe('whatsapp_button');
+  });
+
+  test('returns null for unknown action', () => {
+    expect(parseCallbackData('apr:req-123:unknown_action')).toBeNull();
+  });
+
+  test('returns null for missing prefix', () => {
+    expect(parseCallbackData('xyz:req-123:approve_once')).toBeNull();
+  });
+
+  test('returns null for incomplete data', () => {
+    expect(parseCallbackData('apr:req-123')).toBeNull();
+  });
+
+  test('returns null for empty requestId', () => {
+    expect(parseCallbackData('apr::approve_once')).toBeNull();
   });
 });

--- a/assistant/src/__tests__/permission-types.test.ts
+++ b/assistant/src/__tests__/permission-types.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isAllowDecision } from '../permissions/types.js';
+import type { UserDecision } from '../permissions/types.js';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('isAllowDecision', () => {
+  const allowDecisions: UserDecision[] = [
+    'allow',
+    'allow_10m',
+    'allow_thread',
+    'always_allow',
+    'always_allow_high_risk',
+    'temporary_override',
+  ];
+
+  for (const decision of allowDecisions) {
+    test(`returns true for '${decision}'`, () => {
+      expect(isAllowDecision(decision)).toBe(true);
+    });
+  }
+
+  test("returns false for 'deny'", () => {
+    expect(isAllowDecision('deny')).toBe(false);
+  });
+
+  test("returns false for 'always_deny'", () => {
+    expect(isAllowDecision('always_deny')).toBe(false);
+  });
+});

--- a/assistant/src/__tests__/session-approval-overrides.test.ts
+++ b/assistant/src/__tests__/session-approval-overrides.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import {
+  clearAll,
+  clearMode,
+  getEffectiveMode,
+  hasActiveOverride,
+  setThreadMode,
+  setTimedMode,
+} from '../runtime/session-approval-overrides.js';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('session-approval-overrides', () => {
+  afterEach(() => {
+    clearAll();
+  });
+
+  // -----------------------------------------------------------------------
+  // setThreadMode / getEffectiveMode
+  // -----------------------------------------------------------------------
+  describe('thread mode', () => {
+    test('setThreadMode stores a thread override', () => {
+      setThreadMode('conv-1');
+      const mode = getEffectiveMode('conv-1');
+      expect(mode).not.toBeNull();
+      expect(mode!.kind).toBe('thread');
+    });
+
+    test('thread mode persists across multiple reads', () => {
+      setThreadMode('conv-1');
+      expect(getEffectiveMode('conv-1')).not.toBeNull();
+      expect(getEffectiveMode('conv-1')).not.toBeNull();
+    });
+
+    test('thread mode is scoped to a specific conversationId', () => {
+      setThreadMode('conv-1');
+      expect(getEffectiveMode('conv-1')).not.toBeNull();
+      expect(getEffectiveMode('conv-2')).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // setTimedMode / getEffectiveMode
+  // -----------------------------------------------------------------------
+  describe('timed mode', () => {
+    test('setTimedMode stores a timed override with default 10-minute TTL', () => {
+      const before = Date.now();
+      setTimedMode('conv-1');
+      const after = Date.now();
+
+      const mode = getEffectiveMode('conv-1');
+      expect(mode).not.toBeNull();
+      expect(mode!.kind).toBe('timed');
+
+      const timed = mode!;
+      if (timed.kind === 'timed') {
+        const expectedMin = before + 10 * 60 * 1000;
+        const expectedMax = after + 10 * 60 * 1000;
+        expect(timed.expiresAt).toBeGreaterThanOrEqual(expectedMin);
+        expect(timed.expiresAt).toBeLessThanOrEqual(expectedMax);
+      }
+    });
+
+    test('setTimedMode accepts a custom duration', () => {
+      const before = Date.now();
+      setTimedMode('conv-1', 5000);
+      const after = Date.now();
+
+      const mode = getEffectiveMode('conv-1');
+      expect(mode).not.toBeNull();
+      const timed = mode!;
+      if (timed.kind === 'timed') {
+        expect(timed.expiresAt).toBeGreaterThanOrEqual(before + 5000);
+        expect(timed.expiresAt).toBeLessThanOrEqual(after + 5000);
+      }
+    });
+
+    test('timed mode expires after TTL elapses', async () => {
+      setTimedMode('conv-1', 1); // 1ms TTL
+      // Small delay to ensure expiry
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      expect(getEffectiveMode('conv-1')).toBeNull();
+    });
+
+    test('expired timed mode is lazily cleaned up on read', async () => {
+      setTimedMode('conv-1', 1);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+
+      // First read triggers cleanup and returns null
+      expect(getEffectiveMode('conv-1')).toBeNull();
+      // Subsequent read also returns null (entry was removed)
+      expect(getEffectiveMode('conv-1')).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Mode replacement
+  // -----------------------------------------------------------------------
+  describe('mode replacement', () => {
+    test('setTimedMode replaces an existing thread mode', () => {
+      setThreadMode('conv-1');
+      setTimedMode('conv-1', 60_000);
+
+      const mode = getEffectiveMode('conv-1');
+      expect(mode).not.toBeNull();
+      expect(mode!.kind).toBe('timed');
+    });
+
+    test('setThreadMode replaces an existing timed mode', () => {
+      setTimedMode('conv-1', 60_000);
+      setThreadMode('conv-1');
+
+      const mode = getEffectiveMode('conv-1');
+      expect(mode).not.toBeNull();
+      expect(mode!.kind).toBe('thread');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // clearMode
+  // -----------------------------------------------------------------------
+  describe('clearMode', () => {
+    test('clearMode removes a thread override', () => {
+      setThreadMode('conv-1');
+      clearMode('conv-1');
+      expect(getEffectiveMode('conv-1')).toBeNull();
+    });
+
+    test('clearMode removes a timed override', () => {
+      setTimedMode('conv-1', 60_000);
+      clearMode('conv-1');
+      expect(getEffectiveMode('conv-1')).toBeNull();
+    });
+
+    test('clearMode is a no-op for unknown conversationId', () => {
+      // Should not throw
+      clearMode('nonexistent');
+      expect(getEffectiveMode('nonexistent')).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // hasActiveOverride
+  // -----------------------------------------------------------------------
+  describe('hasActiveOverride', () => {
+    test('returns false when no override is set', () => {
+      expect(hasActiveOverride('conv-1')).toBe(false);
+    });
+
+    test('returns true for active thread override', () => {
+      setThreadMode('conv-1');
+      expect(hasActiveOverride('conv-1')).toBe(true);
+    });
+
+    test('returns true for active timed override', () => {
+      setTimedMode('conv-1', 60_000);
+      expect(hasActiveOverride('conv-1')).toBe(true);
+    });
+
+    test('returns false after timed override expires', async () => {
+      setTimedMode('conv-1', 1);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      expect(hasActiveOverride('conv-1')).toBe(false);
+    });
+
+    test('returns false after clearMode', () => {
+      setThreadMode('conv-1');
+      clearMode('conv-1');
+      expect(hasActiveOverride('conv-1')).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // clearAll
+  // -----------------------------------------------------------------------
+  describe('clearAll', () => {
+    test('clearAll removes all overrides', () => {
+      setThreadMode('conv-1');
+      setTimedMode('conv-2', 60_000);
+      setThreadMode('conv-3');
+
+      clearAll();
+
+      expect(getEffectiveMode('conv-1')).toBeNull();
+      expect(getEffectiveMode('conv-2')).toBeNull();
+      expect(getEffectiveMode('conv-3')).toBeNull();
+    });
+
+    test('clearAll is safe to call on empty store', () => {
+      // Should not throw
+      clearAll();
+      expect(hasActiveOverride('anything')).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getEffectiveMode with no override
+  // -----------------------------------------------------------------------
+  test('getEffectiveMode returns null for unknown conversationId', () => {
+    expect(getEffectiveMode('nonexistent')).toBeNull();
+  });
+});

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -162,10 +162,11 @@ export interface ApplyGuardianDecisionParams {
 export function applyGuardianDecision(params: ApplyGuardianDecisionParams): ApplyGuardianDecisionResult {
   const { approval, decision, actorExternalUserId, actorChannel, decisionContext } = params;
 
-  // Guardians cannot approve_always on behalf of requesters -- downgrade.
-  const effectiveDecision: ApprovalDecisionResult = decision.action === 'approve_always'
-    ? { ...decision, action: 'approve_once' }
-    : decision;
+  // Guardians cannot grant broad allow modes on behalf of requesters -- downgrade.
+  const effectiveDecision: ApprovalDecisionResult =
+    decision.action === 'approve_always' || decision.action === 'approve_10m' || decision.action === 'approve_thread'
+      ? { ...decision, action: 'approve_once' }
+      : decision;
 
   // Capture pending approval info before handleChannelDecision resolves
   // (and removes) the pending interaction. Needed for grant minting.
@@ -282,6 +283,8 @@ export function mintCanonicalRequestGrant(params: {
 /** Valid actions for canonical guardian decisions. */
 const VALID_CANONICAL_ACTIONS: ReadonlySet<ApprovalAction> = new Set([
   'approve_once',
+  'approve_10m',
+  'approve_thread',
   'approve_always',
   'reject',
 ]);
@@ -404,11 +407,13 @@ export async function applyCanonicalGuardianDecision(
     return { applied: false, reason: 'expired' };
   }
 
-  // 3. Downgrade approve_always to approve_once for guardian-on-behalf requests.
-  // Guardians cannot permanently allowlist tools on behalf of requesters.
-  const effectiveAction: ApprovalAction = action === 'approve_always'
-    ? 'approve_once'
-    : action;
+  // 3. Downgrade approve_always and temporary modes to approve_once for
+  // guardian-on-behalf requests. Guardians cannot grant broad allow modes
+  // (permanent, timed, or thread-scoped) on behalf of requesters.
+  const effectiveAction: ApprovalAction =
+    action === 'approve_always' || action === 'approve_10m' || action === 'approve_thread'
+      ? 'approve_once'
+      : action;
 
   // 4. CAS resolve: atomically transition from 'pending' to terminal status
   const targetStatus: CanonicalRequestStatus = effectiveAction === 'reject'

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -232,6 +232,12 @@ export async function startCli(): Promise<void> {
     }
     process.stdout.write(`\u2502\n`);
     process.stdout.write(`\u2502 [a] Allow once\n`);
+    if (req.temporaryOptionsAvailable?.includes('allow_10m')) {
+      process.stdout.write(`\u2502 [t] Allow 10m\n`);
+    }
+    if (req.temporaryOptionsAvailable?.includes('allow_thread')) {
+      process.stdout.write(`\u2502 [T] Allow Thread\n`);
+    }
     process.stdout.write(`\u2502 [d] Deny once\n`);
     if (req.allowlistOptions.length > 0 && req.scopeOptions.length > 0) {
       process.stdout.write(`\u2502 [A] Allowlist...\n`);
@@ -273,6 +279,24 @@ export async function startCli(): Promise<void> {
           type: 'confirmation_response',
           requestId: req.requestId,
           decision: 'allow',
+        });
+        return;
+      }
+
+      if (choice === 't' && trimmed === 't' && req.temporaryOptionsAvailable?.includes('allow_10m')) {
+        send({
+          type: 'confirmation_response',
+          requestId: req.requestId,
+          decision: 'allow_10m',
+        });
+        return;
+      }
+
+      if (trimmed === 'T' && req.temporaryOptionsAvailable?.includes('allow_thread')) {
+        send({
+          type: 'confirmation_response',
+          requestId: req.requestId,
+          decision: 'allow_thread',
         });
         return;
       }

--- a/assistant/src/daemon/approval-generators.ts
+++ b/assistant/src/daemon/approval-generators.ts
@@ -37,11 +37,12 @@ const APPROVAL_CONVERSATION_TOOL_SCHEMA = {
     properties: {
       disposition: {
         type: 'string',
-        enum: ['keep_pending', 'approve_once', 'approve_always', 'reject'],
+        enum: ['keep_pending', 'approve_once', 'approve_10m', 'approve_thread', 'approve_always', 'reject'],
         description:
           'The decision: keep_pending if the user is asking questions or unclear, '
-          + 'approve_once to approve this single request, approve_always to approve '
-          + 'this tool permanently, reject to deny the request.',
+          + 'approve_once to approve this single request, approve_10m to approve all '
+          + 'requests for 10 minutes, approve_thread to approve all requests in this '
+          + 'thread, approve_always to approve this tool permanently, reject to deny the request.',
       },
       replyText: {
         type: 'string',
@@ -61,6 +62,8 @@ const APPROVAL_CONVERSATION_TOOL_SCHEMA = {
 const VALID_DISPOSITIONS: ReadonlySet<string> = new Set([
   'keep_pending',
   'approve_once',
+  'approve_10m',
+  'approve_thread',
   'approve_always',
   'reject',
 ]);

--- a/assistant/src/daemon/handlers/guardian-actions.ts
+++ b/assistant/src/daemon/handlers/guardian-actions.ts
@@ -8,7 +8,7 @@ import { listGuardianDecisionPrompts } from '../../runtime/routes/guardian-actio
 import type { GuardianActionDecision, GuardianActionsPendingRequest } from '../ipc-protocol.js';
 import { defineHandlers, log } from './shared.js';
 
-const VALID_ACTIONS = new Set<string>(['approve_once', 'approve_always', 'reject']);
+const VALID_ACTIONS = new Set<string>(['approve_once', 'approve_10m', 'approve_thread', 'approve_always', 'reject']);
 
 export const guardianActionsHandlers = defineHandlers({
   guardian_actions_pending_request: (msg: GuardianActionsPendingRequest, socket, ctx) => {

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -119,6 +119,7 @@ function makeIpcEventSender(params: {
           allowlistOptions: event.allowlistOptions,
           scopeOptions: event.scopeOptions,
           persistentDecisionsAllowed: event.persistentDecisionsAllowed,
+          temporaryOptionsAvailable: event.temporaryOptionsAvailable,
         },
       });
 

--- a/assistant/src/daemon/ipc-contract/messages.ts
+++ b/assistant/src/daemon/ipc-contract/messages.ts
@@ -30,7 +30,7 @@ export interface UserMessage {
 export interface ConfirmationResponse {
   type: 'confirmation_response';
   requestId: string;
-  decision: 'allow' | 'always_allow' | 'always_allow_high_risk' | 'deny' | 'always_deny';
+  decision: 'allow' | 'allow_10m' | 'allow_thread' | 'always_allow' | 'always_allow_high_risk' | 'deny' | 'always_deny';
   selectedPattern?: string;
   selectedScope?: string;
 }
@@ -119,6 +119,8 @@ export interface ConfirmationRequest {
   sessionId?: string;
   /** When false, the client should hide "always allow" / trust-rule persistence affordances. */
   persistentDecisionsAllowed?: boolean;
+  /** Which temporary approval options the client should render (e.g. "Allow for 10 minutes", "Allow for this thread"). */
+  temporaryOptionsAvailable?: Array<'allow_10m' | 'allow_thread'>;
 }
 
 export interface SecretRequest {

--- a/assistant/src/daemon/ipc-validate.ts
+++ b/assistant/src/daemon/ipc-validate.ts
@@ -137,7 +137,7 @@ const HIGH_RISK_VALIDATORS: Record<string, PropertyValidator> = {
     if (typeof obj.requestId !== 'string' || obj.requestId === '') {
       return 'confirmation_response requires a non-empty string "requestId"';
     }
-    const validDecisions = ['allow', 'always_allow', 'always_allow_high_risk', 'deny', 'always_deny'];
+    const validDecisions = ['allow', 'allow_10m', 'allow_thread', 'always_allow', 'always_allow_high_risk', 'deny', 'always_deny'];
     if (typeof obj.decision !== 'string' || !validDecisions.includes(obj.decision)) {
       return `confirmation_response "decision" must be one of: ${validDecisions.join(', ')}`;
     }

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -163,6 +163,7 @@ function makePendingInteractionRegistrar(
           allowlistOptions: msg.allowlistOptions,
           scopeOptions: msg.scopeOptions,
           persistentDecisionsAllowed: msg.persistentDecisionsAllowed,
+          temporaryOptionsAvailable: msg.temporaryOptionsAvailable,
         },
       });
 

--- a/assistant/src/daemon/session-attachments.ts
+++ b/assistant/src/daemon/session-attachments.ts
@@ -2,6 +2,7 @@ import { AttachmentUploadError,linkAttachmentToMessage, setAttachmentThumbnail, 
 import { check, classifyRisk, generateAllowlistOptions, generateScopeOptions } from '../permissions/checker.js';
 import type { PermissionPrompter } from '../permissions/prompter.js';
 import { addRule } from '../permissions/trust-store.js';
+import { isAllowDecision } from '../permissions/types.js';
 import type { ContentBlock } from '../providers/types.js';
 import { getLogger } from '../util/logger.js';
 import {
@@ -67,7 +68,7 @@ export async function approveHostAttachmentRead(
     addRule(toolName, response.selectedPattern, response.selectedScope, 'deny');
   }
 
-  return response.decision === 'allow' || response.decision === 'always_allow' || response.decision === 'always_allow_high_risk';
+  return isAllowDecision(response.decision);
 }
 
 export function formatAttachmentWarnings(warnings: string[]): string | null {

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -11,6 +11,7 @@ import type { PermissionPrompter } from '../permissions/prompter.js';
 import type { SecretPrompter } from '../permissions/secret-prompter.js';
 import { addRule, findHighestPriorityRule } from '../permissions/trust-store.js';
 import { isAllowDecision } from '../permissions/types.js';
+import { getEffectiveMode } from '../runtime/session-approval-overrides.js';
 import type { Message, ToolDefinition } from '../providers/types.js';
 import type { ToolExecutor } from '../tools/executor.js';
 import type { ToolExecutionResult, ToolLifecycleEventHandler } from '../tools/types.js';
@@ -163,6 +164,12 @@ export function createToolExecutor(
             decision: existingRule.decision === 'allow' ? 'allow' as const : 'deny' as const,
           };
         }
+        // Auto-approve sub-tool confirmations when a temporary approval
+        // override is active for this conversation (guardian only).
+        const guardianTrust = ctx.guardianContext?.trustClass ?? 'guardian';
+        if (guardianTrust === 'guardian' && getEffectiveMode(ctx.conversationId) !== null) {
+          return { decision: 'allow' as const };
+        }
         const allowlistOptions = [
           { label: `cc:${req.toolName}`, description: `Claude Code ${req.toolName}`, pattern: `cc:${req.toolName}` },
           { label: 'cc:*', description: 'All Claude Code sub-tools', pattern: 'cc:*' },
@@ -260,6 +267,13 @@ export function createProxyApprovalCallback(
     // blocking for the full permission timeout before auto-denying.
     if (ctx.hasNoClient) {
       return false;
+    }
+
+    // Auto-approve proxy network requests when a temporary approval
+    // override is active for this conversation (guardian only).
+    const proxyGuardianTrust = ctx.guardianContext?.trustClass ?? 'guardian';
+    if (proxyGuardianTrust === 'guardian' && getEffectiveMode(ctx.conversationId) !== null) {
+      return true;
     }
 
     const response = await prompter.prompt(

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -269,12 +269,10 @@ export function createProxyApprovalCallback(
       return false;
     }
 
-    // Auto-approve proxy network requests when a temporary approval
-    // override is active for this conversation (guardian only).
-    const proxyGuardianTrust = ctx.guardianContext?.trustClass ?? 'guardian';
-    if (proxyGuardianTrust === 'guardian' && getEffectiveMode(ctx.conversationId) !== null) {
-      return true;
-    }
+    // Proxied network requests require per-invocation approval and must
+    // not be auto-approved by temporary overrides (allow_10m / allow_thread).
+    // Unlike regular tool invocations, these represent outbound network
+    // actions that should always receive explicit confirmation.
 
     const response = await prompter.prompt(
       toolName,

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -10,6 +10,7 @@ import { generateAllowlistOptions, generateScopeOptions, normalizeWebFetchUrl } 
 import type { PermissionPrompter } from '../permissions/prompter.js';
 import type { SecretPrompter } from '../permissions/secret-prompter.js';
 import { addRule, findHighestPriorityRule } from '../permissions/trust-store.js';
+import { isAllowDecision } from '../permissions/types.js';
 import type { Message, ToolDefinition } from '../providers/types.js';
 import type { ToolExecutor } from '../tools/executor.js';
 import type { ToolExecutionResult, ToolLifecycleEventHandler } from '../tools/types.js';
@@ -187,7 +188,7 @@ export function createToolExecutor(
           addRule('cc:' + req.toolName, response.selectedPattern, response.selectedScope, 'deny');
         }
         return {
-          decision: (response.decision === 'allow' || response.decision === 'always_allow' || response.decision === 'always_allow_high_risk') ? 'allow' as const : 'deny' as const,
+          decision: isAllowDecision(response.decision) ? 'allow' as const : 'deny' as const,
         };
       },
     });
@@ -283,9 +284,7 @@ export function createProxyApprovalCallback(
       addRule(toolName, response.selectedPattern, response.selectedScope, 'deny');
     }
 
-    return response.decision === 'allow'
-      || response.decision === 'always_allow'
-      || response.decision === 'always_allow_high_risk';
+    return isAllowDecision(response.decision);
   };
 }
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -515,14 +515,10 @@ export class Session {
       decisionContext,
     );
 
-    // Activate conversation-scoped temporary approval override when the
-    // user picks a temporary allow mode. These do not grant persistent
-    // trust and do not mutate allowlists/denylists.
-    if (decision === 'allow_thread') {
-      approvalOverrides.setThreadMode(this.conversationId);
-    } else if (decision === 'allow_10m') {
-      approvalOverrides.setTimedMode(this.conversationId);
-    }
+    // Mode activation (setTimedMode / setThreadMode) is intentionally NOT
+    // done here. It is handled in permission-checker.ts where
+    // persistentDecisionsAllowed context is available — this prevents
+    // proxied bash commands from escalating into blanket auto-approval.
 
     // Emit authoritative confirmation state and activity transition centrally
     // so ALL callers (IPC handlers, /v1/confirm, channel bridges) get

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -34,6 +34,7 @@ import { SecretPrompter } from '../permissions/secret-prompter.js';
 import type { UserDecision } from '../permissions/types.js';
 import type { Message } from '../providers/types.js';
 import type { Provider } from '../providers/types.js';
+import * as approvalOverrides from '../runtime/session-approval-overrides.js';
 import { ToolExecutor } from '../tools/executor.js';
 import type { AssistantAttachmentDraft } from './assistant-attachments.js';
 import type { AssistantActivityState, ConfirmationStateChanged } from './ipc-contract/messages.js';
@@ -428,6 +429,7 @@ export class Session {
   }
 
   dispose(): void {
+    approvalOverrides.clearMode(this.conversationId);
     disposeSession(this);
   }
 
@@ -499,6 +501,12 @@ export class Session {
       decisionText?: string;
     },
   ): void {
+    // Guard: only proceed if the confirmation is still pending. Stale or
+    // already-resolved requests must not activate overrides or emit events.
+    if (!this.prompter.hasPendingRequest(requestId)) {
+      return;
+    }
+
     this.prompter.resolveConfirmation(
       requestId,
       decision,
@@ -506,6 +514,15 @@ export class Session {
       selectedScope,
       decisionContext,
     );
+
+    // Activate conversation-scoped temporary approval override when the
+    // user picks a temporary allow mode. These do not grant persistent
+    // trust and do not mutate allowlists/denylists.
+    if (decision === 'allow_thread') {
+      approvalOverrides.setThreadMode(this.conversationId);
+    } else if (decision === 'allow_10m') {
+      approvalOverrides.setTimedMode(this.conversationId);
+    }
 
     // Emit authoritative confirmation state and activity transition centrally
     // so ALL callers (IPC handlers, /v1/confirm, channel bridges) get

--- a/assistant/src/events/domain-events.ts
+++ b/assistant/src/events/domain-events.ts
@@ -20,7 +20,7 @@ export interface ToolDomainEvents {
     sessionId: string;
     requestId?: string;
     toolName: string;
-    decision: 'allow' | 'always_allow' | 'deny' | 'always_deny';
+    decision: 'allow' | 'allow_10m' | 'allow_thread' | 'always_allow' | 'deny' | 'always_deny';
     riskLevel: string;
     decidedAtMs: number;
   };

--- a/assistant/src/events/tool-domain-event-publisher.ts
+++ b/assistant/src/events/tool-domain-event-publisher.ts
@@ -1,12 +1,7 @@
+import { isAllowDecision, type UserDecision } from '../permissions/types.js';
 import type { ToolLifecycleEventHandler } from '../tools/types.js';
 import type { EventBus } from './bus.js';
 import type { AssistantDomainEvents } from './domain-events.js';
-
-const allowDecisions = new Set(['allow', 'always_allow']);
-
-function isAllowDecision(decision: string): decision is 'allow' | 'always_allow' {
-  return allowDecisions.has(decision);
-}
 
 export function createToolDomainEventPublisher(
   eventBus: EventBus<AssistantDomainEvents>,
@@ -45,7 +40,7 @@ export function createToolDomainEventPublisher(
         });
         break;
       case 'executed':
-        if (isAllowDecision(event.decision)) {
+        if (isAllowDecision(event.decision as UserDecision)) {
           await eventBus.emit('tool.permission.decided', {
             conversationId: event.conversationId,
             sessionId: event.sessionId,
@@ -69,7 +64,7 @@ export function createToolDomainEventPublisher(
         });
         break;
       case 'error':
-        if (isAllowDecision(event.decision)) {
+        if (isAllowDecision(event.decision as UserDecision)) {
           await eventBus.emit('tool.permission.decided', {
             conversationId: event.conversationId,
             sessionId: event.sessionId,

--- a/assistant/src/events/tool-domain-event-publisher.ts
+++ b/assistant/src/events/tool-domain-event-publisher.ts
@@ -46,7 +46,7 @@ export function createToolDomainEventPublisher(
             sessionId: event.sessionId,
             requestId: event.requestId,
             toolName: event.toolName,
-            decision: event.decision,
+            decision: event.decision as AssistantDomainEvents['tool.permission.decided']['decision'],
             riskLevel: event.riskLevel,
             decidedAtMs: Date.now(),
           });
@@ -70,7 +70,7 @@ export function createToolDomainEventPublisher(
             sessionId: event.sessionId,
             requestId: event.requestId,
             toolName: event.toolName,
-            decision: event.decision,
+            decision: event.decision as AssistantDomainEvents['tool.permission.decided']['decision'],
             riskLevel: event.riskLevel,
             decidedAtMs: Date.now(),
           });

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -56,6 +56,7 @@ export class PermissionPrompter {
     executionTarget?: ExecutionTarget,
     persistentDecisionsAllowed?: boolean,
     signal?: AbortSignal,
+    temporaryOptionsAvailable?: Array<'allow_10m' | 'allow_thread'>,
   ): Promise<{
     decision: UserDecision;
     selectedPattern?: string;
@@ -101,6 +102,7 @@ export class PermissionPrompter {
         sessionId,
         executionTarget,
         persistentDecisionsAllowed: persistentDecisionsAllowed ?? true,
+        temporaryOptionsAvailable,
       });
 
       this.onStateChanged?.(requestId, 'pending', 'system');

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -16,7 +16,16 @@ export interface TrustRule {
   allowHighRisk?: boolean;
 }
 
-export type UserDecision = 'allow' | 'always_allow' | 'always_allow_high_risk' | 'deny' | 'always_deny';
+export type UserDecision = 'allow' | 'allow_10m' | 'allow_thread' | 'always_allow' | 'always_allow_high_risk' | 'deny' | 'always_deny';
+
+/** Returns true for any allow-variant decision. Centralizes the check to prevent omissions when new allow variants are added. */
+export function isAllowDecision(decision: UserDecision): boolean {
+  return decision === 'allow'
+    || decision === 'allow_10m'
+    || decision === 'allow_thread'
+    || decision === 'always_allow'
+    || decision === 'always_allow_high_risk';
+}
 
 export interface PermissionCheckResult {
   decision: 'allow' | 'deny' | 'prompt';

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -16,7 +16,7 @@ export interface TrustRule {
   allowHighRisk?: boolean;
 }
 
-export type UserDecision = 'allow' | 'allow_10m' | 'allow_thread' | 'always_allow' | 'always_allow_high_risk' | 'deny' | 'always_deny';
+export type UserDecision = 'allow' | 'allow_10m' | 'allow_thread' | 'always_allow' | 'always_allow_high_risk' | 'deny' | 'always_deny' | 'temporary_override';
 
 /** Returns true for any allow-variant decision. Centralizes the check to prevent omissions when new allow variants are added. */
 export function isAllowDecision(decision: UserDecision): boolean {
@@ -24,7 +24,8 @@ export function isAllowDecision(decision: UserDecision): boolean {
     || decision === 'allow_10m'
     || decision === 'allow_thread'
     || decision === 'always_allow'
-    || decision === 'always_allow_high_risk';
+    || decision === 'always_allow_high_risk'
+    || decision === 'temporary_override';
 }
 
 export interface PermissionCheckResult {

--- a/assistant/src/runtime/approval-conversation-turn.ts
+++ b/assistant/src/runtime/approval-conversation-turn.ts
@@ -21,6 +21,8 @@ import type {
 const VALID_DISPOSITIONS: ReadonlySet<ApprovalConversationDisposition> = new Set([
   'keep_pending',
   'approve_once',
+  'approve_10m',
+  'approve_thread',
   'approve_always',
   'reject',
 ]);
@@ -28,6 +30,8 @@ const VALID_DISPOSITIONS: ReadonlySet<ApprovalConversationDisposition> = new Set
 /** Dispositions that represent an actual decision (not just "keep waiting"). */
 const DECISION_BEARING_DISPOSITIONS: ReadonlySet<ApprovalConversationDisposition> = new Set([
   'approve_once',
+  'approve_10m',
+  'approve_thread',
   'approve_always',
   'reject',
 ]);

--- a/assistant/src/runtime/channel-approval-parser.ts
+++ b/assistant/src/runtime/channel-approval-parser.ts
@@ -18,21 +18,27 @@ import type { ApprovalAction, ApprovalDecisionResult } from './channel-approval-
 // ---------------------------------------------------------------------------
 
 const APPROVE_ONCE_PHRASES = ['yes', 'approve', 'approve once', 'allow', 'go ahead'];
+const APPROVE_10M_PHRASES = ['approve for 10 minutes', 'allow for 10 minutes', 'approve 10m', 'allow 10m', 'approve 10 min', 'allow 10 min'];
+const APPROVE_THREAD_PHRASES = ['approve for thread', 'allow for thread', 'approve thread', 'allow thread'];
 const APPROVE_ALWAYS_PHRASES = ['always', 'approve always', 'allow always'];
 const REJECT_PHRASES = ['no', 'reject', 'deny', 'cancel'];
 
 /**
- * Build a Map from lowercased phrase to action. "Approve always" phrases
- * are checked first (longest-match-wins) because "approve" is a prefix
- * of "approve always".
+ * Build a Map from lowercased phrase to action. Longer phrases are
+ * inserted first so iteration order does not matter — we match on
+ * exact equality after normalising, not prefix matching.
  */
 function buildPhraseMap(): Map<string, ApprovalAction> {
   const map = new Map<string, ApprovalAction>();
 
-  // Insert longer phrases first so iteration order does not matter —
-  // we match on exact equality after normalising, not prefix matching.
   for (const phrase of APPROVE_ALWAYS_PHRASES) {
     map.set(phrase, 'approve_always');
+  }
+  for (const phrase of APPROVE_10M_PHRASES) {
+    map.set(phrase, 'approve_10m');
+  }
+  for (const phrase of APPROVE_THREAD_PHRASES) {
+    map.set(phrase, 'approve_thread');
   }
   for (const phrase of APPROVE_ONCE_PHRASES) {
     map.set(phrase, 'approve_once');

--- a/assistant/src/runtime/channel-approval-types.ts
+++ b/assistant/src/runtime/channel-approval-types.ts
@@ -14,7 +14,7 @@ import type { GuardianDecisionAction } from './guardian-decision-types.js';
 // ---------------------------------------------------------------------------
 
 /** The set of actions a user can take on an approval prompt. */
-export type ApprovalAction = 'approve_once' | 'approve_always' | 'reject';
+export type ApprovalAction = 'approve_once' | 'approve_10m' | 'approve_thread' | 'approve_always' | 'reject';
 
 /** An action presented to the user as a tappable button or text option. */
 export interface ApprovalActionOption {

--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -10,9 +10,11 @@
  */
 
 import { addRule } from '../permissions/trust-store.js';
+import type { UserDecision } from '../permissions/types.js';
 import { getTool } from '../tools/registry.js';
 import { composeApprovalMessage } from './approval-message-composer.js';
 import type {
+  ApprovalAction,
   ApprovalDecisionResult,
   ApprovalUIMetadata,
   ChannelApprovalPrompt,
@@ -111,6 +113,25 @@ export function buildApprovalUIMetadata(
 }
 
 // ---------------------------------------------------------------------------
+// 2.5. Action → UserDecision mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a channel-level `ApprovalAction` to the permission system's
+ * `UserDecision` type. Temporary approval modes (`approve_10m`,
+ * `approve_thread`) map directly to their `allow_*` counterparts so
+ * the permission pipeline can activate the appropriate override.
+ */
+function mapApprovalActionToUserDecision(action: ApprovalAction): UserDecision {
+  switch (action) {
+    case 'reject': return 'deny';
+    case 'approve_10m': return 'allow_10m';
+    case 'approve_thread': return 'allow_thread';
+    default: return 'allow';
+  }
+}
+
+// ---------------------------------------------------------------------------
 // 3. Consume a user decision and apply it to the session
 // ---------------------------------------------------------------------------
 
@@ -176,7 +197,7 @@ export function handleChannelDecision(
   if (!resolved) return { applied: false };
 
   // Map channel-level action to the permission system's UserDecision type.
-  const userDecision = decision.action === 'reject' ? 'deny' as const : 'allow' as const;
+  const userDecision = mapApprovalActionToUserDecision(decision.action);
   if (decisionContext === undefined) {
     resolved.session.handleConfirmationResponse(info.requestId, userDecision);
   } else {

--- a/assistant/src/runtime/guardian-decision-types.ts
+++ b/assistant/src/runtime/guardian-decision-types.ts
@@ -44,6 +44,8 @@ export interface GuardianDecisionAction {
 /** Canonical set of all guardian decision actions with their labels. */
 export const GUARDIAN_DECISION_ACTIONS = {
   approve_once:   { action: 'approve_once',   label: 'Approve once' },
+  approve_10m:    { action: 'approve_10m',    label: 'Allow 10 min' },
+  approve_thread: { action: 'approve_thread', label: 'Allow thread' },
   approve_always: { action: 'approve_always', label: 'Approve always' },
   reject:         { action: 'reject',         label: 'Reject' },
 } as const satisfies Record<string, GuardianDecisionAction>;
@@ -54,16 +56,21 @@ export const GUARDIAN_DECISION_ACTIONS = {
  *
  * When `persistentDecisionsAllowed` is `false`, the `approve_always` action
  * is excluded. When `forGuardianOnBehalf` is `true` (guardian acting on behalf
- * of a requester), `approve_always` is also excluded since guardians cannot
- * permanently allowlist tools on behalf of others.
+ * of a requester), both `approve_always` and the temporary modes are excluded
+ * since guardians cannot grant broad delegated allow modes on behalf of others.
+ *
+ * Temporary modes (`approve_10m`, `approve_thread`) are included for
+ * requester-side standard approval flows when persistent decisions are allowed.
  */
 export function buildDecisionActions(opts?: {
   persistentDecisionsAllowed?: boolean;
   forGuardianOnBehalf?: boolean;
 }): GuardianDecisionAction[] {
   const showAlways = opts?.persistentDecisionsAllowed !== false && !opts?.forGuardianOnBehalf;
+  const showTemporary = opts?.persistentDecisionsAllowed !== false && !opts?.forGuardianOnBehalf;
   return [
     GUARDIAN_DECISION_ACTIONS.approve_once,
+    ...(showTemporary ? [GUARDIAN_DECISION_ACTIONS.approve_10m, GUARDIAN_DECISION_ACTIONS.approve_thread] : []),
     ...(showAlways ? [GUARDIAN_DECISION_ACTIONS.approve_always] : []),
     GUARDIAN_DECISION_ACTIONS.reject,
   ];
@@ -72,16 +79,26 @@ export function buildDecisionActions(opts?: {
 /**
  * Build the plain-text fallback instruction string that matches the given
  * set of decision actions. Ensures the text always includes parser-compatible
- * keywords (yes/always/no) so text-based fallback remains actionable.
+ * keywords so text-based fallback remains actionable.
  */
 export function buildPlainTextFallback(
   promptText: string,
   actions: GuardianDecisionAction[],
 ): string {
   const hasAlways = actions.some(a => a.action === 'approve_always');
-  return hasAlways
-    ? `${promptText}\n\nReply "yes" to approve once, "always" to approve always, or "no" to reject.`
-    : `${promptText}\n\nReply "yes" to approve or "no" to reject.`;
+  const has10m = actions.some(a => a.action === 'approve_10m');
+  const hasThread = actions.some(a => a.action === 'approve_thread');
+
+  if (hasAlways && has10m && hasThread) {
+    return `${promptText}\n\nReply "yes" to approve once, "approve for 10 minutes", "approve for thread", "always" to approve always, or "no" to reject.`;
+  }
+  if (hasAlways) {
+    return `${promptText}\n\nReply "yes" to approve once, "always" to approve always, or "no" to reject.`;
+  }
+  if (has10m && hasThread) {
+    return `${promptText}\n\nReply "yes" to approve once, "approve for 10 minutes", "approve for thread", or "no" to reject.`;
+  }
+  return `${promptText}\n\nReply "yes" to approve or "no" to reject.`;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -108,6 +108,8 @@ export interface GuardianReplyResult {
 
 const VALID_ACTIONS: ReadonlySet<string> = new Set([
   'approve_once',
+  'approve_10m',
+  'approve_thread',
   'approve_always',
   'reject',
 ]);
@@ -476,9 +478,9 @@ export async function routeGuardianReply(
     // Decision-bearing disposition from the engine
     let decisionAction = engineResult.disposition as ApprovalAction;
 
-    // Guardians cannot approve_always — the canonical primitive enforces
-    // this too, but enforce it here for clarity.
-    if (decisionAction === 'approve_always') {
+    // Guardians cannot use broad allow modes — the canonical primitive
+    // enforces this too, but enforce it here for clarity.
+    if (decisionAction === 'approve_always' || decisionAction === 'approve_10m' || decisionAction === 'approve_thread') {
       decisionAction = 'approve_once';
     }
 

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -30,6 +30,8 @@ export type ApprovalCopyGenerator = (
 export type ApprovalConversationDisposition =
   | "keep_pending"
   | "approve_once"
+  | "approve_10m"
+  | "approve_thread"
   | "approve_always"
   | "reject";
 

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -18,6 +18,7 @@ export interface ConfirmationDetails {
   allowlistOptions: Array<{ label: string; description: string; pattern: string }>;
   scopeOptions: Array<{ label: string; scope: string }>;
   persistentDecisionsAllowed?: boolean;
+  temporaryOptionsAvailable?: Array<'allow_10m' | 'allow_thread'>;
 }
 
 export interface PendingInteraction {

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -10,6 +10,7 @@
  */
 import { getConversationByKey } from '../../memory/conversation-key-store.js';
 import { addRule } from '../../permissions/trust-store.js';
+import type { UserDecision } from '../../permissions/types.js';
 import { getTool } from '../../tools/registry.js';
 import { getLogger } from '../../util/logger.js';
 import { httpError } from '../http-errors.js';
@@ -85,8 +86,9 @@ export async function handleConfirm(req: Request, server: ServerWithRequestIP): 
     return httpError('BAD_REQUEST', 'requestId is required', 400);
   }
 
-  if (decision !== 'allow' && decision !== 'deny') {
-    return httpError('BAD_REQUEST', 'decision must be "allow" or "deny"', 400);
+  const validConfirmDecisions = ['allow', 'allow_10m', 'allow_thread', 'deny'];
+  if (typeof decision !== 'string' || !validConfirmDecisions.includes(decision)) {
+    return httpError('BAD_REQUEST', `decision must be one of: ${validConfirmDecisions.join(', ')}`, 400);
   }
 
   const interaction = pendingInteractions.resolve(requestId);
@@ -94,7 +96,7 @@ export async function handleConfirm(req: Request, server: ServerWithRequestIP): 
     return httpError('NOT_FOUND', 'No pending interaction found for this requestId', 404);
   }
 
-  interaction.session.handleConfirmationResponse(requestId, decision, undefined, undefined, undefined, {
+  interaction.session.handleConfirmationResponse(requestId, decision as UserDecision, undefined, undefined, undefined, {
     source: 'button',
   });
   return Response.json({ accepted: true });
@@ -273,6 +275,7 @@ export function handleListPendingInteractions(url: URL, req: Request, server: Se
           })),
           scopeOptions: confirmation.confirmationDetails?.scopeOptions,
           persistentDecisionsAllowed: confirmation.confirmationDetails?.persistentDecisionsAllowed,
+          temporaryOptionsAvailable: confirmation.confirmationDetails?.temporaryOptionsAvailable,
         }
       : null,
     pendingSecret: secret

--- a/assistant/src/runtime/routes/channel-route-shared.ts
+++ b/assistant/src/runtime/routes/channel-route-shared.ts
@@ -69,7 +69,13 @@ export const GUARDIAN_APPROVAL_TTL_MS = 30 * 60 * 1000;
  */
 export function requiredDecisionKeywords(actions: ApprovalUIMetadata['actions']): string[] {
   const hasAlways = actions.some((action) => action.id === 'approve_always');
-  return hasAlways ? ['yes', 'always', 'no'] : ['yes', 'no'];
+  const has10m = actions.some((action) => action.id === 'approve_10m');
+  const hasThread = actions.some((action) => action.id === 'approve_thread');
+  const keywords = ['yes', 'no'];
+  if (has10m) keywords.push('approve for 10 minutes');
+  if (hasThread) keywords.push('approve for thread');
+  if (hasAlways) keywords.push('always');
+  return keywords;
 }
 
 // ---------------------------------------------------------------------------
@@ -78,6 +84,8 @@ export function requiredDecisionKeywords(actions: ApprovalUIMetadata['actions'])
 
 const VALID_ACTIONS: ReadonlySet<string> = new Set<string>([
   'approve_once',
+  'approve_10m',
+  'approve_thread',
   'approve_always',
   'reject',
 ]);

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -338,6 +338,7 @@ function makeHubPublisher(
           allowlistOptions: msg.allowlistOptions,
           scopeOptions: msg.scopeOptions,
           persistentDecisionsAllowed: msg.persistentDecisionsAllowed,
+          temporaryOptionsAvailable: msg.temporaryOptionsAvailable,
         },
       });
 

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -104,9 +104,9 @@ export async function handleGuardianActionDecision(req: Request, server: ServerW
     return httpError('BAD_REQUEST', 'action is required', 400);
   }
 
-  const VALID_ACTIONS = new Set<string>(['approve_once', 'approve_always', 'reject']);
+  const VALID_ACTIONS = new Set<string>(['approve_once', 'approve_10m', 'approve_thread', 'approve_always', 'reject']);
   if (!VALID_ACTIONS.has(action)) {
-    return httpError('BAD_REQUEST', `Invalid action: ${action}. Must be one of: approve_once, approve_always, reject`, 400);
+    return httpError('BAD_REQUEST', `Invalid action: ${action}. Must be one of: approve_once, approve_10m, approve_thread, approve_always, reject`, 400);
   }
 
   // Verify conversationId scoping before applying the canonical decision.

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -18,6 +18,7 @@ import { runApprovalConversationTurn } from '../approval-conversation-turn.js';
 import { composeApprovalMessageGenerative } from '../approval-message-composer.js';
 import { parseApprovalDecision } from '../channel-approval-parser.js';
 import type {
+  ApprovalAction,
   ApprovalDecisionResult,
 } from '../channel-approval-types.js';
 import {
@@ -275,12 +276,12 @@ export async function handleApprovalInterception(
         }
 
         // Decision-bearing disposition from the engine
-        let decisionAction = engineResult.disposition as 'approve_once' | 'approve_always' | 'reject';
+        let decisionAction = engineResult.disposition as ApprovalAction;
 
-        // Belt-and-suspenders: guardians cannot approve_always even if the
-        // engine returns it (the engine's allowedActions validation should
+        // Belt-and-suspenders: guardians cannot use broad allow modes even if
+        // the engine returns them (the engine's allowedActions validation should
         // already prevent this, but enforce it here too).
-        if (decisionAction === 'approve_always') {
+        if (decisionAction === 'approve_always' || decisionAction === 'approve_10m' || decisionAction === 'approve_thread') {
           decisionAction = 'approve_once';
         }
 
@@ -838,7 +839,7 @@ export async function handleApprovalInterception(
     }
 
     // Decision-bearing disposition — map to ApprovalDecisionResult and apply
-    const decisionAction = engineResult.disposition as 'approve_once' | 'approve_always' | 'reject';
+    const decisionAction = engineResult.disposition as ApprovalAction;
     const engineDecision: ApprovalDecisionResult = {
       action: decisionAction,
       source: 'plain_text',

--- a/assistant/src/runtime/session-approval-overrides.ts
+++ b/assistant/src/runtime/session-approval-overrides.ts
@@ -1,0 +1,84 @@
+/**
+ * Per-conversation temporary approval overrides.
+ *
+ * When a user chooses `allow_thread` or `allow_10m`, the session records a
+ * temporary approval mode scoped to the conversation. Subsequent tool-use
+ * confirmations within the same conversation can check this state to
+ * auto-approve without prompting.
+ *
+ * State is in-memory only -- it does not survive daemon restarts, which is
+ * the desired behavior for temporary approvals. Thread-scoped overrides
+ * persist until the session ends or the mode is explicitly cleared. Timed
+ * overrides expire after their TTL (checked at read time, no background sweep).
+ */
+
+export type TemporaryApprovalMode =
+  | { kind: 'thread' }
+  | { kind: 'timed'; expiresAt: number };
+
+const DEFAULT_TIMED_DURATION_MS = 10 * 60 * 1000; // 10 minutes
+
+const store = new Map<string, TemporaryApprovalMode>();
+
+/**
+ * Set thread-scoped temporary approval for a conversation.
+ * Remains active until explicitly cleared or session ends.
+ * Replaces any existing mode for the conversation.
+ */
+export function setThreadMode(conversationId: string): void {
+  store.set(conversationId, { kind: 'thread' });
+}
+
+/**
+ * Set time-limited temporary approval for a conversation.
+ * Replaces any existing mode for the conversation.
+ *
+ * @param conversationId - The conversation to scope the override to
+ * @param durationMs - How long the override lasts (defaults to 10 minutes)
+ */
+export function setTimedMode(
+  conversationId: string,
+  durationMs: number = DEFAULT_TIMED_DURATION_MS,
+): void {
+  store.set(conversationId, {
+    kind: 'timed',
+    expiresAt: Date.now() + durationMs,
+  });
+}
+
+/**
+ * Clear any temporary approval mode for a conversation.
+ */
+export function clearMode(conversationId: string): void {
+  store.delete(conversationId);
+}
+
+/**
+ * Get the effective temporary approval mode for a conversation.
+ *
+ * Returns null if no mode is set or if a timed mode has expired.
+ * Expired timed modes are cleaned up lazily on read.
+ */
+export function getEffectiveMode(conversationId: string): TemporaryApprovalMode | null {
+  const mode = store.get(conversationId);
+  if (!mode) return null;
+
+  if (mode.kind === 'timed' && Date.now() >= mode.expiresAt) {
+    store.delete(conversationId);
+    return null;
+  }
+
+  return mode;
+}
+
+/**
+ * Check whether a conversation has an active (non-expired) temporary approval.
+ */
+export function hasActiveOverride(conversationId: string): boolean {
+  return getEffectiveMode(conversationId) !== null;
+}
+
+/** Clear all overrides. Useful for testing. */
+export function clearAll(): void {
+  store.clear();
+}

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -3,6 +3,7 @@ import { getHookManager } from '../hooks/manager.js';
 import { check, classifyRisk, generateAllowlistOptions, generateScopeOptions } from '../permissions/checker.js';
 import type { PermissionPrompter } from '../permissions/prompter.js';
 import { addRule } from '../permissions/trust-store.js';
+import { getEffectiveMode, setThreadMode, setTimedMode } from '../runtime/session-approval-overrides.js';
 import { getLogger } from '../util/logger.js';
 import { buildPolicyContext } from './policy-context.js';
 import { isSideEffectTool } from './side-effects.js';
@@ -108,6 +109,30 @@ export class PermissionChecker {
             riskLevel,
             content: `Permission denied: tool "${name}" requires user approval but no interactive client is connected. The tool was not executed. To allow this tool in non-interactive sessions, add a trust rule via permission settings.`,
           };
+        }
+
+        // Temporary approval override: if the guardian has enabled a
+        // conversation-scoped "allow all" mode (allow_10m or allow_thread),
+        // skip the interactive prompt and auto-approve. Only applies to
+        // guardian actors — untrusted actors cannot leverage this to bypass
+        // guardian-required gates (those are enforced in pre-execution gates).
+        // Proxied bash commands require per-invocation approval and must not
+        // be auto-approved by a temporary override — they are excluded here
+        // by requiring persistent decisions to be allowed.
+        const persistentDecisionsAllowedForOverride = !(
+          name === 'bash'
+          && input.network_mode === 'proxied'
+        );
+        if (
+          context.guardianTrustClass === 'guardian'
+          && persistentDecisionsAllowedForOverride
+          && getEffectiveMode(context.conversationId) !== null
+        ) {
+          log.info(
+            { toolName: name, riskLevel, conversationId: context.conversationId },
+            'Temporary approval override active — auto-approving without prompt',
+          );
+          return { allowed: true, decision: 'temporary_override', riskLevel };
         }
 
         const allowlistOptions = await generateAllowlistOptions(name, input, context.signal);
@@ -265,6 +290,27 @@ export class PermissionChecker {
           if (effectiveScope) {
             addRule(name, response.selectedPattern, effectiveScope, 'allow', 100, hasOptions ? ruleOptions : undefined);
           }
+        }
+
+        // Activate temporary approval mode when the user chooses a
+        // time-limited or thread-scoped override. Subsequent tool
+        // invocations in this conversation will auto-approve without
+        // prompting (checked above in the temporary override block).
+        // Gated on persistentDecisionsAllowed so that proxied bash
+        // commands (which require per-invocation approval) cannot
+        // escalate into blanket auto-approval.
+        if (persistentDecisionsAllowed && response.decision === 'allow_10m') {
+          setTimedMode(context.conversationId);
+          log.info(
+            { toolName: name, conversationId: context.conversationId },
+            'Activated timed (10m) temporary approval mode',
+          );
+        } else if (persistentDecisionsAllowed && response.decision === 'allow_thread') {
+          setThreadMode(context.conversationId);
+          log.info(
+            { toolName: name, conversationId: context.conversationId },
+            'Activated thread-scoped temporary approval mode',
+          );
         }
 
         return { allowed: true, decision, riskLevel };

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -155,6 +155,14 @@ export class PermissionChecker {
           && input.network_mode === 'proxied'
         );
 
+        // Only offer temporary approval options to guardians when persistent
+        // decisions are allowed (proxied bash is excluded since it requires
+        // per-invocation approval).
+        const temporaryOptionsAvailable: Array<'allow_10m' | 'allow_thread'> | undefined =
+          persistentDecisionsAllowed && context.guardianTrustClass === 'guardian'
+            ? ['allow_10m', 'allow_thread']
+            : undefined;
+
         emitLifecycleEvent({
           type: 'permission_prompt',
           toolName: name,
@@ -192,6 +200,7 @@ export class PermissionChecker {
           executionTarget,
           persistentDecisionsAllowed,
           context.signal,
+          temporaryOptionsAvailable,
         );
 
         const decision = response.decision;

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -41,6 +41,8 @@ struct ChatView: View {
     let onConfirmationAllow: (String) -> Void
     let onConfirmationDeny: (String) -> Void
     let onAlwaysAllow: (String, String, String, String) -> Void
+    /// Called when a temporary approval option is selected: (requestId, decision).
+    var onTemporaryAllow: ((String, String) -> Void)?
     var onGuardianAction: ((String, String) -> Void)?
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
     let sessionError: SessionError?
@@ -193,6 +195,7 @@ struct ChatView: View {
                             onConfirmationAllow: onConfirmationAllow,
                             onConfirmationDeny: onConfirmationDeny,
                             onAlwaysAllow: onAlwaysAllow,
+                            onTemporaryAllow: onTemporaryAllow,
                             onSurfaceAction: onSurfaceAction,
                             onGuardianAction: onGuardianAction,
                             onDismissDocumentWidget: onDismissDocumentWidget,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -21,6 +21,8 @@ struct MessageListView: View {
     let onConfirmationAllow: (String) -> Void
     let onConfirmationDeny: (String) -> Void
     let onAlwaysAllow: (String, String, String, String) -> Void
+    /// Called when a temporary approval option is selected: (requestId, decision).
+    var onTemporaryAllow: ((String, String) -> Void)?
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
     /// Called when a guardian decision action button is clicked: (requestId, action).
     var onGuardianAction: ((String, String) -> Void)?
@@ -303,7 +305,8 @@ struct MessageListView: View {
                                     isKeyboardActive: confirmation.requestId == activePendingRequestId,
                                     onAllow: { onConfirmationAllow(confirmation.requestId) },
                                     onDeny: { onConfirmationDeny(confirmation.requestId) },
-                                    onAlwaysAllow: onAlwaysAllow
+                                    onAlwaysAllow: onAlwaysAllow,
+                                    onTemporaryAllow: onTemporaryAllow
                                 )
                                 .id(message.id)
                                 .transition(.opacity)
@@ -318,7 +321,8 @@ struct MessageListView: View {
                                         confirmation: confirmation,
                                         onAllow: { onConfirmationAllow(confirmation.requestId) },
                                         onDeny: { onConfirmationDeny(confirmation.requestId) },
-                                        onAlwaysAllow: onAlwaysAllow
+                                        onAlwaysAllow: onAlwaysAllow,
+                                        onTemporaryAllow: onTemporaryAllow
                                     )
                                     .id(message.id)
                                     .transition(.opacity)

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -75,6 +75,10 @@ struct MessageListView: View {
     @State private var hoverExitDebounceTask: Task<Void, Never>?
     @State private var threadSwitchSuppressionTask: Task<Void, Never>?
     @State private var suppressScrollbarDuringThreadSwitch: Bool = false
+    /// Tracks the last pending confirmation request ID that triggered an
+    /// auto-focus handoff. Used to detect nil→non-nil transitions so we
+    /// resign first responder exactly once per new confirmation appearance.
+    @State private var lastAutoFocusedRequestId: String?
 
     /// The subset of messages actually shown, honoring the pagination window.
     private var visibleMessages: [ChatMessage] {
@@ -83,6 +87,12 @@ struct MessageListView: View {
         // return everything so new incoming messages don't collapse visible history.
         guard displayedMessageCount < all.count else { return all }
         return Array(all.suffix(displayedMessageCount))
+    }
+
+    /// The active pending confirmation request ID, derived from the visible
+    /// messages. Used by onChange to detect new confirmation appearances.
+    private var currentPendingRequestId: String? {
+        PendingConfirmationFocusSelector.activeRequestId(from: visibleMessages)
     }
 
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
@@ -564,6 +574,35 @@ struct MessageListView: View {
                 isThreadContentHovered = false
                 DispatchQueue.main.async {
                     proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                }
+            }
+            .onChange(of: currentPendingRequestId) {
+                #if os(macOS)
+                if let requestId = currentPendingRequestId, lastAutoFocusedRequestId != requestId {
+                    // A new pending confirmation just appeared. Resign first
+                    // responder from the composer so the confirmation bubble's
+                    // key monitor can intercept Tab/Enter/Escape immediately.
+                    // Only mark as handled after a successful resign so
+                    // didBecomeKeyNotification can retry when the window is inactive.
+                    if let window = NSApp.keyWindow,
+                       let responder = window.firstResponder as? NSTextView,
+                       responder.isEditable {
+                        window.makeFirstResponder(nil)
+                        lastAutoFocusedRequestId = requestId
+                    }
+                } else if currentPendingRequestId == nil {
+                    lastAutoFocusedRequestId = nil
+                }
+                #endif
+            }
+            .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { notification in
+                if let requestId = currentPendingRequestId, lastAutoFocusedRequestId != requestId,
+                   let window = notification.object as? NSWindow,
+                   window === NSApp.keyWindow,
+                   let responder = window.firstResponder as? NSTextView,
+                   responder.isEditable {
+                    window.makeFirstResponder(nil)
+                    lastAutoFocusedRequestId = requestId
                 }
             }
             .onReceive(TaskProgressOverlayManager.shared.$activeSurfaceId) { newId in

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -671,6 +671,7 @@ struct ActiveChatViewWrapper: View {
             onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
             onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") },
             onAlwaysAllow: { requestId, selectedPattern, selectedScope, decision in viewModel.respondToAlwaysAllow(requestId: requestId, selectedPattern: selectedPattern, selectedScope: selectedScope, decision: decision) },
+            onTemporaryAllow: { requestId, decision in viewModel.respondToConfirmation(requestId: requestId, decision: decision) },
             onGuardianAction: { requestId, action in viewModel.submitGuardianDecision(requestId: requestId, action: action) },
             onSurfaceAction: { surfaceId, actionId, data in viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data) },
             sessionError: viewModel.sessionError,

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -43,6 +43,9 @@ public struct ToolConfirmationData: Equatable {
     /// Which temporary approval options the daemon supports for this request (e.g. "allow_10m", "allow_thread").
     public let temporaryOptionsAvailable: [String]
     public var state: ToolConfirmationState = .pending
+    /// The decision string that was used to approve (e.g. "allow", "allow_10m", "allow_thread", "always_allow").
+    /// Set when the state transitions to `.approved`.
+    public var approvedDecision: String?
 
     /// Normalized target label shown in confirmation UIs.
     public var normalizedExecutionTarget: String? {

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -40,6 +40,8 @@ public struct ToolConfirmationData: Equatable {
     public let executionTarget: String?
     /// When false, hide "Always Allow" and trust-rule persistence controls.
     public let persistentDecisionsAllowed: Bool
+    /// Which temporary approval options the daemon supports for this request (e.g. "allow_10m", "allow_thread").
+    public let temporaryOptionsAvailable: [String]
     public var state: ToolConfirmationState = .pending
 
     /// Normalized target label shown in confirmation UIs.
@@ -637,7 +639,7 @@ public struct ToolConfirmationData: Equatable {
         }
     }
 
-    public init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, diff: ConfirmationRequestMessage.ConfirmationDiffInfo? = nil, allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption] = [], scopeOptions: [ConfirmationRequestMessage.ConfirmationScopeOption] = [], executionTarget: String? = nil, persistentDecisionsAllowed: Bool = true, state: ToolConfirmationState = .pending) {
+    public init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, diff: ConfirmationRequestMessage.ConfirmationDiffInfo? = nil, allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption] = [], scopeOptions: [ConfirmationRequestMessage.ConfirmationScopeOption] = [], executionTarget: String? = nil, persistentDecisionsAllowed: Bool = true, temporaryOptionsAvailable: [String] = [], state: ToolConfirmationState = .pending) {
         self.requestId = requestId
         self.toolName = toolName
         self.input = input
@@ -647,6 +649,7 @@ public struct ToolConfirmationData: Equatable {
         self.scopeOptions = scopeOptions
         self.executionTarget = executionTarget
         self.persistentDecisionsAllowed = persistentDecisionsAllowed
+        self.temporaryOptionsAvailable = temporaryOptionsAvailable
         self.state = state
     }
 

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1069,7 +1069,8 @@ extension ChatViewModel {
                 allowlistOptions: msg.allowlistOptions,
                 scopeOptions: msg.scopeOptions,
                 executionTarget: msg.executionTarget,
-                persistentDecisionsAllowed: msg.persistentDecisionsAllowed ?? true
+                persistentDecisionsAllowed: msg.persistentDecisionsAllowed ?? true,
+                temporaryOptionsAvailable: msg.temporaryOptionsAvailable ?? []
             )
             let confirmMsg = ChatMessage(
                 role: .assistant,

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1535,6 +1535,8 @@ extension ChatViewModel {
                 switch msg.state {
                 case "approved":
                     messages[i].confirmation?.state = .approved
+                    // Preserve approvedDecision if already set locally (the daemon
+                    // event doesn't carry the decision mode).
                 case "denied":
                     messages[i].confirmation?.state = .denied
                 case "timed_out":

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1890,7 +1890,8 @@ public final class ChatViewModel: ObservableObject {
         }
         // IPC send succeeded — update the message state
         if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
-            messages[index].confirmation?.state = decision == "allow" ? .approved : .denied
+            let isApproval = decision == "allow" || decision == "allow_10m" || decision == "allow_thread"
+            messages[index].confirmation?.state = isApproval ? .approved : .denied
         }
         // Dismiss the corresponding floating panel / native notification if one exists
         onInlineConfirmationResponse?(requestId, decision)
@@ -1933,7 +1934,7 @@ public final class ChatViewModel: ObservableObject {
     public func updateConfirmationState(requestId: String, decision: String) {
         if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
             switch decision {
-            case "allow":
+            case "allow", "allow_10m", "allow_thread":
                 messages[index].confirmation?.state = .approved
             case "deny":
                 messages[index].confirmation?.state = .denied

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1892,6 +1892,9 @@ public final class ChatViewModel: ObservableObject {
         if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
             let isApproval = decision == "allow" || decision == "allow_10m" || decision == "allow_thread"
             messages[index].confirmation?.state = isApproval ? .approved : .denied
+            if isApproval {
+                messages[index].confirmation?.approvedDecision = decision
+            }
         }
         // Dismiss the corresponding floating panel / native notification if one exists
         onInlineConfirmationResponse?(requestId, decision)
@@ -1924,6 +1927,7 @@ public final class ChatViewModel: ObservableObject {
         // IPC send succeeded — update the message state
         if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
             messages[index].confirmation?.state = .approved
+            messages[index].confirmation?.approvedDecision = decision
         }
         // Dismiss the corresponding floating panel / native notification if one exists
         onInlineConfirmationResponse?(requestId, "allow")
@@ -1936,6 +1940,7 @@ public final class ChatViewModel: ObservableObject {
             switch decision {
             case "allow", "allow_10m", "allow_thread":
                 messages[index].confirmation?.state = .approved
+                messages[index].confirmation?.approvedDecision = decision
             case "deny":
                 messages[index].confirmation?.state = .denied
             default:

--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -52,6 +52,9 @@ public struct MessageBubbleView: View {
                         },
                         onAlwaysAllow: { requestId, pattern, scope, decision in
                             onAlwaysAllow?(requestId, pattern, scope, decision)
+                        },
+                        onTemporaryAllow: { requestId, decision in
+                            onConfirmationResponse?(requestId, decision)
                         }
                     )
                 } else if let guardianDecision = message.guardianDecision {

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -8,6 +8,8 @@ public struct ToolConfirmationBubble: View {
     public let onAllow: () -> Void
     public let onDeny: () -> Void
     public let onAlwaysAllow: (String, String, String, String) -> Void
+    /// Called when a temporary approval option is selected: (requestId, decision).
+    public let onTemporaryAllow: ((String, String) -> Void)?
     /// When `true` this bubble owns the keyboard monitor and shows selection
     /// highlights. When `false` the monitor is removed and keyboard-only state
     /// is cleared so a lower stacked bubble doesn't steal input.
@@ -26,12 +28,13 @@ public struct ToolConfirmationBubble: View {
     @State private var keyMonitor: Any?
     #endif
 
-    public init(confirmation: ToolConfirmationData, isKeyboardActive: Bool = true, onAllow: @escaping () -> Void, onDeny: @escaping () -> Void, onAlwaysAllow: @escaping (String, String, String, String) -> Void) {
+    public init(confirmation: ToolConfirmationData, isKeyboardActive: Bool = true, onAllow: @escaping () -> Void, onDeny: @escaping () -> Void, onAlwaysAllow: @escaping (String, String, String, String) -> Void, onTemporaryAllow: ((String, String) -> Void)? = nil) {
         self.confirmation = confirmation
         self.isKeyboardActive = isKeyboardActive
         self.onAllow = onAllow
         self.onDeny = onDeny
         self.onAlwaysAllow = onAlwaysAllow
+        self.onTemporaryAllow = onTemporaryAllow
     }
 
     private var hasRuleOptions: Bool {
@@ -48,6 +51,14 @@ public struct ToolConfirmationBubble: View {
 
     private var isDecided: Bool {
         confirmation.state != .pending
+    }
+
+    private var hasAllow10m: Bool {
+        confirmation.temporaryOptionsAvailable.contains("allow_10m")
+    }
+
+    private var hasAllowThread: Bool {
+        confirmation.temporaryOptionsAvailable.contains("allow_thread")
     }
 
     /// The decision value to send when "Always Allow" is clicked.
@@ -373,6 +384,8 @@ public struct ToolConfirmationBubble: View {
     /// Build the ordered list of top-level actions based on current confirmation state.
     private var topLevelActions: [ToolConfirmationKeyboardModel.Action] {
         var actions: [ToolConfirmationKeyboardModel.Action] = [.allowOnce]
+        if hasAllow10m { actions.append(.allow10m) }
+        if hasAllowThread { actions.append(.allowThread) }
         if hasRuleOptions && confirmation.persistentDecisionsAllowed {
             actions.append(.alwaysAllow)
         }
@@ -390,6 +403,24 @@ public struct ToolConfirmationBubble: View {
                 isDanger: false,
                 isKeyboardSelected: keyboardModel?.selectedAction == .allowOnce
             ) { markCommandExplanationSeen(); onAllow() }
+            if hasAllow10m {
+                confirmationButton(
+                    "Allow 10m",
+                    isPrimary: false,
+                    isDanger: false,
+                    isKeyboardSelected: keyboardModel?.selectedAction == .allow10m
+                ) { markCommandExplanationSeen(); onTemporaryAllow?(confirmation.requestId, "allow_10m") }
+                .help("Allow this action for 10 minutes")
+            }
+            if hasAllowThread {
+                confirmationButton(
+                    "Allow Thread",
+                    isPrimary: false,
+                    isDanger: false,
+                    isKeyboardSelected: keyboardModel?.selectedAction == .allowThread
+                ) { markCommandExplanationSeen(); onTemporaryAllow?(confirmation.requestId, "allow_thread") }
+                .help("Allow this action for the current thread")
+            }
             if hasRuleOptions && confirmation.persistentDecisionsAllowed { alwaysAllowInlineButton }
             confirmationButton(
                 "Don\u{2019}t Allow",
@@ -614,6 +645,10 @@ public struct ToolConfirmationBubble: View {
         switch action {
         case .allowOnce:
             onAllow()
+        case .allow10m:
+            onTemporaryAllow?(confirmation.requestId, "allow_10m")
+        case .allowThread:
+            onTemporaryAllow?(confirmation.requestId, "allow_thread")
         case .alwaysAllow:
             if confirmation.allowlistOptions.count > 1 {
                 withAnimation(VAnimation.fast) {

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -74,6 +74,27 @@ public struct ToolConfirmationBubble: View {
         return preview.isEmpty ? nil : preview
     }
 
+    /// Label shown in the collapsed state after a decision is made.
+    private var collapsedLabel: String {
+        switch confirmation.state {
+        case .approved:
+            switch confirmation.approvedDecision {
+            case "allow_10m":
+                return "\(confirmation.toolCategory) allowed for 10 minutes"
+            case "allow_thread":
+                return "\(confirmation.toolCategory) allowed for this thread"
+            default:
+                return "\(confirmation.toolCategory) allowed"
+            }
+        case .denied:
+            return "\(confirmation.toolCategory) denied"
+        case .timedOut:
+            return "Timed out"
+        case .pending:
+            return ""
+        }
+    }
+
     /// Color for the risk level badge.
     private var riskColor: Color {
         switch confirmation.riskLevel.lowercased() {
@@ -382,10 +403,12 @@ public struct ToolConfirmationBubble: View {
     // MARK: - Button Row
 
     /// Build the ordered list of top-level actions based on current confirmation state.
+    /// Temporary options come first (matching visual top-to-bottom, left-to-right order).
     private var topLevelActions: [ToolConfirmationKeyboardModel.Action] {
-        var actions: [ToolConfirmationKeyboardModel.Action] = [.allowOnce]
+        var actions: [ToolConfirmationKeyboardModel.Action] = []
         if hasAllow10m { actions.append(.allow10m) }
         if hasAllowThread { actions.append(.allowThread) }
+        actions.append(.allowOnce)
         if hasRuleOptions && confirmation.persistentDecisionsAllowed {
             actions.append(.alwaysAllow)
         }
@@ -393,42 +416,64 @@ public struct ToolConfirmationBubble: View {
         return actions
     }
 
+    private var hasTemporaryOptions: Bool {
+        hasAllow10m || hasAllowThread
+    }
+
     @ViewBuilder
     private var buttonRow: some View {
         let actions = topLevelActions
-        HStack(spacing: VSpacing.xs) {
-            confirmationButton(
-                "Allow Once",
-                isPrimary: true,
-                isDanger: false,
-                isKeyboardSelected: keyboardModel?.selectedAction == .allowOnce
-            ) { markCommandExplanationSeen(); onAllow() }
-            if hasAllow10m {
-                confirmationButton(
-                    "Allow 10m",
-                    isPrimary: false,
-                    isDanger: false,
-                    isKeyboardSelected: keyboardModel?.selectedAction == .allow10m
-                ) { markCommandExplanationSeen(); onTemporaryAllow?(confirmation.requestId, "allow_10m") }
-                .help("Allow this action for 10 minutes")
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            // Top group: temporary approval options (approve all future actions)
+            if hasTemporaryOptions {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Approve all actions")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    HStack(spacing: VSpacing.xs) {
+                        if hasAllow10m {
+                            confirmationButton(
+                                "Allow for 10 minutes",
+                                isPrimary: true,
+                                isDanger: false,
+                                isKeyboardSelected: keyboardModel?.selectedAction == .allow10m
+                            ) { markCommandExplanationSeen(); onTemporaryAllow?(confirmation.requestId, "allow_10m") }
+                        }
+                        if hasAllowThread {
+                            confirmationButton(
+                                "Allow for this thread",
+                                isPrimary: true,
+                                isDanger: false,
+                                isKeyboardSelected: keyboardModel?.selectedAction == .allowThread
+                            ) { markCommandExplanationSeen(); onTemporaryAllow?(confirmation.requestId, "allow_thread") }
+                        }
+                    }
+                }
             }
-            if hasAllowThread {
-                confirmationButton(
-                    "Allow Thread",
-                    isPrimary: false,
-                    isDanger: false,
-                    isKeyboardSelected: keyboardModel?.selectedAction == .allowThread
-                ) { markCommandExplanationSeen(); onTemporaryAllow?(confirmation.requestId, "allow_thread") }
-                .help("Allow this action for the current thread")
+            // Bottom group: per-action options
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                if hasTemporaryOptions {
+                    Text("This action only")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+                HStack(spacing: VSpacing.xs) {
+                    confirmationButton(
+                        "Allow Once",
+                        isPrimary: !hasTemporaryOptions,
+                        isDanger: false,
+                        isKeyboardSelected: keyboardModel?.selectedAction == .allowOnce
+                    ) { markCommandExplanationSeen(); onAllow() }
+                    if hasRuleOptions && confirmation.persistentDecisionsAllowed { alwaysAllowInlineButton }
+                    confirmationButton(
+                        "Don\u{2019}t Allow",
+                        isPrimary: false,
+                        isDanger: false,
+                        isKeyboardSelected: keyboardModel?.selectedAction == .dontAllow
+                    ) { markCommandExplanationSeen(); onDeny() }
+                    Spacer()
+                }
             }
-            if hasRuleOptions && confirmation.persistentDecisionsAllowed { alwaysAllowInlineButton }
-            confirmationButton(
-                "Don\u{2019}t Allow",
-                isPrimary: false,
-                isDanger: false,
-                isKeyboardSelected: keyboardModel?.selectedAction == .dontAllow
-            ) { markCommandExplanationSeen(); onDeny() }
-            Spacer()
         }
         .onAppear {
             if isKeyboardActive {
@@ -894,11 +939,7 @@ public struct ToolConfirmationBubble: View {
             }
             .font(.system(size: 12))
 
-            Text(confirmation.state == .approved
-                 ? "\(confirmation.toolCategory) allowed"
-                 : confirmation.state == .denied
-                 ? "\(confirmation.toolCategory) denied"
-                 : "Timed out")
+            Text(collapsedLabel)
                 .font(VFont.caption)
                 .foregroundColor(VColor.textSecondary)
 

--- a/clients/shared/Features/Chat/ToolConfirmationKeyboardModel.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationKeyboardModel.swift
@@ -10,6 +10,8 @@ struct ToolConfirmationKeyboardModel {
     /// The logical actions that can appear in the button row.
     enum Action: Equatable {
         case allowOnce
+        case allow10m
+        case allowThread
         case alwaysAllow
         case dontAllow
     }

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -910,8 +910,10 @@ public struct IPCConfirmationRequest: Codable, Sendable {
     public let sessionId: String?
     /// When false, the client should hide "always allow" / trust-rule persistence affordances.
     public let persistentDecisionsAllowed: Bool?
+    /// Which temporary approval options the client should render (e.g. "Allow for 10 minutes", "Allow for this thread").
+    public let temporaryOptionsAvailable: [String]?
 
-    public init(type: String, requestId: String, toolName: String, input: [String: AnyCodable], riskLevel: String, executionTarget: String? = nil, allowlistOptions: [IPCConfirmationRequestAllowlistOption], scopeOptions: [IPCConfirmationRequestScopeOption], diff: IPCConfirmationRequestDiff? = nil, sandboxed: Bool? = nil, sessionId: String? = nil, persistentDecisionsAllowed: Bool? = nil) {
+    public init(type: String, requestId: String, toolName: String, input: [String: AnyCodable], riskLevel: String, executionTarget: String? = nil, allowlistOptions: [IPCConfirmationRequestAllowlistOption], scopeOptions: [IPCConfirmationRequestScopeOption], diff: IPCConfirmationRequestDiff? = nil, sandboxed: Bool? = nil, sessionId: String? = nil, persistentDecisionsAllowed: Bool? = nil, temporaryOptionsAvailable: [String]? = nil) {
         self.type = type
         self.requestId = requestId
         self.toolName = toolName
@@ -924,6 +926,7 @@ public struct IPCConfirmationRequest: Codable, Sendable {
         self.sandboxed = sandboxed
         self.sessionId = sessionId
         self.persistentDecisionsAllowed = persistentDecisionsAllowed
+        self.temporaryOptionsAvailable = temporaryOptionsAvailable
     }
 }
 

--- a/gateway/src/whatsapp/send.ts
+++ b/gateway/src/whatsapp/send.ts
@@ -28,6 +28,23 @@ const WHATSAPP_BUTTON_TITLE_MAX_LEN = 20;
 // WhatsApp supports a maximum of 3 reply buttons
 const WHATSAPP_MAX_BUTTONS = 3;
 
+/**
+ * Select up to WHATSAPP_MAX_BUTTONS actions for WhatsApp interactive buttons.
+ * When there are more actions than the cap allows, this ensures that `reject`
+ * and `approve_always` are always preserved (they are the most important
+ * decisions), with remaining slots filled by other approve variants in order.
+ */
+function selectWhatsAppButtons(actions: Array<{ id: string; label: string }>): Array<{ id: string; label: string }> {
+  if (actions.length <= WHATSAPP_MAX_BUTTONS) return actions;
+
+  // Always preserve reject and approve_always when present
+  const pinned = actions.filter(a => a.id === 'reject' || a.id === 'approve_always');
+  const rest = actions.filter(a => a.id !== 'reject' && a.id !== 'approve_always');
+  const slotsForRest = WHATSAPP_MAX_BUTTONS - pinned.length;
+  const selected = [...rest.slice(0, slotsForRest), ...pinned];
+  return selected;
+}
+
 export async function sendWhatsAppReply(
   config: GatewayConfig,
   to: string,
@@ -35,8 +52,11 @@ export async function sendWhatsAppReply(
   approval?: ApprovalPayload,
 ): Promise<void> {
   if (approval) {
-    // WhatsApp interactive buttons: up to 3 buttons, 20-char titles, 1024-char body
-    const buttons = approval.actions.slice(0, WHATSAPP_MAX_BUTTONS).map((action) => ({
+    // WhatsApp interactive buttons: up to 3 buttons, 20-char titles, 1024-char body.
+    // When there are more actions than the button cap allows, prioritize keeping
+    // the reject action visible alongside the most important approve variants.
+    const selectedActions = selectWhatsAppButtons(approval.actions);
+    const buttons = selectedActions.map((action) => ({
       id: `apr:${approval.runId}:${action.id}`,
       title: action.label.slice(0, WHATSAPP_BUTTON_TITLE_MAX_LEN),
     }));


### PR DESCRIPTION
## Summary
Adds two temporary approval modes — "Allow all for 10 minutes" and "Allow all for this thread" — that work across all channels and clients (desktop, mobile, HTTP, channel ingress), enforced at the daemon/tool-execution layer with proper safety guardrails.

## Changes
- Extended `UserDecision` type and IPC/HTTP contracts with `allow_10m`, `allow_thread`, `temporary_override` decisions
- Added `isAllowDecision()` centralized helper for allow-variant checks
- Added in-memory `session-approval-overrides.ts` store keyed by conversationId with thread and timed (TTL) modes
- Integrated temporary override checks in `permission-checker.ts`, gated by `persistentDecisionsAllowed` and guardian trust class
- Extended channel approval actions, parser, callback routing, and WhatsApp 3-button selection
- Added "Allow 10m" and "Allow Thread" buttons to CLI confirmation prompt and shared Swift client UI
- Added macOS auto-focus for confirmation bubbles with keyboard-first approval workflow
- Added `didBecomeKeyNotification` retry for window-inactive scenarios
- Added unit tests for `session-approval-overrides` and `isAllowDecision`
- Updated `assistant/ARCHITECTURE.md` with temporary approval modes documentation

## Milestone PRs (merged into feature branch)
- #11261: M1: Extend approval decision contracts for `allow_10m` and `allow_thread`
- #11276: M2: Add conversation-scoped temporary approval state with TTL support
- #11287: M3: Enforce temporary approval modes in tool permission pipeline
- #11301: M4: Add temporary approval modes to channel decision actions and parsing
- #11314: M5: Expose temporary approval actions in shared clients and CLI
- #11318: M6: macOS permission UI autofocus and keyboard-first selection flow
- #11322: M7: Finalize tests, architecture docs, and rollout safeguards

## Project issue
Closes #11230

## Test plan
- [ ] Verify `allow_10m` auto-approves tools for 10 minutes then expires
- [ ] Verify `allow_thread` auto-approves tools for the conversation session
- [ ] Verify temporary modes don't persist across daemon restarts
- [ ] Verify guardian/untrusted-actor safety invariants are preserved
- [ ] Verify CLI shows new options in confirmation prompt
- [ ] Verify macOS keyboard focus shifts to confirmation bubble on appearance
- [ ] Verify WhatsApp 3-button cap preserves `approve_always`
- [ ] Verify existing `always_allow` persistent trust rules still work

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
