### PR TITLE
chore: notify asharma53 only on CI failures

### DIFF
--- a/.github/config/github_slack_mapping.yaml
+++ b/.github/config/github_slack_mapping.yaml
@@ -1,6 +1,5 @@
 github_to_slack_all_notifications:
   noanflaherty: U04C2QS2404
-  asharma53: U04BTP01B2S
   AnitaKirkovska: U060M1MUT7F
   ashleeradka: U06LGSYA9JP
   awlevin: U07CLDQ4TB3
@@ -13,6 +12,7 @@ github_to_slack_all_notifications:
   Jasonnnz: U09DVL1JN3V
 
 github_to_slack_failure_notifications: # neutral good
+  asharma53: U04BTP01B2S
   siddseethepalli: U04C0B3038A
   dvargas92495: U05D5EGNNMS
   clopen-set: U08QQU27M0W


### PR DESCRIPTION
## Summary
- Removed asharma53 from `github_to_slack_all_notifications` (notified on every CI run)
- Added asharma53 to `github_to_slack_failure_notifications` (notified only on failures)

## Original prompt
Take asharma53 off the "notify on every successful CI run" list and only notify him on failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
