### PR TITLE
fix: correct skills_search description in Skills Catalog skill

### DIFF
--- a/assistant/src/config/bundled-skills/skills-catalog/SKILL.md
+++ b/assistant/src/config/bundled-skills/skills-catalog/SKILL.md
@@ -23,7 +23,7 @@ Community skills are published on [Clawhub](https://clawhub.com) and can be sear
 
 ### Searching for community skills
 
-Use the `skill_load` tool to search the catalog, or check the system prompt's available skills list. The IPC `skills_search` message searches both bundled and community skills.
+Use the `skill_load` tool to search the catalog, or check the system prompt's available skills list. The IPC `skills_search` message searches community skills on Clawhub. Bundled skills are already listed in the system prompt.
 
 ### Installing a community skill
 


### PR DESCRIPTION
## Summary
- Corrected the `skills_search` description in `SKILL.md` to reflect that the IPC handler now only searches community skills on Clawhub, not both bundled and community skills.
- Bundled skills are already surfaced via the catalog/list endpoint and listed in the system prompt.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test skills` passes (114 tests, 0 failures)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
