### PR TITLE
fix: improve pinned button visibility and route all app surfaces to InlineAppCreatedCard

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
@@ -70,7 +70,7 @@ struct InlineAppCreatedCard: View {
                 }
 
                 if isPinned {
-                    VButton(label: "Pinned", leftIcon: "checkmark", style: .success, size: .small, isDisabled: true) {}
+                    VButton(label: "Pinned", leftIcon: "checkmark", style: .success, size: .small) {}
                 } else {
                     VButton(label: "Pin to Homebase", leftIcon: "pin.fill", style: .outlined, size: .small) {
                         isPinned = true

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -32,7 +32,7 @@ public struct InlineSurfaceRouter: View {
     private var isAppCreated: Bool {
         #if os(macOS)
         if case .dynamicPage(let data) = surface.data,
-           let preview = data.preview, preview.context == "app_create" { return true }
+           let preview = data.preview, preview.context == "app_create" || data.appId != nil { return true }
         #endif
         return false
     }
@@ -159,7 +159,7 @@ public struct InlineSurfaceRouter: View {
         case .dynamicPage(let data):
             if let preview = data.preview {
                 #if os(macOS)
-                if preview.context == "app_create" {
+                if preview.context == "app_create" || data.appId != nil {
                     InlineAppCreatedCard(
                         preview: preview,
                         appId: data.appId,


### PR DESCRIPTION
## Summary
- Remove `isDisabled: true` from the "Pinned" VButton so it isn't washed out at 50% opacity on the inverse card background
- Update `isAppCreated` computed property and `surfaceContent` routing to also match on `data.appId != nil`, so older app threads use `InlineAppCreatedCard` instead of the legacy `InlineDynamicPagePreview`

## Test plan
- [ ] Create a new app via chat and verify the pinned button is clearly visible after clicking "Pin to Homebase"
- [ ] Open an older app thread and verify it renders the new `InlineAppCreatedCard` (inverse bg, preview image) instead of the old white card with metric pills

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
