### PR TITLE
fix: keep bootstrap screen active on lockfile write failure

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -209,7 +209,6 @@ struct OnboardingFlowView: View {
             )
 
             guard success else {
-                isBootstrappingManaged = false
                 managedBootstrapError = "Failed to save assistant configuration. Please try again."
                 return
             }


### PR DESCRIPTION
Address review feedback from PR #11413.

When `upsertManagedEntry` fails, `isBootstrappingManaged` was being set to `false`, which hid the `managedBootstrapView` (including the error message and retry button) and dropped users back to the normal onboarding step with no recovery path.

Fix: keep `isBootstrappingManaged = true` on lockfile write failure so the bootstrap screen stays active and shows the error/retry UI. This is consistent with the catch block behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
