### PR TITLE
fix: validate trust-rule decisions and include computer-use sessions in surface-action lookup

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1285,9 +1285,10 @@ export class DaemonServer {
 
   /**
    * Look up an active session by ID without creating one.
-   * Returns undefined if no session with that ID exists.
+   * Checks both normal sessions and computer-use sessions so the HTTP
+   * surface-action path is consistent with IPC dispatch.
    */
-  findSession(sessionId: string): Session | undefined {
-    return this.sessions.get(sessionId);
+  findSession(sessionId: string): Session | ComputerUseSession | undefined {
+    return this.cuSessions.get(sessionId) ?? this.sessions.get(sessionId);
   }
 }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -260,9 +260,15 @@ export class RuntimeHttpServer {
   private pairingStore = new PairingStore();
   private pairingBroadcast?: (msg: ServerMessage) => void;
   private sendMessageDeps?: SendMessageDeps;
-  private findSession?: (
-    sessionId: string,
-  ) => import("../daemon/session.js").Session | undefined;
+  private findSession?: (sessionId: string) =>
+    | {
+        handleSurfaceAction(
+          surfaceId: string,
+          actionId: string,
+          data?: Record<string, unknown>,
+        ): void;
+      }
+    | undefined;
 
   constructor(options: RuntimeHttpServerOptions = {}) {
     this.port = options.port ?? DEFAULT_PORT;

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -186,7 +186,15 @@ export interface RuntimeHttpServerOptions {
   /** Dependencies for the POST /v1/messages queue-if-busy handler. */
   sendMessageDeps?: SendMessageDeps;
   /** Lookup an active session by ID (for surface actions). Returns undefined if not found. */
-  findSession?: (sessionId: string) => Session | undefined;
+  findSession?: (sessionId: string) =>
+    | {
+        handleSurfaceAction(
+          surfaceId: string,
+          actionId: string,
+          data?: Record<string, unknown>,
+        ): void;
+      }
+    | undefined;
 }
 
 export interface RuntimeAttachmentMetadata {

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -4,13 +4,23 @@
  * POST /v1/surface-actions — dispatch a surface action to an active session.
  * Requires the session to already exist (does not create new sessions).
  */
-import type { Session } from "../../daemon/session.js";
 import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
 
 const log = getLogger("surface-action-routes");
 
-export type SessionLookup = (sessionId: string) => Session | undefined;
+/** Any object that can handle a surface action (Session or ComputerUseSession). */
+interface SurfaceActionTarget {
+  handleSurfaceAction(
+    surfaceId: string,
+    actionId: string,
+    data?: Record<string, unknown>,
+  ): void;
+}
+
+export type SessionLookup = (
+  sessionId: string,
+) => SurfaceActionTarget | undefined;
 
 /**
  * POST /v1/surface-actions — handle a UI surface action.


### PR DESCRIPTION
Address review feedback from PR #11419: validate decision values in PATCH handler before storing and include computer-use sessions in HTTP surface-action path for consistency with IPC dispatch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
