### PR TITLE
M2: Add A2A connection schema + store

### DIFF
--- a/assistant/src/a2a/__tests__/a2a-peer-connection-store.test.ts
+++ b/assistant/src/a2a/__tests__/a2a-peer-connection-store.test.ts
@@ -1,0 +1,463 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'a2a-peer-connection-store-test-'));
+
+mock.module('../../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  createConnection,
+  deleteConnection,
+  getConnection,
+  getConnectionByPeerAssistantId,
+  listConnections,
+  updateConnectionCredentials,
+  updateConnectionScopes,
+  updateConnectionStatus,
+} from '../a2a-peer-connection-store.js';
+import { getDb, initializeDb, resetDb } from '../../memory/db.js';
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run('DELETE FROM a2a_peer_connections');
+}
+
+describe('a2a-peer-connection-store', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  afterAll(() => {
+    resetDb();
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  // ── Table creation (migration idempotency) ──────────────────────────
+
+  test('table exists after initializeDb', () => {
+    const db = getDb();
+    const tables = db.all<{ name: string }>(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='a2a_peer_connections'",
+    );
+    expect(tables).toHaveLength(1);
+  });
+
+  test('migration is idempotent (re-running initializeDb does not throw)', () => {
+    expect(() => initializeDb()).not.toThrow();
+  });
+
+  // ── createConnection ────────────────────────────────────────────────
+
+  test('creates a connection with all fields populated', () => {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://peer.example.com/gateway',
+      peerAssistantId: 'peer-assistant-1',
+      peerDisplayName: 'Peer One',
+      inviteId: 'invite-123',
+      status: 'pending',
+      protocolVersion: '1.0.0',
+      capabilities: ['scheduling:read', 'messaging:relay'],
+      scopes: ['scheduling:read'],
+      outboundCredentialHash: 'hash-outbound-abc',
+      inboundCredentialHash: 'hash-inbound-xyz',
+      expiresAt: Date.now() + 86_400_000,
+    });
+
+    expect(conn.id).toBeTruthy();
+    expect(conn.assistantId).toBe('self');
+    expect(conn.peerAssistantId).toBe('peer-assistant-1');
+    expect(conn.peerGatewayUrl).toBe('https://peer.example.com/gateway');
+    expect(conn.peerDisplayName).toBe('Peer One');
+    expect(conn.inviteId).toBe('invite-123');
+    expect(conn.status).toBe('pending');
+    expect(conn.protocolVersion).toBe('1.0.0');
+    expect(conn.capabilities).toEqual(['scheduling:read', 'messaging:relay']);
+    expect(conn.scopes).toEqual(['scheduling:read']);
+    expect(conn.outboundCredentialHash).toBe('hash-outbound-abc');
+    expect(conn.inboundCredentialHash).toBe('hash-inbound-xyz');
+    expect(conn.createdAt).toBeGreaterThan(0);
+    expect(conn.updatedAt).toBeGreaterThan(0);
+    expect(conn.revokedAt).toBeNull();
+    expect(conn.revokedReason).toBeNull();
+    expect(conn.expiresAt).toBeGreaterThan(0);
+  });
+
+  test('creates a connection with minimal fields', () => {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://peer.example.com/gateway',
+    });
+
+    expect(conn.id).toBeTruthy();
+    expect(conn.peerAssistantId).toBeNull();
+    expect(conn.peerDisplayName).toBeNull();
+    expect(conn.inviteId).toBeNull();
+    expect(conn.status).toBe('pending');
+    expect(conn.protocolVersion).toBeNull();
+    expect(conn.capabilities).toEqual([]);
+    expect(conn.scopes).toEqual([]);
+    expect(conn.outboundCredentialHash).toBeNull();
+    expect(conn.inboundCredentialHash).toBeNull();
+    expect(conn.expiresAt).toBeNull();
+  });
+
+  test('each created connection has a unique ID', () => {
+    const conn1 = createConnection({ peerGatewayUrl: 'https://a.example.com' });
+    const conn2 = createConnection({ peerGatewayUrl: 'https://b.example.com' });
+
+    expect(conn1.id).not.toBe(conn2.id);
+  });
+
+  // ── getConnection ───────────────────────────────────────────────────
+
+  test('gets a connection by ID', () => {
+    const created = createConnection({
+      peerGatewayUrl: 'https://peer.example.com/gateway',
+      peerDisplayName: 'My Peer',
+    });
+
+    const fetched = getConnection(created.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.id).toBe(created.id);
+    expect(fetched!.peerGatewayUrl).toBe('https://peer.example.com/gateway');
+    expect(fetched!.peerDisplayName).toBe('My Peer');
+  });
+
+  test('returns null for nonexistent ID', () => {
+    const fetched = getConnection('nonexistent');
+    expect(fetched).toBeNull();
+  });
+
+  // ── getConnectionByPeerAssistantId ──────────────────────────────────
+
+  test('looks up connection by peer assistant ID', () => {
+    createConnection({
+      peerGatewayUrl: 'https://peer-a.example.com',
+      peerAssistantId: 'peer-a',
+    });
+    createConnection({
+      peerGatewayUrl: 'https://peer-b.example.com',
+      peerAssistantId: 'peer-b',
+    });
+
+    const found = getConnectionByPeerAssistantId('peer-b');
+    expect(found).not.toBeNull();
+    expect(found!.peerAssistantId).toBe('peer-b');
+    expect(found!.peerGatewayUrl).toBe('https://peer-b.example.com');
+  });
+
+  test('returns null for nonexistent peer assistant ID', () => {
+    const found = getConnectionByPeerAssistantId('nonexistent');
+    expect(found).toBeNull();
+  });
+
+  // ── listConnections ─────────────────────────────────────────────────
+
+  test('lists all connections with no filters', () => {
+    createConnection({ peerGatewayUrl: 'https://a.example.com' });
+    createConnection({ peerGatewayUrl: 'https://b.example.com' });
+    createConnection({ peerGatewayUrl: 'https://c.example.com' });
+
+    const all = listConnections();
+    expect(all).toHaveLength(3);
+  });
+
+  test('filters by status', () => {
+    createConnection({ peerGatewayUrl: 'https://a.example.com', status: 'pending' });
+    createConnection({ peerGatewayUrl: 'https://b.example.com', status: 'active' });
+    createConnection({ peerGatewayUrl: 'https://c.example.com', status: 'active' });
+
+    const active = listConnections({ status: 'active' });
+    expect(active).toHaveLength(2);
+
+    const pending = listConnections({ status: 'pending' });
+    expect(pending).toHaveLength(1);
+
+    const revoked = listConnections({ status: 'revoked' });
+    expect(revoked).toHaveLength(0);
+  });
+
+  test('returns empty array when no connections exist', () => {
+    const result = listConnections();
+    expect(result).toHaveLength(0);
+  });
+
+  test('respects limit and offset', () => {
+    createConnection({ peerGatewayUrl: 'https://a.example.com' });
+    createConnection({ peerGatewayUrl: 'https://b.example.com' });
+    createConnection({ peerGatewayUrl: 'https://c.example.com' });
+
+    const first = listConnections({ limit: 1 });
+    expect(first).toHaveLength(1);
+
+    const second = listConnections({ limit: 1, offset: 1 });
+    expect(second).toHaveLength(1);
+    expect(second[0].id).not.toBe(first[0].id);
+  });
+
+  // ── updateConnectionStatus (CAS) ───────────────────────────────────
+
+  test('updates status without CAS (no expected status)', () => {
+    const conn = createConnection({ peerGatewayUrl: 'https://a.example.com' });
+
+    const updated = updateConnectionStatus(conn.id, 'active');
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('active');
+    expect(updated!.updatedAt).toBeGreaterThanOrEqual(conn.updatedAt);
+  });
+
+  test('CAS succeeds when expected status matches', () => {
+    const conn = createConnection({ peerGatewayUrl: 'https://a.example.com' });
+
+    const updated = updateConnectionStatus(conn.id, 'active', 'pending');
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('active');
+  });
+
+  test('CAS fails when expected status does not match', () => {
+    const conn = createConnection({ peerGatewayUrl: 'https://a.example.com' });
+
+    // Try to transition from 'active' but it's currently 'pending'
+    const result = updateConnectionStatus(conn.id, 'revoked', 'active');
+    expect(result).toBeNull();
+
+    // Verify the connection is unchanged
+    const unchanged = getConnection(conn.id);
+    expect(unchanged!.status).toBe('pending');
+  });
+
+  test('CAS race condition: two concurrent transitions, only one succeeds', () => {
+    const conn = createConnection({ peerGatewayUrl: 'https://a.example.com' });
+
+    // First transition succeeds: pending -> active
+    const first = updateConnectionStatus(conn.id, 'active', 'pending');
+    expect(first).not.toBeNull();
+    expect(first!.status).toBe('active');
+
+    // Second transition fails: also tries pending -> revoked, but status is now 'active'
+    const second = updateConnectionStatus(conn.id, 'revoked', 'pending');
+    expect(second).toBeNull();
+
+    // Verify the first transition stuck
+    const final = getConnection(conn.id);
+    expect(final!.status).toBe('active');
+  });
+
+  test('returns null for nonexistent connection', () => {
+    const result = updateConnectionStatus('nonexistent', 'active');
+    expect(result).toBeNull();
+  });
+
+  test('auto-populates revokedAt when revoking', () => {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://a.example.com',
+      status: 'active',
+    });
+
+    const revoked = updateConnectionStatus(conn.id, 'revoked', 'active');
+    expect(revoked).not.toBeNull();
+    expect(revoked!.status).toBe('revoked');
+    expect(revoked!.revokedAt).not.toBeNull();
+    expect(revoked!.revokedAt).toBeGreaterThan(0);
+  });
+
+  test('auto-populates revokedAt for revoked_by_peer status', () => {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://a.example.com',
+      status: 'active',
+    });
+
+    const revoked = updateConnectionStatus(conn.id, 'revoked_by_peer', 'active');
+    expect(revoked).not.toBeNull();
+    expect(revoked!.status).toBe('revoked_by_peer');
+    expect(revoked!.revokedAt).not.toBeNull();
+  });
+
+  // ── Full status lifecycle ──────────────────────────────────────────
+
+  test('full lifecycle: pending -> active -> revoked', () => {
+    const conn = createConnection({ peerGatewayUrl: 'https://a.example.com' });
+    expect(conn.status).toBe('pending');
+
+    const activated = updateConnectionStatus(conn.id, 'active', 'pending');
+    expect(activated).not.toBeNull();
+    expect(activated!.status).toBe('active');
+
+    const revoked = updateConnectionStatus(activated!.id, 'revoked', 'active');
+    expect(revoked).not.toBeNull();
+    expect(revoked!.status).toBe('revoked');
+    expect(revoked!.revokedAt).not.toBeNull();
+  });
+
+  // ── updateConnectionScopes ─────────────────────────────────────────
+
+  test('updates scopes for a connection', () => {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://a.example.com',
+      scopes: ['scheduling:read'],
+    });
+
+    const updated = updateConnectionScopes(conn.id, [
+      'scheduling:read',
+      'scheduling:write',
+      'messaging:relay',
+    ]);
+
+    expect(updated).not.toBeNull();
+    expect(updated!.scopes).toEqual(['scheduling:read', 'scheduling:write', 'messaging:relay']);
+    expect(updated!.updatedAt).toBeGreaterThanOrEqual(conn.updatedAt);
+  });
+
+  test('can set scopes to empty array', () => {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://a.example.com',
+      scopes: ['scheduling:read'],
+    });
+
+    const updated = updateConnectionScopes(conn.id, []);
+    expect(updated).not.toBeNull();
+    expect(updated!.scopes).toEqual([]);
+  });
+
+  test('returns null for nonexistent connection', () => {
+    const updated = updateConnectionScopes('nonexistent', ['scheduling:read']);
+    expect(updated).toBeNull();
+  });
+
+  // ── updateConnectionCredentials ────────────────────────────────────
+
+  test('rotates outbound credential', () => {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://a.example.com',
+      outboundCredentialHash: 'old-hash',
+    });
+
+    const updated = updateConnectionCredentials(conn.id, {
+      outboundCredentialHash: 'new-hash',
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.outboundCredentialHash).toBe('new-hash');
+    // Inbound should remain unchanged
+    expect(updated!.inboundCredentialHash).toBeNull();
+  });
+
+  test('rotates inbound credential', () => {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://a.example.com',
+      inboundCredentialHash: 'old-inbound',
+    });
+
+    const updated = updateConnectionCredentials(conn.id, {
+      inboundCredentialHash: 'new-inbound',
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.inboundCredentialHash).toBe('new-inbound');
+  });
+
+  test('rotates both credentials at once', () => {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://a.example.com',
+      outboundCredentialHash: 'old-out',
+      inboundCredentialHash: 'old-in',
+    });
+
+    const updated = updateConnectionCredentials(conn.id, {
+      outboundCredentialHash: 'new-out',
+      inboundCredentialHash: 'new-in',
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.outboundCredentialHash).toBe('new-out');
+    expect(updated!.inboundCredentialHash).toBe('new-in');
+  });
+
+  test('returns null for nonexistent connection', () => {
+    const updated = updateConnectionCredentials('nonexistent', {
+      outboundCredentialHash: 'hash',
+    });
+    expect(updated).toBeNull();
+  });
+
+  // ── deleteConnection ───────────────────────────────────────────────
+
+  test('deletes an existing connection', () => {
+    const conn = createConnection({ peerGatewayUrl: 'https://a.example.com' });
+
+    const deleted = deleteConnection(conn.id);
+    expect(deleted).toBe(true);
+
+    const fetched = getConnection(conn.id);
+    expect(fetched).toBeNull();
+  });
+
+  test('returns false for nonexistent connection', () => {
+    const deleted = deleteConnection('nonexistent');
+    expect(deleted).toBe(false);
+  });
+
+  test('deleted connection no longer appears in list', () => {
+    const conn = createConnection({ peerGatewayUrl: 'https://a.example.com' });
+    createConnection({ peerGatewayUrl: 'https://b.example.com' });
+
+    expect(listConnections()).toHaveLength(2);
+
+    deleteConnection(conn.id);
+
+    expect(listConnections()).toHaveLength(1);
+  });
+
+  // ── JSON field round-trip ──────────────────────────────────────────
+
+  test('capabilities and scopes round-trip through JSON correctly', () => {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://a.example.com',
+      capabilities: ['scheduling:read', 'messaging:relay', 'preferences:read'],
+      scopes: ['scheduling:read', 'messaging:relay'],
+    });
+
+    const fetched = getConnection(conn.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.capabilities).toEqual(['scheduling:read', 'messaging:relay', 'preferences:read']);
+    expect(fetched!.scopes).toEqual(['scheduling:read', 'messaging:relay']);
+  });
+
+  test('empty arrays round-trip correctly', () => {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://a.example.com',
+      capabilities: [],
+      scopes: [],
+    });
+
+    const fetched = getConnection(conn.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.capabilities).toEqual([]);
+    expect(fetched!.scopes).toEqual([]);
+  });
+});

--- a/assistant/src/a2a/__tests__/a2a-peer-connection-store.test.ts
+++ b/assistant/src/a2a/__tests__/a2a-peer-connection-store.test.ts
@@ -16,6 +16,8 @@ mock.module('../../util/platform.js', () => ({
   getDbPath: () => join(testDir, 'test.db'),
   getLogPath: () => join(testDir, 'test.log'),
   ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
 }));
 
 mock.module('../../util/logger.js', () => ({

--- a/assistant/src/a2a/a2a-peer-connection-store.ts
+++ b/assistant/src/a2a/a2a-peer-connection-store.ts
@@ -1,0 +1,333 @@
+/**
+ * CRUD store for A2A peer connections.
+ *
+ * Each connection represents a bidirectional link between this assistant and a
+ * peer assistant. Stores credential hashes (never raw credentials), the peer's
+ * gateway URL, protocol version, negotiated capabilities, and granted scopes.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { and, desc, eq } from 'drizzle-orm';
+
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
+import { getDb } from '../memory/db.js';
+import { a2aPeerConnections } from '../memory/schema.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type A2APeerConnectionStatus =
+  | 'pending'
+  | 'active'
+  | 'revoked'
+  | 'revoked_by_peer'
+  | 'revocation_pending'
+  | 'expired';
+
+export interface A2APeerConnection {
+  id: string;
+  assistantId: string;
+  peerAssistantId: string | null;
+  peerGatewayUrl: string;
+  peerDisplayName: string | null;
+  inviteId: string | null;
+  status: A2APeerConnectionStatus;
+  protocolVersion: string | null;
+  capabilities: string[];
+  scopes: string[];
+  outboundCredentialHash: string | null;
+  inboundCredentialHash: string | null;
+  lastSeenAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+  revokedAt: number | null;
+  revokedReason: string | null;
+  expiresAt: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function rowToConnection(row: typeof a2aPeerConnections.$inferSelect): A2APeerConnection {
+  return {
+    id: row.id,
+    assistantId: row.assistantId,
+    peerAssistantId: row.peerAssistantId,
+    peerGatewayUrl: row.peerGatewayUrl,
+    peerDisplayName: row.peerDisplayName,
+    inviteId: row.inviteId,
+    status: row.status as A2APeerConnectionStatus,
+    protocolVersion: row.protocolVersion,
+    capabilities: JSON.parse(row.capabilities) as string[],
+    scopes: JSON.parse(row.scopes) as string[],
+    outboundCredentialHash: row.outboundCredentialHash,
+    inboundCredentialHash: row.inboundCredentialHash,
+    lastSeenAt: row.lastSeenAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    revokedAt: row.revokedAt,
+    revokedReason: row.revokedReason,
+    expiresAt: row.expiresAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createConnection
+// ---------------------------------------------------------------------------
+
+export function createConnection(params: {
+  peerGatewayUrl: string;
+  peerAssistantId?: string;
+  peerDisplayName?: string;
+  inviteId?: string;
+  status?: A2APeerConnectionStatus;
+  protocolVersion?: string;
+  capabilities?: string[];
+  scopes?: string[];
+  outboundCredentialHash?: string;
+  inboundCredentialHash?: string;
+  expiresAt?: number;
+}): A2APeerConnection {
+  const db = getDb();
+  const now = Date.now();
+  const id = randomUUID();
+
+  const row = {
+    id,
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+    peerAssistantId: params.peerAssistantId ?? null,
+    peerGatewayUrl: params.peerGatewayUrl,
+    peerDisplayName: params.peerDisplayName ?? null,
+    inviteId: params.inviteId ?? null,
+    status: params.status ?? ('pending' as const),
+    protocolVersion: params.protocolVersion ?? null,
+    capabilities: JSON.stringify(params.capabilities ?? []),
+    scopes: JSON.stringify(params.scopes ?? []),
+    outboundCredentialHash: params.outboundCredentialHash ?? null,
+    inboundCredentialHash: params.inboundCredentialHash ?? null,
+    lastSeenAt: null,
+    createdAt: now,
+    updatedAt: now,
+    revokedAt: null,
+    revokedReason: null,
+    expiresAt: params.expiresAt ?? null,
+  };
+
+  db.insert(a2aPeerConnections).values(row).run();
+
+  return rowToConnection(row);
+}
+
+// ---------------------------------------------------------------------------
+// getConnection
+// ---------------------------------------------------------------------------
+
+export function getConnection(connectionId: string): A2APeerConnection | null {
+  const db = getDb();
+
+  const row = db
+    .select()
+    .from(a2aPeerConnections)
+    .where(eq(a2aPeerConnections.id, connectionId))
+    .get();
+
+  return row ? rowToConnection(row) : null;
+}
+
+// ---------------------------------------------------------------------------
+// getConnectionByPeerAssistantId
+// ---------------------------------------------------------------------------
+
+export function getConnectionByPeerAssistantId(peerAssistantId: string): A2APeerConnection | null {
+  const db = getDb();
+
+  const row = db
+    .select()
+    .from(a2aPeerConnections)
+    .where(
+      and(
+        eq(a2aPeerConnections.assistantId, DAEMON_INTERNAL_ASSISTANT_ID),
+        eq(a2aPeerConnections.peerAssistantId, peerAssistantId),
+      ),
+    )
+    .get();
+
+  return row ? rowToConnection(row) : null;
+}
+
+// ---------------------------------------------------------------------------
+// listConnections
+// ---------------------------------------------------------------------------
+
+export function listConnections(filters?: {
+  status?: A2APeerConnectionStatus;
+  limit?: number;
+  offset?: number;
+}): A2APeerConnection[] {
+  const db = getDb();
+
+  const conditions = [eq(a2aPeerConnections.assistantId, DAEMON_INTERNAL_ASSISTANT_ID)];
+
+  if (filters?.status) {
+    conditions.push(eq(a2aPeerConnections.status, filters.status));
+  }
+
+  const rows = db
+    .select()
+    .from(a2aPeerConnections)
+    .where(and(...conditions))
+    .orderBy(desc(a2aPeerConnections.createdAt))
+    .limit(filters?.limit ?? 100)
+    .offset(filters?.offset ?? 0)
+    .all();
+
+  return rows.map(rowToConnection);
+}
+
+// ---------------------------------------------------------------------------
+// updateConnectionStatus (CAS-style)
+// ---------------------------------------------------------------------------
+
+/**
+ * Atomically transition a connection's status. When `expectedCurrentStatus` is
+ * provided, the update only applies if the current status matches (CAS). Returns
+ * the updated connection, or `null` if the connection was not found or the CAS
+ * check failed.
+ */
+export function updateConnectionStatus(
+  connectionId: string,
+  newStatus: A2APeerConnectionStatus,
+  expectedCurrentStatus?: A2APeerConnectionStatus,
+): A2APeerConnection | null {
+  const db = getDb();
+  const now = Date.now();
+
+  const conditions = [eq(a2aPeerConnections.id, connectionId)];
+  if (expectedCurrentStatus) {
+    conditions.push(eq(a2aPeerConnections.status, expectedCurrentStatus));
+  }
+
+  const setFields: Record<string, unknown> = {
+    status: newStatus,
+    updatedAt: now,
+  };
+
+  // Auto-populate revokedAt for revocation statuses
+  if (newStatus === 'revoked' || newStatus === 'revoked_by_peer') {
+    setFields.revokedAt = now;
+  }
+
+  db.update(a2aPeerConnections)
+    .set(setFields)
+    .where(and(...conditions))
+    .run();
+
+  // Re-read to confirm the update took effect
+  const updated = db
+    .select()
+    .from(a2aPeerConnections)
+    .where(eq(a2aPeerConnections.id, connectionId))
+    .get();
+
+  if (!updated) return null;
+
+  // CAS check: if we expected a specific status but the row's status didn't change,
+  // then the CAS failed (concurrent update or wrong expected status).
+  if (expectedCurrentStatus && updated.status !== newStatus) {
+    return null;
+  }
+
+  // Also check updatedAt to confirm our write landed
+  if (updated.updatedAt !== now) {
+    return null;
+  }
+
+  return rowToConnection(updated);
+}
+
+// ---------------------------------------------------------------------------
+// updateConnectionScopes
+// ---------------------------------------------------------------------------
+
+export function updateConnectionScopes(
+  connectionId: string,
+  scopes: string[],
+): A2APeerConnection | null {
+  const db = getDb();
+  const now = Date.now();
+
+  db.update(a2aPeerConnections)
+    .set({
+      scopes: JSON.stringify(scopes),
+      updatedAt: now,
+    })
+    .where(eq(a2aPeerConnections.id, connectionId))
+    .run();
+
+  const updated = db
+    .select()
+    .from(a2aPeerConnections)
+    .where(eq(a2aPeerConnections.id, connectionId))
+    .get();
+
+  return updated ? rowToConnection(updated) : null;
+}
+
+// ---------------------------------------------------------------------------
+// updateConnectionCredentials
+// ---------------------------------------------------------------------------
+
+export function updateConnectionCredentials(
+  connectionId: string,
+  credentials: {
+    outboundCredentialHash?: string;
+    inboundCredentialHash?: string;
+  },
+): A2APeerConnection | null {
+  const db = getDb();
+  const now = Date.now();
+
+  const setFields: Record<string, unknown> = { updatedAt: now };
+
+  if (credentials.outboundCredentialHash !== undefined) {
+    setFields.outboundCredentialHash = credentials.outboundCredentialHash;
+  }
+  if (credentials.inboundCredentialHash !== undefined) {
+    setFields.inboundCredentialHash = credentials.inboundCredentialHash;
+  }
+
+  db.update(a2aPeerConnections)
+    .set(setFields)
+    .where(eq(a2aPeerConnections.id, connectionId))
+    .run();
+
+  const updated = db
+    .select()
+    .from(a2aPeerConnections)
+    .where(eq(a2aPeerConnections.id, connectionId))
+    .get();
+
+  return updated ? rowToConnection(updated) : null;
+}
+
+// ---------------------------------------------------------------------------
+// deleteConnection
+// ---------------------------------------------------------------------------
+
+/**
+ * Hard-delete a connection record. Returns `true` if a row was deleted,
+ * `false` if the connection did not exist.
+ */
+export function deleteConnection(connectionId: string): boolean {
+  const db = getDb();
+
+  const result = db
+    .delete(a2aPeerConnections)
+    .where(eq(a2aPeerConnections.id, connectionId))
+    .run();
+
+  return result.changes > 0;
+}

--- a/assistant/src/a2a/a2a-peer-connection-store.ts
+++ b/assistant/src/a2a/a2a-peer-connection-store.ts
@@ -154,6 +154,7 @@ export function getConnectionByPeerAssistantId(peerAssistantId: string): A2APeer
         eq(a2aPeerConnections.peerAssistantId, peerAssistantId),
       ),
     )
+    .orderBy(desc(a2aPeerConnections.updatedAt))
     .get();
 
   return row ? rowToConnection(row) : null;

--- a/assistant/src/a2a/a2a-peer-connection-store.ts
+++ b/assistant/src/a2a/a2a-peer-connection-store.ts
@@ -12,6 +12,7 @@ import { and, desc, eq } from 'drizzle-orm';
 
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { getDb } from '../memory/db.js';
+import { rawChanges } from '../memory/raw-query.js';
 import { a2aPeerConnections } from '../memory/schema.js';
 
 // ---------------------------------------------------------------------------
@@ -225,27 +226,17 @@ export function updateConnectionStatus(
     .where(and(...conditions))
     .run();
 
-  // Re-read to confirm the update took effect
+  // Use affected-row count to determine if the conditional update applied.
+  // This is reliable even at millisecond precision, unlike timestamp comparison.
+  if (rawChanges() === 0) return null;
+
   const updated = db
     .select()
     .from(a2aPeerConnections)
     .where(eq(a2aPeerConnections.id, connectionId))
     .get();
 
-  if (!updated) return null;
-
-  // CAS check: if we expected a specific status but the row's status didn't change,
-  // then the CAS failed (concurrent update or wrong expected status).
-  if (expectedCurrentStatus && updated.status !== newStatus) {
-    return null;
-  }
-
-  // Also check updatedAt to confirm our write landed
-  if (updated.updatedAt !== now) {
-    return null;
-  }
-
-  return rowToConnection(updated);
+  return updated ? rowToConnection(updated) : null;
 }
 
 // ---------------------------------------------------------------------------
@@ -324,10 +315,9 @@ export function updateConnectionCredentials(
 export function deleteConnection(connectionId: string): boolean {
   const db = getDb();
 
-  const result = db
-    .delete(a2aPeerConnections)
+  db.delete(a2aPeerConnections)
     .where(eq(a2aPeerConnections.id, connectionId))
     .run();
 
-  return result.changes > 0;
+  return rawChanges() > 0;
 }

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -1,6 +1,7 @@
 import { getDb } from './db-connection.js';
 import {
   addCoreColumns,
+  createA2APeerConnectionsTable,
   createActorRefreshTokenRecordsTable,
   createActorTokenRecordsTable,
   createAssistantInboxTables,
@@ -188,6 +189,9 @@ export function initializeDb(): void {
 
   // 31. Enforce NOT NULL on channel_guardian_bindings.guardian_principal_id
   migrateGuardianPrincipalIdNotNull(database);
+
+  // 32. A2A peer connections (bidirectional assistant-to-assistant credentials and state)
+  createA2APeerConnectionsTable(database);
 
   validateMigrationState(database);
 }

--- a/assistant/src/memory/migrations/128-a2a-peer-connections.ts
+++ b/assistant/src/memory/migrations/128-a2a-peer-connections.ts
@@ -1,0 +1,49 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Create the a2a_peer_connections table for bidirectional peer assistant connections.
+ *
+ * Stores the persistent connection state between two assistants: credential pairs,
+ * peer gateway URL, protocol version, negotiated capabilities, granted scopes,
+ * and lifecycle timestamps.
+ */
+export function createA2APeerConnectionsTable(database: DrizzleDb): void {
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS a2a_peer_connections (
+      id TEXT PRIMARY KEY,
+      assistant_id TEXT NOT NULL,
+      peer_assistant_id TEXT,
+      peer_gateway_url TEXT NOT NULL,
+      peer_display_name TEXT,
+      invite_id TEXT,
+      status TEXT NOT NULL DEFAULT 'pending',
+      protocol_version TEXT,
+      capabilities TEXT NOT NULL DEFAULT '[]',
+      scopes TEXT NOT NULL DEFAULT '[]',
+      outbound_credential_hash TEXT,
+      inbound_credential_hash TEXT,
+      last_seen_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      revoked_at INTEGER,
+      revoked_reason TEXT,
+      expires_at INTEGER
+    )
+  `);
+
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_a2a_peer_connections_status
+      ON a2a_peer_connections(assistant_id, status)`,
+  );
+
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_a2a_peer_connections_gateway_url
+      ON a2a_peer_connections(peer_gateway_url)`,
+  );
+
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_a2a_peer_connections_peer_assistant_id
+      ON a2a_peer_connections(peer_assistant_id)
+      WHERE peer_assistant_id IS NOT NULL`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -69,6 +69,7 @@ export { migrateVoiceInviteDisplayMetadata } from './124-voice-invite-display-me
 export { migrateGuardianPrincipalIdColumns } from './125-guardian-principal-id-columns.js';
 export { migrateBackfillGuardianPrincipalId } from './126-backfill-guardian-principal-id.js';
 export { migrateGuardianPrincipalIdNotNull } from './127-guardian-principal-id-not-null.js';
+export { createA2APeerConnectionsTable } from './128-a2a-peer-connections.js';
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -1208,3 +1208,29 @@ export const scopedApprovalGrants = sqliteTable('scoped_approval_grants', {
   index('idx_scoped_grants_tool_sig').on(table.toolName, table.inputDigest),
   index('idx_scoped_grants_status_expires').on(table.status, table.expiresAt),
 ]);
+
+// ── A2A Peer Connections ─────────────────────────────────────────────
+
+export const a2aPeerConnections = sqliteTable('a2a_peer_connections', {
+  id: text('id').primaryKey(),
+  assistantId: text('assistant_id').notNull(),
+  peerAssistantId: text('peer_assistant_id'),
+  peerGatewayUrl: text('peer_gateway_url').notNull(),
+  peerDisplayName: text('peer_display_name'),
+  inviteId: text('invite_id'),
+  status: text('status').notNull().default('pending'),
+  protocolVersion: text('protocol_version'),
+  capabilities: text('capabilities').notNull().default('[]'),
+  scopes: text('scopes').notNull().default('[]'),
+  outboundCredentialHash: text('outbound_credential_hash'),
+  inboundCredentialHash: text('inbound_credential_hash'),
+  lastSeenAt: integer('last_seen_at'),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+  revokedAt: integer('revoked_at'),
+  revokedReason: text('revoked_reason'),
+  expiresAt: integer('expires_at'),
+}, (table) => [
+  index('idx_a2a_peer_connections_status').on(table.assistantId, table.status),
+  index('idx_a2a_peer_connections_gateway_url').on(table.peerGatewayUrl),
+]);


### PR DESCRIPTION
Add a2a_peer_connections table with inline migration, idempotent store API (CRUD, CAS status transitions, credential rotation), and comprehensive tests. Reuses existing tables (ingress_invites, canonical_guardian_requests, channel_guardian_verification_challenges, external_conversation_bindings) for invite tokens, approval workflow, code exchange, and conversation mapping.

Closes #11343
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
