### PR TITLE
fix: use proper email parsing for reply-all recipients

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts
@@ -6,6 +6,57 @@ function extractHeader(headers: Array<{ name: string; value: string }> | undefin
   return headers?.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value ?? '';
 }
 
+/**
+ * RFC 5322-aware address list parser. Splits a header value like
+ * `"Doe, Jane" <jane@example.com>, bob@example.com` into individual
+ * addresses without breaking on commas inside quoted display names.
+ */
+function parseAddressList(header: string): string[] {
+  const addresses: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  let inAngle = false;
+
+  for (let i = 0; i < header.length; i++) {
+    const ch = header[i];
+
+    if (ch === '"' && !inAngle) {
+      inQuotes = !inQuotes;
+      current += ch;
+    } else if (ch === '<' && !inQuotes) {
+      inAngle = true;
+      current += ch;
+    } else if (ch === '>' && !inQuotes) {
+      inAngle = false;
+      current += ch;
+    } else if (ch === ',' && !inQuotes && !inAngle) {
+      const trimmed = current.trim();
+      if (trimmed) addresses.push(trimmed);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+
+  const trimmed = current.trim();
+  if (trimmed) addresses.push(trimmed);
+
+  return addresses;
+}
+
+/**
+ * Extracts the bare email from an address that may be in any of these forms:
+ *   - `user@example.com`
+ *   - `<user@example.com>`
+ *   - `"Display Name" <user@example.com>`
+ *   - `Display Name <user@example.com>`
+ * Returns the lowercase bare email, or the lowercased full string as fallback.
+ */
+function extractEmail(address: string): string {
+  const match = address.match(/<([^>]+)>/);
+  return (match ? match[1] : address).trim().toLowerCase();
+}
+
 export async function run(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
   const platform = input.platform as string | undefined;
   const conversationId = input.conversation_id as string;
@@ -61,15 +112,15 @@ export async function run(input: Record<string, unknown>, context: ToolContext):
         const ccAddrs = extractHeader(latestHeaders, 'Cc');
 
         if (fromAddr) allRecipients.add(fromAddr);
-        for (const addr of toAddrs.split(',').map((a) => a.trim()).filter(Boolean)) {
+        for (const addr of parseAddressList(toAddrs)) {
           allRecipients.add(addr);
         }
-        for (const addr of ccAddrs.split(',').map((a) => a.trim()).filter(Boolean)) {
+        for (const addr of parseAddressList(ccAddrs)) {
           allCc.add(addr);
         }
 
-        // Remove user's own email from recipients
-        const filterSelf = (addr: string) => !addr.toLowerCase().includes(userEmail);
+        // Remove user's own email from recipients using exact email comparison
+        const filterSelf = (addr: string) => extractEmail(addr) !== userEmail;
         const toList = [...allRecipients].filter(filterSelf);
         const ccList = [...allCc].filter(filterSelf);
 


### PR DESCRIPTION
Addresses review feedback from PR #11486. Fixes two issues in messaging-reply.ts: (1) Replace comma split with RFC 5322-aware address parser to handle quoted display names containing commas. (2) Replace substring includes() with exact email comparison for self-filtering to prevent false positives.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
