### PR TITLE
fix: preserve statusText on thinking_delta when no tool has completed

### DIFF
--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -185,10 +185,16 @@ export function handleThinkingDelta(
   if (!state.firstThinkingDeltaEmitted) {
     state.firstThinkingDeltaEmitted = true;
     const lastToolName = state.lastCompletedToolName;
-    const statusText = lastToolName
-      ? `Processing ${friendlyToolName(lastToolName)} results`
-      : undefined;
-    deps.ctx.emitActivityState('thinking', 'thinking_delta', 'assistant_turn', deps.reqId, statusText);
+    // Only emit activity state when we have a tool name to report.
+    // When lastCompletedToolName is undefined (e.g. right after
+    // confirmation_resolved), emitting without statusText would clear
+    // the client's current status (e.g. "Resuming after approval").
+    // The phase is already 'thinking' from either message_dequeued or
+    // confirmation_resolved, so skipping here is safe.
+    if (lastToolName) {
+      const statusText = `Processing ${friendlyToolName(lastToolName)} results`;
+      deps.ctx.emitActivityState('thinking', 'thinking_delta', 'assistant_turn', deps.reqId, statusText);
+    }
   }
   if (!deps.ctx.streamThinking) return;
   emitLlmCallStartedIfNeeded(state, deps);


### PR DESCRIPTION
Addresses review feedback on #11407:

When the first thinking_delta fires after confirmation_resolved, lastCompletedToolName is undefined so statusText was set to undefined, clearing the "Resuming after approval" status. Now we only emit the activity state when we actually have a tool name to report, preserving the client's existing status text.

The phase is already 'thinking' from either message_dequeued or confirmation_resolved, so skipping the emission when there's no tool name is safe.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
