### PR TITLE
fix: keep bootstrap screen active on lockfile write failure

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -209,7 +209,6 @@ struct OnboardingFlowView: View {
             )
 
             guard success else {
-                isBootstrappingManaged = false
                 managedBootstrapError = "Failed to save assistant configuration. Please try again."
                 return
             }


### PR DESCRIPTION
Address review feedback from PR #11413: remove `isBootstrappingManaged = false` from the lockfile write failure guard so the bootstrap view stays visible and the user sees the error message with retry button. Previously, setting this to false would hide the bootstrap view entirely, dropping the user back to onboarding with no error UI.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
