### PR TITLE
fix: human-readable surface actions and prevent response truncation

### DIFF
--- a/assistant/src/__tests__/starter-task-flow.test.ts
+++ b/assistant/src/__tests__/starter-task-flow.test.ts
@@ -74,7 +74,7 @@ describe('starter task surface actions', () => {
     expect(ctx.pendingSurfaceActions.has('surf-1')).toBe(true);
   });
 
-  test('falls back to structured payload when prompt is absent', () => {
+  test('falls back to human-readable summary with action data when prompt is absent', () => {
     const forwarded: string[] = [];
     const ctx = makeContext();
     ctx.processMessage = async (content) => {
@@ -86,16 +86,9 @@ describe('starter task surface actions', () => {
     handleSurfaceAction(ctx, 'surf-2', 'relay_prompt', { topic: 'weather in sf' });
 
     expect(forwarded).toHaveLength(1);
-    const parsed = JSON.parse(forwarded[0]) as {
-      surfaceAction: boolean;
-      surfaceId: string;
-      actionId: string;
-      data: Record<string, unknown>;
-    };
-    expect(parsed.surfaceAction).toBe(true);
-    expect(parsed.surfaceId).toBe('surf-2');
-    expect(parsed.actionId).toBe('relay_prompt');
-    expect(parsed.data.topic).toBe('weather in sf');
+    expect(forwarded[0]).toContain('[User action on dynamic_page surface:');
+    expect(forwarded[0]).toContain('Action data:');
+    expect(forwarded[0]).toContain('"topic":"weather in sf"');
     expect(ctx.pendingSurfaceActions.has('surf-2')).toBe(true);
   });
 
@@ -111,12 +104,8 @@ describe('starter task surface actions', () => {
     handleSurfaceAction(ctx, 'surf-3', 'save_filters', { prompt: 'keep this literal field' });
 
     expect(forwarded).toHaveLength(1);
-    const parsed = JSON.parse(forwarded[0]) as {
-      actionId: string;
-      data: Record<string, unknown>;
-    };
-    expect(parsed.actionId).toBe('save_filters');
-    expect(parsed.data.prompt).toBe('keep this literal field');
+    expect(forwarded[0]).toContain('[User action on dynamic_page surface:');
+    expect(forwarded[0]).toContain('"prompt":"keep this literal field"');
   });
 
   test('consumes non-dynamic pending actions after forwarding', () => {

--- a/assistant/src/daemon/response-tier.ts
+++ b/assistant/src/daemon/response-tier.ts
@@ -37,6 +37,7 @@ const GREETING_PATTERNS = /^(hey|hi|hello|yo|sup|hiya|howdy|what'?s up|thanks|th
 
 const BUILD_KEYWORDS = /\b(build|implement|create|refactor|debug|deploy|migrate|scaffold|architect|redesign|generate|write|develop|fix|convert|add|remove|update|modify|change|delete|replace|integrate|setup|install|configure|optimize|rewrite)\b/i;
 
+const SURFACE_ACTION = /^\[User action on \w+ surface:/;
 const CODE_FENCE = /```/;
 const FILE_PATH = /(?:^|[\s"'(])(?:\/|~\/|\.\/)\S/;
 const MULTI_PARAGRAPH = /\n\s*\n/;
@@ -69,6 +70,7 @@ export function classifyResponseTierDetailed(message: string, _turnCount: number
   );
 
   // ── High signals (any match → high tier, high confidence) ──
+  if (SURFACE_ACTION.test(trimmed)) return tagged('high', 'surface_action', 'high');
   if (len > 500) return tagged('high', 'length>500', 'high');
   if (CODE_FENCE.test(trimmed)) return tagged('high', 'code_fence', 'high');
   if (FILE_PATH.test(trimmed)) return tagged('high', 'file_path', 'high');

--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -393,20 +393,14 @@ export function handleSurfaceAction(ctx: SurfaceSessionContext, surfaceId: strin
       ? data.prompt.trim()
       : '';
 
-  // Build a human-readable summary for confirmation surfaces so the LLM
-  // clearly understands the user's decision instead of parsing raw JSON.
-  let fallbackContent: string;
-  if (pending.surfaceType === 'confirmation') {
-    const summary = buildCompletionSummary('confirmation', actionId, data);
-    fallbackContent = `[User action on confirmation surface: ${summary}]`;
-  } else {
-    fallbackContent = JSON.stringify({
-      surfaceAction: true,
-      surfaceId,
-      surfaceType: pending.surfaceType,
-      actionId,
-      data: data ?? {},
-    });
+  // Build a human-readable summary so the LLM clearly understands the
+  // user's decision instead of parsing raw JSON.
+  const summary = buildCompletionSummary(pending.surfaceType, actionId, data);
+  let fallbackContent = `[User action on ${pending.surfaceType} surface: ${summary}]`;
+  // Append structured data so the LLM has access to IDs/values it needs
+  // to act on (e.g. selectedIds for archiving).
+  if (data && Object.keys(data).length > 0) {
+    fallbackContent += `\n\nAction data: ${JSON.stringify(data)}`;
   }
   const content = prompt || fallbackContent;
 


### PR DESCRIPTION
## Summary
- Surface action messages from table/list/form interactions now display as human-readable summaries (e.g. `[User action on table surface: Selected 5 rows]`) instead of raw JSON blobs
- Surface action messages are now classified as high-tier in the response tier system, giving the LLM the full 16k token budget instead of being throttled to 2k tokens (which caused mid-sentence truncation)
- Updated tests to match the new human-readable format

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
