### PR TITLE
fix: kill daemon/gateway before retire to prevent orphan processes

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -899,6 +899,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         }
 
         if let name = assistantName {
+            // Stop processes FIRST while PID files and lockfile entry still exist.
+            // retire() internally tries to stop them again, which is idempotent.
+            daemonClient.disconnect()
+            assistantCli.stop()
+
             do {
                 try await assistantCli.retire(name: name)
             } catch {


### PR DESCRIPTION
## Summary

- Reorders `performRetireAsync()` in `AppDelegate.swift` to call `daemonClient.disconnect()` and `assistantCli.stop()` **before** `assistantCli.retire()`, ensuring the gateway process is killed while PID files and lockfile entry still exist.

## Problem

`assistantCli.retire()` moves `~/.vellum/` to a staging directory (removing PID files) and clears the lockfile entry. Then when `assistantCli.stop()` runs afterward, it calls `vellum sleep` which fails because the lockfile is empty and PID files are gone — leaving the gateway process orphaned.

## Fix

By stopping processes first (while PID files and the lockfile entry still exist), `vellum sleep` can find and kill the gateway reliably. The existing `daemonClient.disconnect()` and `assistantCli.stop()` calls later in the method are preserved as defense-in-depth since both operations are idempotent.

## Test plan

- [x] macOS build passes (`cd clients/macos && ./build.sh`)
- [ ] Manual test: retire an assistant and verify no orphan gateway process remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
