### PR TITLE
feat: add platform assistant API methods in shared auth layer

### DIFF
--- a/clients/shared/App/Auth/AuthModels.swift
+++ b/clients/shared/App/Auth/AuthModels.swift
@@ -110,3 +110,61 @@ public enum AuthServiceError: LocalizedError {
 }
 
 public struct EmptyData: Codable, Sendable {}
+
+// MARK: - Platform Assistant API Models
+
+public struct PlatformAssistant: Codable, Sendable {
+    public let id: String
+    public let name: String?
+    public let description: String?
+    public let created_at: String?
+
+    public init(id: String, name: String? = nil, description: String? = nil, created_at: String? = nil) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.created_at = created_at
+    }
+}
+
+public struct HatchAssistantRequest: Codable, Sendable {
+    public let name: String?
+    public let description: String?
+    public let anthropic_api_key: String?
+
+    public init(name: String? = nil, description: String? = nil, anthropic_api_key: String? = nil) {
+        self.name = name
+        self.description = description
+        self.anthropic_api_key = anthropic_api_key
+    }
+}
+
+/// Result type for platform assistant lookups where 404 is a normal outcome.
+public enum PlatformAssistantResult: Sendable {
+    case found(PlatformAssistant)
+    case notFound
+}
+
+/// Errors specific to platform API calls (non-allauth endpoints).
+public enum PlatformAPIError: LocalizedError, Sendable {
+    case invalidURL
+    case networkError(String)
+    case decodingError(String)
+    case serverError(statusCode: Int, detail: String?)
+    case authenticationRequired
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "Invalid URL"
+        case .networkError(let message):
+            return message
+        case .decodingError(let message):
+            return "Failed to decode response: \(message)"
+        case .serverError(let statusCode, let detail):
+            return detail ?? "Server error (\(statusCode))"
+        case .authenticationRequired:
+            return "Authentication required"
+        }
+    }
+}

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -113,6 +113,121 @@ public final class AuthService {
         return response
     }
 
+    // MARK: - Platform Assistant API
+
+    /// Fetch the current user's managed assistant.
+    /// Returns `.found` with the assistant on 200, `.notFound` on 404.
+    public func getCurrentAssistant() async throws -> PlatformAssistantResult {
+        let urlString = "\(baseURL)/v1/assistants/current/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "GET"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        if let token = await SessionTokenManager.getTokenAsync() {
+            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        } else {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request GET assistants/current/ -> \(statusCode)")
+
+        if statusCode == 404 {
+            return .notFound
+        }
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            let assistant = try JSONDecoder().decode(PlatformAssistant.self, from: data)
+            return .found(assistant)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
+    /// Create a new managed assistant via the platform hatch endpoint.
+    public func hatchAssistant(
+        name: String? = nil,
+        description: String? = nil,
+        anthropicApiKey: String? = nil
+    ) async throws -> PlatformAssistant {
+        let urlString = "\(baseURL)/v1/assistants/hatch/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        if let token = await SessionTokenManager.getTokenAsync() {
+            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        } else {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        let requestBody = HatchAssistantRequest(
+            name: name,
+            description: description,
+            anthropic_api_key: anthropicApiKey
+        )
+        let encoder = JSONEncoder()
+        urlRequest.httpBody = try encoder.encode(requestBody)
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request POST assistants/hatch/ -> \(statusCode)")
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode(PlatformAssistant.self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Allauth Requests
+
     private func request<T: Codable>(
         path: String,
         method: String = "GET",


### PR DESCRIPTION
## Summary

- Adds `getCurrentAssistant()` and `hatchAssistant()` methods to `AuthService` for discovering and creating managed assistants via the platform API (`GET /v1/assistants/current/`, `POST /v1/assistants/hatch/`)
- Introduces `PlatformAssistant`, `HatchAssistantRequest`, `PlatformAssistantResult`, and `PlatformAPIError` types in `AuthModels.swift`
- 404 response from `getCurrentAssistant()` is returned as `.notFound` (not thrown), enabling callers to distinguish "no assistant exists" from actual errors

## Test plan

- [ ] Verify `swift build` succeeds in `clients/`
- [ ] Verify `getCurrentAssistant()` builds correct URL (`{baseURL}/v1/assistants/current/`) and includes `X-Session-Token` header
- [ ] Verify `hatchAssistant()` serializes `HatchAssistantRequest` body correctly and uses POST
- [ ] Verify 404 response returns `.notFound` instead of throwing
- [ ] Verify 401/403 throws `PlatformAPIError.authenticationRequired`
- [ ] No existing allauth callsites are changed

**Depends on:** None (PR-06 in managed sign-in plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
