### PR TITLE
fix: validate trust-rule decision values in PATCH endpoint

### DIFF
--- a/assistant/src/runtime/routes/trust-rules-routes.ts
+++ b/assistant/src/runtime/routes/trust-rules-routes.ts
@@ -123,6 +123,19 @@ export async function handleUpdateTrustRuleManage(
     priority?: number;
   };
 
+  if (body.decision !== undefined) {
+    const validDecisions = ["allow", "deny", "ask"] as const;
+    if (
+      !validDecisions.includes(body.decision as (typeof validDecisions)[number])
+    ) {
+      return httpError(
+        "BAD_REQUEST",
+        "decision must be one of: allow, deny, ask",
+        400,
+      );
+    }
+  }
+
   try {
     updateRule(id, {
       tool: body.tool,


### PR DESCRIPTION
Address review feedback from PR #11421: add validation to PATCH trust-rules endpoint to only accept allow/deny/ask decisions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
