### PR TITLE
fix: use square checkbox for select-all in table widget

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -29,7 +29,7 @@ public struct InlineTableWidget: View {
                     Button {
                         toggleSelectAll()
                     } label: {
-                        Image(systemName: allSelected ? "checkmark.circle.fill" : "circle")
+                        Image(systemName: allSelected ? "checkmark.square.fill" : "square")
                             .font(.system(size: 14))
                             .foregroundColor(allSelected ? VColor.accent : VColor.textMuted)
                     }


### PR DESCRIPTION
## Summary
- Changed the select-all checkbox in InlineTableWidget header from circle (`checkmark.circle.fill`/`circle`) to square (`checkmark.square.fill`/`square`)
- Individual row checkboxes remain as circles, following the standard UI pattern of square for bulk selection vs circle for individual items

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
