### PR TITLE
fix: restore SIGN_IDENTITY in CI macOS build

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -81,6 +81,7 @@ jobs:
       - name: Build release .app
         working-directory: clients/macos
         run: |
+          SIGN_IDENTITY="Developer ID Application" \
           SKIP_CLEAN=1 \
           RELEASE_ARCH_FLAGS="--arch arm64" \
           ./build.sh release


### PR DESCRIPTION
## Summary
Restores `SIGN_IDENTITY="Developer ID Application"` to `ci-main-macos.yaml`, which was removed in #11401. Without it, `build.sh` auto-detects any available cert, masking certificate issues that then only surface during releases.

All other macOS workflows (`ci-nightly-release.yml`, `pr-macos.yaml`, `release.yml`) already specify this explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
