### PR TITLE
fix: cache onboarding icon to avoid file I/O in SwiftUI body

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -14,6 +14,11 @@ struct OnboardingFlowView: View {
     @State private var isBootstrappingManaged = false
     @State private var managedBootstrapError: String?
 
+    private static let appIcon: NSImage? = {
+        guard let path = ResourceBundle.bundle.path(forResource: "vellum-app-icon", ofType: "png") else { return nil }
+        return NSImage(contentsOfFile: path)
+    }()
+
     private var maxOnboardingStep: Int {
         state.userHostedEnabled ? 2 : 1
     }
@@ -45,8 +50,7 @@ struct OnboardingFlowView: View {
                 VStack(spacing: 0) {
                     Spacer()
 
-                    if let iconPath = ResourceBundle.bundle.path(forResource: "vellum-app-icon", ofType: "png"),
-                       let nsImage = NSImage(contentsOfFile: iconPath) {
+                    if let nsImage = Self.appIcon {
                         Image(nsImage: nsImage)
                             .resizable()
                             .aspectRatio(contentMode: .fit)


### PR DESCRIPTION
Address review feedback from PR #11296: cache the app icon image as a static property instead of loading from disk on every SwiftUI rerender. Follows the same pattern as AvatarAppearanceManager.bundledInitialAvatar.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
