### PR TITLE
fix: correct health path and prevent infinite 401 reconnect in managed mode

### DIFF
--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -1331,7 +1331,8 @@ public final class HTTPTransport {
     /// handleAuthenticationFailureAsync() directly.
     private func handleAuthenticationFailure(responseData: Data? = nil) {
         // Managed mode uses session tokens — the bearer refresh flow does not apply.
-        // Signal session expiry so the app can prompt re-authentication.
+        // Signal session expiry and disconnect to stop SSE/health-check loops
+        // from re-hitting the 401 and re-emitting the error indefinitely.
         if isManagedMode {
             log.warning("401 in managed mode — session token may be expired")
             onMessage?(.sessionError(SessionErrorMessage(
@@ -1340,6 +1341,7 @@ public final class HTTPTransport {
                 userMessage: "Session expired. Please sign in again.",
                 retryable: false
             )))
+            disconnect()
             return
         }
 
@@ -1361,7 +1363,8 @@ public final class HTTPTransport {
     /// `refresh_required`, `UNAUTHORIZED` (expired JWT), and unknown codes —
     /// are treated as refreshable.
     private func handleAuthenticationFailureAsync(responseData: Data? = nil) async -> AuthRefreshResult {
-        // Managed mode: no bearer refresh — emit session-expired and return terminal.
+        // Managed mode: no bearer refresh — emit session-expired, disconnect to
+        // stop loops, and return terminal so callers don't retry.
         if isManagedMode {
             log.warning("401 in managed mode — session token may be expired")
             onMessage?(.sessionError(SessionErrorMessage(
@@ -1370,6 +1373,7 @@ public final class HTTPTransport {
                 userMessage: "Session expired. Please sign in again.",
                 retryable: false
             )))
+            disconnect()
             return .terminalFailure
         }
 


### PR DESCRIPTION
Address review feedback from PR #11396.

- **Health path fix (Codex P1):** Changed proxy-mode health path from `/healthz/` to `/health/` so it resolves to the runtime's `/v1/health` endpoint after the gateway proxy rewrites `/v1/assistants/:id/...` to `/v1/...`. The previous path produced `/v1/healthz/` which the runtime does not handle.

- **Infinite 401 reconnect fix (Devin):** Added `disconnect()` calls in both `handleAuthenticationFailure()` and `handleAuthenticationFailureAsync()` managed-mode branches. Without this, `shouldReconnect` stayed `true` after emitting the session-expired error, causing the SSE reconnect loop and health check loop to keep hitting 401s and re-emitting the error indefinitely.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
