### PR TITLE
fix: move daemon shutdown to after successful retire

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1005,11 +1005,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         }
 
         if let name = assistantName {
-            // Stop processes FIRST while PID files and lockfile entry still exist.
-            // retire() internally tries to stop them again, which is idempotent.
-            daemonClient.disconnect()
-            assistantCli.stop()
-
             do {
                 try await assistantCli.retire(name: name)
             } catch {
@@ -1027,6 +1022,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 // lockfile entry so onboarding can re-run with a fresh lockfile.
                 self.removeLockfileEntry(assistantId: name)
             }
+
+            // Stop processes after retire succeeds (or user chose Force Remove).
+            // This keeps the daemon alive if the user cancels a failed retire.
+            daemonClient.disconnect()
+            assistantCli.stop()
         } else {
             assistantCli.stop()
         }


### PR DESCRIPTION
Address review feedback from PR #11337.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
