### PR TITLE
fix: defer daemon shutdown until retire outcome is known

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1005,11 +1005,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         }
 
         if let name = assistantName {
-            // Stop processes FIRST while PID files and lockfile entry still exist.
-            // retire() internally tries to stop them again, which is idempotent.
-            daemonClient.disconnect()
-            assistantCli.stop()
-
             do {
                 try await assistantCli.retire(name: name)
             } catch {
@@ -1021,10 +1016,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 alert.addButton(withTitle: "Force Remove")
                 alert.addButton(withTitle: "Cancel")
                 if alert.runModal() != .alertFirstButtonReturn {
+                    // Daemon is still running — user can continue using the app.
                     return false
                 }
-                // Retire failed but user chose Force Remove — clean the stale
-                // lockfile entry so onboarding can re-run with a fresh lockfile.
+                // Retire failed but user chose Force Remove — stop the daemon
+                // before cleaning up local state.
+                daemonClient.disconnect()
+                assistantCli.stop()
                 self.removeLockfileEntry(assistantId: name)
             }
         } else {


### PR DESCRIPTION
Address review feedback from PR #11336. Moves daemon disconnect/stop calls from before the retire() attempt to after the outcome is known. If retire fails and the user cancels, the daemon stays running so the app remains functional. If the user force-removes, the daemon is stopped before cleaning up local state.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
