### PR TITLE
fix: restore maxToolUseTurns default to 40

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -205,7 +205,7 @@ export const AssistantConfigSchema = z.object({
     .number({ error: 'maxToolUseTurns must be a number' })
     .int('maxToolUseTurns must be an integer')
     .nonnegative('maxToolUseTurns must be a non-negative integer')
-    .default(0),
+    .default(40),
   thinking: ThinkingConfigSchema.default(ThinkingConfigSchema.parse({})),
   contextWindow: ContextWindowConfigSchema.default(ContextWindowConfigSchema.parse({})),
   memory: MemoryConfigSchema.default(MemoryConfigSchema.parse({})),


### PR DESCRIPTION
Addresses Codex P1 feedback on #11417. The previous PR changed maxToolUseTurns default to 0, which disables the agent loop guard against unbounded tool churn. Restores the original default of 40.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
