### PR TITLE
Remove 3-second pause from pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -806,9 +806,6 @@ if git diff --cached --name-only | grep -q 'assistant/src/config/system-prompt.t
     echo "conversation."
     echo ""
     echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-    echo ""
-    echo "Pausing for 3 seconds so you read the above..."
-    sleep 3
 fi
 
 # --- .claude/commands/ skill migration nudge ---


### PR DESCRIPTION
## Summary
- Remove the 3-second `sleep` from the system-prompt.ts modification warning in the pre-commit hook
- The warning message is still shown — only the artificial pause is removed

## Original prompt
remove the 3 second pause

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
