### PR TITLE
fix: include next_page_token in empty-sender responses

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-sender-digest.ts
@@ -23,6 +23,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
           senders: [],
           total_scanned: result.totalScanned,
           query_used: result.queryUsed,
+          ...(result.truncated ? { truncated: true, next_page_token: result.nextPageToken } : {}),
           message: 'No emails found matching the query. Try broadening the search (e.g. remove category filter or extend date range).',
         }));
       }


### PR DESCRIPTION
Includes pagination metadata (next_page_token, truncated) in the empty-senders early return path of messaging-sender-digest.ts so callers can continue sequential scanning even when a page has no matching senders. Addresses feedback from PR #11435.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
