### PR TITLE
fix: resolve remaining lint errors (import sort, no-null-comparison)

### DIFF
--- a/assistant/src/__tests__/scan-result-store.test.ts
+++ b/assistant/src/__tests__/scan-result-store.test.ts
@@ -1,13 +1,14 @@
-import { describe, expect, it, beforeEach } from 'bun:test';
+import { beforeEach, describe, expect, it } from "bun:test";
+
 import {
-  storeScanResult,
+  _internals,
+  clearScanStore,
   getSenderMessageIds,
   getSenderMetadata,
-  clearScanStore,
-  _internals,
-} from '../config/bundled-skills/messaging/tools/scan-result-store.js';
+  storeScanResult,
+} from "../config/bundled-skills/messaging/tools/scan-result-store.js";
 
-describe('scan-result-store', () => {
+describe("scan-result-store", () => {
   beforeEach(() => {
     clearScanStore();
   });
@@ -20,60 +21,82 @@ describe('scan-result-store', () => {
       newestUnsubscribableMessageId: i % 2 === 0 ? `msg-${i}-a` : null,
     }));
 
-  it('stores and retrieves message IDs', () => {
+  it("stores and retrieves message IDs", () => {
     const senders = makeSenders(3);
     const scanId = storeScanResult(senders);
 
-    const ids = getSenderMessageIds(scanId, ['sender-0', 'sender-2']);
-    expect(ids).toEqual(['msg-0-a', 'msg-0-b', 'msg-2-a', 'msg-2-b']);
+    const ids = getSenderMessageIds(scanId, ["sender-0", "sender-2"]);
+    expect(ids).toEqual(["msg-0-a", "msg-0-b", "msg-2-a", "msg-2-b"]);
   });
 
-  it('returns null for unknown scan ID', () => {
-    expect(getSenderMessageIds('nonexistent', ['sender-0'])).toBeNull();
+  it("returns null for unknown scan ID", () => {
+    expect(getSenderMessageIds("nonexistent", ["sender-0"])).toBeNull();
   });
 
-  it('returns empty array for unknown sender IDs', () => {
+  it("returns empty array for unknown sender IDs", () => {
     const scanId = storeScanResult(makeSenders(1));
-    const ids = getSenderMessageIds(scanId, ['unknown-sender']);
+    const ids = getSenderMessageIds(scanId, ["unknown-sender"]);
     expect(ids).toEqual([]);
   });
 
-  it('retrieves sender metadata', () => {
+  it("retrieves sender metadata", () => {
     const senders = makeSenders(2);
     const scanId = storeScanResult(senders);
 
-    const meta0 = getSenderMetadata(scanId, 'sender-0');
-    expect(meta0).toEqual({ newestMessageId: 'msg-0-a', newestUnsubscribableMessageId: 'msg-0-a' });
+    const meta0 = getSenderMetadata(scanId, "sender-0");
+    expect(meta0).toEqual({
+      newestMessageId: "msg-0-a",
+      newestUnsubscribableMessageId: "msg-0-a",
+    });
 
-    const meta1 = getSenderMetadata(scanId, 'sender-1');
-    expect(meta1).toEqual({ newestMessageId: 'msg-1-a', newestUnsubscribableMessageId: null });
+    const meta1 = getSenderMetadata(scanId, "sender-1");
+    expect(meta1).toEqual({
+      newestMessageId: "msg-1-a",
+      newestUnsubscribableMessageId: null,
+    });
   });
 
-  it('returns null metadata for unknown sender', () => {
+  it("returns null metadata for unknown sender", () => {
     const scanId = storeScanResult(makeSenders(1));
-    expect(getSenderMetadata(scanId, 'unknown')).toBeNull();
+    expect(getSenderMetadata(scanId, "unknown")).toBeNull();
   });
 
-  it('evicts oldest entry when at capacity (LRU)', () => {
+  it("evicts oldest entry when at capacity (LRU)", () => {
     const scanIds: string[] = [];
     for (let i = 0; i < 16; i++) {
-      scanIds.push(storeScanResult([{ id: `s-${i}`, messageIds: [`m-${i}`], newestMessageId: `m-${i}`, newestUnsubscribableMessageId: null }]));
+      scanIds.push(
+        storeScanResult([
+          {
+            id: `s-${i}`,
+            messageIds: [`m-${i}`],
+            newestMessageId: `m-${i}`,
+            newestUnsubscribableMessageId: null,
+          },
+        ]),
+      );
     }
 
     // All 16 should be present
-    expect(getSenderMessageIds(scanIds[0], ['s-0'])).toEqual(['m-0']);
+    expect(getSenderMessageIds(scanIds[0], ["s-0"])).toEqual(["m-0"]);
 
     // Adding a 17th should evict the oldest (scanIds[0] was accessed last via getSenderMessageIds, so scanIds[1] is oldest)
-    const newId = storeScanResult([{ id: 's-new', messageIds: ['m-new'], newestMessageId: 'm-new', newestUnsubscribableMessageId: null }]);
+    const newId = storeScanResult([
+      {
+        id: "s-new",
+        messageIds: ["m-new"],
+        newestMessageId: "m-new",
+        newestUnsubscribableMessageId: null,
+      },
+    ]);
 
     // scanIds[1] should be evicted (it was the LRU after we accessed scanIds[0])
-    expect(getSenderMessageIds(scanIds[1], ['s-1'])).toBeNull();
+    expect(getSenderMessageIds(scanIds[1], ["s-1"])).toBeNull();
     // The new entry and scanIds[0] should still be present
-    expect(getSenderMessageIds(newId, ['s-new'])).toEqual(['m-new']);
-    expect(getSenderMessageIds(scanIds[0], ['s-0'])).toEqual(['m-0']);
+    expect(getSenderMessageIds(newId, ["s-new"])).toEqual(["m-new"]);
+    expect(getSenderMessageIds(scanIds[0], ["s-0"])).toEqual(["m-0"]);
   });
 
-  it('expires entries after TTL', () => {
+  it("expires entries after TTL", () => {
     const scanId = storeScanResult(makeSenders(1));
 
     // Manually age the entry beyond TTL
@@ -81,18 +104,18 @@ describe('scan-result-store', () => {
     expect(entry).toBeDefined();
     entry!.createdAt = Date.now() - _internals.TTL_MS - 1;
 
-    expect(getSenderMessageIds(scanId, ['sender-0'])).toBeNull();
+    expect(getSenderMessageIds(scanId, ["sender-0"])).toBeNull();
     // Entry should be cleaned up
     expect(_internals.store.has(scanId)).toBe(false);
   });
 
-  it('expires entries in getSenderMetadata after TTL', () => {
+  it("expires entries in getSenderMetadata after TTL", () => {
     const scanId = storeScanResult(makeSenders(1));
 
     const entry = _internals.store.get(scanId);
     entry!.createdAt = Date.now() - _internals.TTL_MS - 1;
 
-    expect(getSenderMetadata(scanId, 'sender-0')).toBeNull();
+    expect(getSenderMetadata(scanId, "sender-0")).toBeNull();
     expect(_internals.store.has(scanId)).toBe(false);
   });
 });

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-batch-archive.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-batch-archive.ts
@@ -1,15 +1,23 @@
-import { batchModifyMessages } from '../../../../messaging/providers/gmail/client.js';
-import { getMessagingProvider } from '../../../../messaging/registry.js';
-import { withValidToken } from '../../../../security/token-manager.js';
-import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
-import { getSenderMessageIds } from './scan-result-store.js';
-import { err,ok } from './shared.js';
+import { batchModifyMessages } from "../../../../messaging/providers/gmail/client.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { getSenderMessageIds } from "./scan-result-store.js";
+import { err, ok } from "./shared.js";
 
 const BATCH_MODIFY_LIMIT = 1000;
 
-export async function run(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
   if (!context.triggeredBySurfaceAction) {
-    return err('This tool requires user confirmation via a surface action. Present results in a selection table with action buttons and wait for the user to click before proceeding.');
+    return err(
+      "This tool requires user confirmation via a surface action. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
+    );
   }
 
   const scanId = input.scan_id as string | undefined;
@@ -19,22 +27,26 @@ export async function run(input: Record<string, unknown>, context: ToolContext):
   // Resolve message IDs from scan store if scan_id is provided
   if (scanId && senderIds?.length) {
     const resolved = getSenderMessageIds(scanId, senderIds);
-    if (resolved === null) {
-      return err('Scan results have expired (30-minute window). Please re-run the scan to get fresh results.');
+    if (!resolved) {
+      return err(
+        "Scan results have expired (30-minute window). Please re-run the scan to get fresh results.",
+      );
     }
     messageIds = resolved;
   }
 
   if (!messageIds?.length) {
-    return err('Either message_ids or scan_id + sender_ids is required, and must resolve to at least one message.');
+    return err(
+      "Either message_ids or scan_id + sender_ids is required, and must resolve to at least one message.",
+    );
   }
 
   try {
-    const provider = getMessagingProvider('gmail');
+    const provider = getMessagingProvider("gmail");
     return withValidToken(provider.credentialService, async (token) => {
       for (let i = 0; i < messageIds.length; i += BATCH_MODIFY_LIMIT) {
         const chunk = messageIds.slice(i, i + BATCH_MODIFY_LIMIT);
-        await batchModifyMessages(token, chunk, { removeLabelIds: ['INBOX'] });
+        await batchModifyMessages(token, chunk, { removeLabelIds: ["INBOX"] });
       }
       return ok(`Archived ${messageIds.length} message(s).`);
     });


### PR DESCRIPTION
## Summary
- Fix import sort order in `scan-result-store.test.ts`
- Replace `=== null` with `!resolved` (falsy check) in `gmail-batch-archive.ts` to satisfy `no-restricted-syntax` lint rule

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22604740929/job/65494243509

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
