### PR TITLE
fix: support multiline frontmatter metadata and fix doordash 403 test classification

### DIFF
--- a/assistant/src/config/bundled-skills/doordash/__tests__/doordash-client.test.ts
+++ b/assistant/src/config/bundled-skills/doordash/__tests__/doordash-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { SessionExpiredError } from "../lib/client.js";
+import { RateLimitError, SessionExpiredError } from "../lib/client.js";
 
 describe("SessionExpiredError", () => {
   it("is an instance of Error", () => {
@@ -38,10 +38,12 @@ describe("expired session classification", () => {
   // the parsed response structure that cdpFetch evaluates.
 
   function classifyResponse(parsed: Record<string, unknown>): Error {
-    // Mirrors the classification logic from cdpFetch (client.ts lines 154-159)
+    // Mirrors the classification logic from cdpFetch (client.ts lines 188-200)
     if (parsed.__error) {
-      if (parsed.__status === 403 || parsed.__status === 401) {
+      if (parsed.__status === 401) {
         return new SessionExpiredError("DoorDash session has expired.");
+      } else if (parsed.__status === 403) {
+        return new RateLimitError("DoorDash rate limit hit (HTTP 403).");
       }
       return new Error(
         (parsed.__message as string) ??
@@ -61,14 +63,14 @@ describe("expired session classification", () => {
     expect(err.message).toBe("DoorDash session has expired.");
   });
 
-  it("classifies HTTP 403 as SessionExpiredError", () => {
+  it("classifies HTTP 403 as RateLimitError", () => {
     const err = classifyResponse({
       __error: true,
       __status: 403,
       __body: "Forbidden",
     });
-    expect(err).toBeInstanceOf(SessionExpiredError);
-    expect(err.message).toBe("DoorDash session has expired.");
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err.message).toBe("DoorDash rate limit hit (HTTP 403).");
   });
 
   it("classifies HTTP 500 as a generic Error, not session expired", () => {

--- a/assistant/src/skills/frontmatter.ts
+++ b/assistant/src/skills/frontmatter.ts
@@ -34,14 +34,54 @@ export function parseFrontmatterFields(
   const frontmatter = match[1];
   const fields: Record<string, string> = {};
 
-  for (const line of frontmatter.split(/\r?\n/)) {
+  const lines = frontmatter.split(/\r?\n/);
+  let currentKey: string | undefined;
+  let continuationLines: string[] = [];
+
+  function flushContinuation() {
+    if (currentKey !== undefined) {
+      if (continuationLines.length > 0) {
+        // Join continuation lines, then strip trailing commas before closing
+        // braces/brackets so that prettier-formatted JSON remains valid for JSON.parse.
+        fields[currentKey] = continuationLines
+          .map((l) => l.trim())
+          .join(" ")
+          .replace(/,\s*([}\]])/g, "$1");
+      } else {
+        fields[currentKey] = "";
+      }
+    }
+    currentKey = undefined;
+    continuationLines = [];
+  }
+
+  for (const line of lines) {
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith("#")) continue;
+
+    // Continuation line: indented and no top-level key: pattern
+    // (i.e. starts with whitespace and either has no colon or the colon
+    // is inside braces/quotes — heuristic: line starts with space/tab)
+    if (currentKey !== undefined && /^\s/.test(line)) {
+      continuationLines.push(trimmed);
+      continue;
+    }
+
+    // Flush any pending multiline value
+    flushContinuation();
+
     const separatorIndex = trimmed.indexOf(":");
     if (separatorIndex === -1) continue;
 
     const key = trimmed.slice(0, separatorIndex).trim();
     let value = trimmed.slice(separatorIndex + 1).trim();
+
+    if (!value) {
+      // Value may continue on subsequent indented lines
+      currentKey = key;
+      continuationLines = [];
+      continue;
+    }
 
     const isDoubleQuoted = value.startsWith('"') && value.endsWith('"');
     const isSingleQuoted = value.startsWith("'") && value.endsWith("'");
@@ -60,6 +100,9 @@ export function parseFrontmatterFields(
     }
     fields[key] = value;
   }
+
+  // Flush any trailing multiline value
+  flushContinuation();
 
   return { fields, body: content.slice(match[0].length) };
 }


### PR DESCRIPTION
Address review feedback from PR #11402:

1. **Frontmatter parser**: Update `parseFrontmatterFields` to handle multiline continuation values (indented lines after a key with no inline value). This fixes metadata parsing for prettier-formatted SKILL.md files where the JSON metadata spans multiple lines. Trailing commas from prettier formatting are stripped to ensure valid JSON.

2. **DoorDash test**: Fix `classifyResponse` helper and HTTP 403 test case to match production code — 403 produces `RateLimitError`, not `SessionExpiredError`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
