### PR TITLE
perf: upgrade macOS CI runners to macos-15

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: macOS Build
-    runs-on: macos-14
+    runs-on: macos-15
     timeout-minutes: 15
     env:
       VELLUM_FLAG_FEATURE_FLAG_EDITOR_ENABLED: "true"
@@ -132,7 +132,7 @@ jobs:
 
   test:
     name: macOS Tests
-    runs-on: macos-14
+    runs-on: macos-15
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -16,7 +16,7 @@ jobs:
   build-check:
     if: contains(github.event.pull_request.labels.*.name, 'preview')
     name: macOS Build
-    runs-on: macos-14
+    runs-on: macos-15
     timeout-minutes: 45
     env:
       VELLUM_FLAG_FEATURE_FLAG_EDITOR_ENABLED: "true"


### PR DESCRIPTION
## Summary
- Upgrade `runs-on` from `macos-14` to `macos-15` in `ci-main-macos.yaml` (build + test jobs) and `pr-macos.yaml` for faster Swift compilation on newer hardware.

## Original prompt
Upgrade macOS CI runners from macos-14 to macos-15 for faster builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
