### PR TITLE
fix: clean up surfaceActionRequestIds after request completion and revert maxToolUseTurns default

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -205,7 +205,7 @@ export const AssistantConfigSchema = z.object({
     .number({ error: 'maxToolUseTurns must be a number' })
     .int('maxToolUseTurns must be an integer')
     .nonnegative('maxToolUseTurns must be a non-negative integer')
-    .default(40),
+    .default(0),
   thinking: ThinkingConfigSchema.default(ThinkingConfigSchema.parse({})),
   contextWindow: ContextWindowConfigSchema.default(ContextWindowConfigSchema.parse({})),
   memory: MemoryConfigSchema.default(MemoryConfigSchema.parse({})),

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -841,6 +841,7 @@ export async function runAgentLoopImpl(
 
     ctx.abortController = null;
     ctx.processing = false;
+    ctx.surfaceActionRequestIds.delete(ctx.currentRequestId ?? '');
     ctx.currentRequestId = undefined;
     ctx.currentActiveSurfaceId = undefined;
     ctx.allowedToolNames = undefined;


### PR DESCRIPTION
Addresses review feedback on #11406:

1. Remove completed request ID from surfaceActionRequestIds in the agent loop finally block to prevent unbounded growth in long-lived sessions.
2. Revert maxToolUseTurns default from 40 back to 0 (unlimited) — the declutter safety is already handled by yieldToUser and triggeredBySurfaceAction gates.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
