### PR TITLE
fix: retry button returns to welcome screen on hatch failure

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -218,20 +218,9 @@ struct HatchingStepView: View {
     }
 
     private func retryHatch() {
-        // Reset hatching state
-        state.isHatching = false
-        state.hatchFailed = false
-        state.hatchCompleted = false
-        state.hatchLogLines = []
-        state.hasHatched = false
         hatchStarted = false
         failureReason = nil
-
-        // Clear provider/credential state so the user gets a clean slate
-        state.resetCloudCredentials()
-
-        // Return to the welcome screen (step 0)
-        state.currentStep = 0
+        state.resetForRetry()
     }
 
     // MARK: - Timers

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -227,6 +227,9 @@ struct HatchingStepView: View {
         hatchStarted = false
         failureReason = nil
 
+        // Clear provider/credential state so the user gets a clean slate
+        state.resetCloudCredentials()
+
         // Return to the welcome screen (step 0)
         state.currentStep = 0
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -218,25 +218,17 @@ struct HatchingStepView: View {
     }
 
     private func retryHatch() {
+        // Reset hatching state
+        state.isHatching = false
         state.hatchFailed = false
+        state.hatchCompleted = false
         state.hatchLogLines = []
+        state.hasHatched = false
+        hatchStarted = false
         failureReason = nil
-        eggCracked = false
-        crackTime = nil
-        cliFinished = false
-        elapsedTime = 0
-        progressMessageIndex = 0
-        showTimeEstimate = false
-        hatchStartTime = Date()
-        startWobble()
-        startElapsedTimer()
-        startProgressMessageRotation()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-            withAnimation(.easeIn(duration: 0.5)) {
-                showTimeEstimate = true
-            }
-        }
-        startHatching()
+
+        // Return to the welcome screen (step 0)
+        state.currentStep = 0
     }
 
     // MARK: - Timers

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -167,6 +167,7 @@ final class OnboardingState {
     /// Resets cloud provider and credential fields to defaults.
     func resetCloudCredentials() {
         cloudProvider = "local"
+        UserDefaults.standard.set("local", forKey: "onboarding.cloudProvider")
         gcpProjectId = ""
         gcpZone = "us-central1-a"
         gcpServiceAccountKey = ""

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -174,6 +174,9 @@ final class OnboardingState {
         hatchLogLines = []
         hasHatched = false
 
+        // Clear stored API key so the user starts fresh
+        APIKeyManager.deleteKey()
+
         // Reset cloud credentials (in-memory only; not persisted)
         cloudProvider = "local"
         gcpProjectId = ""

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -164,10 +164,18 @@ final class OnboardingState {
         UserDefaults.standard.set(Self.currentFlowVersion, forKey: "onboarding.flowVersion")
     }
 
-    /// Resets cloud provider and credential fields to defaults.
-    func resetCloudCredentials() {
+    /// Resets all hatch-related and credential state for a clean retry,
+    /// including persisted UserDefaults keys.
+    func resetForRetry() {
+        // Reset hatch flags
+        isHatching = false
+        hatchFailed = false
+        hatchCompleted = false
+        hatchLogLines = []
+        hasHatched = false
+
+        // Reset cloud credentials (in-memory only; not persisted)
         cloudProvider = "local"
-        UserDefaults.standard.set("local", forKey: "onboarding.cloudProvider")
         gcpProjectId = ""
         gcpZone = "us-central1-a"
         gcpServiceAccountKey = ""
@@ -176,6 +184,10 @@ final class OnboardingState {
         sshUser = ""
         sshPrivateKey = ""
         customQRCodeImageData = Data()
+
+        // Return to welcome screen and persist the reset
+        currentStep = 0
+        persist()
     }
 
     static func clearPersistedState() {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -164,6 +164,19 @@ final class OnboardingState {
         UserDefaults.standard.set(Self.currentFlowVersion, forKey: "onboarding.flowVersion")
     }
 
+    /// Resets cloud provider and credential fields to defaults.
+    func resetCloudCredentials() {
+        cloudProvider = "local"
+        gcpProjectId = ""
+        gcpZone = "us-central1-a"
+        gcpServiceAccountKey = ""
+        awsRoleArn = ""
+        sshHost = ""
+        sshUser = ""
+        sshPrivateKey = ""
+        customQRCodeImageData = Data()
+    }
+
     static func clearPersistedState() {
         for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress", "onboarding.flowVersion", "onboarding.cloudProvider"] {
             UserDefaults.standard.removeObject(forKey: key)

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -187,7 +187,7 @@ final class OnboardingState {
 
         // Return to welcome screen and persist the reset
         currentStep = 0
-        persist()
+        if shouldPersist { persist() }
     }
 
     static func clearPersistedState() {


### PR DESCRIPTION
## Summary
- When hatching fails, the "Try Again" button now fully resets all onboarding state and returns the user to the welcome screen (step 0) instead of blindly retrying the hatch with the same configuration
- Clears stored API key from Keychain, cloud provider, and all credential fields (GCP, AWS, SSH, QR) so the user gets a completely clean slate
- Persists the reset to UserDefaults (guarded by `shouldPersist` for auth-gate flows) so the clean state survives app restart
- "Go Back" button behavior unchanged — still returns to the previous onboarding step

## Changes
- **`OnboardingState.swift`**: Added `resetForRetry()` — clears hatch flags, deletes stored API key, resets cloud credentials, sets step to 0, and persists
- **`HatchingStepView.swift`**: Simplified `retryHatch()` to call `state.resetForRetry()`

## Test plan
- [ ] Trigger a hatch failure (e.g., invalid credentials or network issue)
- [ ] Click "Try Again" — should return to the Welcome screen with "Sign in" / "Self-host" options
- [ ] Verify API key field is empty (not pre-filled with stale key)
- [ ] Verify cloud provider is reset to "local" (not pre-selected to previous provider)
- [ ] Click "Go Back" — should return to the previous step (cloud credentials form)
- [ ] Kill and relaunch the app after clicking "Try Again" — should open to the welcome screen, not the old step

🤖 Generated with [Claude Code](https://claude.com/claude-code)