### PR TITLE
docs: update references for bundled skills consolidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -381,7 +381,7 @@ Untrusted actors (`non-guardian`, `unverified_channel`) must never receive privi
 
 Do not add new tool registrations using the `class ____Tool implements Tool {` pattern.
 
-Prefer skills in `assistant/skills/vellum-skills/` that teach the model how to use CLI tools directly.
+Prefer skills in `assistant/src/config/bundled-skills/` that teach the model how to use CLI tools directly.
 
 Keep the system prompt as minimal as possible. Avoid adding instructions about how to use tools; only document what tools exist when they are basic, primitive, and universally useful. Prefer CLI programs that the assistant can progressively learn to use via `--help`.
 


### PR DESCRIPTION
## Summary
- Update `AGENTS.md` (symlinked as `CLAUDE.md`) — replace stale `assistant/skills/vellum-skills/` path with `assistant/src/config/bundled-skills/` in the Tooling Direction section
- `assistant/ARCHITECTURE.md` was already updated to `bundled-skills/` in prior PRs — no changes needed

Part 8 (final) of bundled skills consolidation plan.

## Test plan
- [x] Documentation-only changes — no code affected
- [x] Searched entire repo for stale `vellum-skills/` references — none remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
