### PR TITLE
fix: restore app-level build validation in macOS CI

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -1,4 +1,4 @@
-name: CI Main macOS Tests
+name: CI Main macOS Build & Tests
 
 on:
   workflow_dispatch:
@@ -29,6 +29,10 @@ jobs:
           restore-keys: |
             macos-spm-${{ hashFiles('clients/Package.resolved') }}-
             macos-spm-
+
+      - name: Build executable
+        working-directory: clients
+        run: swift build --product vellum-assistant
 
       - name: Run tests
         working-directory: clients/macos


### PR DESCRIPTION
Address review feedback from PR #11452: restore executable build validation alongside test-only checks.

The original PR #11452 removed the macOS Build job entirely, which meant compile regressions in the `vellum-assistant` executable target could land on main undetected. This adds a `swift build --product vellum-assistant` step before tests to validate the executable target compiles, without requiring the full release build infrastructure (certificates, Bun binaries, app bundling).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
