### PR TITLE
feat: Gmail draft-first safety guardrails

### DIFF
--- a/assistant/src/__tests__/scan-result-store.test.ts
+++ b/assistant/src/__tests__/scan-result-store.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, beforeEach } from 'bun:test';
+import {
+  storeScanResult,
+  getSenderMessageIds,
+  getSenderMetadata,
+  clearScanStore,
+  _internals,
+} from '../config/bundled-skills/messaging/tools/scan-result-store.js';
+
+describe('scan-result-store', () => {
+  beforeEach(() => {
+    clearScanStore();
+  });
+
+  const makeSenders = (count: number) =>
+    Array.from({ length: count }, (_, i) => ({
+      id: `sender-${i}`,
+      messageIds: [`msg-${i}-a`, `msg-${i}-b`],
+      newestMessageId: `msg-${i}-a`,
+      newestUnsubscribableMessageId: i % 2 === 0 ? `msg-${i}-a` : null,
+    }));
+
+  it('stores and retrieves message IDs', () => {
+    const senders = makeSenders(3);
+    const scanId = storeScanResult(senders);
+
+    const ids = getSenderMessageIds(scanId, ['sender-0', 'sender-2']);
+    expect(ids).toEqual(['msg-0-a', 'msg-0-b', 'msg-2-a', 'msg-2-b']);
+  });
+
+  it('returns null for unknown scan ID', () => {
+    expect(getSenderMessageIds('nonexistent', ['sender-0'])).toBeNull();
+  });
+
+  it('returns empty array for unknown sender IDs', () => {
+    const scanId = storeScanResult(makeSenders(1));
+    const ids = getSenderMessageIds(scanId, ['unknown-sender']);
+    expect(ids).toEqual([]);
+  });
+
+  it('retrieves sender metadata', () => {
+    const senders = makeSenders(2);
+    const scanId = storeScanResult(senders);
+
+    const meta0 = getSenderMetadata(scanId, 'sender-0');
+    expect(meta0).toEqual({ newestMessageId: 'msg-0-a', newestUnsubscribableMessageId: 'msg-0-a' });
+
+    const meta1 = getSenderMetadata(scanId, 'sender-1');
+    expect(meta1).toEqual({ newestMessageId: 'msg-1-a', newestUnsubscribableMessageId: null });
+  });
+
+  it('returns null metadata for unknown sender', () => {
+    const scanId = storeScanResult(makeSenders(1));
+    expect(getSenderMetadata(scanId, 'unknown')).toBeNull();
+  });
+
+  it('evicts oldest entry when at capacity (LRU)', () => {
+    const scanIds: string[] = [];
+    for (let i = 0; i < 16; i++) {
+      scanIds.push(storeScanResult([{ id: `s-${i}`, messageIds: [`m-${i}`], newestMessageId: `m-${i}`, newestUnsubscribableMessageId: null }]));
+    }
+
+    // All 16 should be present
+    expect(getSenderMessageIds(scanIds[0], ['s-0'])).toEqual(['m-0']);
+
+    // Adding a 17th should evict the oldest (scanIds[0] was accessed last via getSenderMessageIds, so scanIds[1] is oldest)
+    const newId = storeScanResult([{ id: 's-new', messageIds: ['m-new'], newestMessageId: 'm-new', newestUnsubscribableMessageId: null }]);
+
+    // scanIds[1] should be evicted (it was the LRU after we accessed scanIds[0])
+    expect(getSenderMessageIds(scanIds[1], ['s-1'])).toBeNull();
+    // The new entry and scanIds[0] should still be present
+    expect(getSenderMessageIds(newId, ['s-new'])).toEqual(['m-new']);
+    expect(getSenderMessageIds(scanIds[0], ['s-0'])).toEqual(['m-0']);
+  });
+
+  it('expires entries after TTL', () => {
+    const scanId = storeScanResult(makeSenders(1));
+
+    // Manually age the entry beyond TTL
+    const entry = _internals.store.get(scanId);
+    expect(entry).toBeDefined();
+    entry!.createdAt = Date.now() - _internals.TTL_MS - 1;
+
+    expect(getSenderMessageIds(scanId, ['sender-0'])).toBeNull();
+    // Entry should be cleaned up
+    expect(_internals.store.has(scanId)).toBe(false);
+  });
+
+  it('expires entries in getSenderMetadata after TTL', () => {
+    const scanId = storeScanResult(makeSenders(1));
+
+    const entry = _internals.store.get(scanId);
+    entry!.createdAt = Date.now() - _internals.TTL_MS - 1;
+
+    expect(getSenderMetadata(scanId, 'sender-0')).toBeNull();
+    expect(_internals.store.has(scanId)).toBe(false);
+  });
+});

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -231,11 +231,36 @@ When searching Gmail, the query uses Gmail's search operators:
 | `has:attachment` | `has:attachment`         | Messages with attachments           |
 | `label:`         | `label:work`             | Messages with a specific label      |
 
-## Drafting vs Sending
+## Drafting vs Sending (Gmail)
 
-- Default to drafting (local draft or Gmail native draft) when the user wants to compose.
-- Only send when the user explicitly requests it.
-- When uncertain, always default to drafting.
+Gmail uses a **draft-first workflow**. All compose and reply tools create Gmail drafts automatically:
+
+- `messaging_send` (Gmail) → creates a draft in Gmail Drafts
+- `messaging_reply` (Gmail) → creates a threaded draft with reply-all recipients
+- `gmail_draft` → creates a draft
+- `gmail_send_with_attachments` → creates a draft with attachments
+- `gmail_forward` → creates a forward draft
+
+**To actually send**: Use `gmail_send_draft` with the draft ID after the user has reviewed it. Only call `gmail_send_draft` when the user explicitly says "send it" or equivalent.
+
+**Reply-all**: `messaging_reply` for Gmail automatically builds the reply-all recipient list from the thread. You do not need to manually look up recipients.
+
+Non-Gmail platforms (Slack, Telegram, SMS) send directly via `messaging_send` / `messaging_reply`.
+
+## Email Threading (Gmail)
+
+When replying to or continuing an email thread:
+
+- Use `messaging_reply` with the thread's `thread_id` — it automatically handles threading, reply-all recipients, and subject lines.
+- The `in_reply_to` field on `gmail_draft` requires the **RFC 822 Message-ID header** (looks like `<CABx...@mail.gmail.com>`), NOT the Gmail message ID (which looks like `18e4a5b2c3d4e5f6`). Get it by reading the thread messages and extracting the `Message-ID` header.
+
+## Date Verification
+
+Before composing any email that references a date or time:
+
+1. Check the `<temporal_context>` block in the current turn for today's date and upcoming dates
+2. Verify that "tomorrow" means the day after today's date, "next week" means the upcoming Monday–Friday, etc.
+3. If the email references a date from another message, cross-check it against the temporal context to ensure it's in the future
 
 ## Notifications vs Messages
 
@@ -291,9 +316,9 @@ When a user asks to declutter, clean up, or organize their email — start scann
    - **Show a `task_progress` card** with one step per selected sender (e.g., "Archiving TechCrunch (247 emails)"). Update each step from `in_progress` → `completed` as each sender finishes.
    - When all senders are processed, set the progress card's `status: "completed"`.
 4. **Act on selection**: For each selected sender:
-   - Use `gmail_batch_archive` (or `messaging_archive_by_sender` for non-Gmail) with the sender's `message_ids` array — this archives exactly the messages that were scanned and counted
+   - Use `gmail_batch_archive` (or `messaging_archive_by_sender` for non-Gmail) with `scan_id` + the selected senders' `id` values as `sender_ids` — this resolves message IDs server-side without putting them in context
    - If Gmail and the action is "Archive & Unsubscribe" and `has_unsubscribe` is true, call `gmail_unsubscribe` with the sender's `newest_message_id`
-5. **Accurate summary**: The scan counts are exact — the `message_count` shown in the table matches the number of `message_ids` that were archived. Format: "Cleaned up [total_archived] emails from [sender_count] senders." For Gmail, append: "Unsubscribed from [unsub_count]."
+5. **Accurate summary**: The scan counts are exact — the `message_count` shown in the table matches the number of messages archived. Format: "Cleaned up [total_archived] emails from [sender_count] senders." For Gmail, append: "Unsubscribed from [unsub_count]."
 6. **Ongoing protection offer (Gmail only)**: After reporting results, offer auto-archive filters:
    - "Want me to set up auto-archive filters so future emails from these senders skip your inbox?"
    - If yes, call `gmail_filters` with `action: "create"` for each sender with `from` set to the sender's email and `remove_label_ids: ["INBOX"]`.
@@ -303,10 +328,20 @@ When a user asks to declutter, clean up, or organize their email — start scann
 
 - **Zero results**: Tell the user "No newsletter emails found" and suggest broadening the query (e.g. removing the category filter or extending the date range)
 - **Unsubscribe failures**: Report per-sender success/failure; the existing `gmail_unsubscribe` tool handles edge cases
-- **Large sender counts**: The scan covers up to 2000 messages. If `truncated` is true in the top-level response, the scan was capped and there are more matching emails beyond what was scanned — tell the user the cleanup was partial and offer to run another pass. If `has_more` is true for a sender, it means they had more messages than could be tracked — mention this to the user in the summary
+- **Truncation handling**: The scan covers up to 5000 messages (default 2000). If `truncated` is true:
+  - **Default**: The top senders are captured — this is usually fine. Mention "partial scan" in the summary.
+  - **Comprehensive** (user said "full inbox", "everything", "all of it"): Silently continue scanning with `page_token`, merge results across passes, and present once when complete. Don't ask — just keep going until done.
+
+### Scan ID
+
+Scan tools (`gmail_sender_digest`, `gmail_outreach_scan`, `messaging_sender_digest`) return a `scan_id` that references message IDs stored server-side. This keeps thousands of message IDs out of the conversation context.
+
+- Pass `scan_id` + `sender_ids` to `gmail_batch_archive` instead of `message_ids`
+- Scan results expire after **30 minutes** — if archiving fails with an expiration error, re-run the scan
+- Raw `message_ids` still work as a fallback for non-scan workflows
 
 ## Batch Operations
 
-- Gmail batch tools (`gmail_batch_archive`, `gmail_batch_label`) accept arrays of message IDs.
-- First search or list messages to collect IDs, then apply batch actions.
+- Gmail batch tools (`gmail_batch_archive`, `gmail_batch_label`) support `scan_id` + `sender_ids` (preferred) or raw `message_ids`.
+- First scan to get a `scan_id`, then apply batch actions using it.
 - Always confirm with the user before batch operations on large numbers of messages.

--- a/assistant/src/config/bundled-skills/messaging/TOOLS.json
+++ b/assistant/src/config/bundled-skills/messaging/TOOLS.json
@@ -114,7 +114,7 @@
     },
     {
       "name": "messaging_send",
-      "description": "Send a message on a platform. This is a high-risk action that always requires user approval. Include a confidence score (0-1).",
+      "description": "Compose a message. For Gmail, creates a draft for review; for other platforms, sends directly. High-risk action. Include a confidence score (0-1).",
       "category": "messaging",
       "risk": "high",
       "input_schema": {
@@ -156,7 +156,7 @@
     },
     {
       "name": "messaging_reply",
-      "description": "Reply in a thread. Medium-risk action. Include a confidence score (0-1).",
+      "description": "Reply in a thread. For Gmail, creates a threaded draft with reply-all recipients; for other platforms, sends directly. Include a confidence score (0-1).",
       "category": "messaging",
       "risk": "medium",
       "input_schema": {
@@ -339,18 +339,29 @@
     },
     {
       "name": "gmail_batch_archive",
-      "description": "Archive multiple Gmail messages at once. Include a confidence score (0-1).",
+      "description": "Archive multiple Gmail messages at once. Prefer scan_id + sender_ids (from a prior scan) over raw message_ids. Include a confidence score (0-1).",
       "category": "messaging",
       "risk": "medium",
       "input_schema": {
         "type": "object",
         "properties": {
+          "scan_id": {
+            "type": "string",
+            "description": "Scan result ID from a prior gmail_sender_digest or gmail_outreach_scan call"
+          },
+          "sender_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Sender IDs to archive (used with scan_id to resolve message IDs server-side)"
+          },
           "message_ids": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "description": "Gmail message IDs to archive"
+            "description": "Gmail message IDs to archive (fallback — prefer scan_id + sender_ids)"
           },
           "confidence": {
             "type": "number",
@@ -358,7 +369,6 @@
           }
         },
         "required": [
-          "message_ids",
           "confidence"
         ]
       },
@@ -543,7 +553,15 @@
           },
           "in_reply_to": {
             "type": "string",
-            "description": "Message-ID header of the email being replied to"
+            "description": "RFC 822 Message-ID header value (e.g. `<CABx...@mail.gmail.com>`), NOT the Gmail message ID. Look up the original message's Message-ID header."
+          },
+          "cc": {
+            "type": "string",
+            "description": "CC recipients (comma-separated email addresses)"
+          },
+          "bcc": {
+            "type": "string",
+            "description": "BCC recipients (comma-separated email addresses)"
           }
         },
         "required": [
@@ -553,6 +571,31 @@
         ]
       },
       "executor": "tools/gmail-draft.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_send_draft",
+      "description": "Send an existing Gmail draft. Only use when the user has reviewed and explicitly approved sending.",
+      "category": "messaging",
+      "risk": "high",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "draft_id": {
+            "type": "string",
+            "description": "Gmail draft ID to send"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          }
+        },
+        "required": [
+          "draft_id",
+          "confidence"
+        ]
+      },
+      "executor": "tools/gmail-send-draft.ts",
       "execution_target": "host"
     },
     {
@@ -607,7 +650,7 @@
     },
     {
       "name": "gmail_send_with_attachments",
-      "description": "Send an email with file attachments. High-risk action requiring user approval. Include a confidence score (0-1).",
+      "description": "Create a Gmail draft with file attachments for review. Include a confidence score (0-1).",
       "category": "messaging",
       "risk": "high",
       "input_schema": {
@@ -658,7 +701,7 @@
     },
     {
       "name": "gmail_forward",
-      "description": "Forward a Gmail message to another recipient, preserving attachments. Include a confidence score (0-1).",
+      "description": "Create a draft forwarding a Gmail message to another recipient, preserving attachments. Include a confidence score (0-1).",
       "category": "messaging",
       "risk": "high",
       "input_schema": {
@@ -916,7 +959,7 @@
           },
           "max_messages": {
             "type": "number",
-            "description": "Maximum messages to scan (default 2000, cap 2000)"
+            "description": "Maximum messages to scan (default 2000, cap 5000)"
           },
           "max_senders": {
             "type": "number",

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-batch-archive.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-batch-archive.ts
@@ -2,6 +2,7 @@ import { batchModifyMessages } from '../../../../messaging/providers/gmail/clien
 import { getMessagingProvider } from '../../../../messaging/registry.js';
 import { withValidToken } from '../../../../security/token-manager.js';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { getSenderMessageIds } from './scan-result-store.js';
 import { err,ok } from './shared.js';
 
 const BATCH_MODIFY_LIMIT = 1000;
@@ -11,10 +12,21 @@ export async function run(input: Record<string, unknown>, context: ToolContext):
     return err('This tool requires user confirmation via a surface action. Present results in a selection table with action buttons and wait for the user to click before proceeding.');
   }
 
-  const messageIds = input.message_ids as string[];
+  const scanId = input.scan_id as string | undefined;
+  const senderIds = input.sender_ids as string[] | undefined;
+  let messageIds = input.message_ids as string[] | undefined;
+
+  // Resolve message IDs from scan store if scan_id is provided
+  if (scanId && senderIds?.length) {
+    const resolved = getSenderMessageIds(scanId, senderIds);
+    if (resolved === null) {
+      return err('Scan results have expired (30-minute window). Please re-run the scan to get fresh results.');
+    }
+    messageIds = resolved;
+  }
 
   if (!messageIds?.length) {
-    return err('message_ids is required and must not be empty.');
+    return err('Either message_ids or scan_id + sender_ids is required, and must resolve to at least one message.');
   }
 
   try {

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-draft.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-draft.ts
@@ -9,6 +9,8 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
   const subject = input.subject as string;
   const body = input.body as string;
   const inReplyTo = input.in_reply_to as string | undefined;
+  const cc = input.cc as string | undefined;
+  const bcc = input.bcc as string | undefined;
 
   if (!to) return err('to is required.');
   if (!subject) return err('subject is required.');
@@ -17,7 +19,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
   try {
     const provider = getMessagingProvider('gmail');
     return withValidToken(provider.credentialService, async (token) => {
-      const draft = await createDraft(token, to, subject, body, inReplyTo);
+      const draft = await createDraft(token, to, subject, body, inReplyTo, cc, bcc);
       return ok(`Draft created (ID: ${draft.id}). It will appear in your Gmail Drafts.`);
     });
   } catch (e) {

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-forward.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-forward.ts
@@ -1,4 +1,4 @@
-import { getAttachment, getMessage, sendMessageRaw } from '../../../../messaging/providers/gmail/client.js';
+import { createDraftRaw, getAttachment, getMessage } from '../../../../messaging/providers/gmail/client.js';
 import { buildMultipartMime } from '../../../../messaging/providers/gmail/mime-builder.js';
 import type { GmailMessagePart } from '../../../../messaging/providers/gmail/types.js';
 import { getMessagingProvider } from '../../../../messaging/registry.js';
@@ -88,14 +88,13 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
 
       if (attachments.length > 0) {
         const raw = buildMultipartMime({ to: forwardTo, subject, body: forwardHeader, attachments });
-        const result = await sendMessageRaw(token, raw);
-        return ok(`Message forwarded to ${forwardTo} with ${attachments.length} attachment(s) (ID: ${result.id}).`);
+        const draft = await createDraftRaw(token, raw);
+        return ok(`Forward draft created to ${forwardTo} with ${attachments.length} attachment(s) (Draft ID: ${draft.id}). Review in Gmail Drafts, then tell me to send it or send it yourself.`);
       }
 
-      // No attachments — use sendMessageRaw with a simple text MIME
       const raw = buildMultipartMime({ to: forwardTo, subject, body: forwardHeader, attachments: [] });
-      const result = await sendMessageRaw(token, raw);
-      return ok(`Message forwarded to ${forwardTo} (ID: ${result.id}).`);
+      const draft = await createDraftRaw(token, raw);
+      return ok(`Forward draft created to ${forwardTo} (Draft ID: ${draft.id}). Review in Gmail Drafts, then tell me to send it or send it yourself.`);
     });
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-outreach-scan.ts
@@ -4,6 +4,7 @@ import { batchGetMessages,listMessages } from '../../../../messaging/providers/g
 import { getMessagingProvider } from '../../../../messaging/registry.js';
 import { withValidToken } from '../../../../security/token-manager.js';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { storeScanResult } from './scan-result-store.js';
 import { err,ok } from './shared.js';
 
 const MAX_MESSAGES_CAP = 2000;
@@ -210,14 +211,21 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         newest_message_id: s.newestMessageId,
         oldest_date: s.oldestDate,
         newest_date: s.newestDate,
-        message_ids: s.messageIds,
-        has_more: s.hasMore,
         search_query: `from:${s.email}`,
         sample_subjects: s.sampleSubjects,
         suggested_actions: buildSuggestedActions(s.email, s.messageCount),
       }));
 
+      // Store message IDs server-side to keep them out of LLM context
+      const scanId = storeScanResult(sorted.map((s) => ({
+        id: Buffer.from(s.email).toString('base64url'),
+        messageIds: s.messageIds,
+        newestMessageId: s.newestMessageId,
+        newestUnsubscribableMessageId: null,
+      })));
+
       return ok(JSON.stringify({
+        scan_id: scanId,
         senders,
         total_scanned: allMessageIds.length,
         outreach_detected: totalOutreachDetected,

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-send-draft.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-send-draft.ts
@@ -1,0 +1,20 @@
+import { sendDraft } from '../../../../messaging/providers/gmail/client.js';
+import { getMessagingProvider } from '../../../../messaging/registry.js';
+import { withValidToken } from '../../../../security/token-manager.js';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { err, ok } from './shared.js';
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const draftId = input.draft_id as string;
+  if (!draftId) return err('draft_id is required.');
+
+  try {
+    const provider = getMessagingProvider('gmail');
+    return withValidToken(provider.credentialService, async (token) => {
+      const msg = await sendDraft(token, draftId);
+      return ok(`Draft sent (Message ID: ${msg.id}).`);
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-send-with-attachments.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-send-with-attachments.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { basename, extname } from 'node:path';
 
-import { sendMessageRaw } from '../../../../messaging/providers/gmail/client.js';
+import { createDraftRaw } from '../../../../messaging/providers/gmail/client.js';
 import { buildMultipartMime } from '../../../../messaging/providers/gmail/mime-builder.js';
 import { getMessagingProvider } from '../../../../messaging/registry.js';
 import { withValidToken } from '../../../../security/token-manager.js';
@@ -67,11 +67,10 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
       );
 
       const raw = buildMultipartMime({ to, subject, body, inReplyTo, attachments });
-      const result = await sendMessageRaw(token, raw, threadId);
+      const draft = await createDraftRaw(token, raw, threadId);
 
       const filenames = attachments.map((a) => a.filename).join(', ');
-      const threadSuffix = result.threadId ? `, "thread_id": "${result.threadId}"` : '';
-      return ok(`Message sent with ${attachments.length} attachment(s): ${filenames} (ID: ${result.id}${threadSuffix}).`);
+      return ok(`Gmail draft created with ${attachments.length} attachment(s): ${filenames} (Draft ID: ${draft.id}). Review in Gmail Drafts, then tell me to send it or send it yourself.`);
     });
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
@@ -2,10 +2,11 @@ import { batchGetMessages,listMessages } from '../../../../messaging/providers/g
 import { getMessagingProvider } from '../../../../messaging/registry.js';
 import { withValidToken } from '../../../../security/token-manager.js';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { storeScanResult } from './scan-result-store.js';
 import { err,ok } from './shared.js';
 
-const MAX_MESSAGES_CAP = 500;
-const MAX_IDS_PER_SENDER = 500;
+const MAX_MESSAGES_CAP = 5000;
+const MAX_IDS_PER_SENDER = 5000;
 const MAX_SAMPLE_SUBJECTS = 3;
 
 interface SenderAggregation {
@@ -36,7 +37,7 @@ function parseFrom(from: string): { displayName: string; email: string } {
 
 export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
   const query = (input.query as string) ?? 'category:promotions newer_than:90d';
-  const maxMessages = Math.min((input.max_messages as number) ?? 500, MAX_MESSAGES_CAP);
+  const maxMessages = Math.min((input.max_messages as number) ?? 2000, MAX_MESSAGES_CAP);
   const maxSenders = (input.max_senders as number) ?? 30;
   const inputPageToken = input.page_token as string | undefined;
 
@@ -149,7 +150,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         .sort((a, b) => b.messageCount - a.messageCount)
         .slice(0, maxSenders);
 
-      const result = sorted.map((s) => ({
+      const resultSenders = sorted.map((s) => ({
         id: Buffer.from(s.email).toString('base64url'),
         display_name: s.displayName || s.email.split('@')[0],
         email: s.email,
@@ -161,19 +162,26 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
           : s.newestMessageId,
         oldest_date: s.oldestDate,
         newest_date: s.newestDate,
-        message_ids: s.messageIds,
-        has_more: s.hasMore,
         // Preserve original query filters so follow-up searches stay scoped
         search_query: `from:${s.email} ${query}`,
         sample_subjects: s.sampleSubjects,
       }));
 
+      // Store message IDs server-side to keep them out of LLM context
+      const scanId = storeScanResult(sorted.map((s) => ({
+        id: Buffer.from(s.email).toString('base64url'),
+        messageIds: s.messageIds,
+        newestMessageId: s.newestMessageId,
+        newestUnsubscribableMessageId: s.newestUnsubscribableMessageId,
+      })));
+
       return ok(JSON.stringify({
-        senders: result,
+        scan_id: scanId,
+        senders: resultSenders,
         total_scanned: allMessageIds.length,
         query_used: query,
         ...(truncated ? { truncated: true, next_page_token: pageToken } : {}),
-        note: `message_count reflects emails found per sender within the ${allMessageIds.length} messages scanned. Use the message_ids array with gmail_batch_archive to archive exactly these messages.`,
+        note: `message_count reflects emails found per sender within the ${allMessageIds.length} messages scanned. Use scan_id with gmail_batch_archive to archive messages (pass scan_id + sender_ids instead of message_ids).`,
       }));
     });
   } catch (e) {

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts
@@ -1,5 +1,10 @@
+import { batchGetMessages, createDraft, getProfile, listMessages } from '../../../../messaging/providers/gmail/client.js';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
 import { err,ok, resolveProvider, withProviderToken } from './shared.js';
+
+function extractHeader(headers: Array<{ name: string; value: string }> | undefined, name: string): string {
+  return headers?.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value ?? '';
+}
 
 export async function run(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
   const platform = input.platform as string | undefined;
@@ -19,6 +24,77 @@ export async function run(input: Record<string, unknown>, context: ToolContext):
 
   try {
     const provider = resolveProvider(platform);
+
+    // Gmail: create a threaded draft with reply-all recipients
+    if (provider.id === 'gmail') {
+      return withProviderToken(provider, async (token) => {
+        // Fetch thread messages to extract recipients and threading headers
+        const list = await listMessages(token, `thread:${threadId}`, 10);
+        if (!list.messages?.length) {
+          return err('No messages found in this thread.');
+        }
+
+        const messages = await batchGetMessages(token, list.messages.map((m) => m.id), 'metadata', [
+          'From', 'To', 'Cc', 'Message-ID', 'Subject',
+        ]);
+
+        // Use the latest message for threading and recipient extraction
+        const latest = messages[messages.length - 1];
+        const latestHeaders = latest.payload?.headers ?? [];
+
+        const messageIdHeader = extractHeader(latestHeaders, 'Message-ID');
+        let subject = extractHeader(latestHeaders, 'Subject');
+        if (subject && !subject.startsWith('Re:')) {
+          subject = `Re: ${subject}`;
+        }
+
+        // Build reply-all recipient list, excluding the user's own email
+        const profile = await getProfile(token);
+        const userEmail = profile.emailAddress.toLowerCase();
+
+        const allRecipients = new Set<string>();
+        const allCc = new Set<string>();
+
+        // From the latest message: From goes to To, original To/Cc go to Cc
+        const fromAddr = extractHeader(latestHeaders, 'From');
+        const toAddrs = extractHeader(latestHeaders, 'To');
+        const ccAddrs = extractHeader(latestHeaders, 'Cc');
+
+        if (fromAddr) allRecipients.add(fromAddr);
+        for (const addr of toAddrs.split(',').map((a) => a.trim()).filter(Boolean)) {
+          allRecipients.add(addr);
+        }
+        for (const addr of ccAddrs.split(',').map((a) => a.trim()).filter(Boolean)) {
+          allCc.add(addr);
+        }
+
+        // Remove user's own email from recipients
+        const filterSelf = (addr: string) => !addr.toLowerCase().includes(userEmail);
+        const toList = [...allRecipients].filter(filterSelf);
+        const ccList = [...allCc].filter(filterSelf);
+
+        if (toList.length === 0) {
+          return err('Could not determine reply recipients from thread.');
+        }
+
+        const draft = await createDraft(
+          token,
+          toList.join(', '),
+          subject,
+          text,
+          messageIdHeader || undefined,
+          ccList.length > 0 ? ccList.join(', ') : undefined,
+          undefined,
+          threadId,
+        );
+
+        const recipientSummary = ccList.length > 0
+          ? `To: ${toList.join(', ')}; Cc: ${ccList.join(', ')}`
+          : `To: ${toList.join(', ')}`;
+        return ok(`Gmail draft created (ID: ${draft.id}). ${recipientSummary}. Review in Gmail Drafts, then tell me to send it or send it yourself.`);
+      });
+    }
+
     return withProviderToken(provider, async (token) => {
       const result = await provider.sendMessage(token, conversationId, text, {
         threadId,

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -1,3 +1,4 @@
+import { createDraft } from '../../../../messaging/providers/gmail/client.js';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
 import { err,ok, resolveProvider, withProviderToken } from './shared.js';
 
@@ -17,6 +18,15 @@ export async function run(input: Record<string, unknown>, context: ToolContext):
 
   try {
     const provider = resolveProvider(platform);
+
+    // Gmail: create a draft instead of sending directly
+    if (provider.id === 'gmail') {
+      return withProviderToken(provider, async (token) => {
+        const draft = await createDraft(token, conversationId, subject ?? '', text, inReplyTo);
+        return ok(`Gmail draft created (ID: ${draft.id}). Review it in your Gmail Drafts, then tell me to send it or send it yourself from Gmail.`);
+      });
+    }
+
     return withProviderToken(provider, async (token) => {
       const result = await provider.sendMessage(token, conversationId, text, {
         subject,

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-sender-digest.ts
@@ -1,4 +1,5 @@
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { storeScanResult } from './scan-result-store.js';
 import { err, ok, resolveProvider, withProviderToken } from './shared.js';
 
 export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
@@ -37,16 +38,23 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         has_unsubscribe: s.hasUnsubscribe,
         newest_message_id: s.newestMessageId,
         search_query: s.searchQuery,
-        message_ids: s.messageIds,
-        has_more: s.hasMore,
       }));
 
+      // Store message IDs server-side to keep them out of LLM context
+      const scanId = storeScanResult(result.senders.map((s) => ({
+        id: s.id,
+        messageIds: s.messageIds,
+        newestMessageId: s.newestMessageId,
+        newestUnsubscribableMessageId: null,
+      })));
+
       return ok(JSON.stringify({
+        scan_id: scanId,
         senders,
         total_scanned: result.totalScanned,
         query_used: result.queryUsed,
         ...(result.truncated ? { truncated: true, next_page_token: result.nextPageToken } : {}),
-        note: `message_count reflects emails found per sender within the ${result.totalScanned} messages scanned. Use the message_ids array with the archive tool to archive exactly these messages.`,
+        note: `message_count reflects emails found per sender within the ${result.totalScanned} messages scanned. Use scan_id with the archive tool to archive messages (pass scan_id + sender_ids instead of message_ids).`,
       }));
     });
   } catch (e) {

--- a/assistant/src/config/bundled-skills/messaging/tools/scan-result-store.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/scan-result-store.ts
@@ -1,0 +1,86 @@
+import { randomBytes } from 'crypto';
+
+interface SenderData {
+  messageIds: string[];
+  newestMessageId: string;
+  newestUnsubscribableMessageId: string | null;
+}
+
+interface ScanEntry {
+  senders: Map<string, SenderData>;
+  createdAt: number;
+}
+
+const MAX_ENTRIES = 16;
+const TTL_MS = 30 * 60_000; // 30 minutes
+
+const _store = new Map<string, ScanEntry>();
+
+/** Store scan results and return a unique scan ID. */
+export function storeScanResult(
+  senders: Array<{ id: string; messageIds: string[]; newestMessageId: string; newestUnsubscribableMessageId: string | null }>,
+): string {
+  const scanId = randomBytes(8).toString('hex');
+
+  // LRU eviction: remove oldest if at capacity
+  if (_store.size >= MAX_ENTRIES) {
+    const oldest = _store.keys().next().value;
+    if (oldest !== undefined) _store.delete(oldest);
+  }
+
+  const senderMap = new Map<string, SenderData>();
+  for (const s of senders) {
+    senderMap.set(s.id, {
+      messageIds: s.messageIds,
+      newestMessageId: s.newestMessageId,
+      newestUnsubscribableMessageId: s.newestUnsubscribableMessageId,
+    });
+  }
+
+  _store.set(scanId, { senders: senderMap, createdAt: Date.now() });
+  return scanId;
+}
+
+/** Retrieve message IDs for the given senders from a scan result. */
+export function getSenderMessageIds(scanId: string, senderIds: string[]): string[] | null {
+  const entry = _store.get(scanId);
+  if (!entry) return null;
+  if (Date.now() - entry.createdAt > TTL_MS) {
+    _store.delete(scanId);
+    return null;
+  }
+  // LRU: move to end
+  _store.delete(scanId);
+  _store.set(scanId, entry);
+
+  const ids: string[] = [];
+  for (const sid of senderIds) {
+    const data = entry.senders.get(sid);
+    if (data) ids.push(...data.messageIds);
+  }
+  return ids;
+}
+
+/** Retrieve metadata for a single sender from a scan result. */
+export function getSenderMetadata(
+  scanId: string,
+  senderId: string,
+): { newestMessageId: string; newestUnsubscribableMessageId: string | null } | null {
+  const entry = _store.get(scanId);
+  if (!entry) return null;
+  if (Date.now() - entry.createdAt > TTL_MS) {
+    _store.delete(scanId);
+    return null;
+  }
+  const data = entry.senders.get(senderId);
+  if (!data) return null;
+  return { newestMessageId: data.newestMessageId, newestUnsubscribableMessageId: data.newestUnsubscribableMessageId };
+}
+
+/** Clear the store (for tests). */
+export function clearScanStore(): void {
+  _store.clear();
+}
+
+/** Visible for testing: override TTL check by returning internal store reference. */
+export const _internals = { store: _store, TTL_MS };

--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -193,12 +193,17 @@ export async function createDraft(
   subject: string,
   body: string,
   inReplyTo?: string,
+  cc?: string,
+  bcc?: string,
+  threadId?: string,
 ): Promise<GmailDraft> {
   const headers = [
     `To: ${to}`,
     `Subject: ${subject}`,
     'Content-Type: text/plain; charset=utf-8',
   ];
+  if (cc) headers.push(`Cc: ${cc}`);
+  if (bcc) headers.push(`Bcc: ${bcc}`);
   if (inReplyTo) {
     headers.push(`In-Reply-To: ${inReplyTo}`);
     headers.push(`References: ${inReplyTo}`);
@@ -208,9 +213,36 @@ export async function createDraft(
     .replace(/\+/g, '-')
     .replace(/\//g, '_')
     .replace(/=+$/, '');
+  const message: Record<string, unknown> = { raw };
+  if (threadId) message.threadId = threadId;
   return request<GmailDraft>(token, '/drafts', {
     method: 'POST',
-    body: JSON.stringify({ message: { raw } }),
+    body: JSON.stringify({ message }),
+  });
+}
+
+/** Create a draft from a pre-built base64url MIME payload. */
+export async function createDraftRaw(
+  token: string,
+  raw: string,
+  threadId?: string,
+): Promise<GmailDraft> {
+  const message: Record<string, unknown> = { raw };
+  if (threadId) message.threadId = threadId;
+  return request<GmailDraft>(token, '/drafts', {
+    method: 'POST',
+    body: JSON.stringify({ message }),
+  });
+}
+
+/** Send an existing draft by ID. */
+export async function sendDraft(
+  token: string,
+  draftId: string,
+): Promise<GmailMessage> {
+  return request<GmailMessage>(token, '/drafts/send', {
+    method: 'POST',
+    body: JSON.stringify({ id: draftId }),
   });
 }
 

--- a/assistant/src/messaging/providers/gmail/mime-builder.ts
+++ b/assistant/src/messaging/providers/gmail/mime-builder.ts
@@ -16,6 +16,8 @@ export interface MimeMessageOptions {
   subject: string;
   body: string;
   inReplyTo?: string;
+  cc?: string;
+  bcc?: string;
   attachments: MimeAttachment[];
 }
 
@@ -32,7 +34,7 @@ function toBase64Url(input: Buffer): string {
  * Returns a base64url-encoded string ready for Gmail's messages.send `raw` field.
  */
 export function buildMultipartMime(options: MimeMessageOptions): string {
-  const { to, subject, body, inReplyTo, attachments } = options;
+  const { to, subject, body, inReplyTo, cc, bcc, attachments } = options;
   const boundary = `----=_Part_${randomBytes(16).toString('hex')}`;
 
   const headers = [
@@ -41,6 +43,8 @@ export function buildMultipartMime(options: MimeMessageOptions): string {
     'MIME-Version: 1.0',
     `Content-Type: multipart/mixed; boundary="${boundary}"`,
   ];
+  if (cc) headers.push(`Cc: ${cc}`);
+  if (bcc) headers.push(`Bcc: ${bcc}`);
   if (inReplyTo) {
     headers.push(`In-Reply-To: ${inReplyTo}`);
     headers.push(`References: ${inReplyTo}`);


### PR DESCRIPTION
## Summary

- **Draft-first workflow**: All Gmail outbound paths (`messaging_send`, `messaging_reply`, `gmail_send_with_attachments`, `gmail_forward`, `gmail_draft`) now create drafts instead of sending directly. A new `gmail_send_draft` tool lets the user explicitly send a reviewed draft.
- **Reply-all**: `messaging_reply` for Gmail automatically fetches thread messages, extracts From/To/Cc headers, and builds the reply-all recipient list (excluding the user's own email).
- **CC/BCC support**: Added optional `cc` and `bcc` parameters to `createDraft()`, `gmail_draft` tool, and the MIME builder.
- **Scan result store**: Message IDs from sender digest/outreach scans are stored server-side (30-min TTL) and referenced by `scan_id` + `sender_ids`, keeping thousands of IDs out of LLM context.
- **SKILL.md**: Replaced "Drafting vs Sending" with comprehensive draft-first documentation, added "Email Threading" and "Date Verification" sections.

## Original prompt

Implement Gmail draft-first safety guardrails: force all Gmail outbound paths through a draft-first workflow to prevent accidental sends, add CC/BCC support, auto reply-all for messaging_reply, and scan-result-store for server-side message ID storage.

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/skills.test.ts` — 44 pass, 0 fail
- [ ] Manual: `messaging_send` for Gmail creates draft, not sends
- [ ] Manual: `messaging_reply` for Gmail creates threaded draft with reply-all
- [ ] Manual: `gmail_send_draft` sends existing draft
- [ ] Manual: `gmail_send_with_attachments` creates draft
- [ ] Manual: `gmail_forward` creates draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
