### PR TITLE
fix: emit thinking activity without clearing statusText

### DIFF
--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -185,16 +185,13 @@ export function handleThinkingDelta(
   if (!state.firstThinkingDeltaEmitted) {
     state.firstThinkingDeltaEmitted = true;
     const lastToolName = state.lastCompletedToolName;
-    // Only emit activity state when we have a tool name to report.
-    // When lastCompletedToolName is undefined (e.g. right after
-    // confirmation_resolved), emitting without statusText would clear
-    // the client's current status (e.g. "Resuming after approval").
-    // The phase is already 'thinking' from either message_dequeued or
-    // confirmation_resolved, so skipping here is safe.
-    if (lastToolName) {
-      const statusText = `Processing ${friendlyToolName(lastToolName)} results`;
-      deps.ctx.emitActivityState('thinking', 'thinking_delta', 'assistant_turn', deps.reqId, statusText);
-    }
+    // When a tool just completed, show "Processing <tool> results".
+    // When no tool has completed (e.g. right after confirmation_resolved),
+    // omit statusText so the client preserves its current status
+    // (e.g. "Resuming after approval") — emitActivityState only includes
+    // statusText in the message when it's truthy.
+    const statusText = lastToolName ? `Processing ${friendlyToolName(lastToolName)} results` : undefined;
+    deps.ctx.emitActivityState('thinking', 'thinking_delta', 'assistant_turn', deps.reqId, statusText);
   }
   if (!deps.ctx.streamThinking) return;
   emitLlmCallStartedIfNeeded(state, deps);


### PR DESCRIPTION
Addresses Codex P2 feedback on #11418. Instead of completely skipping the thinking activity emission when no tool has completed, now always emits the thinking state while preserving the client's current statusText by omitting the statusText parameter (which emitActivityState handles by not including it in the message).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
