### PR TITLE
fix: enforce lockfile persistence before completing managed onboarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -193,11 +193,18 @@ struct OnboardingFlowView: View {
             let runtimeUrl = AuthService.shared.baseURL
             let hatchedAt = ISO8601DateFormatter().string(from: Date())
 
-            LockfileAssistant.upsertManagedEntry(
+            let success = LockfileAssistant.upsertManagedEntry(
                 assistantId: assistant.id,
                 runtimeUrl: runtimeUrl,
                 hatchedAt: hatchedAt
             )
+
+            guard success else {
+                isBootstrappingManaged = false
+                managedBootstrapError = "Failed to save assistant configuration. Please try again."
+                return
+            }
+
             UserDefaults.standard.set(assistant.id, forKey: "connectedAssistantId")
 
             isBootstrappingManaged = false


### PR DESCRIPTION
## Summary
- Check return value of `LockfileAssistant.upsertManagedEntry()` in `performManagedBootstrap()`
- If the lockfile write fails, keep the user on the onboarding screen with an error message and retry option
- Prevents completing onboarding without a persistent lockfile entry, which would cause the app to "forget" the managed assistant on next launch

## Test plan
- [x] `swift build` succeeds
- [x] Failed lockfile write shows error, does not call `onComplete()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
