### PR TITLE
fix: resolve CI type-check errors

### DIFF
--- a/assistant/src/runtime/http-errors.ts
+++ b/assistant/src/runtime/http-errors.ts
@@ -16,16 +16,17 @@
  * internal assistant-layer errors.
  */
 export type HttpErrorCode =
-  | 'BAD_REQUEST'
-  | 'UNAUTHORIZED'
-  | 'FORBIDDEN'
-  | 'NOT_FOUND'
-  | 'CONFLICT'
-  | 'GONE'
-  | 'RATE_LIMITED'
-  | 'UNPROCESSABLE_ENTITY'
-  | 'INTERNAL_ERROR'
-  | 'SERVICE_UNAVAILABLE';
+  | "BAD_REQUEST"
+  | "UNAUTHORIZED"
+  | "FORBIDDEN"
+  | "NOT_FOUND"
+  | "CONFLICT"
+  | "GONE"
+  | "RATE_LIMITED"
+  | "UNPROCESSABLE_ENTITY"
+  | "INTERNAL_ERROR"
+  | "NOT_IMPLEMENTED"
+  | "SERVICE_UNAVAILABLE";
 
 // ── Response type ────────────────────────────────────────────────────────────
 
@@ -79,15 +80,27 @@ export function httpError(
  */
 export function httpErrorCodeFromStatus(status: number): HttpErrorCode {
   switch (status) {
-    case 400: return 'BAD_REQUEST';
-    case 401: return 'UNAUTHORIZED';
-    case 403: return 'FORBIDDEN';
-    case 404: return 'NOT_FOUND';
-    case 409: return 'CONFLICT';
-    case 410: return 'GONE';
-    case 422: return 'UNPROCESSABLE_ENTITY';
-    case 429: return 'RATE_LIMITED';
-    case 503: return 'SERVICE_UNAVAILABLE';
-    default:  return 'INTERNAL_ERROR';
+    case 400:
+      return "BAD_REQUEST";
+    case 401:
+      return "UNAUTHORIZED";
+    case 403:
+      return "FORBIDDEN";
+    case 404:
+      return "NOT_FOUND";
+    case 409:
+      return "CONFLICT";
+    case 410:
+      return "GONE";
+    case 422:
+      return "UNPROCESSABLE_ENTITY";
+    case 429:
+      return "RATE_LIMITED";
+    case 501:
+      return "NOT_IMPLEMENTED";
+    case 503:
+      return "SERVICE_UNAVAILABLE";
+    default:
+      return "INTERNAL_ERROR";
   }
 }

--- a/assistant/src/runtime/routes/trust-rules-routes.ts
+++ b/assistant/src/runtime/routes/trust-rules-routes.ts
@@ -53,8 +53,16 @@ export async function handleAddTrustRuleManage(
   if (!scope || typeof scope !== "string") {
     return httpError("BAD_REQUEST", "scope is required", 400);
   }
-  if (!decision || typeof decision !== "string") {
-    return httpError("BAD_REQUEST", "decision is required", 400);
+  const validDecisions = ["allow", "deny", "ask"] as const;
+  if (
+    !decision ||
+    !validDecisions.includes(decision as (typeof validDecisions)[number])
+  ) {
+    return httpError(
+      "BAD_REQUEST",
+      "decision must be one of: allow, deny, ask",
+      400,
+    );
   }
 
   try {
@@ -63,7 +71,7 @@ export async function handleAddTrustRuleManage(
       toolName,
       pattern,
       scope,
-      decision,
+      decision as "allow" | "deny" | "ask",
       undefined,
       hasMetadata ? { allowHighRisk, executionTarget } : undefined,
     );


### PR DESCRIPTION
## Summary
- Add `NOT_IMPLEMENTED` to the `HttpErrorCode` union and `httpErrorCodeFromStatus` switch to fix TS2345 in `http-server.ts`
- Validate `decision` against allowed values (`allow`, `deny`, `ask`) and cast to the expected literal type in `trust-rules-routes.ts` to fix TS2345

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22601969021/job/65485650519

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
