### PR TITLE
fix: add pendingInteractions endpoint case and managed mode docs

### DIFF
--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -54,6 +54,42 @@ Requires Apple Developer account + App Store Connect setup. Deferred to PR 12-13
 
 **Daemon Connection Note:** The iOS app connects to the daemon through the HTTP gateway. Pair via QR code (Settings → Connect → Show QR Code on Mac, Scan QR Code on iPhone). All pairings require Mac-side approval. Devices approved with "Always Allow" auto-approve on future pairings.
 
+## Managed Mode
+
+The app supports a **managed sign-in** flow that connects to a platform-hosted assistant instead of a local daemon.
+
+### Sign-in Flow
+
+1. User clicks "Sign in" during onboarding (or from Settings)
+2. WorkOS authentication opens in the system browser
+3. On success, `ManagedAssistantBootstrapService.ensureManagedAssistant()` discovers or creates a platform assistant
+4. A lockfile entry is written with `cloud: "vellum"` and the `connectedAssistantId` is persisted in UserDefaults
+5. HTTP transport is configured in `platformAssistantProxy` mode with session token auth
+
+### Transport Modes
+
+The `HTTPTransport` supports two route modes:
+
+- **`runtimeFlat`** -- Used for local daemon connections and custom remote setups. Paths follow the runtime layout (e.g., `/v1/messages`, `/v1/events`).
+- **`platformAssistantProxy`** -- Used in managed mode. Paths are scoped under `/v1/assistants/{id}/` with trailing slashes (Django convention), e.g., `/v1/assistants/{id}/messages/`.
+
+### Key Differences in Managed Mode
+
+- No local daemon process -- the assistant runs on the Vellum platform
+- No actor credentials or bearer token -- session token auth is used instead (stored in Keychain)
+- Onboarding skips local daemon hatching and Fn key setup
+- If bootstrap fails, the user stays on the onboarding screen with a retry option
+
+### Where State Lives
+
+| State | Location |
+|-------|----------|
+| Session token | Keychain (`AuthManager`) |
+| Lockfile entry | `~/.vellum/lockfile.json` (with `cloud: "vellum"`) |
+| Connected assistant ID | UserDefaults (`connectedAssistantId`) |
+
+For the full managed sign-in architecture, see `clients/ARCHITECTURE.md`.
+
 ## Download
 
 To install the pre-built macOS app, download the signed and notarized DMG:

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -158,6 +158,7 @@ public final class HTTPTransport {
         case surfaceAction
         case trustRulesManage
         case trustRuleManageById(id: String)
+        case pendingInteractions(conversationKey: String?)
     }
 
     /// Build a URL for the given endpoint using the current route mode.
@@ -227,6 +228,12 @@ public final class HTTPTransport {
         case .trustRuleManageById(let id):
             let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
             return ("/v1/trust-rules/manage/\(encoded)", nil)
+        case .pendingInteractions(let conversationKey):
+            if let key = conversationKey {
+                let encoded = key.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? key
+                return ("/v1/pending-interactions", "conversationKey=\(encoded)")
+            }
+            return ("/v1/pending-interactions", nil)
         }
     }
 
@@ -277,6 +284,12 @@ public final class HTTPTransport {
         case .trustRuleManageById(let id):
             let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
             return ("\(prefix)/trust-rules/manage/\(encoded)/", nil)
+        case .pendingInteractions(let conversationKey):
+            if let key = conversationKey {
+                let encoded = key.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? key
+                return ("\(prefix)/pending-interactions/", "conversationKey=\(encoded)")
+            }
+            return ("\(prefix)/pending-interactions/", nil)
         }
     }
 


### PR DESCRIPTION
## Summary
- Add the missing `pendingInteractions` case to the `HTTPTransport.Endpoint` enum in `HTTPDaemonClient.swift`, with path mappings for both `runtimeFlat` (`/v1/pending-interactions`) and `platformAssistantProxy` (`{prefix}/pending-interactions/`) route modes. The runtime and platform already handle this endpoint -- only the client-side enum was missing.
- Add a Managed Mode section to `clients/macos/README.md` covering the sign-in flow, transport modes, key behavioral differences, and where state lives.

## Test plan
- [x] `swift build` passes with no errors
- [ ] Verify the new endpoint case compiles and is accessible from call sites
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
