### PR TITLE
fix: gate re-auth bootstrap on current assistant mode

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -842,7 +842,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             state: state,
             daemonClient: daemonClient,
             authManager: authManager,
-            managedBootstrapEnabled: false,
+            managedBootstrapEnabled: isCurrentAssistantManaged,
             onComplete: { [weak self] in
                 self?.proceedToApp()
             },


### PR DESCRIPTION
Address review feedback from PR #11433.

## Summary
- The re-auth window (`showAuthWindow()`) unconditionally passed `managedBootstrapEnabled: false`, which skipped `ensureManagedAssistant()` even when the previously selected assistant was managed
- This could leave a stale `connectedAssistantId` after logout+login into a different WorkOS account
- Now gates on `isCurrentAssistantManaged` so managed assistants get proper bootstrap on re-auth

## Test plan
- [ ] Verify re-auth flow with a managed assistant preserves managed association
- [ ] Verify re-auth flow with a non-managed assistant still skips managed bootstrap
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
