### PR TITLE
fix: revert certificate secret names to CERTIFICATE_P12/PASSWORD

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -33,10 +33,10 @@ jobs:
           security set-keychain-settings -lut 3600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
-          echo "${{ secrets.DIST_CERTIFICATE_P12 }}" | base64 -D > /tmp/certificate.p12
+          echo "${{ secrets.CERTIFICATE_P12 }}" | base64 -D > /tmp/certificate.p12
           security import /tmp/certificate.p12 \
             -k "$KEYCHAIN_PATH" \
-            -P "${{ secrets.DIST_CERTIFICATE_PASSWORD }}" \
+            -P "${{ secrets.CERTIFICATE_PASSWORD }}" \
             -T /usr/bin/codesign \
             -T /usr/bin/security
           rm /tmp/certificate.p12

--- a/.github/workflows/ci-nightly-release.yml
+++ b/.github/workflows/ci-nightly-release.yml
@@ -63,10 +63,10 @@ jobs:
           security set-keychain-settings -lut 3600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
-          echo "${{ secrets.DIST_CERTIFICATE_P12 }}" | base64 -D > /tmp/certificate.p12
+          echo "${{ secrets.CERTIFICATE_P12 }}" | base64 -D > /tmp/certificate.p12
           security import /tmp/certificate.p12 \
             -k "$KEYCHAIN_PATH" \
-            -P "${{ secrets.DIST_CERTIFICATE_PASSWORD }}" \
+            -P "${{ secrets.CERTIFICATE_PASSWORD }}" \
             -T /usr/bin/codesign \
             -T /usr/bin/security
           rm /tmp/certificate.p12

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -38,10 +38,10 @@ jobs:
           security set-keychain-settings -lut 3600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
-          echo "${{ secrets.DIST_CERTIFICATE_P12 }}" | base64 -D > /tmp/certificate.p12
+          echo "${{ secrets.CERTIFICATE_P12 }}" | base64 -D > /tmp/certificate.p12
           security import /tmp/certificate.p12 \
             -k "$KEYCHAIN_PATH" \
-            -P "${{ secrets.DIST_CERTIFICATE_PASSWORD }}" \
+            -P "${{ secrets.CERTIFICATE_PASSWORD }}" \
             -T /usr/bin/codesign \
             -T /usr/bin/security
           rm /tmp/certificate.p12

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -732,10 +732,10 @@ jobs:
           security set-keychain-settings -lut 3600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
-          echo "${{ secrets.DIST_CERTIFICATE_P12 }}" | base64 -D > /tmp/certificate.p12
+          echo "${{ secrets.CERTIFICATE_P12 }}" | base64 -D > /tmp/certificate.p12
           security import /tmp/certificate.p12 \
             -k "$KEYCHAIN_PATH" \
-            -P "${{ secrets.DIST_CERTIFICATE_PASSWORD }}" \
+            -P "${{ secrets.CERTIFICATE_PASSWORD }}" \
             -T /usr/bin/codesign \
             -T /usr/bin/security
           rm /tmp/certificate.p12
@@ -1005,10 +1005,10 @@ jobs:
           security set-keychain-settings -lut 3600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
-          echo "${{ secrets.DIST_CERTIFICATE_P12 }}" | base64 -D > /tmp/certificate.p12
+          echo "${{ secrets.CERTIFICATE_P12 }}" | base64 -D > /tmp/certificate.p12
           security import /tmp/certificate.p12 \
             -k "$KEYCHAIN_PATH" \
-            -P "${{ secrets.DIST_CERTIFICATE_PASSWORD }}" \
+            -P "${{ secrets.CERTIFICATE_PASSWORD }}" \
             -T /usr/bin/codesign \
             -T /usr/bin/security
           rm /tmp/certificate.p12
@@ -1385,10 +1385,10 @@ jobs:
           security set-keychain-settings -lut 3600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
-          echo "${{ secrets.DIST_CERTIFICATE_P12 }}" | base64 -D > /tmp/ios-certificate.p12
+          echo "${{ secrets.CERTIFICATE_P12 }}" | base64 -D > /tmp/ios-certificate.p12
           security import /tmp/ios-certificate.p12 \
             -k "$KEYCHAIN_PATH" \
-            -P "${{ secrets.DIST_CERTIFICATE_PASSWORD }}" \
+            -P "${{ secrets.CERTIFICATE_PASSWORD }}" \
             -T /usr/bin/codesign \
             -T /usr/bin/security
           rm /tmp/ios-certificate.p12


### PR DESCRIPTION
## Summary
- Revert `DIST_CERTIFICATE_P12` → `CERTIFICATE_P12` and `DIST_CERTIFICATE_PASSWORD` → `CERTIFICATE_PASSWORD` across all workflow files

## Why
The previous PR (#11321) renamed the certificate secrets before the new `DIST_CERTIFICATE_*` secrets were created in GitHub, causing the "Import code-signing certificate" step to fail with a bash syntax error (empty secret expansion breaks shell quoting).

## Files Changed
- `.github/workflows/ci-main-macos.yaml`
- `.github/workflows/ci-nightly-release.yml`
- `.github/workflows/pr-macos.yaml`
- `.github/workflows/release.yml` (build-macos, build-macos-split-arch, and release-ios jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
