### PR TITLE
Add optional branch argument to /update skill

### DIFF
--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: update
 description: >
-  Pull latest from main, use vellum ps/sleep/wake to manage daemon and gateway lifecycle, rebuild/launch the macOS app, and print a startup summary.
+  Pull latest from main (or a specified branch), use vellum ps/sleep/wake to manage daemon and gateway lifecycle, rebuild/launch the macOS app, and print a startup summary.
+args: "[branch]"
 ---
 
 # Update — Pull Latest and Restart Vellum
 
-Pull the latest changes from main, use `vellum` lifecycle CLI to stop and restart processes, rebuild/launch the macOS app.
+Pull the latest changes from main (or a specified branch), use `vellum` lifecycle CLI to stop and restart processes, rebuild/launch the macOS app.
+
+The user may pass an optional `branch` argument (e.g., `/update feature/phone-setup`). If provided, check out and pull that branch instead of `main`. If not provided, default to `main`.
 
 ## Steps
 
@@ -45,10 +48,15 @@ Pull the latest changes from main, use `vellum` lifecycle CLI to stop and restar
    ```
    After fallback cleanup, run `vellum ps` again to confirm all processes are stopped.
 
-5. Switch to main and pull latest:
+5. Determine the target branch and switch to it:
+   - If the user passed a `branch` argument, use that branch.
+   - Otherwise, default to `main`.
+
    ```bash
-   git checkout main
-   git pull origin main
+   # Replace <branch> with the resolved branch name
+   git fetch origin <branch>
+   git checkout <branch>
+   git pull origin <branch>
    ```
 
 6. Install any new dependencies:


### PR DESCRIPTION
## Summary
- The `/update` command now accepts an optional `branch` argument (e.g., `/update feature/phone-setup`)
- When provided, checks out and pulls the specified branch instead of defaulting to `main`
- No argument still defaults to `main` (backward compatible)

## Original prompt
Update our `/update` command to accept an optional argument called `branch` that allows you to specify a github branch name that you'd like to use instead of using the default of `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
