### PR TITLE
fix: suggest formatting only staged files in pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -649,7 +649,7 @@ for DIR in "${DIRS_TO_CHECK[@]}"; do
             echo -e "${RED}Prettier formatting issues found in ${DIR}/!${NC}"
             echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
             echo ""
-            echo "Run: cd ${DIR} && bun run format"
+            echo "Run: cd ${DIR} && bunx prettier --write ${REL_FILES[*]}"
             echo "Then stage the fixed files and commit again."
             exit 1
         fi


### PR DESCRIPTION
## Summary
- Change the pre-commit hook's prettier failure message to suggest `bunx prettier --write <files>` with only the staged files, instead of `bun run format` which reformats the entire directory

## Original prompt
Fix the pre-commit hook format suggestion to only format staged files instead of the whole project

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
