### PR TITLE
fix: auto-dismiss stale pending surfaces so new interactive UI surfaces are not blocked

### DIFF
--- a/assistant/src/__tests__/session-agent-loop.test.ts
+++ b/assistant/src/__tests__/session-agent-loop.test.ts
@@ -1107,6 +1107,65 @@ describe("session-agent-loop", () => {
     });
   });
 
+  describe("stale pending surface cleanup", () => {
+    test("auto-completes non-dynamic_page pending surfaces on regular user message", async () => {
+      const events: ServerMessage[] = [];
+
+      const ctx = makeCtx();
+      // Pre-populate a stale pending table surface
+      ctx.pendingSurfaceActions.set("stale-table-1", { surfaceType: "table" });
+      ctx.pendingSurfaceActions.set("stale-form-1", { surfaceType: "form" });
+      // dynamic_page should be preserved
+      ctx.pendingSurfaceActions.set("page-1", { surfaceType: "dynamic_page" });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+
+      // The stale table and form surfaces should have been auto-completed
+      const completeEvents = events.filter((e) => e.type === "ui_surface_complete");
+      expect(completeEvents).toHaveLength(2);
+      for (const evt of completeEvents) {
+        const typed = evt as { surfaceId: string; summary: string };
+        expect(typed.summary).toBe("Dismissed");
+        expect(["stale-table-1", "stale-form-1"]).toContain(typed.surfaceId);
+      }
+
+      // dynamic_page should still be pending
+      expect(ctx.pendingSurfaceActions.has("page-1")).toBe(true);
+      expect(ctx.pendingSurfaceActions.has("stale-table-1")).toBe(false);
+      expect(ctx.pendingSurfaceActions.has("stale-form-1")).toBe(false);
+    });
+
+    test("does not auto-complete surfaces when request is a surface action", async () => {
+      const events: ServerMessage[] = [];
+
+      const ctx = makeCtx();
+      ctx.pendingSurfaceActions.set("active-table-1", { surfaceType: "table" });
+      // Mark the request ID as a surface action response
+      ctx.currentRequestId = "surface-action-req";
+      ctx.surfaceActionRequestIds.add("surface-action-req");
+
+      await runAgentLoopImpl(ctx, "[User action on table surface]", "msg-1", (msg) => events.push(msg));
+
+      // No ui_surface_complete should have been emitted
+      const completeEvents = events.filter((e) => e.type === "ui_surface_complete");
+      expect(completeEvents).toHaveLength(0);
+      // The pending surface should still be there
+      expect(ctx.pendingSurfaceActions.has("active-table-1")).toBe(true);
+    });
+
+    test("no-op when no pending surfaces exist", async () => {
+      const events: ServerMessage[] = [];
+
+      const ctx = makeCtx();
+      // No pending surfaces
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+
+      const completeEvents = events.filter((e) => e.type === "ui_surface_complete");
+      expect(completeEvents).toHaveLength(0);
+    });
+  });
+
   describe("error-only response with no assistant text", () => {
     test("synthesizes error assistant message when provider returns no response", async () => {
       const events: ServerMessage[] = [];

--- a/assistant/src/__tests__/session-surfaces-task-progress.test.ts
+++ b/assistant/src/__tests__/session-surfaces-task-progress.test.ts
@@ -180,4 +180,42 @@ describe('task_progress surface compatibility', () => {
     expect(templateData.status).toBe('completed');
     expect(Array.isArray(templateData.steps)).toBe(true);
   });
+
+  test('ui_show rejects new interactive surface when a non-dynamic_page pending surface exists', async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    // Pre-populate a pending table surface (simulates a previously shown interactive surface)
+    ctx.pendingSurfaceActions.set('stale-surface-1', { surfaceType: 'table' });
+
+    const result = await surfaceProxyResolver(ctx, 'ui_show', {
+      surface_type: 'table',
+      title: 'New Table',
+      data: { columns: [], rows: [] },
+      actions: [{ id: 'archive', label: 'Archive' }],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Another interactive surface is already awaiting user input');
+    // The stale entry should still be present (guard only rejects, doesn't clean up)
+    expect(ctx.pendingSurfaceActions.has('stale-surface-1')).toBe(true);
+  });
+
+  test('ui_show allows new interactive surface when only dynamic_page surfaces are pending', async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    // dynamic_page pending entries should not block new interactive surfaces
+    ctx.pendingSurfaceActions.set('page-1', { surfaceType: 'dynamic_page' });
+
+    const result = await surfaceProxyResolver(ctx, 'ui_show', {
+      surface_type: 'table',
+      title: 'Email Table',
+      data: { columns: [], rows: [] },
+      actions: [{ id: 'archive', label: 'Archive' }],
+    });
+
+    expect(result.isError).toBe(false);
+    expect(sent.some(m => m.type === 'ui_surface_show')).toBe(true);
+  });
 });

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -170,6 +170,22 @@ export async function runAgentLoopImpl(
   const rlog = log.child({ conversationId: ctx.conversationId, requestId: reqId });
   let yieldedForHandoff = false;
 
+  // Auto-complete stale interactive surfaces from previous turns.
+  // When the user sends a new message (not a surface action response),
+  // any non-dynamic_page pending surfaces are effectively abandoned.
+  if (!ctx.surfaceActionRequestIds.has(reqId)) {
+    for (const [surfaceId, entry] of ctx.pendingSurfaceActions) {
+      if (entry.surfaceType === 'dynamic_page') continue;
+      onEvent({
+        type: 'ui_surface_complete',
+        sessionId: ctx.conversationId,
+        surfaceId,
+        summary: 'Dismissed',
+      });
+      ctx.pendingSurfaceActions.delete(surfaceId);
+    }
+  }
+
   // Capture the turn channel context *before* any awaits so a second
   // message from a different channel can't overwrite it mid-flight.
   // When context is unavailable (e.g. regenerate after daemon restart),

--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -150,6 +150,7 @@ export interface SurfaceSessionContext {
     attachments: never[],
     onEvent: (msg: ServerMessage) => void,
     requestId: string,
+    activeSurfaceId?: string,
   ): { queued: boolean; rejected?: boolean; requestId: string };
   getQueueDepth(): number;
   processMessage(
@@ -425,7 +426,7 @@ export function handleSurfaceAction(ctx: SurfaceSessionContext, surfaceId: strin
     attributes: { source: 'surface_action', surfaceId, actionId },
   });
 
-  const result = ctx.enqueueMessage(content, [], onEvent, requestId);
+  const result = ctx.enqueueMessage(content, [], onEvent, requestId, surfaceId);
   if (result.queued) {
     const position = ctx.getQueueDepth();
     if (!retainPending) {
@@ -630,6 +631,21 @@ export async function surfaceProxyResolver(
         ? hasActions
         : INTERACTIVE_SURFACE_TYPES.includes(surfaceType);
     const awaitAction = (input.await_action as boolean) ?? isInteractive;
+
+    // Only one non-persistent interactive surface at a time. If another
+    // surface is already awaiting user input, reject this one so the LLM
+    // presents surfaces sequentially.
+    if (awaitAction) {
+      const hasExistingPending = [...ctx.pendingSurfaceActions.values()].some(
+        entry => entry.surfaceType !== 'dynamic_page'
+      );
+      if (hasExistingPending) {
+        return {
+          content: 'Another interactive surface is already awaiting user input. Present one at a time — wait for the user to respond to the current surface before showing the next.',
+          isError: true,
+        };
+      }
+    }
 
     // Track surface state for ui_update merging
     ctx.surfaceState.set(surfaceId, { surfaceType, data, title });


### PR DESCRIPTION
## Summary
- Auto-complete stale non-`dynamic_page` pending surfaces at the start of `runAgentLoopImpl` when a regular user message arrives, emitting `ui_surface_complete` with summary `"Dismissed"`
- Add guard in `surfaceProxyResolver` to reject new interactive `ui_show` when a non-`dynamic_page` surface is already pending
- Pass `activeSurfaceId` through `enqueueMessage` so queued surface actions retain context
- Add 5 tests covering guard behavior, cleanup logic, and edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
