### PR TITLE
fix: add HTTP transport handlers for surface actions and trust rules

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -437,6 +437,7 @@ export async function runDaemon(): Promise<void> {
             data: a.dataBase64,
           })),
       },
+      findSession: (sessionId) => server.findSession(sessionId),
     });
 
     // Inject voice bridge deps BEFORE attempting to start the HTTP server.

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1,61 +1,91 @@
-import { chmodSync, existsSync, readFileSync,statSync } from 'node:fs';
-import * as net from 'node:net';
-import { join } from 'node:path';
-import * as tls from 'node:tls';
+import { chmodSync, existsSync, readFileSync, statSync } from "node:fs";
+import * as net from "node:net";
+import { join } from "node:path";
+import * as tls from "node:tls";
 
-import { createAssistantMessage,createUserMessage } from '../agent/message-types.js';
-import { type ChannelId, type InterfaceId,parseChannelId, parseInterfaceId } from '../channels/types.js';
-import { getConfig } from '../config/loader.js';
-import { buildSystemPrompt } from '../config/system-prompt.js';
-import type { HeartbeatService } from '../heartbeat/heartbeat-service.js';
-import { bootstrapHomeBaseAppLink } from '../home-base/bootstrap.js';
-import * as attachmentsStore from '../memory/attachments-store.js';
+import {
+  createAssistantMessage,
+  createUserMessage,
+} from "../agent/message-types.js";
+import {
+  type ChannelId,
+  type InterfaceId,
+  parseChannelId,
+  parseInterfaceId,
+} from "../channels/types.js";
+import { getConfig } from "../config/loader.js";
+import { buildSystemPrompt } from "../config/system-prompt.js";
+import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
+import { bootstrapHomeBaseAppLink } from "../home-base/bootstrap.js";
+import * as attachmentsStore from "../memory/attachments-store.js";
 import {
   createCanonicalGuardianRequest,
   generateCanonicalRequestCode,
-} from '../memory/canonical-guardian-store.js';
-import * as conversationStore from '../memory/conversation-store.js';
-import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
-import { RateLimitProvider } from '../providers/ratelimit.js';
-import { getFailoverProvider, initializeProviders } from '../providers/registry.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
-import { bridgeConfirmationRequestToGuardian } from '../runtime/confirmation-request-guardian-bridge.js';
-import * as pendingInteractions from '../runtime/pending-interactions.js';
-import { checkIngressForSecrets } from '../security/secret-ingress.js';
-import { getSubagentManager } from '../subagent/index.js';
-import { IngressBlockedError } from '../util/errors.js';
-import { getLogger } from '../util/logger.js';
-import { getLocalIPv4 } from '../util/network-info.js';
-import { getSandboxWorkingDir, getSocketPath, getTCPHost, getTCPPort, getWorkspacePromptPath, isIOSPairingEnabled,isTCPEnabled, removeSocketFile } from '../util/platform.js';
-import { registerDaemonCallbacks } from '../work-items/work-item-runner.js';
-import { AuthManager } from './auth-manager.js';
-import { ComputerUseSession } from './computer-use-session.js';
-import { ConfigWatcher } from './config-watcher.js';
-import { handleMessage, type HandlerContext, type SessionCreateOptions } from './handlers.js';
-import { parseIdentityFields } from './handlers/identity.js';
-import { cleanupRecordingsOnDisconnect } from './handlers/recording.js';
-import { ensureBlobDir, sweepStaleBlobs } from './ipc-blob-store.js';
-import { IpcSender } from './ipc-handler.js';
+} from "../memory/canonical-guardian-store.js";
+import * as conversationStore from "../memory/conversation-store.js";
+import { provenanceFromGuardianContext } from "../memory/conversation-store.js";
+import { RateLimitProvider } from "../providers/ratelimit.js";
+import {
+  getFailoverProvider,
+  initializeProviders,
+} from "../providers/registry.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import { bridgeConfirmationRequestToGuardian } from "../runtime/confirmation-request-guardian-bridge.js";
+import * as pendingInteractions from "../runtime/pending-interactions.js";
+import { checkIngressForSecrets } from "../security/secret-ingress.js";
+import { getSubagentManager } from "../subagent/index.js";
+import { IngressBlockedError } from "../util/errors.js";
+import { getLogger } from "../util/logger.js";
+import { getLocalIPv4 } from "../util/network-info.js";
+import {
+  getSandboxWorkingDir,
+  getSocketPath,
+  getTCPHost,
+  getTCPPort,
+  getWorkspacePromptPath,
+  isIOSPairingEnabled,
+  isTCPEnabled,
+  removeSocketFile,
+} from "../util/platform.js";
+import { registerDaemonCallbacks } from "../work-items/work-item-runner.js";
+import { AuthManager } from "./auth-manager.js";
+import { ComputerUseSession } from "./computer-use-session.js";
+import { ConfigWatcher } from "./config-watcher.js";
+import {
+  handleMessage,
+  type HandlerContext,
+  type SessionCreateOptions,
+} from "./handlers.js";
+import { parseIdentityFields } from "./handlers/identity.js";
+import { cleanupRecordingsOnDisconnect } from "./handlers/recording.js";
+import { ensureBlobDir, sweepStaleBlobs } from "./ipc-blob-store.js";
+import { IpcSender } from "./ipc-handler.js";
 import {
   createMessageParser,
   MAX_LINE_SIZE,
   normalizeThreadType,
   serialize,
   type ServerMessage,
-} from './ipc-protocol.js';
-import { validateClientMessage } from './ipc-validate.js';
-import { DEFAULT_MEMORY_POLICY, Session, type SessionMemoryPolicy } from './session.js';
-import { SessionEvictor } from './session-evictor.js';
-import { resolveChannelCapabilities } from './session-runtime-assembly.js';
-import { resolveSlash } from './session-slash.js';
-import { ensureTlsCert } from './tls-certs.js';
+} from "./ipc-protocol.js";
+import { validateClientMessage } from "./ipc-validate.js";
+import {
+  DEFAULT_MEMORY_POLICY,
+  Session,
+  type SessionMemoryPolicy,
+} from "./session.js";
+import { SessionEvictor } from "./session-evictor.js";
+import { resolveChannelCapabilities } from "./session-runtime-assembly.js";
+import { resolveSlash } from "./session-slash.js";
+import { ensureTlsCert } from "./tls-certs.js";
 
-const log = getLogger('server');
+const log = getLogger("server");
 
 function readPackageVersion(): string | undefined {
   try {
-    const pkgPath = join(import.meta.dir, '../../package.json');
-    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as { version?: string };
+    const pkgPath = join(import.meta.dir, "../../package.json");
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+      version?: string;
+    };
     return pkg.version;
   } catch {
     return undefined;
@@ -64,7 +94,10 @@ function readPackageVersion(): string | undefined {
 
 const daemonVersion = readPackageVersion();
 
-function resolveTurnChannel(sourceChannel?: string, transportChannelId?: string): ChannelId {
+function resolveTurnChannel(
+  sourceChannel?: string,
+  transportChannelId?: string,
+): ChannelId {
   if (sourceChannel != null) {
     const parsed = parseChannelId(sourceChannel);
     if (!parsed) {
@@ -79,7 +112,7 @@ function resolveTurnChannel(sourceChannel?: string, transportChannelId?: string)
     }
     return parsed;
   }
-  return 'vellum';
+  return "vellum";
 }
 
 function resolveTurnInterface(sourceInterface?: string): InterfaceId {
@@ -92,17 +125,19 @@ function resolveTurnInterface(sourceInterface?: string): InterfaceId {
   }
   // Interface and channel are orthogonal dimensions; default explicitly
   // instead of deriving interface from channel.
-  return 'vellum';
+  return "vellum";
 }
 
-function resolveCanonicalRequestSourceType(sourceChannel: string | undefined): 'desktop' | 'channel' | 'voice' {
-  if (sourceChannel === 'voice') {
-    return 'voice';
+function resolveCanonicalRequestSourceType(
+  sourceChannel: string | undefined,
+): "desktop" | "channel" | "voice" {
+  if (sourceChannel === "voice") {
+    return "voice";
   }
-  if (sourceChannel === 'vellum') {
-    return 'desktop';
+  if (sourceChannel === "vellum") {
+    return "desktop";
   }
-  return 'channel';
+  return "channel";
 }
 
 /**
@@ -115,11 +150,11 @@ function makePendingInteractionRegistrar(
   conversationId: string,
 ): (msg: ServerMessage) => void {
   return (msg: ServerMessage) => {
-    if (msg.type === 'confirmation_request') {
+    if (msg.type === "confirmation_request") {
       pendingInteractions.register(msg.requestId, {
         session,
         conversationId,
-        kind: 'confirmation',
+        kind: "confirmation",
         confirmationDetails: {
           toolName: msg.toolName,
           input: msg.input,
@@ -135,19 +170,20 @@ function makePendingInteractionRegistrar(
       // via applyCanonicalGuardianDecision.
       try {
         const guardianContext = session.guardianContext;
-        const sourceChannel = guardianContext?.sourceChannel ?? 'vellum';
+        const sourceChannel = guardianContext?.sourceChannel ?? "vellum";
         const canonicalRequest = createCanonicalGuardianRequest({
           id: msg.requestId,
-          kind: 'tool_approval',
+          kind: "tool_approval",
           sourceType: resolveCanonicalRequestSourceType(sourceChannel),
           sourceChannel,
           conversationId,
           requesterExternalUserId: guardianContext?.requesterExternalUserId,
           requesterChatId: guardianContext?.requesterChatId,
           guardianExternalUserId: guardianContext?.guardianExternalUserId,
-          guardianPrincipalId: guardianContext?.guardianPrincipalId ?? undefined,
+          guardianPrincipalId:
+            guardianContext?.guardianPrincipalId ?? undefined,
           toolName: msg.toolName,
-          status: 'pending',
+          status: "pending",
           requestCode: generateCanonicalRequestCode(),
           expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
         });
@@ -166,14 +202,14 @@ function makePendingInteractionRegistrar(
       } catch (err) {
         log.debug(
           { err, requestId: msg.requestId, conversationId },
-          'Failed to create canonical request from pending interaction registrar',
+          "Failed to create canonical request from pending interaction registrar",
         );
       }
-    } else if (msg.type === 'secret_request') {
+    } else if (msg.type === "secret_request") {
       pendingInteractions.register(msg.requestId, {
         session,
         conversationId,
-        kind: 'secret',
+        kind: "secret",
       });
     }
   };
@@ -206,7 +242,7 @@ export class DaemonServer {
   /**
    * Logical assistant identifier used when publishing to the assistant-events hub.
    */
-  assistantId: string = 'default';
+  assistantId: string = "default";
 
   /** Optional heartbeat service reference for "Run Now" from the UI. */
   private _heartbeatService?: HeartbeatService;
@@ -216,8 +252,9 @@ export class DaemonServer {
   }
 
   private deriveMemoryPolicy(conversationId: string): SessionMemoryPolicy {
-    const threadType = conversationStore.getConversationThreadType(conversationId);
-    if (threadType === 'private') {
+    const threadType =
+      conversationStore.getConversationThreadType(conversationId);
+    if (threadType === "private") {
       return {
         scopeId: conversationStore.getConversationMemoryScopeId(conversationId),
         includeDefaultFallback: true,
@@ -227,10 +264,16 @@ export class DaemonServer {
     return DEFAULT_MEMORY_POLICY;
   }
 
-  private applyTransportMetadata(_session: Session, options: SessionCreateOptions | undefined): void {
+  private applyTransportMetadata(
+    _session: Session,
+    options: SessionCreateOptions | undefined,
+  ): void {
     const transport = options?.transport;
     if (!transport) return;
-    log.debug({ channelId: transport.channelId }, 'Transport metadata received');
+    log.debug(
+      { channelId: transport.channelId },
+      "Transport metadata received",
+    );
   }
 
   constructor() {
@@ -242,26 +285,57 @@ export class DaemonServer {
     };
     this.evictor.shouldProtect = (sessionId: string) => {
       const children = getSubagentManager().getChildrenOf(sessionId);
-      return children.some((c) => c.status === 'running' || c.status === 'pending');
+      return children.some(
+        (c) => c.status === "running" || c.status === "pending",
+      );
     };
-    getSubagentManager().onSubagentFinished = async (parentSessionId, message, sendToClient, notification) => {
+    getSubagentManager().onSubagentFinished = async (
+      parentSessionId,
+      message,
+      sendToClient,
+      notification,
+    ) => {
       const parentSession = this.sessions.get(parentSessionId);
       if (!parentSession) {
-        log.warn({ parentSessionId }, 'Subagent finished but parent session not found');
+        log.warn(
+          { parentSessionId },
+          "Subagent finished but parent session not found",
+        );
         return;
       }
       const requestId = `subagent-notify-${Date.now()}`;
       const metadata = { subagentNotification: notification };
-      const enqueueResult = parentSession.enqueueMessage(message, [], sendToClient, requestId, undefined, undefined, metadata);
+      const enqueueResult = parentSession.enqueueMessage(
+        message,
+        [],
+        sendToClient,
+        requestId,
+        undefined,
+        undefined,
+        metadata,
+      );
       if (enqueueResult.rejected) {
-        log.warn({ parentSessionId }, 'Parent session queue full, dropping subagent notification');
+        log.warn(
+          { parentSessionId },
+          "Parent session queue full, dropping subagent notification",
+        );
         return;
       }
       if (!enqueueResult.queued) {
-        const messageId = await parentSession.persistUserMessage(message, [], undefined, metadata);
-        parentSession.runAgentLoop(message, messageId, sendToClient).catch((err) => {
-          log.error({ parentSessionId, err }, 'Failed to process subagent notification in parent');
-        });
+        const messageId = await parentSession.persistUserMessage(
+          message,
+          [],
+          undefined,
+          metadata,
+        );
+        parentSession
+          .runAgentLoop(message, messageId, sendToClient)
+          .catch((err) => {
+            log.error(
+              { parentSessionId, err },
+              "Failed to process subagent notification in parent",
+            );
+          });
       }
     };
   }
@@ -284,11 +358,13 @@ export class DaemonServer {
 
   private broadcastIdentityChanged(): void {
     try {
-      const identityPath = getWorkspacePromptPath('IDENTITY.md');
-      const content = existsSync(identityPath) ? readFileSync(identityPath, 'utf-8') : '';
+      const identityPath = getWorkspacePromptPath("IDENTITY.md");
+      const content = existsSync(identityPath)
+        ? readFileSync(identityPath, "utf-8")
+        : "";
       const fields = parseIdentityFields(content);
       this.broadcast({
-        type: 'identity_changed',
+        type: "identity_changed",
         name: fields.name,
         role: fields.role,
         personality: fields.personality,
@@ -296,7 +372,7 @@ export class DaemonServer {
         home: fields.home,
       });
     } catch (err) {
-      log.error({ err }, 'Failed to broadcast identity change');
+      log.error({ err }, "Failed to broadcast identity change");
     }
   }
 
@@ -312,22 +388,29 @@ export class DaemonServer {
     try {
       bootstrapHomeBaseAppLink();
     } catch (err) {
-      log.warn({ err }, 'Failed to bootstrap Home Base app link at daemon startup');
+      log.warn(
+        { err },
+        "Failed to bootstrap Home Base app link at daemon startup",
+      );
     }
 
     this.evictor.start();
 
     registerDaemonCallbacks({
-      getOrCreateSession: (conversationId) => this.getOrCreateSession(conversationId),
+      getOrCreateSession: (conversationId) =>
+        this.getOrCreateSession(conversationId),
       broadcast: (msg) => this.broadcast(msg),
     });
 
     ensureBlobDir();
-    this.blobSweepTimer = setInterval(() => {
-      sweepStaleBlobs(30 * 60 * 1000).catch((err) => {
-        log.warn({ err }, 'Blob sweep failed');
-      });
-    }, 5 * 60 * 1000);
+    this.blobSweepTimer = setInterval(
+      () => {
+        sweepStaleBlobs(30 * 60 * 1000).catch((err) => {
+          log.warn({ err }, "Blob sweep failed");
+        });
+      },
+      5 * 60 * 1000,
+    );
 
     this.configWatcher.start(
       () => this.evictSessionsForReload(),
@@ -335,12 +418,16 @@ export class DaemonServer {
     );
     this.auth.initToken();
 
-    let tlsCreds: { cert: string; key: string; fingerprint: string } | null = null;
+    let tlsCreds: { cert: string; key: string; fingerprint: string } | null =
+      null;
     if (isTCPEnabled()) {
       try {
         tlsCreds = await ensureTlsCert();
       } catch (err) {
-        log.error({ err }, 'Failed to generate TLS certificate — TCP listener will not start');
+        log.error(
+          { err },
+          "Failed to generate TLS certificate — TCP listener will not start",
+        );
       }
     }
 
@@ -351,53 +438,68 @@ export class DaemonServer {
 
       const oldUmask = process.umask(0o177);
 
-      this.server.once('error', (err) => {
+      this.server.once("error", (err) => {
         process.umask(oldUmask);
-        log.error({ err, socketPath: this.socketPath }, 'Server failed to start (is another daemon already running?)');
+        log.error(
+          { err, socketPath: this.socketPath },
+          "Server failed to start (is another daemon already running?)",
+        );
         reject(err);
       });
 
       this.server.listen(this.socketPath, () => {
         process.umask(oldUmask);
-        this.server!.removeAllListeners('error');
-        this.server!.on('error', (err) => {
-          log.error({ err, socketPath: this.socketPath }, 'Server socket error while running');
+        this.server!.removeAllListeners("error");
+        this.server!.on("error", (err) => {
+          log.error(
+            { err, socketPath: this.socketPath },
+            "Server socket error while running",
+          );
         });
         chmodSync(this.socketPath, 0o600);
         // Validate the chmod actually took effect — some filesystems
         // (e.g. FAT32 mounts, container overlays) silently ignore chmod.
         const socketStat = statSync(this.socketPath);
         if ((socketStat.mode & 0o077) !== 0) {
-          const actual = '0o' + (socketStat.mode & 0o777).toString(8);
+          const actual = "0o" + (socketStat.mode & 0o777).toString(8);
           log.error(
             { socketPath: this.socketPath, mode: actual },
-            'IPC socket is accessible by other users (expected 0600) — filesystem may not support Unix permissions',
+            "IPC socket is accessible by other users (expected 0600) — filesystem may not support Unix permissions",
           );
         }
-        log.info({ socketPath: this.socketPath }, 'Daemon server listening');
+        log.info({ socketPath: this.socketPath }, "Daemon server listening");
 
         if (tlsCreds) {
           const tcpPort = getTCPPort();
           const tcpHost = getTCPHost();
           this.tcpServer = tls.createServer(
             { cert: tlsCreds.cert, key: tlsCreds.key },
-            (socket) => { this.handleConnection(socket); },
+            (socket) => {
+              this.handleConnection(socket);
+            },
           );
-          this.tcpServer.on('error', (err) => {
-            log.error({ err, tcpPort }, 'TLS TCP server error');
+          this.tcpServer.on("error", (err) => {
+            log.error({ err, tcpPort }, "TLS TCP server error");
           });
           const fingerprint = tlsCreds.fingerprint;
           this.tcpServer.listen(tcpPort, tcpHost, () => {
             const localIP = getLocalIPv4();
             log.info(
-              { tcpPort, tcpHost, fingerprint, localIP, iosPairing: isIOSPairingEnabled() },
-              'TLS TCP listener started',
+              {
+                tcpPort,
+                tcpHost,
+                fingerprint,
+                localIP,
+                iosPairing: isIOSPairingEnabled(),
+              },
+              "TLS TCP listener started",
             );
             if (isIOSPairingEnabled() && localIP) {
               log.warn(
                 { localIP, tcpPort },
-                'iOS pairing enabled — daemon is reachable on the local network at %s:%d',
-                localIP, tcpPort,
+                "iOS pairing enabled — daemon is reachable on the local network at %s:%d",
+                localIP,
+                tcpPort,
               );
             }
           });
@@ -424,7 +526,10 @@ export class DaemonServer {
           try {
             removeSocketFile(this.socketPath);
           } catch (err) {
-            log.warn({ err, socketPath: this.socketPath }, 'Failed to remove socket file during shutdown');
+            log.warn(
+              { err, socketPath: this.socketPath },
+              "Failed to remove socket file during shutdown",
+            );
           }
           resolve();
         });
@@ -462,75 +567,117 @@ export class DaemonServer {
     this.cuObservationParseSequence.clear();
 
     await Promise.all([serverClosed, tcpServerClosed]);
-    log.info('Daemon server stopped');
+    log.info("Daemon server stopped");
   }
 
   // ── Connection handling ─────────────────────────────────────────────
 
   private handleConnection(socket: net.Socket): void {
     if (this.connectedSockets.size >= DaemonServer.MAX_CONNECTIONS) {
-      log.warn({ current: this.connectedSockets.size, max: DaemonServer.MAX_CONNECTIONS }, 'Connection limit reached, rejecting client');
-      socket.once('error', (err) => {
-        log.error({ err }, 'Socket error while rejecting connection');
+      log.warn(
+        {
+          current: this.connectedSockets.size,
+          max: DaemonServer.MAX_CONNECTIONS,
+        },
+        "Connection limit reached, rejecting client",
+      );
+      socket.once("error", (err) => {
+        log.error({ err }, "Socket error while rejecting connection");
       });
-      socket.write(serialize({ type: 'error', message: `Connection limit reached (max ${DaemonServer.MAX_CONNECTIONS})` }));
+      socket.write(
+        serialize({
+          type: "error",
+          message: `Connection limit reached (max ${DaemonServer.MAX_CONNECTIONS})`,
+        }),
+      );
       socket.destroy();
       return;
     }
 
-    log.info('Client connected');
+    log.info("Client connected");
     this.connectedSockets.add(socket);
     const parser = createMessageParser({ maxLineSize: MAX_LINE_SIZE });
 
     if (this.auth.shouldAutoAuth()) {
       this.auth.markAuthenticated(socket);
-      log.warn('Auto-authenticated client (VELLUM_DAEMON_NOAUTH is set — token auth bypassed)');
-      this.send(socket, { type: 'auth_result', success: true });
+      log.warn(
+        "Auto-authenticated client (VELLUM_DAEMON_NOAUTH is set — token auth bypassed)",
+      );
+      this.send(socket, { type: "auth_result", success: true });
       this.sendInitialSession(socket).catch((err) => {
-        log.error({ err }, 'Failed to send initial session info after auto-auth');
+        log.error(
+          { err },
+          "Failed to send initial session info after auto-auth",
+        );
       });
     }
 
     this.auth.startTimeout(socket, () => {
-      this.send(socket, { type: 'error', message: 'Authentication timeout' });
+      this.send(socket, { type: "error", message: "Authentication timeout" });
       socket.destroy();
     });
 
-    socket.on('data', (data) => {
+    socket.on("data", (data) => {
       const chunkReceivedAtMs = Date.now();
       const parseStartNs = process.hrtime.bigint();
       let parsed;
       try {
         parsed = parser.feedRaw(data.toString());
       } catch (err) {
-        log.error({ err }, 'IPC parse error (malformed JSON or message exceeded size limit), dropping client');
-        socket.write(serialize({ type: 'error', message: `IPC parse error: ${(err as Error).message}` }));
+        log.error(
+          { err },
+          "IPC parse error (malformed JSON or message exceeded size limit), dropping client",
+        );
+        socket.write(
+          serialize({
+            type: "error",
+            message: `IPC parse error: ${(err as Error).message}`,
+          }),
+        );
         socket.destroy();
         return;
       }
       const parsedAtMs = Date.now();
-      const parseDurationMs = Number(process.hrtime.bigint() - parseStartNs) / 1_000_000;
+      const parseDurationMs =
+        Number(process.hrtime.bigint() - parseStartNs) / 1_000_000;
       for (const entry of parsed) {
         const msg = entry.msg;
-        if (typeof msg === 'object' && msg != null && (msg as { type?: unknown }).type === 'cu_observation') {
+        if (
+          typeof msg === "object" &&
+          msg != null &&
+          (msg as { type?: unknown }).type === "cu_observation"
+        ) {
           const maybeSessionId = (msg as { sessionId?: unknown }).sessionId;
-          const sessionId = typeof maybeSessionId === 'string' ? maybeSessionId : 'unknown';
-          const previousSequence = this.cuObservationParseSequence.get(sessionId) ?? 0;
+          const sessionId =
+            typeof maybeSessionId === "string" ? maybeSessionId : "unknown";
+          const previousSequence =
+            this.cuObservationParseSequence.get(sessionId) ?? 0;
           const sequence = previousSequence + 1;
           this.cuObservationParseSequence.set(sessionId, sequence);
-          log.info({
-            sessionId,
-            sequence,
-            chunkReceivedAtMs,
-            parsedAtMs,
-            parseDurationMs,
-            messageBytes: entry.rawByteLength,
-          }, 'IPC_METRIC cu_observation_parse');
+          log.info(
+            {
+              sessionId,
+              sequence,
+              chunkReceivedAtMs,
+              parsedAtMs,
+              parseDurationMs,
+              messageBytes: entry.rawByteLength,
+            },
+            "IPC_METRIC cu_observation_parse",
+          );
         }
         const result = validateClientMessage(msg);
         if (!result.valid) {
-          log.warn({ reason: result.reason }, 'Invalid IPC message, dropping client');
-          socket.write(serialize({ type: 'error', message: `Invalid message: ${result.reason}` }));
+          log.warn(
+            { reason: result.reason },
+            "Invalid IPC message, dropping client",
+          );
+          socket.write(
+            serialize({
+              type: "error",
+              message: `Invalid message: ${result.reason}`,
+            }),
+          );
           socket.destroy();
           return;
         }
@@ -539,29 +686,42 @@ export class DaemonServer {
         if (!this.auth.isAuthenticated(socket)) {
           this.auth.clearTimeout(socket);
 
-          if (result.message.type === 'auth') {
-            const authMsg = result.message as { type: 'auth'; token: string };
+          if (result.message.type === "auth") {
+            const authMsg = result.message as { type: "auth"; token: string };
             if (this.auth.authenticate(socket, authMsg.token)) {
-              this.send(socket, { type: 'auth_result', success: true });
+              this.send(socket, { type: "auth_result", success: true });
               this.sendInitialSession(socket).catch((err) => {
-                log.error({ err }, 'Failed to send initial session info after auth');
+                log.error(
+                  { err },
+                  "Failed to send initial session info after auth",
+                );
               });
             } else {
-              this.send(socket, { type: 'auth_result', success: false, message: 'Invalid token' });
+              this.send(socket, {
+                type: "auth_result",
+                success: false,
+                message: "Invalid token",
+              });
               socket.destroy();
             }
             continue;
           }
 
-          log.warn({ type: result.message.type }, 'Unauthenticated client sent non-auth message, disconnecting');
-          this.send(socket, { type: 'error', message: 'Authentication required' });
+          log.warn(
+            { type: result.message.type },
+            "Unauthenticated client sent non-auth message, disconnecting",
+          );
+          this.send(socket, {
+            type: "error",
+            message: "Authentication required",
+          });
           socket.destroy();
           return;
         }
 
         // Already-authenticated socket sending auth (e.g. auto-auth'd + local token)
-        if (result.message.type === 'auth') {
-          this.send(socket, { type: 'auth_result', success: true });
+        if (result.message.type === "auth") {
+          this.send(socket, { type: "auth_result", success: true });
           continue;
         }
 
@@ -569,7 +729,7 @@ export class DaemonServer {
       }
     });
 
-    socket.on('close', () => {
+    socket.on("close", () => {
       this.auth.cleanupSocket(socket);
       this.connectedSockets.delete(socket);
       this.socketSandboxOverride.delete(socket);
@@ -604,11 +764,14 @@ export class DaemonServer {
         }
       }
       this.socketToCuSession.delete(socket);
-      log.info('Client disconnected');
+      log.info("Client disconnected");
     });
 
-    socket.on('error', (err) => {
-      log.error({ err, remoteAddress: socket.remoteAddress }, 'Client socket error');
+    socket.on("error", (err) => {
+      log.error(
+        { err, remoteAddress: socket.remoteAddress },
+        "Client socket error",
+      );
     });
   }
 
@@ -617,7 +780,7 @@ export class DaemonServer {
   setHttpPort(port: number): void {
     this.httpPort = port;
     this.broadcast({
-      type: 'daemon_status',
+      type: "daemon_status",
       httpPort: port,
       version: daemonVersion,
     });
@@ -670,7 +833,7 @@ export class DaemonServer {
     const conversation = conversationStore.getLatestConversation();
     if (!conversation) {
       this.send(socket, {
-        type: 'daemon_status',
+        type: "daemon_status",
         httpPort: this.httpPort,
         version: daemonVersion,
       });
@@ -680,14 +843,14 @@ export class DaemonServer {
     await this.getOrCreateSession(conversation.id, undefined, false);
 
     this.send(socket, {
-      type: 'session_info',
+      type: "session_info",
       sessionId: conversation.id,
-      title: conversation.title ?? 'New Conversation',
+      title: conversation.title ?? "New Conversation",
       threadType: normalizeThreadType(conversation.threadType),
     });
 
     this.send(socket, {
-      type: 'daemon_status',
+      type: "daemon_status",
       httpPort: this.httpPort,
       version: daemonVersion,
     });
@@ -710,7 +873,7 @@ export class DaemonServer {
       getSubagentManager().updateParentSender(conversationId, sendToClient);
     };
 
-    if (options && Object.values(options).some(v => v !== undefined)) {
+    if (options && Object.values(options).some((v) => v !== undefined)) {
       this.sessionOptions.set(conversationId, {
         ...this.sessionOptions.get(conversationId),
         ...options,
@@ -734,14 +897,25 @@ export class DaemonServer {
 
       const createPromise = (async () => {
         const config = getConfig();
-        let provider = getFailoverProvider(config.provider, config.providerOrder);
+        let provider = getFailoverProvider(
+          config.provider,
+          config.providerOrder,
+        );
         const { rateLimit } = config;
-        if (rateLimit.maxRequestsPerMinute > 0 || rateLimit.maxTokensPerSession > 0) {
-          provider = new RateLimitProvider(provider, rateLimit, this.sharedRequestTimestamps);
+        if (
+          rateLimit.maxRequestsPerMinute > 0 ||
+          rateLimit.maxTokensPerSession > 0
+        ) {
+          provider = new RateLimitProvider(
+            provider,
+            rateLimit,
+            this.sharedRequestTimestamps,
+          );
         }
         const workingDir = getSandboxWorkingDir();
 
-        const systemPrompt = storedOptions?.systemPromptOverride ?? buildSystemPrompt();
+        const systemPrompt =
+          storedOptions?.systemPromptOverride ?? buildSystemPrompt();
         const maxTokens = storedOptions?.maxResponseTokens ?? config.maxTokens;
 
         const memoryPolicy = this.deriveMemoryPolicy(conversationId);
@@ -795,7 +969,9 @@ export class DaemonServer {
       sharedRequestTimestamps: this.sharedRequestTimestamps,
       debounceTimers: this.configWatcher.timers,
       suppressConfigReload: this.configWatcher.suppressConfigReload,
-      setSuppressConfigReload: (value: boolean) => { this.configWatcher.suppressConfigReload = value; },
+      setSuppressConfigReload: (value: boolean) => {
+        this.configWatcher.suppressConfigReload = value;
+      },
       updateConfigFingerprint: () => {
         this.configWatcher.updateFingerprint();
       },
@@ -809,16 +985,25 @@ export class DaemonServer {
     };
   }
 
-  private dispatchMessage(msg: Parameters<typeof handleMessage>[0], socket: net.Socket): void {
-    if (msg.type !== 'ping') {
+  private dispatchMessage(
+    msg: Parameters<typeof handleMessage>[0],
+    socket: net.Socket,
+  ): void {
+    if (msg.type !== "ping") {
       const now = Date.now();
-      if (now - this.configWatcher.lastConfigRefreshTime >= ConfigWatcher.REFRESH_INTERVAL_MS) {
+      if (
+        now - this.configWatcher.lastConfigRefreshTime >=
+        ConfigWatcher.REFRESH_INTERVAL_MS
+      ) {
         try {
           const changed = this.configWatcher.refreshConfigFromSources();
           if (changed) this.evictSessionsForReload();
           this.configWatcher.lastConfigRefreshTime = now;
         } catch (err) {
-          log.warn({ err }, 'Failed to refresh config from secure sources before handling IPC message');
+          log.warn(
+            { err },
+            "Failed to refresh config from secure sources before handling IPC message",
+          );
         }
       }
     }
@@ -834,24 +1019,47 @@ export class DaemonServer {
     options: SessionCreateOptions | undefined,
     sourceChannel: string | undefined,
     sourceInterface: string | undefined,
-  ): Promise<{ session: Session; attachments: { id: string; filename: string; mimeType: string; data: string }[] }> {
+  ): Promise<{
+    session: Session;
+    attachments: {
+      id: string;
+      filename: string;
+      mimeType: string;
+      data: string;
+    }[];
+  }> {
     const ingressCheck = checkIngressForSecrets(content);
     if (ingressCheck.blocked) {
-      throw new IngressBlockedError(ingressCheck.userNotice!, ingressCheck.detectedTypes);
+      throw new IngressBlockedError(
+        ingressCheck.userNotice!,
+        ingressCheck.detectedTypes,
+      );
     }
 
-    const session = await this.getOrCreateSession(conversationId, undefined, true, options);
+    const session = await this.getOrCreateSession(
+      conversationId,
+      undefined,
+      true,
+      options,
+    );
 
     if (session.isProcessing()) {
-      throw new Error('Session is already processing a message');
+      throw new Error("Session is already processing a message");
     }
 
-    const resolvedChannel = resolveTurnChannel(sourceChannel, options?.transport?.channelId);
+    const resolvedChannel = resolveTurnChannel(
+      sourceChannel,
+      options?.transport?.channelId,
+    );
     const resolvedInterface = resolveTurnInterface(sourceInterface);
-    session.setAssistantId(options?.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID);
+    session.setAssistantId(
+      options?.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
+    );
     session.setGuardianContext(options?.guardianContext ?? null);
     await session.ensureActorScopedHistory();
-    session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel, sourceInterface));
+    session.setChannelCapabilities(
+      resolveChannelCapabilities(sourceChannel, sourceInterface),
+    );
     session.setCommandIntent(options?.commandIntent ?? null);
     session.setTurnChannelContext({
       userMessageChannel: resolvedChannel,
@@ -883,11 +1091,20 @@ export class DaemonServer {
     sourceInterface?: string,
   ): Promise<{ messageId: string }> {
     const { session, attachments } = await this.prepareSessionForMessage(
-      conversationId, content, attachmentIds, options, sourceChannel, sourceInterface,
+      conversationId,
+      content,
+      attachmentIds,
+      options,
+      sourceChannel,
+      sourceInterface,
     );
 
     const requestId = crypto.randomUUID();
-    const messageId = await session.persistUserMessage(content, attachments, requestId);
+    const messageId = await session.persistUserMessage(
+      content,
+      attachments,
+      requestId,
+    );
 
     // Register pending interactions so channel approval interception can
     // find the session by requestId when confirmation/secret events fire.
@@ -900,16 +1117,22 @@ export class DaemonServer {
       session.updateClient(onEvent, false);
     }
 
-    session.runAgentLoop(content, messageId, onEvent, { isInteractive: options?.isInteractive ?? false })
+    session
+      .runAgentLoop(content, messageId, onEvent, {
+        isInteractive: options?.isInteractive ?? false,
+      })
       .finally(() => {
         // Only reset if no other caller (e.g. a real IPC client) has rebound
         // the session's sender while the agent loop was running.
-        if (options?.isInteractive === true && session.getCurrentSender() === onEvent) {
+        if (
+          options?.isInteractive === true &&
+          session.getCurrentSender() === onEvent
+        ) {
           session.updateClient(() => {}, true);
         }
       })
       .catch((err) => {
-        log.error({ err, conversationId }, 'Background agent loop failed');
+        log.error({ err, conversationId }, "Background agent loop failed");
       });
 
     return { messageId };
@@ -924,28 +1147,42 @@ export class DaemonServer {
     sourceInterface?: string,
   ): Promise<{ messageId: string }> {
     const { session, attachments } = await this.prepareSessionForMessage(
-      conversationId, content, attachmentIds, options, sourceChannel, sourceInterface,
+      conversationId,
+      content,
+      attachmentIds,
+      options,
+      sourceChannel,
+      sourceInterface,
     );
 
     const slashResult = resolveSlash(content);
 
-    if (slashResult.kind === 'unknown') {
+    if (slashResult.kind === "unknown") {
       const serverTurnCtx = session.getTurnChannelContext();
       const serverInterfaceCtx = session.getTurnInterfaceContext();
-      const serverProvenance = provenanceFromGuardianContext(session.guardianContext);
+      const serverProvenance = provenanceFromGuardianContext(
+        session.guardianContext,
+      );
       const serverChannelMeta = {
         ...serverProvenance,
         ...(serverTurnCtx
-          ? { userMessageChannel: serverTurnCtx.userMessageChannel, assistantMessageChannel: serverTurnCtx.assistantMessageChannel }
+          ? {
+              userMessageChannel: serverTurnCtx.userMessageChannel,
+              assistantMessageChannel: serverTurnCtx.assistantMessageChannel,
+            }
           : {}),
         ...(serverInterfaceCtx
-          ? { userMessageInterface: serverInterfaceCtx.userMessageInterface, assistantMessageInterface: serverInterfaceCtx.assistantMessageInterface }
+          ? {
+              userMessageInterface: serverInterfaceCtx.userMessageInterface,
+              assistantMessageInterface:
+                serverInterfaceCtx.assistantMessageInterface,
+            }
           : {}),
       };
       const userMsg = createUserMessage(content, attachments);
       const persisted = await conversationStore.addMessage(
         conversationId,
-        'user',
+        "user",
         JSON.stringify(userMsg.content),
         serverChannelMeta,
       );
@@ -953,23 +1190,35 @@ export class DaemonServer {
 
       if (serverTurnCtx) {
         try {
-          conversationStore.setConversationOriginChannelIfUnset(conversationId, serverTurnCtx.userMessageChannel);
+          conversationStore.setConversationOriginChannelIfUnset(
+            conversationId,
+            serverTurnCtx.userMessageChannel,
+          );
         } catch (err) {
-          log.warn({ err, conversationId }, 'Failed to set origin channel (best-effort)');
+          log.warn(
+            { err, conversationId },
+            "Failed to set origin channel (best-effort)",
+          );
         }
       }
       if (serverInterfaceCtx) {
         try {
-          conversationStore.setConversationOriginInterfaceIfUnset(conversationId, serverInterfaceCtx.userMessageInterface);
+          conversationStore.setConversationOriginInterfaceIfUnset(
+            conversationId,
+            serverInterfaceCtx.userMessageInterface,
+          );
         } catch (err) {
-          log.warn({ err, conversationId }, 'Failed to set origin interface (best-effort)');
+          log.warn(
+            { err, conversationId },
+            "Failed to set origin interface (best-effort)",
+          );
         }
       }
 
       const assistantMsg = createAssistantMessage(slashResult.message);
       await conversationStore.addMessage(
         conversationId,
-        'assistant',
+        "assistant",
         JSON.stringify(assistantMsg.content),
         serverChannelMeta,
       );
@@ -979,14 +1228,18 @@ export class DaemonServer {
 
     const resolvedContent = slashResult.content;
 
-    if (slashResult.kind === 'rewritten') {
+    if (slashResult.kind === "rewritten") {
       session.setPreactivatedSkillIds([slashResult.skillId]);
     }
 
     const requestId = crypto.randomUUID();
     let messageId: string;
     try {
-      messageId = await session.persistUserMessage(resolvedContent, attachments, requestId);
+      messageId = await session.persistUserMessage(
+        resolvedContent,
+        attachments,
+        requestId,
+      );
     } catch (err) {
       session.setPreactivatedSkillIds(undefined);
       throw err;
@@ -1004,16 +1257,16 @@ export class DaemonServer {
     }
 
     try {
-      await session.runAgentLoop(
-        resolvedContent,
-        messageId,
-        onEvent,
-        { isInteractive: options?.isInteractive ?? false },
-      );
+      await session.runAgentLoop(resolvedContent, messageId, onEvent, {
+        isInteractive: options?.isInteractive ?? false,
+      });
     } finally {
       // Only reset if no other caller (e.g. a real IPC client) has rebound
       // the session's sender while the agent loop was running.
-      if (options?.isInteractive === true && session.getCurrentSender() === onEvent) {
+      if (
+        options?.isInteractive === true &&
+        session.getCurrentSender() === onEvent
+      ) {
         session.updateClient(() => {}, true);
       }
     }
@@ -1029,4 +1282,11 @@ export class DaemonServer {
     return this.getOrCreateSession(conversationId, undefined, true);
   }
 
+  /**
+   * Look up an active session by ID without creating one.
+   * Returns undefined if no session with that ID exists.
+   */
+  findSession(sessionId: string): Session | undefined {
+    return this.sessions.get(sessionId);
+  }
 }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -5,44 +5,55 @@
  * configured port (default: 7821).
  */
 
-import { existsSync, readFileSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
 
-import type { ServerWebSocket } from 'bun';
+import type { ServerWebSocket } from "bun";
 
-import type { BrowserRelayWebSocketData } from '../browser-extension-relay/server.js';
-import { extensionRelayServer } from '../browser-extension-relay/server.js';
+import type { BrowserRelayWebSocketData } from "../browser-extension-relay/server.js";
+import { extensionRelayServer } from "../browser-extension-relay/server.js";
 import {
   startGuardianActionSweep,
   stopGuardianActionSweep,
-} from '../calls/guardian-action-sweep.js';
-import type { RelayWebSocketData } from '../calls/relay-server.js';
-import { activeRelayConnections,RelayConnection } from '../calls/relay-server.js';
+} from "../calls/guardian-action-sweep.js";
+import type { RelayWebSocketData } from "../calls/relay-server.js";
+import {
+  activeRelayConnections,
+  RelayConnection,
+} from "../calls/relay-server.js";
 import {
   handleConnectAction,
   handleStatusCallback,
   handleVoiceWebhook,
-} from '../calls/twilio-routes.js';
-import { parseChannelId } from '../channels/types.js';
+} from "../calls/twilio-routes.js";
+import { parseChannelId } from "../channels/types.js";
 import {
   getGatewayInternalBaseUrl,
   getRuntimeGatewayOriginSecret,
   hasUngatedHttpAuthDisabled,
   isHttpAuthDisabled,
-} from '../config/env.js';
-import type { ServerMessage } from '../daemon/ipc-contract.js';
-import { PairingStore } from '../daemon/pairing-store.js';
-import { type Confidence, getAttentionStateByConversationIds, recordConversationSeenSignal,type SignalType } from '../memory/conversation-attention-store.js';
-import * as conversationStore from '../memory/conversation-store.js';
-import * as externalConversationStore from '../memory/external-conversation-store.js';
-import { consumeCallback, consumeCallbackError } from '../security/oauth-callback-registry.js';
-import { getLogger } from '../util/logger.js';
-import { buildAssistantEvent } from './assistant-event.js';
-import { assistantEventHub } from './assistant-event-hub.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
-import { sweepFailedEvents } from './channel-retry-sweep.js';
-import { httpError } from './http-errors.js';
+} from "../config/env.js";
+import type { ServerMessage } from "../daemon/ipc-contract.js";
+import { PairingStore } from "../daemon/pairing-store.js";
+import {
+  type Confidence,
+  getAttentionStateByConversationIds,
+  recordConversationSeenSignal,
+  type SignalType,
+} from "../memory/conversation-attention-store.js";
+import * as conversationStore from "../memory/conversation-store.js";
+import * as externalConversationStore from "../memory/external-conversation-store.js";
+import {
+  consumeCallback,
+  consumeCallbackError,
+} from "../security/oauth-callback-registry.js";
+import { getLogger } from "../util/logger.js";
+import { buildAssistantEvent } from "./assistant-event.js";
+import { assistantEventHub } from "./assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
+import { sweepFailedEvents } from "./channel-retry-sweep.js";
+import { httpError } from "./http-errors.js";
 // Middleware
 import {
   extractBearerToken,
@@ -50,16 +61,16 @@ import {
   isPrivateNetworkOrigin,
   isPrivateNetworkPeer,
   verifyBearerToken,
-} from './middleware/auth.js';
-import { withErrorHandling } from './middleware/error-handler.js';
+} from "./middleware/auth.js";
+import { withErrorHandling } from "./middleware/error-handler.js";
 import {
   apiRateLimiter,
   extractClientIp,
   ipRateLimiter,
   rateLimitHeaders,
   rateLimitResponse,
-} from './middleware/rate-limiter.js';
-import { withRequestLogging } from './middleware/request-logger.js';
+} from "./middleware/rate-limiter.js";
+import { withRequestLogging } from "./middleware/request-logger.js";
 import {
   cloneRequestWithBody,
   GATEWAY_ONLY_BLOCKED_SUBPATHS,
@@ -67,42 +78,46 @@ import {
   TWILIO_GATEWAY_WEBHOOK_RE,
   TWILIO_WEBHOOK_RE,
   validateTwilioWebhook,
-} from './middleware/twilio-validation.js';
+} from "./middleware/twilio-validation.js";
 import {
   handleDeleteSharedApp,
   handleDownloadSharedApp,
   handleGetSharedAppMetadata,
   handleServePage,
   handleShareApp,
-} from './routes/app-routes.js';
+} from "./routes/app-routes.js";
 import {
   handleConfirm,
   handleListPendingInteractions,
   handleSecret,
   handleTrustRule,
-} from './routes/approval-routes.js';
+} from "./routes/approval-routes.js";
 import {
   handleDeleteAttachment,
   handleGetAttachment,
   handleGetAttachmentContent,
   handleUploadAttachment,
-} from './routes/attachment-routes.js';
-import { handleGetBrainGraph, handleServeBrainGraphUI, handleServeHomeBaseUI } from './routes/brain-graph-routes.js';
+} from "./routes/attachment-routes.js";
+import {
+  handleGetBrainGraph,
+  handleServeBrainGraphUI,
+  handleServeHomeBaseUI,
+} from "./routes/brain-graph-routes.js";
 import {
   handleAnswerCall,
   handleCancelCall,
   handleGetCallStatus,
   handleInstructionCall,
   handleStartCall,
-} from './routes/call-routes.js';
+} from "./routes/call-routes.js";
 import {
   startCanonicalGuardianExpirySweep,
   stopCanonicalGuardianExpirySweep,
-} from './routes/canonical-guardian-expiry-sweep.js';
+} from "./routes/canonical-guardian-expiry-sweep.js";
 import {
   handleGetChannelReadiness,
   handleRefreshChannelReadiness,
-} from './routes/channel-readiness-routes.js';
+} from "./routes/channel-readiness-routes.js";
 import {
   handleChannelDeliveryAck,
   handleChannelInbound,
@@ -111,29 +126,29 @@ import {
   handleReplayDeadLetters,
   startGuardianExpirySweep,
   stopGuardianExpirySweep,
-} from './routes/channel-routes.js';
+} from "./routes/channel-routes.js";
 import {
   handleGetContact,
   handleListContacts,
   handleMergeContacts,
-} from './routes/contact-routes.js';
-import { handleListConversationAttention } from './routes/conversation-attention-routes.js';
+} from "./routes/contact-routes.js";
+import { handleListConversationAttention } from "./routes/conversation-attention-routes.js";
 // Route handlers — grouped by domain
 import {
   handleGetSuggestion,
   handleListMessages,
   handleSearchConversations,
   handleSendMessage,
-} from './routes/conversation-routes.js';
-import { handleDebug } from './routes/debug-routes.js';
-import { handleSubscribeAssistantEvents } from './routes/events-routes.js';
+} from "./routes/conversation-routes.js";
+import { handleDebug } from "./routes/debug-routes.js";
+import { handleSubscribeAssistantEvents } from "./routes/events-routes.js";
 import {
   handleGuardianActionDecision,
   handleGuardianActionsPending,
-} from './routes/guardian-action-routes.js';
-import { handleGuardianBootstrap } from './routes/guardian-bootstrap-routes.js';
-import { handleGuardianRefresh } from './routes/guardian-refresh-routes.js';
-import { handleGetIdentity,handleHealth } from './routes/identity-routes.js';
+} from "./routes/guardian-action-routes.js";
+import { handleGuardianBootstrap } from "./routes/guardian-bootstrap-routes.js";
+import { handleGuardianRefresh } from "./routes/guardian-refresh-routes.js";
+import { handleGetIdentity, handleHealth } from "./routes/identity-routes.js";
 import {
   handleBlockMember,
   handleCreateInvite,
@@ -143,7 +158,7 @@ import {
   handleRevokeInvite,
   handleRevokeMember,
   handleUpsertMember,
-} from './routes/ingress-routes.js';
+} from "./routes/ingress-routes.js";
 import {
   handleCancelOutbound,
   handleClearSlackChannelConfig,
@@ -158,15 +173,22 @@ import {
   handleSetTelegramConfig,
   handleSetupTelegram,
   handleStartOutbound,
-} from './routes/integration-routes.js';
-import type { PairingHandlerContext } from './routes/pairing-routes.js';
+} from "./routes/integration-routes.js";
+import type { PairingHandlerContext } from "./routes/pairing-routes.js";
 // Extracted route handlers
 import {
   handlePairingRegister,
   handlePairingRequest,
   handlePairingStatus,
-} from './routes/pairing-routes.js';
-import { handleAddSecret, handleDeleteSecret } from './routes/secret-routes.js';
+} from "./routes/pairing-routes.js";
+import { handleAddSecret, handleDeleteSecret } from "./routes/secret-routes.js";
+import { handleSurfaceAction } from "./routes/surface-action-routes.js";
+import {
+  handleAddTrustRuleManage,
+  handleListTrustRules,
+  handleRemoveTrustRuleManage,
+  handleUpdateTrustRuleManage,
+} from "./routes/trust-rules-routes.js";
 import {
   handleAssignTwilioNumber,
   handleClearTwilioCredentials,
@@ -181,10 +203,10 @@ import {
   handleSmsSendTest,
   handleSubmitTollfreeVerification,
   handleUpdateTollfreeVerification,
-} from './routes/twilio-routes.js';
+} from "./routes/twilio-routes.js";
 
 // Re-export for consumers
-export { isPrivateAddress } from './middleware/auth.js';
+export { isPrivateAddress } from "./middleware/auth.js";
 
 // Re-export shared types so existing consumers don't need to update imports
 export type {
@@ -198,7 +220,7 @@ export type {
   RuntimeHttpServerOptions,
   RuntimeMessageSessionOptions,
   SendMessageDeps,
-} from './http-types.js';
+} from "./http-types.js";
 
 import type {
   ApprovalConversationGenerator,
@@ -209,12 +231,12 @@ import type {
   NonBlockingMessageProcessor,
   RuntimeHttpServerOptions,
   SendMessageDeps,
-} from './http-types.js';
+} from "./http-types.js";
 
-const log = getLogger('runtime-http');
+const log = getLogger("runtime-http");
 
 const DEFAULT_PORT = 7821;
-const DEFAULT_HOSTNAME = '127.0.0.1';
+const DEFAULT_HOSTNAME = "127.0.0.1";
 
 /** Global hard cap on request body size (50 MB). */
 const MAX_REQUEST_BODY_BYTES = 50 * 1024 * 1024;
@@ -238,6 +260,9 @@ export class RuntimeHttpServer {
   private pairingStore = new PairingStore();
   private pairingBroadcast?: (msg: ServerMessage) => void;
   private sendMessageDeps?: SendMessageDeps;
+  private findSession?: (
+    sessionId: string,
+  ) => import("../daemon/session.js").Session | undefined;
 
   constructor(options: RuntimeHttpServerOptions = {}) {
     this.port = options.port ?? DEFAULT_PORT;
@@ -248,9 +273,11 @@ export class RuntimeHttpServer {
     this.approvalCopyGenerator = options.approvalCopyGenerator;
     this.approvalConversationGenerator = options.approvalConversationGenerator;
     this.guardianActionCopyGenerator = options.guardianActionCopyGenerator;
-    this.guardianFollowUpConversationGenerator = options.guardianFollowUpConversationGenerator;
+    this.guardianFollowUpConversationGenerator =
+      options.guardianFollowUpConversationGenerator;
     this.interfacesDir = options.interfacesDir ?? null;
     this.sendMessageDeps = options.sendMessageDeps;
+    this.findSession = options.findSession;
   }
 
   /** The port the server is actually listening on (resolved after start). */
@@ -272,8 +299,8 @@ export class RuntimeHttpServer {
   private readFeatureFlagToken(): string | undefined {
     try {
       const baseDir = process.env.BASE_DATA_DIR?.trim() || homedir();
-      const tokenPath = join(baseDir, '.vellum', 'feature-flag-token');
-      const token = readFileSync(tokenPath, 'utf-8').trim();
+      const tokenPath = join(baseDir, ".vellum", "feature-flag-token");
+      const token = readFileSync(tokenPath, "utf-8").trim();
       return token || undefined;
     } catch {
       return undefined;
@@ -292,7 +319,9 @@ export class RuntimeHttpServer {
             ipcBroadcast(msg);
             // Also publish to the event hub so HTTP/SSE clients (e.g. macOS
             // app with localHttpEnabled) receive pairing approval requests.
-            void assistantEventHub.publish(buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, msg));
+            void assistantEventHub.publish(
+              buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, msg),
+            );
           }
         : undefined,
     };
@@ -309,22 +338,33 @@ export class RuntimeHttpServer {
       websocket: {
         open(ws) {
           const data = ws.data as AllWebSocketData;
-          if ('wsType' in data && data.wsType === 'browser-relay') {
-            extensionRelayServer.handleOpen(ws as ServerWebSocket<BrowserRelayWebSocketData>);
+          if ("wsType" in data && data.wsType === "browser-relay") {
+            extensionRelayServer.handleOpen(
+              ws as ServerWebSocket<BrowserRelayWebSocketData>,
+            );
             return;
           }
           const callSessionId = (data as RelayWebSocketData).callSessionId;
-          log.info({ callSessionId }, 'ConversationRelay WebSocket opened');
+          log.info({ callSessionId }, "ConversationRelay WebSocket opened");
           if (callSessionId) {
-            const connection = new RelayConnection(ws as ServerWebSocket<RelayWebSocketData>, callSessionId);
+            const connection = new RelayConnection(
+              ws as ServerWebSocket<RelayWebSocketData>,
+              callSessionId,
+            );
             activeRelayConnections.set(callSessionId, connection);
           }
         },
         message(ws, message) {
           const data = ws.data as AllWebSocketData;
-          const raw = typeof message === 'string' ? message : new TextDecoder().decode(message);
-          if ('wsType' in data && data.wsType === 'browser-relay') {
-            extensionRelayServer.handleMessage(ws as ServerWebSocket<BrowserRelayWebSocketData>, raw);
+          const raw =
+            typeof message === "string"
+              ? message
+              : new TextDecoder().decode(message);
+          if ("wsType" in data && data.wsType === "browser-relay") {
+            extensionRelayServer.handleMessage(
+              ws as ServerWebSocket<BrowserRelayWebSocketData>,
+              raw,
+            );
             return;
           }
           const callSessionId = (data as RelayWebSocketData).callSessionId;
@@ -335,12 +375,19 @@ export class RuntimeHttpServer {
         },
         close(ws, code, reason) {
           const data = ws.data as AllWebSocketData;
-          if ('wsType' in data && data.wsType === 'browser-relay') {
-            extensionRelayServer.handleClose(ws as ServerWebSocket<BrowserRelayWebSocketData>, code, reason?.toString());
+          if ("wsType" in data && data.wsType === "browser-relay") {
+            extensionRelayServer.handleClose(
+              ws as ServerWebSocket<BrowserRelayWebSocketData>,
+              code,
+              reason?.toString(),
+            );
             return;
           }
           const callSessionId = (data as RelayWebSocketData).callSessionId;
-          log.info({ callSessionId, code, reason: reason?.toString() }, 'ConversationRelay WebSocket closed');
+          log.info(
+            { callSessionId, code, reason: reason?.toString() },
+            "ConversationRelay WebSocket closed",
+          );
           if (callSessionId) {
             const connection = activeRelayConnections.get(callSessionId);
             connection?.handleTransportClosed(code, reason?.toString());
@@ -357,33 +404,58 @@ export class RuntimeHttpServer {
       this.retrySweepTimer = setInterval(() => {
         if (this.sweepInProgress) return;
         this.sweepInProgress = true;
-        sweepFailedEvents(pm, bt).finally(() => { this.sweepInProgress = false; });
+        sweepFailedEvents(pm, bt).finally(() => {
+          this.sweepInProgress = false;
+        });
       }, 30_000);
     }
 
-    startGuardianExpirySweep(getGatewayInternalBaseUrl(), this.bearerToken, this.approvalCopyGenerator);
-    log.info('Guardian approval expiry sweep started');
+    startGuardianExpirySweep(
+      getGatewayInternalBaseUrl(),
+      this.bearerToken,
+      this.approvalCopyGenerator,
+    );
+    log.info("Guardian approval expiry sweep started");
 
-    startGuardianActionSweep(getGatewayInternalBaseUrl(), this.bearerToken, this.guardianActionCopyGenerator);
-    log.info('Guardian action expiry sweep started');
+    startGuardianActionSweep(
+      getGatewayInternalBaseUrl(),
+      this.bearerToken,
+      this.guardianActionCopyGenerator,
+    );
+    log.info("Guardian action expiry sweep started");
 
     startCanonicalGuardianExpirySweep();
-    log.info('Canonical guardian request expiry sweep started');
+    log.info("Canonical guardian request expiry sweep started");
 
-    log.info('Running in gateway-only ingress mode. Direct webhook routes disabled.');
+    log.info(
+      "Running in gateway-only ingress mode. Direct webhook routes disabled.",
+    );
     if (!isLoopbackHost(this.hostname)) {
-      log.warn('RUNTIME_HTTP_HOST is not bound to loopback. This may expose the runtime to direct public access.');
+      log.warn(
+        "RUNTIME_HTTP_HOST is not bound to loopback. This may expose the runtime to direct public access.",
+      );
     }
 
     this.pairingStore.start();
 
     if (hasUngatedHttpAuthDisabled()) {
-      log.warn('DISABLE_HTTP_AUTH is set but VELLUM_UNSAFE_AUTH_BYPASS=1 is not — auth bypass is IGNORED and HTTP authentication remains enabled. Set VELLUM_UNSAFE_AUTH_BYPASS=1 to confirm the bypass.');
+      log.warn(
+        "DISABLE_HTTP_AUTH is set but VELLUM_UNSAFE_AUTH_BYPASS=1 is not — auth bypass is IGNORED and HTTP authentication remains enabled. Set VELLUM_UNSAFE_AUTH_BYPASS=1 to confirm the bypass.",
+      );
     } else if (isHttpAuthDisabled()) {
-      log.warn('DISABLE_HTTP_AUTH is set — HTTP API authentication is DISABLED. All API endpoints are accessible without a bearer token. Do not use in production.');
+      log.warn(
+        "DISABLE_HTTP_AUTH is set — HTTP API authentication is DISABLED. All API endpoints are accessible without a bearer token. Do not use in production.",
+      );
     }
 
-    log.info({ port: this.actualPort, hostname: this.hostname, auth: !!this.bearerToken }, 'Runtime HTTP server listening');
+    log.info(
+      {
+        port: this.actualPort,
+        hostname: this.hostname,
+        auth: !!this.bearerToken,
+      },
+      "Runtime HTTP server listening",
+    );
   }
 
   async stop(): Promise<void> {
@@ -398,36 +470,48 @@ export class RuntimeHttpServer {
     if (this.server) {
       this.server.stop(true);
       this.server = null;
-      log.info('Runtime HTTP server stopped');
+      log.info("Runtime HTTP server stopped");
     }
   }
 
-  private async handleRequest(req: Request, server: ReturnType<typeof Bun.serve>): Promise<Response> {
+  private async handleRequest(
+    req: Request,
+    server: ReturnType<typeof Bun.serve>,
+  ): Promise<Response> {
     server.timeout(req, 1800);
     // Skip request logging for health-check probes to reduce log noise.
     const url = new URL(req.url);
-    if (url.pathname === '/healthz' && req.method === 'GET') {
+    if (url.pathname === "/healthz" && req.method === "GET") {
       return this.routeRequest(req, server);
     }
     return withRequestLogging(req, () => this.routeRequest(req, server));
   }
 
-  private async routeRequest(req: Request, server: ReturnType<typeof Bun.serve>): Promise<Response> {
+  private async routeRequest(
+    req: Request,
+    server: ReturnType<typeof Bun.serve>,
+  ): Promise<Response> {
     const url = new URL(req.url);
     const path = url.pathname;
 
-    if (path === '/healthz' && req.method === 'GET') {
+    if (path === "/healthz" && req.method === "GET") {
       return handleHealth();
     }
 
     // WebSocket upgrade for the Chrome extension browser relay.
-    if (path === '/v1/browser-relay' && req.headers.get('upgrade')?.toLowerCase() === 'websocket') {
+    if (
+      path === "/v1/browser-relay" &&
+      req.headers.get("upgrade")?.toLowerCase() === "websocket"
+    ) {
       return this.handleBrowserRelayUpgrade(req, server);
     }
 
     // WebSocket upgrade for ConversationRelay — before auth check because
     // Twilio WebSocket connections don't use bearer tokens.
-    if (path.startsWith('/v1/calls/relay') && req.headers.get('upgrade')?.toLowerCase() === 'websocket') {
+    if (
+      path.startsWith("/v1/calls/relay") &&
+      req.headers.get("upgrade")?.toLowerCase() === "websocket"
+    ) {
       return this.handleRelayUpgrade(req, server);
     }
 
@@ -437,10 +521,10 @@ export class RuntimeHttpServer {
     if (twilioResponse) return twilioResponse;
 
     // Pairing endpoints (unauthenticated, secret-gated)
-    if (path === '/v1/pairing/request' && req.method === 'POST') {
+    if (path === "/v1/pairing/request" && req.method === "POST") {
       return await handlePairingRequest(req, this.pairingContext);
     }
-    if (path === '/v1/pairing/status' && req.method === 'GET') {
+    if (path === "/v1/pairing/status" && req.method === "GET") {
       return handlePairingStatus(url, this.pairingContext);
     }
 
@@ -448,7 +532,7 @@ export class RuntimeHttpServer {
     if (!isHttpAuthDisabled() && this.bearerToken) {
       const token = extractBearerToken(req);
       if (!token || !verifyBearerToken(token, this.bearerToken)) {
-        return httpError('UNAUTHORIZED', 'Unauthorized', 401);
+        return httpError("UNAUTHORIZED", "Unauthorized", 401);
       }
     }
 
@@ -457,7 +541,7 @@ export class RuntimeHttpServer {
     // abuse surface. We key on IP rather than bearer token because the gateway
     // uses a single shared token for all proxied requests, which would collapse
     // all users into one bucket.
-    if (path.startsWith('/v1/')) {
+    if (path.startsWith("/v1/")) {
       const clientIp = extractClientIp(req, server);
       const token = extractBearerToken(req);
       const result = token
@@ -467,7 +551,12 @@ export class RuntimeHttpServer {
         return rateLimitResponse(result);
       }
       // Attach rate limit headers to the eventual response
-      const originalResponse = await this.handleAuthenticatedRequest(req, url, path, server);
+      const originalResponse = await this.handleAuthenticatedRequest(
+        req,
+        url,
+        path,
+        server,
+      );
       const headers = new Headers(originalResponse.headers);
       for (const [k, v] of Object.entries(rateLimitHeaders(result))) {
         headers.set(k, v);
@@ -485,67 +574,98 @@ export class RuntimeHttpServer {
   /**
    * Handle requests that have already passed auth and rate limiting.
    */
-  private async handleAuthenticatedRequest(req: Request, url: URL, path: string, server: ReturnType<typeof Bun.serve>): Promise<Response> {
+  private async handleAuthenticatedRequest(
+    req: Request,
+    url: URL,
+    path: string,
+    server: ReturnType<typeof Bun.serve>,
+  ): Promise<Response> {
     // Pairing registration (bearer-authenticated)
-    if (path === '/v1/pairing/register' && req.method === 'POST') {
+    if (path === "/v1/pairing/register" && req.method === "POST") {
       return await handlePairingRegister(req, this.pairingContext);
     }
 
     // Serve shareable app pages
     const pagesMatch = path.match(/^\/pages\/([^/]+)$/);
-    if (pagesMatch && req.method === 'GET') {
+    if (pagesMatch && req.method === "GET") {
       try {
         return handleServePage(pagesMatch[1]);
       } catch (err) {
-        log.error({ err, appId: pagesMatch[1] }, 'Runtime HTTP handler error serving page');
-        return httpError('INTERNAL_ERROR', 'Internal server error', 500);
+        log.error(
+          { err, appId: pagesMatch[1] },
+          "Runtime HTTP handler error serving page",
+        );
+        return httpError("INTERNAL_ERROR", "Internal server error", 500);
       }
     }
 
     // Cloud sharing endpoints
-    if (path === '/v1/apps/share' && req.method === 'POST') {
-      try { return await handleShareApp(req); } catch (err) {
-        log.error({ err }, 'Runtime HTTP handler error sharing app');
-        return httpError('INTERNAL_ERROR', 'Internal server error', 500);
+    if (path === "/v1/apps/share" && req.method === "POST") {
+      try {
+        return await handleShareApp(req);
+      } catch (err) {
+        log.error({ err }, "Runtime HTTP handler error sharing app");
+        return httpError("INTERNAL_ERROR", "Internal server error", 500);
       }
     }
 
     const sharedTokenMatch = path.match(/^\/v1\/apps\/shared\/([^/]+)$/);
     if (sharedTokenMatch) {
       const shareToken = sharedTokenMatch[1];
-      if (req.method === 'GET') {
-        try { return handleDownloadSharedApp(shareToken); } catch (err) {
-          log.error({ err, shareToken }, 'Runtime HTTP handler error downloading shared app');
-          return httpError('INTERNAL_ERROR', 'Internal server error', 500);
+      if (req.method === "GET") {
+        try {
+          return handleDownloadSharedApp(shareToken);
+        } catch (err) {
+          log.error(
+            { err, shareToken },
+            "Runtime HTTP handler error downloading shared app",
+          );
+          return httpError("INTERNAL_ERROR", "Internal server error", 500);
         }
       }
-      if (req.method === 'DELETE') {
-        try { return handleDeleteSharedApp(shareToken); } catch (err) {
-          log.error({ err, shareToken }, 'Runtime HTTP handler error deleting shared app');
-          return httpError('INTERNAL_ERROR', 'Internal server error', 500);
+      if (req.method === "DELETE") {
+        try {
+          return handleDeleteSharedApp(shareToken);
+        } catch (err) {
+          log.error(
+            { err, shareToken },
+            "Runtime HTTP handler error deleting shared app",
+          );
+          return httpError("INTERNAL_ERROR", "Internal server error", 500);
         }
       }
     }
 
-    const sharedMetadataMatch = path.match(/^\/v1\/apps\/shared\/([^/]+)\/metadata$/);
-    if (sharedMetadataMatch && req.method === 'GET') {
-      try { return handleGetSharedAppMetadata(sharedMetadataMatch[1]); } catch (err) {
-        log.error({ err, shareToken: sharedMetadataMatch[1] }, 'Runtime HTTP handler error getting shared app metadata');
-        return httpError('INTERNAL_ERROR', 'Internal server error', 500);
+    const sharedMetadataMatch = path.match(
+      /^\/v1\/apps\/shared\/([^/]+)\/metadata$/,
+    );
+    if (sharedMetadataMatch && req.method === "GET") {
+      try {
+        return handleGetSharedAppMetadata(sharedMetadataMatch[1]);
+      } catch (err) {
+        log.error(
+          { err, shareToken: sharedMetadataMatch[1] },
+          "Runtime HTTP handler error getting shared app metadata",
+        );
+        return httpError("INTERNAL_ERROR", "Internal server error", 500);
       }
     }
 
     // Secret management endpoint
-    if (path === '/v1/secrets' && req.method === 'POST') {
-      try { return await handleAddSecret(req); } catch (err) {
-        log.error({ err }, 'Runtime HTTP handler error adding secret');
-        return httpError('INTERNAL_ERROR', 'Internal server error', 500);
+    if (path === "/v1/secrets" && req.method === "POST") {
+      try {
+        return await handleAddSecret(req);
+      } catch (err) {
+        log.error({ err }, "Runtime HTTP handler error adding secret");
+        return httpError("INTERNAL_ERROR", "Internal server error", 500);
       }
     }
-    if (path === '/v1/secrets' && req.method === 'DELETE') {
-      try { return await handleDeleteSecret(req); } catch (err) {
-        log.error({ err }, 'Runtime HTTP handler error deleting secret');
-        return httpError('INTERNAL_ERROR', 'Internal server error', 500);
+    if (path === "/v1/secrets" && req.method === "DELETE") {
+      try {
+        return await handleDeleteSecret(req);
+      } catch (err) {
+        log.error({ err }, "Runtime HTTP handler error deleting secret");
+        return httpError("INTERNAL_ERROR", "Internal server error", 500);
       }
     }
 
@@ -555,65 +675,94 @@ export class RuntimeHttpServer {
       return this.dispatchEndpoint(routeMatch[1], req, url, server);
     }
 
-    return httpError('NOT_FOUND', 'Not found', 404);
+    return httpError("NOT_FOUND", "Not found", 404);
   }
 
-  private handleBrowserRelayUpgrade(req: Request, server: ReturnType<typeof Bun.serve>): Response {
-    if (!isLoopbackHost(new URL(req.url).hostname) && !isPrivateNetworkPeer(server, req)) {
-      return httpError('FORBIDDEN', 'Browser relay only accepts connections from localhost', 403);
+  private handleBrowserRelayUpgrade(
+    req: Request,
+    server: ReturnType<typeof Bun.serve>,
+  ): Response {
+    if (
+      !isLoopbackHost(new URL(req.url).hostname) &&
+      !isPrivateNetworkPeer(server, req)
+    ) {
+      return httpError(
+        "FORBIDDEN",
+        "Browser relay only accepts connections from localhost",
+        403,
+      );
     }
 
     if (!isHttpAuthDisabled() && this.bearerToken) {
       const wsUrl = new URL(req.url);
-      const token = wsUrl.searchParams.get('token');
+      const token = wsUrl.searchParams.get("token");
       if (!token || !verifyBearerToken(token, this.bearerToken)) {
-        return httpError('UNAUTHORIZED', 'Unauthorized', 401);
+        return httpError("UNAUTHORIZED", "Unauthorized", 401);
       }
     }
 
     const connectionId = crypto.randomUUID();
     const upgraded = server.upgrade(req, {
-      data: { wsType: 'browser-relay', connectionId } satisfies BrowserRelayWebSocketData,
+      data: {
+        wsType: "browser-relay",
+        connectionId,
+      } satisfies BrowserRelayWebSocketData,
     });
     if (!upgraded) {
-      return new Response('WebSocket upgrade failed', { status: 500 });
+      return new Response("WebSocket upgrade failed", { status: 500 });
     }
     // Bun's WebSocket upgrade consumes the request — no Response is sent.
     return undefined!;
   }
 
-  private handleRelayUpgrade(req: Request, server: ReturnType<typeof Bun.serve>): Response {
+  private handleRelayUpgrade(
+    req: Request,
+    server: ReturnType<typeof Bun.serve>,
+  ): Response {
     if (!isPrivateNetworkPeer(server, req) || !isPrivateNetworkOrigin(req)) {
-      return httpError('FORBIDDEN', 'Direct relay access disabled — only private network peers allowed', 403);
+      return httpError(
+        "FORBIDDEN",
+        "Direct relay access disabled — only private network peers allowed",
+        403,
+      );
     }
 
     const wsUrl = new URL(req.url);
-    const callSessionId = wsUrl.searchParams.get('callSessionId');
+    const callSessionId = wsUrl.searchParams.get("callSessionId");
     if (!callSessionId) {
-      return new Response('Missing callSessionId', { status: 400 });
+      return new Response("Missing callSessionId", { status: 400 });
     }
     const upgraded = server.upgrade(req, { data: { callSessionId } });
     if (!upgraded) {
-      return new Response('WebSocket upgrade failed', { status: 500 });
+      return new Response("WebSocket upgrade failed", { status: 500 });
     }
     // Bun's WebSocket upgrade consumes the request — no Response is sent.
     return undefined!;
   }
 
-  private async handleTwilioWebhook(req: Request, path: string): Promise<Response | null> {
+  private async handleTwilioWebhook(
+    req: Request,
+    path: string,
+  ): Promise<Response | null> {
     const twilioMatch = path.match(TWILIO_WEBHOOK_RE);
-    const gatewayTwilioMatch = !twilioMatch ? path.match(TWILIO_GATEWAY_WEBHOOK_RE) : null;
+    const gatewayTwilioMatch = !twilioMatch
+      ? path.match(TWILIO_GATEWAY_WEBHOOK_RE)
+      : null;
     const resolvedTwilioSubpath = twilioMatch
       ? twilioMatch[1]
       : gatewayTwilioMatch
         ? GATEWAY_SUBPATH_MAP[gatewayTwilioMatch[1]]
         : null;
-    if (!resolvedTwilioSubpath || req.method !== 'POST') return null;
+    if (!resolvedTwilioSubpath || req.method !== "POST") return null;
 
     const twilioSubpath = resolvedTwilioSubpath;
 
     if (GATEWAY_ONLY_BLOCKED_SUBPATHS.has(twilioSubpath)) {
-      return httpError('GONE', 'Direct webhook access disabled. Use the gateway.', 410);
+      return httpError(
+        "GONE",
+        "Direct webhook access disabled. Use the gateway.",
+        410,
+      );
     }
 
     const validation = await validateTwilioWebhook(req);
@@ -621,9 +770,12 @@ export class RuntimeHttpServer {
 
     const validatedReq = cloneRequestWithBody(req, validation.body);
 
-    if (twilioSubpath === 'voice-webhook') return await handleVoiceWebhook(validatedReq);
-    if (twilioSubpath === 'status') return await handleStatusCallback(validatedReq);
-    if (twilioSubpath === 'connect-action') return await handleConnectAction(validatedReq);
+    if (twilioSubpath === "voice-webhook")
+      return await handleVoiceWebhook(validatedReq);
+    if (twilioSubpath === "status")
+      return await handleStatusCallback(validatedReq);
+    if (twilioSubpath === "connect-action")
+      return await handleConnectAction(validatedReq);
 
     return null;
   }
@@ -639,61 +791,100 @@ export class RuntimeHttpServer {
   ): Promise<Response> {
     const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
     return withErrorHandling(endpoint, async () => {
-      if (endpoint === 'health' && req.method === 'GET') return handleHealth();
-      if (endpoint === 'debug' && req.method === 'GET') return handleDebug();
+      if (endpoint === "health" && req.method === "GET") return handleHealth();
+      if (endpoint === "debug" && req.method === "GET") return handleDebug();
 
-      if (endpoint === 'browser-relay/status' && req.method === 'GET') {
+      if (endpoint === "browser-relay/status" && req.method === "GET") {
         return Response.json(extensionRelayServer.getStatus());
       }
 
-      if (endpoint === 'browser-relay/command' && req.method === 'POST') {
+      if (endpoint === "browser-relay/command" && req.method === "POST") {
         try {
-          const body = await req.json() as Record<string, unknown>;
-          const resp = await extensionRelayServer.sendCommand(body as Omit<import('../browser-extension-relay/protocol.js').ExtensionCommand, 'id'>);
+          const body = (await req.json()) as Record<string, unknown>;
+          const resp = await extensionRelayServer.sendCommand(
+            body as Omit<
+              import("../browser-extension-relay/protocol.js").ExtensionCommand,
+              "id"
+            >,
+          );
           return Response.json(resp);
         } catch (err) {
-          return httpError('INTERNAL_ERROR', err instanceof Error ? err.message : String(err), 500);
+          return httpError(
+            "INTERNAL_ERROR",
+            err instanceof Error ? err.message : String(err),
+            500,
+          );
         }
       }
 
-      if (endpoint === 'conversations' && req.method === 'GET') {
-        const limit = Number(url.searchParams.get('limit') ?? 50);
-        const offset = Number(url.searchParams.get('offset') ?? 0);
-        const conversations = conversationStore.listConversations(limit, false, offset);
+      if (endpoint === "conversations" && req.method === "GET") {
+        const limit = Number(url.searchParams.get("limit") ?? 50);
+        const offset = Number(url.searchParams.get("offset") ?? 0);
+        const conversations = conversationStore.listConversations(
+          limit,
+          false,
+          offset,
+        );
         const totalCount = conversationStore.countConversations();
         const conversationIds = conversations.map((c) => c.id);
-        const bindings = externalConversationStore.getBindingsForConversations(conversationIds);
-        const attentionStates = getAttentionStateByConversationIds(conversationIds);
+        const bindings =
+          externalConversationStore.getBindingsForConversations(
+            conversationIds,
+          );
+        const attentionStates =
+          getAttentionStateByConversationIds(conversationIds);
         return Response.json({
           sessions: conversations.map((c) => {
             const binding = bindings.get(c.id);
             const originChannel = parseChannelId(c.originChannel);
             const attn = attentionStates.get(c.id);
-            const assistantAttention = attn ? {
-              hasUnseenLatestAssistantMessage: attn.latestAssistantMessageAt != null &&
-                (attn.lastSeenAssistantMessageAt == null || attn.lastSeenAssistantMessageAt < attn.latestAssistantMessageAt),
-              ...(attn.latestAssistantMessageAt != null ? { latestAssistantMessageAt: attn.latestAssistantMessageAt } : {}),
-              ...(attn.lastSeenAssistantMessageAt != null ? { lastSeenAssistantMessageAt: attn.lastSeenAssistantMessageAt } : {}),
-              ...(attn.lastSeenConfidence != null ? { lastSeenConfidence: attn.lastSeenConfidence } : {}),
-              ...(attn.lastSeenSignalType != null ? { lastSeenSignalType: attn.lastSeenSignalType } : {}),
-            } : undefined;
+            const assistantAttention = attn
+              ? {
+                  hasUnseenLatestAssistantMessage:
+                    attn.latestAssistantMessageAt != null &&
+                    (attn.lastSeenAssistantMessageAt == null ||
+                      attn.lastSeenAssistantMessageAt <
+                        attn.latestAssistantMessageAt),
+                  ...(attn.latestAssistantMessageAt != null
+                    ? {
+                        latestAssistantMessageAt: attn.latestAssistantMessageAt,
+                      }
+                    : {}),
+                  ...(attn.lastSeenAssistantMessageAt != null
+                    ? {
+                        lastSeenAssistantMessageAt:
+                          attn.lastSeenAssistantMessageAt,
+                      }
+                    : {}),
+                  ...(attn.lastSeenConfidence != null
+                    ? { lastSeenConfidence: attn.lastSeenConfidence }
+                    : {}),
+                  ...(attn.lastSeenSignalType != null
+                    ? { lastSeenSignalType: attn.lastSeenSignalType }
+                    : {}),
+                }
+              : undefined;
             return {
               id: c.id,
-              title: c.title ?? 'Untitled',
+              title: c.title ?? "Untitled",
               createdAt: c.createdAt,
               updatedAt: c.updatedAt,
-              threadType: c.threadType === 'private' ? 'private' : 'standard',
-              source: c.source ?? 'user',
-              ...(binding ? {
-                channelBinding: {
-                  sourceChannel: binding.sourceChannel,
-                  externalChatId: binding.externalChatId,
-                  externalUserId: binding.externalUserId,
-                  displayName: binding.displayName,
-                  username: binding.username,
-                },
-              } : {}),
-              ...(originChannel ? { conversationOriginChannel: originChannel } : {}),
+              threadType: c.threadType === "private" ? "private" : "standard",
+              source: c.source ?? "user",
+              ...(binding
+                ? {
+                    channelBinding: {
+                      sourceChannel: binding.sourceChannel,
+                      externalChatId: binding.externalChatId,
+                      externalUserId: binding.externalUserId,
+                      displayName: binding.displayName,
+                      username: binding.username,
+                    },
+                  }
+                : {}),
+              ...(originChannel
+                ? { conversationOriginChannel: originChannel }
+                : {}),
               ...(assistantAttention ? { assistantAttention } : {}),
             };
           }),
@@ -701,132 +892,288 @@ export class RuntimeHttpServer {
         });
       }
 
-      if (endpoint === 'conversations/attention' && req.method === 'GET') return handleListConversationAttention(url);
+      if (endpoint === "conversations/attention" && req.method === "GET")
+        return handleListConversationAttention(url);
 
-      if (endpoint === 'conversations/seen' && req.method === 'POST') {
-        const body = await req.json() as Record<string, unknown>;
+      if (endpoint === "conversations/seen" && req.method === "POST") {
+        const body = (await req.json()) as Record<string, unknown>;
         const conversationId = body.conversationId as string | undefined;
-        if (!conversationId) return httpError('BAD_REQUEST', 'Missing conversationId', 400);
+        if (!conversationId)
+          return httpError("BAD_REQUEST", "Missing conversationId", 400);
         try {
           recordConversationSeenSignal({
             conversationId,
             assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
-            sourceChannel: (body.sourceChannel as string) ?? 'vellum',
-            signalType: (body.signalType as string ?? 'macos_conversation_opened') as SignalType,
-            confidence: (body.confidence as string ?? 'explicit') as Confidence,
-            source: (body.source as string) ?? 'http-api',
+            sourceChannel: (body.sourceChannel as string) ?? "vellum",
+            signalType: ((body.signalType as string) ??
+              "macos_conversation_opened") as SignalType,
+            confidence: ((body.confidence as string) ??
+              "explicit") as Confidence,
+            source: (body.source as string) ?? "http-api",
             evidenceText: body.evidenceText as string | undefined,
             metadata: body.metadata as Record<string, unknown> | undefined,
             observedAt: body.observedAt as number | undefined,
           });
           return Response.json({ ok: true });
         } catch (err) {
-          log.error({ err, conversationId }, 'POST /v1/conversations/seen: failed');
-          return httpError('INTERNAL_ERROR', 'Failed to record seen signal', 500);
+          log.error(
+            { err, conversationId },
+            "POST /v1/conversations/seen: failed",
+          );
+          return httpError(
+            "INTERNAL_ERROR",
+            "Failed to record seen signal",
+            500,
+          );
         }
       }
 
-      if (endpoint === 'messages' && req.method === 'GET') return handleListMessages(url, this.interfacesDir);
-      if (endpoint === 'search' && req.method === 'GET') return handleSearchConversations(url);
+      if (endpoint === "messages" && req.method === "GET")
+        return handleListMessages(url, this.interfacesDir);
+      if (endpoint === "search" && req.method === "GET")
+        return handleSearchConversations(url);
 
-      if (endpoint === 'messages' && req.method === 'POST') {
-        return await handleSendMessage(req, {
-          processMessage: this.processMessage,
-          persistAndProcessMessage: this.persistAndProcessMessage,
-          sendMessageDeps: this.sendMessageDeps,
-          approvalConversationGenerator: this.approvalConversationGenerator,
-        }, server);
+      if (endpoint === "messages" && req.method === "POST") {
+        return await handleSendMessage(
+          req,
+          {
+            processMessage: this.processMessage,
+            persistAndProcessMessage: this.persistAndProcessMessage,
+            sendMessageDeps: this.sendMessageDeps,
+            approvalConversationGenerator: this.approvalConversationGenerator,
+          },
+          server,
+        );
       }
 
       // Standalone approval endpoints — keyed by requestId, orthogonal to message sending
-      if (endpoint === 'confirm' && req.method === 'POST') return await handleConfirm(req, server);
-      if (endpoint === 'secret' && req.method === 'POST') return await handleSecret(req, server);
-      if (endpoint === 'trust-rules' && req.method === 'POST') return await handleTrustRule(req, server);
-      if (endpoint === 'pending-interactions' && req.method === 'GET') return handleListPendingInteractions(url, req, server);
+      if (endpoint === "confirm" && req.method === "POST")
+        return await handleConfirm(req, server);
+      if (endpoint === "secret" && req.method === "POST")
+        return await handleSecret(req, server);
+      if (endpoint === "trust-rules" && req.method === "POST")
+        return await handleTrustRule(req, server);
+      if (endpoint === "pending-interactions" && req.method === "GET")
+        return handleListPendingInteractions(url, req, server);
+
+      // Trust rule CRUD — standalone management (not approval-flow)
+      if (endpoint === "trust-rules/manage" && req.method === "GET")
+        return handleListTrustRules();
+      if (endpoint === "trust-rules/manage" && req.method === "POST")
+        return await handleAddTrustRuleManage(req);
+      const trustRuleManageMatch = endpoint.match(
+        /^trust-rules\/manage\/([^/]+)$/,
+      );
+      if (trustRuleManageMatch && req.method === "DELETE")
+        return handleRemoveTrustRuleManage(trustRuleManageMatch[1]);
+      if (trustRuleManageMatch && req.method === "PATCH")
+        return await handleUpdateTrustRuleManage(req, trustRuleManageMatch[1]);
+
+      // Surface action dispatch
+      if (endpoint === "surface-actions" && req.method === "POST") {
+        if (!this.findSession) {
+          return httpError(
+            "NOT_IMPLEMENTED",
+            "Surface actions not available",
+            501,
+          );
+        }
+        return await handleSurfaceAction(req, this.findSession);
+      }
 
       // Guardian action endpoints — deterministic button-based decisions
-      if (endpoint === 'guardian-actions/pending' && req.method === 'GET') return handleGuardianActionsPending(req, server);
-      if (endpoint === 'guardian-actions/decision' && req.method === 'POST') return await handleGuardianActionDecision(req, server);
+      if (endpoint === "guardian-actions/pending" && req.method === "GET")
+        return handleGuardianActionsPending(req, server);
+      if (endpoint === "guardian-actions/decision" && req.method === "POST")
+        return await handleGuardianActionDecision(req, server);
 
       // Contacts
-      if (endpoint === 'contacts' && req.method === 'GET') return handleListContacts(url);
-      if (endpoint === 'contacts/merge' && req.method === 'POST') return await handleMergeContacts(req);
+      if (endpoint === "contacts" && req.method === "GET")
+        return handleListContacts(url);
+      if (endpoint === "contacts/merge" && req.method === "POST")
+        return await handleMergeContacts(req);
       const contactMatch = endpoint.match(/^contacts\/([^/]+)$/);
-      if (contactMatch && req.method === 'GET') return handleGetContact(contactMatch[1]);
+      if (contactMatch && req.method === "GET")
+        return handleGetContact(contactMatch[1]);
 
       // Ingress members
-      if (endpoint === 'ingress/members' && req.method === 'GET') return handleListMembers(url);
-      if (endpoint === 'ingress/members' && req.method === 'POST') return await handleUpsertMember(req);
-      const memberBlockMatch = endpoint.match(/^ingress\/members\/([^/]+)\/block$/);
-      if (memberBlockMatch && req.method === 'POST') return await handleBlockMember(req, memberBlockMatch[1]);
+      if (endpoint === "ingress/members" && req.method === "GET")
+        return handleListMembers(url);
+      if (endpoint === "ingress/members" && req.method === "POST")
+        return await handleUpsertMember(req);
+      const memberBlockMatch = endpoint.match(
+        /^ingress\/members\/([^/]+)\/block$/,
+      );
+      if (memberBlockMatch && req.method === "POST")
+        return await handleBlockMember(req, memberBlockMatch[1]);
       const memberMatch = endpoint.match(/^ingress\/members\/([^/]+)$/);
-      if (memberMatch && req.method === 'DELETE') return await handleRevokeMember(req, memberMatch[1]);
+      if (memberMatch && req.method === "DELETE")
+        return await handleRevokeMember(req, memberMatch[1]);
 
       // Ingress invites
-      if (endpoint === 'ingress/invites' && req.method === 'GET') return handleListInvites(url);
-      if (endpoint === 'ingress/invites' && req.method === 'POST') return await handleCreateInvite(req);
-      if (endpoint === 'ingress/invites/redeem' && req.method === 'POST') return await handleRedeemInvite(req);
+      if (endpoint === "ingress/invites" && req.method === "GET")
+        return handleListInvites(url);
+      if (endpoint === "ingress/invites" && req.method === "POST")
+        return await handleCreateInvite(req);
+      if (endpoint === "ingress/invites/redeem" && req.method === "POST")
+        return await handleRedeemInvite(req);
       const inviteMatch = endpoint.match(/^ingress\/invites\/([^/]+)$/);
-      if (inviteMatch && req.method === 'DELETE') return handleRevokeInvite(inviteMatch[1]);
+      if (inviteMatch && req.method === "DELETE")
+        return handleRevokeInvite(inviteMatch[1]);
 
       // Integrations — Telegram config
-      if (endpoint === 'integrations/telegram/config' && req.method === 'GET') return handleGetTelegramConfig();
-      if (endpoint === 'integrations/telegram/config' && req.method === 'POST') return await handleSetTelegramConfig(req);
-      if (endpoint === 'integrations/telegram/config' && req.method === 'DELETE') return await handleClearTelegramConfig();
-      if (endpoint === 'integrations/telegram/commands' && req.method === 'POST') return await handleSetTelegramCommands(req);
-      if (endpoint === 'integrations/telegram/setup' && req.method === 'POST') return await handleSetupTelegram(req);
+      if (endpoint === "integrations/telegram/config" && req.method === "GET")
+        return handleGetTelegramConfig();
+      if (endpoint === "integrations/telegram/config" && req.method === "POST")
+        return await handleSetTelegramConfig(req);
+      if (
+        endpoint === "integrations/telegram/config" &&
+        req.method === "DELETE"
+      )
+        return await handleClearTelegramConfig();
+      if (
+        endpoint === "integrations/telegram/commands" &&
+        req.method === "POST"
+      )
+        return await handleSetTelegramCommands(req);
+      if (endpoint === "integrations/telegram/setup" && req.method === "POST")
+        return await handleSetupTelegram(req);
 
       // Integrations — Slack channel config
-      if (endpoint === 'integrations/slack/channel/config' && req.method === 'GET') return handleGetSlackChannelConfig();
-      if (endpoint === 'integrations/slack/channel/config' && req.method === 'POST') return await handleSetSlackChannelConfig(req);
-      if (endpoint === 'integrations/slack/channel/config' && req.method === 'DELETE') return handleClearSlackChannelConfig();
+      if (
+        endpoint === "integrations/slack/channel/config" &&
+        req.method === "GET"
+      )
+        return handleGetSlackChannelConfig();
+      if (
+        endpoint === "integrations/slack/channel/config" &&
+        req.method === "POST"
+      )
+        return await handleSetSlackChannelConfig(req);
+      if (
+        endpoint === "integrations/slack/channel/config" &&
+        req.method === "DELETE"
+      )
+        return handleClearSlackChannelConfig();
 
       // Integrations — Guardian verification
-      if (endpoint === 'integrations/guardian/challenge' && req.method === 'POST') return await handleCreateGuardianChallenge(req);
-      if (endpoint === 'integrations/guardian/status' && req.method === 'GET') return handleGetGuardianStatus(url);
-      if (endpoint === 'integrations/guardian/outbound/start' && req.method === 'POST') return await handleStartOutbound(req);
-      if (endpoint === 'integrations/guardian/outbound/resend' && req.method === 'POST') return await handleResendOutbound(req);
-      if (endpoint === 'integrations/guardian/outbound/cancel' && req.method === 'POST') return await handleCancelOutbound(req);
+      if (
+        endpoint === "integrations/guardian/challenge" &&
+        req.method === "POST"
+      )
+        return await handleCreateGuardianChallenge(req);
+      if (endpoint === "integrations/guardian/status" && req.method === "GET")
+        return handleGetGuardianStatus(url);
+      if (
+        endpoint === "integrations/guardian/outbound/start" &&
+        req.method === "POST"
+      )
+        return await handleStartOutbound(req);
+      if (
+        endpoint === "integrations/guardian/outbound/resend" &&
+        req.method === "POST"
+      )
+        return await handleResendOutbound(req);
+      if (
+        endpoint === "integrations/guardian/outbound/cancel" &&
+        req.method === "POST"
+      )
+        return await handleCancelOutbound(req);
 
       // Guardian vellum channel bootstrap
-      if (endpoint === 'integrations/guardian/vellum/bootstrap' && req.method === 'POST') return await handleGuardianBootstrap(req, server);
-      if (endpoint === 'integrations/guardian/vellum/refresh' && req.method === 'POST') return await handleGuardianRefresh(req);
+      if (
+        endpoint === "integrations/guardian/vellum/bootstrap" &&
+        req.method === "POST"
+      )
+        return await handleGuardianBootstrap(req, server);
+      if (
+        endpoint === "integrations/guardian/vellum/refresh" &&
+        req.method === "POST"
+      )
+        return await handleGuardianRefresh(req);
 
       // Integrations — Twilio config
-      if (endpoint === 'integrations/twilio/config' && req.method === 'GET') return handleGetTwilioConfig();
-      if (endpoint === 'integrations/twilio/credentials' && req.method === 'POST') return await handleSetTwilioCredentials(req);
-      if (endpoint === 'integrations/twilio/credentials' && req.method === 'DELETE') return handleClearTwilioCredentials();
-      if (endpoint === 'integrations/twilio/numbers' && req.method === 'GET') return await handleListTwilioNumbers();
-      if (endpoint === 'integrations/twilio/numbers/provision' && req.method === 'POST') return await handleProvisionTwilioNumber(req);
-      if (endpoint === 'integrations/twilio/numbers/assign' && req.method === 'POST') return await handleAssignTwilioNumber(req);
-      if (endpoint === 'integrations/twilio/numbers/release' && req.method === 'POST') return await handleReleaseTwilioNumber(req);
-      if (endpoint === 'integrations/twilio/sms/compliance' && req.method === 'GET') return await handleGetSmsCompliance();
-      if (endpoint === 'integrations/twilio/sms/compliance/tollfree' && req.method === 'POST') return await handleSubmitTollfreeVerification(req);
-      if (endpoint === 'integrations/twilio/sms/test' && req.method === 'POST') return await handleSmsSendTest(req);
-      if (endpoint === 'integrations/twilio/sms/doctor' && req.method === 'POST') return await handleSmsDoctor();
+      if (endpoint === "integrations/twilio/config" && req.method === "GET")
+        return handleGetTwilioConfig();
+      if (
+        endpoint === "integrations/twilio/credentials" &&
+        req.method === "POST"
+      )
+        return await handleSetTwilioCredentials(req);
+      if (
+        endpoint === "integrations/twilio/credentials" &&
+        req.method === "DELETE"
+      )
+        return handleClearTwilioCredentials();
+      if (endpoint === "integrations/twilio/numbers" && req.method === "GET")
+        return await handleListTwilioNumbers();
+      if (
+        endpoint === "integrations/twilio/numbers/provision" &&
+        req.method === "POST"
+      )
+        return await handleProvisionTwilioNumber(req);
+      if (
+        endpoint === "integrations/twilio/numbers/assign" &&
+        req.method === "POST"
+      )
+        return await handleAssignTwilioNumber(req);
+      if (
+        endpoint === "integrations/twilio/numbers/release" &&
+        req.method === "POST"
+      )
+        return await handleReleaseTwilioNumber(req);
+      if (
+        endpoint === "integrations/twilio/sms/compliance" &&
+        req.method === "GET"
+      )
+        return await handleGetSmsCompliance();
+      if (
+        endpoint === "integrations/twilio/sms/compliance/tollfree" &&
+        req.method === "POST"
+      )
+        return await handleSubmitTollfreeVerification(req);
+      if (endpoint === "integrations/twilio/sms/test" && req.method === "POST")
+        return await handleSmsSendTest(req);
+      if (
+        endpoint === "integrations/twilio/sms/doctor" &&
+        req.method === "POST"
+      )
+        return await handleSmsDoctor();
 
       // Twilio toll-free verification PATCH/DELETE with :verificationSid
-      const tollfreeVerificationMatch = endpoint.match(/^integrations\/twilio\/sms\/compliance\/tollfree\/([^/]+)$/);
+      const tollfreeVerificationMatch = endpoint.match(
+        /^integrations\/twilio\/sms\/compliance\/tollfree\/([^/]+)$/,
+      );
       if (tollfreeVerificationMatch) {
         const verificationSid = tollfreeVerificationMatch[1];
-        if (req.method === 'PATCH') return await handleUpdateTollfreeVerification(req, verificationSid);
-        if (req.method === 'DELETE') return await handleDeleteTollfreeVerification(verificationSid);
+        if (req.method === "PATCH")
+          return await handleUpdateTollfreeVerification(req, verificationSid);
+        if (req.method === "DELETE")
+          return await handleDeleteTollfreeVerification(verificationSid);
       }
 
       // Channel readiness
-      if (endpoint === 'channels/readiness' && req.method === 'GET') return await handleGetChannelReadiness(url);
-      if (endpoint === 'channels/readiness/refresh' && req.method === 'POST') return await handleRefreshChannelReadiness(req);
+      if (endpoint === "channels/readiness" && req.method === "GET")
+        return await handleGetChannelReadiness(url);
+      if (endpoint === "channels/readiness/refresh" && req.method === "POST")
+        return await handleRefreshChannelReadiness(req);
 
-      if (endpoint === 'attachments' && req.method === 'POST') return await handleUploadAttachment(req);
-      if (endpoint === 'attachments' && req.method === 'DELETE') return await handleDeleteAttachment(req);
+      if (endpoint === "attachments" && req.method === "POST")
+        return await handleUploadAttachment(req);
+      if (endpoint === "attachments" && req.method === "DELETE")
+        return await handleDeleteAttachment(req);
 
-      const attachmentContentMatch = endpoint.match(/^attachments\/([^/]+)\/content$/);
-      if (attachmentContentMatch && req.method === 'GET') return handleGetAttachmentContent(attachmentContentMatch[1], req);
+      const attachmentContentMatch = endpoint.match(
+        /^attachments\/([^/]+)\/content$/,
+      );
+      if (attachmentContentMatch && req.method === "GET")
+        return handleGetAttachmentContent(attachmentContentMatch[1], req);
 
       const attachmentMatch = endpoint.match(/^attachments\/([^/]+)$/);
-      if (attachmentMatch && req.method === 'GET') return handleGetAttachment(attachmentMatch[1]);
+      if (attachmentMatch && req.method === "GET")
+        return handleGetAttachment(attachmentMatch[1]);
 
-      if (endpoint === 'suggestion' && req.method === 'GET') {
+      if (endpoint === "suggestion" && req.method === "GET") {
         return await handleGetSuggestion(url, {
           suggestionCache: this.suggestionCache,
           suggestionInFlight: this.suggestionInFlight,
@@ -834,94 +1181,156 @@ export class RuntimeHttpServer {
       }
 
       const interfacesMatch = endpoint.match(/^interfaces\/(.+)$/);
-      if (interfacesMatch && req.method === 'GET') return this.handleGetInterface(interfacesMatch[1]);
+      if (interfacesMatch && req.method === "GET")
+        return this.handleGetInterface(interfacesMatch[1]);
 
-      if (endpoint === 'channels/conversation' && req.method === 'DELETE') return await handleDeleteConversation(req, assistantId);
+      if (endpoint === "channels/conversation" && req.method === "DELETE")
+        return await handleDeleteConversation(req, assistantId);
 
-      if (endpoint === 'channels/inbound' && req.method === 'POST') {
+      if (endpoint === "channels/inbound" && req.method === "POST") {
         const gatewayOriginSecret = getRuntimeGatewayOriginSecret();
-        return await handleChannelInbound(req, this.processMessage, this.bearerToken, assistantId, gatewayOriginSecret, this.approvalCopyGenerator, this.approvalConversationGenerator, this.guardianActionCopyGenerator, this.guardianFollowUpConversationGenerator);
+        return await handleChannelInbound(
+          req,
+          this.processMessage,
+          this.bearerToken,
+          assistantId,
+          gatewayOriginSecret,
+          this.approvalCopyGenerator,
+          this.approvalConversationGenerator,
+          this.guardianActionCopyGenerator,
+          this.guardianFollowUpConversationGenerator,
+        );
       }
 
-      if (endpoint === 'channels/delivery-ack' && req.method === 'POST') return await handleChannelDeliveryAck(req);
-      if (endpoint === 'channels/dead-letters' && req.method === 'GET') return handleListDeadLetters();
-      if (endpoint === 'channels/replay' && req.method === 'POST') return await handleReplayDeadLetters(req);
+      if (endpoint === "channels/delivery-ack" && req.method === "POST")
+        return await handleChannelDeliveryAck(req);
+      if (endpoint === "channels/dead-letters" && req.method === "GET")
+        return handleListDeadLetters();
+      if (endpoint === "channels/replay" && req.method === "POST")
+        return await handleReplayDeadLetters(req);
 
-      if (endpoint === 'calls/start' && req.method === 'POST') return await handleStartCall(req, assistantId);
+      if (endpoint === "calls/start" && req.method === "POST")
+        return await handleStartCall(req, assistantId);
 
-      const callsMatch = endpoint.match(/^calls\/([^/]+?)(\/cancel|\/answer|\/instruction)?$/);
+      const callsMatch = endpoint.match(
+        /^calls\/([^/]+?)(\/cancel|\/answer|\/instruction)?$/,
+      );
       if (callsMatch) {
         const callSessionId = callsMatch[1];
-        if (callSessionId !== 'twilio' && callSessionId !== 'relay' && callSessionId !== 'start') {
-          if (callsMatch[2] === '/cancel' && req.method === 'POST') return await handleCancelCall(req, callSessionId);
-          if (callsMatch[2] === '/answer' && req.method === 'POST') return await handleAnswerCall(req, callSessionId);
-          if (callsMatch[2] === '/instruction' && req.method === 'POST') return await handleInstructionCall(req, callSessionId);
-          if (!callsMatch[2] && req.method === 'GET') return handleGetCallStatus(callSessionId);
+        if (
+          callSessionId !== "twilio" &&
+          callSessionId !== "relay" &&
+          callSessionId !== "start"
+        ) {
+          if (callsMatch[2] === "/cancel" && req.method === "POST")
+            return await handleCancelCall(req, callSessionId);
+          if (callsMatch[2] === "/answer" && req.method === "POST")
+            return await handleAnswerCall(req, callSessionId);
+          if (callsMatch[2] === "/instruction" && req.method === "POST")
+            return await handleInstructionCall(req, callSessionId);
+          if (!callsMatch[2] && req.method === "GET")
+            return handleGetCallStatus(callSessionId);
         }
       }
 
       // Internal Twilio forwarding endpoints (gateway -> runtime)
-      if (endpoint === 'internal/twilio/voice-webhook' && req.method === 'POST') {
-        const json = await req.json() as { params: Record<string, string>; originalUrl?: string };
+      if (
+        endpoint === "internal/twilio/voice-webhook" &&
+        req.method === "POST"
+      ) {
+        const json = (await req.json()) as {
+          params: Record<string, string>;
+          originalUrl?: string;
+        };
         const formBody = new URLSearchParams(json.params).toString();
         const reconstructedUrl = json.originalUrl ?? req.url;
-        const fakeReq = new Request(reconstructedUrl, { method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, body: formBody });
+        const fakeReq = new Request(reconstructedUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: formBody,
+        });
         return await handleVoiceWebhook(fakeReq);
       }
 
-      if (endpoint === 'internal/twilio/status' && req.method === 'POST') {
-        const json = await req.json() as { params: Record<string, string> };
+      if (endpoint === "internal/twilio/status" && req.method === "POST") {
+        const json = (await req.json()) as { params: Record<string, string> };
         const formBody = new URLSearchParams(json.params).toString();
-        const fakeReq = new Request(req.url, { method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, body: formBody });
+        const fakeReq = new Request(req.url, {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: formBody,
+        });
         return await handleStatusCallback(fakeReq);
       }
 
-      if (endpoint === 'internal/twilio/connect-action' && req.method === 'POST') {
-        const json = await req.json() as { params: Record<string, string> };
+      if (
+        endpoint === "internal/twilio/connect-action" &&
+        req.method === "POST"
+      ) {
+        const json = (await req.json()) as { params: Record<string, string> };
         const formBody = new URLSearchParams(json.params).toString();
-        const fakeReq = new Request(req.url, { method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, body: formBody });
+        const fakeReq = new Request(req.url, {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: formBody,
+        });
         return await handleConnectAction(fakeReq);
       }
 
-      if (endpoint === 'identity' && req.method === 'GET') return handleGetIdentity();
-      if (endpoint === 'brain-graph' && req.method === 'GET') return handleGetBrainGraph();
-      if (endpoint === 'brain-graph-ui' && req.method === 'GET') return handleServeBrainGraphUI(this.bearerToken);
-      if (endpoint === 'home-base-ui' && req.method === 'GET') return handleServeHomeBaseUI(this.bearerToken);
-      if (endpoint === 'events' && req.method === 'GET') return handleSubscribeAssistantEvents(req, url, { server });
+      if (endpoint === "identity" && req.method === "GET")
+        return handleGetIdentity();
+      if (endpoint === "brain-graph" && req.method === "GET")
+        return handleGetBrainGraph();
+      if (endpoint === "brain-graph-ui" && req.method === "GET")
+        return handleServeBrainGraphUI(this.bearerToken);
+      if (endpoint === "home-base-ui" && req.method === "GET")
+        return handleServeHomeBaseUI(this.bearerToken);
+      if (endpoint === "events" && req.method === "GET")
+        return handleSubscribeAssistantEvents(req, url, { server });
 
       // Internal OAuth callback endpoint (gateway -> runtime)
-      if (endpoint === 'internal/oauth/callback' && req.method === 'POST') {
-        const json = await req.json() as { state: string; code?: string; error?: string };
-        if (!json.state) return httpError('BAD_REQUEST', 'Missing state parameter', 400);
+      if (endpoint === "internal/oauth/callback" && req.method === "POST") {
+        const json = (await req.json()) as {
+          state: string;
+          code?: string;
+          error?: string;
+        };
+        if (!json.state)
+          return httpError("BAD_REQUEST", "Missing state parameter", 400);
         if (json.error) {
           const consumed = consumeCallbackError(json.state, json.error);
-          return consumed ? Response.json({ ok: true }) : httpError('NOT_FOUND', 'Unknown state', 404);
+          return consumed
+            ? Response.json({ ok: true })
+            : httpError("NOT_FOUND", "Unknown state", 404);
         }
         if (json.code) {
           const consumed = consumeCallback(json.state, json.code);
-          return consumed ? Response.json({ ok: true }) : httpError('NOT_FOUND', 'Unknown state', 404);
+          return consumed
+            ? Response.json({ ok: true })
+            : httpError("NOT_FOUND", "Unknown state", 404);
         }
-        return httpError('BAD_REQUEST', 'Missing code or error parameter', 400);
+        return httpError("BAD_REQUEST", "Missing code or error parameter", 400);
       }
 
-      return httpError('NOT_FOUND', 'Not found', 404);
+      return httpError("NOT_FOUND", "Not found", 404);
     });
   }
 
   private handleGetInterface(interfacePath: string): Response {
     if (!this.interfacesDir) {
-      return httpError('NOT_FOUND', 'Interface not found', 404);
+      return httpError("NOT_FOUND", "Interface not found", 404);
     }
     const fullPath = resolve(this.interfacesDir, interfacePath);
     if (
-      (fullPath !== this.interfacesDir && !fullPath.startsWith(this.interfacesDir + '/')) ||
+      (fullPath !== this.interfacesDir &&
+        !fullPath.startsWith(this.interfacesDir + "/")) ||
       !existsSync(fullPath)
     ) {
-      return httpError('NOT_FOUND', 'Interface not found', 404);
+      return httpError("NOT_FOUND", "Interface not found", 404);
     }
-    const source = readFileSync(fullPath, 'utf-8');
+    const source = readFileSync(fullPath, "utf-8");
     return new Response(source, {
-      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
     });
   }
 }

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -1,15 +1,18 @@
 /**
  * Shared types for the runtime HTTP server and its route handlers.
  */
-import type { ChannelId, InterfaceId } from '../channels/types.js';
-import type { Session } from '../daemon/session.js';
-import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
-import type { ApprovalMessageContext, ComposeApprovalMessageGenerativeOptions } from './approval-message-composer.js';
-import type { AssistantEventHub } from './assistant-event-hub.js';
+import type { ChannelId, InterfaceId } from "../channels/types.js";
+import type { Session } from "../daemon/session.js";
+import type { GuardianRuntimeContext } from "../daemon/session-runtime-assembly.js";
+import type {
+  ApprovalMessageContext,
+  ComposeApprovalMessageGenerativeOptions,
+} from "./approval-message-composer.js";
+import type { AssistantEventHub } from "./assistant-event-hub.js";
 import type {
   ComposeGuardianActionMessageOptions,
   GuardianActionMessageContext,
-} from './guardian-action-message-composer.js';
+} from "./guardian-action-message-composer.js";
 /**
  * Daemon-injected function that generates approval copy using a provider.
  * Returns generated text or `null` on failure (caller falls back to deterministic text).
@@ -25,10 +28,10 @@ export type ApprovalCopyGenerator = (
 
 /** The disposition returned by the approval conversation engine. */
 export type ApprovalConversationDisposition =
-  | 'keep_pending'
-  | 'approve_once'
-  | 'approve_always'
-  | 'reject';
+  | "keep_pending"
+  | "approve_once"
+  | "approve_always"
+  | "reject";
 
 /** Structured result from a single turn of the approval conversation. */
 export interface ApprovalConversationResult {
@@ -42,7 +45,7 @@ export interface ApprovalConversationResult {
 export interface ApprovalConversationContext {
   toolName: string;
   allowedActions: string[];
-  role: 'requester' | 'guardian';
+  role: "requester" | "guardian";
   pendingApprovals: Array<{ requestId: string; toolName: string }>;
   userMessage: string;
 }
@@ -70,10 +73,10 @@ export type GuardianActionCopyGenerator = (
 
 /** The disposition returned by the guardian follow-up conversation engine. */
 export type GuardianFollowUpDisposition =
-  | 'call_back'
-  | 'message_back'
-  | 'decline'
-  | 'keep_pending';
+  | "call_back"
+  | "message_back"
+  | "decline"
+  | "keep_pending";
 
 /** Structured result from a single turn of the guardian follow-up conversation. */
 export interface GuardianFollowUpTurnResult {
@@ -180,6 +183,8 @@ export interface RuntimeHttpServerOptions {
   guardianFollowUpConversationGenerator?: GuardianFollowUpConversationGenerator;
   /** Dependencies for the POST /v1/messages queue-if-busy handler. */
   sendMessageDeps?: SendMessageDeps;
+  /** Lookup an active session by ID (for surface actions). Returns undefined if not found. */
+  findSession?: (sessionId: string) => Session | undefined;
 }
 
 export interface RuntimeAttachmentMetadata {
@@ -196,6 +201,11 @@ export interface RuntimeMessagePayload {
   content: string;
   timestamp: string;
   attachments: RuntimeAttachmentMetadata[];
-  toolCalls?: Array<{ name: string; input: Record<string, unknown>; result?: string; isError?: boolean }>;
+  toolCalls?: Array<{
+    name: string;
+    input: Record<string, unknown>;
+    result?: string;
+    isError?: boolean;
+  }>;
   interfaces?: string[];
 }

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -1,0 +1,66 @@
+/**
+ * Route handler for surface action operations.
+ *
+ * POST /v1/surface-actions — dispatch a surface action to an active session.
+ * Requires the session to already exist (does not create new sessions).
+ */
+import type { Session } from "../../daemon/session.js";
+import { getLogger } from "../../util/logger.js";
+import { httpError } from "../http-errors.js";
+
+const log = getLogger("surface-action-routes");
+
+export type SessionLookup = (sessionId: string) => Session | undefined;
+
+/**
+ * POST /v1/surface-actions — handle a UI surface action.
+ *
+ * Body: { sessionId, surfaceId, actionId, data? }
+ */
+export async function handleSurfaceAction(
+  req: Request,
+  findSession: SessionLookup,
+): Promise<Response> {
+  const body = (await req.json()) as {
+    sessionId?: string;
+    surfaceId?: string;
+    actionId?: string;
+    data?: Record<string, unknown>;
+  };
+
+  const { sessionId, surfaceId, actionId, data } = body;
+
+  if (!sessionId || typeof sessionId !== "string") {
+    return httpError("BAD_REQUEST", "sessionId is required", 400);
+  }
+  if (!surfaceId || typeof surfaceId !== "string") {
+    return httpError("BAD_REQUEST", "surfaceId is required", 400);
+  }
+  if (!actionId || typeof actionId !== "string") {
+    return httpError("BAD_REQUEST", "actionId is required", 400);
+  }
+
+  const session = findSession(sessionId);
+  if (!session) {
+    return httpError(
+      "NOT_FOUND",
+      "No active session found for this sessionId",
+      404,
+    );
+  }
+
+  try {
+    session.handleSurfaceAction(surfaceId, actionId, data);
+    log.info(
+      { sessionId, surfaceId, actionId },
+      "Surface action handled via HTTP",
+    );
+    return Response.json({ ok: true });
+  } catch (err) {
+    log.error(
+      { err, sessionId, surfaceId, actionId },
+      "Failed to handle surface action via HTTP",
+    );
+    return httpError("INTERNAL_ERROR", "Failed to handle surface action", 500);
+  }
+}

--- a/assistant/src/runtime/routes/trust-rules-routes.ts
+++ b/assistant/src/runtime/routes/trust-rules-routes.ts
@@ -1,0 +1,132 @@
+/**
+ * Route handlers for trust rule CRUD operations.
+ *
+ * These endpoints manage persistent trust rules independently of
+ * the approval-flow trust-rule endpoint in approval-routes.ts.
+ * All endpoints are bearer-token authenticated (standard runtime auth).
+ */
+import {
+  addRule,
+  getAllRules,
+  removeRule,
+  updateRule,
+} from "../../permissions/trust-store.js";
+import { getLogger } from "../../util/logger.js";
+import { httpError } from "../http-errors.js";
+
+const log = getLogger("trust-rules-routes");
+
+/**
+ * GET /v1/trust-rules/manage — list all trust rules.
+ */
+export function handleListTrustRules(): Response {
+  const rules = getAllRules();
+  return Response.json({ type: "trust_rules_list_response", rules });
+}
+
+/**
+ * POST /v1/trust-rules/manage — add a trust rule (standalone, not approval-flow).
+ *
+ * Body: { toolName, pattern, scope, decision, allowHighRisk?, executionTarget? }
+ */
+export async function handleAddTrustRuleManage(
+  req: Request,
+): Promise<Response> {
+  const body = (await req.json()) as {
+    toolName?: string;
+    pattern?: string;
+    scope?: string;
+    decision?: string;
+    allowHighRisk?: boolean;
+    executionTarget?: string;
+  };
+
+  const { toolName, pattern, scope, decision, allowHighRisk, executionTarget } =
+    body;
+
+  if (!toolName || typeof toolName !== "string") {
+    return httpError("BAD_REQUEST", "toolName is required", 400);
+  }
+  if (!pattern || typeof pattern !== "string") {
+    return httpError("BAD_REQUEST", "pattern is required", 400);
+  }
+  if (!scope || typeof scope !== "string") {
+    return httpError("BAD_REQUEST", "scope is required", 400);
+  }
+  if (!decision || typeof decision !== "string") {
+    return httpError("BAD_REQUEST", "decision is required", 400);
+  }
+
+  try {
+    const hasMetadata = allowHighRisk != null || executionTarget != null;
+    addRule(
+      toolName,
+      pattern,
+      scope,
+      decision,
+      undefined,
+      hasMetadata ? { allowHighRisk, executionTarget } : undefined,
+    );
+    log.info(
+      { toolName, pattern, scope, decision },
+      "Trust rule added via HTTP",
+    );
+    return Response.json({ ok: true });
+  } catch (err) {
+    log.error(
+      { err, toolName, pattern, scope },
+      "Failed to add trust rule via HTTP",
+    );
+    return httpError("INTERNAL_ERROR", "Failed to add trust rule", 500);
+  }
+}
+
+/**
+ * DELETE /v1/trust-rules/manage/:id — remove a trust rule by ID.
+ */
+export function handleRemoveTrustRuleManage(id: string): Response {
+  try {
+    const removed = removeRule(id);
+    if (!removed) {
+      return httpError("NOT_FOUND", "Trust rule not found", 404);
+    }
+    log.info({ id }, "Trust rule removed via HTTP");
+    return Response.json({ ok: true });
+  } catch (err) {
+    log.error({ err, id }, "Failed to remove trust rule via HTTP");
+    return httpError("INTERNAL_ERROR", "Failed to remove trust rule", 500);
+  }
+}
+
+/**
+ * PATCH /v1/trust-rules/manage/:id — update fields on an existing trust rule.
+ *
+ * Body: { tool?, pattern?, scope?, decision?, priority? }
+ */
+export async function handleUpdateTrustRuleManage(
+  req: Request,
+  id: string,
+): Promise<Response> {
+  const body = (await req.json()) as {
+    tool?: string;
+    pattern?: string;
+    scope?: string;
+    decision?: string;
+    priority?: number;
+  };
+
+  try {
+    updateRule(id, {
+      tool: body.tool,
+      pattern: body.pattern,
+      scope: body.scope,
+      decision: body.decision as "allow" | "deny" | "ask" | undefined,
+      priority: body.priority,
+    });
+    log.info({ id }, "Trust rule updated via HTTP");
+    return Response.json({ ok: true });
+  } catch (err) {
+    log.error({ err, id }, "Failed to update trust rule via HTTP");
+    return httpError("INTERNAL_ERROR", "Failed to update trust rule", 500);
+  }
+}

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -155,6 +155,9 @@ public final class HTTPTransport {
         case identity
         case featureFlags
         case featureFlagUpdate(key: String)
+        case surfaceAction
+        case trustRulesManage
+        case trustRuleManageById(id: String)
     }
 
     /// Build a URL for the given endpoint using the current route mode.
@@ -217,6 +220,13 @@ public final class HTTPTransport {
         case .featureFlagUpdate(let key):
             let encoded = key.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? key
             return ("/v1/feature-flags/\(encoded)", nil)
+        case .surfaceAction:
+            return ("/v1/surface-actions", nil)
+        case .trustRulesManage:
+            return ("/v1/trust-rules/manage", nil)
+        case .trustRuleManageById(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/trust-rules/manage/\(encoded)", nil)
         }
     }
 
@@ -260,6 +270,13 @@ public final class HTTPTransport {
         case .featureFlagUpdate(let key):
             let encoded = key.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? key
             return ("\(prefix)/feature-flags/\(encoded)/", nil)
+        case .surfaceAction:
+            return ("\(prefix)/surface-actions/", nil)
+        case .trustRulesManage:
+            return ("\(prefix)/trust-rules/manage/", nil)
+        case .trustRuleManageById(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/trust-rules/manage/\(encoded)/", nil)
         }
     }
 
@@ -476,6 +493,16 @@ public final class HTTPTransport {
             Task { await self.fetchGuardianActionsPending(conversationId: msg.conversationId) }
         } else if let msg = message as? GuardianActionDecisionMessage {
             Task { await self.submitGuardianActionDecision(requestId: msg.requestId, action: msg.action, conversationId: msg.conversationId) }
+        } else if let msg = message as? UiSurfaceActionMessage {
+            Task { await self.sendSurfaceAction(msg) }
+        } else if let msg = message as? AddTrustRuleMessage {
+            Task { await self.sendAddTrustRule(msg) }
+        } else if message is TrustRulesListMessage {
+            Task { await self.fetchTrustRules() }
+        } else if let msg = message as? RemoveTrustRuleMessage {
+            Task { await self.sendRemoveTrustRule(msg) }
+        } else if let msg = message as? UpdateTrustRuleMessage {
+            Task { await self.sendUpdateTrustRule(msg) }
         } else if message is PingMessage {
             // No-op for HTTP transport — SSE keepalive is handled by the connection
         } else {
@@ -782,6 +809,194 @@ public final class HTTPTransport {
             }
         } catch {
             log.error("Conversation seen signal error: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Surface Actions
+
+    private func sendSurfaceAction(_ action: UiSurfaceActionMessage, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .surfaceAction) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        var body: [String: Any] = [
+            "sessionId": action.sessionId,
+            "surfaceId": action.surfaceId,
+            "actionId": action.actionId,
+        ]
+        if let data = action.data {
+            // Convert [String: AnyCodable] to [String: Any] for JSONSerialization
+            var dataDict: [String: Any] = [:]
+            for (key, value) in data {
+                dataDict[key] = value.value
+            }
+            body["data"] = dataDict
+        }
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (_, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync()
+                    if case .success = refreshResult {
+                        await sendSurfaceAction(action, isRetry: true)
+                    }
+                } else if http.statusCode != 200 {
+                    log.error("HTTPTransport: surface action failed (\(http.statusCode))")
+                }
+            }
+        } catch {
+            log.error("HTTPTransport: surface action error: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Trust Rule Management
+
+    private func sendAddTrustRule(_ rule: AddTrustRuleMessage, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .trustRulesManage) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        var body: [String: Any] = [
+            "toolName": rule.toolName,
+            "pattern": rule.pattern,
+            "scope": rule.scope,
+            "decision": rule.decision,
+        ]
+        if let allowHighRisk = rule.allowHighRisk {
+            body["allowHighRisk"] = allowHighRisk
+        }
+        if let executionTarget = rule.executionTarget {
+            body["executionTarget"] = executionTarget
+        }
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (_, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync()
+                    if case .success = refreshResult {
+                        await sendAddTrustRule(rule, isRetry: true)
+                    }
+                } else if http.statusCode != 200 {
+                    log.error("HTTPTransport: add trust rule failed (\(http.statusCode))")
+                }
+            }
+        } catch {
+            log.error("HTTPTransport: add trust rule error: \(error.localizedDescription)")
+        }
+    }
+
+    private func fetchTrustRules(isRetry: Bool = false) async {
+        guard let url = buildURL(for: .trustRulesManage) else { return }
+
+        var request = URLRequest(url: url)
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync()
+                    if case .success = refreshResult {
+                        await fetchTrustRules(isRetry: true)
+                    }
+                    return
+                }
+                guard http.statusCode == 200 else {
+                    log.error("HTTPTransport: fetch trust rules failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            do {
+                let decoded = try decoder.decode(IPCTrustRulesListResponse.self, from: data)
+                onMessage?(.trustRulesListResponse(decoded))
+            } catch {
+                log.error("HTTPTransport: failed to decode trust rules response: \(error)")
+            }
+        } catch {
+            log.error("HTTPTransport: fetch trust rules error: \(error.localizedDescription)")
+        }
+    }
+
+    private func sendRemoveTrustRule(_ rule: RemoveTrustRuleMessage, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .trustRuleManageById(id: rule.id)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        applyAuth(&request)
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync()
+                    if case .success = refreshResult {
+                        await sendRemoveTrustRule(rule, isRetry: true)
+                    }
+                } else if http.statusCode != 200 {
+                    log.error("HTTPTransport: remove trust rule failed (\(http.statusCode))")
+                }
+            }
+        } catch {
+            log.error("HTTPTransport: remove trust rule error: \(error.localizedDescription)")
+        }
+    }
+
+    private func sendUpdateTrustRule(_ rule: UpdateTrustRuleMessage, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .trustRuleManageById(id: rule.id)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "PATCH"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        var body: [String: Any] = [:]
+        if let tool = rule.tool {
+            body["tool"] = tool
+        }
+        if let pattern = rule.pattern {
+            body["pattern"] = pattern
+        }
+        if let scope = rule.scope {
+            body["scope"] = scope
+        }
+        if let decision = rule.decision {
+            body["decision"] = decision
+        }
+        if let priority = rule.priority {
+            body["priority"] = priority
+        }
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (_, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync()
+                    if case .success = refreshResult {
+                        await sendUpdateTrustRule(rule, isRetry: true)
+                    }
+                } else if http.statusCode != 200 {
+                    log.error("HTTPTransport: update trust rule failed (\(http.statusCode))")
+                }
+            }
+        } catch {
+            log.error("HTTPTransport: update trust rule error: \(error.localizedDescription)")
         }
     }
 


### PR DESCRIPTION
## Summary
- Added `send()` handlers in `HTTPDaemonClient` for `UiSurfaceActionMessage`, `AddTrustRuleMessage`, `TrustRulesListMessage`, `RemoveTrustRuleMessage`, and `UpdateTrustRuleMessage` — previously these were logged as "unhandled" and silently dropped in HTTP transport mode
- Added corresponding server-side HTTP endpoints: `POST /v1/surface-actions`, `GET/POST /v1/trust-rules/manage`, `DELETE/PATCH /v1/trust-rules/manage/:id`
- Added `findSession()` to `DaemonServer` for non-creating session lookup, wired through `RuntimeHttpServerOptions`

## Test plan
- [x] `swift build` succeeds with no compilation errors
- [x] Prettier formatting passes for all TypeScript files
- [x] ESLint passes for all TypeScript files
- [x] New handlers follow existing patterns (auth, 401 retry with token refresh, error logging)
- [x] New endpoints are bearer-token authenticated (behind existing auth middleware)
- [x] Both `runtimeFlat` and `platformAssistantProxy` URL layouts are covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
