### PR TITLE
fix: use design system tokens in wake word overlay

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordActivationIndicator.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordActivationIndicator.swift
@@ -1,6 +1,7 @@
-import VellumAssistantShared
+import AppKit
 import SwiftUI
 import os
+import VellumAssistantShared
 
 private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "WakeWordActivationIndicator")
 
@@ -12,78 +13,16 @@ enum WakeWordIndicatorState {
     case listening
 }
 
-/// A small floating indicator shown briefly when the wake word is detected
-/// or when the app returns to passive listening mode. Auto-dismisses after
-/// a short delay as the voice mode UI takes over.
-struct WakeWordActivationIndicator: View {
-    let state: WakeWordIndicatorState
-
-    @State private var isVisible = false
-
-    var body: some View {
-        HStack(spacing: VSpacing.sm) {
-            Circle()
-                .fill(dotColor)
-                .frame(width: 8, height: 8)
-
-            Text(labelText)
-                .font(VFont.caption)
-                .foregroundColor(VColor.textPrimary)
-        }
-        .padding(.horizontal, VSpacing.lg)
-        .padding(.vertical, VSpacing.sm)
-        .background(VColor.background.opacity(0.92))
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .stroke(borderColor, lineWidth: 1)
-        )
-        .opacity(isVisible ? 1 : 0)
-        .scaleEffect(isVisible ? 1 : 0.85)
-        .onAppear {
-            withAnimation(VAnimation.fast) {
-                isVisible = true
-            }
-        }
-    }
-
-    private var labelText: String {
-        switch state {
-        case .activated:
-            return "Activated"
-        case .listening:
-            return "Listening for \u{201C}hey vellum\u{201D}"
-        }
-    }
-
-    private var dotColor: Color {
-        switch state {
-        case .activated:
-            return VColor.accent
-        case .listening:
-            return VColor.success
-        }
-    }
-
-    private var borderColor: Color {
-        switch state {
-        case .activated:
-            return VColor.accent.opacity(0.4)
-        case .listening:
-            return VColor.surfaceBorder
-        }
-    }
-}
-
-/// A floating NSPanel that displays the `WakeWordActivationIndicator`
-/// in the top-right area of the screen, matching the placement approach
-/// used by `VoiceTranscriptionWindow`.
+/// A floating NSPanel that displays a small indicator pill in the top-right
+/// area of the screen when the wake word is detected or the app returns to
+/// passive listening. Uses AppKit + design system tokens to match the
+/// DictationOverlayWindow style and respect light/dark mode.
 @MainActor
 final class WakeWordActivationWindow {
     private var panel: NSPanel?
     private var dismissTask: Task<Void, Never>?
 
-    private let panelWidth: CGFloat = 220
+    private let panelWidth: CGFloat = 240
     private let panelHeight: CGFloat = 36
     private let margin: CGFloat = 16
 
@@ -92,35 +31,30 @@ final class WakeWordActivationWindow {
     func show(state: WakeWordIndicatorState, dismissAfter: TimeInterval = 1.5) {
         close()
 
-        let hostingController = NSHostingController(
-            rootView: WakeWordActivationIndicator(state: state)
-        )
+        let contentView = buildContentView(state: state)
 
         let panel = NSPanel(
             contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: panelHeight),
-            styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
+            styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
 
-        panel.contentViewController = hostingController
+        panel.isFloatingPanel = true
         panel.level = .floating
-        panel.titleVisibility = .hidden
-        panel.titlebarAppearsTransparent = true
-        panel.alphaValue = 0.95
-        panel.isReleasedWhenClosed = false
-        panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
         panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = true
+        panel.contentView = contentView
+        panel.isMovableByWindowBackground = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
 
         // Position top-right, slightly below where VoiceTranscriptionWindow appears
         if let screen = NSScreen.main {
             let screenFrame = screen.visibleFrame
             let x = screenFrame.maxX - panelWidth - margin
             let y = screenFrame.maxY - panelHeight - margin
-            panel.setFrame(
-                NSRect(x: x, y: y, width: panelWidth, height: panelHeight),
-                display: false
-            )
+            panel.setFrameOrigin(NSPoint(x: x, y: y))
         }
 
         panel.orderFront(nil)
@@ -139,15 +73,98 @@ final class WakeWordActivationWindow {
     func close() {
         dismissTask?.cancel()
         dismissTask = nil
-        panel?.close()
+        panel?.orderOut(nil)
         panel = nil
+    }
+
+    // MARK: - AppKit Content
+
+    private func buildContentView(state: WakeWordIndicatorState) -> NSView {
+        let container = WakeWordOverlayBackgroundView()
+        container.wantsLayer = true
+
+        let dot = makeDot(for: state)
+        let label = makeLabel(for: state)
+
+        dot.translatesAutoresizingMaskIntoConstraints = false
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(dot)
+        container.addSubview(label)
+
+        NSLayoutConstraint.activate([
+            dot.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            dot.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            dot.widthAnchor.constraint(equalToConstant: 8),
+            dot.heightAnchor.constraint(equalToConstant: 8),
+
+            label.leadingAnchor.constraint(equalTo: dot.trailingAnchor, constant: 8),
+            label.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -16),
+            label.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+        ])
+
+        return container
+    }
+
+    private func makeDot(for state: WakeWordIndicatorState) -> NSView {
+        let dot = NSView(frame: NSRect(x: 0, y: 0, width: 8, height: 8))
+        dot.wantsLayer = true
+        let color: Color = state == .activated ? VColor.accent : VColor.success
+        dot.layer?.backgroundColor = NSColor(color).cgColor
+        dot.layer?.cornerRadius = 4
+        return dot
+    }
+
+    private func makeLabel(for state: WakeWordIndicatorState) -> NSTextField {
+        let text: String
+        switch state {
+        case .activated:
+            text = "Activated"
+        case .listening:
+            let keyword = UserDefaults.standard.string(forKey: "wakeWordKeyword") ?? "computer"
+            text = "Listening for \u{201C}\(keyword)\u{201D}"
+        }
+
+        let field = NSTextField(labelWithString: text)
+        field.font = NSFont(name: "Inter", size: 11) ?? NSFont.systemFont(ofSize: 11)
+        field.textColor = NSColor(VColor.textSecondary)
+        field.lineBreakMode = .byTruncatingTail
+        field.maximumNumberOfLines = 1
+        return field
+    }
+}
+
+/// Rounded, semi-transparent background using design system tokens.
+private class WakeWordOverlayBackgroundView: NSView {
+    override var wantsUpdateLayer: Bool { true }
+
+    override func updateLayer() {
+        layer?.backgroundColor = NSColor(VColor.surface).withAlphaComponent(0.95).cgColor
+        layer?.cornerRadius = VRadius.lg
+        layer?.borderWidth = 1
+        layer?.borderColor = NSColor(VColor.surfaceBorder).cgColor
     }
 }
 
 #Preview("Activated") {
     ZStack {
         VColor.background.ignoresSafeArea()
-        WakeWordActivationIndicator(state: .activated)
+        HStack(spacing: VSpacing.sm) {
+            Circle()
+                .fill(VColor.accent)
+                .frame(width: 8, height: 8)
+            Text("Activated")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+        .background(VColor.surface.opacity(0.95))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
     }
     .frame(width: 300, height: 80)
 }
@@ -155,7 +172,22 @@ final class WakeWordActivationWindow {
 #Preview("Listening") {
     ZStack {
         VColor.background.ignoresSafeArea()
-        WakeWordActivationIndicator(state: .listening)
+        HStack(spacing: VSpacing.sm) {
+            Circle()
+                .fill(VColor.success)
+                .frame(width: 8, height: 8)
+            Text("Listening for \u{201C}computer\u{201D}")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+        .background(VColor.surface.opacity(0.95))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
     }
     .frame(width: 300, height: 80)
 }


### PR DESCRIPTION
## Summary
- Migrate wake word activation indicator from SwiftUI + `.hudWindow` to pure AppKit + `.borderless` panel with design system tokens
- Matches the pattern from #11308 (DictationOverlayWindow migration)
- Fix hardcoded `"hey vellum"` in listening state — now reads actual keyword from UserDefaults

## Test plan
- [x] Build succeeds
- [x] Wake word overlay appears with correct styling (dark background, accent dot, border)
- [x] "Listening" state shows actual configured keyword
- [ ] CI passes

Refs #11247 #11248

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
