### PR TITLE
test: add Swift tests for managed sign-in components

### DIFF
--- a/clients/macos/vellum-assistantTests/LockfileAssistantManagedTests.swift
+++ b/clients/macos/vellum-assistantTests/LockfileAssistantManagedTests.swift
@@ -1,0 +1,315 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class LockfileAssistantManagedTests: XCTestCase {
+    private var tempDir: URL!
+    private var lockfilePath: String!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        lockfilePath = tempDir.appendingPathComponent(".vellum.lock.json").path
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    // MARK: - upsertManagedEntry: insert when absent
+
+    func testUpsertInsertsWhenLockfileDoesNotExist() {
+        let result = LockfileAssistant.upsertManagedEntry(
+            assistantId: "test-id",
+            runtimeUrl: "https://platform.vellum.ai",
+            hatchedAt: "2024-01-01T00:00:00Z",
+            lockfilePath: lockfilePath
+        )
+        XCTAssertTrue(result)
+
+        let data = try! Data(contentsOf: URL(fileURLWithPath: lockfilePath))
+        let json = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let assistants = json["assistants"] as! [[String: Any]]
+        XCTAssertEqual(assistants.count, 1)
+        XCTAssertEqual(assistants[0]["assistantId"] as? String, "test-id")
+        XCTAssertEqual(assistants[0]["cloud"] as? String, "vellum")
+        XCTAssertEqual(assistants[0]["runtimeUrl"] as? String, "https://platform.vellum.ai")
+        XCTAssertEqual(assistants[0]["hatchedAt"] as? String, "2024-01-01T00:00:00Z")
+    }
+
+    func testUpsertInsertsIntoEmptyLockfile() {
+        // Pre-create an empty lockfile object.
+        let empty: [String: Any] = [:]
+        let data = try! JSONSerialization.data(withJSONObject: empty)
+        try! data.write(to: URL(fileURLWithPath: lockfilePath))
+
+        let result = LockfileAssistant.upsertManagedEntry(
+            assistantId: "new-id",
+            runtimeUrl: "https://platform.vellum.ai",
+            hatchedAt: "2024-03-01T00:00:00Z",
+            lockfilePath: lockfilePath
+        )
+        XCTAssertTrue(result)
+
+        let readData = try! Data(contentsOf: URL(fileURLWithPath: lockfilePath))
+        let json = try! JSONSerialization.jsonObject(with: readData) as! [String: Any]
+        let assistants = json["assistants"] as! [[String: Any]]
+        XCTAssertEqual(assistants.count, 1)
+        XCTAssertEqual(assistants[0]["assistantId"] as? String, "new-id")
+    }
+
+    // MARK: - upsertManagedEntry: update existing
+
+    func testUpsertUpdatesExistingEntryBySameAssistantId() {
+        // Insert first entry.
+        LockfileAssistant.upsertManagedEntry(
+            assistantId: "test-id",
+            runtimeUrl: "https://old.example.com",
+            hatchedAt: "2024-01-01T00:00:00Z",
+            lockfilePath: lockfilePath
+        )
+
+        // Update the same assistantId with new values.
+        let result = LockfileAssistant.upsertManagedEntry(
+            assistantId: "test-id",
+            runtimeUrl: "https://new.example.com",
+            hatchedAt: "2024-06-01T00:00:00Z",
+            lockfilePath: lockfilePath
+        )
+        XCTAssertTrue(result)
+
+        let data = try! Data(contentsOf: URL(fileURLWithPath: lockfilePath))
+        let json = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let assistants = json["assistants"] as! [[String: Any]]
+        XCTAssertEqual(assistants.count, 1, "Should have exactly 1 entry after update, not 2")
+        XCTAssertEqual(assistants[0]["runtimeUrl"] as? String, "https://new.example.com")
+        XCTAssertEqual(assistants[0]["hatchedAt"] as? String, "2024-06-01T00:00:00Z")
+    }
+
+    // MARK: - upsertManagedEntry: preserves other entries
+
+    func testUpsertPreservesOtherAssistantEntries() {
+        // Pre-populate with a local entry.
+        let existing: [String: Any] = [
+            "assistants": [
+                [
+                    "assistantId": "local-id",
+                    "cloud": "local",
+                    "runtimeUrl": "http://localhost:7821",
+                    "hatchedAt": "2024-01-01T00:00:00Z",
+                ] as [String: Any],
+            ]
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: existing)
+        try! data.write(to: URL(fileURLWithPath: lockfilePath))
+
+        // Add a managed entry.
+        let result = LockfileAssistant.upsertManagedEntry(
+            assistantId: "managed-id",
+            runtimeUrl: "https://platform.vellum.ai",
+            hatchedAt: "2024-06-01T00:00:00Z",
+            lockfilePath: lockfilePath
+        )
+        XCTAssertTrue(result)
+
+        let readData = try! Data(contentsOf: URL(fileURLWithPath: lockfilePath))
+        let json = try! JSONSerialization.jsonObject(with: readData) as! [String: Any]
+        let assistants = json["assistants"] as! [[String: Any]]
+        XCTAssertEqual(assistants.count, 2)
+        XCTAssertTrue(assistants.contains(where: { ($0["assistantId"] as? String) == "local-id" }))
+        XCTAssertTrue(assistants.contains(where: { ($0["assistantId"] as? String) == "managed-id" }))
+    }
+
+    func testUpsertPreservesNonAssistantLockfileKeys() {
+        // Pre-populate with extra top-level keys.
+        let existing: [String: Any] = [
+            "version": 1,
+            "assistants": [] as [[String: Any]],
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: existing)
+        try! data.write(to: URL(fileURLWithPath: lockfilePath))
+
+        LockfileAssistant.upsertManagedEntry(
+            assistantId: "test-id",
+            runtimeUrl: "https://platform.vellum.ai",
+            hatchedAt: "2024-01-01T00:00:00Z",
+            lockfilePath: lockfilePath
+        )
+
+        let readData = try! Data(contentsOf: URL(fileURLWithPath: lockfilePath))
+        let json = try! JSONSerialization.jsonObject(with: readData) as! [String: Any]
+        XCTAssertEqual(json["version"] as? Int, 1, "Non-assistant keys should be preserved")
+    }
+
+    // MARK: - upsertManagedEntry: always sets cloud to "vellum"
+
+    func testUpsertAlwaysSetsCloudToVellum() {
+        LockfileAssistant.upsertManagedEntry(
+            assistantId: "test-id",
+            runtimeUrl: "https://platform.vellum.ai",
+            hatchedAt: "2024-01-01T00:00:00Z",
+            lockfilePath: lockfilePath
+        )
+
+        let data = try! Data(contentsOf: URL(fileURLWithPath: lockfilePath))
+        let json = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let assistants = json["assistants"] as! [[String: Any]]
+        XCTAssertEqual(assistants[0]["cloud"] as? String, "vellum")
+    }
+
+    // MARK: - isManaged property
+
+    func testIsManagedReturnsTrueForVellumCloud() {
+        let assistant = LockfileAssistant(
+            assistantId: "test-id",
+            runtimeUrl: "https://platform.vellum.ai",
+            bearerToken: nil,
+            cloud: "vellum",
+            project: nil,
+            region: nil,
+            zone: nil,
+            instanceId: nil,
+            hatchedAt: "2024-01-01T00:00:00Z"
+        )
+        XCTAssertTrue(assistant.isManaged)
+    }
+
+    func testIsManagedReturnsFalseForLocalCloud() {
+        let assistant = LockfileAssistant(
+            assistantId: "test-id",
+            runtimeUrl: nil,
+            bearerToken: nil,
+            cloud: "local",
+            project: nil,
+            region: nil,
+            zone: nil,
+            instanceId: nil,
+            hatchedAt: nil
+        )
+        XCTAssertFalse(assistant.isManaged)
+    }
+
+    func testIsManagedReturnsFalseForGcpCloud() {
+        let assistant = LockfileAssistant(
+            assistantId: "test-id",
+            runtimeUrl: nil,
+            bearerToken: nil,
+            cloud: "gcp",
+            project: "my-project",
+            region: nil,
+            zone: "us-central1-a",
+            instanceId: "inst-1",
+            hatchedAt: nil
+        )
+        XCTAssertFalse(assistant.isManaged)
+    }
+
+    func testIsManagedIsCaseInsensitive() {
+        let assistant = LockfileAssistant(
+            assistantId: "test-id",
+            runtimeUrl: "https://platform.vellum.ai",
+            bearerToken: nil,
+            cloud: "Vellum",
+            project: nil,
+            region: nil,
+            zone: nil,
+            instanceId: nil,
+            hatchedAt: nil
+        )
+        XCTAssertTrue(assistant.isManaged, "isManaged should be case-insensitive")
+    }
+
+    // MARK: - isRemote property
+
+    func testIsRemoteReturnsFalseForLocal() {
+        let assistant = LockfileAssistant(
+            assistantId: "test-id",
+            runtimeUrl: nil,
+            bearerToken: nil,
+            cloud: "local",
+            project: nil,
+            region: nil,
+            zone: nil,
+            instanceId: nil,
+            hatchedAt: nil
+        )
+        XCTAssertFalse(assistant.isRemote)
+    }
+
+    func testIsRemoteReturnsTrueForVellum() {
+        let assistant = LockfileAssistant(
+            assistantId: "test-id",
+            runtimeUrl: "https://platform.vellum.ai",
+            bearerToken: nil,
+            cloud: "vellum",
+            project: nil,
+            region: nil,
+            zone: nil,
+            instanceId: nil,
+            hatchedAt: nil
+        )
+        XCTAssertTrue(assistant.isRemote)
+    }
+
+    func testIsRemoteReturnsTrueForGcp() {
+        let assistant = LockfileAssistant(
+            assistantId: "test-id",
+            runtimeUrl: nil,
+            bearerToken: nil,
+            cloud: "gcp",
+            project: nil,
+            region: nil,
+            zone: nil,
+            instanceId: nil,
+            hatchedAt: nil
+        )
+        XCTAssertTrue(assistant.isRemote)
+    }
+
+    // MARK: - home property for vellum cloud
+
+    func testHomeReturnsVellumVariantForManagedAssistant() {
+        let assistant = LockfileAssistant(
+            assistantId: "test-id",
+            runtimeUrl: "https://platform.vellum.ai",
+            bearerToken: nil,
+            cloud: "vellum",
+            project: nil,
+            region: nil,
+            zone: nil,
+            instanceId: nil,
+            hatchedAt: nil
+        )
+        if case .vellum(let runtimeUrl) = assistant.home {
+            XCTAssertEqual(runtimeUrl, "https://platform.vellum.ai")
+        } else {
+            XCTFail("Expected .vellum home for managed assistant, got \(assistant.home)")
+        }
+    }
+
+    // MARK: - upsertManagedEntry: multiple different assistants
+
+    func testUpsertMultipleDifferentAssistants() {
+        LockfileAssistant.upsertManagedEntry(
+            assistantId: "assistant-1",
+            runtimeUrl: "https://platform.vellum.ai",
+            hatchedAt: "2024-01-01T00:00:00Z",
+            lockfilePath: lockfilePath
+        )
+        LockfileAssistant.upsertManagedEntry(
+            assistantId: "assistant-2",
+            runtimeUrl: "https://platform.vellum.ai",
+            hatchedAt: "2024-02-01T00:00:00Z",
+            lockfilePath: lockfilePath
+        )
+
+        let data = try! Data(contentsOf: URL(fileURLWithPath: lockfilePath))
+        let json = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let assistants = json["assistants"] as! [[String: Any]]
+        XCTAssertEqual(assistants.count, 2)
+        XCTAssertEqual(assistants[0]["assistantId"] as? String, "assistant-1")
+        XCTAssertEqual(assistants[1]["assistantId"] as? String, "assistant-2")
+    }
+}

--- a/clients/macos/vellum-assistantTests/TransportMetadataTests.swift
+++ b/clients/macos/vellum-assistantTests/TransportMetadataTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+final class TransportMetadataTests: XCTestCase {
+
+    // MARK: - Default local metadata
+
+    func testDefaultLocalMetadataHasRuntimeFlatRouteMode() {
+        let metadata = TransportMetadata.defaultLocal
+        XCTAssertEqual(metadata.routeMode, .runtimeFlat)
+    }
+
+    func testDefaultLocalMetadataHasBearerTokenAuthMode() {
+        let metadata = TransportMetadata.defaultLocal
+        XCTAssertEqual(metadata.authMode, .bearerToken)
+    }
+
+    func testDefaultLocalMetadataHasNilPlatformAssistantId() {
+        let metadata = TransportMetadata.defaultLocal
+        XCTAssertNil(metadata.platformAssistantId)
+    }
+
+    // MARK: - Managed (platform proxy) metadata
+
+    func testManagedMetadataStoresAllFields() {
+        let metadata = TransportMetadata(
+            routeMode: .platformAssistantProxy,
+            authMode: .sessionToken,
+            platformAssistantId: "test-uuid-123"
+        )
+        XCTAssertEqual(metadata.routeMode, .platformAssistantProxy)
+        XCTAssertEqual(metadata.authMode, .sessionToken)
+        XCTAssertEqual(metadata.platformAssistantId, "test-uuid-123")
+    }
+
+    // MARK: - Init defaults
+
+    func testInitDefaultsMatchDefaultLocal() {
+        let metadata = TransportMetadata()
+        XCTAssertEqual(metadata.routeMode, .runtimeFlat)
+        XCTAssertEqual(metadata.authMode, .bearerToken)
+        XCTAssertNil(metadata.platformAssistantId)
+    }
+
+    func testInitWithOnlyRouteMode() {
+        let metadata = TransportMetadata(routeMode: .platformAssistantProxy)
+        XCTAssertEqual(metadata.routeMode, .platformAssistantProxy)
+        // Other fields should still have defaults.
+        XCTAssertEqual(metadata.authMode, .bearerToken)
+        XCTAssertNil(metadata.platformAssistantId)
+    }
+
+    func testInitWithOnlyAuthMode() {
+        let metadata = TransportMetadata(authMode: .sessionToken)
+        XCTAssertEqual(metadata.authMode, .sessionToken)
+        // Other fields should still have defaults.
+        XCTAssertEqual(metadata.routeMode, .runtimeFlat)
+        XCTAssertNil(metadata.platformAssistantId)
+    }
+
+    // MARK: - RouteMode enum coverage
+
+    func testRouteModeRuntimeFlatIsNotEqualToPlatformAssistantProxy() {
+        XCTAssertNotEqual(RouteMode.runtimeFlat, RouteMode.platformAssistantProxy)
+    }
+
+    // MARK: - AuthMode enum coverage
+
+    func testAuthModeEnumCasesAreDistinct() {
+        XCTAssertNotEqual(AuthMode.bearerToken, AuthMode.sessionToken)
+    }
+
+    // MARK: - DaemonConfig transportMetadata
+
+    func testDaemonConfigDefaultsToDefaultLocalMetadata() {
+        let config = DaemonConfig(
+            transport: .http(baseURL: "https://example.com", bearerToken: nil, conversationKey: "test"),
+            transportMetadata: .defaultLocal,
+            featureFlagToken: nil
+        )
+        XCTAssertEqual(config.transportMetadata.routeMode, .runtimeFlat)
+        XCTAssertEqual(config.transportMetadata.authMode, .bearerToken)
+        XCTAssertNil(config.transportMetadata.platformAssistantId)
+    }
+
+    func testDaemonConfigWithManagedMetadata() {
+        let managedMetadata = TransportMetadata(
+            routeMode: .platformAssistantProxy,
+            authMode: .sessionToken,
+            platformAssistantId: "platform-uuid"
+        )
+        let config = DaemonConfig(
+            transport: .http(baseURL: "https://platform.vellum.ai", bearerToken: nil, conversationKey: "key"),
+            transportMetadata: managedMetadata,
+            featureFlagToken: nil
+        )
+        XCTAssertEqual(config.transportMetadata.routeMode, .platformAssistantProxy)
+        XCTAssertEqual(config.transportMetadata.authMode, .sessionToken)
+        XCTAssertEqual(config.transportMetadata.platformAssistantId, "platform-uuid")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `LockfileAssistantManagedTests.swift` with 15 tests covering `upsertManagedEntry()` (insert when absent, insert into empty lockfile, update existing by same ID, preserve other entries, preserve non-assistant keys, always sets cloud to vellum, multiple different assistants), `isManaged`/`isRemote` computed properties, and the `home` property for vellum cloud.
- Adds `TransportMetadataTests.swift` with 11 tests covering `TransportMetadata.defaultLocal`, managed metadata construction, init defaults, partial init, `RouteMode`/`AuthMode` enum distinctness, and `DaemonConfig` integration with `transportMetadata`.

## Test plan
- [x] `swift build` compiles successfully
- [x] `swift test --filter "LockfileAssistantManagedTests|TransportMetadataTests"` — all 26 tests pass with 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
