### PR TITLE
fix: address late review feedback — migrate readHttpToken to JWT, enforce policy on all routes

### DIFF
--- a/assistant/src/amazon/client.ts
+++ b/assistant/src/amazon/client.ts
@@ -52,7 +52,7 @@ import type { ExtensionCommand, ExtensionResponse } from '../browser-extension-r
 import { extensionRelayServer } from '../browser-extension-relay/server.js';
 import { getGatewayInternalBaseUrl } from '../config/env.js';
 import type { ExtractedCredential } from '../tools/browser/network-recording-types.js';
-import { readHttpToken } from '../util/platform.js';
+import { mintDaemonDeliveryToken } from '../runtime/auth/token-service.js';
 import {
   type AmazonSession,
   loadSession,
@@ -76,10 +76,7 @@ export async function sendRelayCommand(command: Record<string, unknown>): Promis
   }
 
   // Fall back to HTTP relay endpoint on the daemon
-  const token = readHttpToken();
-  if (!token) {
-    throw new Error('Browser extension relay is not connected and no HTTP token found. Is the daemon running?');
-  }
+  const token = mintDaemonDeliveryToken();
 
   const resp = await fetch(`${getGatewayInternalBaseUrl()}/v1/browser-relay/command`, {
     method: 'POST',

--- a/assistant/src/amazon/client.ts
+++ b/assistant/src/amazon/client.ts
@@ -52,7 +52,8 @@ import type { ExtensionCommand, ExtensionResponse } from '../browser-extension-r
 import { extensionRelayServer } from '../browser-extension-relay/server.js';
 import { getGatewayInternalBaseUrl } from '../config/env.js';
 import type { ExtractedCredential } from '../tools/browser/network-recording-types.js';
-import { mintDaemonDeliveryToken } from '../runtime/auth/token-service.js';
+import { isSigningKeyInitialized, mintDaemonDeliveryToken } from '../runtime/auth/token-service.js';
+import { readHttpToken } from '../util/platform.js';
 import {
   type AmazonSession,
   loadSession,
@@ -75,8 +76,13 @@ export async function sendRelayCommand(command: Record<string, unknown>): Promis
     return extensionRelayServer.sendCommand(command as Omit<ExtensionCommand, 'id'>);
   }
 
-  // Fall back to HTTP relay endpoint on the daemon
-  const token = mintDaemonDeliveryToken();
+  // Fall back to HTTP relay endpoint on the daemon.
+  // In CLI (out-of-process) context the signing key may not be initialized,
+  // so fall back to the legacy shared-secret token from disk.
+  const token = isSigningKeyInitialized() ? mintDaemonDeliveryToken() : readHttpToken();
+  if (!token) {
+    throw new Error('No auth token available — daemon may not be running');
+  }
 
   const resp = await fetch(`${getGatewayInternalBaseUrl()}/v1/browser-relay/command`, {
     method: 'POST',

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -25,7 +25,7 @@ import * as pendingInteractions from '../runtime/pending-interactions.js';
 import { getTool } from '../tools/registry.js';
 import { TC_GRANT_WAIT_MAX_MS } from '../tools/tool-approval-handler.js';
 import { getLogger } from '../util/logger.js';
-import { readHttpToken } from '../util/platform.js';
+import { mintDaemonDeliveryToken } from '../runtime/auth/token-service.js';
 
 const log = getLogger('guardian-request-resolvers');
 
@@ -313,7 +313,7 @@ const accessRequestResolver: GuardianRequestResolver = {
     const decidedByExternalUserId = ctx.actor.externalUserId ?? '';
     const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
     const desktopDeliverUrl = resolveDeliverCallbackUrlForChannel(channel);
-    const desktopBearerToken = readHttpToken() ?? undefined;
+    const desktopBearerToken = mintDaemonDeliveryToken();
 
     if (decision.action === 'reject') {
       log.info(

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -21,7 +21,7 @@ import { revokeScopedApprovalGrantsForContext } from '../memory/scoped-approval-
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
 import { getLogger } from '../util/logger.js';
-import { readHttpToken } from '../util/platform.js';
+import { mintDaemonDeliveryToken } from '../runtime/auth/token-service.js';
 import { getMaxCallDurationMs, getSilenceTimeoutMs, getUserConsultationTimeoutMs } from './call-constants.js';
 import { persistCallCompletionMessage } from './call-conversation-messages.js';
 import { addPointerMessage, formatDuration } from './call-pointer-messages.js';
@@ -949,7 +949,7 @@ export class CallController {
           canonicalDeliveries,
           this.assistantId,
           getGatewayInternalBaseUrl(),
-          readHttpToken() ?? undefined,
+          mintDaemonDeliveryToken(),
         ).catch((err) => {
           log.error(
             { err, callSessionId: this.callSessionId, requestId: pendingActionRequest.id },

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -10,7 +10,7 @@ import { getCallWelcomeGreeting, getRuntimeProxyBearerToken } from '../config/en
 import { loadConfig } from '../config/loader.js';
 import { getTwilioRelayUrl } from '../inbound/public-ingress-urls.js';
 import { getLogger } from '../util/logger.js';
-import { readHttpToken } from '../util/platform.js';
+import { mintDaemonDeliveryToken } from '../runtime/auth/token-service.js';
 import { persistCallCompletionMessage } from './call-conversation-messages.js';
 import { createInboundVoiceSession } from './call-domain.js';
 import { logDeadLetterEvent } from './call-recovery.js';
@@ -264,7 +264,7 @@ function buildVoiceWebhookTwiml(
 
   // Use the same token resolution the gateway uses for runtimeProxyBearerToken:
   // env var override first, then the on-disk http-token file.
-  const relayToken = getRuntimeProxyBearerToken() ?? readHttpToken() ?? undefined;
+  const relayToken = getRuntimeProxyBearerToken() ?? mintDaemonDeliveryToken();
 
   // Propagate guardianVerificationSessionId as a TwiML <Parameter> for
   // observability. This is not the sole source of truth; the relay

--- a/assistant/src/daemon/handlers/config-ingress.ts
+++ b/assistant/src/daemon/handlers/config-ingress.ts
@@ -18,7 +18,7 @@ import {
   type IngressConfig,
 } from '../../inbound/public-ingress-urls.js';
 import { getSecureKey } from '../../security/secure-keys.js';
-import { readHttpToken } from '../../util/platform.js';
+import { mintDaemonDeliveryToken } from '../../runtime/auth/token-service.js';
 import type { IngressConfigRequest } from '../ipc-protocol.js';
 import { CONFIG_RELOAD_DEBOUNCE_MS, defineHandlers, type HandlerContext,log } from './shared.js';
 
@@ -47,11 +47,7 @@ export function computeGatewayTarget(): string {
  */
 export function triggerGatewayReconcile(ingressPublicBaseUrl: string | undefined): void {
   const gatewayBase = computeGatewayTarget();
-  const token = readHttpToken();
-  if (!token) {
-    log.debug('Skipping gateway reconcile trigger: no HTTP bearer token available');
-    return;
-  }
+  const token = mintDaemonDeliveryToken();
 
   const url = `${gatewayBase}/internal/telegram/reconcile`;
   const body = JSON.stringify({ ingressPublicBaseUrl: ingressPublicBaseUrl ?? '' });

--- a/assistant/src/influencer/client.ts
+++ b/assistant/src/influencer/client.ts
@@ -48,7 +48,8 @@
 import type { ExtensionCommand, ExtensionResponse } from '../browser-extension-relay/protocol.js';
 import { extensionRelayServer } from '../browser-extension-relay/server.js';
 import { getGatewayInternalBaseUrl } from '../config/env.js';
-import { mintDaemonDeliveryToken } from '../runtime/auth/token-service.js';
+import { isSigningKeyInitialized, mintDaemonDeliveryToken } from '../runtime/auth/token-service.js';
+import { readHttpToken } from '../util/platform.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -126,8 +127,13 @@ async function sendRelayCommand(command: Record<string, unknown>): Promise<Exten
     return extensionRelayServer.sendCommand(command as Omit<ExtensionCommand, 'id'>);
   }
 
-  // Fall back to HTTP relay endpoint on the daemon
-  const token = mintDaemonDeliveryToken();
+  // Fall back to HTTP relay endpoint on the daemon.
+  // In CLI (out-of-process) context the signing key may not be initialized,
+  // so fall back to the legacy shared-secret token from disk.
+  const token = isSigningKeyInitialized() ? mintDaemonDeliveryToken() : readHttpToken();
+  if (!token) {
+    throw new Error('No auth token available — daemon may not be running');
+  }
 
   const resp = await fetch(`${getGatewayInternalBaseUrl()}/v1/browser-relay/command`, {
     method: 'POST',

--- a/assistant/src/influencer/client.ts
+++ b/assistant/src/influencer/client.ts
@@ -48,7 +48,7 @@
 import type { ExtensionCommand, ExtensionResponse } from '../browser-extension-relay/protocol.js';
 import { extensionRelayServer } from '../browser-extension-relay/server.js';
 import { getGatewayInternalBaseUrl } from '../config/env.js';
-import { readHttpToken } from '../util/platform.js';
+import { mintDaemonDeliveryToken } from '../runtime/auth/token-service.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -127,12 +127,7 @@ async function sendRelayCommand(command: Record<string, unknown>): Promise<Exten
   }
 
   // Fall back to HTTP relay endpoint on the daemon
-  const token = readHttpToken();
-  if (!token) {
-    throw new Error(
-      'Browser extension relay is not connected and no HTTP token found. Is the daemon running?',
-    );
-  }
+  const token = mintDaemonDeliveryToken();
 
   const resp = await fetch(`${getGatewayInternalBaseUrl()}/v1/browser-relay/command`, {
     method: 'POST',

--- a/assistant/src/messaging/providers/sms/adapter.ts
+++ b/assistant/src/messaging/providers/sms/adapter.ts
@@ -20,7 +20,7 @@ import { getOrCreateConversation } from '../../../memory/conversation-key-store.
 import * as externalConversationStore from '../../../memory/external-conversation-store.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../../../runtime/assistant-scope.js';
 import { getSecureKey } from '../../../security/secure-keys.js';
-import { readHttpToken } from '../../../util/platform.js';
+import { mintDaemonDeliveryToken } from '../../../runtime/auth/token-service.js';
 import type { MessagingProvider } from '../../provider.js';
 import type {
   ConnectionInfo,
@@ -40,13 +40,9 @@ function getGatewayUrl(): string {
   return getGatewayInternalBaseUrl();
 }
 
-/** Read the runtime HTTP bearer token used to authenticate with the gateway. */
+/** Mint a short-lived JWT for authenticating with the gateway. */
 function getBearerToken(): string {
-  const token = readHttpToken();
-  if (!token) {
-    throw new Error('No runtime HTTP bearer token available — is the daemon running?');
-  }
-  return token;
+  return mintDaemonDeliveryToken();
 }
 
 /** Check whether Twilio credentials are stored. */

--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -15,7 +15,7 @@ import { getGatewayInternalBaseUrl } from '../../../config/env.js';
 import { getOrCreateConversation } from '../../../memory/conversation-key-store.js';
 import * as externalConversationStore from '../../../memory/external-conversation-store.js';
 import { getSecureKey } from '../../../security/secure-keys.js';
-import { readHttpToken } from '../../../util/platform.js';
+import { mintDaemonDeliveryToken } from '../../../runtime/auth/token-service.js';
 import type { MessagingProvider } from '../../provider.js';
 import type {
   ConnectionInfo,
@@ -35,13 +35,9 @@ function getGatewayUrl(): string {
   return getGatewayInternalBaseUrl();
 }
 
-/** Read the runtime HTTP bearer token used to authenticate with the gateway. */
+/** Mint a short-lived JWT for authenticating with the gateway. */
 function getBearerToken(): string {
-  const token = readHttpToken();
-  if (!token) {
-    throw new Error('No runtime HTTP bearer token available — is the daemon running?');
-  }
-  return token;
+  return mintDaemonDeliveryToken();
 }
 
 /** Read the Telegram bot token from the credential vault. */

--- a/assistant/src/messaging/providers/whatsapp/adapter.ts
+++ b/assistant/src/messaging/providers/whatsapp/adapter.ts
@@ -14,7 +14,7 @@ import { getGatewayInternalBaseUrl } from '../../../config/env.js';
 import { getOrCreateConversation } from '../../../memory/conversation-key-store.js';
 import * as externalConversationStore from '../../../memory/external-conversation-store.js';
 import { getSecureKey } from '../../../security/secure-keys.js';
-import { readHttpToken } from '../../../util/platform.js';
+import { mintDaemonDeliveryToken } from '../../../runtime/auth/token-service.js';
 import type { MessagingProvider } from '../../provider.js';
 import type {
   ConnectionInfo,
@@ -34,13 +34,9 @@ function getGatewayUrl(): string {
   return getGatewayInternalBaseUrl();
 }
 
-/** Read the runtime HTTP bearer token used to authenticate with the gateway. */
+/** Mint a short-lived JWT for authenticating with the gateway. */
 function getBearerToken(): string {
-  const token = readHttpToken();
-  if (!token) {
-    throw new Error('No runtime HTTP bearer token available — is the daemon running?');
-  }
-  return token;
+  return mintDaemonDeliveryToken();
 }
 
 /** Check whether WhatsApp credentials are stored. */

--- a/assistant/src/notifications/adapters/sms.ts
+++ b/assistant/src/notifications/adapters/sms.ts
@@ -15,7 +15,7 @@
 import { getGatewayInternalBaseUrl } from '../../config/env.js';
 import { deliverChannelReply } from '../../runtime/gateway-client.js';
 import { getLogger } from '../../util/logger.js';
-import { readHttpToken } from '../../util/platform.js';
+import { mintDaemonDeliveryToken } from '../../runtime/auth/token-service.js';
 import { nonEmpty } from '../copy-composer.js';
 import type {
   ChannelAdapter,
@@ -59,7 +59,7 @@ export class SmsAdapter implements ChannelAdapter {
       await deliverChannelReply(
         deliverUrl,
         { chatId: phoneNumber, text: messageText, assistantId: payload.assistantId },
-        readHttpToken() ?? undefined,
+        mintDaemonDeliveryToken(),
       );
 
       log.info(

--- a/assistant/src/notifications/adapters/telegram.ts
+++ b/assistant/src/notifications/adapters/telegram.ts
@@ -10,7 +10,7 @@
 import { getGatewayInternalBaseUrl } from '../../config/env.js';
 import { deliverChannelReply } from '../../runtime/gateway-client.js';
 import { getLogger } from '../../util/logger.js';
-import { readHttpToken } from '../../util/platform.js';
+import { mintDaemonDeliveryToken } from '../../runtime/auth/token-service.js';
 import { nonEmpty } from '../copy-composer.js';
 import { isThreadSeedSane } from '../thread-seed-composer.js';
 import type {
@@ -61,7 +61,7 @@ export class TelegramAdapter implements ChannelAdapter {
       await deliverChannelReply(
         deliverUrl,
         { chatId, text: messageText },
-        readHttpToken() ?? undefined,
+        mintDaemonDeliveryToken(),
       );
 
       log.info(

--- a/assistant/src/runtime/auth/token-service.ts
+++ b/assistant/src/runtime/auth/token-service.ts
@@ -82,6 +82,17 @@ export function initAuthSigningKey(key: Buffer): void {
   _authSigningKey = key;
 }
 
+/**
+ * Check whether the auth signing key has been initialized.
+ *
+ * Useful for out-of-process contexts (CLI) that may run without
+ * daemon startup, where callers need to decide whether they can
+ * mint JWTs or must fall back to the legacy shared-secret token.
+ */
+export function isSigningKeyInitialized(): boolean {
+  return _authSigningKey !== null;
+}
+
 // ---------------------------------------------------------------------------
 // Base64url helpers
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/guardian-action-followup-executor.ts
+++ b/assistant/src/runtime/guardian-action-followup-executor.ts
@@ -29,7 +29,7 @@ import {
   type GuardianActionRequest,
 } from '../memory/guardian-action-store.js';
 import { getLogger } from '../util/logger.js';
-import { readHttpToken } from '../util/platform.js';
+import { mintDaemonDeliveryToken } from './auth/token-service.js';
 import { deliverChannelReply } from './gateway-client.js';
 import { composeGuardianActionMessageGenerative } from './guardian-action-message-composer.js';
 import type { GuardianActionCopyGenerator } from './http-types.js';
@@ -115,7 +115,7 @@ async function executeMessageBack(
 
     const gatewayBase = getGatewayInternalBaseUrl();
     const deliverUrl = `${gatewayBase}/deliver/sms`;
-    const bearerToken = readHttpToken() ?? undefined;
+    const bearerToken = mintDaemonDeliveryToken();
 
     await deliverChannelReply(
       deliverUrl,

--- a/assistant/src/runtime/guardian-outbound-actions.ts
+++ b/assistant/src/runtime/guardian-outbound-actions.ts
@@ -16,7 +16,7 @@ import { sendMessage as sendSms } from "../messaging/providers/sms/client.js";
 import { getCredentialMetadata } from "../tools/credentials/metadata-store.js";
 import { getLogger } from "../util/logger.js";
 import { normalizePhoneNumber } from "../util/phone.js";
-import { readHttpToken } from "../util/platform.js";
+import { mintDaemonDeliveryToken } from "./auth/token-service.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
 import {
   countRecentSendsToDestination,
@@ -153,13 +153,7 @@ function deliverVerificationSms(
   (async () => {
     try {
       const gatewayUrl = getGatewayInternalBaseUrl();
-      const bearerToken = readHttpToken();
-      if (!bearerToken) {
-        log.error(
-          "Cannot deliver verification SMS: no runtime HTTP token available",
-        );
-        return;
-      }
+      const bearerToken = mintDaemonDeliveryToken();
       await sendSms(gatewayUrl, bearerToken, to, text, assistantId);
       log.info({ to, assistantId }, "Verification SMS delivered");
     } catch (err) {
@@ -184,13 +178,7 @@ function deliverVerificationTelegram(
   (async () => {
     try {
       const gatewayUrl = getGatewayInternalBaseUrl();
-      const bearerToken = readHttpToken();
-      if (!bearerToken) {
-        log.error(
-          "Cannot deliver verification Telegram message: no runtime HTTP token available",
-        );
-        return;
-      }
+      const bearerToken = mintDaemonDeliveryToken();
       const url = `${gatewayUrl}/deliver/telegram`;
       const resp = await fetch(url, {
         method: "POST",
@@ -646,13 +634,7 @@ function deliverVerificationSlack(
   (async () => {
     try {
       const gatewayUrl = getGatewayInternalBaseUrl();
-      const bearerToken = readHttpToken();
-      if (!bearerToken) {
-        log.error(
-          "Cannot deliver verification Slack DM: no runtime HTTP token available",
-        );
-        return;
-      }
+      const bearerToken = mintDaemonDeliveryToken();
       const url = `${gatewayUrl}/deliver/slack`;
       const resp = await fetch(url, {
         method: "POST",

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -260,8 +260,18 @@ const PARAMETERIZED_ROUTE_PATTERNS: Array<{ re: RegExp; policyBase: string }> = 
  *
  * For example, `calls/abc123` becomes `calls`, and
  * `attachments/abc123/content` becomes `attachments/content`.
+ *
+ * If the raw endpoint already has a direct policy registered (either
+ * bare or with a method qualifier), normalization is skipped. This
+ * prevents literal sub-routes like `calls/start` from being
+ * incorrectly collapsed to `calls`.
  */
-function normalizeEndpointForPolicy(endpoint: string): string {
+function normalizeEndpointForPolicy(endpoint: string, method: string): string {
+  // If the exact endpoint (with or without method) has a direct policy, don't normalize
+  if (getPolicy(`${endpoint}:${method}`) || getPolicy(endpoint)) {
+    return endpoint;
+  }
+
   for (const { re, policyBase } of PARAMETERIZED_ROUTE_PATTERNS) {
     const match = endpoint.match(re);
     if (match) {
@@ -725,7 +735,7 @@ export class RuntimeHttpServer {
     // Normalize parameterized endpoints to their base policy key so that
     // routes like `calls/abc123` match the registered key `calls` and
     // `attachments/abc123/content` matches `attachments/content`.
-    const normalizedEndpoint = normalizeEndpointForPolicy(endpoint);
+    const normalizedEndpoint = normalizeEndpointForPolicy(endpoint, req.method);
 
     // Enforce route-level scope/principal policy before invoking any handler.
     // Try method-specific key first (e.g. "messages:POST"); fall back to the

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -222,6 +222,56 @@ const DEFAULT_HOSTNAME = '127.0.0.1';
 /** Global hard cap on request body size (50 MB). */
 const MAX_REQUEST_BODY_BYTES = 50 * 1024 * 1024;
 
+// ---------------------------------------------------------------------------
+// Parameterized endpoint normalization for policy lookup
+// ---------------------------------------------------------------------------
+
+/**
+ * Patterns that map parameterized URLs back to their policy registry keys.
+ * Order matters: more specific patterns must come before general ones so
+ * that e.g. `attachments/{id}/content` matches before `attachments/{id}`.
+ */
+const PARAMETERIZED_ROUTE_PATTERNS: Array<{ re: RegExp; policyBase: string }> = [
+  // calls/{id}/cancel, calls/{id}/answer, calls/{id}/instruction
+  { re: /^calls\/[^/]+\/(cancel|answer|instruction)$/, policyBase: 'calls/$1' },
+  // calls/{id} (GET status)
+  { re: /^calls\/[^/]+$/, policyBase: 'calls' },
+  // contacts/{id}
+  { re: /^contacts\/[^/]+$/, policyBase: 'contacts' },
+  // ingress/members/{id}/block
+  { re: /^ingress\/members\/[^/]+\/block$/, policyBase: 'ingress/members/block' },
+  // ingress/members/{id}
+  { re: /^ingress\/members\/[^/]+$/, policyBase: 'ingress/members' },
+  // ingress/invites/{id}
+  { re: /^ingress\/invites\/[^/]+$/, policyBase: 'ingress/invites' },
+  // integrations/twilio/sms/compliance/tollfree/{sid}
+  { re: /^integrations\/twilio\/sms\/compliance\/tollfree\/[^/]+$/, policyBase: 'integrations/twilio/sms/compliance/tollfree' },
+  // attachments/{id}/content
+  { re: /^attachments\/[^/]+\/content$/, policyBase: 'attachments/content' },
+  // attachments/{id}
+  { re: /^attachments\/[^/]+$/, policyBase: 'attachments' },
+  // interfaces/{path}
+  { re: /^interfaces\/.+$/, policyBase: 'interfaces' },
+];
+
+/**
+ * Strip parameterized segments from an endpoint string so it matches
+ * the base route name used in the policy registry.
+ *
+ * For example, `calls/abc123` becomes `calls`, and
+ * `attachments/abc123/content` becomes `attachments/content`.
+ */
+function normalizeEndpointForPolicy(endpoint: string): string {
+  for (const { re, policyBase } of PARAMETERIZED_ROUTE_PATTERNS) {
+    const match = endpoint.match(re);
+    if (match) {
+      // Support capture-group substitution (e.g. calls/$1 -> calls/cancel)
+      return policyBase.replace(/\$(\d+)/g, (_, idx) => match[Number(idx)] ?? '');
+    }
+  }
+  return endpoint;
+}
+
 export class RuntimeHttpServer {
   private server: ReturnType<typeof Bun.serve> | null = null;
   private port: number;
@@ -502,6 +552,8 @@ export class RuntimeHttpServer {
   private async handleAuthenticatedRequest(req: Request, url: URL, path: string, server: ReturnType<typeof Bun.serve>, authContext: AuthContext): Promise<Response> {
     // Pairing registration (bearer-authenticated)
     if (path === '/v1/pairing/register' && req.method === 'POST') {
+      const policyDenied = enforcePolicy('pairing/register', authContext);
+      if (policyDenied) return policyDenied;
       return await handlePairingRegister(req, this.pairingContext);
     }
 
@@ -518,6 +570,8 @@ export class RuntimeHttpServer {
 
     // Cloud sharing endpoints
     if (path === '/v1/apps/share' && req.method === 'POST') {
+      const policyDenied = enforcePolicy('apps/share', authContext);
+      if (policyDenied) return policyDenied;
       try { return await handleShareApp(req); } catch (err) {
         log.error({ err }, 'Runtime HTTP handler error sharing app');
         return httpError('INTERNAL_ERROR', 'Internal server error', 500);
@@ -528,12 +582,16 @@ export class RuntimeHttpServer {
     if (sharedTokenMatch) {
       const shareToken = sharedTokenMatch[1];
       if (req.method === 'GET') {
+        const policyDenied = enforcePolicy('apps/shared:GET', authContext);
+        if (policyDenied) return policyDenied;
         try { return handleDownloadSharedApp(shareToken); } catch (err) {
           log.error({ err, shareToken }, 'Runtime HTTP handler error downloading shared app');
           return httpError('INTERNAL_ERROR', 'Internal server error', 500);
         }
       }
       if (req.method === 'DELETE') {
+        const policyDenied = enforcePolicy('apps/shared:DELETE', authContext);
+        if (policyDenied) return policyDenied;
         try { return handleDeleteSharedApp(shareToken); } catch (err) {
           log.error({ err, shareToken }, 'Runtime HTTP handler error deleting shared app');
           return httpError('INTERNAL_ERROR', 'Internal server error', 500);
@@ -543,6 +601,8 @@ export class RuntimeHttpServer {
 
     const sharedMetadataMatch = path.match(/^\/v1\/apps\/shared\/([^/]+)\/metadata$/);
     if (sharedMetadataMatch && req.method === 'GET') {
+      const policyDenied = enforcePolicy('apps/shared/metadata', authContext);
+      if (policyDenied) return policyDenied;
       try { return handleGetSharedAppMetadata(sharedMetadataMatch[1]); } catch (err) {
         log.error({ err, shareToken: sharedMetadataMatch[1] }, 'Runtime HTTP handler error getting shared app metadata');
         return httpError('INTERNAL_ERROR', 'Internal server error', 500);
@@ -551,12 +611,16 @@ export class RuntimeHttpServer {
 
     // Secret management endpoint
     if (path === '/v1/secrets' && req.method === 'POST') {
+      const policyDenied = enforcePolicy('secrets', authContext);
+      if (policyDenied) return policyDenied;
       try { return await handleAddSecret(req); } catch (err) {
         log.error({ err }, 'Runtime HTTP handler error adding secret');
         return httpError('INTERNAL_ERROR', 'Internal server error', 500);
       }
     }
     if (path === '/v1/secrets' && req.method === 'DELETE') {
+      const policyDenied = enforcePolicy('secrets', authContext);
+      if (policyDenied) return policyDenied;
       try { return await handleDeleteSecret(req); } catch (err) {
         log.error({ err }, 'Runtime HTTP handler error deleting secret');
         return httpError('INTERNAL_ERROR', 'Internal server error', 500);
@@ -658,11 +722,16 @@ export class RuntimeHttpServer {
   ): Promise<Response> {
     const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
 
+    // Normalize parameterized endpoints to their base policy key so that
+    // routes like `calls/abc123` match the registered key `calls` and
+    // `attachments/abc123/content` matches `attachments/content`.
+    const normalizedEndpoint = normalizeEndpointForPolicy(endpoint);
+
     // Enforce route-level scope/principal policy before invoking any handler.
     // Try method-specific key first (e.g. "messages:POST"); fall back to the
     // plain endpoint key only when no method-specific policy is registered.
-    const methodKey = `${endpoint}:${req.method}`;
-    const policyKey = getPolicy(methodKey) ? methodKey : endpoint;
+    const methodKey = `${normalizedEndpoint}:${req.method}`;
+    const policyKey = getPolicy(methodKey) ? methodKey : normalizedEndpoint;
     const policyDenied = enforcePolicy(policyKey, authContext);
     if (policyDenied) return policyDenied;
 

--- a/assistant/src/runtime/routes/twilio-routes.ts
+++ b/assistant/src/runtime/routes/twilio-routes.ts
@@ -38,7 +38,7 @@ import { syncTwilioWebhooks } from '../../daemon/handlers/config-ingress.js';
 import type { IngressConfig } from '../../inbound/public-ingress-urls.js';
 import { deleteSecureKey, getSecureKey, setSecureKey } from '../../security/secure-keys.js';
 import { deleteCredentialMetadata, upsertCredentialMetadata } from '../../tools/credentials/metadata-store.js';
-import { readHttpToken } from '../../util/platform.js';
+import { mintDaemonDeliveryToken } from '../auth/token-service.js';
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -716,14 +716,14 @@ export async function handleSmsSendTest(req: Request): Promise<Response> {
   const text = body.text || 'Test SMS from your Vellum assistant';
 
   // Send via gateway's /deliver/sms endpoint
-  const bearerToken = readHttpToken();
+  const bearerToken = mintDaemonDeliveryToken();
   const gatewayUrl = getGatewayInternalBaseUrl();
 
   const sendResp = await fetch(`${gatewayUrl}/deliver/sms`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      ...(bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {}),
+      Authorization: `Bearer ${bearerToken}`,
     },
     body: JSON.stringify({ to, text }),
     signal: AbortSignal.timeout(30_000),

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -1089,7 +1089,7 @@ public final class HTTPTransport {
     private func applyAuth(_ request: inout URLRequest) {
         // The JWT access token is the sole auth credential — it serves as
         // both authentication and identity.
-        if let accessToken = ActorTokenManager.getToken() {
+        if let accessToken = ActorTokenManager.getToken(), !accessToken.isEmpty {
             request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         } else if let token = bearerToken {
             // Fallback to legacy bearer token for initial bootstrap before


### PR DESCRIPTION
Addresses unresolved late review feedback from merged milestone PRs: (1) Replace readHttpToken() with mintDaemonDeliveryToken() across 15+ daemon→gateway callers, (2) add isEmpty guard on Swift applyAuth, (3) enforce route policy on early-return routes, (4) normalize parameterized paths for policy lookup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
