### PR TITLE
feat: startup guardrails for managed mode (PR-13)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -977,7 +977,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
         hasSetupDaemon = false
         setupDaemonClient()
-        ensureActorCredentials()
+
+        // Actor credential bootstrap uses runtime bearer flows that don't
+        // exist in managed mode — identity comes from the platform session.
+        if !isCurrentAssistantManaged {
+            ensureActorCredentials()
+        }
     }
 
     @objc func performRetire() {


### PR DESCRIPTION
## Summary

- Gates `ensureActorCredentials()` in `performSwitchAssistant(to:)` behind `!isCurrentAssistantManaged`, fixing a gap where switching to a managed assistant would start the actor token bootstrap/refresh loop. Managed assistants derive identity from the platform session, not local actor tokens.

PR-12 already landed the following managed mode guardrails in AppDelegate:
- Managed transport selection when `cloud == "vellum"` (in `configureDaemonTransport`)
- Skipping `ensureActorCredentials()` in `proceedToApp()` for managed mode
- Skipping local daemon hatch retry in the bootstrap retry coordinator
- The hatch path in `setupDaemonClient` is gated by `!isCurrentAssistantRemote`, which is already true for managed assistants
- `HTTPDaemonClient` already short-circuits 401 recovery in managed mode (no bearer refresh)

This PR fixes the one remaining gap: the `performSwitchAssistant(to:)` path which was calling `ensureActorCredentials()` unconditionally.

**Depends on:** PR-12 (merged)

## Test plan

- [ ] Verify that switching to a managed assistant does not start actor token bootstrap
- [ ] Verify that switching to a local/remote assistant still bootstraps actor credentials
- [ ] Verify Swift build compiles successfully
- [ ] Verify existing non-managed flows are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
