### PR TITLE
fix: split macOS/iOS cert secrets (DEVID vs DIST)

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Import code-signing certificate
         env:
-          CERT_P12: ${{ secrets.DIST_CERTIFICATE_P12 }}
-          CERT_PASSWORD: ${{ secrets.DIST_CERTIFICATE_PASSWORD }}
+          CERT_P12: ${{ secrets.DEVID_CERTIFICATE_P12 }}
+          CERT_PASSWORD: ${{ secrets.DEVID_CERTIFICATE_PASSWORD }}
         run: |
           KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME-db"
 

--- a/.github/workflows/ci-nightly-release.yml
+++ b/.github/workflows/ci-nightly-release.yml
@@ -57,8 +57,8 @@ jobs:
 
       - name: Import code-signing certificate
         env:
-          CERT_P12: ${{ secrets.DIST_CERTIFICATE_P12 }}
-          CERT_PASSWORD: ${{ secrets.DIST_CERTIFICATE_PASSWORD }}
+          CERT_P12: ${{ secrets.DEVID_CERTIFICATE_P12 }}
+          CERT_PASSWORD: ${{ secrets.DEVID_CERTIFICATE_PASSWORD }}
         run: |
           KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME-db"
 

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -32,8 +32,8 @@ jobs:
 
       - name: Import code-signing certificate
         env:
-          CERT_P12: ${{ secrets.DIST_CERTIFICATE_P12 }}
-          CERT_PASSWORD: ${{ secrets.DIST_CERTIFICATE_PASSWORD }}
+          CERT_P12: ${{ secrets.DEVID_CERTIFICATE_P12 }}
+          CERT_PASSWORD: ${{ secrets.DEVID_CERTIFICATE_PASSWORD }}
         run: |
           KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME-db"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -726,8 +726,8 @@ jobs:
 
       - name: Import code-signing certificate
         env:
-          CERT_P12: ${{ secrets.DIST_CERTIFICATE_P12 }}
-          CERT_PASSWORD: ${{ secrets.DIST_CERTIFICATE_PASSWORD }}
+          CERT_P12: ${{ secrets.DEVID_CERTIFICATE_P12 }}
+          CERT_PASSWORD: ${{ secrets.DEVID_CERTIFICATE_PASSWORD }}
         run: |
           KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME-db"
 
@@ -1006,8 +1006,8 @@ jobs:
 
       - name: Import code-signing certificate
         env:
-          CERT_P12: ${{ secrets.DIST_CERTIFICATE_P12 }}
-          CERT_PASSWORD: ${{ secrets.DIST_CERTIFICATE_PASSWORD }}
+          CERT_P12: ${{ secrets.DEVID_CERTIFICATE_P12 }}
+          CERT_PASSWORD: ${{ secrets.DEVID_CERTIFICATE_PASSWORD }}
         run: |
           KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME-db"
 


### PR DESCRIPTION
## Summary
macOS CI builds are failing because `DIST_CERTIFICATE_P12` contains an "Apple Distribution" cert, but macOS DMG builds require a "Developer ID Application" cert. These are different Apple certificate types for different distribution channels.

## Changes
- macOS workflows use `DEVID_CERTIFICATE_P12` / `DEVID_CERTIFICATE_PASSWORD` (Developer ID Application — for DMG/direct distribution)
- iOS workflow keeps `DIST_CERTIFICATE_P12` / `DIST_CERTIFICATE_PASSWORD` (Apple Distribution — for App Store/TestFlight)

### Files changed
- `.github/workflows/ci-main-macos.yaml`
- `.github/workflows/ci-nightly-release.yml`
- `.github/workflows/pr-macos.yaml`
- `.github/workflows/release.yml` (build-macos + build-macos-split-arch jobs only; release-ios unchanged)

## Prerequisites
Before merging, add these GitHub secrets:
- `DEVID_CERTIFICATE_P12` — base64-encoded .p12 of the Vellum org "Developer ID Application" certificate
- `DEVID_CERTIFICATE_PASSWORD` — password for the .p12

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
