### PR TITLE
feat: add select-all toggle to table widget

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -12,12 +12,30 @@ public struct InlineTableWidget: View {
         self.onAction = onAction
     }
 
+    private var selectableIds: Set<String> {
+        Set(data.rows.filter(\.selectable).map(\.id))
+    }
+
+    private var allSelected: Bool {
+        let ids = selectableIds
+        return !ids.isEmpty && ids.isSubset(of: selectedIds)
+    }
+
     public var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             // Column headers
             HStack(spacing: 0) {
-                if data.selectionMode != .none {
-                    // Checkbox column header
+                if data.selectionMode == .multiple {
+                    Button {
+                        toggleSelectAll()
+                    } label: {
+                        Image(systemName: allSelected ? "checkmark.circle.fill" : "circle")
+                            .font(.system(size: 14))
+                            .foregroundColor(allSelected ? VColor.accent : VColor.textMuted)
+                    }
+                    .buttonStyle(.plain)
+                    .frame(width: 28)
+                } else if data.selectionMode != .none {
                     Color.clear
                         .frame(width: 28)
                 }
@@ -95,6 +113,15 @@ public struct InlineTableWidget: View {
                 toggleSelection(row.id)
             }
         }
+    }
+
+    private func toggleSelectAll() {
+        if allSelected {
+            selectedIds.subtract(selectableIds)
+        } else {
+            selectedIds.formUnion(selectableIds)
+        }
+        onAction("selection_changed", ["selectedIds": AnyCodable(Array(selectedIds))])
     }
 
     private func toggleSelection(_ id: String) {


### PR DESCRIPTION
## Summary

- Add a select-all checkbox in the `InlineTableWidget` header row when `selectionMode == .multiple`
- Clicking it toggles all selectable rows on/off and emits `selection_changed`
- Single-selection and no-selection tables are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
