### PR TITLE
fix: scope managed bootstrap to first-run onboarding only

### DIFF
--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -323,6 +323,7 @@ For example, views with dependencies need them passed in:
         state: OnboardingState(),
         daemonClient: DaemonClient(),
         authManager: AuthManager(),
+        managedBootstrapEnabled: true,
         onComplete: {},
         onOpenSettings: {}
     )

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -841,6 +841,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             state: state,
             daemonClient: daemonClient,
             authManager: authManager,
+            managedBootstrapEnabled: false,
             onComplete: { [weak self] in
                 self?.proceedToApp()
             },

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -6,6 +6,7 @@ struct OnboardingFlowView: View {
     @Bindable var state: OnboardingState
     let daemonClient: DaemonClientProtocol
     @Bindable var authManager: AuthManager
+    let managedBootstrapEnabled: Bool
     var onComplete: () -> Void
     var onOpenSettings: () -> Void
 
@@ -124,8 +125,12 @@ struct OnboardingFlowView: View {
         }
         .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
             if isAuthenticated {
-                Task {
-                    await performManagedBootstrap()
+                if managedBootstrapEnabled {
+                    Task {
+                        await performManagedBootstrap()
+                    }
+                } else {
+                    onComplete()
                 }
             }
         }
@@ -221,6 +226,7 @@ struct OnboardingFlowView: View {
         state: OnboardingState(),
         daemonClient: DaemonClient(),
         authManager: AuthManager(),
+        managedBootstrapEnabled: true,
         onComplete: {},
         onOpenSettings: {}
     )

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
@@ -27,6 +27,7 @@ final class OnboardingWindow {
             state: state,
             daemonClient: daemonClient,
             authManager: authManager,
+            managedBootstrapEnabled: true,
             onComplete: { [weak self] in
                 guard let self else { return }
                 self.onComplete?(self.state)


### PR DESCRIPTION
## Summary
- Add `managedBootstrapEnabled` parameter to `OnboardingFlowView` to control whether managed assistant bootstrap runs after authentication
- Pass `true` in `OnboardingWindow` (first-run onboarding) where managed bootstrap should run
- Pass `false` in `AppDelegate.showAuthWindow()` (re-auth after logout) where it should skip bootstrap and just complete

## Problem
The `.onChange(of: authManager.isAuthenticated)` handler in `OnboardingFlowView` always triggered `performManagedBootstrap()` on any authentication success. This meant a user who logged out and back in via `showAuthWindow()` could have their existing local/self-hosted assistant replaced with a managed one.

## Test plan
- [ ] First-run onboarding: sign in via WorkOS -> managed bootstrap runs, assistant is provisioned
- [ ] Re-auth after logout: sign in via WorkOS -> completes immediately without bootstrap, existing assistant preserved
- [ ] Build succeeds (`swift build` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
