### PR TITLE
fix: remove macOS keychain usage from Swift app to eliminate auth prompts

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Security
 
 extension Notification.Name {
     static let apiKeyManagerDidChange = Notification.Name("APIKeyManager.didChange")
@@ -12,26 +11,10 @@ extension Notification.Name {
     static let identityChanged = Notification.Name("identityChanged")
 }
 
-/// Manages API keys in the macOS login keychain via native SecItem* APIs.
+/// Manages API keys using UserDefaults. The daemon owns the canonical encrypted
+/// store; the app syncs keys to the daemon via HTTP on save/clear/reconnect.
 enum APIKeyManager {
-    /// Shared with the daemon (keychain.ts uses service "vellum-assistant", account = provider name).
-    private static let service = "vellum-assistant"
-
-    // Legacy keychain entry (pre-daemon era). Migrated on first access.
-    private static let legacyService = "com.vellum-assistant.anthropic-api-key"
-    private static let legacyAccount = "anthropic-api-key"
-
-    private struct CachedKeyRead {
-        let value: String?
-        let cachedAt: Date
-    }
-
-    private static var readCache: [String: CachedKeyRead] = [:]
-    private static let readCacheLock = NSLock()
-    private static let readCacheHitTTL: TimeInterval = 60
-    /// Short TTL for misses so external writes (e.g. from the daemon) are picked up quickly
-    /// while still batching rapid sequential calls like hasAnyKey().
-    private static let readCacheMissTTL: TimeInterval = 5
+    private static let udPrefix = "vellum_provider_"
 
     // MARK: - Anthropic (convenience wrappers for backward compatibility)
 
@@ -50,238 +33,17 @@ enum APIKeyManager {
     // MARK: - Generic provider access
 
     static func getKey(for provider: String) -> String? {
-        migrateCliToNativeIfNeeded()
-
-        let cached = cachedValue(for: provider)
-        if cached.hit { return cached.value }
-
-        if provider == "anthropic" {
-            // migrateIfNeeded returns the key if it was already read during
-            // the migration check, avoiding a redundant security CLI spawn
-            // (each spawn triggers a macOS keychain authorization prompt).
-            if let migrated = migrateIfNeeded() {
-                setCachedValue(migrated, for: provider)
-                return migrated
-            }
-        }
-        let value = nativeGetKey(service: service, account: provider)
-        setCachedValue(value, for: provider)
-        return value
+        UserDefaults.standard.string(forKey: udPrefix + provider)
     }
 
     static func setKey(_ key: String, for provider: String) {
-        if nativeSetKey(service: service, account: provider, value: key) {
-            setCachedValue(key, for: provider)
-        } else {
-            invalidateCachedValue(for: provider)
-        }
+        UserDefaults.standard.set(key, forKey: udPrefix + provider)
         notifyKeyDidChange()
     }
 
     static func deleteKey(for provider: String) {
-        nativeDeleteKey(service: service, account: provider)
-        invalidateCachedValue(for: provider)
+        UserDefaults.standard.removeObject(forKey: udPrefix + provider)
         notifyKeyDidChange()
-    }
-
-    private static func cachedValue(for provider: String) -> (hit: Bool, value: String?) {
-        readCacheLock.lock()
-        defer { readCacheLock.unlock() }
-
-        guard let entry = readCache[provider] else {
-            return (false, nil)
-        }
-
-        let ttl = entry.value != nil ? readCacheHitTTL : readCacheMissTTL
-        if Date().timeIntervalSince(entry.cachedAt) > ttl {
-            readCache.removeValue(forKey: provider)
-            return (false, nil)
-        }
-
-        return (true, entry.value)
-    }
-
-    private static func setCachedValue(_ value: String?, for provider: String) {
-        readCacheLock.lock()
-        defer { readCacheLock.unlock() }
-        readCache[provider] = CachedKeyRead(value: value, cachedAt: Date())
-    }
-
-    private static func invalidateCachedValue(for provider: String) {
-        readCacheLock.lock()
-        defer { readCacheLock.unlock() }
-        readCache.removeValue(forKey: provider)
-    }
-
-    // MARK: - Native Keychain (SecItem)
-
-    /// Read a generic password via `SecItemCopyMatching`.
-    private static func nativeGetKey(service: String, account: String) -> String? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne
-        ]
-        var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess,
-              let data = result as? Data,
-              let value = String(data: data, encoding: .utf8) else {
-            return nil
-        }
-        return value
-    }
-
-    /// Write a generic password via `SecItemAdd` (deletes existing first).
-    @discardableResult
-    private static func nativeSetKey(service: String, account: String, value: String) -> Bool {
-        guard let data = value.data(using: .utf8) else { return false }
-
-        // Delete existing entry (ignore status since it may not exist)
-        let deleteQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account
-        ]
-        SecItemDelete(deleteQuery as CFDictionary)
-
-        // Add new entry
-        let addQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
-            kSecValueData as String: data,
-            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked
-        ]
-        let status = SecItemAdd(addQuery as CFDictionary, nil)
-        return status == errSecSuccess
-    }
-
-    /// Delete a generic password via `SecItemDelete`.
-    @discardableResult
-    private static func nativeDeleteKey(service: String, account: String) -> Bool {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account
-        ]
-        let status = SecItemDelete(query as CFDictionary)
-        return status == errSecSuccess || status == errSecItemNotFound
-    }
-
-    // MARK: - CLI Helpers
-
-    /// Read a generic password via `security find-generic-password`.
-    private static func cliGetKey(service: String, account: String) -> String? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
-        process.arguments = ["find-generic-password", "-s", service, "-a", account, "-w"]
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = FileHandle.nullDevice
-        do {
-            try process.run()
-            process.waitUntilExit()
-            guard process.terminationStatus == 0 else { return nil }
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .newlines)
-        } catch {
-            return nil
-        }
-    }
-
-    /// Write a generic password via `security add-generic-password -U` (update if exists).
-    @discardableResult
-    private static func cliSetKey(service: String, account: String, value: String) -> Bool {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
-        process.arguments = ["add-generic-password", "-s", service, "-a", account, "-w", value, "-U"]
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-        do {
-            try process.run()
-            process.waitUntilExit()
-            return process.terminationStatus == 0
-        } catch {
-            return false
-        }
-    }
-
-    /// Delete a generic password via `security delete-generic-password`.
-    @discardableResult
-    private static func cliDeleteKey(service: String, account: String) -> Bool {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
-        process.arguments = ["delete-generic-password", "-s", service, "-a", account]
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-        do {
-            try process.run()
-            process.waitUntilExit()
-            return process.terminationStatus == 0
-        } catch {
-            return false
-        }
-    }
-
-    // MARK: - Migration
-
-    /// One-time migration from the legacy keychain entry to the daemon-shared entry.
-    /// Returns the current anthropic key if it was read during the check, so the
-    /// caller can reuse it without a second CLI invocation.
-    @discardableResult
-    private static func migrateIfNeeded() -> String? {
-        // Skip if new entry already exists — return the value we just read
-        if let existing = nativeGetKey(service: service, account: "anthropic") { return existing }
-
-        // Read from legacy entry (uses Security.framework since the old entry was created with SecItemAdd)
-        let legacyQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: legacyService,
-            kSecAttrAccount as String: legacyAccount,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne
-        ]
-        var result: AnyObject?
-        guard SecItemCopyMatching(legacyQuery as CFDictionary, &result) == errSecSuccess,
-              let data = result as? Data,
-              let key = String(data: data, encoding: .utf8) else { return nil }
-
-        // Write to new entry via native SecItem API (prompt-free)
-        nativeSetKey(service: service, account: "anthropic", value: key)
-
-        // Delete legacy entry
-        let deleteQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: legacyService,
-            kSecAttrAccount as String: legacyAccount
-        ]
-        SecItemDelete(deleteQuery as CFDictionary)
-
-        return key
-    }
-
-    /// One-time migration from CLI-created keychain items to native SecItem entries.
-    /// CLI-created items are owned by `/usr/bin/security` and trigger macOS authorization
-    /// prompts; native entries are owned by the app and are prompt-free.
-    private static func migrateCliToNativeIfNeeded() {
-        guard !UserDefaults.standard.bool(forKey: "keychain-native-migration-done") else { return }
-
-        let providers = [
-            "anthropic", "openai", "gemini", "fireworks",
-            "brave", "perplexity", "elevenlabs", "openrouter", "ollama"
-        ]
-
-        for provider in providers {
-            if let value = cliGetKey(service: service, account: provider) {
-                nativeSetKey(service: service, account: provider, value: value)
-                cliDeleteKey(service: service, account: provider)
-            }
-        }
-
-        UserDefaults.standard.set(true, forKey: "keychain-native-migration-done")
     }
 
     private static func notifyKeyDidChange() {

--- a/clients/shared/App/SigningIdentityManager.swift
+++ b/clients/shared/App/SigningIdentityManager.swift
@@ -1,7 +1,6 @@
 #if os(macOS)
 import CryptoKit
 import Foundation
-import Security
 import os
 
 private let log = Logger(
@@ -9,16 +8,20 @@ private let log = Logger(
     category: "SigningIdentityManager"
 )
 
-/// Manages the Ed25519 signing identity stored in the macOS Keychain.
-/// Key is generated on first access and persisted across launches.
+/// Manages the Ed25519 signing identity stored on disk in ~/.vellum/protected/.
+/// Previously used the macOS Keychain, which triggers repeated authorization
+/// prompts with ad-hoc code-signed builds.
 @MainActor
 public final class SigningIdentityManager {
     public static let shared = SigningIdentityManager()
 
-    private let service = "vellum-assistant"
-    private let account = "signing-key"
+    /// File path for the signing key: ~/.vellum/protected/app-signing-key
+    private var keyFilePath: URL {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return home.appendingPathComponent(".vellum/protected/app-signing-key")
+    }
 
-    /// Cached private key to avoid repeated Keychain lookups.
+    /// Cached private key to avoid repeated file reads.
     private var cachedKey: Curve25519.Signing.PrivateKey?
 
     /// Get or create the Ed25519 signing private key.
@@ -27,15 +30,15 @@ public final class SigningIdentityManager {
             return cached
         }
 
-        // Try to load from Keychain
-        if let key = try loadFromKeychain() {
+        // Try to load from file
+        if let key = try loadFromFile() {
             cachedKey = key
             return key
         }
 
         // Generate a new key and store it
         let key = Curve25519.Signing.PrivateKey()
-        try saveToKeychain(key)
+        try saveToFile(key)
         cachedKey = key
         log.info("Generated new Ed25519 signing key")
         return key
@@ -59,83 +62,38 @@ public final class SigningIdentityManager {
         return try signingKey.signature(for: data)
     }
 
-    // MARK: - Keychain Helpers
+    // MARK: - File Storage
 
-    private func loadFromKeychain() throws -> Curve25519.Signing.PrivateKey? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]
-
-        var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-
-        switch status {
-        case errSecSuccess:
-            guard let data = result as? Data else {
-                log.error("Keychain returned non-data result for signing key")
-                return nil
-            }
-            return try Curve25519.Signing.PrivateKey(rawRepresentation: data)
-
-        case errSecItemNotFound:
+    private func loadFromFile() throws -> Curve25519.Signing.PrivateKey? {
+        let path = keyFilePath
+        guard FileManager.default.fileExists(atPath: path.path) else {
             return nil
-
-        default:
-            log.error("Keychain read failed with status \(status)")
-            throw KeychainError.readFailed(status)
         }
+        let data = try Data(contentsOf: path)
+        return try Curve25519.Signing.PrivateKey(rawRepresentation: data)
     }
 
-    private func saveToKeychain(_ key: Curve25519.Signing.PrivateKey) throws {
+    private func saveToFile(_ key: Curve25519.Signing.PrivateKey) throws {
+        let path = keyFilePath
+        let dir = path.deletingLastPathComponent()
+
+        // Ensure directory exists with restrictive permissions
+        if !FileManager.default.fileExists(atPath: dir.path) {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            // Set directory permissions to owner-only
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o700],
+                ofItemAtPath: dir.path
+            )
+        }
+
         let rawData = key.rawRepresentation
-
-        let attributes: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
-            kSecValueData as String: rawData,
-            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-        ]
-
-        // Try to add; if it already exists, update it
-        var status = SecItemAdd(attributes as CFDictionary, nil)
-
-        if status == errSecDuplicateItem {
-            let query: [String: Any] = [
-                kSecClass as String: kSecClassGenericPassword,
-                kSecAttrService as String: service,
-                kSecAttrAccount as String: account,
-            ]
-            let update: [String: Any] = [
-                kSecValueData as String: rawData,
-            ]
-            status = SecItemUpdate(query as CFDictionary, update as CFDictionary)
-        }
-
-        guard status == errSecSuccess else {
-            log.error("Keychain write failed with status \(status)")
-            throw KeychainError.writeFailed(status)
-        }
-    }
-
-    // MARK: - Errors
-
-    enum KeychainError: Error, LocalizedError {
-        case readFailed(OSStatus)
-        case writeFailed(OSStatus)
-
-        var errorDescription: String? {
-            switch self {
-            case .readFailed(let status):
-                return "Failed to read signing key from Keychain (status \(status))"
-            case .writeFailed(let status):
-                return "Failed to write signing key to Keychain (status \(status))"
-            }
-        }
+        try rawData.write(to: path, options: .atomic)
+        // Set file permissions to owner read/write only
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: path.path
+        )
     }
 }
 #endif

--- a/clients/shared/Utilities/APIKeyManager.swift
+++ b/clients/shared/Utilities/APIKeyManager.swift
@@ -1,10 +1,10 @@
 import Foundation
 #if os(iOS)
 import UIKit
+import Security
 #elseif os(macOS)
 import AppKit
 #endif
-import Security
 
 public class APIKeyManager {
     public static let shared = APIKeyManager()
@@ -14,7 +14,7 @@ public class APIKeyManager {
     private init() {}
 
     public func getAPIKey(provider: String = "anthropic") -> String? {
-        #if targetEnvironment(simulator)
+        #if os(macOS) || targetEnvironment(simulator)
         return UserDefaults.standard.string(forKey: udKey(provider))
         #else
         let query: [String: Any] = [
@@ -38,7 +38,7 @@ public class APIKeyManager {
     }
 
     public func setAPIKey(_ key: String, provider: String = "anthropic") -> Bool {
-        #if targetEnvironment(simulator)
+        #if os(macOS) || targetEnvironment(simulator)
         UserDefaults.standard.set(key, forKey: udKey(provider))
         return true
         #else
@@ -66,7 +66,7 @@ public class APIKeyManager {
     }
 
     public func deleteAPIKey(provider: String = "anthropic") -> Bool {
-        #if targetEnvironment(simulator)
+        #if os(macOS) || targetEnvironment(simulator)
         UserDefaults.standard.removeObject(forKey: udKey(provider))
         return true
         #else


### PR DESCRIPTION
## Summary
- Switch macOS `APIKeyManager` (enum) from SecItem keychain APIs to UserDefaults, removing all CLI helpers and legacy migration code
- Switch shared `APIKeyManager` (class) to UserDefaults on macOS (`#if os(macOS)`) while keeping keychain on iOS
- Switch `SigningIdentityManager` from keychain to file-based storage at `~/.vellum/protected/app-signing-key` with `0600` permissions

Ad-hoc signed dev builds change code signature on every rebuild, causing macOS to prompt for keychain access on every launch. The daemon already moved to encrypted file storage — this aligns the Swift app.

## Original prompt
rebuild the local version and remove these keychain things showing up it's not going away at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
