### PR TITLE
feat: add managed assistant bootstrap orchestrator

### DIFF
--- a/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
@@ -1,0 +1,98 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ManagedAssistantBootstrap")
+
+/// Outcome of a managed assistant bootstrap attempt.
+public enum ManagedBootstrapOutcome: Sendable {
+    case reusedExisting(PlatformAssistant)
+    case createdNew(PlatformAssistant)
+}
+
+/// Errors that can occur during managed assistant bootstrapping.
+public enum ManagedBootstrapError: LocalizedError, Sendable {
+    case authenticationRequired
+    case networkError(String)
+    case serverError(statusCode: Int, detail: String?)
+    case hatchFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .authenticationRequired:
+            return "Sign in required to set up your assistant"
+        case .networkError(let message):
+            return "Network error: \(message)"
+        case .serverError(let statusCode, let detail):
+            return detail ?? "Server error (\(statusCode))"
+        case .hatchFailed(let message):
+            return "Failed to create assistant: \(message)"
+        }
+    }
+}
+
+/// Orchestrates discovery or creation of a managed assistant on the platform.
+///
+/// The bootstrap flow:
+/// 1. Try to fetch the current user's managed assistant.
+/// 2. If one exists (200), return it as `.reusedExisting`.
+/// 3. If none exists (404), create one via hatch and return `.createdNew`.
+/// 4. Any other error is surfaced as a typed `ManagedBootstrapError`.
+@MainActor
+public final class ManagedAssistantBootstrapService {
+    public static let shared = ManagedAssistantBootstrapService()
+
+    private let authService: AuthService
+
+    public init(authService: AuthService = .shared) {
+        self.authService = authService
+    }
+
+    public func ensureManagedAssistant(
+        name: String? = nil,
+        description: String? = nil,
+        anthropicApiKey: String? = nil
+    ) async throws -> ManagedBootstrapOutcome {
+        let currentResult: PlatformAssistantResult
+        do {
+            currentResult = try await authService.getCurrentAssistant()
+        } catch let error as PlatformAPIError {
+            throw mapPlatformError(error)
+        }
+
+        switch currentResult {
+        case .found(let assistant):
+            log.info("Found existing managed assistant: \(assistant.id, privacy: .public)")
+            return .reusedExisting(assistant)
+
+        case .notFound:
+            log.info("No managed assistant found, hatching a new one")
+            let newAssistant: PlatformAssistant
+            do {
+                newAssistant = try await authService.hatchAssistant(
+                    name: name,
+                    description: description,
+                    anthropicApiKey: anthropicApiKey
+                )
+            } catch let error as PlatformAPIError {
+                throw mapPlatformError(error)
+            }
+            log.info("Created new managed assistant: \(newAssistant.id, privacy: .public)")
+            return .createdNew(newAssistant)
+        }
+    }
+
+    private func mapPlatformError(_ error: PlatformAPIError) -> ManagedBootstrapError {
+        switch error {
+        case .authenticationRequired:
+            return .authenticationRequired
+        case .networkError(let message):
+            return .networkError(message)
+        case .serverError(let statusCode, let detail):
+            return .serverError(statusCode: statusCode, detail: detail)
+        case .invalidURL:
+            return .serverError(statusCode: 0, detail: "Invalid URL configuration")
+        case .decodingError(let message):
+            return .hatchFailed(message)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `ManagedAssistantBootstrapService` in `clients/shared/App/Auth/` that orchestrates discovery-or-creation of a managed assistant
- `ensureManagedAssistant()` tries `getCurrentAssistant()` first; if 404, falls back to `hatchAssistant()`
- Returns typed `ManagedBootstrapOutcome` (`.reusedExisting` or `.createdNew`) for telemetry and UI
- Exposes `ManagedBootstrapError` with user-friendly error descriptions

## Test plan

- [ ] Verify `swift build` succeeds in `clients/`
- [ ] Verify existing assistant path: when `getCurrentAssistant()` returns `.found`, outcome is `.reusedExisting`
- [ ] Verify 404-then-hatch path: when `getCurrentAssistant()` returns `.notFound`, `hatchAssistant()` is called and outcome is `.createdNew`
- [ ] Verify hatch failure propagation: if `hatchAssistant()` throws, `ManagedBootstrapError` is surfaced
- [ ] Verify non-404 failure propagation: server errors from `getCurrentAssistant()` map to `ManagedBootstrapError`
- [ ] No existing callsites are changed

**Depends on:** PR-06 (#11388)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
