### PR TITLE
perf: invoke IPC check scripts directly instead of via bun run

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -731,7 +731,9 @@ if [ $IPC_CHANGED -eq 1 ]; then
         echo -e "${YELLOW}⚠️  bun not found — skipping IPC generation check${NC}"
         echo "  Install bun or run 'cd assistant && bun run generate:ipc' manually."
     else
-        if ! (cd assistant && "$BUN" run check:ipc-generated) 2>/dev/null; then
+        # Invoke script files directly instead of `bun run <script-name>` to
+        # skip package.json resolution and shell indirection (3 processes vs 9).
+        if ! (cd assistant && "$BUN" scripts/ipc/generate-swift.ts --check) 2>/dev/null; then
             echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
             echo -e "${RED}Generated IPC Swift models are out of date!${NC}"
             echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
@@ -742,7 +744,7 @@ if [ $IPC_CHANGED -eq 1 ]; then
         fi
         echo "✅ Generated IPC Swift models are up to date"
 
-        if ! (cd assistant && "$BUN" run ipc:inventory) 2>/dev/null; then
+        if ! (cd assistant && "$BUN" scripts/ipc/check-contract-inventory.ts) 2>/dev/null; then
             echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
             echo -e "${RED}IPC contract inventory snapshot is out of date!${NC}"
             echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
@@ -753,7 +755,7 @@ if [ $IPC_CHANGED -eq 1 ]; then
         fi
         echo "✅ IPC contract inventory is up to date"
 
-        if ! (cd assistant && "$BUN" run ipc:check-swift-drift) 2>/dev/null; then
+        if ! (cd assistant && "$BUN" scripts/ipc/check-swift-decoder-drift.ts) 2>/dev/null; then
             echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
             echo -e "${RED}Swift decoder is out of sync with the IPC contract!${NC}"
             echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"


### PR DESCRIPTION
## Summary
- Replace `"$BUN" run check:ipc-generated` (etc.) with direct script invocation `"$BUN" scripts/ipc/generate-swift.ts --check`
- Skips package.json resolution and shell indirection per check (3 processes instead of 9)

## Original prompt
these optimizations as 3 separate PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
