### PR TITLE
feat: DaemonConfig transport metadata extension for managed mode

### DIFF
--- a/clients/shared/IPC/DaemonConfig.swift
+++ b/clients/shared/IPC/DaemonConfig.swift
@@ -35,6 +35,49 @@ public struct RemoteIdentityInfo: Decodable {
     }
 }
 
+/// How endpoint paths are constructed for HTTP transport.
+public enum RouteMode {
+    /// Current runtime-flat paths: `/healthz`, `/v1/messages`, etc.
+    case runtimeFlat
+    /// Platform assistant proxy paths: `/v1/assistants/{id}/healthz/`, etc.
+    case platformAssistantProxy
+}
+
+/// How authentication headers are applied for HTTP transport.
+public enum AuthMode {
+    /// `Authorization: Bearer {token}` (current default for local/gateway).
+    case bearerToken
+    /// `X-Session-Token: {token}` from SessionTokenManager (managed mode).
+    case sessionToken
+}
+
+/// Optional metadata that governs how HTTP transport constructs URLs and
+/// applies authentication. Defaults preserve existing behavior so this
+/// is a no-op refactor when not explicitly configured.
+public struct TransportMetadata {
+    public let routeMode: RouteMode
+    public let authMode: AuthMode
+    /// Platform-assigned assistant UUID, required for `.platformAssistantProxy` route mode.
+    public let platformAssistantId: String?
+
+    public init(
+        routeMode: RouteMode = .runtimeFlat,
+        authMode: AuthMode = .bearerToken,
+        platformAssistantId: String? = nil
+    ) {
+        self.routeMode = routeMode
+        self.authMode = authMode
+        self.platformAssistantId = platformAssistantId
+    }
+
+    /// Default metadata preserving existing local/gateway behavior.
+    public static let defaultLocal = TransportMetadata(
+        routeMode: .runtimeFlat,
+        authMode: .bearerToken,
+        platformAssistantId: nil
+    )
+}
+
 public struct DaemonConfig {
     /// Transport mode for communicating with the assistant daemon.
     public enum Transport {
@@ -49,6 +92,10 @@ public struct DaemonConfig {
     }
 
     public let transport: Transport
+
+    /// Metadata governing URL construction and auth for HTTP transport.
+    /// Defaults to `.defaultLocal` which preserves existing behavior.
+    public let transportMetadata: TransportMetadata
 
     /// Feature-flag bearer token for authenticating PATCH /v1/feature-flags/:flagKey requests.
     /// On macOS this is read from `~/.vellum/feature-flag-token`.
@@ -70,6 +117,7 @@ public struct DaemonConfig {
     /// Convenience initializer for socket transport (backwards compatible).
     public init(socketPath: String) {
         self.transport = .socket(path: socketPath)
+        self.transportMetadata = .defaultLocal
         self.featureFlagToken = readFeatureFlagToken()
     }
 
@@ -78,8 +126,9 @@ public struct DaemonConfig {
     }
     #endif
 
-    public init(transport: Transport, featureFlagToken: String? = nil) {
+    public init(transport: Transport, transportMetadata: TransportMetadata = .defaultLocal, featureFlagToken: String? = nil) {
         self.transport = transport
+        self.transportMetadata = transportMetadata
         #if os(macOS)
         self.featureFlagToken = featureFlagToken ?? readFeatureFlagToken()
         #else

--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -247,7 +247,8 @@ extension DaemonClient {
         let transport = HTTPTransport(
             baseURL: baseURL,
             bearerToken: bearerToken,
-            conversationKey: conversationKey
+            conversationKey: conversationKey,
+            transportMetadata: config.transportMetadata
         )
 
         // Wire incoming SSE messages through the existing handleServerMessage infrastructure.

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -56,6 +56,7 @@ public final class HTTPTransport {
     public private(set) var bearerToken: String?
     private let conversationKey: String
     private let sourceChannel: String
+    let transportMetadata: TransportMetadata
 
     private static var defaultSourceChannel: String {
         return "vellum"
@@ -126,12 +127,13 @@ public final class HTTPTransport {
 
     // MARK: - Init
 
-    init(baseURL: String, bearerToken: String?, conversationKey: String) {
+    init(baseURL: String, bearerToken: String?, conversationKey: String, transportMetadata: TransportMetadata = .defaultLocal) {
         // Strip trailing slash for clean URL construction
         self.baseURL = baseURL.hasSuffix("/") ? String(baseURL.dropLast()) : baseURL
         self.bearerToken = bearerToken
         self.conversationKey = conversationKey
         self.sourceChannel = Self.defaultSourceChannel
+        self.transportMetadata = transportMetadata
     }
 
     // MARK: - Connect (health check driven)


### PR DESCRIPTION
## Summary

- Adds `RouteMode`, `AuthMode`, and `TransportMetadata` types to support managed mode URL construction and authentication without changing any existing behavior
- Threads `TransportMetadata` through `DaemonConfig` -> `DaemonConnection` -> `HTTPTransport` constructor chain
- All defaults preserve existing `runtimeFlat` + `bearerToken` behavior — zero behavior change

## Context

PR-09 of the managed sign-in plan. This is a no-op structural refactor that prepares the transport stack for managed mode configuration in subsequent PRs (PR-10, PR-11, PR-12).

### Dependency
None (first PR in the desktop transport chain: PR-09 -> PR-10 -> PR-11 -> PR-12).

## Test plan

- [x] `swift build` succeeds with no errors
- [x] Default config still uses runtime-flat + bearer-token behavior (verified via default parameter values)
- [x] All existing transport paths unchanged — metadata defaults to `.defaultLocal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
