### PR TITLE
fix: auto-enable bundled skills on install to prevent regression

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -299,10 +299,42 @@ export async function handleSkillsInstall(
       (s) => s.id === msg.slug && s.source === "bundled",
     );
     if (bundled) {
+      // Auto-enable the bundled skill so it's immediately usable
+      try {
+        const raw = loadRawConfig();
+        ensureSkillEntry(raw, msg.slug).enabled = true;
+        ctx.setSuppressConfigReload(true);
+        try {
+          saveRawConfig(raw);
+        } catch (err) {
+          ctx.setSuppressConfigReload(false);
+          throw err;
+        }
+        invalidateConfigCache();
+        ctx.debounceTimers.schedule(
+          "__suppress_reset__",
+          () => {
+            ctx.setSuppressConfigReload(false);
+          },
+          CONFIG_RELOAD_DEBOUNCE_MS,
+        );
+        ctx.updateConfigFingerprint();
+      } catch (err) {
+        log.warn(
+          { err, skillId: msg.slug },
+          "Failed to auto-enable bundled skill",
+        );
+      }
+
       ctx.send(socket, {
         type: "skills_operation_response",
         operation: "install",
         success: true,
+      });
+      ctx.broadcast({
+        type: "skills_state_changed",
+        name: msg.slug,
+        state: "enabled",
       });
       return;
     }


### PR DESCRIPTION
Address P2 review feedback from PR #11380. The bundled-skill fast path in handleSkillsInstall returned success immediately without running the auto-enable/config update logic, causing installed bundled skills to remain disabled. This adds the same auto-enable pattern used for clawhub installs.

Note: P1/Devin feedback about vellum_skills_catalog SKILL.md references was already addressed by other PRs — no references remain in the codebase.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
