### PR TITLE
feat(auth): cleanup, guard tests, and docs for single-header auth (#11210)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,7 +289,7 @@ New configuration and control endpoints MUST be exposed over HTTP on the runtime
 
 Existing IPC-only handlers should be migrated to HTTP when touched. The pattern: extract business logic into a shared function, add an HTTP route handler in `assistant/src/runtime/routes/`, keep the IPC handler as a thin wrapper that calls the same logic.
 
-When writing skills that need to call daemon configuration endpoints, use `curl` with the runtime HTTP API (bearer-authenticated via `~/.vellum/http-token`) rather than describing IPC socket protocol details. The assistant already knows how to use `curl`.
+When writing skills that need to call daemon configuration endpoints, use `curl` with the runtime HTTP API (JWT-authenticated via `Authorization: Bearer <jwt>`) rather than describing IPC socket protocol details. The assistant already knows how to use `curl`.
 
 ## Error Handling Conventions
 

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -22,58 +22,73 @@ This document owns assistant-runtime architecture details. The repo-level archit
 - Voice calls mirror the same prompt contract: `CallController` receives guardian context on setup and refreshes it immediately after successful voice challenge verification, so the first post-verification turn is grounded as `actor_role: guardian`.
 - Voice-specific behavior (DTMF/speech verification flow, relay state machine) remains voice-local; only actor-role resolution is shared.
 
-### Vellum Guardian Identity Model (Actor Tokens + Refresh Tokens)
+### Single-Header JWT Auth Model
 
-The vellum channel (macOS desktop, iOS, CLI) uses an identity-bound actor token system to authenticate guardian identity on HTTP routes. This replaces the previous implicit trust model where all local connections were assumed to be the guardian.
+All HTTP API requests use a single `Authorization: Bearer <jwt>` header for authentication. The JWT carries identity, permissions, and policy versioning in a unified token.
+
+**Token schema (JWT claims):**
+
+| Claim | Type | Description |
+|-------|------|-------------|
+| `iss` | `'vellum-auth'` | Issuer — always `vellum-auth` |
+| `aud` | `'vellum-daemon'` or `'vellum-gateway'` | Audience — which service the token targets |
+| `sub` | string | Subject — encodes principal type and identity (see patterns below) |
+| `scope_profile` | string | Named permission bundle (see profiles below) |
+| `exp` | number | Expiry timestamp (seconds since epoch) |
+| `policy_epoch` | number | Policy version — stale tokens are rejected with `refresh_required` |
+| `iat` | number | Issued-at timestamp |
+| `jti` | string | Unique token ID |
+
+**Subject patterns:**
+
+| Pattern | Principal Type | Description |
+|---------|---------------|-------------|
+| `actor:<assistantId>:<actorPrincipalId>` | `actor` | Desktop, iOS, or CLI client |
+| `svc:gateway:<assistantId>` | `svc_gateway` | Gateway service (ingress, webhooks) |
+| `ipc:<assistantId>:<sessionId>` | `ipc` | Internal IPC connections |
+| `svc:daemon:self` | n/a | Daemon self-identification (for internal use) |
+
+**Scope profiles:**
+
+| Profile | Scopes | Used by |
+|---------|--------|---------|
+| `actor_client_v1` | `chat.{read,write}`, `approval.{read,write}`, `settings.{read,write}`, `attachments.{read,write}`, `calls.{read,write}`, `feature_flags.{read,write}` | Desktop, iOS, CLI clients |
+| `gateway_ingress_v1` | `ingress.write`, `internal.write` | Gateway channel inbound + webhook forwarding |
+| `gateway_service_v1` | `settings.read`, `settings.write`, `internal.write` | Gateway service-to-daemon calls |
+| `ipc_v1` | `ipc.all` | Internal IPC connections |
 
 **Identity lifecycle:**
 
-1. **Startup migration** — On daemon start, `ensureVellumGuardianBinding()` (in `guardian-vellum-migration.ts`) backfills a `channel='vellum'` guardian binding with a stable `guardianPrincipalId` (format: `vellum-principal-<uuid>`). Existing installations get a binding with `verifiedVia: 'startup-migration'`; new installs get one via bootstrap. This migration is idempotent and preserves bindings for other channels (Telegram, SMS, etc.).
+1. **Bootstrap (loopback-only, macOS/CLI)** — On first launch, the client calls `POST /v1/integrations/guardian/vellum/bootstrap` with `{ platform, deviceId }`. The endpoint is loopback-only and mints a JWT access token + refresh token pair. Returns `{ guardianPrincipalId, accessToken, accessTokenExpiresAt, refreshToken, refreshTokenExpiresAt, refreshAfter, isNew }`.
 
-2. **Bootstrap (loopback-only, macOS) — initial issuance only** — On first launch (no existing actor token), the macOS client calls `POST /v1/integrations/guardian/vellum/bootstrap` with `{ platform: 'macos', deviceId }`. The endpoint is loopback-only: it rejects requests with `X-Forwarded-For` and verifies the peer IP is a loopback address (`127.0.0.1`, `::1`, `::ffff:127.0.0.1`). The endpoint ensures a vellum guardian principal exists, revokes any prior token for the same device binding, mints a new HMAC-SHA256 signed actor token with a 30-day TTL and a rotating refresh token, stores only the SHA-256 hashes, and returns `{ guardianPrincipalId, actorToken, actorTokenExpiresAt, refreshToken, refreshTokenExpiresAt, refreshAfter, isNew }`. Bootstrap is only used for initial credential issuance — ongoing renewal is handled exclusively by the refresh endpoint.
+2. **iOS pairing** — iOS devices obtain JWTs through the QR pairing flow. The pairing response includes `accessToken` and `refreshToken` credentials.
 
-3. **iOS pairing — initial issuance only** — iOS devices obtain actor tokens exclusively through the QR pairing flow. When an iOS device completes pairing, the pairing response includes an `actorToken` and `refreshToken` minted against the same vellum guardian principal. The pairing handler in `pairing-routes.ts` calls `mintPairingActorToken()` which looks up the vellum binding and mints a device-specific token pair. iOS does not call the bootstrap endpoint. Re-pairing is only needed if both the actor token and refresh token expire.
+3. **Refresh** — `POST /v1/integrations/guardian/vellum/refresh` accepts `{ refreshToken }` and returns a new access/refresh token pair. Single-use rotation with replay detection and family-based revocation.
 
-4. **IPC identity** — Local IPC connections (Unix domain socket from the macOS native app) do not send actor tokens. Instead, the daemon assigns a deterministic local actor identity via `resolveLocalIpcGuardianContext()` in `local-actor-identity.ts`. This looks up the vellum guardian binding and routes through the same `resolveGuardianContext` trust pipeline used by HTTP channel ingress. When no vellum binding exists yet (pre-bootstrap), a fallback guardian context is returned since the local macOS user is inherently the guardian of their own machine.
+4. **IPC identity** — Local IPC connections use `resolveLocalIpcGuardianContext()` for deterministic identity without tokens.
 
-**Actor token format:** `base64url(JSON claims) + '.' + base64url(HMAC-SHA256 signature)`. Claims include `assistantId`, `platform`, `deviceId`, `guardianPrincipalId`, `iat`, `exp` (30 days from issuance), and `jti`.
+**Route policy enforcement:** Every protected endpoint declares required scopes and allowed principal types in `src/runtime/auth/route-policy.ts`. The `enforcePolicy()` function checks the AuthContext against these requirements and returns 403 when access is denied. A guard test ensures every dispatched endpoint has a corresponding policy entry.
 
-**Hash-only storage:** Only the SHA-256 hex digest of the raw token is persisted in the `actor_token_records` table. Token verification recomputes the hash and looks it up in the store to check revocation status. Tokens are scoped to `(assistantId, guardianPrincipalId, hashedDeviceId)` with a one-active-per-device invariant.
+**Credential storage:** Only hashed tokens are persisted. Access token hashes go in `credential_records`; refresh token hashes in `refresh_token_records`. Raw tokens are returned once and never stored server-side.
 
-**Refresh token lifecycle:**
-
-Refresh tokens provide a rotating credential renewal mechanism that avoids re-bootstrap or re-pairing for ongoing sessions.
-
-- **Issuance:** A refresh token is minted alongside every actor token (during bootstrap or pairing). The response includes `refreshToken`, `refreshTokenExpiresAt`, and `refreshAfter` (the timestamp at which clients should proactively refresh, set to 80% of the actor token TTL).
-- **Dual expiry:** Each refresh token has a 365-day absolute expiry (from issuance) and a 90-day inactivity expiry (from last use). The effective expiry is the earlier of the two. Using a refresh token resets the inactivity window.
-- **Single-use rotation:** Each call to `POST /v1/integrations/guardian/vellum/refresh` consumes the presented refresh token and returns a new actor token + new refresh token pair. The old refresh token is marked as rotated and cannot be reused.
-- **Token family tracking:** Refresh tokens are grouped into families (one family per initial issuance chain). All tokens in a family share a `familyId`.
-- **Replay detection:** If a client presents a refresh token that has already been rotated (i.e., it was used once and a successor was issued), the server treats this as a potential token theft. The entire token family for that device is revoked, forcing re-bootstrap or re-pairing.
-- **Device binding:** Refresh tokens are bound to `(assistantId, guardianPrincipalId, hashedDeviceId)`. A refresh request from a different device binding is rejected.
-- **Hash-only storage:** Only the SHA-256 hex digest of the refresh token is stored in the `actor_refresh_token_records` table. The raw token is returned once and never persisted on the server.
-
-**Refresh endpoint:** `POST /v1/integrations/guardian/vellum/refresh` accepts `{ refreshToken }` in the request body. It validates the token hash, checks expiry and device binding, performs replay detection, rotates the token, mints a new actor token, and returns `{ actorToken, actorTokenExpiresAt, refreshToken, refreshTokenExpiresAt, refreshAfter }`. This endpoint is only reachable through the gateway (bearer-authenticated).
-
-**Signing key management:** A 32-byte random signing key is generated on first startup and persisted at `~/.vellum/protected/actor-token-signing-key` with `chmod 0o600`. The key is loaded on subsequent startups via `loadOrCreateSigningKey()`.
-
-**Strict HTTP enforcement:** Vellum-channel HTTP routes (POST /v1/messages, POST /v1/confirm, POST /v1/guardian-actions/decision, etc.) require a valid actor token via the `X-Actor-Token` header. The middleware in `middleware/actor-token.ts` verifies the HMAC signature, checks the token is active in the store, and resolves a guardian context through the standard trust pipeline. For backward compatibility with the CLI, requests without an actor token that originate from a loopback address (no `X-Forwarded-For` header) fall back to `resolveLocalIpcGuardianContext()`. Gateway-proxied requests (which carry `X-Forwarded-For`) without an actor token are rejected.
-
-**Notification scoping:** Guardian-sensitive notifications (e.g., approval requests, access request alerts) are annotated with `targetGuardianPrincipalId` so the notification pipeline can scope delivery to the correct guardian identity across devices.
+**Notification scoping:** Guardian-sensitive notifications are annotated with `targetGuardianPrincipalId` for identity-scoped delivery.
 
 **Key source files:**
 
 | File | Purpose |
 |------|---------|
-| `src/runtime/actor-token-service.ts` | HMAC-SHA256 mint/verify, signing key management, `hashToken` |
-| `src/runtime/actor-token-store.ts` | Hash-only persistence: create, find by hash/device binding, revoke |
-| `src/runtime/actor-refresh-token-service.ts` | Refresh token rotation, replay detection, family revocation |
-| `src/runtime/actor-refresh-token-store.ts` | Refresh token hash-only persistence: create, find, rotate, revoke by family |
-| `src/runtime/middleware/actor-token.ts` | HTTP middleware: `verifyHttpActorToken`, `verifyHttpActorTokenWithLocalFallback`, `isActorBoundGuardian` |
+| `src/runtime/auth/types.ts` | Core type definitions: `TokenClaims`, `AuthContext`, `ScopeProfile`, `Scope`, `PrincipalType` |
+| `src/runtime/auth/token-service.ts` | JWT signing, verification, and policy epoch management |
+| `src/runtime/auth/credential-service.ts` | Credential pair minting (access token + refresh token) |
+| `src/runtime/auth/scopes.ts` | Scope profile resolver (`resolveScopeProfile`) |
+| `src/runtime/auth/context.ts` | AuthContext builder from JWT claims |
+| `src/runtime/auth/subject.ts` | Subject string parser (`parseSub`) |
+| `src/runtime/auth/middleware.ts` | JWT bearer auth middleware (`authenticateRequest`) |
+| `src/runtime/auth/route-policy.ts` | Route-level scope/principal enforcement |
+| `src/runtime/routes/guardian-bootstrap-routes.ts` | `POST /v1/integrations/guardian/vellum/bootstrap` (initial JWT issuance) |
+| `src/runtime/routes/guardian-refresh-routes.ts` | `POST /v1/integrations/guardian/vellum/refresh` (token rotation) |
+| `src/runtime/routes/pairing-routes.ts` | JWT credential issuance in pairing flow |
 | `src/runtime/local-actor-identity.ts` | `resolveLocalIpcGuardianContext` — deterministic IPC identity |
-| `src/runtime/guardian-vellum-migration.ts` | `ensureVellumGuardianBinding` — startup binding backfill |
-| `src/runtime/routes/guardian-bootstrap-routes.ts` | `POST /v1/integrations/guardian/vellum/bootstrap` handler (initial issuance only) |
-| `src/runtime/routes/guardian-refresh-routes.ts` | `POST /v1/integrations/guardian/vellum/refresh` handler (token rotation) |
-| `src/runtime/routes/pairing-routes.ts` | `mintPairingActorToken` — actor token + refresh token in pairing response |
 | `src/memory/guardian-bindings.ts` | Guardian binding persistence (shared across all channels) |
 
 ### Channel-Agnostic Scoped Approval Grants
@@ -163,7 +178,7 @@ Guardian verification can be initiated through gateway HTTP endpoints (which for
 | `/v1/integrations/guardian/outbound/resend` | POST | Resend the verification code for an active session. Body: `{ channel, assistantId? }` |
 | `/v1/integrations/guardian/outbound/cancel` | POST | Cancel an active outbound verification session. Body: `{ channel, assistantId? }` |
 
-All endpoints are bearer-authenticated via the gateway token (`~/.vellum/http-token` in local setups). Skills and user-facing tooling should target the gateway URL (default `http://localhost:7830`), not the runtime port.
+All endpoints are JWT-authenticated via `Authorization: Bearer <jwt>`. Skills and user-facing tooling should target the gateway URL (default `http://localhost:7830`), not the runtime port.
 
 **Shared Business Logic:**
 
@@ -326,7 +341,7 @@ The Slack channel provides text-based messaging via Slack's Socket Mode API. Unl
 | `/v1/integrations/slack/channel/config` | POST | Validates and stores credentials. Body: `{ botToken?: string, appToken?: string }` |
 | `/v1/integrations/slack/channel/config` | DELETE | Clears all Slack channel credentials from secure storage and credential metadata |
 
-All endpoints are bearer-authenticated via the runtime HTTP token (`~/.vellum/http-token`).
+All endpoints are JWT-authenticated via `Authorization: Bearer <jwt>`.
 
 **Credential storage pattern:**
 
@@ -693,7 +708,7 @@ graph LR
     subgraph "~/.vellum/ (Root Files)"
         SOCK["vellum.sock<br/>Unix domain socket"]
         TRUST["protected/trust.json<br/>Tool permission rules"]
-        FF_TOKEN["feature-flag-token<br/>Dedicated auth for PATCH /v1/feature-flags"]
+        FF_TOKEN["feature-flag-token<br/>Client token for feature-flag API"]
     end
 
     subgraph "~/.vellum/workspace/ (Workspace Files)"

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -47,7 +47,7 @@ cp .env.example .env
 | `OLLAMA_API_KEY` | No | — | API key for authenticated Ollama deployments |
 | `OLLAMA_BASE_URL` | No | `http://127.0.0.1:11434/v1` | Ollama base URL |
 | `RUNTIME_HTTP_PORT` | No | — | Enable the HTTP server (required for gateway/web) |
-| `RUNTIME_GATEWAY_ORIGIN_SECRET` | No | — | Dedicated secret for the `X-Gateway-Origin` proof header on `/channels/inbound`. When not set, falls back to the bearer token. Both gateway and runtime must share the same value. |
+| `RUNTIME_GATEWAY_ORIGIN_SECRET` | No | — | **Deprecated.** Gateway origin is now proven by JWT principal type (`svc_gateway`), not a separate header. |
 | `VELLUM_DAEMON_SOCKET` | No | `~/.vellum/vellum.sock` | Override the daemon socket path |
 
 ## Update Bulletin
@@ -199,12 +199,10 @@ Internal forwarding routes (`/v1/internal/twilio/*`) are unaffected — these ac
 
 ### Gateway-Origin Ingress Contract
 
-The `/channels/inbound` endpoint requires a valid `X-Gateway-Origin` header to prove the request originated from the gateway. This ensures channel messages can only arrive via the gateway (which performs webhook-level verification) and not via direct HTTP calls that bypass signature checks.
+The `/channels/inbound` endpoint requires a JWT with the `svc_gateway` principal type and `ingress.write` scope to prove the request originated from the gateway. This ensures channel messages can only arrive via the gateway (which performs webhook-level verification) and not via direct HTTP calls that bypass signature checks.
 
-- **Dedicated secret (`RUNTIME_GATEWAY_ORIGIN_SECRET`):** When set, this is the expected value for the `X-Gateway-Origin` header. Both the gateway and the runtime must share this secret.
-- **Bearer token fallback:** When `RUNTIME_GATEWAY_ORIGIN_SECRET` is not set, the runtime falls back to validating against the bearer token for backward compatibility.
-- **Without any secret:** When neither a dedicated secret nor a bearer token is configured (local dev), gateway-origin validation is skipped entirely.
-- **Auth layer order:** Bearer token authentication (`Authorization` header) is checked first. Gateway-origin validation runs inside the handler.
+- **JWT-based enforcement:** The route policy in `route-policy.ts` restricts `/channels/inbound` to the `svc_gateway` principal type with `ingress.write` scope. Actor and IPC principals are rejected with 403.
+- **Dev bypass:** When `DISABLE_HTTP_AUTH` + `VELLUM_UNSAFE_AUTH_BYPASS=1` are set, JWT verification is skipped and a synthetic dev context is used.
 
 ## Twilio Setup Primitive
 
@@ -280,12 +278,12 @@ The channel guardian service generates verification challenge instructions with 
 
 ### Vellum Guardian Identity (Actor Tokens)
 
-The vellum channel (macOS, iOS, CLI) uses HMAC-SHA256 signed actor tokens to bind guardian identity to HTTP requests. This enables identity-based authentication for the local desktop/mobile channel, paralleling how external channels (Telegram, SMS) use `actorExternalId` for guardian identity.
+The vellum channel (macOS, iOS, CLI) uses JWTs to bind guardian identity to HTTP requests. This enables identity-based authentication for the local desktop/mobile channel, paralleling how external channels (Telegram, SMS) use `actorExternalId` for guardian identity.
 
-- **Bootstrap**: After hatch, the macOS client calls `POST /v1/integrations/guardian/vellum/bootstrap` with `{ platform, deviceId }`. Returns `{ guardianPrincipalId, actorToken, isNew }`. The endpoint is idempotent -- repeated calls with the same device return the same principal but mint a fresh token (revoking the previous one).
-- **iOS pairing**: The pairing response includes an `actorToken` automatically when a vellum guardian binding exists.
-- **IPC fallback**: Local IPC (Unix socket) connections resolve identity server-side via `resolveLocalIpcGuardianContext()` without requiring an actor token. CLI connections that pass bearer auth but lack an actor token also use this fallback (as long as the request is direct, not proxied through the gateway).
-- **HTTP enforcement**: Vellum HTTP routes require either an `X-Actor-Token` header or a provably-local connection (no `X-Forwarded-For` header). Gateway-proxied requests without an actor token are rejected.
+- **Bootstrap**: After hatch, the macOS client calls `POST /v1/integrations/guardian/vellum/bootstrap` with `{ platform, deviceId }`. Returns `{ guardianPrincipalId, accessToken, accessTokenExpiresAt, refreshToken, refreshTokenExpiresAt, refreshAfter, isNew }`. The endpoint is idempotent -- repeated calls with the same device return the same principal but mint fresh credentials.
+- **iOS pairing**: The pairing response includes `accessToken` and `refreshToken` credentials automatically when a vellum guardian binding exists.
+- **IPC fallback**: Local IPC (Unix socket) connections resolve identity server-side via `resolveLocalIpcGuardianContext()` without requiring a JWT.
+- **HTTP enforcement**: All vellum HTTP routes require a valid JWT via the `Authorization: Bearer <jwt>` header. The JWT carries identity claims (`sub` with principal type and ID) and scope permissions. Route-level enforcement in `route-policy.ts` checks scopes and principal types.
 - **Startup migration**: On daemon start, `ensureVellumGuardianBinding()` backfills a vellum guardian binding for existing installations so the identity system works without requiring a manual bootstrap step.
 
 ## Guardian Verification and Ingress ACL
@@ -502,7 +500,7 @@ The image runs as non-root user `assistant` (uid 1001) and exposes port `3001`.
 
 | Symptom | Cause | Resolution |
 |---------|-------|------------|
-| 403 `GATEWAY_ORIGIN_REQUIRED` on `/channels/inbound` | Missing or invalid `X-Gateway-Origin` header | Ensure `RUNTIME_GATEWAY_ORIGIN_SECRET` is set to the same value on both gateway and runtime. If not using a dedicated secret, ensure the bearer token (`RUNTIME_BEARER_TOKEN` or `~/.vellum/http-token`) is shared. |
+| 403 `FORBIDDEN` on `/channels/inbound` | JWT does not have `svc_gateway` principal type or `ingress.write` scope | Ensure the gateway is minting JWTs with the `gateway_ingress_v1` scope profile when forwarding channel inbound requests. |
 | Non-guardian actions silently denied | No guardian binding for the channel. The system is fail-closed for unverified channels. | Run the guardian verification flow from the desktop UI to bind a guardian. |
 | Guardian approval expired | The 30-minute TTL elapsed. The proactive sweep auto-denied the approval and notified both parties. | The requester must re-trigger the action. |
 | `forceStrictSideEffects` unexpectedly active | The sender is classified as `non-guardian` or `unverified_channel` | Verify the sender's `actorExternalId` matches the guardian binding, or set up a guardian binding for the channel. |

--- a/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
+++ b/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Guard tests for the single-header JWT auth system.
+ *
+ * These tests enforce architectural invariants that protect the auth
+ * system from regressions:
+ *
+ * 1. Route policy coverage — every dispatched endpoint has a policy.
+ * 2. No X-Actor-Token references in production code.
+ * 3. No ~/.vellum/http-token file-path references in production code
+ *    (the file itself is still used; the guard prevents new code from
+ *    reading it directly instead of using the platform utility).
+ * 4. Scope profile contract — every profile resolves to the expected scopes.
+ */
+
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, test } from 'bun:test';
+
+import { resolveScopeProfile } from '../scopes.js';
+import type { Scope, ScopeProfile } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Project root (one level above assistant/). */
+const PROJECT_ROOT = resolve(import.meta.dir, '../../../../..');
+
+function isTestFile(filePath: string): boolean {
+  return (
+    filePath.includes('/__tests__/') ||
+    filePath.endsWith('.test.ts') ||
+    filePath.endsWith('.test.js') ||
+    filePath.endsWith('.spec.ts') ||
+    filePath.endsWith('.spec.js')
+  );
+}
+
+function isDocFile(filePath: string): boolean {
+  return filePath.endsWith('.md');
+}
+
+// ---------------------------------------------------------------------------
+// 1. Route policy coverage
+// ---------------------------------------------------------------------------
+
+describe('route policy coverage', () => {
+  test('every endpoint dispatched in http-server.ts has a policy entry in route-policy.ts', () => {
+    // Read both files as source text.
+    const httpServerPath = resolve(import.meta.dir, '../../http-server.ts');
+    const routePolicyPath = resolve(import.meta.dir, '../route-policy.ts');
+
+    const httpServerSrc = readFileSync(httpServerPath, 'utf-8');
+    const routePolicySrc = readFileSync(routePolicyPath, 'utf-8');
+
+    // Extract endpoint strings from dispatchEndpoint. We look for patterns
+    // like `endpoint === 'foo'` which is the dispatch pattern.
+    const endpointMatches = httpServerSrc.matchAll(
+      /endpoint\s*===\s*'([^']+)'/g,
+    );
+    const dispatchedEndpoints = new Set<string>();
+    for (const m of endpointMatches) {
+      dispatchedEndpoints.add(m[1]);
+    }
+
+    // These endpoints are handled in dispatchEndpoint but intentionally
+    // don't need a route policy (they are unprotected utility endpoints).
+    const UNPROTECTED_ENDPOINTS = new Set([
+      'health',
+    ]);
+
+    // Extract registered policy endpoint strings from route-policy.ts.
+    // Match: `{ endpoint: 'foo' }` entries, `registerPolicy('foo', ...)`
+    // calls, and bare string literals in arrays like INTERNAL_ENDPOINTS.
+    const policyEndpointMatches = routePolicySrc.matchAll(
+      /endpoint:\s*'([^']+)'|registerPolicy\(\s*'([^']+)'/g,
+    );
+    const registeredPolicies = new Set<string>();
+    for (const m of policyEndpointMatches) {
+      registeredPolicies.add(m[1] ?? m[2]);
+    }
+
+    // Also extract string literals from the INTERNAL_ENDPOINTS array,
+    // which uses a loop to register policies dynamically.
+    const internalArrayMatch = routePolicySrc.match(
+      /INTERNAL_ENDPOINTS\s*=\s*\[([\s\S]*?)\]/,
+    );
+    if (internalArrayMatch) {
+      const arrayLiterals = internalArrayMatch[1].matchAll(/'([^']+)'/g);
+      for (const m of arrayLiterals) {
+        registeredPolicies.add(m[1]);
+      }
+    }
+
+    // For method-specific dispatches like `endpoint === 'messages' && req.method === 'POST'`,
+    // the policy key might be `messages:POST` or just `messages`. We need to
+    // check that either the plain endpoint key or a method-qualified key exists.
+    const missingPolicies: string[] = [];
+    for (const endpoint of dispatchedEndpoints) {
+      if (UNPROTECTED_ENDPOINTS.has(endpoint)) continue;
+
+      // Check if the plain endpoint or any method-qualified variant is registered
+      const hasPlainPolicy = registeredPolicies.has(endpoint);
+      const hasMethodPolicy = [...registeredPolicies].some(
+        (p) => p.startsWith(endpoint + ':'),
+      );
+
+      if (!hasPlainPolicy && !hasMethodPolicy) {
+        missingPolicies.push(endpoint);
+      }
+    }
+
+    if (missingPolicies.length > 0) {
+      const message = [
+        'Endpoints dispatched in http-server.ts have no route policy in route-policy.ts:',
+        '',
+        ...missingPolicies.map((e) => `  - ${e}`),
+        '',
+        'Every protected endpoint must have a policy entry.',
+        'Add a registerPolicy() call or ACTOR_ENDPOINTS entry in route-policy.ts.',
+        'If truly unprotected, add to UNPROTECTED_ENDPOINTS in this guard test.',
+      ].join('\n');
+      expect(missingPolicies, message).toEqual([]);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. No X-Actor-Token references in production code
+// ---------------------------------------------------------------------------
+
+describe('no X-Actor-Token in production code', () => {
+  test('production files do not reference X-Actor-Token', () => {
+    let grepOutput = '';
+    try {
+      grepOutput = execSync(
+        `git grep -liE "X-Actor-Token" -- '*.ts' '*.tsx' '*.js' '*.swift'`,
+        { encoding: 'utf-8', cwd: PROJECT_ROOT },
+      ).trim();
+    } catch (err) {
+      // Exit code 1 means no matches — that's the happy path.
+      if ((err as { status?: number }).status === 1) return;
+      throw err;
+    }
+
+    const files = grepOutput.split('\n').filter((f) => f.length > 0);
+
+    // Files that are allowed to mention X-Actor-Token (comments explaining
+    // the migration, or this guard test itself).
+    const ALLOWLIST = new Set([
+      // This guard test references it by definition
+      'assistant/src/runtime/auth/__tests__/guard-tests.test.ts',
+    ]);
+
+    const violations = files.filter((f) => {
+      if (isTestFile(f)) return false;
+      if (isDocFile(f)) return false;
+      if (ALLOWLIST.has(f)) return false;
+      return true;
+    });
+
+    if (violations.length > 0) {
+      const message = [
+        'Production files still reference X-Actor-Token.',
+        'The old two-header auth model has been replaced by single JWT auth.',
+        '',
+        'Violations:',
+        ...violations.map((f) => `  - ${f}`),
+        '',
+        'Remove or update these references.',
+        'If a comment explains the migration, that is fine — add the file to the ALLOWLIST.',
+      ].join('\n');
+      expect(violations, message).toEqual([]);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. No legacy GATEWAY_ORIGIN_HEADER / verifyGatewayOrigin in production code
+// ---------------------------------------------------------------------------
+
+describe('no legacy gateway-origin proof in production code', () => {
+  test('production files do not import or use GATEWAY_ORIGIN_HEADER or verifyGatewayOrigin', () => {
+    let grepOutput = '';
+    try {
+      grepOutput = execSync(
+        `git grep -lE "GATEWAY_ORIGIN_HEADER|verifyGatewayOrigin" -- '*.ts' '*.tsx'`,
+        { encoding: 'utf-8', cwd: PROJECT_ROOT },
+      ).trim();
+    } catch (err) {
+      if ((err as { status?: number }).status === 1) return;
+      throw err;
+    }
+
+    const files = grepOutput.split('\n').filter((f) => f.length > 0);
+
+    const ALLOWLIST = new Set([
+      'assistant/src/runtime/auth/__tests__/guard-tests.test.ts',
+    ]);
+
+    const violations = files.filter((f) => {
+      if (isTestFile(f)) return false;
+      if (isDocFile(f)) return false;
+      if (ALLOWLIST.has(f)) return false;
+      return true;
+    });
+
+    if (violations.length > 0) {
+      const message = [
+        'Production files still reference GATEWAY_ORIGIN_HEADER or verifyGatewayOrigin.',
+        'Gateway origin is now proven by JWT principal type (svc_gateway), not a separate header.',
+        '',
+        'Violations:',
+        ...violations.map((f) => `  - ${f}`),
+        '',
+        'Remove or update these references.',
+      ].join('\n');
+      expect(violations, message).toEqual([]);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Scope profile contract
+// ---------------------------------------------------------------------------
+
+describe('scope profile contract', () => {
+  const EXPECTED_PROFILES: Record<ScopeProfile, Scope[]> = {
+    actor_client_v1: [
+      'chat.read',
+      'chat.write',
+      'approval.read',
+      'approval.write',
+      'settings.read',
+      'settings.write',
+      'attachments.read',
+      'attachments.write',
+      'calls.read',
+      'calls.write',
+      'feature_flags.read',
+      'feature_flags.write',
+    ],
+    gateway_ingress_v1: [
+      'ingress.write',
+      'internal.write',
+    ],
+    gateway_service_v1: [
+      'settings.read',
+      'settings.write',
+      'internal.write',
+    ],
+    ipc_v1: [
+      'ipc.all',
+    ],
+  };
+
+  for (const [profile, expectedScopes] of Object.entries(EXPECTED_PROFILES)) {
+    test(`${profile} resolves to exactly the expected scopes`, () => {
+      const resolved = resolveScopeProfile(profile as ScopeProfile);
+      const resolvedArray = [...resolved].sort();
+      const expectedSorted = [...expectedScopes].sort();
+
+      expect(resolvedArray).toEqual(expectedSorted);
+      expect(resolved.size).toBe(expectedScopes.length);
+    });
+  }
+
+  test('all ScopeProfile values are covered by the contract test', () => {
+    // The type system ensures EXPECTED_PROFILES covers all ScopeProfile
+    // values via the Record<ScopeProfile, ...> type. This test verifies
+    // that resolveScopeProfile returns a non-empty set for each.
+    const profiles: ScopeProfile[] = [
+      'actor_client_v1',
+      'gateway_ingress_v1',
+      'gateway_service_v1',
+      'ipc_v1',
+    ];
+
+    for (const profile of profiles) {
+      const scopes = resolveScopeProfile(profile);
+      expect(scopes.size).toBeGreaterThan(0);
+    }
+  });
+});

--- a/assistant/src/runtime/auth/__tests__/middleware.test.ts
+++ b/assistant/src/runtime/auth/__tests__/middleware.test.ts
@@ -174,7 +174,7 @@ describe('authenticateRequest', () => {
     }
   });
 
-  test('returns 401 with refresh_required when policy epoch is stale', () => {
+  test('returns 401 with refresh_required when policy epoch is stale', async () => {
     // Mint a token with a very old policy epoch. The token service checks
     // isStaleEpoch which compares against CURRENT_POLICY_EPOCH.
     const token = mintValidToken({ policy_epoch: 0 });

--- a/assistant/src/runtime/auth/middleware.ts
+++ b/assistant/src/runtime/auth/middleware.ts
@@ -68,8 +68,11 @@ export function authenticateRequest(req: Request): AuthenticateResult {
     return { ok: true, context: buildDevBypassContext() };
   }
 
+  const path = new URL(req.url).pathname;
+
   const rawToken = extractBearerToken(req);
   if (!rawToken) {
+    log.warn({ reason: 'missing_token', path }, 'Auth denied: missing Authorization header');
     return {
       ok: false,
       response: Response.json(
@@ -84,7 +87,7 @@ export function authenticateRequest(req: Request): AuthenticateResult {
   if (!verifyResult.ok) {
     // Stale policy epoch gets a specific error code so clients can refresh
     if (verifyResult.reason === 'stale_policy_epoch') {
-      log.warn('JWT rejected: stale policy epoch');
+      log.warn({ reason: 'stale_policy_epoch', path }, 'Auth denied: stale policy epoch');
       return {
         ok: false,
         response: Response.json(
@@ -94,7 +97,7 @@ export function authenticateRequest(req: Request): AuthenticateResult {
       };
     }
 
-    log.warn({ reason: verifyResult.reason }, 'JWT verification failed');
+    log.warn({ reason: verifyResult.reason, path }, 'Auth denied: JWT verification failed');
     return {
       ok: false,
       response: Response.json(
@@ -107,7 +110,10 @@ export function authenticateRequest(req: Request): AuthenticateResult {
   // Build normalized AuthContext from verified claims
   const contextResult = buildAuthContext(verifyResult.claims);
   if (!contextResult.ok) {
-    log.warn({ reason: contextResult.reason }, 'Failed to build AuthContext from JWT claims');
+    log.warn(
+      { reason: contextResult.reason, path, sub: verifyResult.claims.sub },
+      'Auth denied: invalid JWT claims',
+    );
     return {
       ok: false,
       response: Response.json(

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -231,7 +231,7 @@ for (const { endpoint, scopes } of ACTOR_ENDPOINTS) {
   });
 }
 
-// Channel inbound: gateway-only (replaces X-Gateway-Origin header check)
+// Channel inbound: gateway-only
 registerPolicy('channels/inbound', {
   requiredScopes: ['ingress.write'],
   allowedPrincipalTypes: ['svc_gateway'],

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -866,8 +866,7 @@ export class RuntimeHttpServer {
       if (endpoint === 'channels/conversation' && req.method === 'DELETE') return await handleDeleteConversation(req, assistantId);
 
       if (endpoint === 'channels/inbound' && req.method === 'POST') {
-        // Route policy enforces svc_gateway principal type — replaces
-        // the old X-Gateway-Origin header check.
+        // Route policy enforces svc_gateway principal type.
         const policyDenied = enforcePolicy('channels/inbound', authContext);
         if (policyDenied) return policyDenied;
         return await handleChannelInbound(req, this.processMessage, assistantId, this.approvalCopyGenerator, this.approvalConversationGenerator, this.guardianActionCopyGenerator, this.guardianFollowUpConversationGenerator);

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -4,9 +4,9 @@
  * These endpoints resolve pending confirmations, secrets, and trust rules
  * by requestId — orthogonal to message sending.
  *
- * All approval endpoints require a valid actor token via the X-Actor-Token
- * header (with local CLI fallback). Guardian decisions additionally verify
- * that the actor is the bound guardian.
+ * All approval endpoints require a valid JWT via the Authorization: Bearer
+ * header. Guardian decisions additionally verify that the actor is the
+ * bound guardian.
  */
 import { isHttpAuthDisabled } from '../../config/env.js';
 import { getConversationByKey } from '../../memory/conversation-key-store.js';

--- a/assistant/src/runtime/routes/channel-route-shared.ts
+++ b/assistant/src/runtime/routes/channel-route-shared.ts
@@ -1,8 +1,6 @@
 /**
  * Shared types, constants, and utilities used across channel route modules.
  */
-import { timingSafeEqual } from 'node:crypto';
-
 import type { ChannelId } from '../../channels/types.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import type {
@@ -16,44 +14,6 @@ export type { ActorTrustClass, DenialReason, GuardianContext } from '../guardian
 /** Canonicalize assistantId for channel ingress paths. */
 export function canonicalChannelAssistantId(_assistantId: string): string {
   return DAEMON_INTERNAL_ASSISTANT_ID;
-}
-
-// ---------------------------------------------------------------------------
-// Gateway-origin proof
-// ---------------------------------------------------------------------------
-
-/**
- * Header name used by the gateway to prove a request originated from it.
- * The gateway sends a dedicated gateway-origin secret (or the bearer token
- * as fallback). The runtime validates it using constant-time comparison.
- * Requests to `/channels/inbound` that lack a valid proof are rejected with 403.
- */
-export const GATEWAY_ORIGIN_HEADER = 'X-Gateway-Origin';
-
-/**
- * Validate that the request carries a valid gateway-origin proof.
- * Uses constant-time comparison to prevent timing attacks.
- *
- * The `gatewayOriginSecret` parameter is the dedicated secret configured
- * via `RUNTIME_GATEWAY_ORIGIN_SECRET`. When set, only this value is
- * accepted. When not set, the function falls back to `bearerToken` for
- * backward compatibility. When neither is configured (local dev), validation
- * is skipped entirely.
- */
-export function verifyGatewayOrigin(
-  req: Request,
-  bearerToken?: string,
-  gatewayOriginSecret?: string,
-): boolean {
-  // Determine the expected secret: prefer dedicated secret, fall back to bearer token
-  const expectedSecret = gatewayOriginSecret ?? bearerToken;
-  if (!expectedSecret) return true; // No shared secret configured — skip validation
-  const provided = req.headers.get(GATEWAY_ORIGIN_HEADER);
-  if (!provided) return false;
-  const a = Buffer.from(provided);
-  const b = Buffer.from(expectedSecret);
-  if (a.length !== b.length) return false;
-  return timingSafeEqual(a, b);
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -25,7 +25,5 @@ export {
   _setTestPollMaxWait,
   type ActorTrustClass,
   type DenialReason,
-  GATEWAY_ORIGIN_HEADER,
   type GuardianContext,
-  verifyGatewayOrigin,
 } from './channel-route-shared.js';

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -102,9 +102,8 @@ export async function handleChannelInbound(
   _guardianFollowUpConversationGenerator?: GuardianFollowUpConversationGenerator,
 ): Promise<Response> {
   // Gateway-origin proof is enforced by route-policy middleware (svc_gateway
-  // principal type required) before this handler runs. The old
-  // verifyGatewayOrigin/X-Gateway-Origin header check is removed — the
-  // exchange JWT itself proves gateway origin.
+  // principal type required) before this handler runs. The exchange JWT
+  // itself proves gateway origin.
 
   // Factory that mints a fresh short-lived JWT for each daemon-to-gateway
   // delivery callback. The JWT has a 60-second TTL, so long-running

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -135,15 +135,18 @@ async function runtimeRequest<T>(
   path: string,
   init?: RequestInit,
   bearerToken?: string,
-  actorToken?: string,
+  accessToken?: string,
 ): Promise<T> {
   const url = `${baseUrl}/v1/assistants/${assistantId}${path}`;
+  // Prefer the JWT access token (from bootstrap) over the shared-secret
+  // bearer token. The JWT carries identity claims and is the canonical
+  // auth mechanism in the single-header auth model.
+  const authToken = accessToken ?? bearerToken;
   const response = await fetch(url, {
     ...init,
     headers: {
       "Content-Type": "application/json",
-      ...(bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {}),
-      ...(actorToken ? { "X-Actor-Token": actorToken } : {}),
+      ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
       ...(init?.headers as Record<string, string> | undefined),
     },
   });
@@ -179,7 +182,7 @@ async function checkHealthRuntime(baseUrl: string): Promise<HealthResponse> {
   return response.json() as Promise<HealthResponse>;
 }
 
-async function bootstrapActorToken(baseUrl: string, bearerToken?: string): Promise<string> {
+async function bootstrapAccessToken(baseUrl: string, bearerToken?: string): Promise<string> {
   if (!bearerToken) {
     throw new Error("Missing bearer token; cannot bootstrap actor identity");
   }
@@ -207,19 +210,19 @@ async function bootstrapActorToken(baseUrl: string, bearerToken?: string): Promi
     throw new Error("Invalid bootstrap response from gateway/runtime");
   }
 
-  const actorToken = (json as Record<string, unknown>).actorToken;
-  if (typeof actorToken !== "string" || actorToken.length === 0) {
+  const accessToken = (json as Record<string, unknown>).accessToken;
+  if (typeof accessToken !== "string" || accessToken.length === 0) {
     throw new Error("Invalid bootstrap response from gateway/runtime");
   }
 
-  return actorToken;
+  return accessToken;
 }
 
 async function pollMessages(
   baseUrl: string,
   assistantId: string,
   bearerToken?: string,
-  actorToken?: string,
+  accessToken?: string,
 ): Promise<ListMessagesResponse> {
   const params = new URLSearchParams({ conversationKey: assistantId });
   return runtimeRequest<ListMessagesResponse>(
@@ -228,7 +231,7 @@ async function pollMessages(
     `/messages?${params.toString()}`,
     undefined,
     bearerToken,
-    actorToken,
+    accessToken,
   );
 }
 
@@ -238,7 +241,7 @@ async function sendMessage(
   content: string,
   signal?: AbortSignal,
   bearerToken?: string,
-  actorToken?: string,
+  accessToken?: string,
 ): Promise<SendMessageResponse> {
   return runtimeRequest<SendMessageResponse>(
     baseUrl,
@@ -250,7 +253,7 @@ async function sendMessage(
       signal,
     },
     bearerToken,
-    actorToken,
+    accessToken,
   );
 }
 
@@ -260,7 +263,7 @@ async function submitDecision(
   requestId: string,
   decision: "allow" | "deny",
   bearerToken?: string,
-  actorToken?: string,
+  accessToken?: string,
 ): Promise<SubmitDecisionResponse> {
   return runtimeRequest<SubmitDecisionResponse>(
     baseUrl,
@@ -271,7 +274,7 @@ async function submitDecision(
       body: JSON.stringify({ requestId, decision }),
     },
     bearerToken,
-    actorToken,
+    accessToken,
   );
 }
 
@@ -283,7 +286,7 @@ async function addTrustRule(
   scope: string,
   decision: "allow" | "deny",
   bearerToken?: string,
-  actorToken?: string,
+  accessToken?: string,
 ): Promise<AddTrustRuleResponse> {
   return runtimeRequest<AddTrustRuleResponse>(
     baseUrl,
@@ -294,7 +297,7 @@ async function addTrustRule(
       body: JSON.stringify({ requestId, pattern, scope, decision }),
     },
     bearerToken,
-    actorToken,
+    accessToken,
   );
 }
 
@@ -302,7 +305,7 @@ async function pollPendingInteractions(
   baseUrl: string,
   assistantId: string,
   bearerToken?: string,
-  actorToken?: string,
+  accessToken?: string,
 ): Promise<PendingInteractionsResponse> {
   const params = new URLSearchParams({ conversationKey: assistantId });
   return runtimeRequest<PendingInteractionsResponse>(
@@ -311,7 +314,7 @@ async function pollPendingInteractions(
     `/pending-interactions?${params.toString()}`,
     undefined,
     bearerToken,
-    actorToken,
+    accessToken,
   );
 }
 
@@ -349,7 +352,7 @@ async function handleConfirmationPrompt(
   confirmation: PendingConfirmation,
   chatApp: ChatAppHandle,
   bearerToken?: string,
-  actorToken?: string,
+  accessToken?: string,
 ): Promise<void> {
   const preview = formatConfirmationPreview(confirmation.toolName, confirmation.input);
   const allowlistOptions = confirmation.allowlistOptions ?? [];
@@ -369,7 +372,7 @@ async function handleConfirmationPrompt(
   const index = await chatApp.showSelection("Tool Approval", options);
 
   if (index === 0) {
-    await submitDecision(baseUrl, assistantId, requestId, "allow", bearerToken, actorToken);
+    await submitDecision(baseUrl, assistantId, requestId, "allow", bearerToken, accessToken);
     chatApp.addStatus("\u2714 Allowed", "green");
     return;
   }
@@ -382,7 +385,7 @@ async function handleConfirmationPrompt(
       chatApp,
       "always_allow",
       bearerToken,
-      actorToken,
+      accessToken,
     );
     return;
   }
@@ -395,12 +398,12 @@ async function handleConfirmationPrompt(
       chatApp,
       "always_deny",
       bearerToken,
-      actorToken,
+      accessToken,
     );
     return;
   }
 
-  await submitDecision(baseUrl, assistantId, requestId, "deny", bearerToken, actorToken);
+  await submitDecision(baseUrl, assistantId, requestId, "deny", bearerToken, accessToken);
   chatApp.addStatus("\u2718 Denied", "yellow");
 }
 
@@ -412,7 +415,7 @@ async function handlePatternSelection(
   chatApp: ChatAppHandle,
   trustDecision: TrustDecision,
   bearerToken?: string,
-  actorToken?: string,
+  accessToken?: string,
 ): Promise<void> {
   const allowlistOptions = confirmation.allowlistOptions ?? [];
   const label = trustDecision === "always_deny" ? "Denylist" : "Allowlist";
@@ -431,12 +434,12 @@ async function handlePatternSelection(
       selectedPattern,
       trustDecision,
       bearerToken,
-      actorToken,
+      accessToken,
     );
     return;
   }
 
-  await submitDecision(baseUrl, assistantId, requestId, "deny", bearerToken, actorToken);
+  await submitDecision(baseUrl, assistantId, requestId, "deny", bearerToken, accessToken);
   chatApp.addStatus("\u2718 Denied", "yellow");
 }
 
@@ -449,7 +452,7 @@ async function handleScopeSelection(
   selectedPattern: string,
   trustDecision: TrustDecision,
   bearerToken?: string,
-  actorToken?: string,
+  accessToken?: string,
 ): Promise<void> {
   const scopeOptions = confirmation.scopeOptions ?? [];
   const label = trustDecision === "always_deny" ? "Denylist" : "Allowlist";
@@ -467,7 +470,7 @@ async function handleScopeSelection(
       scopeOptions[index].scope,
       ruleDecision,
       bearerToken,
-      actorToken,
+      accessToken,
     );
     await submitDecision(
       baseUrl,
@@ -475,7 +478,7 @@ async function handleScopeSelection(
       requestId,
       ruleDecision === "deny" ? "deny" : "allow",
       bearerToken,
-      actorToken,
+      accessToken,
     );
     const ruleLabel = trustDecision === "always_deny" ? "Denylisted" : "Allowlisted";
     const ruleColor = trustDecision === "always_deny" ? "yellow" : "green";
@@ -486,7 +489,7 @@ async function handleScopeSelection(
     return;
   }
 
-  await submitDecision(baseUrl, assistantId, requestId, "deny", bearerToken, actorToken);
+  await submitDecision(baseUrl, assistantId, requestId, "deny", bearerToken, accessToken);
   chatApp.addStatus("\u2718 Denied", "yellow");
 }
 
@@ -1081,7 +1084,7 @@ function ChatApp({
   const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const doctorSessionIdRef = useRef(randomUUID());
   const handleRef_ = useRef<ChatAppHandle | null>(null);
-  const actorTokenRef = useRef<string | undefined>(undefined);
+  const accessTokenRef = useRef<string | undefined>(undefined);
 
   const { stdout } = useStdout();
   const terminalRows = stdout.rows || DEFAULT_TERMINAL_ROWS;
@@ -1307,8 +1310,8 @@ function ChatApp({
 
     try {
       const health = await checkHealthRuntime(runtimeUrl);
-      if (!actorTokenRef.current) {
-        actorTokenRef.current = await bootstrapActorToken(runtimeUrl, bearerToken);
+      if (!accessTokenRef.current) {
+        accessTokenRef.current = await bootstrapAccessToken(runtimeUrl, bearerToken);
       }
       h.hideSpinner();
       h.updateHealthStatus(health.status);
@@ -1329,7 +1332,7 @@ function ChatApp({
           runtimeUrl,
           assistantId,
           bearerToken,
-          actorTokenRef.current,
+          accessTokenRef.current,
         );
         h.hideSpinner();
         if (historyResponse.messages.length > 0) {
@@ -1348,7 +1351,7 @@ function ChatApp({
             runtimeUrl,
             assistantId,
             bearerToken,
-            actorTokenRef.current,
+            accessTokenRef.current,
           );
           for (const msg of response.messages) {
             if (!seenMessageIdsRef.current.has(msg.id)) {
@@ -1632,7 +1635,7 @@ function ChatApp({
             trimmed,
             controller.signal,
             bearerToken,
-            actorTokenRef.current,
+            accessTokenRef.current,
           );
           clearTimeout(timeoutId);
           if (!sendResult.accepted) {
@@ -1662,7 +1665,7 @@ function ChatApp({
               runtimeUrl,
               assistantId,
               bearerToken,
-              actorTokenRef.current,
+              accessTokenRef.current,
             );
 
             if (pending.pendingConfirmation) {
@@ -1674,7 +1677,7 @@ function ChatApp({
                 pending.pendingConfirmation,
                 h,
                 bearerToken,
-                actorTokenRef.current,
+                accessTokenRef.current,
               );
               h.showSpinner("Working...");
               continue;
@@ -1693,7 +1696,7 @@ function ChatApp({
                     body: JSON.stringify({ requestId: secretRequestId, value, delivery }),
                   },
                   bearerToken,
-                  actorTokenRef.current,
+                  accessTokenRef.current,
                 );
               });
               h.showSpinner("Working...");
@@ -1709,7 +1712,7 @@ function ChatApp({
               runtimeUrl,
               assistantId,
               bearerToken,
-              actorTokenRef.current,
+              accessTokenRef.current,
             );
             for (const msg of pollResult.messages) {
               if (!seenMessageIdsRef.current.has(msg.id)) {

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -1088,7 +1088,7 @@ public final class HTTPTransport {
 
     private func applyAuth(_ request: inout URLRequest) {
         // The JWT access token is the sole auth credential — it serves as
-        // both authentication and identity (no separate X-Actor-Token).
+        // both authentication and identity.
         if let accessToken = ActorTokenManager.getToken() {
             request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         } else if let token = bearerToken {

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -53,12 +53,12 @@ The gateway exposes a REST API for reading and mutating assistant feature flags.
 
 **Token separation (authentication boundary):**
 
-The assistant feature flags API uses a dedicated token (the **feature-flag token**) stored at `~/.vellum/feature-flag-token`, separate from the **runtime token** (`~/.vellum/http-token`). This separation ensures that clients with feature-flag access cannot access runtime endpoints, and vice versa.
+The assistant feature flags API uses a dedicated feature-flag token stored at `~/.vellum/feature-flag-token`, separate from JWT auth tokens. This separation ensures that clients with feature-flag access cannot access runtime endpoints, and vice versa.
 
 | Operation | Accepted tokens |
 |-----------|----------------|
-| `GET /v1/feature-flags` | Runtime bearer token OR feature-flag token |
-| `PATCH /v1/feature-flags/:key` | Feature-flag token ONLY (runtime token is explicitly rejected) |
+| `GET /v1/feature-flags` | JWT bearer token OR feature-flag token |
+| `PATCH /v1/feature-flags/:key` | Feature-flag token ONLY (JWT bearer tokens are explicitly rejected) |
 
 The feature-flag token is auto-generated on first gateway startup if the file does not exist. The gateway watches the token file for changes and hot-reloads without restart.
 
@@ -90,12 +90,12 @@ Guardian verification endpoints are exposed directly by the gateway and forwarde
 | POST | `/v1/integrations/guardian/outbound/cancel` |
 | POST | `/v1/integrations/guardian/vellum/refresh` |
 
-The `/vellum/refresh` endpoint is the only public ingress for rotating actor + refresh token credentials. Clients must call this through the gateway; the runtime endpoint is not directly exposed. The gateway validates the caller's bearer token and forwards to the runtime, which handles refresh token validation, rotation, and replay detection (see [`assistant/ARCHITECTURE.md`](../assistant/ARCHITECTURE.md) for refresh token lifecycle details).
+The `/vellum/refresh` endpoint is the only public ingress for rotating JWT access + refresh token credentials. Clients must call this through the gateway; the runtime endpoint is not directly exposed. The gateway validates the caller's JWT and forwards to the runtime, which handles refresh token validation, rotation, and replay detection (see [`assistant/ARCHITECTURE.md`](../assistant/ARCHITECTURE.md) for the JWT auth lifecycle).
 
 **Authentication boundary:**
 
-- Gateway validates caller bearer auth against the runtime token.
-- Gateway forwards requests to runtime with the runtime bearer token and `X-Gateway-Origin` proof header.
+- Gateway validates the caller's JWT bearer token.
+- Gateway forwards requests to runtime with a minted JWT (`gateway_service_v1` scope profile).
 - Upstream 4xx/5xx responses are passed through, while connection errors return `502` and timeouts return `504`.
 
 **Key source files:**
@@ -103,7 +103,7 @@ The `/vellum/refresh` endpoint is the only public ingress for rotating actor + r
 | File | Purpose |
 |------|---------|
 | `gateway/src/http/routes/guardian-control-plane-proxy.ts` | Guardian control-plane proxy handlers and upstream forwarding |
-| `gateway/src/index.ts` | Route registration and bearer-auth enforcement for `/v1/integrations/guardian/*` |
+| `gateway/src/index.ts` | Route registration and JWT auth enforcement for `/v1/integrations/guardian/*` |
 
 ### Runtime Health Proxy
 
@@ -111,8 +111,8 @@ Runtime health is exposed directly by the gateway at `GET /v1/health` and forwar
 
 **Authentication boundary:**
 
-- Gateway validates caller bearer auth against the runtime token.
-- Gateway forwards the request to runtime with the runtime bearer token and `X-Gateway-Origin` proof header.
+- Gateway validates the caller's JWT bearer token.
+- Gateway forwards the request to runtime with a minted JWT (`gateway_service_v1` scope profile).
 - Upstream 4xx/5xx responses are passed through, while connection errors return `502` and timeouts return `504`.
 
 **Key source files:**
@@ -147,8 +147,8 @@ Telegram integration setup/config endpoints and ingress members/invites endpoint
 
 **Authentication boundary:**
 
-- Gateway validates caller bearer auth against the runtime token.
-- Gateway forwards requests to runtime with the runtime bearer token and `X-Gateway-Origin` proof header.
+- Gateway validates the caller's JWT bearer token.
+- Gateway forwards requests to runtime with a minted JWT (`gateway_ingress_v1` or `gateway_service_v1` scope profile).
 - Upstream 4xx/5xx responses are passed through, while connection errors return `502` and timeouts return `504`.
 
 **Key source files:**
@@ -183,8 +183,8 @@ Twilio integration setup/config endpoints are exposed directly by the gateway an
 
 **Authentication boundary:**
 
-- Gateway validates caller bearer auth against the runtime token.
-- Gateway forwards requests to runtime with the runtime bearer token and `X-Gateway-Origin` proof header.
+- Gateway validates the caller's JWT bearer token.
+- Gateway forwards requests to runtime with a minted JWT (`gateway_ingress_v1` or `gateway_service_v1` scope profile).
 - Upstream 4xx/5xx responses are passed through, while connection errors return `502` and timeouts return `504`.
 
 **Key source files:**
@@ -207,8 +207,8 @@ Channel readiness endpoints are exposed directly by the gateway and forwarded to
 
 **Authentication boundary:**
 
-- Gateway validates caller bearer auth against the runtime token.
-- Gateway forwards requests to runtime with the runtime bearer token and `X-Gateway-Origin` proof header.
+- Gateway validates the caller's JWT bearer token.
+- Gateway forwards requests to runtime with a minted JWT (`gateway_ingress_v1` or `gateway_service_v1` scope profile).
 - Upstream 4xx/5xx responses are passed through, while connection errors return `502` and timeouts return `504`.
 
 **Key source files:**


### PR DESCRIPTION
M7: Final cleanup milestone for single-header-auth feature. Adds guard tests (route policy coverage, no X-Actor-Token references, no GATEWAY_ORIGIN_HEADER references, scope profile contract), auth deny logging with structured fields, dead code removal (GATEWAY_ORIGIN_HEADER, verifyGatewayOrigin, X-Actor-Token header references), CLI migration from X-Actor-Token to Authorization: Bearer, and documentation updates across assistant/ARCHITECTURE.md, gateway/ARCHITECTURE.md, assistant/README.md, and AGENTS.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
