### PR TITLE
fix: prevent app bouncing during /update

### DIFF
--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -20,9 +20,10 @@ Pull the latest changes from main, use `vellum` lifecycle CLI to stop and restar
    vellum ps
    ```
 
-2. Kill the macOS app first (it manages its own daemon/gateway, so it must be stopped before quiescing processes):
+2. Kill the macOS app and any stale file-watcher processes first (old `build.sh run` watchers will detect git-pulled Swift changes and bounce the app repeatedly):
    ```bash
    pkill -x "Vellum" || true
+   pkill -f "build\.sh run" || true
    ```
 
 3. Quiesce with `vellum sleep` — stop daemon and gateway processes. This is directory-agnostic and stops processes globally regardless of CWD:
@@ -61,12 +62,7 @@ Pull the latest changes from main, use `vellum` lifecycle CLI to stop and restar
    vellum wake
    ```
 
-8. Build the macOS app from source synchronously (wait for build to complete before launching to avoid opening a stale build), then launch with file-watching in the background:
-   ```bash
-   REPO_ROOT="$(pwd)"
-   cd clients/macos && VELLUM_GATEWAY_DIR="$REPO_ROOT/gateway" ./build.sh
-   ```
-
+8. Build and launch the macOS app with file-watching (`./build.sh run` builds synchronously before launching, so no stale build risk):
    ```bash
    REPO_ROOT="$(pwd)"
    cd clients/macos && VELLUM_GATEWAY_DIR="$REPO_ROOT/gateway" ./build.sh run &


### PR DESCRIPTION
## Summary
- Kill stale `build.sh run` file-watcher processes early in the `/update` flow (before `git pull`), preventing old watchers from detecting Swift file changes and repeatedly rebuilding+relaunching the app
- Remove redundant double-build (`./build.sh` then `./build.sh run`) — `run` already builds synchronously before launching

## Test plan
- [ ] Run `/update` when an old `build.sh run` watcher is active — app should no longer bounce
- [ ] Verify the app builds and launches correctly with the single `./build.sh run &` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
