### PR TITLE
fix: trigger PID-based fallback when vellum sleep exits non-zero

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -899,6 +899,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         }
 
         if let name = assistantName {
+            // Stop processes FIRST while PID files and lockfile entry still exist.
+            // retire() internally tries to stop them again, which is idempotent.
+            daemonClient.disconnect()
+            assistantCli.stop()
+
             do {
                 try await assistantCli.retire(name: name)
             } catch {

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -295,6 +295,11 @@ final class AssistantCli {
             try proc.run()
             proc.waitUntilExit()
             log.info("CLI stop completed with exit code \(proc.terminationStatus)")
+            if proc.terminationStatus != 0 {
+                log.warning("CLI stop exited non-zero (\(proc.terminationStatus)) — falling back to PID-based kill")
+                killViaPIDFile()
+                killGatewayViaPIDFile()
+            }
         } catch {
             log.error("CLI stop failed: \(error.localizedDescription)")
             // Fallback: kill via PID file directly


### PR DESCRIPTION
## Summary

- When `vellum sleep` exits with a non-zero code (e.g., lockfile is empty), `proc.run()` does not throw — the process ran, it just failed. Previously, the PID-based fallback (`killViaPIDFile` / `killGatewayViaPIDFile`) was only in the `catch` block, so stale processes would survive.
- Added a check on `proc.terminationStatus` after `waitUntilExit` to trigger the fallback on non-zero exit.

## Test plan

- [x] Builds successfully (`cd clients/macos && ./build.sh`)
- [ ] Manual: stop the daemon when lockfile is empty — verify gateway process is killed via PID fallback

Generated with [Claude Code](https://claude.ai/code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
