### PR TITLE
fix: add missing await on withSlackToken in slack-channel-details

### DIFF
--- a/assistant/src/config/bundled-skills/slack/tools/slack-channel-details.ts
+++ b/assistant/src/config/bundled-skills/slack/tools/slack-channel-details.ts
@@ -10,7 +10,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
   }
 
   try {
-    return withSlackToken(async (token) => {
+    return await withSlackToken(async (token) => {
       const resp = await slack.conversationInfo(token, channelId);
       const conv = resp.channel;
 


### PR DESCRIPTION
Adds the missing `await` on `return withSlackToken(...)` in `slack-channel-details.ts` — the same fix that PR #11447 applied to the other 4 Slack tool files. Without `await`, the local `catch` block is dead code since async rejections propagate as unhandled Promise rejections.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
