### PR TITLE
fix: pipe git show output instead of storing in shell variable

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -559,11 +559,10 @@ while IFS= read -r -d '' FILE; do
 
     CHECKED_FILES=$((CHECKED_FILES + 1))
 
-    # Cache staged file content once (avoids repeated git show calls per pattern)
-    FILE_CONTENT=$(git show ":$FILE" 2>/dev/null) || continue
-
-    # Single grep with combined pattern instead of N separate greps
-    MATCHES=$(printf '%s\n' "$FILE_CONTENT" | grep -niE -- "$COMBINED_PATTERN" 2>/dev/null)
+    # Pipe git show directly to grep to avoid NUL byte dropping from command
+    # substitution (which would corrupt binary-ish staged files and cause
+    # false-positive secret detections).
+    MATCHES=$(git show ":$FILE" 2>/dev/null | grep -niE -- "$COMBINED_PATTERN" 2>/dev/null)
 
     if [ ! -z "$MATCHES" ]; then
         FILTERED_MATCHES=""


### PR DESCRIPTION
Address review feedback from PR #11409: avoid NUL byte dropping by piping git show output directly instead of command substitution.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
