### PR TITLE
fix: remove hardcoded SIGN_IDENTITY in CI macOS build

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -81,7 +81,6 @@ jobs:
       - name: Build release .app
         working-directory: clients/macos
         run: |
-          SIGN_IDENTITY="Developer ID Application" \
           SKIP_CLEAN=1 \
           RELEASE_ARCH_FLAGS="--arch arm64" \
           ./build.sh release


### PR DESCRIPTION
## Summary
- Remove hardcoded `SIGN_IDENTITY="Developer ID Application"` from `ci-main-macos.yaml`
- Let `build.sh` auto-detect the signing identity from whatever certificate is available in the keychain
- The `DEVID_CERTIFICATE_P12` secret currently contains an "Apple Distribution" certificate, not a "Developer ID Application" certificate, causing all CI builds to fail with "no identity found"

## Original prompt
fix this CI failure: https://github.com/vellum-ai/vellum-assistant/actions/runs/22600688283/job/65481623471

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
