### PR TITLE
fix: align DEFAULT_CONFIG maxToolUseTurns with schema default of 40

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -41,7 +41,7 @@ export type AgentEvent =
 
 const DEFAULT_CONFIG: AgentLoopConfig = {
   maxTokens: 16000,
-  maxToolUseTurns: 0,
+  maxToolUseTurns: 40,
   minTurnIntervalMs: 150,
 };
 


### PR DESCRIPTION
## Summary
- Updates `DEFAULT_CONFIG` in `agent/loop.ts` to set `maxToolUseTurns` to `40`, matching the Zod schema default.
- This ensures callers like `computer-use-session.ts` that omit `maxToolUseTurns` get the intended 40-turn limit instead of unlimited (`0`).
- Addresses review feedback from PR #11427.

## Test plan
- [x] Verified the change is a single-line value update from `0` to `40`
- [x] Consistent with the Zod schema default in `schema.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
