### PR TITLE
fix: skip release optimizations for CI validation build

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -82,6 +82,7 @@ jobs:
         working-directory: clients/macos
         run: |
           SKIP_CLEAN=1 \
+          SKIP_RELEASE_OPTIMIZATIONS=1 \
           RELEASE_ARCH_FLAGS="--arch arm64" \
           ./build.sh release
           ls -la "dist/Vellum.app"

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 #   DISPLAY_VERSION   Override CFBundleShortVersionString (default: 0.1.0)
 #   BUILD_VERSION     Override CFBundleVersion (default: 1)
 #   SIGN_IDENTITY     Override code signing identity
+#   SKIP_RELEASE_OPTIMIZATIONS  Set to 1 to build release without Swift optimizations (CI check)
 
 # ---------------------------------------------------------------------------
 # swift_with_retry — run a swift command with retries for transient SPM
@@ -262,7 +263,15 @@ CONFIG="debug"
 SWIFT_FLAGS=""
 if [ "$CMD" = "release" ]; then
     CONFIG="release"
-    SWIFT_FLAGS="-c release ${RELEASE_ARCH_FLAGS:---arch arm64 --arch x86_64}"
+    # SKIP_RELEASE_OPTIMIZATIONS=1 keeps -c release (so #if DEBUG guards and
+    # release-only compilation behavior are preserved) but disables the
+    # expensive optimiser passes. Useful for CI validation builds that verify
+    # compilation + codesigning without producing a distributable artifact.
+    if [ "${SKIP_RELEASE_OPTIMIZATIONS:-}" = "1" ]; then
+        SWIFT_FLAGS="-c release -Xswiftc -Onone ${RELEASE_ARCH_FLAGS:---arch arm64 --arch x86_64}"
+    else
+        SWIFT_FLAGS="-c release ${RELEASE_ARCH_FLAGS:---arch arm64 --arch x86_64}"
+    fi
     if [ -n "${PREBUILT_BIN_PATH:-}" ]; then
         # Using prebuilt binaries from parallel CI jobs — only clean dist
         echo "Release build: using prebuilt binaries, cleaning dist only..."


### PR DESCRIPTION
## Summary
- Add `SKIP_RELEASE_OPTIMIZATIONS` env var to `build.sh` that passes `-Xswiftc -Onone` alongside `-c release`, keeping release compilation behavior (e.g. `#if DEBUG` guards) while skipping expensive optimiser passes
- Set `SKIP_RELEASE_OPTIMIZATIONS=1` in the CI main macOS build workflow — this is a validation build (not producing a distributable artifact), so optimizations are unnecessary
- The actual release workflow (`release.yml`) is unaffected and continues to build with full optimizations

## Original prompt
https://github.com/vellum-ai/vellum-assistant/actions/runs/22602681196 Skip release optimizations for CI check — this is a CI validation workflow (not producing a distributable artifact), but it builds with -c release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
