### PR TITLE
feat(clients): Swift client cutover to single JWT bearer auth (#11209)

### DIFF
--- a/clients/ARCHITECTURE.md
+++ b/clients/ARCHITECTURE.md
@@ -615,32 +615,32 @@ iOS pairing uses a v4 QR code protocol with Mac-side approval. There is no manua
 
 **Approved devices:** Devices paired with "Always Allow" are persisted to `~/.vellum/protected/approved-devices.json` (keyed by hashed deviceId). Future pairings from allowlisted devices auto-approve without a prompt. The macOS Connect tab shows an Approved Devices list with remove/clear actions.
 
-### Actor Credential Refresh (Shared: macOS + iOS)
+### JWT Credential Refresh (Shared: macOS + iOS)
 
-Both macOS and iOS clients use a shared credential refresh mechanism to maintain valid actor tokens without re-bootstrapping or re-pairing. Bootstrap (macOS) and pairing (iOS) are only used for initial credential issuance.
+Both macOS and iOS clients use a single JWT access token for all HTTP authentication, sent as `Authorization: Bearer <jwt>`. The JWT serves as both authentication and identity — there is no separate `X-Actor-Token` header. A shared credential refresh mechanism maintains valid tokens without re-bootstrapping or re-pairing. Bootstrap (macOS) and pairing (iOS) are only used for initial credential issuance.
 
-**Credential storage:** The client stores the following in the Keychain alongside the bearer token:
+**Credential storage:** The client stores the following in the Keychain:
 
 | Data | Storage | Purpose |
 |------|---------|---------|
-| Actor token | Keychain | `X-Actor-Token` header for authenticated requests |
+| Access token (JWT) | Keychain | `Authorization: Bearer <jwt>` header for authenticated requests |
 | Refresh token | Keychain | Presented to the refresh endpoint to rotate credentials |
-| Actor token expiry | Keychain | Absolute expiry timestamp of the current actor token |
+| Access token expiry | Keychain | Absolute expiry timestamp of the current access token |
 | Refresh token expiry | Keychain | Absolute expiry timestamp of the current refresh token |
-| `refreshAfter` | Keychain | Timestamp at which the client should proactively refresh (80% of actor token TTL) |
+| `refreshAfter` | Keychain | Timestamp at which the client should proactively refresh (80% of access token TTL) |
 
-**Proactive refresh:** Both macOS and iOS run a periodic check every 5 minutes. If `now >= refreshAfter`, the client calls `POST /v1/integrations/guardian/vellum/refresh` (through the gateway) with the current refresh token. On success, the response provides a new `actorToken`, `refreshToken`, `actorTokenExpiresAt`, `refreshTokenExpiresAt`, and `refreshAfter`. All stored credentials are updated atomically.
+**Proactive refresh:** Both macOS and iOS run a periodic check every 5 minutes. If `now >= refreshAfter`, the client calls `POST /v1/integrations/guardian/vellum/refresh` (through the gateway) with the current refresh token and `Authorization: Bearer <jwt>`. On success, the response provides a new `accessToken`, `refreshToken`, `accessTokenExpiresAt`, `refreshTokenExpiresAt`, and `refreshAfter`. All stored credentials are updated atomically.
 
-**401 recovery:** When an HTTP request receives a 401 response, the `HTTPDaemonClient` attempts a single refresh before surfacing a "Session expired" error. If the refresh succeeds, the original request is retried with the new actor token. If the refresh also fails (e.g., refresh token expired or revoked), the client surfaces the session-expired error and the user must re-pair (iOS) or re-bootstrap (macOS).
+**401 recovery:** When an HTTP request receives a 401 response with `{ "code": "refresh_required" }`, the `HTTPTransport` attempts a single refresh before surfacing a "Session expired" error. If the refresh succeeds, the original request is retried with the new JWT. If the 401 contains a different code or the refresh fails (e.g., refresh token expired or revoked), the client surfaces the session-expired error and the user must re-pair (iOS) or re-bootstrap (macOS).
 
 **Shared utility:** `ActorCredentialRefresher` is a shared utility used by both platforms. It encapsulates the refresh HTTP call, credential update, and error handling. `ActorTokenManager` on each platform delegates to this refresher for both proactive and reactive (401-recovery) refresh flows.
 
-**No legacy bootstrap-as-renewal:** macOS no longer re-bootstraps on every launch. Bootstrap runs only when no actor token exists at all (first launch or after credential wipe). All subsequent renewal is handled by the refresh flow.
+**No legacy bootstrap-as-renewal:** macOS no longer re-bootstraps on every launch. Bootstrap runs only when no access token exists at all (first launch or after credential wipe). All subsequent renewal is handled by the refresh flow.
 
 ### Prerequisites
 
 - A gateway URL must be configured (cloud tunnel or LAN). LAN pairing works automatically via `localLanUrl` in the QR payload.
-- The bearer token is read from `~/.vellum/http-token` and persists across daemon restarts.
+- The legacy bearer token from `~/.vellum/http-token` is used only as a fallback for initial bootstrap before the first JWT is issued.
 - A conversation key is auto-generated on first connect and stored in UserDefaults.
 - iOS maintains a stable `deviceId` (UUID) in the Keychain across reinstalls.
 

--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -401,16 +401,19 @@ struct QRPairingSheet: View {
                 phase = .error
                 return
             }
-            guard let actorToken = response["actorToken"] as? String, !actorToken.isEmpty else {
+            // Accept "accessToken" (new JWT field) or legacy "actorToken"
+            let accessToken = (response["accessToken"] as? String) ?? (response["actorToken"] as? String)
+            guard let accessToken, !accessToken.isEmpty else {
                 errorMessage = "Pairing succeeded but device identity token is missing. Update your Assistant and pair again."
-                failureReason = "Missing actorToken in approved pairing response"
+                failureReason = "Missing accessToken in approved pairing response"
                 phase = .error
                 return
             }
             let localLanUrl = response["localLanUrl"] as? String
             let featureFlagToken = response["featureFlagToken"] as? String
             let refreshToken = response["refreshToken"] as? String
-            let actorTokenExpiresAt = response["actorTokenExpiresAt"] as? Int
+            // Accept "accessTokenExpiresAt" (new) or legacy "actorTokenExpiresAt"
+            let accessTokenExpiresAt = (response["accessTokenExpiresAt"] as? Int) ?? (response["actorTokenExpiresAt"] as? Int)
             let refreshTokenExpiresAt = response["refreshTokenExpiresAt"] as? Int
             let refreshAfter = response["refreshAfter"] as? Int
             savePairingConfig(
@@ -419,9 +422,9 @@ struct QRPairingSheet: View {
                 hostId: payload.hostId,
                 localLanUrl: localLanUrl,
                 featureFlagToken: featureFlagToken,
-                actorToken: actorToken,
+                actorToken: accessToken,
                 refreshToken: refreshToken,
-                actorTokenExpiresAt: actorTokenExpiresAt,
+                actorTokenExpiresAt: accessTokenExpiresAt,
                 refreshTokenExpiresAt: refreshTokenExpiresAt,
                 refreshAfter: refreshAfter
             )
@@ -496,16 +499,19 @@ struct QRPairingSheet: View {
                         phase = .error
                         return
                     }
-                    guard let actorToken = json["actorToken"] as? String, !actorToken.isEmpty else {
+                    // Accept "accessToken" (new JWT field) or legacy "actorToken"
+                    let pollAccessToken = (json["accessToken"] as? String) ?? (json["actorToken"] as? String)
+                    guard let pollAccessToken, !pollAccessToken.isEmpty else {
                         errorMessage = "Pairing succeeded but device identity token is missing. Update your Assistant and pair again."
-                        failureReason = "Missing actorToken in approved pairing poll response"
+                        failureReason = "Missing accessToken in approved pairing poll response"
                         phase = .error
                         return
                     }
                     let localLanUrl = json["localLanUrl"] as? String
                     let featureFlagToken = json["featureFlagToken"] as? String
                     let refreshToken = json["refreshToken"] as? String
-                    let actorTokenExpiresAt = json["actorTokenExpiresAt"] as? Int
+                    // Accept "accessTokenExpiresAt" (new) or legacy "actorTokenExpiresAt"
+                    let pollAccessTokenExpiresAt = (json["accessTokenExpiresAt"] as? Int) ?? (json["actorTokenExpiresAt"] as? Int)
                     let refreshTokenExpiresAt = json["refreshTokenExpiresAt"] as? Int
                     let refreshAfter = json["refreshAfter"] as? Int
                     savePairingConfig(
@@ -514,9 +520,9 @@ struct QRPairingSheet: View {
                         hostId: payload.hostId,
                         localLanUrl: localLanUrl,
                         featureFlagToken: featureFlagToken,
-                        actorToken: actorToken,
+                        actorToken: pollAccessToken,
                         refreshToken: refreshToken,
-                        actorTokenExpiresAt: actorTokenExpiresAt,
+                        actorTokenExpiresAt: pollAccessTokenExpiresAt,
                         refreshTokenExpiresAt: refreshTokenExpiresAt,
                         refreshAfter: refreshAfter
                     )
@@ -555,8 +561,8 @@ struct QRPairingSheet: View {
         // Don't delete on absence — the server may not send featureFlagToken yet,
         // so a missing field shouldn't wipe a previously stored token.
 
-        // Persist the actor token and refresh credentials received during pairing
-        // so subsequent HTTP requests include the X-Actor-Token header immediately.
+        // Persist the JWT access token and refresh credentials received during pairing
+        // so subsequent HTTP requests include the Authorization: Bearer header immediately.
         // When re-pairing to an assistant that omits the token, clear the
         // previous value so the old credential is never sent to the new gateway.
         if let actorToken = actorToken, !actorToken.isEmpty,
@@ -588,10 +594,10 @@ struct QRPairingSheet: View {
         phase = .connecting
         clientProvider.rebuildClient()
 
-        // If the pairing response did not include an actor token, re-trigger
-        // the bootstrap loop so the device obtains one from the daemon now
+        // If the pairing response did not include an access token, re-trigger
+        // the credential loop so the device obtains one from the daemon now
         // that a valid gateway URL is configured. Without this, a fresh
-        // install that pairs in-session would lack an actor token until the
+        // install that pairs in-session would lack an access token until the
         // next app restart.
         if !ActorTokenManager.hasToken {
             if let appDelegate = UIApplication.shared.delegate as? AppDelegate {

--- a/clients/ios/Views/Settings/TwilioSettingsSection.swift
+++ b/clients/ios/Views/Settings/TwilioSettingsSection.swift
@@ -274,11 +274,12 @@ struct TwilioSettingsSection: View {
         var request = URLRequest(url: url)
         request.httpMethod = method
         request.timeoutInterval = 30
-        if let token = endpoint.bearerToken, !token.isEmpty {
+        // Use the JWT access token as the sole Authorization bearer.
+        // Falls back to the legacy runtime bearer token if no JWT is available.
+        if let accessToken = ActorTokenManager.getToken(), !accessToken.isEmpty {
+            request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        } else if let token = endpoint.bearerToken, !token.isEmpty {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        }
-        if let actorToken = ActorTokenManager.getToken() {
-            request.setValue(actorToken, forHTTPHeaderField: "X-Actor-Token")
         }
         if let body {
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1153,11 +1153,12 @@ public final class SettingsStore: ObservableObject {
         var request = URLRequest(url: url)
         request.httpMethod = method
         request.timeoutInterval = 30
-        if let token = endpoint.bearerToken, !token.isEmpty {
+        // Use the JWT access token as the sole Authorization bearer.
+        // Falls back to the legacy runtime bearer token if no JWT is available.
+        if let accessToken = ActorTokenManager.getToken(), !accessToken.isEmpty {
+            request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        } else if let token = endpoint.bearerToken, !token.isEmpty {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        }
-        if let actorToken = ActorTokenManager.getToken() {
-            request.setValue(actorToken, forHTTPHeaderField: "X-Actor-Token")
         }
         if let body {
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/clients/shared/App/Auth/ActorCredentialRefresher.swift
+++ b/clients/shared/App/Auth/ActorCredentialRefresher.swift
@@ -13,7 +13,7 @@ public class ActorCredentialRefresher {
 
     /// Attempts a single refresh. Thread-safe via @MainActor or serial dispatch.
     /// `baseURL` is the gateway URL (e.g. https://gateway.example.com).
-    /// `bearerToken` is the runtime bearer for auth.
+    /// `bearerToken` is the legacy runtime bearer (used only as fallback if no JWT yet).
     public static func refresh(baseURL: String, bearerToken: String?, platform: String, deviceId: String) async -> RefreshResult {
         guard let refreshToken = ActorTokenManager.getRefreshToken() else {
             return .terminalError(reason: "no_refresh_token")
@@ -32,12 +32,12 @@ public class ActorCredentialRefresher {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = 15
-        if let token = bearerToken, !token.isEmpty {
+        // Use the JWT access token as the sole Authorization bearer.
+        // Falls back to the legacy runtime bearer token if no JWT is available.
+        if let accessToken = ActorTokenManager.getToken(), !accessToken.isEmpty {
+            request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        } else if let token = bearerToken, !token.isEmpty {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        }
-        // Attach current actor token for identification
-        if let actorToken = ActorTokenManager.getToken() {
-            request.setValue(actorToken, forHTTPHeaderField: "X-Actor-Token")
         }
 
         let body: [String: Any] = ["refreshToken": refreshToken, "platform": platform, "deviceId": deviceId]
@@ -52,17 +52,26 @@ public class ActorCredentialRefresher {
 
             if (200..<300).contains(http.statusCode) {
                 guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                      let newActorToken = json["actorToken"] as? String,
                       let newRefreshToken = json["refreshToken"] as? String,
-                      let actorTokenExpiresAt = json["actorTokenExpiresAt"] as? Int,
                       let refreshTokenExpiresAt = json["refreshTokenExpiresAt"] as? Int,
                       let refreshAfter = json["refreshAfter"] as? Int else {
                     return .transientError
                 }
 
+                // Accept "accessTokenExpiresAt" (new) or legacy "actorTokenExpiresAt"
+                guard let accessTokenExpiresAt = (json["accessTokenExpiresAt"] as? Int) ?? (json["actorTokenExpiresAt"] as? Int) else {
+                    return .transientError
+                }
+
+                // Accept either "accessToken" (new) or "actorToken" (legacy) field name
+                let newAccessToken = (json["accessToken"] as? String) ?? (json["actorToken"] as? String)
+                guard let token = newAccessToken else {
+                    return .transientError
+                }
+
                 ActorTokenManager.storeCredentials(
-                    actorToken: newActorToken,
-                    actorTokenExpiresAt: actorTokenExpiresAt,
+                    actorToken: token,
+                    actorTokenExpiresAt: accessTokenExpiresAt,
                     refreshToken: newRefreshToken,
                     refreshTokenExpiresAt: refreshTokenExpiresAt,
                     refreshAfter: refreshAfter

--- a/clients/shared/App/Auth/ActorTokenManager.swift
+++ b/clients/shared/App/Auth/ActorTokenManager.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-/// Cross-platform actor-token storage using Keychain via APIKeyManager.
-/// The actor token is an HMAC-signed credential that binds an assistant,
-/// platform, device, and guardian principal. It is transmitted as
-/// `X-Actor-Token` on HTTP requests to the runtime.
+/// Cross-platform JWT access token storage using Keychain via APIKeyManager.
+/// The access token (JWT) serves as both authentication and identity for
+/// HTTP requests to the runtime, transmitted as `Authorization: Bearer <jwt>`.
+///
+/// Note: Keychain storage keys are intentionally unchanged from the original
+/// "actor-token" naming to avoid orphaning existing credentials on upgrade.
 ///
 /// Follows the same Keychain persistence pattern as SessionTokenManager.
 public enum ActorTokenManager {
@@ -147,11 +149,13 @@ public enum ActorTokenManager {
         return Self.extractGuardianPrincipalIdFromToken(token)
     }
 
-    /// Decode the base64url-encoded JWT payload from an actor token and
-    /// extract the `guardianPrincipalId` claim.
+    /// Decode the base64url-encoded JWT payload and extract the
+    /// `guardianPrincipalId` claim. JWT format: header.payload.signature
     static func extractGuardianPrincipalIdFromToken(_ token: String) -> String? {
-        let parts = token.split(separator: ".", maxSplits: 2)
-        guard let payloadSegment = parts.first else { return nil }
+        let parts = token.split(separator: ".")
+        // JWT payload is the second segment (index 1)
+        guard parts.count >= 2 else { return nil }
+        let payloadSegment = parts[1]
 
         // base64url -> base64
         var base64 = String(payloadSegment)

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1753,17 +1753,52 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     // MARK: - Actor Token Bootstrap
 
     /// Response from `POST /v1/integrations/guardian/vellum/bootstrap`.
+    /// Accepts both `accessToken` (new) and `actorToken` (legacy) field names.
     public struct GuardianBootstrapResponse: Decodable {
         public let guardianPrincipalId: String
-        public let actorToken: String
-        public let actorTokenExpiresAt: Int?
+        /// The JWT access token — accepts either `accessToken` or legacy `actorToken`.
+        public let accessToken: String
+        public let accessTokenExpiresAt: Int?
         public let refreshToken: String?
         public let refreshTokenExpiresAt: Int?
         public let refreshAfter: Int?
         public let isNew: Bool
+
+        private enum CodingKeys: String, CodingKey {
+            case guardianPrincipalId
+            case accessToken
+            case actorToken
+            case accessTokenExpiresAt
+            case actorTokenExpiresAt
+            case refreshToken
+            case refreshTokenExpiresAt
+            case refreshAfter
+            case isNew
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            guardianPrincipalId = try container.decode(String.self, forKey: .guardianPrincipalId)
+            // Accept "accessToken" first, fall back to legacy "actorToken"
+            if let token = try container.decodeIfPresent(String.self, forKey: .accessToken) {
+                accessToken = token
+            } else {
+                accessToken = try container.decode(String.self, forKey: .actorToken)
+            }
+            // Accept "accessTokenExpiresAt" first, fall back to legacy "actorTokenExpiresAt"
+            if let expiresAt = try container.decodeIfPresent(Int.self, forKey: .accessTokenExpiresAt) {
+                accessTokenExpiresAt = expiresAt
+            } else {
+                accessTokenExpiresAt = try container.decodeIfPresent(Int.self, forKey: .actorTokenExpiresAt)
+            }
+            refreshToken = try container.decodeIfPresent(String.self, forKey: .refreshToken)
+            refreshTokenExpiresAt = try container.decodeIfPresent(Int.self, forKey: .refreshTokenExpiresAt)
+            refreshAfter = try container.decodeIfPresent(Int.self, forKey: .refreshAfter)
+            isNew = try container.decode(Bool.self, forKey: .isNew)
+        }
     }
 
-    /// Calls the runtime's guardian bootstrap endpoint to obtain an actor token.
+    /// Calls the runtime's guardian bootstrap endpoint to obtain a JWT access token.
     /// The token is bound to (assistantId, platform, deviceId) and persisted
     /// in Keychain via `ActorTokenManager`.
     ///
@@ -1779,7 +1814,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             baseURL = local.baseURL
             bearerToken = local.bearerToken
         } else {
-            log.error("Cannot bootstrap actor token — no HTTP endpoint available")
+            log.error("Cannot bootstrap access token — no HTTP endpoint available")
             return false
         }
 
@@ -1807,18 +1842,18 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
             guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
                 let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
-                log.error("Actor token bootstrap failed (HTTP \(statusCode))")
+                log.error("Access token bootstrap failed (HTTP \(statusCode))")
                 return false
             }
 
             let decoded = try JSONDecoder().decode(GuardianBootstrapResponse.self, from: data)
             if let refreshToken = decoded.refreshToken,
-               let actorTokenExpiresAt = decoded.actorTokenExpiresAt,
+               let accessTokenExpiresAt = decoded.accessTokenExpiresAt,
                let refreshTokenExpiresAt = decoded.refreshTokenExpiresAt,
                let refreshAfter = decoded.refreshAfter {
                 ActorTokenManager.storeCredentials(
-                    actorToken: decoded.actorToken,
-                    actorTokenExpiresAt: actorTokenExpiresAt,
+                    actorToken: decoded.accessToken,
+                    actorTokenExpiresAt: accessTokenExpiresAt,
                     refreshToken: refreshToken,
                     refreshTokenExpiresAt: refreshTokenExpiresAt,
                     refreshAfter: refreshAfter,
@@ -1828,14 +1863,14 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                 // Legacy fallback for older runtimes that don't return refresh tokens.
                 // Clear any stale refresh metadata from prior pairings so proactive
                 // refresh / 401 recovery don't send an expired token.
-                ActorTokenManager.setToken(decoded.actorToken)
+                ActorTokenManager.setToken(decoded.accessToken)
                 ActorTokenManager.setGuardianPrincipalId(decoded.guardianPrincipalId)
                 ActorTokenManager.clearRefreshMetadata()
             }
-            log.info("Actor token bootstrap succeeded (isNew=\(decoded.isNew))")
+            log.info("Access token bootstrap succeeded (isNew=\(decoded.isNew))")
             return true
         } catch {
-            log.error("Actor token bootstrap error: \(error.localizedDescription)")
+            log.error("Access token bootstrap error: \(error.localizedDescription)")
             return false
         }
     }

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -164,11 +164,11 @@ public final class HTTPTransport {
         applyAuth(&healthReq)
 
         do {
-            let (_, response) = try await URLSession.shared.data(for: healthReq)
+            let (data, response) = try await URLSession.shared.data(for: healthReq)
             guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
                 let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
                 if statusCode == 401 {
-                    handleAuthenticationFailure()
+                    handleAuthenticationFailure(responseData: data)
                 }
                 throw HTTPTransportError.healthCheckFailed
             }
@@ -382,7 +382,7 @@ public final class HTTPTransport {
             if http.statusCode == 202 || http.statusCode == 200 {
                 log.info("Message sent successfully")
             } else if http.statusCode == 401 && !isRetry {
-                let refreshResult = await handleAuthenticationFailureAsync()
+                let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
                 switch refreshResult {
                 case .success:
                     await sendMessage(content: content, sessionId: sessionId, isRetry: true)
@@ -433,11 +433,11 @@ public final class HTTPTransport {
 
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await URLSession.shared.data(for: request)
 
             if let http = response as? HTTPURLResponse {
                 if http.statusCode == 401 && !isRetry {
-                    let refreshResult = await handleAuthenticationFailureAsync()
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
                     switch refreshResult {
                     case .success:
                         await sendDecision(requestId: requestId, decision: decision, isRetry: true)
@@ -470,11 +470,11 @@ public final class HTTPTransport {
 
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await URLSession.shared.data(for: request)
 
             if let http = response as? HTTPURLResponse {
                 if http.statusCode == 401 && !isRetry {
-                    let refreshResult = await handleAuthenticationFailureAsync()
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
                     switch refreshResult {
                     case .success:
                         await sendSecret(requestId: requestId, value: value, isRetry: true)
@@ -504,7 +504,7 @@ public final class HTTPTransport {
 
             if let http = response as? HTTPURLResponse {
                 if http.statusCode == 401 && !isRetry {
-                    let refreshResult = await handleAuthenticationFailureAsync()
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
                     switch refreshResult {
                     case .success:
                         await fetchGuardianActionsPending(conversationId: conversationId, isRetry: true)
@@ -554,7 +554,7 @@ public final class HTTPTransport {
 
             if let http = response as? HTTPURLResponse {
                 if http.statusCode == 401 && !isRetry {
-                    let refreshResult = await handleAuthenticationFailureAsync()
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
                     switch refreshResult {
                     case .success:
                         await submitGuardianActionDecision(requestId: requestId, action: action, conversationId: conversationId, isRetry: true)
@@ -639,11 +639,11 @@ public final class HTTPTransport {
 
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await URLSession.shared.data(for: request)
 
             if let http = response as? HTTPURLResponse {
                 if http.statusCode == 401 && !isRetry {
-                    let refreshResult = await handleAuthenticationFailureAsync()
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
                     if case .success = refreshResult {
                         await sendConversationSeen(signal, isRetry: true)
                     }
@@ -668,7 +668,7 @@ public final class HTTPTransport {
             guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
                 let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
                 if statusCode == 401 && !isRetry {
-                    let refreshResult = await handleAuthenticationFailureAsync()
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
                     if case .success = refreshResult {
                         await fetchSessionList(offset: offset, limit: limit, isRetry: true)
                         return
@@ -709,7 +709,7 @@ public final class HTTPTransport {
             guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
                 let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
                 if statusCode == 401 && !isRetry {
-                    let refreshResult = await handleAuthenticationFailureAsync()
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
                     if case .success = refreshResult {
                         await fetchHistory(sessionId: sessionId, isRetry: true)
                         return
@@ -951,10 +951,10 @@ public final class HTTPTransport {
     /// Fire-and-forget token refresh for non-async callers (health check, SSE).
     /// Async callers that need retry-or-skip semantics should use
     /// handleAuthenticationFailureAsync() directly.
-    private func handleAuthenticationFailure() {
+    private func handleAuthenticationFailure(responseData: Data? = nil) {
         Task { @MainActor [weak self] in
             guard let self else { return }
-            _ = await self.handleAuthenticationFailureAsync()
+            _ = await self.handleAuthenticationFailureAsync(responseData: responseData)
         }
     }
 
@@ -963,7 +963,29 @@ public final class HTTPTransport {
     /// On `.terminalFailure`, callers must NOT emit their own error — `performRefresh()`
     /// already emitted `.authenticationRequired` which is the correct final user-facing state.
     /// On `.transientFailure`, callers may emit a generic error (refresh will retry on next 401).
-    private func handleAuthenticationFailureAsync() async -> AuthRefreshResult {
+    ///
+    /// When the server returns 401 with `{ "code": "refresh_required" }`, the client
+    /// attempts a credential refresh and retries once. Other 401 bodies are treated
+    /// as terminal auth failures.
+    private func handleAuthenticationFailureAsync(responseData: Data? = nil) async -> AuthRefreshResult {
+        // Parse the 401 body to determine if this is a refreshable error.
+        // If the body contains `{ "code": "refresh_required" }`, attempt refresh.
+        // If it contains a different code, treat as terminal.
+        if let data = responseData,
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let code = json["code"] as? String {
+            if code != "refresh_required" {
+                // Non-refreshable 401 — terminal failure
+                log.error("Non-refreshable 401 code: \(code) — re-auth required")
+                self.onMessage?(.sessionError(SessionErrorMessage(
+                    sessionId: "",
+                    code: .authenticationRequired,
+                    userMessage: "Session expired. Please re-pair your device.",
+                    retryable: false
+                )))
+                return .terminalFailure
+            }
+        }
         // If a refresh is already in flight, wait for its outcome instead of
         // returning false (which would drop the caller's user action).
         if let existing = refreshTask {
@@ -1057,12 +1079,14 @@ public final class HTTPTransport {
     // MARK: - Helpers
 
     private func applyAuth(_ request: inout URLRequest) {
-        if let token = bearerToken {
+        // The JWT access token is the sole auth credential — it serves as
+        // both authentication and identity (no separate X-Actor-Token).
+        if let accessToken = ActorTokenManager.getToken() {
+            request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        } else if let token = bearerToken {
+            // Fallback to legacy bearer token for initial bootstrap before
+            // the first JWT is issued.
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        }
-        // Attach actor token when available for identity-bound requests.
-        if let actorToken = ActorTokenManager.getToken() {
-            request.setValue(actorToken, forHTTPHeaderField: "X-Actor-Token")
         }
     }
 

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -964,17 +964,25 @@ public final class HTTPTransport {
     /// already emitted `.authenticationRequired` which is the correct final user-facing state.
     /// On `.transientFailure`, callers may emit a generic error (refresh will retry on next 401).
     ///
-    /// When the server returns 401 with `{ "code": "refresh_required" }`, the client
-    /// attempts a credential refresh and retries once. Other 401 bodies are treated
-    /// as terminal auth failures.
+    /// When the server returns 401 with `{ "error": { "code": "refresh_required" } }`,
+    /// the client attempts a credential refresh and retries once. Other 401 bodies
+    /// are treated as terminal auth failures.
     private func handleAuthenticationFailureAsync(responseData: Data? = nil) async -> AuthRefreshResult {
         // Parse the 401 body to determine if this is a refreshable error.
-        // If the body contains `{ "code": "refresh_required" }`, attempt refresh.
-        // If it contains a different code, treat as terminal.
+        // The server's auth middleware returns errors in a standard envelope:
+        //   { "error": { "code": "refresh_required", "message": "..." } }
+        // We also accept a top-level "code" for forward compatibility.
         if let data = responseData,
-           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-           let code = json["code"] as? String {
-            if code != "refresh_required" {
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            // Server returns { error: { code: "...", message: "..." } }
+            let code: String? = {
+                if let errorObj = json["error"] as? [String: Any] {
+                    return errorObj["code"] as? String
+                }
+                // Also accept top-level { code: "..." } for forward-compat
+                return json["code"] as? String
+            }()
+            if let code, code != "refresh_required" {
                 // Non-refreshable 401 — terminal failure
                 log.error("Non-refreshable 401 code: \(code) — re-auth required")
                 self.onMessage?(.sessionError(SessionErrorMessage(

--- a/gateway/src/auth/token-exchange.ts
+++ b/gateway/src/auth/token-exchange.ts
@@ -30,9 +30,16 @@ const EXCHANGE_TOKEN_TTL_SECONDS = 60;
  * Validate a JWT edge token intended for the gateway (aud=vellum-gateway).
  *
  * Returns the verified claims on success, or a structured error on failure.
+ * Pass `allowExpired: true` to accept expired-but-otherwise-valid tokens
+ * (signature, audience, and policy epoch are still checked). This is used
+ * by the refresh endpoint so clients can obtain new credentials even after
+ * the access token has expired.
  */
-export function validateEdgeToken(token: string): VerifyResult {
-  return verifyToken(token, 'vellum-gateway');
+export function validateEdgeToken(
+  token: string,
+  opts?: { allowExpired?: boolean },
+): VerifyResult {
+  return verifyToken(token, 'vellum-gateway', opts);
 }
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/auth/token-service.ts
+++ b/gateway/src/auth/token-service.ts
@@ -139,7 +139,11 @@ export function mintToken(params: {
 // Verify
 // ---------------------------------------------------------------------------
 
-export function verifyToken(token: string, expectedAud: TokenAudience): VerifyResult {
+export function verifyToken(
+  token: string,
+  expectedAud: TokenAudience,
+  opts?: { allowExpired?: boolean },
+): VerifyResult {
   const parts = token.split('.');
   if (parts.length !== 3) {
     return { ok: false, reason: 'malformed_token: expected 3 dot-separated parts' };
@@ -174,7 +178,7 @@ export function verifyToken(token: string, expectedAud: TokenAudience): VerifyRe
   }
 
   const nowSeconds = Math.floor(Date.now() / 1000);
-  if (claims.exp <= nowSeconds) {
+  if (!opts?.allowExpired && claims.exp <= nowSeconds) {
     return { ok: false, reason: 'token_expired' };
   }
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -485,9 +485,23 @@ function main() {
       }
 
       // ── Guardian vellum refresh proxy ──
+      // Accept expired-but-otherwise-valid JWTs on the refresh path.
+      // The refresh endpoint's purpose is to obtain a new access token,
+      // so rejecting expired tokens here would create a deadlock once
+      // the JWT expires. Signature, audience, and policy epoch are still
+      // verified — only the expiration check is relaxed.
       if (url.pathname === "/v1/integrations/guardian/vellum/refresh" && req.method === "POST") {
-        const authError = requireEdgeAuth();
-        if (authError) return authError;
+        const authHeader = tracedReq.headers.get("authorization");
+        if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
+          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+          return Response.json({ error: "Unauthorized" }, { status: 401 });
+        }
+        const token = authHeader.slice(7);
+        const result = validateEdgeToken(token, { allowExpired: true });
+        if (!result.ok) {
+          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+          return Response.json({ error: "Unauthorized" }, { status: 401 });
+        }
         return guardianControlPlaneProxy.handleGuardianRefresh(tracedReq);
       }
 


### PR DESCRIPTION
## Summary
- macOS/iOS clients now send only Authorization: Bearer <jwt>
- Removed X-Actor-Token header from all Swift code
- Handle refresh_required 401 response code for credential refresh
- Bootstrap and pairing flows consume accessToken field
- Single JWT serves as both authentication and identity

Closes #11209
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
