### PR TITLE
fix: add fractional seconds to hatchedAt timestamp in managed bootstrap

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -200,7 +200,9 @@ struct OnboardingFlowView: View {
             }
 
             let runtimeUrl = AuthService.shared.baseURL
-            let hatchedAt = ISO8601DateFormatter().string(from: Date())
+            let isoFormatter = ISO8601DateFormatter()
+            isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            let hatchedAt = isoFormatter.string(from: Date())
 
             let success = LockfileAssistant.upsertManagedEntry(
                 assistantId: assistant.id,


### PR DESCRIPTION
Address review feedback from PR #11403. The ISO8601DateFormatter now includes .withFractionalSeconds to match the format expected by LockfileAssistant.loadAll(), which parses with [.withInternetDateTime, .withFractionalSeconds]. Without fractional seconds, the parse returns nil and hatchedAt falls back to .distantPast, breaking newest-first sorting.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
