### PR TITLE
fix: VDropdown click handling and conversation timeout setting

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -555,7 +555,9 @@ final class VoiceModeManager: ObservableObject {
 
     private func startConversationTimeout() {
         cancelConversationTimeout()
-        let interval = conversationTimeoutInterval
+        // Read the user's preference each time so changes take effect immediately
+        let storedTimeout = UserDefaults.standard.integer(forKey: "wakeWordTimeoutSeconds")
+        let interval = storedTimeout > 0 ? TimeInterval(storedTimeout) : conversationTimeoutInterval
         let clampedInterval = max(1.0, interval.isFinite ? interval : 30.0)
         conversationTimeoutTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(clampedInterval * 1_000_000_000))

--- a/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
@@ -1,8 +1,7 @@
 import SwiftUI
 
-/// A generic dropdown that looks pixel-identical to VTextField with a trailing chevron.
-/// Uses a ZStack: the visual layer is a plain styled HStack (no Menu chrome),
-/// and the interactive layer is a transparent Menu overlay on top.
+/// A styled dropdown using a native macOS `Menu` rendered inside a styled container.
+/// The visual layer is drawn separately and the Menu is overlaid transparently on top.
 public struct VDropdown<T: Hashable>: View {
     public let placeholder: String
     @Binding public var selection: T
@@ -30,56 +29,103 @@ public struct VDropdown<T: Hashable>: View {
     }
 
     public var body: some View {
-        ZStack {
-            // Visual layer — identical to VTextField(trailingIcon: "chevron.down")
-            HStack(spacing: VSpacing.md) {
-                Group {
-                    if let label = selectedLabel {
-                        Text(label)
-                            .foregroundColor(VColor.textPrimary)
-                    } else {
-                        Text(placeholder)
-                            .foregroundColor(VColor.textMuted)
-                    }
-                }
-                .font(VFont.body)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                Image(systemName: "chevron.down")
-                    .foregroundColor(VColor.textMuted)
-                    .font(.system(size: 14))
-                    .accessibilityHidden(true)
-            }
-            .padding(VSpacing.md)
-            .background(VColor.inputBackground)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-            )
-
-            // Interaction layer — transparent Menu, no visual chrome
-            Menu {
-                ForEach(options, id: \.value) { option in
-                    Button {
-                        selection = option.value
-                    } label: {
-                        HStack {
-                            Text(option.label)
-                            if option.value == selection {
-                                Image(systemName: "checkmark")
-                            }
-                        }
-                    }
-                }
-            } label: {
-                Color.clear.contentShape(Rectangle())
-            }
-            .menuStyle(.borderlessButton)
-            .menuIndicator(.hidden)
-            .accessibilityLabel(selectedLabel ?? placeholder)
-        }
+        VDropdownButton(
+            label: selectedLabel,
+            placeholder: placeholder,
+            options: options.map { ($0.label, $0.value) },
+            selection: $selection
+        )
+        .accessibilityLabel(selectedLabel ?? placeholder)
         .frame(maxWidth: .infinity)
+    }
+}
+
+/// NSViewRepresentable that wraps an NSPopUpButton styled to match the design system.
+/// This avoids SwiftUI Menu hit-testing issues entirely.
+private struct VDropdownButton<T: Hashable>: NSViewRepresentable {
+    let label: String?
+    let placeholder: String
+    let options: [(String, T)]
+    @Binding var selection: T
+
+    func makeNSView(context: Context) -> NSView {
+        let button = NSPopUpButton(frame: .zero, pullsDown: false)
+        button.bezelStyle = .roundRect
+        button.isBordered = false
+        button.font = NSFont(name: "Inter", size: 13) ?? NSFont.systemFont(ofSize: 13)
+        button.target = context.coordinator
+        button.action = #selector(Coordinator.selectionChanged(_:))
+
+        populateItems(button)
+        selectCurrentItem(button)
+
+        // Wrap in a container with a styled border
+        let container = NSView()
+        container.wantsLayer = true
+        container.layer?.cornerRadius = CGFloat(VRadius.md)
+        container.layer?.borderWidth = 1
+        container.layer?.borderColor = NSColor(VColor.surfaceBorder).withAlphaComponent(0.5).cgColor
+        container.layer?.backgroundColor = NSColor(VColor.inputBackground).cgColor
+
+        button.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(button)
+        NSLayoutConstraint.activate([
+            button.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 4),
+            button.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -4),
+            button.topAnchor.constraint(equalTo: container.topAnchor, constant: 2),
+            button.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -2),
+        ])
+
+        // Store button reference for updates
+        context.coordinator.button = button
+
+        return container
+    }
+
+    func updateNSView(_ container: NSView, context: Context) {
+        guard let button = context.coordinator.button else { return }
+        let currentTitles = button.itemTitles
+        let newTitles = options.map { $0.0 }
+        if currentTitles != newTitles {
+            populateItems(button)
+        }
+        selectCurrentItem(button)
+
+        // Update border color for light/dark mode changes
+        container.layer?.borderColor = NSColor(VColor.surfaceBorder).withAlphaComponent(0.5).cgColor
+        container.layer?.backgroundColor = NSColor(VColor.inputBackground).cgColor
+    }
+
+    private func populateItems(_ button: NSPopUpButton) {
+        button.removeAllItems()
+        for (label, _) in options {
+            button.addItem(withTitle: label)
+        }
+    }
+
+    private func selectCurrentItem(_ button: NSPopUpButton) {
+        if let idx = options.firstIndex(where: { $0.1 == selection }) {
+            button.selectItem(at: idx)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject {
+        var parent: VDropdownButton
+        weak var button: NSPopUpButton?
+
+        init(_ parent: VDropdownButton) {
+            self.parent = parent
+        }
+
+        @objc func selectionChanged(_ sender: NSPopUpButton) {
+            let idx = sender.indexOfSelectedItem
+            guard idx >= 0, idx < parent.options.count else { return }
+            parent.selection = parent.options[idx].1
+        }
     }
 }
 

--- a/clients/shared/DesignSystem/Modifiers/CardModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/CardModifier.swift
@@ -11,11 +11,14 @@ public struct CardModifier: ViewModifier {
 
     public func body(content: Content) -> some View {
         content
-            .background(background)
-            .clipShape(RoundedRectangle(cornerRadius: radius))
+            .background(
+                RoundedRectangle(cornerRadius: radius)
+                    .fill(background)
+            )
             .overlay(
                 RoundedRectangle(cornerRadius: radius)
                     .stroke(VColor.surfaceBorder, lineWidth: 1)
+                    .allowsHitTesting(false)
             )
     }
 }


### PR DESCRIPTION
## Summary
- **VDropdown**: Rewrite from SwiftUI Menu overlay to `NSPopUpButton` via `NSViewRepresentable` — fixes dropdown not responding to clicks in settings panels (the transparent Menu label in a ZStack failed to receive hit tests inside `.vCard` containers)
- **CardModifier**: Replace `.clipShape` with `.fill` background to avoid clipping interactive child content; add `.allowsHitTesting(false)` on border overlay
- **VoiceModeManager**: Read `wakeWordTimeoutSeconds` from UserDefaults so the conversation timeout picker in Voice Settings actually takes effect (was hardcoded to 30s)

## Test plan
- [x] VDropdown opens and selects options in Voice Settings
- [x] Timeout setting change takes effect (tested 5s and 30s)
- [x] Conversation auto-deactivates after configured timeout
- [x] Build succeeds
- [ ] CI passes
- [ ] Verify VDropdown works in ToolPermissionTesterView (other usage site)

Refs #11248 #11255

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
