### PR TITLE
chore: remove macOS Build job from CI workflow

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -1,4 +1,4 @@
-name: CI Main macOS Build
+name: CI Main macOS Tests
 
 on:
   workflow_dispatch:
@@ -10,127 +10,6 @@ on:
       - '.github/workflows/ci-main-macos.yaml'
 
 jobs:
-  build:
-    name: macOS Build
-    runs-on: macos-15
-    timeout-minutes: 15
-    env:
-      VELLUM_FLAG_FEATURE_FLAG_EDITOR_ENABLED: "true"
-      KEYCHAIN_NAME: build.keychain
-      KEYCHAIN_PASSWORD: temporary-ci-password
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Select Xcode 16.2
-        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
-
-      - name: Import code-signing certificate
-        env:
-          CERT_P12: ${{ secrets.DEVID_CERTIFICATE_P12 }}
-          CERT_PASSWORD: ${{ secrets.DEVID_CERTIFICATE_PASSWORD }}
-        run: |
-          KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME-db"
-
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
-          security set-keychain-settings -lut 3600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          echo "$CERT_P12" | base64 -D > /tmp/certificate.p12
-          security import /tmp/certificate.p12 \
-            -k "$KEYCHAIN_PATH" \
-            -P "$CERT_PASSWORD" \
-            -T /usr/bin/codesign \
-            -T /usr/bin/security
-          rm /tmp/certificate.p12
-
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
-          security default-keychain -s "$KEYCHAIN_PATH"
-
-          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
-
-      - name: Cache SPM build artifacts
-        uses: actions/cache@v4
-        with:
-          path: clients/.build
-          key: macos-spm-${{ hashFiles('clients/Package.resolved') }}-${{ hashFiles('clients/**/*.swift') }}
-          restore-keys: |
-            macos-spm-${{ hashFiles('clients/Package.resolved') }}-
-            macos-spm-
-
-      - name: Cache Bun dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            assistant/node_modules
-            cli/node_modules
-            gateway/node_modules
-          key: macos-bun-${{ hashFiles('assistant/bun.lock', 'cli/bun.lock', 'gateway/bun.lock') }}
-          restore-keys: macos-bun-
-
-      - name: Install Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Build binaries
-        working-directory: clients/macos
-        run: ./build.sh binaries
-
-      - name: Build release .app
-        working-directory: clients/macos
-        run: |
-          SKIP_CLEAN=1 \
-          SKIP_RELEASE_OPTIMIZATIONS=1 \
-          RELEASE_ARCH_FLAGS="--arch arm64" \
-          ./build.sh release
-          ls -la "dist/Vellum.app"
-
-          codesign --verify --deep --strict "dist/Vellum.app"
-          echo "Code signature verified"
-
-      - name: Cleanup keychain
-        if: always()
-        run: |
-          KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME-db"
-          security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
-
-      - name: Track consecutive failures
-        if: always()
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # github.workflow returns the display name, not the filename.
-          # Extract the filename from github.workflow_ref instead.
-          WORKFLOW_REF="${{ github.workflow_ref }}"
-          WORKFLOW_NAME="${WORKFLOW_REF%%@*}"
-          WORKFLOW_NAME="${WORKFLOW_NAME##*/}"
-
-          # Get the last 100 completed runs of this workflow on main (excluding current)
-          RUNS=$(gh api "/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_NAME}/runs?branch=main&status=completed&per_page=100" \
-            --jq '[.workflow_runs[] | select(.id != '${{ github.run_id }}') | .conclusion]')
-
-          # Count consecutive failures from most recent
-          CONSECUTIVE=0
-          for conclusion in $(echo "$RUNS" | jq -r '.[]'); do
-            if [ "$conclusion" = "failure" ]; then
-              CONSECUTIVE=$((CONSECUTIVE + 1))
-            else
-              break
-            fi
-          done
-
-          # Add current run result
-          if [ "${{ job.status }}" = "failure" ]; then
-            CONSECUTIVE=$((CONSECUTIVE + 1))
-          else
-            CONSECUTIVE=0
-          fi
-
-          echo "Consecutive failures on main: $CONSECUTIVE"
-
   test:
     name: macOS Tests
     runs-on: macos-15
@@ -157,7 +36,7 @@ jobs:
 
   notify:
     name: Slack Notification
-    needs: [build, test]
+    needs: [test]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -169,11 +48,11 @@ jobs:
         run: |
           GITHUB_USER="${{ github.actor }}"
 
-          if [[ "${{ needs.build.result }}" == "failure" || "${{ needs.test.result }}" == "failure" ]]; then
+          if [[ "${{ needs.test.result }}" == "failure" ]]; then
             STATUS="failure"
-          elif [[ "${{ needs.build.result }}" == "cancelled" || "${{ needs.test.result }}" == "cancelled" ]]; then
+          elif [[ "${{ needs.test.result }}" == "cancelled" ]]; then
             STATUS="cancelled"
-          elif [[ "${{ needs.build.result }}" == "skipped" || "${{ needs.test.result }}" == "skipped" ]]; then
+          elif [[ "${{ needs.test.result }}" == "skipped" ]]; then
             STATUS="skipped"
           else
             STATUS="success"

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -20,7 +20,6 @@ set -euo pipefail
 #   DISPLAY_VERSION   Override CFBundleShortVersionString (default: 0.1.0)
 #   BUILD_VERSION     Override CFBundleVersion (default: 1)
 #   SIGN_IDENTITY     Override code signing identity
-#   SKIP_RELEASE_OPTIMIZATIONS  Set to 1 to build release without Swift optimizations (CI check)
 
 # ---------------------------------------------------------------------------
 # swift_with_retry — run a swift command with retries for transient SPM
@@ -263,15 +262,7 @@ CONFIG="debug"
 SWIFT_FLAGS=""
 if [ "$CMD" = "release" ]; then
     CONFIG="release"
-    # SKIP_RELEASE_OPTIMIZATIONS=1 keeps -c release (so #if DEBUG guards and
-    # release-only compilation behavior are preserved) but disables the
-    # expensive optimiser passes. Useful for CI validation builds that verify
-    # compilation + codesigning without producing a distributable artifact.
-    if [ "${SKIP_RELEASE_OPTIMIZATIONS:-}" = "1" ]; then
-        SWIFT_FLAGS="-c release -Xswiftc -Onone ${RELEASE_ARCH_FLAGS:---arch arm64 --arch x86_64}"
-    else
-        SWIFT_FLAGS="-c release ${RELEASE_ARCH_FLAGS:---arch arm64 --arch x86_64}"
-    fi
+    SWIFT_FLAGS="-c release ${RELEASE_ARCH_FLAGS:---arch arm64 --arch x86_64}"
     if [ -n "${PREBUILT_BIN_PATH:-}" ]; then
         # Using prebuilt binaries from parallel CI jobs — only clean dist
         echo "Release build: using prebuilt binaries, cleaning dist only..."


### PR DESCRIPTION
## Summary
- Remove the `macOS Build` job from `ci-main-macos.yaml` — it validated release compilation + codesigning on every push to main but provided marginal value over the test job (which already compiles all Swift code) and the actual release workflow
- Revert `SKIP_RELEASE_OPTIMIZATIONS` support from `build.sh` since its only consumer was this CI job
- Update Slack notification job to depend only on the test job

## Original prompt
remove it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
