### PR TITLE
fix: mock isHttpAuthDisabled in approval-routes-http test to bypass JWT auth

### DIFF
--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -4,42 +4,45 @@
  * Tests POST /v1/confirm, POST /v1/secret, and POST /v1/trust-rules
  * through RuntimeHttpServer with pending-interactions tracking.
  */
-import { mkdtempSync, realpathSync,rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { afterAll, beforeEach, describe, expect, mock,test } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { ServerMessage } from '../daemon/ipc-protocol.js';
-import type { Session } from '../daemon/session.js';
+import type { ServerMessage } from "../daemon/ipc-protocol.js";
+import type { Session } from "../daemon/session.js";
 
-const testDir = realpathSync(mkdtempSync(join(tmpdir(), 'approval-routes-http-test-')));
+const testDir = realpathSync(
+  mkdtempSync(join(tmpdir(), "approval-routes-http-test-")),
+);
 
-mock.module('../util/platform.js', () => ({
+mock.module("../util/platform.js", () => ({
   getRootDir: () => testDir,
   getDataDir: () => testDir,
-  isMacOS: () => process.platform === 'darwin',
-  isLinux: () => process.platform === 'linux',
-  isWindows: () => process.platform === 'win32',
-  getSocketPath: () => join(testDir, 'test.sock'),
-  getPidPath: () => join(testDir, 'test.pid'),
-  getDbPath: () => join(testDir, 'test.db'),
-  getLogPath: () => join(testDir, 'test.log'),
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getSocketPath: () => join(testDir, "test.sock"),
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
   ensureDataDir: () => {},
 }));
 
-mock.module('../util/logger.js', () => ({
-  getLogger: () => new Proxy({} as Record<string, unknown>, {
-    get: () => () => {},
-  }),
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
 }));
 
-mock.module('../config/loader.js', () => ({
+mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
-    
-    model: 'test',
-    provider: 'test',
+
+    model: "test",
+    provider: "test",
     apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
@@ -48,16 +51,36 @@ mock.module('../config/loader.js', () => ({
   }),
 }));
 
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  hasUngatedHttpAuthDisabled: () => false,
+  getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
+  getGatewayPort: () => 7830,
+  getRuntimeHttpPort: () => 7821,
+  getRuntimeHttpHost: () => "127.0.0.1",
+  getRuntimeProxyBearerToken: () => undefined,
+  getRuntimeGatewayOriginSecret: () => undefined,
+  getIngressPublicBaseUrl: () => undefined,
+  setIngressPublicBaseUrl: () => {},
+}));
+
 // Mock the trust store so addRule doesn't touch disk or require full config
-mock.module('../permissions/trust-store.js', () => ({
-  addRule: () => ({ id: 'test-rule', tool: 'test', pattern: '*', scope: 'everywhere', decision: 'allow', priority: 100 }),
+mock.module("../permissions/trust-store.js", () => ({
+  addRule: () => ({
+    id: "test-rule",
+    tool: "test",
+    pattern: "*",
+    scope: "everywhere",
+    decision: "allow",
+    priority: 100,
+  }),
   getRules: () => [],
 }));
 
-import { getDb, initializeDb, resetDb } from '../memory/db.js';
-import { AssistantEventHub } from '../runtime/assistant-event-hub.js';
-import { RuntimeHttpServer } from '../runtime/http-server.js';
-import * as pendingInteractions from '../runtime/pending-interactions.js';
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
+import { RuntimeHttpServer } from "../runtime/http-server.js";
+import * as pendingInteractions from "../runtime/pending-interactions.js";
 
 initializeDb();
 
@@ -72,11 +95,19 @@ function makeIdleSession(opts?: {
   let processing = false;
   return {
     isProcessing: () => processing,
-    persistUserMessage: (_content: string, _attachments: unknown[], requestId?: string) => {
+    persistUserMessage: (
+      _content: string,
+      _attachments: unknown[],
+      requestId?: string,
+    ) => {
       processing = true;
-      return requestId ?? 'msg-1';
+      return requestId ?? "msg-1";
     },
-    memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
+    memoryPolicy: {
+      scopeId: "default",
+      includeDefaultFallback: false,
+      strictSideEffects: false,
+    },
     setChannelCapabilities: () => {},
     setAssistantId: () => {},
     setGuardianContext: () => {},
@@ -85,17 +116,25 @@ function makeIdleSession(opts?: {
     setTurnInterfaceContext: () => {},
     setStateSignalListener: () => {},
     updateClient: () => {},
-    enqueueMessage: () => ({ queued: false, requestId: 'noop' }),
+    enqueueMessage: () => ({ queued: false, requestId: "noop" }),
     hasAnyPendingConfirmation: () => false,
-    runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
-      onEvent({ type: 'assistant_text_delta', text: 'Hello!' });
-      onEvent({ type: 'message_complete', sessionId: 'test-session' });
+    runAgentLoop: async (
+      _content: string,
+      _messageId: string,
+      onEvent: (msg: ServerMessage) => void,
+    ) => {
+      onEvent({ type: "assistant_text_delta", text: "Hello!" });
+      onEvent({ type: "message_complete", sessionId: "test-session" });
       processing = false;
     },
     handleConfirmationResponse: (requestId: string, decision: string) => {
       opts?.onConfirmation?.(requestId, decision);
     },
-    handleSecretResponse: (requestId: string, value?: string, delivery?: string) => {
+    handleSecretResponse: (
+      requestId: string,
+      value?: string,
+      delivery?: string,
+    ) => {
       opts?.onSecret?.(requestId, value, delivery);
     },
   } as unknown as Session;
@@ -111,15 +150,23 @@ function makeConfirmationEmittingSession(opts?: {
   toolName?: string;
 }): Session {
   let processing = false;
-  const reqId = opts?.confirmRequestId ?? 'confirm-req-1';
-  const tool = opts?.toolName ?? 'shell_command';
+  const reqId = opts?.confirmRequestId ?? "confirm-req-1";
+  const tool = opts?.toolName ?? "shell_command";
   return {
     isProcessing: () => processing,
-    persistUserMessage: (_content: string, _attachments: unknown[], requestId?: string) => {
+    persistUserMessage: (
+      _content: string,
+      _attachments: unknown[],
+      requestId?: string,
+    ) => {
       processing = true;
-      return requestId ?? 'msg-1';
+      return requestId ?? "msg-1";
     },
-    memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
+    memoryPolicy: {
+      scopeId: "default",
+      includeDefaultFallback: false,
+      strictSideEffects: false,
+    },
     setChannelCapabilities: () => {},
     setAssistantId: () => {},
     setGuardianContext: () => {},
@@ -128,23 +175,25 @@ function makeConfirmationEmittingSession(opts?: {
     setTurnInterfaceContext: () => {},
     setStateSignalListener: () => {},
     updateClient: () => {},
-    enqueueMessage: () => ({ queued: false, requestId: 'noop' }),
+    enqueueMessage: () => ({ queued: false, requestId: "noop" }),
     hasAnyPendingConfirmation: () => false,
-    runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
+    runAgentLoop: async (
+      _content: string,
+      _messageId: string,
+      onEvent: (msg: ServerMessage) => void,
+    ) => {
       // Emit confirmation_request — this triggers the hub publisher to register
       // the pending interaction
       onEvent({
-        type: 'confirmation_request',
+        type: "confirmation_request",
         requestId: reqId,
         toolName: tool,
-        input: { command: 'ls' },
-        riskLevel: 'medium',
+        input: { command: "ls" },
+        riskLevel: "medium",
         allowlistOptions: [
-          { label: 'Allow ls', description: 'Allow ls command', pattern: 'ls' },
+          { label: "Allow ls", description: "Allow ls command", pattern: "ls" },
         ],
-        scopeOptions: [
-          { label: 'This session', scope: 'session' },
-        ],
+        scopeOptions: [{ label: "This session", scope: "session" }],
         persistentDecisionsAllowed: true,
       });
       // Hang to simulate waiting for decision
@@ -161,26 +210,30 @@ function makeConfirmationEmittingSession(opts?: {
 // Tests
 // ---------------------------------------------------------------------------
 
-const TEST_TOKEN = 'test-bearer-token-approvals';
+const TEST_TOKEN = "test-bearer-token-approvals";
 const AUTH_HEADERS = { Authorization: `Bearer ${TEST_TOKEN}` };
 
-describe('standalone approval endpoints — HTTP layer', () => {
+describe("standalone approval endpoints — HTTP layer", () => {
   let server: RuntimeHttpServer;
   let port: number;
   let eventHub: AssistantEventHub;
 
   beforeEach(() => {
     const db = getDb();
-    db.run('DELETE FROM messages');
-    db.run('DELETE FROM conversations');
-    db.run('DELETE FROM conversation_keys');
+    db.run("DELETE FROM messages");
+    db.run("DELETE FROM conversations");
+    db.run("DELETE FROM conversation_keys");
     pendingInteractions.clear();
     eventHub = new AssistantEventHub();
   });
 
   afterAll(() => {
     resetDb();
-    try { rmSync(testDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
   });
 
   async function startServer(sessionFactory: () => Session): Promise<void> {
@@ -207,8 +260,8 @@ describe('standalone approval endpoints — HTTP layer', () => {
 
   // ── POST /v1/confirm ─────────────────────────────────────────────────
 
-  describe('POST /v1/confirm', () => {
-    test('resolves a pending confirmation by requestId', async () => {
+  describe("POST /v1/confirm", () => {
+    test("resolves a pending confirmation by requestId", async () => {
       let confirmedRequestId: string | undefined;
       let confirmedDecision: string | undefined;
 
@@ -222,44 +275,44 @@ describe('standalone approval endpoints — HTTP layer', () => {
       await startServer(() => session);
 
       // Manually register a pending interaction
-      pendingInteractions.register('req-abc', {
+      pendingInteractions.register("req-abc", {
         session,
-        conversationId: 'conv-1',
-        kind: 'confirmation',
+        conversationId: "conv-1",
+        kind: "confirmation",
         confirmationDetails: {
-          toolName: 'shell_command',
-          input: { command: 'ls' },
-          riskLevel: 'medium',
+          toolName: "shell_command",
+          input: { command: "ls" },
+          riskLevel: "medium",
           allowlistOptions: [],
           scopeOptions: [],
         },
       });
 
-      const res = await fetch(url('confirm'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ requestId: 'req-abc', decision: 'allow' }),
+      const res = await fetch(url("confirm"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({ requestId: "req-abc", decision: "allow" }),
       });
-      const body = await res.json() as { accepted: boolean };
+      const body = (await res.json()) as { accepted: boolean };
 
       expect(res.status).toBe(200);
       expect(body.accepted).toBe(true);
-      expect(confirmedRequestId).toBe('req-abc');
-      expect(confirmedDecision).toBe('allow');
+      expect(confirmedRequestId).toBe("req-abc");
+      expect(confirmedDecision).toBe("allow");
 
       // Interaction should be removed after resolution
-      expect(pendingInteractions.get('req-abc')).toBeUndefined();
+      expect(pendingInteractions.get("req-abc")).toBeUndefined();
 
       await stopServer();
     });
 
-    test('returns 404 for unknown requestId', async () => {
+    test("returns 404 for unknown requestId", async () => {
       await startServer(() => makeIdleSession());
 
-      const res = await fetch(url('confirm'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ requestId: 'nonexistent', decision: 'allow' }),
+      const res = await fetch(url("confirm"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({ requestId: "nonexistent", decision: "allow" }),
       });
 
       expect(res.status).toBe(404);
@@ -267,42 +320,42 @@ describe('standalone approval endpoints — HTTP layer', () => {
       await stopServer();
     });
 
-    test('returns 404 for already-resolved requestId', async () => {
+    test("returns 404 for already-resolved requestId", async () => {
       const session = makeIdleSession();
       await startServer(() => session);
 
-      pendingInteractions.register('req-once', {
+      pendingInteractions.register("req-once", {
         session,
-        conversationId: 'conv-1',
-        kind: 'confirmation',
+        conversationId: "conv-1",
+        kind: "confirmation",
       });
 
       // First resolution succeeds
-      const res1 = await fetch(url('confirm'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ requestId: 'req-once', decision: 'allow' }),
+      const res1 = await fetch(url("confirm"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({ requestId: "req-once", decision: "allow" }),
       });
       expect(res1.status).toBe(200);
 
       // Second resolution fails (already consumed)
-      const res2 = await fetch(url('confirm'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ requestId: 'req-once', decision: 'deny' }),
+      const res2 = await fetch(url("confirm"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({ requestId: "req-once", decision: "deny" }),
       });
       expect(res2.status).toBe(404);
 
       await stopServer();
     });
 
-    test('returns 400 for missing requestId', async () => {
+    test("returns 400 for missing requestId", async () => {
       await startServer(() => makeIdleSession());
 
-      const res = await fetch(url('confirm'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ decision: 'allow' }),
+      const res = await fetch(url("confirm"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({ decision: "allow" }),
       });
 
       expect(res.status).toBe(400);
@@ -310,13 +363,13 @@ describe('standalone approval endpoints — HTTP layer', () => {
       await stopServer();
     });
 
-    test('returns 400 for invalid decision', async () => {
+    test("returns 400 for invalid decision", async () => {
       await startServer(() => makeIdleSession());
 
-      const res = await fetch(url('confirm'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ requestId: 'req-1', decision: 'maybe' }),
+      const res = await fetch(url("confirm"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({ requestId: "req-1", decision: "maybe" }),
       });
 
       expect(res.status).toBe(400);
@@ -327,8 +380,8 @@ describe('standalone approval endpoints — HTTP layer', () => {
 
   // ── POST /v1/secret ──────────────────────────────────────────────────
 
-  describe('POST /v1/secret', () => {
-    test('resolves a pending secret request by requestId', async () => {
+  describe("POST /v1/secret", () => {
+    test("resolves a pending secret request by requestId", async () => {
       let secretRequestId: string | undefined;
       let secretValue: string | undefined;
       let secretDelivery: string | undefined;
@@ -343,38 +396,42 @@ describe('standalone approval endpoints — HTTP layer', () => {
 
       await startServer(() => session);
 
-      pendingInteractions.register('secret-req-1', {
+      pendingInteractions.register("secret-req-1", {
         session,
-        conversationId: 'conv-1',
-        kind: 'secret',
+        conversationId: "conv-1",
+        kind: "secret",
       });
 
-      const res = await fetch(url('secret'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ requestId: 'secret-req-1', value: 'my-secret-key', delivery: 'store' }),
+      const res = await fetch(url("secret"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({
+          requestId: "secret-req-1",
+          value: "my-secret-key",
+          delivery: "store",
+        }),
       });
-      const body = await res.json() as { accepted: boolean };
+      const body = (await res.json()) as { accepted: boolean };
 
       expect(res.status).toBe(200);
       expect(body.accepted).toBe(true);
-      expect(secretRequestId).toBe('secret-req-1');
-      expect(secretValue).toBe('my-secret-key');
-      expect(secretDelivery).toBe('store');
+      expect(secretRequestId).toBe("secret-req-1");
+      expect(secretValue).toBe("my-secret-key");
+      expect(secretDelivery).toBe("store");
 
       // Interaction should be removed after resolution
-      expect(pendingInteractions.get('secret-req-1')).toBeUndefined();
+      expect(pendingInteractions.get("secret-req-1")).toBeUndefined();
 
       await stopServer();
     });
 
-    test('returns 404 for unknown requestId', async () => {
+    test("returns 404 for unknown requestId", async () => {
       await startServer(() => makeIdleSession());
 
-      const res = await fetch(url('secret'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ requestId: 'nonexistent', value: 'test' }),
+      const res = await fetch(url("secret"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({ requestId: "nonexistent", value: "test" }),
       });
 
       expect(res.status).toBe(404);
@@ -382,13 +439,13 @@ describe('standalone approval endpoints — HTTP layer', () => {
       await stopServer();
     });
 
-    test('returns 400 for missing requestId', async () => {
+    test("returns 400 for missing requestId", async () => {
       await startServer(() => makeIdleSession());
 
-      const res = await fetch(url('secret'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ value: 'test' }),
+      const res = await fetch(url("secret"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({ value: "test" }),
       });
 
       expect(res.status).toBe(400);
@@ -396,13 +453,17 @@ describe('standalone approval endpoints — HTTP layer', () => {
       await stopServer();
     });
 
-    test('returns 400 for invalid delivery', async () => {
+    test("returns 400 for invalid delivery", async () => {
       await startServer(() => makeIdleSession());
 
-      const res = await fetch(url('secret'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ requestId: 'req-1', value: 'test', delivery: 'invalid' }),
+      const res = await fetch(url("secret"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({
+          requestId: "req-1",
+          value: "test",
+          delivery: "invalid",
+        }),
       });
 
       expect(res.status).toBe(400);
@@ -413,14 +474,19 @@ describe('standalone approval endpoints — HTTP layer', () => {
 
   // ── POST /v1/trust-rules ─────────────────────────────────────────────
 
-  describe('POST /v1/trust-rules', () => {
-    test('returns 404 for unknown requestId', async () => {
+  describe("POST /v1/trust-rules", () => {
+    test("returns 404 for unknown requestId", async () => {
       await startServer(() => makeIdleSession());
 
-      const res = await fetch(url('trust-rules'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ requestId: 'nonexistent', pattern: 'ls', scope: 'session', decision: 'allow' }),
+      const res = await fetch(url("trust-rules"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({
+          requestId: "nonexistent",
+          pattern: "ls",
+          scope: "session",
+          decision: "allow",
+        }),
       });
 
       expect(res.status).toBe(404);
@@ -428,13 +494,17 @@ describe('standalone approval endpoints — HTTP layer', () => {
       await stopServer();
     });
 
-    test('returns 400 for missing requestId', async () => {
+    test("returns 400 for missing requestId", async () => {
       await startServer(() => makeIdleSession());
 
-      const res = await fetch(url('trust-rules'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ pattern: 'ls', scope: 'session', decision: 'allow' }),
+      const res = await fetch(url("trust-rules"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({
+          pattern: "ls",
+          scope: "session",
+          decision: "allow",
+        }),
       });
 
       expect(res.status).toBe(400);
@@ -442,13 +512,17 @@ describe('standalone approval endpoints — HTTP layer', () => {
       await stopServer();
     });
 
-    test('returns 400 for missing pattern', async () => {
+    test("returns 400 for missing pattern", async () => {
       await startServer(() => makeIdleSession());
 
-      const res = await fetch(url('trust-rules'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ requestId: 'req-1', scope: 'session', decision: 'allow' }),
+      const res = await fetch(url("trust-rules"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({
+          requestId: "req-1",
+          scope: "session",
+          decision: "allow",
+        }),
       });
 
       expect(res.status).toBe(400);
@@ -456,13 +530,17 @@ describe('standalone approval endpoints — HTTP layer', () => {
       await stopServer();
     });
 
-    test('returns 400 for missing scope', async () => {
+    test("returns 400 for missing scope", async () => {
       await startServer(() => makeIdleSession());
 
-      const res = await fetch(url('trust-rules'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ requestId: 'req-1', pattern: 'ls', decision: 'allow' }),
+      const res = await fetch(url("trust-rules"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({
+          requestId: "req-1",
+          pattern: "ls",
+          decision: "allow",
+        }),
       });
 
       expect(res.status).toBe(400);
@@ -470,13 +548,18 @@ describe('standalone approval endpoints — HTTP layer', () => {
       await stopServer();
     });
 
-    test('returns 400 for invalid decision', async () => {
+    test("returns 400 for invalid decision", async () => {
       await startServer(() => makeIdleSession());
 
-      const res = await fetch(url('trust-rules'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ requestId: 'req-1', pattern: 'ls', scope: 'session', decision: 'maybe' }),
+      const res = await fetch(url("trust-rules"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({
+          requestId: "req-1",
+          pattern: "ls",
+          scope: "session",
+          decision: "maybe",
+        }),
       });
 
       expect(res.status).toBe(400);
@@ -484,21 +567,26 @@ describe('standalone approval endpoints — HTTP layer', () => {
       await stopServer();
     });
 
-    test('returns 409 when no confirmation details available', async () => {
+    test("returns 409 when no confirmation details available", async () => {
       const session = makeIdleSession();
       await startServer(() => session);
 
       // Register without confirmationDetails
-      pendingInteractions.register('req-no-details', {
+      pendingInteractions.register("req-no-details", {
         session,
-        conversationId: 'conv-1',
-        kind: 'secret',
+        conversationId: "conv-1",
+        kind: "secret",
       });
 
-      const res = await fetch(url('trust-rules'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ requestId: 'req-no-details', pattern: 'ls', scope: 'session', decision: 'allow' }),
+      const res = await fetch(url("trust-rules"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({
+          requestId: "req-no-details",
+          pattern: "ls",
+          scope: "session",
+          decision: "allow",
+        }),
       });
 
       expect(res.status).toBe(409);
@@ -506,28 +594,35 @@ describe('standalone approval endpoints — HTTP layer', () => {
       await stopServer();
     });
 
-    test('returns 403 when persistent decisions are not allowed', async () => {
+    test("returns 403 when persistent decisions are not allowed", async () => {
       const session = makeIdleSession();
       await startServer(() => session);
 
-      pendingInteractions.register('req-no-persist', {
+      pendingInteractions.register("req-no-persist", {
         session,
-        conversationId: 'conv-1',
-        kind: 'confirmation',
+        conversationId: "conv-1",
+        kind: "confirmation",
         confirmationDetails: {
-          toolName: 'shell_command',
-          input: { command: 'rm -rf' },
-          riskLevel: 'high',
-          allowlistOptions: [{ label: 'Allow', description: 'test', pattern: 'rm' }],
-          scopeOptions: [{ label: 'Session', scope: 'session' }],
+          toolName: "shell_command",
+          input: { command: "rm -rf" },
+          riskLevel: "high",
+          allowlistOptions: [
+            { label: "Allow", description: "test", pattern: "rm" },
+          ],
+          scopeOptions: [{ label: "Session", scope: "session" }],
           persistentDecisionsAllowed: false,
         },
       });
 
-      const res = await fetch(url('trust-rules'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ requestId: 'req-no-persist', pattern: 'rm', scope: 'session', decision: 'allow' }),
+      const res = await fetch(url("trust-rules"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({
+          requestId: "req-no-persist",
+          pattern: "rm",
+          scope: "session",
+          decision: "allow",
+        }),
       });
 
       expect(res.status).toBe(403);
@@ -535,93 +630,118 @@ describe('standalone approval endpoints — HTTP layer', () => {
       await stopServer();
     });
 
-    test('returns 403 when pattern does not match allowlist', async () => {
+    test("returns 403 when pattern does not match allowlist", async () => {
       const session = makeIdleSession();
       await startServer(() => session);
 
-      pendingInteractions.register('req-bad-pattern', {
+      pendingInteractions.register("req-bad-pattern", {
         session,
-        conversationId: 'conv-1',
-        kind: 'confirmation',
+        conversationId: "conv-1",
+        kind: "confirmation",
         confirmationDetails: {
-          toolName: 'shell_command',
-          input: { command: 'ls' },
-          riskLevel: 'medium',
-          allowlistOptions: [{ label: 'Allow ls', description: 'test', pattern: 'ls' }],
-          scopeOptions: [{ label: 'Session', scope: 'session' }],
+          toolName: "shell_command",
+          input: { command: "ls" },
+          riskLevel: "medium",
+          allowlistOptions: [
+            { label: "Allow ls", description: "test", pattern: "ls" },
+          ],
+          scopeOptions: [{ label: "Session", scope: "session" }],
         },
       });
 
-      const res = await fetch(url('trust-rules'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ requestId: 'req-bad-pattern', pattern: 'rm', scope: 'session', decision: 'allow' }),
+      const res = await fetch(url("trust-rules"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({
+          requestId: "req-bad-pattern",
+          pattern: "rm",
+          scope: "session",
+          decision: "allow",
+        }),
       });
 
       expect(res.status).toBe(403);
-      const body = await res.json() as { error: { message: string; code?: string } };
-      expect(body.error.message).toContain('pattern');
+      const body = (await res.json()) as {
+        error: { message: string; code?: string };
+      };
+      expect(body.error.message).toContain("pattern");
 
       await stopServer();
     });
 
-    test('returns 403 when scope does not match scope options', async () => {
+    test("returns 403 when scope does not match scope options", async () => {
       const session = makeIdleSession();
       await startServer(() => session);
 
-      pendingInteractions.register('req-bad-scope', {
+      pendingInteractions.register("req-bad-scope", {
         session,
-        conversationId: 'conv-1',
-        kind: 'confirmation',
+        conversationId: "conv-1",
+        kind: "confirmation",
         confirmationDetails: {
-          toolName: 'shell_command',
-          input: { command: 'ls' },
-          riskLevel: 'medium',
-          allowlistOptions: [{ label: 'Allow ls', description: 'test', pattern: 'ls' }],
-          scopeOptions: [{ label: 'Session', scope: 'session' }],
+          toolName: "shell_command",
+          input: { command: "ls" },
+          riskLevel: "medium",
+          allowlistOptions: [
+            { label: "Allow ls", description: "test", pattern: "ls" },
+          ],
+          scopeOptions: [{ label: "Session", scope: "session" }],
         },
       });
 
-      const res = await fetch(url('trust-rules'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ requestId: 'req-bad-scope', pattern: 'ls', scope: 'global', decision: 'allow' }),
+      const res = await fetch(url("trust-rules"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({
+          requestId: "req-bad-scope",
+          pattern: "ls",
+          scope: "global",
+          decision: "allow",
+        }),
       });
 
       expect(res.status).toBe(403);
-      const body = await res.json() as { error: { message: string; code?: string } };
-      expect(body.error.message).toContain('scope');
+      const body = (await res.json()) as {
+        error: { message: string; code?: string };
+      };
+      expect(body.error.message).toContain("scope");
 
       await stopServer();
     });
 
-    test('does not remove the pending interaction after adding trust rule', async () => {
+    test("does not remove the pending interaction after adding trust rule", async () => {
       const session = makeIdleSession();
       await startServer(() => session);
 
-      pendingInteractions.register('req-keep', {
+      pendingInteractions.register("req-keep", {
         session,
-        conversationId: 'conv-1',
-        kind: 'confirmation',
+        conversationId: "conv-1",
+        kind: "confirmation",
         confirmationDetails: {
-          toolName: 'shell_command',
-          input: { command: 'ls' },
-          riskLevel: 'medium',
-          allowlistOptions: [{ label: 'Allow ls', description: 'test', pattern: 'ls' }],
-          scopeOptions: [{ label: 'Session', scope: 'session' }],
+          toolName: "shell_command",
+          input: { command: "ls" },
+          riskLevel: "medium",
+          allowlistOptions: [
+            { label: "Allow ls", description: "test", pattern: "ls" },
+          ],
+          scopeOptions: [{ label: "Session", scope: "session" }],
         },
       });
 
-      const res = await fetch(url('trust-rules'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ requestId: 'req-keep', pattern: 'ls', scope: 'session', decision: 'allow' }),
+      const res = await fetch(url("trust-rules"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({
+          requestId: "req-keep",
+          pattern: "ls",
+          scope: "session",
+          decision: "allow",
+        }),
       });
 
       expect(res.status).toBe(200);
 
       // Interaction should still be present (not consumed)
-      expect(pendingInteractions.get('req-keep')).toBeDefined();
+      expect(pendingInteractions.get("req-keep")).toBeDefined();
 
       await stopServer();
     });
@@ -629,13 +749,14 @@ describe('standalone approval endpoints — HTTP layer', () => {
 
   // ── Hub publisher integration ────────────────────────────────────────
 
-  describe('hub publisher registers pending interactions', () => {
-    test('confirmation_request events register pending interactions', async () => {
-      const confirmReceived: Array<{ requestId: string; decision: string }> = [];
+  describe("hub publisher registers pending interactions", () => {
+    test("confirmation_request events register pending interactions", async () => {
+      const confirmReceived: Array<{ requestId: string; decision: string }> =
+        [];
 
       const session = makeConfirmationEmittingSession({
-        confirmRequestId: 'auto-req-1',
-        toolName: 'shell_command',
+        confirmRequestId: "auto-req-1",
+        toolName: "shell_command",
         onConfirmation: (reqId, dec) => {
           confirmReceived.push({ requestId: reqId, decision: dec });
         },
@@ -644,10 +765,15 @@ describe('standalone approval endpoints — HTTP layer', () => {
       await startServer(() => session);
 
       // Send a message that triggers a confirmation_request
-      const res = await fetch(url('messages'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ conversationKey: 'conv-auto', content: 'Run ls', sourceChannel: 'vellum', interface: 'macos' }),
+      const res = await fetch(url("messages"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({
+          conversationKey: "conv-auto",
+          content: "Run ls",
+          sourceChannel: "vellum",
+          interface: "macos",
+        }),
       });
       expect(res.status).toBe(202);
 
@@ -655,22 +781,22 @@ describe('standalone approval endpoints — HTTP layer', () => {
       await new Promise((r) => setTimeout(r, 100));
 
       // The pending interaction should have been auto-registered
-      const interaction = pendingInteractions.get('auto-req-1');
+      const interaction = pendingInteractions.get("auto-req-1");
       expect(interaction).toBeDefined();
-      expect(interaction!.kind).toBe('confirmation');
-      expect(interaction!.confirmationDetails?.toolName).toBe('shell_command');
+      expect(interaction!.kind).toBe("confirmation");
+      expect(interaction!.confirmationDetails?.toolName).toBe("shell_command");
 
       // Now resolve it via the confirm endpoint
-      const confirmRes = await fetch(url('confirm'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ requestId: 'auto-req-1', decision: 'allow' }),
+      const confirmRes = await fetch(url("confirm"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({ requestId: "auto-req-1", decision: "allow" }),
       });
       expect(confirmRes.status).toBe(200);
 
       expect(confirmReceived).toHaveLength(1);
-      expect(confirmReceived[0].requestId).toBe('auto-req-1');
-      expect(confirmReceived[0].decision).toBe('allow');
+      expect(confirmReceived[0].requestId).toBe("auto-req-1");
+      expect(confirmReceived[0].decision).toBe("allow");
 
       await stopServer();
     });
@@ -678,36 +804,39 @@ describe('standalone approval endpoints — HTTP layer', () => {
 
   // ── getByConversation ────────────────────────────────────────────────
 
-  describe('getByConversation', () => {
-    test('returns all pending interactions for a conversation', async () => {
+  describe("getByConversation", () => {
+    test("returns all pending interactions for a conversation", async () => {
       const session = makeIdleSession();
       await startServer(() => session);
 
-      pendingInteractions.register('req-a', {
+      pendingInteractions.register("req-a", {
         session,
-        conversationId: 'conv-x',
-        kind: 'confirmation',
+        conversationId: "conv-x",
+        kind: "confirmation",
       });
-      pendingInteractions.register('req-b', {
+      pendingInteractions.register("req-b", {
         session,
-        conversationId: 'conv-x',
-        kind: 'secret',
+        conversationId: "conv-x",
+        kind: "secret",
       });
-      pendingInteractions.register('req-c', {
+      pendingInteractions.register("req-c", {
         session,
-        conversationId: 'conv-y',
-        kind: 'confirmation',
+        conversationId: "conv-y",
+        kind: "confirmation",
       });
 
-      const results = pendingInteractions.getByConversation('conv-x');
+      const results = pendingInteractions.getByConversation("conv-x");
       expect(results).toHaveLength(2);
-      expect(results.map((r) => r.requestId).sort()).toEqual(['req-a', 'req-b']);
+      expect(results.map((r) => r.requestId).sort()).toEqual([
+        "req-a",
+        "req-b",
+      ]);
 
-      const resultsY = pendingInteractions.getByConversation('conv-y');
+      const resultsY = pendingInteractions.getByConversation("conv-y");
       expect(resultsY).toHaveLength(1);
-      expect(resultsY[0].requestId).toBe('req-c');
+      expect(resultsY[0].requestId).toBe("req-c");
 
-      const resultsZ = pendingInteractions.getByConversation('conv-z');
+      const resultsZ = pendingInteractions.getByConversation("conv-z");
       expect(resultsZ).toHaveLength(0);
 
       await stopServer();


### PR DESCRIPTION
## Summary

- Mock `config/env.js` with `isHttpAuthDisabled: () => true` in `approval-routes-http.test.ts` so the auth middleware uses the dev bypass path instead of attempting JWT verification on a plain bearer token
- Matches the pattern used by other HTTP integration tests in the codebase

## Original prompt
fix: mock isHttpAuthDisabled in approval-routes-http test to bypass JWT auth

The test was passing a plain bearer token but the auth middleware now requires JWT verification. Mock `config/env.js` with `isHttpAuthDisabled: () => true` so the auth middleware uses the dev bypass path, matching other HTTP integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
