### PR TITLE
feat: wire onboarding sign-in to managed assistant bootstrap

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -10,6 +10,8 @@ struct OnboardingFlowView: View {
     var onOpenSettings: () -> Void
 
     @State private var isAdvancingFromWakeUp = false
+    @State private var isBootstrappingManaged = false
+    @State private var managedBootstrapError: String?
 
     private var maxOnboardingStep: Int {
         state.userHostedEnabled ? 2 : 1
@@ -55,32 +57,36 @@ struct OnboardingFlowView: View {
                     // Step content — Group flattens into parent VStack so
                     // the inner Spacer flexes with the top Spacer above.
                     Group {
-                        switch state.currentStep {
-                        case 0:
-                            WakeUpStepView(
-                                state: state,
-                                authManager: authManager,
-                                isAdvancing: isAdvancingFromWakeUp,
-                                onStartWithAPIKey: {
-                                    guard !isAdvancingFromWakeUp else { return }
-                                    isAdvancingFromWakeUp = true
-                                    state.hasHatched = true
-                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                                        state.advance()
+                        if isBootstrappingManaged {
+                            managedBootstrapView
+                        } else {
+                            switch state.currentStep {
+                            case 0:
+                                WakeUpStepView(
+                                    state: state,
+                                    authManager: authManager,
+                                    isAdvancing: isAdvancingFromWakeUp,
+                                    onStartWithAPIKey: {
+                                        guard !isAdvancingFromWakeUp else { return }
+                                        isAdvancingFromWakeUp = true
+                                        state.hasHatched = true
+                                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                                            state.advance()
+                                        }
+                                    },
+                                    onContinueWithVellum: {
+                                        Task {
+                                            await authManager.startWorkOSLogin()
+                                        }
                                     }
-                                },
-                                onContinueWithVellum: {
-                                    Task {
-                                        await authManager.startWorkOSLogin()
-                                    }
-                                }
-                            )
-                        case 1:
-                            APIKeyStepView(state: state)
-                        case 2:
-                            CloudCredentialsStepView(state: state)
-                        default:
-                            EmptyView()
+                                )
+                            case 1:
+                                APIKeyStepView(state: state)
+                            case 2:
+                                CloudCredentialsStepView(state: state)
+                            default:
+                                EmptyView()
+                            }
                         }
                     }
                     .transition(
@@ -89,7 +95,7 @@ struct OnboardingFlowView: View {
                             removal: .opacity.combined(with: .offset(y: -8))
                         )
                     )
-                    .id(state.currentStep)
+                    .id(isBootstrappingManaged ? -1 : state.currentStep)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(
@@ -118,13 +124,86 @@ struct OnboardingFlowView: View {
         }
         .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
             if isAuthenticated {
-                onComplete()
+                Task {
+                    await performManagedBootstrap()
+                }
             }
         }
         .onChange(of: state.hatchCompleted) { _, completed in
             if completed {
                 onComplete()
             }
+        }
+    }
+
+    // MARK: - Managed Bootstrap
+
+    @ViewBuilder
+    private var managedBootstrapView: some View {
+        VStack(spacing: VSpacing.lg) {
+            if managedBootstrapError == nil {
+                HStack(spacing: VSpacing.sm) {
+                    ProgressView()
+                        .controlSize(.small)
+                        .progressViewStyle(.circular)
+                    Text("Setting up your assistant...")
+                        .font(VFont.monoMedium)
+                        .foregroundColor(VColor.textSecondary)
+                }
+            } else {
+                Text("Setup failed")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundColor(VColor.textPrimary)
+
+                if let error = managedBootstrapError {
+                    Text(error)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.error)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: 280)
+                }
+
+                OnboardingButton(title: "Try again", style: .primary) {
+                    Task {
+                        await performManagedBootstrap()
+                    }
+                }
+                .frame(maxWidth: 280)
+            }
+        }
+
+        Spacer()
+    }
+
+    private func performManagedBootstrap() async {
+        isBootstrappingManaged = true
+        managedBootstrapError = nil
+
+        do {
+            let outcome = try await ManagedAssistantBootstrapService.shared.ensureManagedAssistant()
+
+            let assistant: PlatformAssistant
+            switch outcome {
+            case .reusedExisting(let existing):
+                assistant = existing
+            case .createdNew(let created):
+                assistant = created
+            }
+
+            let runtimeUrl = AuthService.shared.baseURL
+            let hatchedAt = ISO8601DateFormatter().string(from: Date())
+
+            LockfileAssistant.upsertManagedEntry(
+                assistantId: assistant.id,
+                runtimeUrl: runtimeUrl,
+                hatchedAt: hatchedAt
+            )
+            UserDefaults.standard.set(assistant.id, forKey: "connectedAssistantId")
+
+            isBootstrappingManaged = false
+            onComplete()
+        } catch {
+            managedBootstrapError = error.localizedDescription
         }
     }
 


### PR DESCRIPTION
## Summary

- After WorkOS login succeeds during onboarding, runs `ManagedAssistantBootstrapService.ensureManagedAssistant()` to discover or create a managed assistant before proceeding to the app
- Shows a loading spinner ("Setting up your assistant...") during bootstrap, with actionable error text and a retry button on failure
- On success, persists the managed lockfile entry via `LockfileAssistant.upsertManagedEntry()` and stores `connectedAssistantId` in UserDefaults before calling `onComplete()`

## Test plan

- [ ] Fresh install: sign in with existing managed assistant -> app launches connected to managed assistant
- [ ] Fresh install: sign in with no managed assistant -> assistant is created, then app launches managed-connected
- [ ] Sign-in + bootstrap failure (e.g. network error) -> error message shown with "Try again" button, user stays on onboarding
- [ ] Login cancelled -> unchanged behavior, stays on onboarding welcome screen
- [ ] Self-host path (API key) -> unchanged behavior, no managed bootstrap triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
