### PR TITLE
refactor: replace vellum_skills_catalog refs with skill_load

### DIFF
--- a/assistant/src/config/bundled-skills/google-calendar/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-calendar/SKILL.md
@@ -2,7 +2,7 @@
 name: "Google Calendar"
 description: "View, create, and manage Google Calendar events and check availability"
 user-invocable: true
-metadata: {"vellum": {"emoji": "📅"}}
+metadata: { "vellum": { "emoji": "📅" } }
 ---
 
 You are a Google Calendar assistant with full access to the user's calendar. Use the Calendar tools to help them view, create, and manage events.
@@ -12,10 +12,9 @@ You are a Google Calendar assistant with full access to the user's calendar. Use
 Before using any Calendar tool, verify that Google Calendar is connected by attempting a lightweight call (e.g., `calendar_list_events` with a narrow date range). If the call fails with a token/authorization error:
 
 1. **Do NOT call `credential_store oauth2_connect` yourself.** You do not have valid OAuth client credentials, and fabricating a client_id will cause a "401: invalid_client" error from Google.
-2. Instead, install and load the **google-oauth-setup** skill, which walks the user through creating real credentials in Google Cloud Console:
-   - Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "google-oauth-setup"`.
-   - Then call `vellum_skills_catalog` with `action: "load"` and `skill_id: "google-oauth-setup"`.
-3. Tell the user: *"Google Calendar isn't connected yet. I've loaded a setup guide that will walk you through connecting your Google account — it only takes a couple of minutes."*
+2. Instead, load the **google-oauth-setup** skill, which walks the user through creating real credentials in Google Cloud Console:
+   - Call `skill_load` with `skill_id: "google-oauth-setup"` to load the dependency skill.
+3. Tell the user: _"Google Calendar isn't connected yet. I've loaded a setup guide that will walk you through connecting your Google account — it only takes a couple of minutes."_
 
 ## Capabilities
 

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -2,7 +2,7 @@
 name: "Messaging"
 description: "Read, search, send, and manage messages across Slack, Gmail, Telegram, and other platforms"
 user-invocable: true
-metadata: {"vellum": {"emoji": "💬"}}
+metadata: { "vellum": { "emoji": "💬" } }
 ---
 
 You are a unified messaging assistant with access to multiple platforms (Slack, Gmail, Telegram, and more). Use the messaging tools to help users read, search, organize, draft, and send messages across all connected platforms.
@@ -39,10 +39,10 @@ When the user asks to "connect my email", "set up email", "manage my email", or 
 3. **Once the provider is known, act immediately.** Don't present setup options or explain OAuth. If it's Gmail, follow the Gmail section below. For any other provider, let the user know that only Gmail is fully supported right now, and offer to set up Gmail instead.
 
 ### Gmail
+
 1. **Try connecting directly first.** Call `credential_store` with `action: "oauth2_connect"` and `service: "gmail"`. The tool auto-fills Google's OAuth endpoints and looks up any previously stored client credentials — so this single call may be all that's needed.
-2. **If it fails because no client_id is found:** The user needs to create Google Cloud OAuth credentials first. Install and load the **google-oauth-setup** skill (which depends on **public-ingress** for the redirect URI):
-   - Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "google-oauth-setup"`.
-   - Then call `skill_load` with `skill: "google-oauth-setup"`.
+2. **If it fails because no client_id is found:** The user needs to create Google Cloud OAuth credentials first. Load the **google-oauth-setup** skill (which depends on **public-ingress** for the redirect URI):
+   - Call `skill_load` with `skill_id: "google-oauth-setup"` to load the dependency skill.
    - Tell the user Gmail isn't connected yet and briefly explain what the setup involves, then use `ui_show` with `surface_type: "confirmation"` to ask for permission to start:
      - **message:** "Ready to set up Gmail?"
      - **detail:** "I'll open a browser where you sign in to Google, then automate everything else — creating a project, enabling APIs, and connecting your account. Takes 2-3 minutes and you can watch in the browser preview panel."
@@ -52,10 +52,10 @@ When the user asks to "connect my email", "set up email", "manage my email", or 
 3. **If the user provides a client_id directly in chat:** Call `credential_store` with `action: "oauth2_connect"`, `service: "gmail"`, and `client_id: "<their value>"`. Include `client_secret` too if they provide one. Everything else is auto-filled.
 
 ### Slack
+
 1. **Try connecting directly first.** Call `credential_store` with `action: "oauth2_connect"` and `service: "slack"`. The tool auto-fills Slack's OAuth endpoints and looks up any previously stored client credentials.
-2. **If it fails because no client_id is found:** The user needs to create a Slack App first. Install and load the **slack-oauth-setup** skill:
-   - Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "slack-oauth-setup"`.
-   - Then call `skill_load` with `skill: "slack-oauth-setup"`.
+2. **If it fails because no client_id is found:** The user needs to create a Slack App first. Load the **slack-oauth-setup** skill:
+   - Call `skill_load` with `skill_id: "slack-oauth-setup"` to load the dependency skill.
    - Tell the user Slack isn't connected yet and briefly explain what the setup involves, then use `ui_show` with `surface_type: "confirmation"` to ask for permission to start:
      - **message:** "Ready to set up Slack?"
      - **detail:** "I'll walk you through creating a Slack App and connecting your workspace. The process takes a few minutes, and I'll ask for your approval before each step."
@@ -65,20 +65,22 @@ When the user asks to "connect my email", "set up email", "manage my email", or 
 3. **If the user provides client_id and client_secret directly in chat:** Call `credential_store` with `action: "oauth2_connect"`, `service: "slack"`, `client_id`, and `client_secret`. Everything else is auto-filled. Note: Slack always requires a client_secret.
 
 ### Telegram
-Telegram uses a bot token (not OAuth). Install and load the **telegram-setup** skill (which depends on **public-ingress** for the webhook URL) which automates the full setup:
-   - Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "telegram-setup"`.
-   - Then call `skill_load` with `skill: "telegram-setup"`.
-   - Tell the user: *"I've loaded a setup guide for Telegram. It will walk you through connecting a Telegram bot to your assistant."*
+
+Telegram uses a bot token (not OAuth). Load the **telegram-setup** skill (which depends on **public-ingress** for the webhook URL) which automates the full setup:
+
+- Call `skill_load` with `skill_id: "telegram-setup"` to load the dependency skill.
+- Tell the user: _"I've loaded a setup guide for Telegram. It will walk you through connecting a Telegram bot to your assistant."_
 
 The telegram-setup skill handles: verifying the bot token from @BotFather, generating a webhook secret, registering bot commands, and storing credentials securely via the secure credential prompt flow. **Never accept a Telegram bot token pasted in plaintext chat — always use the secure prompt.** Webhook registration with Telegram is handled automatically by the gateway on startup and whenever credentials change.
 
 The telegram-setup skill also includes **guardian verification**, which links your Telegram account as the trusted guardian for the bot.
 
 ### SMS (Twilio)
+
 SMS messaging uses Twilio as the telephony provider. Twilio credentials and phone number configuration are shared with the **phone-calls** skill. Load the **sms-setup** skill for complete SMS configuration including compliance and testing:
-   - Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "sms-setup"`.
-   - Then call `skill_load` with `skill: "sms-setup"`.
-   - Tell the user: *"I've loaded the SMS setup guide. It will walk you through configuring Twilio, handling compliance requirements, and testing SMS delivery."*
+
+- Call `skill_load` with `skill_id: "sms-setup"` to load the dependency skill.
+- Tell the user: _"I've loaded the SMS setup guide. It will walk you through configuring Twilio, handling compliance requirements, and testing SMS delivery."_
 
 The sms-setup skill handles: Twilio credential storage (Account SID + Auth Token), phone number provisioning or assignment, public ingress setup, SMS compliance verification, and end-to-end test sending. Once SMS is set up, messaging is available automatically — no additional feature flag is needed.
 
@@ -86,10 +88,9 @@ The sms-setup skill also includes optional **guardian verification** for SMS, wh
 
 ### Guardian Verification (SMS, Voice, or Telegram)
 
-If the user asks to verify their guardian identity for any channel (SMS, voice, or Telegram), install and load the **guardian-verify-setup** skill:
+If the user asks to verify their guardian identity for any channel (SMS, voice, or Telegram), load the **guardian-verify-setup** skill:
 
-- Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "guardian-verify-setup"`.
-- Then call `skill_load` with `skill: "guardian-verify-setup"`.
+- Call `skill_load` with `skill_id: "guardian-verify-setup"` to load the dependency skill.
 
 The guardian-verify-setup skill handles the full outbound verification flow for all supported channels. It collects the user's destination (phone number or Telegram chat ID/handle), initiates an outbound verification session, and guides the user through entering or replying with the verification code. This is the single source of truth for guardian verification setup -- do not duplicate the verification flow inline.
 
@@ -107,11 +108,12 @@ When a messaging tool fails with a token or authorization error:
 - If the user specifies a platform (e.g., "check my Slack"), pass it as the `platform` parameter.
 - If only one platform is connected, it is auto-selected.
 - If multiple platforms are connected and the user doesn't specify, ask which platform they mean — or search across all of them.
-- **Be action-oriented with email.** When the user says "email" and wants to *do* something (declutter, check, search, send), check what's connected first. If nothing is connected, ask which provider briefly and then go straight into setup — don't present menus, options lists, or explain the setup process. Just do it.
+- **Be action-oriented with email.** When the user says "email" and wants to _do_ something (declutter, check, search, send), check what's connected first. If nothing is connected, ask which provider briefly and then go straight into setup — don't present menus, options lists, or explain the setup process. Just do it.
 
 ## Capabilities
 
 ### Universal (Slack, Gmail)
+
 - **Auth Test**: Verify connection and show account info
 - **List Conversations**: Show channels, inboxes, DMs with unread counts
 - **Read Messages**: Read message history from a conversation
@@ -121,40 +123,48 @@ When a messaging tool fails with a token or authorization error:
 - **Mark Read**: Mark conversation as read
 
 ### Telegram
+
 Telegram is supported as a messaging provider with limited capabilities compared to Slack and Gmail due to Bot API constraints:
 
 - **Send**: Send a message to a known chat ID (high risk — requires user approval)
 - **Auth Test**: Verify bot token and show bot info
 
 **Not available** (Bot API limitations):
+
 - List conversations — the Bot API does not expose a method to enumerate chats a bot belongs to
 - Read message history — bots cannot retrieve past messages from a chat
 - Search messages — no search API is available for bots
 
 **Bot-account limits:**
+
 - The bot can only message users or groups that have previously interacted with it (sent `/start` or been added to a group). Bots cannot initiate conversations with arbitrary phone numbers.
 - Future support for MTProto user-account sessions may lift some of these restrictions.
 
 ### SMS (Twilio)
+
 SMS is supported as a messaging provider with limited capabilities. The conversation ID is the recipient's phone number in E.164 format (e.g. `+14155551234`):
 
 - **Send**: Send an SMS to a phone number (high risk — requires user approval)
 - **Auth Test**: Verify Twilio credentials and show the configured phone number
 
 **Not available** (SMS limitations):
+
 - List conversations — SMS is stateless; there is no API to enumerate past conversations
 - Read message history — message history is not available through the gateway
 - Search messages — no search API is available for SMS
 
 **SMS limits:**
+
 - Outbound SMS uses the assistant's configured Twilio phone number as the sender. The phone number must be provisioned and assigned via the twilio-setup skill.
 - SMS messages are subject to Twilio's character limits and carrier filtering. Long messages may be split into multiple segments.
 
 ### Slack-specific
+
 - **Add Reaction**: Add an emoji reaction to a message
 - **Leave Channel**: Leave a Slack channel
 
 ### Gmail-specific
+
 - **Archive**: Remove message from inbox
 - **Label**: Add/remove labels
 - **Trash**: Move to trash
@@ -162,6 +172,7 @@ SMS is supported as a messaging provider with limited capabilities. The conversa
 - **Draft (native)**: Create a draft in Gmail's Drafts folder
 
 ### Attachments (Gmail)
+
 - **List Attachments**: `gmail_list_attachments` — list all attachments on a message with filename, MIME type, size, and attachment ID
 - **Download Attachment**: `gmail_download_attachment` — download an attachment to the working directory by message ID + attachment ID
 - **Send with Attachments**: `gmail_send_with_attachments` — send an email with file attachments (reads files from disk, builds multipart MIME)
@@ -169,21 +180,25 @@ SMS is supported as a messaging provider with limited capabilities. The conversa
 Workflow: use `gmail_list_attachments` to discover attachments, then `gmail_download_attachment` to save them locally.
 
 ### Forward & Thread Operations (Gmail)
+
 - **Forward**: `gmail_forward` — forward a message to another recipient, preserving all attachments. Optionally prepend your own text
 - **Summarize Thread**: `gmail_summarize_thread` — LLM-powered thread summary with participants, decisions, open questions, and sentiment
 - **Follow-up Tracking**: `gmail_follow_up` — track/untrack messages for follow-up using a dedicated "Follow-up" label, or list all tracked messages
 
 ### Smart Triage (Gmail)
+
 - **Triage**: `gmail_triage` — LLM-powered inbox classification of unread emails into categories: `needs_reply`, `fyi_only`, `can_archive`, `urgent`, `newsletter`, `promotional`
   - Returns grouped report with reasoning and suggested actions per email
   - Set `auto_apply: true` to auto-archive `can_archive` emails and label `needs_reply` as "Follow-up"
   - Custom query support (default: `is:unread in:inbox`)
 
 ### Inbox Automation (Gmail)
+
 - **Filters**: `gmail_filters` — list, create, or delete Gmail filters. Filter criteria include from, to, subject, query, has_attachment. Actions include adding/removing labels and forwarding
 - **Vacation Responder**: `gmail_vacation` — get, enable, or disable the vacation auto-responder with custom message, date range, and domain/contact restrictions
 
 ### Google Contacts
+
 - **Contacts**: `google_contacts` — list or search Google Contacts by name or email. Returns name, email, phone, and organization
   - Requires the `contacts.readonly` scope — users may need to re-authorize Gmail to grant this additional permission
 
@@ -191,30 +206,30 @@ Workflow: use `gmail_list_attachments` to discover attachments, then `gmail_down
 
 When searching Slack, the query is passed directly to Slack's search API:
 
-| Operator | Example | What it finds |
-|---|---|---|
-| `from:` | `from:@alice` | Messages from a specific user |
-| `in:` | `in:#general` | Messages in a specific channel |
-| `has:` | `has:link` | Messages containing links |
-| `before:` | `before:2024-01-01` | Messages before a date |
-| `after:` | `after:2024-01-01` | Messages after a date |
-| `has:reaction` | `has:reaction` | Messages with reactions |
-| `has:star` | `has:star` | Starred messages |
+| Operator       | Example             | What it finds                  |
+| -------------- | ------------------- | ------------------------------ |
+| `from:`        | `from:@alice`       | Messages from a specific user  |
+| `in:`          | `in:#general`       | Messages in a specific channel |
+| `has:`         | `has:link`          | Messages containing links      |
+| `before:`      | `before:2024-01-01` | Messages before a date         |
+| `after:`       | `after:2024-01-01`  | Messages after a date          |
+| `has:reaction` | `has:reaction`      | Messages with reactions        |
+| `has:star`     | `has:star`          | Starred messages               |
 
 ## Gmail Search Syntax
 
 When searching Gmail, the query uses Gmail's search operators:
 
-| Operator | Example | What it finds |
-|---|---|---|
-| `from:` | `from:alice@example.com` | Messages from a specific sender |
-| `to:` | `to:bob@example.com` | Messages sent to a recipient |
-| `subject:` | `subject:meeting` | Messages with a word in the subject |
-| `newer_than:` | `newer_than:7d` | Messages from the last 7 days |
-| `older_than:` | `older_than:30d` | Messages older than 30 days |
-| `is:unread` | `is:unread` | Unread messages |
-| `has:attachment` | `has:attachment` | Messages with attachments |
-| `label:` | `label:work` | Messages with a specific label |
+| Operator         | Example                  | What it finds                       |
+| ---------------- | ------------------------ | ----------------------------------- |
+| `from:`          | `from:alice@example.com` | Messages from a specific sender     |
+| `to:`            | `to:bob@example.com`     | Messages sent to a recipient        |
+| `subject:`       | `subject:meeting`        | Messages with a word in the subject |
+| `newer_than:`    | `newer_than:7d`          | Messages from the last 7 days       |
+| `older_than:`    | `older_than:30d`         | Messages older than 30 days         |
+| `is:unread`      | `is:unread`              | Unread messages                     |
+| `has:attachment` | `has:attachment`         | Messages with attachments           |
+| `label:`         | `label:work`             | Messages with a specific label      |
 
 ## Drafting vs Sending
 

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -2,7 +2,8 @@
 name: "Phone Calls"
 description: "Set up Twilio for AI-powered voice calls — both outgoing calls on behalf of the user and incoming calls where the assistant answers as a receptionist"
 user-invocable: true
-metadata: {"vellum": {"emoji": "📞", "requires": {"config": ["calls.enabled"]}}}
+metadata:
+  { "vellum": { "emoji": "📞", "requires": { "config": ["calls.enabled"] } } }
 includes: ["public-ingress"]
 ---
 
@@ -34,6 +35,7 @@ When someone dials the assistant's Twilio phone number:
 6. The assistant converses naturally, using ASK_GUARDIAN to consult the user when needed, just like outbound calls.
 
 Three voice quality modes are available:
+
 - **`twilio_standard`** (default) — Fully supported. Standard Twilio TTS with Google voices. No extra setup required.
 - **`twilio_elevenlabs_tts`** — Fully supported. Uses ElevenLabs voices through Twilio ConversationRelay for more natural speech.
 - **`elevenlabs_agent`** — **Experimental/restricted.** Full ElevenLabs conversational agent mode. Consultation bridging (`waiting_on_user`) is not yet supported in this mode; the runtime guard blocks it before any ElevenLabs API calls are made. See the "Runtime behavior" section below for fallback and strict-fail details.
@@ -60,8 +62,7 @@ If `hasCredentials` is `true`, `phoneNumber` is set, and `calls.enabled` is `tru
 
 If Twilio is not yet configured, load the **twilio-setup** skill — it handles credential storage, phone number provisioning, and public ingress setup:
 
-- Call `vellum_skills_catalog` with `action: "install"`, `skill_id: "twilio-setup"`, and `overwrite: true`.
-- Then call `skill_load` with `skill: "twilio-setup"`.
+- Call `skill_load` with `skill_id: "twilio-setup"` to load the dependency skill.
 
 Once twilio-setup completes, return here to enable calls.
 
@@ -74,6 +75,7 @@ vellum config set calls.enabled true
 ```
 
 Verify:
+
 ```bash
 vellum config get calls.enabled
 ```
@@ -108,10 +110,10 @@ credential_store action=store service=twilio field=user_phone_number value=+1415
 
 ### Configuration reference
 
-| Setting | Description | Default |
-|---|---|---|
-| `calls.callerIdentity.allowPerCallOverride` | Whether per-call mode selection is allowed | `true` |
-| `calls.callerIdentity.userNumber` | Optional E.164 phone number for user-number mode (alternative to storing via `credential_store`) | *(empty)* |
+| Setting                                     | Description                                                                                      | Default   |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------ | --------- |
+| `calls.callerIdentity.allowPerCallOverride` | Whether per-call mode selection is allowed                                                       | `true`    |
+| `calls.callerIdentity.userNumber`           | Optional E.164 phone number for user-number mode (alternative to storing via `credential_store`) | _(empty)_ |
 
 ## DTMF Callee Verification
 
@@ -127,10 +129,10 @@ An optional verification step where the callee must enter a numeric code via the
 
 ### Configuration
 
-| Setting | Description | Default |
-|---|---|---|
-| `calls.verification.enabled` | Enable DTMF callee verification | `false` |
-| `calls.verification.codeLength` | Number of digits in the verification code | `6` |
+| Setting                         | Description                               | Default |
+| ------------------------------- | ----------------------------------------- | ------- |
+| `calls.verification.enabled`    | Enable DTMF callee verification           | `false` |
+| `calls.verification.codeLength` | Number of digits in the verification code | `6`     |
 
 ## Optional: Higher Quality Voice with ElevenLabs
 
@@ -218,6 +220,7 @@ vellum config set calls.voice.mode twilio_standard
 ## Making Outbound Calls
 
 Use the `call_start` tool to place outbound calls. Every call requires:
+
 - **phone_number**: The number to call in E.164 format (e.g. `+14155551234`)
 - **task**: What the call should accomplish — this becomes the AI voice agent's objective
 - **context** (optional): Additional background information for the conversation
@@ -225,16 +228,19 @@ Use the `call_start` tool to place outbound calls. Every call requires:
 ### Example calls:
 
 **Making a reservation:**
+
 ```
 call_start phone_number="+14155551234" task="Make a dinner reservation for 2 people tonight at 7pm" context="The user's name is John Smith. Prefer a table by the window if available."
 ```
 
 **Calling a business:**
+
 ```
 call_start phone_number="+18005551234" task="Check if they have a specific product in stock" context="Looking for a 65-inch Samsung OLED TV, model QN65S95D. Ask about availability and price."
 ```
 
 **Following up on an appointment:**
+
 ```
 call_start phone_number="+12125551234" task="Confirm the dentist appointment scheduled for next Tuesday at 2pm" context="The appointment is under the name Jane Doe, DOB 03/15/1990."
 ```
@@ -244,11 +250,13 @@ call_start phone_number="+12125551234" task="Confirm the dentist appointment sch
 Implicit calls always use the assistant's Twilio number (`assistant_number`). Only specify `caller_identity_mode` when the user explicitly requests a different identity for a specific call.
 
 **Default call (assistant number):**
+
 ```
 call_start phone_number="+14155551234" task="Check store hours for today"
 ```
 
 **Call from the user's own number:**
+
 ```
 call_start phone_number="+14155551234" task="Check store hours for today" caller_identity_mode="user_number"
 ```
@@ -258,6 +266,7 @@ call_start phone_number="+14155551234" task="Check store hours for today" caller
 ### Phone number format
 
 Phone numbers MUST be in E.164 format: `+` followed by country code and number with no spaces, dashes, or parentheses.
+
 - US/Canada: `+1XXXXXXXXXX` (e.g. `+14155551234`)
 - UK: `+44XXXXXXXXXX` (e.g. `+442071234567`)
 - International: `+{country_code}{number}`
@@ -267,6 +276,7 @@ If the user provides a number in a different format, convert it to E.164 before 
 ### Trial account limitations
 
 On Twilio trial accounts, outbound calls can ONLY be made to **verified numbers**. If a call fails with a "not verified" error:
+
 1. Tell the user they need to verify the number at https://console.twilio.com/us1/develop/phone-numbers/manage/verified
 2. Or upgrade to a paid Twilio account to call any number
 
@@ -283,7 +293,7 @@ No additional configuration is needed beyond Twilio setup and `calls.enabled` be
 
 ### Guardian voice verification for inbound calls
 
-For guardian verification setup, first install the skill via `vellum_skills_catalog` with `action: "install"` and `skill_id: "guardian-verify-setup"`, then load it with `skill_load` using `skill: "guardian-verify-setup"`. This skill handles the full outbound verification flow; `phone-calls` does not orchestrate it inline. Do not use `call_start` to place guardian verification calls — the guardian outbound verification endpoints already place those calls.
+For guardian verification setup, load the skill by calling `skill_load` with `skill_id: "guardian-verify-setup"`. This skill handles the full outbound verification flow; `phone-calls` does not orchestrate it inline. Do not use `call_start` to place guardian verification calls — the guardian outbound verification endpoints already place those calls.
 
 Once a guardian binding exists for the voice channel, inbound callers may be prompted for verification before calls proceed. The relay server detects pending challenges and prompts callers: "Please enter your six-digit verification code using your keypad, or speak the digits now." If verification fails after 3 attempts, the call ends with "Verification failed. Goodbye."
 
@@ -345,6 +355,7 @@ The instruction is injected into the AI voice agent's conversation context as hi
 ### Ending a call early
 
 Use `call_end` with the call session ID to terminate an active call:
+
 ```
 call_end call_session_id="<session_id>" reason="User requested to end the call"
 ```
@@ -371,6 +382,7 @@ sqlite3 ~/.vellum/workspace/data/db/assistant.db \
 ```
 
 This returns all messages in chronological order with:
+
 - `role: "user"` — caller speech (prefixed with `[SPEAKER]` tags) and system events
 - `role: "assistant"` — assistant responses, including `text` content and any `tool_use`/`tool_result` blocks
 
@@ -385,22 +397,22 @@ sqlite3 ~/.vellum/workspace/data/db/assistant.db \
 
 ### Additional tables for call metadata
 
-| Table | What it contains |
-|---|---|
-| `call_sessions` | Session metadata (start time, duration, phone numbers, status) |
-| `call_events` | Granular event log for the call lifecycle |
-| `notification_decisions` | Whether notifications were evaluated during the call |
-| `notification_deliveries` | Notification delivery attempts |
+| Table                     | What it contains                                               |
+| ------------------------- | -------------------------------------------------------------- |
+| `call_sessions`           | Session metadata (start time, duration, phone numbers, status) |
+| `call_events`             | Granular event log for the call lifecycle                      |
+| `notification_decisions`  | Whether notifications were evaluated during the call           |
+| `notification_deliveries` | Notification delivery attempts                                 |
 
 ### Key paths
 
-| Resource | Path |
-|---|---|
+| Resource                                   | Path                                       |
+| ------------------------------------------ | ------------------------------------------ |
 | Daemon logs (caller-side transcripts only) | `~/.vellum/workspace/data/logs/vellum.log` |
-| Full conversation database | `~/.vellum/workspace/data/db/assistant.db` |
-| Messages table | `messages` (keyed by `conversation_id`) |
-| Call sessions table | `call_sessions` |
-| Call events table | `call_events` |
+| Full conversation database                 | `~/.vellum/workspace/data/db/assistant.db` |
+| Messages table                             | `messages` (keyed by `conversation_id`)    |
+| Call sessions table                        | `call_sessions`                            |
+| Call events table                          | `call_events`                              |
 
 ### Important
 
@@ -429,6 +441,7 @@ The `context` field is powerful — use it to give the agent background that hel
 ### Things the AI voice agent handles well
 
 **Outbound calls:**
+
 - Making reservations and appointments
 - Checking business hours, availability, or pricing
 - Confirming or rescheduling existing appointments
@@ -437,6 +450,7 @@ The `context` field is powerful — use it to give the agent background that hel
 - Leaving voicemails (it will speak the message if voicemail picks up)
 
 **Inbound calls:**
+
 - Answering as a receptionist and routing caller requests to the user via ASK_GUARDIAN
 - Taking messages when the user is unavailable
 - Answering questions the assistant already knows from memory/context
@@ -453,27 +467,27 @@ The `context` field is powerful — use it to give the agent background that hel
 
 All call-related settings can be managed via `vellum config`:
 
-| Setting | Description | Default |
-|---|---|---|
-| `calls.enabled` | Master switch for the calling feature | `false` |
-| `calls.provider` | Voice provider (currently only `twilio`) | `twilio` |
-| `calls.maxDurationSeconds` | Maximum call length in seconds | `3600` (1 hour) |
-| `calls.userConsultTimeoutSeconds` | How long to wait for user answers | `120` (2 min) |
-| `calls.disclosure.enabled` | Whether the AI announces itself at call start | `true` |
-| `calls.disclosure.text` | The disclosure message spoken at call start | `"At the very beginning of the call, introduce yourself as an assistant calling on behalf of my human."` |
-| `calls.model` | Override LLM model for call orchestration | *(uses default model)* |
-| `calls.callerIdentity.allowPerCallOverride` | Allow per-call caller identity selection | `true` |
-| `calls.callerIdentity.userNumber` | E.164 phone number for user-number mode | *(empty)* |
-| `calls.voice.mode` | Voice quality mode (`twilio_standard`, `twilio_elevenlabs_tts`, `elevenlabs_agent`) | `twilio_standard` |
-| `calls.voice.language` | Language code for TTS and transcription | `en-US` |
-| `calls.voice.transcriptionProvider` | Speech-to-text provider (`Deepgram`, `Google`) | `Deepgram` |
-| `calls.voice.fallbackToStandardOnError` | Auto-fallback to standard Twilio TTS on ElevenLabs errors | `true` |
-| `calls.voice.elevenlabs.voiceId` | Advanced/internal ElevenLabs voice identifier. Usually set by the assistant based on requested voice style | *(empty)* |
-| `calls.voice.elevenlabs.voiceModelId` | Optional Twilio ConversationRelay model suffix. Leave empty to send bare `voiceId` | *(empty)* |
-| `calls.voice.elevenlabs.agentId` | ElevenLabs agent ID (for `elevenlabs_agent` mode) | *(empty)* |
-| `calls.voice.elevenlabs.speed` | Playback speed (`0.7` – `1.2`) | `1.0` |
-| `calls.voice.elevenlabs.stability` | Voice stability (`0.0` – `1.0`) | `0.5` |
-| `calls.voice.elevenlabs.similarityBoost` | Voice similarity boost (`0.0` – `1.0`) | `0.75` |
+| Setting                                     | Description                                                                                                | Default                                                                                                  |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `calls.enabled`                             | Master switch for the calling feature                                                                      | `false`                                                                                                  |
+| `calls.provider`                            | Voice provider (currently only `twilio`)                                                                   | `twilio`                                                                                                 |
+| `calls.maxDurationSeconds`                  | Maximum call length in seconds                                                                             | `3600` (1 hour)                                                                                          |
+| `calls.userConsultTimeoutSeconds`           | How long to wait for user answers                                                                          | `120` (2 min)                                                                                            |
+| `calls.disclosure.enabled`                  | Whether the AI announces itself at call start                                                              | `true`                                                                                                   |
+| `calls.disclosure.text`                     | The disclosure message spoken at call start                                                                | `"At the very beginning of the call, introduce yourself as an assistant calling on behalf of my human."` |
+| `calls.model`                               | Override LLM model for call orchestration                                                                  | _(uses default model)_                                                                                   |
+| `calls.callerIdentity.allowPerCallOverride` | Allow per-call caller identity selection                                                                   | `true`                                                                                                   |
+| `calls.callerIdentity.userNumber`           | E.164 phone number for user-number mode                                                                    | _(empty)_                                                                                                |
+| `calls.voice.mode`                          | Voice quality mode (`twilio_standard`, `twilio_elevenlabs_tts`, `elevenlabs_agent`)                        | `twilio_standard`                                                                                        |
+| `calls.voice.language`                      | Language code for TTS and transcription                                                                    | `en-US`                                                                                                  |
+| `calls.voice.transcriptionProvider`         | Speech-to-text provider (`Deepgram`, `Google`)                                                             | `Deepgram`                                                                                               |
+| `calls.voice.fallbackToStandardOnError`     | Auto-fallback to standard Twilio TTS on ElevenLabs errors                                                  | `true`                                                                                                   |
+| `calls.voice.elevenlabs.voiceId`            | Advanced/internal ElevenLabs voice identifier. Usually set by the assistant based on requested voice style | _(empty)_                                                                                                |
+| `calls.voice.elevenlabs.voiceModelId`       | Optional Twilio ConversationRelay model suffix. Leave empty to send bare `voiceId`                         | _(empty)_                                                                                                |
+| `calls.voice.elevenlabs.agentId`            | ElevenLabs agent ID (for `elevenlabs_agent` mode)                                                          | _(empty)_                                                                                                |
+| `calls.voice.elevenlabs.speed`              | Playback speed (`0.7` – `1.2`)                                                                             | `1.0`                                                                                                    |
+| `calls.voice.elevenlabs.stability`          | Voice stability (`0.0` – `1.0`)                                                                            | `0.5`                                                                                                    |
+| `calls.voice.elevenlabs.similarityBoost`    | Voice similarity boost (`0.0` – `1.0`)                                                                     | `0.75`                                                                                                   |
 
 ### Adjusting settings
 
@@ -494,60 +508,77 @@ vellum config set calls.userConsultTimeoutSeconds 300
 ## Troubleshooting
 
 ### "Twilio credentials not configured"
+
 Load the `twilio-setup` skill to store your Account SID and Auth Token.
 
 ### "Calls feature is disabled"
+
 Run `vellum config set calls.enabled true`.
 
 ### "No public base URL configured"
+
 Run the **public-ingress** skill to set up ngrok and configure `ingress.publicBaseUrl`.
 
 ### Call fails immediately after initiating
+
 - Check that the phone number is in E.164 format
 - Verify Twilio credentials are correct (wrong auth token causes API errors)
 - On trial accounts, ensure the destination number is verified
 - Check that the ngrok tunnel is still running (`curl -s http://127.0.0.1:4040/api/tunnels`)
 
 ### Call connects but no audio / one-way audio
+
 - The ConversationRelay WebSocket may not be connecting. Check that `ingress.publicBaseUrl` is correct and the tunnel is active
 - Verify the gateway is running at `$GATEWAY_BASE_URL`
 
 ### "Number not eligible for caller identity"
+
 The user's phone number is not owned by or verified with the Twilio account. The number must be either purchased through Twilio or added as a verified caller ID at https://console.twilio.com/us1/develop/phone-numbers/manage/verified.
 
 ### "Per-call caller identity override is disabled"
+
 The setting `calls.callerIdentity.allowPerCallOverride` is set to `false`, so per-call `caller_identity_mode` selection is not allowed. Re-enable overrides with `vellum config set calls.callerIdentity.allowPerCallOverride true`.
 
 ### Caller identity call fails on trial account
+
 Twilio trial accounts can only place calls to verified numbers, regardless of caller identity mode. The user's phone number must also be verified with Twilio. Upgrade to a paid account or verify both the source and destination numbers.
 
 ### "This phone number is not allowed to be called"
+
 Emergency numbers (911, 112, 999, 000, 110, 119) are permanently blocked for safety.
 
 ### ngrok tunnel URL changed
+
 If you restarted ngrok, the public URL has changed. Update it:
+
 ```bash
 vellum config set ingress.publicBaseUrl "<new-url>"
 ```
+
 Or re-run the public-ingress skill to auto-detect and save the new URL.
 
 ### Call drops after 30 seconds of silence
+
 The system has a 30-second silence timeout. If nobody speaks for 30 seconds, the agent will ask "Are you still there?" This is expected behavior.
 
 ### Call quality didn't improve after enabling ElevenLabs
+
 - Verify `calls.voice.mode` is set to `twilio_elevenlabs_tts` or `elevenlabs_agent` (not still `twilio_standard`)
 - Ask for the desired voice style again and try a different voice selection
 - If configuring manually: check that `calls.voice.elevenlabs.voiceId` contains a valid ElevenLabs voice ID
 - If mode is `elevenlabs_agent`, ensure `calls.voice.elevenlabs.agentId` is also set
 
 ### Twilio says "application error" right after answer
+
 - This often means ConversationRelay rejected voice configuration after TwiML fetch
 - Keep `calls.voice.elevenlabs.voiceModelId` empty first (bare `voiceId` mode)
 - If you set `voiceModelId`, try clearing it and retesting:
   `vellum config set calls.voice.elevenlabs.voiceModelId ""`
 
 ### ElevenLabs mode falls back to standard
+
 When `calls.voice.fallbackToStandardOnError` is `true` (the default), the system silently falls back to standard Twilio TTS if ElevenLabs encounters an error or restriction. Check:
+
 - For `elevenlabs_agent` mode: this mode is currently restricted (consultation bridging not yet supported) and will always fall back to standard when fallback is enabled. If fallback is disabled, the voice webhook returns HTTP 501.
 - For `twilio_elevenlabs_tts` mode: verify `calls.voice.elevenlabs.voiceId` is set to a valid voice ID
 - For invalid configs (missing voiceId/agentId): if fallback is disabled, the voice webhook returns HTTP 500 with the config error

--- a/assistant/src/config/bundled-skills/sms-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/sms-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: "SMS Setup"
 description: "Set up and troubleshoot SMS messaging with guided Twilio configuration, compliance, and verification"
 user-invocable: true
-metadata: {"vellum": {"emoji": "\ud83d\udce8"}}
+metadata: { "vellum": { "emoji": "\ud83d\udce8" } }
 ---
 
 You are helping your user set up SMS messaging. This skill orchestrates Twilio setup, SMS-specific compliance, and end-to-end testing through a conversational flow.
@@ -30,7 +30,7 @@ If SMS baseline is not ready (missing credentials, phone number, or ingress), lo
 skill_load skill=twilio-setup
 ```
 
-Tell the user: *"SMS needs Twilio configured first. I've loaded the Twilio setup guide — let's walk through it."*
+Tell the user: _"SMS needs Twilio configured first. I've loaded the Twilio setup guide — let's walk through it."_
 
 After twilio-setup completes, re-check readiness by calling the config endpoint again:
 
@@ -53,6 +53,7 @@ curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/sms/compliance" \
 ```
 
 Examine the compliance results:
+
 - If all checks pass, proceed to Step 4.
 - If compliance issues are found (e.g., toll-free verification needed), guide the user through the compliance flow.
 
@@ -71,18 +72,18 @@ The response includes a `compliance` object with `numberType`, `tollfreePhoneNum
 
 **Step 3b: Collect user information.** Collect the following from the user (assume individual/sole proprietor by default):
 
-| Field | `verificationParams` key | Notes |
-|---|---|---|
-| Name | `businessName` | Can be personal name |
-| Business type | `businessType` | Use `SOLE_PROPRIETOR` for individuals. Valid values: `PRIVATE_PROFIT`, `PUBLIC_PROFIT`, `SOLE_PROPRIETOR`, `NON_PROFIT`, `GOVERNMENT` |
-| Website | `businessWebsite` | LinkedIn or personal site is fine |
-| Notification email | `notificationEmail` | Where Twilio sends status updates |
-| Use case category | `useCaseCategories` | Array, e.g. `["ACCOUNT_NOTIFICATIONS"]` |
-| Use case summary | `useCaseSummary` | Plain English description |
-| Message volume | `messageVolume` | Must be one of: `10`, `100`, `1,000`, `10,000`, `100,000`, `250,000`, `500,000`, `750,000`, `1,000,000`, `5,000,000`, `10,000,000+` |
-| Sample message | `productionMessageSample` | A realistic example message |
-| Opt-in type | `optInType` | `VERBAL`, `WEB_FORM`, `PAPER_FORM`, `VIA_TEXT`, `MOBILE_QR_CODE` |
-| Opt-in image URL | `optInImageUrls` | Array of URLs showing opt-in mechanism (can be website URL) |
+| Field              | `verificationParams` key  | Notes                                                                                                                                 |
+| ------------------ | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Name               | `businessName`            | Can be personal name                                                                                                                  |
+| Business type      | `businessType`            | Use `SOLE_PROPRIETOR` for individuals. Valid values: `PRIVATE_PROFIT`, `PUBLIC_PROFIT`, `SOLE_PROPRIETOR`, `NON_PROFIT`, `GOVERNMENT` |
+| Website            | `businessWebsite`         | LinkedIn or personal site is fine                                                                                                     |
+| Notification email | `notificationEmail`       | Where Twilio sends status updates                                                                                                     |
+| Use case category  | `useCaseCategories`       | Array, e.g. `["ACCOUNT_NOTIFICATIONS"]`                                                                                               |
+| Use case summary   | `useCaseSummary`          | Plain English description                                                                                                             |
+| Message volume     | `messageVolume`           | Must be one of: `10`, `100`, `1,000`, `10,000`, `100,000`, `250,000`, `500,000`, `750,000`, `1,000,000`, `5,000,000`, `10,000,000+`   |
+| Sample message     | `productionMessageSample` | A realistic example message                                                                                                           |
+| Opt-in type        | `optInType`               | `VERBAL`, `WEB_FORM`, `PAPER_FORM`, `VIA_TEXT`, `MOBILE_QR_CODE`                                                                      |
+| Opt-in image URL   | `optInImageUrls`          | Array of URLs showing opt-in mechanism (can be website URL)                                                                           |
 
 The `tollfreePhoneNumberSid` is returned by the compliance status response in the `compliance` object. Use `compliance.tollfreePhoneNumberSid` from the Step 3a response as the value for `tollfreePhoneNumberSid` when submitting. Do NOT ask for EIN, business registration number, or business registration authority. Explain that Twilio labels some fields as "business" fields even for individual submitters.
 
@@ -140,6 +141,7 @@ curl -s -X DELETE "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/sms/complia
 After deletion, return to Step 3b to collect information and resubmit. Warn the user that deleting resets their position in the review queue.
 
 **Common errors:**
+
 - `"Customer profiles submitted with verifications must be either ISV Starters or Secondary Customer Profiles"` — The number is linked to a Primary Customer Profile in Trust Hub, which blocks toll-free verification. Tell the user and suggest they resolve the profile assignment in the Twilio Console.
 - Missing required fields — The endpoint validates and reports which fields are missing.
 - Invalid enum values — The endpoint validates `optInType`, `messageVolume`, and `useCaseCategories` and reports valid values.
@@ -152,19 +154,19 @@ After deletion, return to Step 3b to collect information and resubmit. Warn the 
 
 Now link the user's phone number as the trusted SMS guardian. Tell the user: "Now let's verify your guardian identity for SMS. This links your phone number as the trusted guardian for SMS messaging."
 
-Install and load the **guardian-verify-setup** skill to handle the verification flow:
+Load the **guardian-verify-setup** skill to handle the verification flow:
 
-- Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "guardian-verify-setup"`.
-- Then call `skill_load` with `skill: "guardian-verify-setup"`.
+- Call `skill_load` with `skill_id: "guardian-verify-setup"` to load the dependency skill.
 
 When invoking the skill, indicate the channel is `sms`. The guardian-verify-setup skill manages the full outbound verification flow, including:
+
 - Collecting the user's phone number as the destination (accepts any common format -- the API normalizes to E.164)
 - Starting the outbound verification session via the gateway endpoint `POST /v1/integrations/guardian/outbound/start` with `channel: "sms"`
 - Sending a 6-digit code to the phone number that the user must reply with from the SMS channel
 - Checking guardian status to confirm the binding was created
 - Handling resend, cancel, and error cases
 
-Tell the user: *"I've loaded the guardian verification guide. It will walk you through linking your phone number as the trusted SMS guardian."*
+Tell the user: _"I've loaded the guardian verification guide. It will walk you through linking your phone number as the trusted SMS guardian."_
 
 **Note:** Guardian verification is optional but recommended. If the user declines or wants to skip, proceed to Step 4 without blocking.
 
@@ -172,7 +174,7 @@ Tell the user: *"I've loaded the guardian verification guide. It will walk you t
 
 Run a test SMS to verify end-to-end delivery:
 
-Tell the user: *"Let's send a test SMS to verify everything works. What phone number should I send the test to?"*
+Tell the user: _"Let's send a test SMS to verify everything works. What phone number should I send the test to?"_
 
 **Important:** If toll-free verification is pending (not yet approved), inform the user that test messages may be silently dropped by carriers even though Twilio accepts them. Offer to attempt the test anyway, but set expectations.
 
@@ -189,7 +191,8 @@ curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/sms/test" \
 ```
 
 Report the result honestly:
-- If the send succeeds: *"The message was accepted by Twilio. Note: 'accepted' means Twilio received it for delivery, not that it reached the handset yet. Delivery can take a few seconds to a few minutes. If verification is still pending, carriers may silently drop the message."*
+
+- If the send succeeds: _"The message was accepted by Twilio. Note: 'accepted' means Twilio received it for delivery, not that it reached the handset yet. Delivery can take a few seconds to a few minutes. If verification is still pending, carriers may silently drop the message."_
 - If the send fails: report the error and suggest troubleshooting steps
 
 ### SMS Diagnostics
@@ -209,7 +212,8 @@ This runs a comprehensive health diagnostic, checking channel readiness, complia
 After completing (or skipping) the test, present a clear summary:
 
 **If everything passed:**
-*"SMS is ready! Here's your setup status:"*
+_"SMS is ready! Here's your setup status:"_
+
 - Twilio credentials: configured
 - Phone number: {number}
 - Ingress: configured
@@ -217,17 +221,20 @@ After completing (or skipping) the test, present a clear summary:
 - Test send: {result}
 
 **If there are blockers:**
-*"SMS setup is partially complete. Here's what still needs attention:"*
+_"SMS setup is partially complete. Here's what still needs attention:"_
+
 - List each blocker with the specific next action
 
 ## Troubleshooting
 
 If the user returns to this skill after initial setup:
+
 1. Always start with Step 1 (readiness check) to assess current state
 2. Skip steps that are already complete
 3. Focus on the specific issue the user is experiencing
 
 Common issues:
+
 - **"Messages not delivering"** — Check compliance status (toll-free verification), verify the number isn't flagged
 - **"Twilio error on send"** — Check credentials, phone number assignment, and ingress
 - **"Trial account limitations"** — Explain that trial accounts can only send to verified numbers

--- a/assistant/src/config/bundled-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/telegram-setup/SKILL.md
@@ -3,7 +3,7 @@ name: "Telegram Setup"
 description: "Connect a Telegram bot to the Vellum Assistant gateway with automated webhook registration and credential storage"
 user-invocable: true
 includes: ["public-ingress"]
-metadata: {"vellum": {"emoji": "\ud83e\udd16"}}
+metadata: { "vellum": { "emoji": "\ud83e\udd16" } }
 ---
 
 You are helping your user connect a Telegram bot to the Vellum Assistant gateway. Telegram webhooks are received exclusively by the gateway (the public ingress boundary) — they never hit the assistant runtime directly. When this skill is invoked, walk through each step below using only existing tools.
@@ -28,6 +28,7 @@ Before beginning setup, verify these conditions are met:
 ### Step 1: Collect the Bot Token Securely
 
 Collect the bot token through the secure credential prompt:
+
 - Call `credential_store` with `action: "prompt"`, `service: "telegram"`, `field: "bot_token"`, `label: "Telegram Bot Token"`, `description: "Enter the bot token you received from @BotFather"`, and `placeholder: "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"`.
 
 The token is collected securely via a system-level prompt and is never exposed in plaintext chat.
@@ -44,6 +45,7 @@ curl -sf -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/telegram/setup" \
 ```
 
 This endpoint automatically:
+
 - Retrieves the bot token from secure storage
 - Validates the token by calling the Telegram `getMe` API
 - Stores the bot token with bot username metadata
@@ -65,12 +67,12 @@ If the webhook secret changes (e.g., secret rotation), the gateway's credential 
 
 Now link the user's Telegram account as the trusted guardian for this bot. Tell the user: "Now let's verify your guardian identity. This links your Telegram account as the trusted guardian for this bot."
 
-Install and load the **guardian-verify-setup** skill to handle the verification flow:
+Load the **guardian-verify-setup** skill to handle the verification flow:
 
-- Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "guardian-verify-setup"`.
-- Then call `skill_load` with `skill: "guardian-verify-setup"`.
+- Call `skill_load` with `skill_id: "guardian-verify-setup"` to load the dependency skill.
 
 The guardian-verify-setup skill manages the full outbound verification flow for Telegram, including:
+
 - Collecting the user's Telegram chat ID or @handle as the destination
 - Starting the outbound verification session via the gateway endpoint `POST /v1/integrations/guardian/outbound/start` with `channel: "telegram"`
 - Handling the bootstrap deep-link flow when the user provides an @handle (the response includes a `telegramBootstrapUrl` that the user must click before receiving the code)
@@ -78,7 +80,7 @@ The guardian-verify-setup skill manages the full outbound verification flow for 
 - Checking guardian status to confirm the binding was created
 - Handling resend, cancel, and error cases
 
-Tell the user: *"I've loaded the guardian verification guide. It will walk you through linking your Telegram account as the trusted guardian."*
+Tell the user: _"I've loaded the guardian verification guide. It will walk you through linking your Telegram account as the trusted guardian."_
 
 After the guardian-verify-setup skill completes (or the user skips), continue to Step 5.
 
@@ -111,6 +113,7 @@ If the binding is absent and the user said they completed the verification:
 ### Step 7: Report Success
 
 Summarize what was done:
+
 - Bot verified and credentials stored securely
 - Webhook registration: handled automatically by the gateway
 - Bot commands registered: /new
@@ -136,17 +139,17 @@ These limitations apply to all Telegram bots regardless of configuration. Future
 
 The following steps are now **automated** by the gateway and CLI:
 
-| Step | Status | Details |
-|------|--------|---------|
-| Webhook registration | Automated | The gateway reconciles the webhook URL on startup and when credentials change |
+| Step                  | Status                       | Details                                                                                         |
+| --------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------- |
+| Webhook registration  | Automated                    | The gateway reconciles the webhook URL on startup and when credentials change                   |
 | Routing configuration | Automated (single-assistant) | The CLI sets `GATEWAY_UNMAPPED_POLICY=default` and `GATEWAY_DEFAULT_ASSISTANT_ID` automatically |
-| Credential detection | Automated | The gateway watches the credential vault for changes |
+| Credential detection  | Automated                    | The gateway watches the credential vault for changes                                            |
 
 The following steps still require **manual** action:
 
-| Step | Details |
-|------|---------|
-| Bot token from @BotFather | User must create a bot and provide the token via secure prompt |
+| Step                                       | Details                                                                                            |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| Bot token from @BotFather                  | User must create a bot and provide the token via secure prompt                                     |
 | Bot configuration and command registration | Configured via the setup skill (Step 2 above) using the `/v1/integrations/telegram/setup` endpoint |
-| Guardian verification | Handled via the guardian-verify-setup skill using the outbound verification flow (Step 4 above) |
-| Multi-assistant routing | Requires manual `GATEWAY_ASSISTANT_ROUTING_JSON` configuration |
+| Guardian verification                      | Handled via the guardian-verify-setup skill using the outbound verification flow (Step 4 above)    |
+| Multi-assistant routing                    | Requires manual `GATEWAY_ASSISTANT_ROUTING_JSON` configuration                                     |

--- a/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
@@ -3,7 +3,7 @@ name: "Twilio Setup"
 description: "Configure Twilio credentials and phone numbers for voice calls and SMS messaging"
 user-invocable: true
 includes: ["public-ingress"]
-metadata: {"vellum": {"emoji": "\ud83d\udcf1"}}
+metadata: { "vellum": { "emoji": "\ud83d\udcf1" } }
 ---
 
 You are helping your user configure Twilio for voice calls and SMS messaging. Twilio is the shared telephony provider for both the **phone-calls** and **SMS messaging** capabilities. When this skill is invoked, walk through each step below using the Twilio HTTP control-plane endpoints and existing tools.
@@ -30,6 +30,7 @@ For voice call setup after Twilio is configured, use `phone-calls` + `call_start
 ## Overview
 
 This skill manages the full Twilio lifecycle:
+
 - **Credential storage** — Account SID and Auth Token
 - **Phone number provisioning** — Buy a new number directly from Twilio
 - **Phone number assignment** — Assign an existing Twilio number to the assistant
@@ -42,16 +43,19 @@ All operations go through the Twilio HTTP control-plane endpoints on the gateway
 In a multi-assistant environment (multiple assistants sharing the same daemon), some actions are **assistant-scoped** while others are **global** (shared across all assistants):
 
 **Global actions** (ignore `assistantId` — credentials are shared across all assistants):
+
 - `POST /v1/integrations/twilio/credentials` — Stores Account SID and Auth Token in global secure storage (`credential:twilio:*` keys). All assistants share the same Twilio account credentials.
 - `DELETE /v1/integrations/twilio/credentials` — Removes the globally stored Account SID and Auth Token. This affects all assistants.
 
 **Assistant-scoped actions** (use `assistantId` query parameter to scope phone number configuration per assistant):
+
 - `GET /v1/integrations/twilio/config` — Returns the phone number assigned to the specified assistant.
 - `POST /v1/integrations/twilio/numbers/assign` — Assigns a phone number to a specific assistant via the per-assistant mapping.
 - `POST /v1/integrations/twilio/numbers/provision` — Provisions a new number and assigns it to the specified assistant.
 - `GET /v1/integrations/twilio/numbers` — Lists all phone numbers on the shared Twilio account (uses global credentials).
 
 Include `assistantId` as a query parameter in assistant-scoped requests whenever:
+
 - Multiple assistants share the same Twilio account but use different phone numbers
 - You want to ensure configuration changes only affect a specific assistant
 - The user has explicitly selected or referenced a particular assistant
@@ -69,6 +73,7 @@ curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/config" \
 ```
 
 The response includes:
+
 - `hasCredentials` — whether Account SID and Auth Token are stored
 - `phoneNumber` — the currently assigned phone number (if any)
 
@@ -124,6 +129,7 @@ curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/numbers/provi
 The endpoint provisions the number via the Twilio API, automatically assigns it to the assistant (persisting to both secure storage and config), and configures Twilio webhooks (voice, status callback, SMS) if a public ingress URL is available. The response includes the new `phoneNumber`. No separate assign call is needed.
 
 **Webhook auto-configuration:** When `ingress.publicBaseUrl` is configured, the endpoint automatically sets the following webhooks on the Twilio phone number:
+
 - Voice webhook: `{publicBaseUrl}/webhooks/twilio/voice`
 - Voice status callback: `{publicBaseUrl}/webhooks/twilio/status`
 - SMS webhook: `{publicBaseUrl}/webhooks/twilio/sms`
@@ -192,6 +198,7 @@ skill_load skill=public-ingress
 ```
 
 **Twilio webhook endpoints (auto-configured on provision/assign):**
+
 - Voice webhook: `{publicBaseUrl}/webhooks/twilio/voice`
 - Voice status callback: `{publicBaseUrl}/webhooks/twilio/status`
 - ConversationRelay WebSocket: `{publicBaseUrl}/webhooks/twilio/relay` (wss://)
@@ -210,6 +217,7 @@ curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/config" \
 ```
 
 Confirm:
+
 - `hasCredentials` is `true`
 - `phoneNumber` is set to the expected number
 
@@ -219,12 +227,12 @@ Tell the user: **"Twilio is configured. Your assistant's phone number is {phoneN
 
 Now link the user's phone number as the trusted guardian for SMS and/or voice channels. Tell the user: "Now let's verify your guardian identity. This links your phone number as the trusted guardian for messaging and calls."
 
-Install and load the **guardian-verify-setup** skill to handle the verification flow:
+Load the **guardian-verify-setup** skill to handle the verification flow:
 
-- Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "guardian-verify-setup"`.
-- Then call `skill_load` with `skill: "guardian-verify-setup"`.
+- Call `skill_load` with `skill_id: "guardian-verify-setup"` to load the dependency skill.
 
 The guardian-verify-setup skill manages the full outbound verification flow for **one channel at a time** (sms, voice, or telegram). Each invocation handles:
+
 - Collecting the user's phone number as the destination (accepts any common format -- the API normalizes to E.164)
 - Starting the outbound verification session via the gateway endpoint `POST /v1/integrations/guardian/outbound/start`
 - For **SMS**: sending a 6-digit code to the phone number that the user must reply with from the SMS channel
@@ -234,13 +242,14 @@ The guardian-verify-setup skill manages the full outbound verification flow for 
 
 **If the user wants to verify both SMS and voice**, load the skill twice -- once for SMS and once for voice. Each channel requires its own separate verification session.
 
-Tell the user: *"I've loaded the guardian verification guide. It will walk you through linking your phone number as the trusted guardian. We'll verify one channel at a time."*
+Tell the user: _"I've loaded the guardian verification guide. It will walk you through linking your phone number as the trusted guardian. We'll verify one channel at a time."_
 
 After the guardian-verify-setup skill completes verification for a channel, load it again for the next channel if needed. Once all desired channels are verified (or the user skips), continue to Step 6.
 
 **Note:** Guardian verification is optional but recommended. If the user declines or wants to skip, proceed to Step 6 without blocking.
 
 To re-check guardian status later, query the channel(s) that were verified:
+
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
 # Check SMS guardian status
@@ -258,6 +267,7 @@ Check the status for whichever channel(s) the user actually verified (SMS, voice
 Now that Twilio is configured, the user can enable the features that depend on it:
 
 **For voice calls:**
+
 ```bash
 vellum config set calls.enabled true
 ```
@@ -282,22 +292,27 @@ This removes the stored Account SID and Auth Token. Phone number assignments are
 ## Troubleshooting
 
 ### "Twilio credentials not configured"
+
 Run Steps 2 and 3 to store credentials and assign a phone number.
 
 ### "No phone number assigned"
+
 Run Step 3 to provision or assign a phone number.
 
 ### Phone number provisioning fails
+
 - Verify Twilio credentials are correct
 - On trial accounts, you may already have a free number — check "Active Numbers" in the Console
 - Ensure the Twilio account has sufficient balance for paid accounts
 
 ### Calls/SMS fail after setup
+
 - Verify public ingress is running (`ingress.publicBaseUrl` must be set)
 - For calls, ensure `calls.enabled` is `true`
 - On trial accounts, outbound calls and SMS can only reach verified numbers
 
 ### "Number not found" when assigning
+
 - The number must be owned by the same Twilio account
 - Use the list numbers endpoint to see available numbers
 - Ensure the number is in E.164 format (`+` followed by country code and number)


### PR DESCRIPTION
## Summary
- Update `messaging/SKILL.md` — replace `vellum_skills_catalog` install refs with `skill_load`
- Update `google-calendar/SKILL.md` — replace `vellum_skills_catalog` install refs with `skill_load`
- Update `phone-calls/SKILL.md` — replace `vellum_skills_catalog` install refs with `skill_load`
- Update `sms-setup/SKILL.md` — replace `vellum_skills_catalog` install refs with `skill_load`
- Update `telegram-setup/SKILL.md` — replace `vellum_skills_catalog` install refs with `skill_load`
- Update `twilio-setup/SKILL.md` — replace `vellum_skills_catalog` install refs with `skill_load`

Part 7 of bundled skills consolidation plan (BUNDLED_SKILLS.md).

## Test plan
- [x] No code changes — only SKILL.md instruction updates
- [x] Verified no remaining `vellum_skills_catalog` references in bundled-skills directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
