### PR TITLE
feat: add sequential pagination to Gmail scan tools

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/TOOLS.json
+++ b/assistant/src/config/bundled-skills/messaging/TOOLS.json
@@ -1011,6 +1011,10 @@
           "max_senders": {
             "type": "number",
             "description": "Maximum senders to return (default 30)"
+          },
+          "page_token": {
+            "type": "string",
+            "description": "Resume token from a previous scan's next_page_token to continue scanning beyond the cap"
           }
         }
       },
@@ -1040,6 +1044,10 @@
           "max_senders": {
             "type": "number",
             "description": "Maximum senders to return (default 30)"
+          },
+          "page_token": {
+            "type": "string",
+            "description": "Resume token from a previous scan's next_page_token to continue scanning beyond the cap"
           }
         }
       },
@@ -1098,6 +1106,10 @@
           "min_confidence": {
             "type": "number",
             "description": "Minimum confidence threshold 0-1 (default 0.5)"
+          },
+          "page_token": {
+            "type": "string",
+            "description": "Resume token from a previous scan's next_page_token to continue scanning beyond the cap"
           }
         }
       },

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-outreach-scan.ts
@@ -70,6 +70,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
   const maxSenders = (input.max_senders as number) ?? 30;
   const timeRange = (input.time_range as string) ?? '90d';
   const minConfidence = (input.min_confidence as number) ?? 0.5;
+  const inputPageToken = input.page_token as string | undefined;
 
   const query = `in:inbox -has:unsubscribe newer_than:${timeRange}`;
 
@@ -78,7 +79,8 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
     return withValidToken(provider.credentialService, async (token) => {
       // Paginate through listMessages to collect up to maxMessages IDs
       const allMessageIds: string[] = [];
-      let pageToken: string | undefined;
+      let pageToken: string | undefined = inputPageToken;
+      let truncated = false;
 
       while (allMessageIds.length < maxMessages) {
         const pageSize = Math.min(100, maxMessages - allMessageIds.length);
@@ -88,6 +90,10 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         allMessageIds.push(...ids);
         pageToken = listResp.nextPageToken ?? undefined;
         if (!pageToken) break;
+      }
+
+      if (allMessageIds.length >= maxMessages && pageToken) {
+        truncated = true;
       }
 
       if (allMessageIds.length === 0) {
@@ -215,6 +221,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         senders,
         total_scanned: allMessageIds.length,
         outreach_detected: totalOutreachDetected,
+        ...(truncated ? { truncated: true, next_page_token: pageToken } : {}),
       }));
     });
   } catch (e) {

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
@@ -38,13 +38,14 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
   const query = (input.query as string) ?? 'category:promotions newer_than:90d';
   const maxMessages = Math.min((input.max_messages as number) ?? 500, MAX_MESSAGES_CAP);
   const maxSenders = (input.max_senders as number) ?? 30;
+  const inputPageToken = input.page_token as string | undefined;
 
   try {
     const provider = getMessagingProvider('gmail');
     return withValidToken(provider.credentialService, async (token) => {
       // Paginate through listMessages to collect up to maxMessages IDs
       const allMessageIds: string[] = [];
-      let pageToken: string | undefined;
+      let pageToken: string | undefined = inputPageToken;
       let truncated = false;
 
       while (allMessageIds.length < maxMessages) {
@@ -171,7 +172,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         senders: result,
         total_scanned: allMessageIds.length,
         query_used: query,
-        ...(truncated ? { truncated: true } : {}),
+        ...(truncated ? { truncated: true, next_page_token: pageToken } : {}),
         note: `message_count reflects emails found per sender within the ${allMessageIds.length} messages scanned. Use the message_ids array with gmail_batch_archive to archive exactly these messages.`,
       }));
     });

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-sender-digest.ts
@@ -6,6 +6,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
   const query = (input.query as string) ?? 'category:promotions newer_than:90d';
   const maxMessages = input.max_messages as number | undefined;
   const maxSenders = input.max_senders as number | undefined;
+  const pageToken = input.page_token as string | undefined;
 
   try {
     const provider = resolveProvider(platform);
@@ -15,7 +16,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
     }
 
     return withProviderToken(provider, async (token) => {
-      const result = await provider.senderDigest!(token, query, { maxMessages, maxSenders });
+      const result = await provider.senderDigest!(token, query, { maxMessages, maxSenders, pageToken });
 
       if (result.senders.length === 0) {
         return ok(JSON.stringify({
@@ -43,7 +44,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         senders,
         total_scanned: result.totalScanned,
         query_used: result.queryUsed,
-        ...(result.truncated ? { truncated: true } : {}),
+        ...(result.truncated ? { truncated: true, next_page_token: result.nextPageToken } : {}),
         note: `message_count reflects emails found per sender within the ${result.totalScanned} messages scanned. Use the message_ids array with the archive tool to archive exactly these messages.`,
       }));
     });

--- a/assistant/src/messaging/provider-types.ts
+++ b/assistant/src/messaging/provider-types.ts
@@ -101,6 +101,8 @@ export interface SenderDigestResult {
   queryUsed: string;
   /** True when pagination was stopped because the scan cap was reached but more messages exist. */
   truncated?: boolean;
+  /** Resume token for sequential scanning — present when truncated is true. */
+  nextPageToken?: string;
 }
 
 export interface ArchiveResult {

--- a/assistant/src/messaging/provider.ts
+++ b/assistant/src/messaging/provider.ts
@@ -41,7 +41,7 @@ export interface MessagingProvider {
   markRead?(token: string, conversationId: string, messageId?: string): Promise<void>;
 
   /** Scan messages and group by sender for bulk cleanup (e.g. newsletter decluttering). */
-  senderDigest?(token: string, query: string, options?: { maxMessages?: number; maxSenders?: number }): Promise<SenderDigestResult>;
+  senderDigest?(token: string, query: string, options?: { maxMessages?: number; maxSenders?: number; pageToken?: string }): Promise<SenderDigestResult>;
   /** Archive messages matching a search query. */
   archiveByQuery?(token: string, query: string): Promise<ArchiveResult>;
 

--- a/assistant/src/messaging/providers/gmail/adapter.ts
+++ b/assistant/src/messaging/providers/gmail/adapter.ts
@@ -195,13 +195,13 @@ export const gmailMessagingProvider: MessagingProvider = {
     await gmail.modifyMessage(token, messageId, { removeLabelIds: ['UNREAD'] });
   },
 
-  async senderDigest(token: string, query: string, options?: { maxMessages?: number; maxSenders?: number }): Promise<SenderDigestResult> {
+  async senderDigest(token: string, query: string, options?: { maxMessages?: number; maxSenders?: number; pageToken?: string }): Promise<SenderDigestResult> {
     const maxMessages = Math.min(options?.maxMessages ?? 2000, 2000);
     const maxSenders = options?.maxSenders ?? 30;
     const maxIdsPerSender = 2000;
 
     const allMessageIds: string[] = [];
-    let pageToken: string | undefined;
+    let pageToken: string | undefined = options?.pageToken;
     let truncated = false;
 
     while (allMessageIds.length < maxMessages) {
@@ -289,7 +289,7 @@ export const gmailMessagingProvider: MessagingProvider = {
       hasMore: s.hasMore,
     }));
 
-    return { senders, totalScanned: allMessageIds.length, queryUsed: query, ...(truncated ? { truncated } : {}) };
+    return { senders, totalScanned: allMessageIds.length, queryUsed: query, ...(truncated ? { truncated, nextPageToken: pageToken } : {}) };
   },
 
   async archiveByQuery(token: string, query: string): Promise<ArchiveResult> {


### PR DESCRIPTION
## Summary
- Add `page_token` input and `next_page_token` output to `gmail_sender_digest`, `gmail_outreach_scan`, and `messaging_sender_digest` tools
- When a scan is truncated at the cap (500/2000 messages), the response now includes a `next_page_token` that can be passed to the next invocation to continue scanning from where it left off
- Updated the provider interface (`MessagingProvider.senderDigest`), Gmail adapter, and TOOLS.json schemas to support the new parameter

## Original prompt
Add pagination (sequential scanning) to Gmail scan tools — expose the Gmail API `nextPageToken` as both an input and output parameter so scans can continue beyond their caps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
