### PR TITLE
fix: make declutter email counts exact — archive scanned IDs, not re-query

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -276,9 +276,9 @@ When a user asks to declutter, clean up, or organize their email — start scann
    - **Show a `task_progress` card** with one step per selected sender (e.g., "Archiving TechCrunch (247 emails)"). Update each step from `in_progress` → `completed` as each sender finishes.
    - When all senders are processed, set the progress card's `status: "completed"`.
 4. **Act on selection**: For each selected sender:
-   - Use `gmail_archive_by_query` (or `messaging_archive_by_sender` for non-Gmail) with the sender's `search_query` — this archives all matching messages in one call, regardless of volume
+   - Use `gmail_batch_archive` (or `messaging_archive_by_sender` for non-Gmail) with the sender's `message_ids` array — this archives exactly the messages that were scanned and counted
    - If Gmail and the action is "Archive & Unsubscribe" and `has_unsubscribe` is true, call `gmail_unsubscribe` with the sender's `newest_message_id`
-5. **Accurate summary**: Use the **actual counts returned by the archive tool**, not the scan counts from the digest. The scan is a sample; the archive is comprehensive. Format: "Cleaned up [total_archived] emails from [sender_count] senders." For Gmail, append: "Unsubscribed from [unsub_count]."
+5. **Accurate summary**: The scan counts are exact — the `message_count` shown in the table matches the number of `message_ids` that were archived. Format: "Cleaned up [total_archived] emails from [sender_count] senders." For Gmail, append: "Unsubscribed from [unsub_count]."
 6. **Ongoing protection offer (Gmail only)**: After reporting results, offer auto-archive filters:
    - "Want me to set up auto-archive filters so future emails from these senders skip your inbox?"
    - If yes, call `gmail_filters` with `action: "create"` for each sender with `from` set to the sender's email and `remove_label_ids: ["INBOX"]`.
@@ -288,7 +288,7 @@ When a user asks to declutter, clean up, or organize their email — start scann
 
 - **Zero results**: Tell the user "No newsletter emails found" and suggest broadening the query (e.g. removing the category filter or extending the date range)
 - **Unsubscribe failures**: Report per-sender success/failure; the existing `gmail_unsubscribe` tool handles edge cases
-- **Large sender counts**: The `has_more` flag indicates a sender had more messages than collected — `gmail_archive_by_query` handles this automatically via its own pagination
+- **Large sender counts**: The scan covers up to 2000 messages. If `has_more` is true for a sender, it means they had more messages than could be tracked — mention this to the user in the summary
 
 ## Batch Operations
 

--- a/assistant/src/config/bundled-skills/messaging/TOOLS.json
+++ b/assistant/src/config/bundled-skills/messaging/TOOLS.json
@@ -1006,7 +1006,7 @@
           },
           "max_messages": {
             "type": "number",
-            "description": "Maximum messages to scan (default 500, cap 2000)"
+            "description": "Maximum messages to scan (default 2000, cap 2000)"
           },
           "max_senders": {
             "type": "number",
@@ -1035,7 +1035,7 @@
           },
           "max_messages": {
             "type": "number",
-            "description": "Maximum messages to scan (default 500, cap 2000)"
+            "description": "Maximum messages to scan (default 2000, cap 2000)"
           },
           "max_senders": {
             "type": "number",

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-batch-archive.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-batch-archive.ts
@@ -4,6 +4,8 @@ import { withValidToken } from '../../../../security/token-manager.js';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
 import { err,ok } from './shared.js';
 
+const BATCH_MODIFY_LIMIT = 1000;
+
 export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
   const messageIds = input.message_ids as string[];
 
@@ -14,7 +16,10 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
   try {
     const provider = getMessagingProvider('gmail');
     return withValidToken(provider.credentialService, async (token) => {
-      await batchModifyMessages(token, messageIds, { removeLabelIds: ['INBOX'] });
+      for (let i = 0; i < messageIds.length; i += BATCH_MODIFY_LIMIT) {
+        const chunk = messageIds.slice(i, i + BATCH_MODIFY_LIMIT);
+        await batchModifyMessages(token, chunk, { removeLabelIds: ['INBOX'] });
+      }
       return ok(`Archived ${messageIds.length} message(s).`);
     });
   } catch (e) {

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
@@ -5,7 +5,7 @@ import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.j
 import { err,ok } from './shared.js';
 
 const MAX_MESSAGES_CAP = 2000;
-const MAX_IDS_PER_SENDER = 1000;
+const MAX_IDS_PER_SENDER = 2000;
 const MAX_SAMPLE_SUBJECTS = 3;
 
 interface SenderAggregation {
@@ -36,7 +36,7 @@ function parseFrom(from: string): { displayName: string; email: string } {
 
 export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
   const query = (input.query as string) ?? 'category:promotions newer_than:90d';
-  const maxMessages = Math.min((input.max_messages as number) ?? 500, MAX_MESSAGES_CAP);
+  const maxMessages = Math.min((input.max_messages as number) ?? 2000, MAX_MESSAGES_CAP);
   const maxSenders = (input.max_senders as number) ?? 30;
 
   try {
@@ -165,7 +165,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         senders: result,
         total_scanned: allMessageIds.length,
         query_used: query,
-        note: `message_count reflects emails found per sender within the ${allMessageIds.length} messages scanned. The archive tool may find additional messages beyond this sample.`,
+        note: `message_count reflects emails found per sender within the ${allMessageIds.length} messages scanned. Use the message_ids array with gmail_batch_archive to archive exactly these messages.`,
       }));
     });
   } catch (e) {

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-sender-digest.ts
@@ -43,7 +43,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         senders,
         total_scanned: result.totalScanned,
         query_used: result.queryUsed,
-        note: `message_count reflects emails found per sender within the ${result.totalScanned} messages scanned. The archive tool may find additional messages beyond this sample.`,
+        note: `message_count reflects emails found per sender within the ${result.totalScanned} messages scanned. Use the message_ids array with the archive tool to archive exactly these messages.`,
       }));
     });
   } catch (e) {

--- a/assistant/src/messaging/providers/gmail/adapter.ts
+++ b/assistant/src/messaging/providers/gmail/adapter.ts
@@ -196,9 +196,9 @@ export const gmailMessagingProvider: MessagingProvider = {
   },
 
   async senderDigest(token: string, query: string, options?: { maxMessages?: number; maxSenders?: number }): Promise<SenderDigestResult> {
-    const maxMessages = Math.min(options?.maxMessages ?? 500, 2000);
+    const maxMessages = Math.min(options?.maxMessages ?? 2000, 2000);
     const maxSenders = options?.maxSenders ?? 30;
-    const maxIdsPerSender = 1000;
+    const maxIdsPerSender = 2000;
 
     const allMessageIds: string[] = [];
     let pageToken: string | undefined;


### PR DESCRIPTION
## Summary

- Bumped default scan from 500 → 2000 messages and `MAX_IDS_PER_SENDER` from 1000 → 2000 so every counted message has its ID tracked
- Switched declutter archive step from `gmail_archive_by_query` (independent re-search) to `gmail_batch_archive` (exact scanned `message_ids`), ensuring table counts match archived counts
- Added chunking to `gmail_batch_archive` (1000 per Gmail API call) to handle large ID sets

## Original prompt
The count shown in the declutter table wasn't the actual count of unsubscribed emails. Made scan = archive by using exact message IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
