### PR TITLE
fix: add missing isUserMessage flag to POST /v1/messages idle path

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -595,7 +595,7 @@ export async function handleSendMessage(
 
     // Fire-and-forget the agent loop; events flow to the hub via onEvent.
     // Mark non-interactive so conflict clarification doesn't block the turn.
-    session.runAgentLoop(content ?? '', messageId, onEvent, { isInteractive: false }).catch((err) => {
+    session.runAgentLoop(content ?? '', messageId, onEvent, { isInteractive: false, isUserMessage: true }).catch((err) => {
       log.error({ err, conversationId: mapping.conversationId }, 'Agent loop failed (POST /messages)');
     });
 


### PR DESCRIPTION
Addresses review feedback from PR #11462. The stale-surface dismissal gate requires isUserMessage: true but the POST /v1/messages idle-session path was missing it, creating inconsistent behavior where user messages through the HTTP API wouldn't auto-dismiss stale surfaces.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
