### PR TITLE
fix: remove lockfile guard from vellum sleep

### DIFF
--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -1,7 +1,6 @@
 import { homedir } from "os";
 import { join } from "path";
 
-import { loadAllAssistants } from "../lib/assistant-config";
 import { stopProcessByPidFile } from "../lib/process";
 
 export async function sleep(): Promise<void> {
@@ -13,20 +12,15 @@ export async function sleep(): Promise<void> {
     process.exit(0);
   }
 
-  const assistants = loadAllAssistants();
-  const hasLocal = assistants.some((a) => a.cloud === "local");
-  if (!hasLocal) {
-    console.error("Error: No local assistant found in lock file. Run 'vellum hatch local' first.");
-    process.exit(1);
-  }
-
   const vellumDir = join(homedir(), ".vellum");
   const daemonPidFile = join(vellumDir, "vellum.pid");
   const socketFile = join(vellumDir, "vellum.sock");
   const gatewayPidFile = join(vellumDir, "gateway.pid");
 
   // Stop daemon
-  const daemonStopped = await stopProcessByPidFile(daemonPidFile, "daemon", [socketFile]);
+  const daemonStopped = await stopProcessByPidFile(daemonPidFile, "daemon", [
+    socketFile,
+  ]);
   if (!daemonStopped) {
     console.log("Daemon is not running.");
   } else {


### PR DESCRIPTION
## Summary

- Remove the `loadAllAssistants` lockfile guard from `vellum sleep` that prevented it from working when no assistant is in the lockfile
- After retiring, the lockfile is empty but leftover daemon/gateway processes may still need to be killed. The guard caused `vellum sleep` to exit early with code 1, preventing cleanup
- PID files are the authoritative source for which processes to kill — the lockfile check was redundant and harmful

## Test plan

- [x] Type-check passes (`bunx tsc --noEmit` in cli/)
- [ ] `vellum sleep` works correctly when lockfile has a local assistant
- [ ] `vellum sleep` works correctly when lockfile is empty (post-retire)
- [ ] `vellum sleep` correctly reports when daemon/gateway are not running

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
