### PR TITLE
fix: correct managed sign-in doc scope and lockfile path

### DIFF
--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -60,7 +60,7 @@ The app supports a **managed sign-in** flow that connects to a platform-hosted a
 
 ### Sign-in Flow
 
-1. User clicks "Sign in" during onboarding (or from Settings)
+1. User clicks "Sign in" during first-run onboarding
 2. WorkOS authentication opens in the system browser
 3. On success, `ManagedAssistantBootstrapService.ensureManagedAssistant()` discovers or creates a platform assistant
 4. A lockfile entry is written with `cloud: "vellum"` and the `connectedAssistantId` is persisted in UserDefaults
@@ -85,7 +85,7 @@ The `HTTPTransport` supports two route modes:
 | State | Location |
 |-------|----------|
 | Session token | Keychain (`AuthManager`) |
-| Lockfile entry | `~/.vellum/lockfile.json` (with `cloud: "vellum"`) |
+| Lockfile entry | `~/.vellum.lock.json` (with `cloud: "vellum"`) |
 | Connected assistant ID | UserDefaults (`connectedAssistantId`) |
 
 For the full managed sign-in architecture, see `clients/ARCHITECTURE.md`.


### PR DESCRIPTION
## Summary
- Changed "during onboarding (or from Settings)" to "during first-run onboarding" to match the plan's locked scope
- Fixed lockfile path from `~/.vellum/lockfile.json` to `~/.vellum.lock.json` to match `LockfilePaths.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
