### PR TITLE
fix: remove bundled skills from search results per migration plan

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -26,7 +26,6 @@ import {
   clawhubInspect,
   clawhubInstall,
   clawhubSearch,
-  type ClawhubSearchResultItem,
   clawhubUpdate,
 } from "../../skills/clawhub.js";
 import {
@@ -546,43 +545,13 @@ export async function handleSkillsSearch(
   ctx: HandlerContext,
 ): Promise<void> {
   try {
-    // Bundled skills are already in loadSkillCatalog() — surface them as
-    // search results alongside clawhub community results.
-    const catalog = loadSkillCatalog();
-    const query = (msg.query ?? "").toLowerCase();
-    const matchingBundled: ClawhubSearchResultItem[] = catalog
-      .filter((s) => s.source === "bundled")
-      .filter((s) => {
-        if (!query) return true;
-        return (
-          s.name.toLowerCase().includes(query) ||
-          s.description.toLowerCase().includes(query) ||
-          s.id.toLowerCase().includes(query)
-        );
-      })
-      .map((s) => ({
-        name: s.name,
-        slug: s.id,
-        description: s.description,
-        author: "Vellum",
-        stars: 0,
-        installs: 0,
-        version: "",
-        createdAt: 0,
-        source: "vellum" as const,
-      }));
-
-    // Search clawhub (community)
-    const clawhubResult = await clawhubSearch(msg.query);
-
-    // Merge: bundled first, then clawhub
-    const merged = { skills: [...matchingBundled, ...clawhubResult.skills] };
+    const result = await clawhubSearch(msg.query);
 
     ctx.send(socket, {
       type: "skills_operation_response",
       operation: "search",
       success: true,
-      data: merged,
+      data: result,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Removed bundled skills filtering/mapping logic from `handleSkillsSearch` — the function now only returns clawhub community search results
- Bundled skills were redundantly surfaced in search results with `source: "vellum"` despite already being loaded via `loadSkillCatalog()` and visible in the skills list
- Cleaned up the unused `ClawhubSearchResultItem` type import

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test skills` passes (114 tests, 0 failures)
- [ ] Verify search results no longer include bundled skills with `source: "vellum"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
