### PR TITLE
fix: update stale comments referencing removed Vellum catalog installer

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -75,9 +75,8 @@ function resolveProvenance(summary: SkillSummary): SkillProvenance {
     return { kind: "first-party", provider: "Vellum" };
   }
 
-  // Managed skills could be either first-party (installed from Vellum catalog)
-  // or third-party (installed from clawhub). The homepage field serves as a
-  // heuristic: Vellum catalog skills don't typically have a clawhub homepage.
+  // Managed skills are third-party (installed from clawhub). The homepage field
+  // confirms provenance.
   if (summary.source === "managed") {
     if (
       summary.homepage?.includes("skills.sh") ||
@@ -92,8 +91,8 @@ function resolveProvenance(summary: SkillSummary): SkillProvenance {
           `${CLAWHUB_BASE_URL}/skills/${encodeURIComponent(summary.id)}`,
       };
     }
-    // No positive evidence of origin -- could be user-authored or from Vellum catalog.
-    // Default to "local" to avoid mislabeling user-created skills as first-party.
+    // No positive evidence of clawhub origin -- likely user-authored.
+    // Default to "local" to avoid mislabeling.
     return { kind: "local" };
   }
 

--- a/assistant/src/skills/frontmatter.ts
+++ b/assistant/src/skills/frontmatter.ts
@@ -2,8 +2,8 @@
  * Shared frontmatter parsing for SKILL.md files.
  *
  * Frontmatter is a YAML-like block delimited by `---` at the top of a file.
- * This module provides a single implementation used by the skill catalog loader,
- * the Vellum catalog installer, and the CC command registry.
+ * This module provides a single implementation used by the skill catalog loader
+ * and the CC command registry.
  */
 
 /** Matches a `---` delimited frontmatter block at the start of a file. */
@@ -25,7 +25,9 @@ export interface FrontmatterParseResult {
  *
  * Returns `null` if no frontmatter block is found.
  */
-export function parseFrontmatterFields(content: string): FrontmatterParseResult | null {
+export function parseFrontmatterFields(
+  content: string,
+): FrontmatterParseResult | null {
   const match = content.match(FRONTMATTER_REGEX);
   if (!match) return null;
 
@@ -34,8 +36,8 @@ export function parseFrontmatterFields(content: string): FrontmatterParseResult 
 
   for (const line of frontmatter.split(/\r?\n/)) {
     const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    const separatorIndex = trimmed.indexOf(':');
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const separatorIndex = trimmed.indexOf(":");
     if (separatorIndex === -1) continue;
 
     const key = trimmed.slice(0, separatorIndex).trim();
@@ -50,8 +52,8 @@ export function parseFrontmatterFields(content: string): FrontmatterParseResult 
         // Only for double-quoted values — single-quoted YAML treats backslashes literally.
         // Single-pass to avoid misinterpreting \\n (escaped backslash + n) as a newline.
         value = value.replace(/\\(["\\nr])/g, (_, ch) => {
-          if (ch === 'n') return '\n';
-          if (ch === 'r') return '\r';
+          if (ch === "n") return "\n";
+          if (ch === "r") return "\r";
           return ch; // handles \\ → \ and \" → "
         });
       }


### PR DESCRIPTION
## Summary
- Updated module docstring in `frontmatter.ts` to remove reference to the removed Vellum catalog installer, leaving only the two current consumers (skill catalog loader and CC command registry).
- Updated inline comments in `skills.ts` `resolveProvenance()` to reflect that managed skills now only come from Clawhub (not from a Vellum catalog).
- Updated a secondary comment in the same function that also referenced the Vellum catalog.

## Test plan
- [x] `bunx tsc --noEmit` passes (pre-existing errors only, unrelated to this change)
- [x] `bun test skills` passes (37 pass, 2 pre-existing failures from missing packages in worktree)
- [x] Prettier and ESLint pass via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
