### PR TITLE
fix: include actionId in surface completion summary for list/table surfaces

### DIFF
--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -528,13 +528,15 @@ export function buildCompletionSummary(surfaceType: string | undefined, actionId
   }
   if (surfaceType === 'list' && data) {
     const selectedIds = data.selectedIds as string[] | undefined;
-    if (selectedIds?.length === 1) return `Selected: ${selectedIds[0]}`;
-    if (selectedIds?.length) return `Selected ${selectedIds.length} items`;
+    const actionSuffix = actionId ? ` (action: ${actionId})` : '';
+    if (selectedIds?.length === 1) return `Selected: ${selectedIds[0]}${actionSuffix}`;
+    if (selectedIds?.length) return `Selected ${selectedIds.length} items${actionSuffix}`;
   }
   if (surfaceType === 'table' && data) {
     const selectedIds = data.selectedIds as string[] | undefined;
-    if (selectedIds?.length === 1) return `Selected 1 row`;
-    if (selectedIds?.length) return `Selected ${selectedIds.length} rows`;
+    const actionSuffix = actionId ? ` (action: ${actionId})` : '';
+    if (selectedIds?.length === 1) return `Selected 1 row${actionSuffix}`;
+    if (selectedIds?.length) return `Selected ${selectedIds.length} rows${actionSuffix}`;
   }
   return actionId.charAt(0).toUpperCase() + actionId.slice(1);
 }


### PR DESCRIPTION
Addresses review feedback from PR #11379:

**Codex feedback**: The human-readable surface fallback dropped `actionId`, making it ambiguous for list/table surfaces with multiple action buttons. Updated `buildCompletionSummary()` to include the actionId in the summary for list and table surfaces (e.g., 'Selected 5 rows (action: archive_selected)' instead of just 'Selected 5 rows'). This gives the LLM enough context to know which button was clicked without reverting to raw JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
