### PR TITLE
feat: wire managed transport selection in AppDelegate

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -213,6 +213,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     /// When true, local daemon hatching is skipped.
     private var isCurrentAssistantRemote = false
 
+    /// Whether the current assistant is platform-managed (cloud == "vellum").
+    /// When true, actor credential bootstrap is skipped since identity is
+    /// derived from the platform session, not local actor tokens.
+    private var isCurrentAssistantManaged = false
+
     @AppStorage("themePreference") private var themePreference: String = "system"
 
     public func applicationDidFinishLaunching(_ notification: Notification) {
@@ -374,7 +379,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         // Ensure actor credentials are present. On first launch this performs
         // initial bootstrap; on subsequent launches it schedules proactive
         // refresh when the access token nears expiry.
-        ensureActorCredentials()
+        // Skipped in managed mode where actor identity is derived from the
+        // platform session, not local actor tokens.
+        if !isCurrentAssistantManaged {
+            ensureActorCredentials()
+        }
 
         if isFirstLaunch {
             // Enter the bootstrap state machine. The sequence is:
@@ -554,15 +563,18 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 // If the daemon socket doesn't exist, the daemon process
                 // likely isn't running (e.g. hatch failed). Re-attempt hatch
                 // so we don't loop forever on connect-only retries.
-                let socketPath = DaemonClient.resolveSocketPath()
-                if !FileManager.default.fileExists(atPath: socketPath) {
-                    bootstrapFailureKind = .socketMissing
-                    log.info("Daemon socket missing during bootstrap retry — re-attempting hatch")
-                    try? await assistantCli.hatch(daemonOnly: true)
-                } else if !DaemonClient.isDaemonProcessAlive() {
-                    bootstrapFailureKind = .daemonNotRunning
-                    log.info("Daemon process not alive during bootstrap retry — re-attempting hatch")
-                    try? await assistantCli.hatch(daemonOnly: true)
+                // Managed mode skips local hatch — the platform hosts the daemon.
+                if !isCurrentAssistantManaged {
+                    let socketPath = DaemonClient.resolveSocketPath()
+                    if !FileManager.default.fileExists(atPath: socketPath) {
+                        bootstrapFailureKind = .socketMissing
+                        log.info("Daemon socket missing during bootstrap retry — re-attempting hatch")
+                        try? await assistantCli.hatch(daemonOnly: true)
+                    } else if !DaemonClient.isDaemonProcessAlive() {
+                        bootstrapFailureKind = .daemonNotRunning
+                        log.info("Daemon process not alive during bootstrap retry — re-attempting hatch")
+                        try? await assistantCli.hatch(daemonOnly: true)
+                    }
                 }
 
                 // Attempt a connection if not already connected or in progress.
@@ -1142,11 +1154,34 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     }
 
     /// Configure the daemon client's transport based on the lockfile assistant.
-    /// Remote assistants (cloud != "local") use HTTP+SSE via the gateway URL.
+    /// Managed assistants (cloud == "vellum") use platform proxy with session token auth.
+    /// Other remote assistants (cloud != "local") use HTTP+SSE via the gateway URL.
     /// Local assistants use the default Unix domain socket, unless the
     /// `localHttpEnabled` flag redirects them to the daemon's runtime HTTP server.
     private func configureDaemonTransport(for assistant: LockfileAssistant?) {
         isCurrentAssistantRemote = assistant?.isRemote ?? false
+        isCurrentAssistantManaged = assistant?.isManaged ?? false
+
+        // Managed assistant: use platform proxy URLs with session token auth.
+        if let assistant, assistant.isManaged {
+            let platformBaseURL = AuthService.shared.baseURL
+            let metadata = TransportMetadata(
+                routeMode: .platformAssistantProxy,
+                authMode: .sessionToken,
+                platformAssistantId: assistant.assistantId
+            )
+            let config = DaemonConfig(
+                transport: .http(
+                    baseURL: platformBaseURL,
+                    bearerToken: nil,
+                    conversationKey: assistant.assistantId
+                ),
+                transportMetadata: metadata
+            )
+            services.reconfigureDaemonClient(config: config)
+            log.info("Configured managed transport for assistant \(assistant.assistantId) via platform at \(platformBaseURL, privacy: .public)")
+            return
+        }
 
         guard let assistant, assistant.isRemote, let runtimeUrl = assistant.runtimeUrl else {
             // Local assistant or no assistant.


### PR DESCRIPTION
## Summary

- When the lockfile assistant has `cloud == "vellum"` (`isManaged`), configures the daemon client with managed HTTP transport: `platformAssistantProxy` route mode + `sessionToken` auth mode via the platform base URL from `AuthService`
- Adds `isCurrentAssistantManaged` flag to gate local-only startup flows
- Skips `ensureActorCredentials()` in managed mode (actor identity comes from the platform session)
- Skips local daemon hatch in bootstrap retry coordinator for managed mode
- Existing local and custom remote transport paths are completely unchanged

## Behavior Change

If the selected lockfile assistant has `cloud == "vellum"`:
1. App configures daemon client for managed HTTP transport (platform proxy URLs + session token auth)
2. Local daemon hatch is skipped (already was via `isCurrentAssistantRemote`, now also in bootstrap retry)
3. Actor credential bootstrap is skipped (managed mode uses platform session identity)

Local and custom remote assistants continue to use existing transport paths with no changes.

## Context

PR-12 of the managed sign-in plan (depends on PR-09, PR-10, PR-11 — all merged).

### Dependency
PR-09 (merged) -> PR-10 (merged) -> PR-11 (merged) -> **PR-12**

## Test plan

- [x] `swift build` succeeds with no errors
- [x] Local assistant -> unchanged local behavior (socket transport, hatch, actor credentials)
- [x] Custom/GCP/AWS remote assistant -> unchanged remote behavior (HTTP transport with bearer token)
- [x] Managed assistant (`cloud == "vellum"`) -> new managed behavior (platform proxy + session token)
- [x] Managed mode skips `ensureActorCredentials()`
- [x] Managed mode skips local hatch in bootstrap retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
