### PR TITLE
feat: rich inline card for app_create with inverse bg and preview

### DIFF
--- a/assistant/src/daemon/ipc-contract/surfaces.ts
+++ b/assistant/src/daemon/ipc-contract/surfaces.ts
@@ -76,6 +76,8 @@ export interface DynamicPagePreview {
   description?: string;
   icon?: string;
   metrics?: Array<{ label: string; value: string }>;
+  context?: 'app_create' | 'general';
+  previewImage?: string;  // base64 PNG
 }
 
 export interface DynamicPageSurfaceData {

--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -4,7 +4,7 @@ import {
   findSeededHomeBaseApp,
   getPrebuiltHomeBasePreview,
 } from '../home-base/prebuilt/seed.js';
-import { getApp, updateApp } from '../memory/app-store.js';
+import { getApp, getAppPreview, updateApp } from '../memory/app-store.js';
 import type { ToolExecutionResult } from '../tools/types.js';
 import { getLogger } from '../util/logger.js';
 import { isPlainObject } from '../util/object.js';
@@ -772,11 +772,12 @@ export async function surfaceProxyResolver(
       // un-clickable fallback chip) after session restart.
       : { title: app.name, subtitle: app.description };
 
+    const storedPreview = getAppPreview(app.id);
     const surfaceData: DynamicPageSurfaceData = {
       html: app.htmlDefinition,
       appId: app.id,
       appType: app.appType,
-      preview: preview ?? defaultPreview,
+      preview: { ...defaultPreview, ...preview, ...(storedPreview ? { previewImage: storedPreview } : {}) },
     };
     const surfaceId = uuid();
     ctx.surfaceState.set(surfaceId, {

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -125,7 +125,8 @@ export async function executeAppCreate(
 
   // Auto-open the app via the shared open-proxy helper
   if (autoOpen && proxyToolResolver) {
-    const extraInput = preview ? { preview } : undefined;
+    const createPreview = { ...(preview ?? {}), context: 'app_create' as const };
+    const extraInput = { preview: createPreview };
     const openResultText = await openAppViaSurface(app.id, proxyToolResolver, extraInput);
 
     // Determine whether the open succeeded by checking for the fallback text

--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -12,6 +12,7 @@ extension Notification.Name {
     static let identityChanged = Notification.Name("identityChanged")
     static let pinAppToHomebase = Notification.Name("MainWindow.pinAppToHomebase")
     static let appPreviewImageCaptured = Notification.Name("MainWindow.appPreviewImageCaptured")
+    static let requestAppPreview = Notification.Name("MainWindow.requestAppPreview")
 }
 
 /// Manages API keys in the macOS login keychain via native SecItem* APIs.

--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -10,6 +10,8 @@ extension Notification.Name {
     static let navigateToSettingsTab = Notification.Name("MainWindow.navigateToSettingsTab")
     static let activationKeyChanged = Notification.Name("activationKeyChanged")
     static let identityChanged = Notification.Name("identityChanged")
+    static let pinAppToHomebase = Notification.Name("MainWindow.pinAppToHomebase")
+    static let appPreviewImageCaptured = Notification.Name("MainWindow.appPreviewImageCaptured")
 }
 
 /// Manages API keys in the macOS login keychain via native SecItem* APIs.

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -743,6 +743,15 @@ struct MainWindowView: View {
                 try? daemonClient.sendAppOpen(appId: reopenId)
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .pinAppToHomebase)) { notification in
+            guard let appId = notification.userInfo?["appId"] as? String,
+                  let name = notification.userInfo?["name"] as? String else { return }
+            let icon = notification.userInfo?["icon"] as? String
+            let appType = notification.userInfo?["appType"] as? String
+            let description = notification.userInfo?["description"] as? String
+            appListManager.recordAppOpen(id: appId, name: name, icon: icon, appType: appType, description: description)
+            appListManager.pinApp(id: appId)
+        }
         .onReceive(NotificationCenter.default.publisher(for: .openDocumentEditor)) { notification in
             guard let surfaceId = notification.userInfo?["documentSurfaceId"] as? String else { return }
             if documentManager.hasActiveDocument && documentManager.surfaceId == surfaceId {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -768,6 +768,25 @@ struct MainWindowView: View {
                 windowState.activeDynamicParsedSurface = updated
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .requestAppPreview)) { notification in
+            guard let appId = notification.userInfo?["appId"] as? String else { return }
+            let stream = daemonClient.subscribe()
+            do { try daemonClient.sendAppPreview(appId: appId) } catch { return }
+            Task { @MainActor in
+                for await message in stream {
+                    if case .appPreviewResponse(let response) = message,
+                       response.appId == appId,
+                       let base64 = response.preview, !base64.isEmpty {
+                        NotificationCenter.default.post(
+                            name: .appPreviewImageCaptured,
+                            object: nil,
+                            userInfo: ["appId": appId, "previewImage": base64]
+                        )
+                        return
+                    }
+                }
+            }
+        }
         .onReceive(NotificationCenter.default.publisher(for: .dismissDynamicWorkspace)) { notification in
             // If a specific surfaceId was dismissed, only clear if it matches.
             if let surfaceId = notification.userInfo?["surfaceId"] as? String {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -855,6 +855,11 @@ struct DynamicWorkspaceWrapper: View {
                 onSnapshotCaptured: data.appId != nil ? { [weak daemonClient] base64 in
                     guard let appId = data.appId else { return }
                     try? daemonClient?.sendAppUpdatePreview(appId: appId, preview: base64)
+                    NotificationCenter.default.post(
+                        name: .appPreviewImageCaptured,
+                        object: nil,
+                        userInfo: ["appId": appId, "previewImage": base64]
+                    )
                 } : nil,
                 onLinkOpen: { url, metadata in
                     surfaceManager.onLinkOpen?(url, metadata)

--- a/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
@@ -1,0 +1,105 @@
+#if os(macOS)
+import SwiftUI
+
+/// Rich card shown inline in chat when a new app is created via `app_create`.
+/// Displays a preview image, icon + title + description, and action buttons.
+struct InlineAppCreatedCard: View {
+    let preview: DynamicPagePreview
+    let appId: String?
+    let onOpenApp: () -> Void
+    let onPinToHomebase: () -> Void
+
+    @State private var previewImage: String?
+    @State private var isPinned: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Preview image
+            if let base64 = previewImage,
+               let data = Data(base64Encoded: base64),
+               let nsImage = NSImage(data: data) {
+                Image(nsImage: nsImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 180)
+                    .clipped()
+            }
+
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                // Icon + title row
+                HStack(spacing: VSpacing.sm) {
+                    if let icon = preview.icon {
+                        Text(icon)
+                            .font(.system(size: 28))
+                    }
+
+                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                        Text(preview.title)
+                            .font(VFont.bodyBold)
+                            .foregroundColor(VColor.textPrimary)
+                            .lineLimit(2)
+                    }
+                }
+
+                if let description = preview.description, !description.isEmpty {
+                    Text(description)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                        .lineLimit(3)
+                }
+
+                // Action buttons
+                HStack(spacing: VSpacing.sm) {
+                    VButton(label: "Open App", leftIcon: "arrow.up.right", style: .primary, size: .small) {
+                        onOpenApp()
+                    }
+
+                    if isPinned {
+                        VButton(label: "Pinned", leftIcon: "checkmark", style: .success, size: .small, isDisabled: true) {}
+                    } else {
+                        VButton(label: "Pin to Homebase", leftIcon: "pin", style: .outlined, size: .small) {
+                            isPinned = true
+                            onPinToHomebase()
+                        }
+                    }
+                }
+            }
+            .padding(VSpacing.lg)
+        }
+        .background(RoundedRectangle(cornerRadius: VRadius.lg).fill(VColor.surface))
+        .overlay(RoundedRectangle(cornerRadius: VRadius.lg).stroke(VColor.surfaceBorder.opacity(0.4), lineWidth: 1))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .onAppear {
+            previewImage = preview.previewImage
+        }
+        .onReceive(NotificationCenter.default.publisher(for: Notification.Name("MainWindow.appPreviewImageCaptured"))) { notification in
+            guard let notifAppId = notification.userInfo?["appId"] as? String,
+                  notifAppId == appId,
+                  let base64 = notification.userInfo?["previewImage"] as? String else { return }
+            previewImage = base64
+        }
+    }
+}
+
+#if DEBUG
+#Preview("InlineAppCreatedCard") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        InlineAppCreatedCard(
+            preview: DynamicPagePreview(
+                title: "Kanban Board",
+                description: "Here's a simple dashboard with drag-and-drop task management.",
+                icon: "🎯"
+            ),
+            appId: "test-app-id",
+            onOpenApp: {},
+            onPinToHomebase: {}
+        )
+        .frame(width: 400)
+        .padding()
+    }
+    .frame(width: 500, height: 400)
+}
+#endif
+#endif

--- a/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
@@ -3,17 +3,34 @@ import SwiftUI
 
 /// Rich card shown inline in chat when a new app is created via `app_create`.
 /// Displays a preview image, icon + title + description, and action buttons.
+/// Background inverts the current color scheme: light mode → dark card, dark mode → light card.
 struct InlineAppCreatedCard: View {
     let preview: DynamicPagePreview
     let appId: String?
     let onOpenApp: () -> Void
     let onPinToHomebase: () -> Void
 
+    @Environment(\.colorScheme) private var colorScheme
     @State private var previewImage: String?
     @State private var isPinned: Bool = false
 
+    /// Inverse card background: dark in light mode, light in dark mode.
+    private var cardBackground: Color {
+        colorScheme == .light
+            ? Color(red: 0x20/255, green: 0x20/255, blue: 0x1E/255) // #20201E
+            : Color(red: 0xF5/255, green: 0xF3/255, blue: 0xEB/255) // #F5F3EB
+    }
+
+    /// Text colors that contrast with the inverse background.
+    private var cardTextPrimary: Color {
+        colorScheme == .light ? .white : .black
+    }
+    private var cardTextSecondary: Color {
+        colorScheme == .light ? Color.white.opacity(0.65) : Color.black.opacity(0.55)
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
             // Preview image
             if let base64 = previewImage,
                let data = Data(base64Encoded: base64),
@@ -22,56 +39,59 @@ struct InlineAppCreatedCard: View {
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .frame(maxWidth: .infinity)
-                    .frame(height: 180)
-                    .clipped()
+                    .frame(height: 140)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             }
 
-            VStack(alignment: .leading, spacing: VSpacing.md) {
-                // Icon + title row
-                HStack(spacing: VSpacing.sm) {
-                    if let icon = preview.icon {
-                        Text(icon)
-                            .font(.system(size: 28))
-                    }
-
-                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                        Text(preview.title)
-                            .font(VFont.bodyBold)
-                            .foregroundColor(VColor.textPrimary)
-                            .lineLimit(2)
-                    }
+            // Icon + title row
+            HStack(spacing: VSpacing.sm) {
+                if let icon = preview.icon {
+                    Text(icon)
+                        .font(.system(size: 14))
                 }
 
-                if let description = preview.description, !description.isEmpty {
-                    Text(description)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                        .lineLimit(3)
+                Text(preview.title)
+                    .font(VFont.bodyBold)
+                    .foregroundColor(cardTextPrimary)
+                    .lineLimit(2)
+            }
+
+            if let description = preview.description, !description.isEmpty {
+                Text(description)
+                    .font(VFont.caption)
+                    .foregroundColor(cardTextSecondary)
+                    .lineLimit(3)
+            }
+
+            // Action buttons
+            HStack(spacing: VSpacing.sm) {
+                VButton(label: "Open App", leftIcon: "arrow.up.right", style: .primary, size: .small) {
+                    onOpenApp()
                 }
 
-                // Action buttons
-                HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Open App", leftIcon: "arrow.up.right", style: .primary, size: .small) {
-                        onOpenApp()
-                    }
-
-                    if isPinned {
-                        VButton(label: "Pinned", leftIcon: "checkmark", style: .success, size: .small, isDisabled: true) {}
-                    } else {
-                        VButton(label: "Pin to Homebase", leftIcon: "pin", style: .outlined, size: .small) {
-                            isPinned = true
-                            onPinToHomebase()
-                        }
+                if isPinned {
+                    VButton(label: "Pinned", leftIcon: "checkmark", style: .success, size: .small, isDisabled: true) {}
+                } else {
+                    VButton(label: "Pin to Homebase", leftIcon: "pin.fill", style: .outlined, size: .small) {
+                        isPinned = true
+                        onPinToHomebase()
                     }
                 }
             }
-            .padding(VSpacing.lg)
         }
-        .background(RoundedRectangle(cornerRadius: VRadius.lg).fill(VColor.surface))
-        .overlay(RoundedRectangle(cornerRadius: VRadius.lg).stroke(VColor.surfaceBorder.opacity(0.4), lineWidth: 1))
+        .padding(16)
+        .background(RoundedRectangle(cornerRadius: VRadius.lg).fill(cardBackground))
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .onAppear {
             previewImage = preview.previewImage
+            // If no preview image yet, request one from the daemon
+            if previewImage == nil, let appId = appId {
+                NotificationCenter.default.post(
+                    name: Notification.Name("MainWindow.requestAppPreview"),
+                    object: nil,
+                    userInfo: ["appId": appId]
+                )
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: Notification.Name("MainWindow.appPreviewImageCaptured"))) { notification in
             guard let notifAppId = notification.userInfo?["appId"] as? String,

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -29,6 +29,14 @@ public struct InlineSurfaceRouter: View {
         return false
     }
 
+    private var isAppCreated: Bool {
+        #if os(macOS)
+        if case .dynamicPage(let data) = surface.data,
+           let preview = data.preview, preview.context == "app_create" { return true }
+        #endif
+        return false
+    }
+
     private var isDocumentPreview: Bool {
         if case .documentPreview = surface.data { return true }
         return false
@@ -56,8 +64,9 @@ public struct InlineSurfaceRouter: View {
                 onAction(surface.id, actionId, nil)
             }
             .frame(maxWidth: 540, alignment: .leading)
-        } else if isChipOnlySurface {
+        } else if isChipOnlySurface || isAppCreated {
             surfaceContent
+                .frame(maxWidth: isAppCreated ? 400 : nil, alignment: .leading)
         } else {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             // Template cards and dynamic page previews handle their own header
@@ -76,7 +85,7 @@ public struct InlineSurfaceRouter: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .inlineWidgetCard(interactive: isDynamicPreview || isDocumentPreview)
         .overlay(alignment: .topTrailing) {
-            if isDynamicPreview {
+            if isDynamicPreview && !isAppCreated {
                 Button {
                     if let ref = surface.surfaceRef {
                         NotificationCenter.default.post(
@@ -121,7 +130,7 @@ public struct InlineSurfaceRouter: View {
             }
         }
         // Consistent width for all widget cards; dynamic page previews and document previews are more compact.
-        .frame(maxWidth: isDynamicPreview || isDocumentPreview ? 350 : 540, alignment: .leading)
+        .frame(maxWidth: isAppCreated ? 400 : (isDynamicPreview || isDocumentPreview ? 350 : 540), alignment: .leading)
         }
         }
         .onChange(of: surface) { oldSurface, newSurface in
@@ -149,6 +158,47 @@ public struct InlineSurfaceRouter: View {
             }
         case .dynamicPage(let data):
             if let preview = data.preview {
+                #if os(macOS)
+                if preview.context == "app_create" {
+                    InlineAppCreatedCard(
+                        preview: preview,
+                        appId: data.appId,
+                        onOpenApp: {
+                            if let ref = surface.surfaceRef {
+                                NotificationCenter.default.post(
+                                    name: Notification.Name("MainWindow.openDynamicWorkspace"),
+                                    object: nil,
+                                    userInfo: ["surfaceRef": ref]
+                                )
+                            }
+                        },
+                        onPinToHomebase: {
+                            guard let appId = data.appId else { return }
+                            NotificationCenter.default.post(
+                                name: Notification.Name("MainWindow.pinAppToHomebase"),
+                                object: nil,
+                                userInfo: [
+                                    "appId": appId,
+                                    "name": preview.title,
+                                    "icon": preview.icon as Any,
+                                    "appType": data.appType as Any,
+                                    "description": preview.description as Any,
+                                ]
+                            )
+                        }
+                    )
+                } else {
+                    InlineDynamicPagePreview(preview: preview) {
+                        if let ref = surface.surfaceRef {
+                            NotificationCenter.default.post(
+                                name: Notification.Name("MainWindow.openDynamicWorkspace"),
+                                object: nil,
+                                userInfo: ["surfaceRef": ref]
+                            )
+                        }
+                    }
+                }
+                #else
                 InlineDynamicPagePreview(preview: preview) {
                     // Post notification to open (or re-open) the workspace
                     if let ref = surface.surfaceRef {
@@ -159,6 +209,7 @@ public struct InlineSurfaceRouter: View {
                         )
                     }
                 }
+                #endif
             } else {
                 // Still allow opening the workspace even without a preview card.
                 Button {

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -279,20 +279,25 @@ public struct DynamicPagePreview: Sendable, Equatable {
     public let description: String?
     public let icon: String?
     public let metrics: [(label: String, value: String)]?
+    public let context: String?
+    public var previewImage: String?
 
-    public init(title: String, subtitle: String? = nil, description: String? = nil, icon: String? = nil, metrics: [(label: String, value: String)]? = nil) {
+    public init(title: String, subtitle: String? = nil, description: String? = nil, icon: String? = nil, metrics: [(label: String, value: String)]? = nil, context: String? = nil, previewImage: String? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.description = description
         self.icon = icon
         self.metrics = metrics
+        self.context = context
+        self.previewImage = previewImage
     }
 
     public static func == (lhs: DynamicPagePreview, rhs: DynamicPagePreview) -> Bool {
         guard lhs.title == rhs.title,
               lhs.subtitle == rhs.subtitle,
               lhs.description == rhs.description,
-              lhs.icon == rhs.icon else { return false }
+              lhs.icon == rhs.icon,
+              lhs.context == rhs.context else { return false }
         switch (lhs.metrics, rhs.metrics) {
         case (.none, .none):
             return true
@@ -937,7 +942,9 @@ public extension Surface {
             subtitle: dict["subtitle"] as? String,
             description: dict["description"] as? String,
             icon: dict["icon"] as? String,
-            metrics: metrics
+            metrics: metrics,
+            context: dict["context"] as? String,
+            previewImage: dict["previewImage"] as? String
         )
     }
 

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1506,13 +1506,17 @@ public struct IPCDynamicPagePreview: Codable, Sendable {
     public let description: String?
     public let icon: String?
     public let metrics: [IPCDynamicPagePreviewMetric]?
+    public let context: String?
+    public let previewImage: String?
 
-    public init(title: String, subtitle: String? = nil, description: String? = nil, icon: String? = nil, metrics: [IPCDynamicPagePreviewMetric]? = nil) {
+    public init(title: String, subtitle: String? = nil, description: String? = nil, icon: String? = nil, metrics: [IPCDynamicPagePreviewMetric]? = nil, context: String? = nil, previewImage: String? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.description = description
         self.icon = icon
         self.metrics = metrics
+        self.context = context
+        self.previewImage = previewImage
     }
 }
 


### PR DESCRIPTION
## Summary
- Rich inline card shown in chat when a new app is created via `app_create`
- Inverse card background (#20201E in light mode, #F5F3EB in dark mode) for visual contrast
- Fetches app preview image from daemon on appear so the card shows the app screenshot
- Compact layout with uniform 16px padding, inset rounded preview image, and smaller emoji icon
- Pin icon uses `pin.fill` to match the rest of the app

## Test plan
- [ ] Create an app via chat and verify the inline card renders with inverse background
- [ ] Verify preview image loads from daemon (may take a moment after first app open)
- [ ] Toggle light/dark mode and confirm card background inverts correctly
- [ ] Verify "Pin to Homebase" button works and transitions to "Pinned" state
- [ ] Verify "Open App" button opens the app workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
