### PR TITLE
fix: include fractional seconds in managed hatchedAt and make parser tolerant

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -268,11 +268,18 @@ struct LockfileAssistant {
             return []
         }
 
-        let isoFormatter = ISO8601DateFormatter()
-        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let fractionalFormatter = ISO8601DateFormatter()
+        fractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let plainFormatter = ISO8601DateFormatter()
+        plainFormatter.formatOptions = [.withInternetDateTime]
+
+        func parseISO8601(_ s: String) -> Date? {
+            fractionalFormatter.date(from: s) ?? plainFormatter.date(from: s)
+        }
+
         let sorted = assistants.sorted { a, b in
-            let dateA = (a["hatchedAt"] as? String).flatMap { isoFormatter.date(from: $0) } ?? .distantPast
-            let dateB = (b["hatchedAt"] as? String).flatMap { isoFormatter.date(from: $0) } ?? .distantPast
+            let dateA = (a["hatchedAt"] as? String).flatMap(parseISO8601) ?? .distantPast
+            let dateB = (b["hatchedAt"] as? String).flatMap(parseISO8601) ?? .distantPast
             return dateA > dateB
         }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -200,7 +200,9 @@ struct OnboardingFlowView: View {
             }
 
             let runtimeUrl = AuthService.shared.baseURL
-            let hatchedAt = ISO8601DateFormatter().string(from: Date())
+            let fmt = ISO8601DateFormatter()
+            fmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            let hatchedAt = fmt.string(from: Date())
 
             let success = LockfileAssistant.upsertManagedEntry(
                 assistantId: assistant.id,


### PR DESCRIPTION
Address review feedback from PR #11403.

- Use .withFractionalSeconds when generating the hatchedAt timestamp during managed bootstrap, so the parser in loadAll() can correctly parse it.
- Make the loadAll() parser tolerant of both fractional and non-fractional ISO-8601 timestamps, so existing lockfile entries without fractional seconds are still correctly sorted.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
