### PR TITLE
fix: correct iOS bundle ID to match provisioning profile

### DIFF
--- a/clients/ios/Resources/Info.plist
+++ b/clients/ios/Resources/Info.plist
@@ -18,7 +18,7 @@
 	<array>
 		<dict>
 			<key>CFBundleURLName</key>
-			<string>ai.vellum.assistant-ios</string>
+			<string>ai.vocify-inc.vellum-assistant-ios</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>vellum</string>

--- a/clients/ios/build.sh
+++ b/clients/ios/build.sh
@@ -189,7 +189,7 @@ cat > "$EXPORT_OPTIONS" <<PLIST
     <string>manual</string>
     <key>provisioningProfiles</key>
     <dict>
-        <key>ai.vellum.assistant-ios</key>
+        <key>ai.vocify-inc.vellum-assistant-ios</key>
         <string>$PROVISIONING_PROFILE_NAME</string>
     </dict>
     <key>uploadSymbols</key>

--- a/clients/ios/project.yml
+++ b/clients/ios/project.yml
@@ -24,7 +24,7 @@ targets:
         product: VellumAssistantShared
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: ai.vellum.assistant-ios
+        PRODUCT_BUNDLE_IDENTIFIER: ai.vocify-inc.vellum-assistant-ios
         INFOPLIST_FILE: Resources/Info.plist
         GENERATE_INFOPLIST_FILE: "NO"
         CODE_SIGN_ENTITLEMENTS: Resources/vellum-assistant-ios.entitlements


### PR DESCRIPTION
## Summary
Changes the iOS bundle ID from `ai.vellum.assistant-ios` to `ai.vocify-inc.vellum-assistant-ios` to match the provisioning profile registered in Apple Developer portal.

### Files changed
- `clients/ios/project.yml` — PRODUCT_BUNDLE_IDENTIFIER
- `clients/ios/build.sh` — exportOptions.plist bundle ID key
- `clients/ios/Resources/Info.plist` — CFBundleURLName

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
