### PR TITLE
fix: add scan truncation signal and update SKILL.md safety guard for gmail_batch_archive

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -268,11 +268,11 @@ Use `messaging_analyze_activity` to classify channels or conversations by activi
 
 When a user asks to declutter, clean up, or organize their email — start scanning immediately. Don't ask what kind of cleanup they want or request permission to read their inbox. Go straight to scanning — but once results are ready, always show them via `ui_show` and let the user choose actions before archiving or unsubscribing.
 
-**CRITICAL**: Never call `gmail_archive_by_query`, `gmail_unsubscribe`, or `messaging_archive_by_sender` unless the user has clicked an action button on the table for that specific batch. Each batch of results requires its own explicit user confirmation via the table UI. If the user says "keep going" or "keep decluttering," that means scan and present a new table — NOT auto-archive. Previous batch approvals do not carry forward.
+**CRITICAL**: Never call `gmail_batch_archive`, `gmail_unsubscribe`, or `messaging_archive_by_sender` unless the user has clicked an action button on the table for that specific batch. Each batch of results requires its own explicit user confirmation via the table UI. If the user says "keep going" or "keep decluttering," that means scan and present a new table — NOT auto-archive. Previous batch approvals do not carry forward.
 
 ### Provider Selection
 
-- **Gmail connected**: Use the Gmail-specific tools (`gmail_sender_digest`, `gmail_archive_by_query`, `gmail_unsubscribe`, `gmail_filters`) — they have richer features like unsubscribe support and filter creation.
+- **Gmail connected**: Use the Gmail-specific tools (`gmail_sender_digest`, `gmail_batch_archive`, `gmail_unsubscribe`, `gmail_filters`) — they have richer features like unsubscribe support and filter creation.
 - **Non-Gmail email connected**: Use the generic tools (`messaging_sender_digest`, `messaging_archive_by_sender`) — they work with any provider that supports these operations. Skip unsubscribe and filter offers since they are Gmail-specific.
 - **Nothing connected**: Ask which email provider they use. If it's Gmail, go straight into the Gmail connection flow. For other providers, let the user know only Gmail is supported right now and offer to set up Gmail instead. Don't present a menu of options or explain what OAuth is.
 
@@ -303,7 +303,7 @@ When a user asks to declutter, clean up, or organize their email — start scann
 
 - **Zero results**: Tell the user "No newsletter emails found" and suggest broadening the query (e.g. removing the category filter or extending the date range)
 - **Unsubscribe failures**: Report per-sender success/failure; the existing `gmail_unsubscribe` tool handles edge cases
-- **Large sender counts**: The scan covers up to 2000 messages. If `has_more` is true for a sender, it means they had more messages than could be tracked — mention this to the user in the summary
+- **Large sender counts**: The scan covers up to 2000 messages. If `truncated` is true in the top-level response, the scan was capped and there are more matching emails beyond what was scanned — tell the user the cleanup was partial and offer to run another pass. If `has_more` is true for a sender, it means they had more messages than could be tracked — mention this to the user in the summary
 
 ## Batch Operations
 

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
@@ -45,6 +45,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
       // Paginate through listMessages to collect up to maxMessages IDs
       const allMessageIds: string[] = [];
       let pageToken: string | undefined;
+      let truncated = false;
 
       while (allMessageIds.length < maxMessages) {
         const pageSize = Math.min(100, maxMessages - allMessageIds.length);
@@ -54,6 +55,11 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         allMessageIds.push(...ids);
         pageToken = listResp.nextPageToken ?? undefined;
         if (!pageToken) break;
+      }
+
+      // If we stopped because we hit the cap but there were still more pages, flag truncation
+      if (allMessageIds.length >= maxMessages && pageToken) {
+        truncated = true;
       }
 
       if (allMessageIds.length === 0) {
@@ -165,6 +171,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         senders: result,
         total_scanned: allMessageIds.length,
         query_used: query,
+        ...(truncated ? { truncated: true } : {}),
         note: `message_count reflects emails found per sender within the ${allMessageIds.length} messages scanned. Use the message_ids array with gmail_batch_archive to archive exactly these messages.`,
       }));
     });

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-sender-digest.ts
@@ -43,6 +43,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         senders,
         total_scanned: result.totalScanned,
         query_used: result.queryUsed,
+        ...(result.truncated ? { truncated: true } : {}),
         note: `message_count reflects emails found per sender within the ${result.totalScanned} messages scanned. Use the message_ids array with the archive tool to archive exactly these messages.`,
       }));
     });

--- a/assistant/src/messaging/provider-types.ts
+++ b/assistant/src/messaging/provider-types.ts
@@ -99,6 +99,8 @@ export interface SenderDigestResult {
   senders: SenderDigestEntry[];
   totalScanned: number;
   queryUsed: string;
+  /** True when pagination was stopped because the scan cap was reached but more messages exist. */
+  truncated?: boolean;
 }
 
 export interface ArchiveResult {

--- a/assistant/src/messaging/providers/gmail/adapter.ts
+++ b/assistant/src/messaging/providers/gmail/adapter.ts
@@ -202,6 +202,7 @@ export const gmailMessagingProvider: MessagingProvider = {
 
     const allMessageIds: string[] = [];
     let pageToken: string | undefined;
+    let truncated = false;
 
     while (allMessageIds.length < maxMessages) {
       const pageSize = Math.min(100, maxMessages - allMessageIds.length);
@@ -211,6 +212,11 @@ export const gmailMessagingProvider: MessagingProvider = {
       allMessageIds.push(...ids);
       pageToken = listResp.nextPageToken ?? undefined;
       if (!pageToken) break;
+    }
+
+    // If we stopped because we hit the cap but there were still more pages, flag truncation
+    if (allMessageIds.length >= maxMessages && pageToken) {
+      truncated = true;
     }
 
     if (allMessageIds.length === 0) {
@@ -283,7 +289,7 @@ export const gmailMessagingProvider: MessagingProvider = {
       hasMore: s.hasMore,
     }));
 
-    return { senders, totalScanned: allMessageIds.length, queryUsed: query };
+    return { senders, totalScanned: allMessageIds.length, queryUsed: query, ...(truncated ? { truncated } : {}) };
   },
 
   async archiveByQuery(token: string, query: string): Promise<ArchiveResult> {


### PR DESCRIPTION
Addresses review feedback from PR #11375:

1. **Codex feedback**: Added a top-level `truncated` flag to gmail-sender-digest and messaging-sender-digest output when the scan hit the message cap but more messages exist. This lets the SKILL.md instructions inform users that cleanup was partial.

2. **Devin feedback**: Updated SKILL.md to replace remaining `gmail_archive_by_query` references with `gmail_batch_archive` in the safety guard (CRITICAL note) and provider selection sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
