### PR TITLE
fix: map decoding errors to neutral bootstrap error instead of hatchFailed

### DIFF
--- a/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
@@ -15,6 +15,7 @@ public enum ManagedBootstrapError: LocalizedError, Sendable {
     case networkError(String)
     case serverError(statusCode: Int, detail: String?)
     case hatchFailed(String)
+    case unexpectedResponse(String)
 
     public var errorDescription: String? {
         switch self {
@@ -26,6 +27,8 @@ public enum ManagedBootstrapError: LocalizedError, Sendable {
             return detail ?? "Server error (\(statusCode))"
         case .hatchFailed(let message):
             return "Failed to create assistant: \(message)"
+        case .unexpectedResponse(let message):
+            return "Unexpected response format: \(message)"
         }
     }
 }
@@ -92,7 +95,7 @@ public final class ManagedAssistantBootstrapService {
         case .invalidURL:
             return .serverError(statusCode: 0, detail: "Invalid URL configuration")
         case .decodingError(let message):
-            return .hatchFailed(message)
+            return .unexpectedResponse(message)
         }
     }
 }


### PR DESCRIPTION
Address review feedback from PR #11390: use neutral error type for decoding failures in managed assistant bootstrap.

- Added new `ManagedBootstrapError.unexpectedResponse` case with message "Unexpected response format: ..."
- Changed `mapPlatformError` to map `decodingError` to `.unexpectedResponse` instead of `.hatchFailed`
- This prevents misleading "Failed to create assistant" errors when the failure is actually a response decoding issue from `getCurrentAssistant()`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
