### PR TITLE
fix: add VoiceOver accessibility label to select-all button

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -34,6 +34,7 @@ public struct InlineTableWidget: View {
                             .foregroundColor(allSelected ? VColor.accent : VColor.textMuted)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel(allSelected ? "Deselect all" : "Select all")
                     .frame(width: 28)
                 } else if data.selectionMode != .none {
                     Color.clear


### PR DESCRIPTION
Adds .accessibilityLabel to the select-all toggle in InlineTableWidget so VoiceOver users can identify it. Label reflects current state (Select all / Deselect all). Addresses feedback from PR #11425.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
