### PR TITLE
fix: gate stale-surface dismissal to user messages and move inside try/finally

### DIFF
--- a/assistant/src/__tests__/session-agent-loop.test.ts
+++ b/assistant/src/__tests__/session-agent-loop.test.ts
@@ -1118,7 +1118,7 @@ describe("session-agent-loop", () => {
       // dynamic_page should be preserved
       ctx.pendingSurfaceActions.set("page-1", { surfaceType: "dynamic_page" });
 
-      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg), { isUserMessage: true });
 
       // The stale table and form surfaces should have been auto-completed
       const completeEvents = events.filter((e) => e.type === "ui_surface_complete");
@@ -1144,7 +1144,7 @@ describe("session-agent-loop", () => {
       ctx.currentRequestId = "surface-action-req";
       ctx.surfaceActionRequestIds.add("surface-action-req");
 
-      await runAgentLoopImpl(ctx, "[User action on table surface]", "msg-1", (msg) => events.push(msg));
+      await runAgentLoopImpl(ctx, "[User action on table surface]", "msg-1", (msg) => events.push(msg), { isUserMessage: true });
 
       // No ui_surface_complete should have been emitted
       const completeEvents = events.filter((e) => e.type === "ui_surface_complete");
@@ -1159,10 +1159,49 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx();
       // No pending surfaces
 
-      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg), { isUserMessage: true });
 
       const completeEvents = events.filter((e) => e.type === "ui_surface_complete");
       expect(completeEvents).toHaveLength(0);
+    });
+
+    test("does not auto-complete surfaces for internal/subagent turns (no isUserMessage)", async () => {
+      const events: ServerMessage[] = [];
+
+      const ctx = makeCtx();
+      ctx.pendingSurfaceActions.set("active-table-1", { surfaceType: "table" });
+      ctx.pendingSurfaceActions.set("active-form-1", { surfaceType: "form" });
+
+      // Internal turn: no isUserMessage option
+      await runAgentLoopImpl(ctx, "subagent notification", "msg-1", (msg) => events.push(msg));
+
+      // No ui_surface_complete should have been emitted
+      const completeEvents = events.filter((e) => e.type === "ui_surface_complete");
+      expect(completeEvents).toHaveLength(0);
+      // Pending surfaces should still be there
+      expect(ctx.pendingSurfaceActions.has("active-table-1")).toBe(true);
+      expect(ctx.pendingSurfaceActions.has("active-form-1")).toBe(true);
+    });
+
+    test("finally block still runs if onEvent throws during stale surface dismissal", async () => {
+      let eventCount = 0;
+      const ctx = makeCtx();
+      ctx.pendingSurfaceActions.set("stale-table-1", { surfaceType: "table" });
+
+      const throwingOnEvent = (msg: ServerMessage) => {
+        eventCount++;
+        if (msg.type === "ui_surface_complete") {
+          throw new Error("onEvent sink failed");
+        }
+      };
+
+      // The error from onEvent should be caught by the try/catch,
+      // and the finally block should still clean up session state
+      await runAgentLoopImpl(ctx, "hello", "msg-1", throwingOnEvent, { isUserMessage: true });
+
+      expect(ctx.processing).toBe(false);
+      expect(ctx.abortController).toBeNull();
+      expect(ctx.currentRequestId).toBeUndefined();
     });
   });
 

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1121,6 +1121,7 @@ export class DaemonServer {
     session
       .runAgentLoop(content, messageId, onEvent, {
         isInteractive: options?.isInteractive ?? false,
+        isUserMessage: true,
       })
       .finally(() => {
         // Only reset if no other caller (e.g. a real IPC client) has rebound
@@ -1260,6 +1261,7 @@ export class DaemonServer {
     try {
       await session.runAgentLoop(resolvedContent, messageId, onEvent, {
         isInteractive: options?.isInteractive ?? false,
+        isUserMessage: true,
       });
     } finally {
       // Only reset if no other caller (e.g. a real IPC client) has rebound

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -160,7 +160,7 @@ export async function runAgentLoopImpl(
   content: string,
   userMessageId: string,
   onEvent: (msg: ServerMessage) => void,
-  options?: { skipPreMessageRollback?: boolean; isInteractive?: boolean; titleText?: string },
+  options?: { skipPreMessageRollback?: boolean; isInteractive?: boolean; isUserMessage?: boolean; titleText?: string },
 ): Promise<void> {
   if (!ctx.abortController) {
     throw new Error('runAgentLoop called without prior persistUserMessage');
@@ -169,22 +169,6 @@ export async function runAgentLoopImpl(
   const reqId = ctx.currentRequestId ?? uuid();
   const rlog = log.child({ conversationId: ctx.conversationId, requestId: reqId });
   let yieldedForHandoff = false;
-
-  // Auto-complete stale interactive surfaces from previous turns.
-  // When the user sends a new message (not a surface action response),
-  // any non-dynamic_page pending surfaces are effectively abandoned.
-  if (!ctx.surfaceActionRequestIds.has(reqId)) {
-    for (const [surfaceId, entry] of ctx.pendingSurfaceActions) {
-      if (entry.surfaceType === 'dynamic_page') continue;
-      onEvent({
-        type: 'ui_surface_complete',
-        sessionId: ctx.conversationId,
-        surfaceId,
-        summary: 'Dismissed',
-      });
-      ctx.pendingSurfaceActions.delete(surfaceId);
-    }
-  }
 
   // Capture the turn channel context *before* any awaits so a second
   // message from a different channel can't overwrite it mid-flight.
@@ -229,6 +213,24 @@ export async function runAgentLoopImpl(
   let turnStarted = false;
 
   try {
+    // Auto-complete stale interactive surfaces from previous turns.
+    // Only dismiss when the user sends a new message (not a surface action
+    // response), so internal turns (subagent notifications, lifecycle
+    // instructions) don't accidentally clear active interactive prompts.
+    // Placed inside try so the finally block still runs if onEvent throws.
+    if (options?.isUserMessage && !ctx.surfaceActionRequestIds.has(reqId)) {
+      for (const [surfaceId, entry] of ctx.pendingSurfaceActions) {
+        if (entry.surfaceType === 'dynamic_page') continue;
+        onEvent({
+          type: 'ui_surface_complete',
+          sessionId: ctx.conversationId,
+          surfaceId,
+          summary: 'Dismissed',
+        });
+        ctx.pendingSurfaceActions.delete(surfaceId);
+      }
+    }
+
     const preMessageResult = await getHookManager().trigger('pre-message', {
       sessionId: ctx.conversationId,
       messagePreview: truncate(content, 200, ''),

--- a/assistant/src/daemon/session-history.ts
+++ b/assistant/src/daemon/session-history.ts
@@ -264,7 +264,7 @@ export interface HistorySessionContext {
     content: string,
     userMessageId: string,
     onEvent: (msg: ServerMessage) => void,
-    options?: { skipPreMessageRollback?: boolean; titleText?: string },
+    options?: { skipPreMessageRollback?: boolean; isUserMessage?: boolean; titleText?: string },
   ): Promise<void>;
 }
 
@@ -435,5 +435,5 @@ export async function regenerate(
   session.abortController = new AbortController();
   session.currentRequestId = requestId ?? uuid();
 
-  await session.runAgentLoop(content, existingUserMessageId, onEvent, { skipPreMessageRollback: true });
+  await session.runAgentLoop(content, existingUserMessageId, onEvent, { skipPreMessageRollback: true, isUserMessage: true });
 }

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -81,7 +81,7 @@ export interface ProcessSessionContext {
     content: string,
     userMessageId: string,
     onEvent: (msg: ServerMessage) => void,
-    options?: { skipPreMessageRollback?: boolean; isInteractive?: boolean; titleText?: string },
+    options?: { skipPreMessageRollback?: boolean; isInteractive?: boolean; isUserMessage?: boolean; titleText?: string },
   ): Promise<void>;
   getTurnChannelContext(): TurnChannelContext | null;
   setTurnChannelContext(ctx: TurnChannelContext): void;
@@ -329,13 +329,11 @@ export async function drainQueue(session: ProcessSessionContext, reason: QueueDr
   // Fire-and-forget: persistUserMessage set session.processing = true
   // so subsequent messages will still be enqueued.
   // runAgentLoop's finally block will call drainQueue when this run completes.
-  const drainLoopOptions: { isInteractive?: boolean; titleText?: string } = {};
+  const drainLoopOptions: { isInteractive?: boolean; isUserMessage?: boolean; titleText?: string } = { isUserMessage: true };
   if (next.isInteractive !== undefined) drainLoopOptions.isInteractive = next.isInteractive;
   if (agentLoopContent !== resolvedContent) drainLoopOptions.titleText = resolvedContent;
 
-  session.runAgentLoop(agentLoopContent, userMessageId, next.onEvent,
-    Object.keys(drainLoopOptions).length > 0 ? drainLoopOptions : undefined,
-  ).catch((err) => {
+  session.runAgentLoop(agentLoopContent, userMessageId, next.onEvent, drainLoopOptions).catch((err) => {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, conversationId: session.conversationId, requestId: next.requestId }, 'Error processing queued message');
     next.onEvent({ type: 'error', message: `Failed to process queued message: ${message}` });
@@ -559,12 +557,10 @@ export async function processMessage(
       });
   }
 
-  const loopOptions: { isInteractive?: boolean; titleText?: string } = {};
+  const loopOptions: { isInteractive?: boolean; isUserMessage?: boolean; titleText?: string } = { isUserMessage: true };
   if (options?.isInteractive !== undefined) loopOptions.isInteractive = options.isInteractive;
   if (agentLoopContent !== resolvedContent) loopOptions.titleText = resolvedContent;
 
-  await session.runAgentLoop(agentLoopContent, userMessageId, onEvent,
-    Object.keys(loopOptions).length > 0 ? loopOptions : undefined,
-  );
+  await session.runAgentLoop(agentLoopContent, userMessageId, onEvent, loopOptions);
   return userMessageId;
 }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -630,7 +630,7 @@ export class Session {
     content: string,
     userMessageId: string,
     onEvent: (msg: ServerMessage) => void,
-    options?: { skipPreMessageRollback?: boolean; isInteractive?: boolean; titleText?: string },
+    options?: { skipPreMessageRollback?: boolean; isInteractive?: boolean; isUserMessage?: boolean; titleText?: string },
   ): Promise<void> {
     return runAgentLoopImpl(this, content, userMessageId, onEvent, options);
   }


### PR DESCRIPTION
## Summary
- **P1**: Gate stale-surface dismissal to only fire on actual user messages, not internal/subagent turns (e.g. `onSubagentFinished`, lifecycle instructions), by adding an `isUserMessage` option flag that `processMessage`, drain-queue, and HTTP server callers set to `true`
- **P2**: Move the stale-surface cleanup inside the `try` block so the `finally` block always runs and properly resets session state even if the event sink throws

## Test plan
- [x] Existing stale surface tests updated to pass `isUserMessage: true` (user message behavior)
- [x] New test: internal/subagent turns (no `isUserMessage`) do NOT dismiss pending surfaces
- [x] New test: if `onEvent` throws during stale surface dismissal, `finally` block still cleans up session state (`processing`, `abortController`, `currentRequestId`)
- [x] All 25 session-agent-loop tests pass
- [x] TypeScript type-check passes

Addresses feedback from #11451.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
