### PR TITLE
fix: only emit thinking_delta activity when tool name is available

### DIFF
--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -185,13 +185,17 @@ export function handleThinkingDelta(
   if (!state.firstThinkingDeltaEmitted) {
     state.firstThinkingDeltaEmitted = true;
     const lastToolName = state.lastCompletedToolName;
-    // When a tool just completed, show "Processing <tool> results".
-    // When no tool has completed (e.g. right after confirmation_resolved),
-    // omit statusText so the client preserves its current status
-    // (e.g. "Resuming after approval") — emitActivityState only includes
-    // statusText in the message when it's truthy.
-    const statusText = lastToolName ? `Processing ${friendlyToolName(lastToolName)} results` : undefined;
-    deps.ctx.emitActivityState('thinking', 'thinking_delta', 'assistant_turn', deps.reqId, statusText);
+    // Only emit an activity state when a tool just completed, so we can
+    // show "Processing <tool> results". When no tool has completed yet
+    // (e.g. right after confirmation_resolved), skip the emission entirely
+    // so the client preserves its current status text (e.g. "Resuming
+    // after approval"). Even omitting statusText from the message would
+    // cause the client to clear it, since the client overwrites
+    // assistantStatusText for every assistant_activity_state event.
+    if (lastToolName) {
+      const statusText = `Processing ${friendlyToolName(lastToolName)} results`;
+      deps.ctx.emitActivityState('thinking', 'thinking_delta', 'assistant_turn', deps.reqId, statusText);
+    }
   }
   if (!deps.ctx.streamThinking) return;
   emitLlmCallStartedIfNeeded(state, deps);


### PR DESCRIPTION
## Summary
- Restores the conditional check so `thinking_delta` activity state is only emitted when `lastCompletedToolName` is truthy
- When no tool has completed (e.g. right after `confirmation_resolved`), the emission is skipped entirely so the client preserves its current status text (e.g. "Resuming after approval")
- Emitting with undefined/omitted `statusText` causes the client to clear existing status text, which is a regression for post-approval status flow

## Test plan
- [ ] Verify that after approval flow, the "Resuming after approval" status text persists through the thinking phase
- [ ] Verify that after a tool completes, the "Processing <tool> results" status text is shown during thinking
- [ ] Verify thinking delta streaming still works correctly in both scenarios

Addresses feedback from PR #11429.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
