### PR TITLE
fix: call setupViewMenu() so CMD+/- zoom shortcuts work

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -364,6 +364,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         setupDaemonClient(isFirstLaunch: isFirstLaunch)
         setupMenuBar()
         setupFileMenu()
+        setupViewMenu()
         setupHotKey()
         setupEscapeMonitor()
         setupVoiceInput()


### PR DESCRIPTION
## Summary
- The View menu with zoom keyboard shortcuts (CMD+/-, CMD+0, Option+CMD+/-, Option+CMD+0) was fully implemented but `setupViewMenu()` was never called during app initialization
- Added the missing call in the startup sequence, right after `setupFileMenu()`

## Test plan
- [ ] Build and launch the macOS app
- [ ] Verify CMD+ and CMD- zoom conversation text in/out
- [ ] Verify CMD+0 resets conversation zoom
- [ ] Verify Option+CMD+/- zoom the entire window
- [ ] Verify zoom percentage indicator appears briefly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
