### PR TITLE
fix: use lockfile runtimeUrl for managed transport configuration

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1169,7 +1169,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
         // Managed assistant: use platform proxy URLs with session token auth.
         if let assistant, assistant.isManaged {
-            let platformBaseURL = AuthService.shared.baseURL
+            let platformBaseURL = assistant.runtimeUrl ?? AuthService.shared.baseURL
             let metadata = TransportMetadata(
                 routeMode: .platformAssistantProxy,
                 authMode: .sessionToken,


### PR DESCRIPTION
## Summary
- Changed managed transport to use `assistant.runtimeUrl ?? AuthService.shared.baseURL`
- The lockfile `runtimeUrl` is set during bootstrap and persisted — it should be the source of truth
- Matches the pattern already used for remote (non-managed) assistants
- Falls back to `AuthService.shared.baseURL` if `runtimeUrl` is nil

## Test plan
- [x] swift build succeeds
- [x] Managed transport uses persisted URL, consistent with remote assistant handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
