### PR TITLE
fix: preserve legacy lockfile entries during upsertManagedEntry migration

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -335,11 +335,15 @@ struct LockfileAssistant {
         let path = lockfilePath ?? LockfilePaths.primaryPath
         let fileURL = URL(fileURLWithPath: path)
 
-        // Read existing lockfile or start fresh.
+        // Read existing lockfile: try primary first, then fall back to
+        // LockfilePaths.read() which includes legacy path migration.
         var lockfile: [String: Any]
         if let data = try? Data(contentsOf: fileURL),
            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
             lockfile = json
+        } else if lockfilePath == nil, let legacy = LockfilePaths.read() {
+            // Primary doesn't exist but legacy does — migrate entries forward.
+            lockfile = legacy
         } else {
             lockfile = [:]
         }


### PR DESCRIPTION
## Summary
- **Bug:** `LockfileAssistant.upsertManagedEntry()` only reads from `LockfilePaths.primaryPath`. When a user has only a legacy lockfile at `~/.vellum.lockfile.json`, the upsert reads nothing, starts fresh, and writes a new primary lockfile containing only the managed entry — silently dropping all existing entries.
- **Fix:** Fall back to `LockfilePaths.read()` (which checks both primary and legacy paths) when the primary file doesn't exist and no custom `lockfilePath` override is provided. This preserves all existing entries during the migration to the primary path.

## Test plan
- [x] `swift build` passes
- [ ] Manually verify: create a legacy lockfile at `~/.vellum.lockfile.json` with multiple entries, remove `~/.vellum.lock.json`, call `upsertManagedEntry()`, confirm all legacy entries are preserved in the new primary lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
