### PR TITLE
fix: replace opaque bearer tokens with JWT in daemon-to-gateway delivery paths

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -1209,7 +1209,7 @@ describe('expired guardian approval auto-denies via sweep', () => {
     });
 
     // Run the sweep
-    sweepExpiredGuardianApprovals('https://gateway.test', 'token');
+    sweepExpiredGuardianApprovals('https://gateway.test', () => 'token');
 
     // Wait for async notifications
     await new Promise((resolve) => setTimeout(resolve, 200));
@@ -1262,7 +1262,7 @@ describe('expired guardian approval auto-denies via sweep', () => {
       expiresAt: Date.now() + 300_000, // still valid
     });
 
-    sweepExpiredGuardianApprovals('https://gateway.test', 'token');
+    sweepExpiredGuardianApprovals('https://gateway.test', () => 'token');
 
     await new Promise((resolve) => setTimeout(resolve, 200));
 

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -949,7 +949,7 @@ export class CallController {
           canonicalDeliveries,
           this.assistantId,
           getGatewayInternalBaseUrl(),
-          mintDaemonDeliveryToken(),
+          () => mintDaemonDeliveryToken(),
         ).catch((err) => {
           log.error(
             { err, callSessionId: this.callSessionId, requestId: pendingActionRequest.id },

--- a/assistant/src/calls/guardian-action-sweep.ts
+++ b/assistant/src/calls/guardian-action-sweep.ts
@@ -49,7 +49,7 @@ export async function sendGuardianExpiryNotices(
   deliveries: ExpiryDeliveryInfo[],
   assistantId: string,
   gatewayBaseUrl: string,
-  bearerToken?: string,
+  mintBearerToken?: () => string,
   guardianActionCopyGenerator?: GuardianActionCopyGenerator,
 ): Promise<void> {
   for (const delivery of deliveries) {
@@ -80,7 +80,7 @@ export async function sendGuardianExpiryNotices(
           chatId: delivery.destinationChatId,
           text: expiryText,
           assistantId,
-        }, bearerToken);
+        }, mintBearerToken?.());
       }
     } catch (err) {
       log.error(
@@ -96,7 +96,7 @@ export async function sendGuardianExpiryNotices(
  */
 export async function sweepExpiredGuardianActions(
   gatewayBaseUrl: string,
-  bearerToken?: string,
+  mintBearerToken?: () => string,
   guardianActionCopyGenerator?: GuardianActionCopyGenerator,
 ): Promise<void> {
   const expired = getExpiredGuardianActionRequests();
@@ -120,7 +120,7 @@ export async function sweepExpiredGuardianActions(
       deliveries,
       request.assistantId,
       gatewayBaseUrl,
-      bearerToken,
+      mintBearerToken,
       guardianActionCopyGenerator,
     );
   }
@@ -128,7 +128,7 @@ export async function sweepExpiredGuardianActions(
 
 export function startGuardianActionSweep(
   gatewayBaseUrl: string,
-  bearerToken?: string,
+  mintBearerToken?: () => string,
   guardianActionCopyGenerator?: GuardianActionCopyGenerator,
 ): void {
   if (sweepTimer) return;
@@ -136,7 +136,7 @@ export function startGuardianActionSweep(
     if (sweepInProgress) return;
     sweepInProgress = true;
     try {
-      await sweepExpiredGuardianActions(gatewayBaseUrl, bearerToken, guardianActionCopyGenerator);
+      await sweepExpiredGuardianActions(gatewayBaseUrl, mintBearerToken, guardianActionCopyGenerator);
     } catch (err) {
       log.error({ err }, 'Guardian action sweep failed');
     } finally {

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -6,7 +6,7 @@
  * - handleConnectAction: called when the ConversationRelay connection ends
  */
 
-import { getCallWelcomeGreeting, getRuntimeProxyBearerToken } from '../config/env.js';
+import { getCallWelcomeGreeting } from '../config/env.js';
 import { loadConfig } from '../config/loader.js';
 import { getTwilioRelayUrl } from '../inbound/public-ingress-urls.js';
 import { mintEdgeRelayToken } from '../runtime/auth/token-service.js';
@@ -262,9 +262,7 @@ function buildVoiceWebhookTwiml(
   }
   const welcomeGreeting = buildWelcomeGreeting(task, getCallWelcomeGreeting());
 
-  // Use the same token resolution the gateway uses for runtimeProxyBearerToken:
-  // env var override first, then the on-disk http-token file.
-  const relayToken = getRuntimeProxyBearerToken() ?? mintEdgeRelayToken();
+  const relayToken = mintEdgeRelayToken();
 
   // Propagate guardianVerificationSessionId as a TwiML <Parameter> for
   // observability. This is not the sole source of truth; the relay

--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -2,7 +2,8 @@ import * as net from 'node:net';
 
 import type { ChannelId } from '../../channels/types.js';
 import { isChannelId, isInterfaceId } from '../../channels/types.js';
-import { getGatewayInternalBaseUrl, getRuntimeProxyBearerToken } from '../../config/env.js';
+import { getGatewayInternalBaseUrl } from '../../config/env.js';
+import { mintDaemonDeliveryToken } from '../../runtime/auth/token-service.js';
 import { getLatestStoredPayload } from '../../memory/channel-delivery-store.js';
 import type { GuardianApprovalRequest } from '../../memory/channel-guardian-store.js';
 import {
@@ -325,7 +326,7 @@ async function executeApprove(
   const replyCallbackUrl = typeof payload?.replyCallbackUrl === 'string'
     ? payload.replyCallbackUrl
     : null;
-  const bearerToken = getRuntimeProxyBearerToken();
+  const bearerToken = mintDaemonDeliveryToken();
 
   if (replyCallbackUrl) {
     const binding = getBindingByConversation(conversationId);
@@ -372,7 +373,7 @@ async function executeDeny(
 
   const gatewayBaseUrl = getGatewayInternalBaseUrl();
   const deliverUrl = `${gatewayBaseUrl}/deliver/${sourceChannel}`;
-  const bearerToken = getRuntimeProxyBearerToken();
+  const bearerToken = mintDaemonDeliveryToken();
 
   const denialText = reason
     ? `Your message was reviewed and declined. Reason: ${reason}`

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -54,7 +54,7 @@ function parseGuardianRuntimeContext(value: unknown): GuardianRuntimeContext | u
  */
 export async function sweepFailedEvents(
   processMessage: MessageProcessor,
-  bearerToken: string | undefined,
+  mintBearerToken: (() => string) | undefined,
 ): Promise<void> {
   const events = channelDeliveryStore.getRetryableEvents();
   if (events.length === 0) return;
@@ -175,7 +175,7 @@ export async function sweepFailedEvents(
             event.conversationId,
             externalChatId,
             replyCallbackUrl,
-            bearerToken,
+            mintBearerToken?.(),
             assistantId,
             {
               startFromSegment: 0,

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -46,7 +46,7 @@ import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
 // Auth
 import { authenticateRequest } from './auth/middleware.js';
 import { enforcePolicy, getPolicy } from './auth/route-policy.js';
-import { verifyToken } from './auth/token-service.js';
+import { mintDaemonDeliveryToken, verifyToken } from './auth/token-service.js';
 import type { AuthContext } from './auth/types.js';
 import { sweepFailedEvents } from './channel-retry-sweep.js';
 import { httpError } from './http-errors.js';
@@ -302,6 +302,7 @@ export class RuntimeHttpServer {
   private server: ReturnType<typeof Bun.serve> | null = null;
   private port: number;
   private hostname: string;
+  /** Legacy shared secret for pairing routes (not used for delivery or auth). */
   private bearerToken: string | undefined;
   private processMessage?: MessageProcessor;
   private persistAndProcessMessage?: NonBlockingMessageProcessor;
@@ -463,11 +464,11 @@ export class RuntimeHttpServer {
 
     if (this.processMessage) {
       const pm = this.processMessage;
-      const bt = this.bearerToken;
+      const mintBt = () => mintDaemonDeliveryToken();
       this.retrySweepTimer = setInterval(() => {
         if (this.sweepInProgress) return;
         this.sweepInProgress = true;
-        sweepFailedEvents(pm, bt).finally(() => {
+        sweepFailedEvents(pm, mintBt).finally(() => {
           this.sweepInProgress = false;
         });
       }, 30_000);
@@ -475,14 +476,14 @@ export class RuntimeHttpServer {
 
     startGuardianExpirySweep(
       getGatewayInternalBaseUrl(),
-      this.bearerToken,
+      () => mintDaemonDeliveryToken(),
       this.approvalCopyGenerator,
     );
     log.info("Guardian approval expiry sweep started");
 
     startGuardianActionSweep(
       getGatewayInternalBaseUrl(),
-      this.bearerToken,
+      () => mintDaemonDeliveryToken(),
       this.guardianActionCopyGenerator,
     );
     log.info("Guardian action expiry sweep started");
@@ -1317,8 +1318,8 @@ export class RuntimeHttpServer {
 
       if (endpoint === 'identity' && req.method === 'GET') return handleGetIdentity();
       if (endpoint === 'brain-graph' && req.method === 'GET') return handleGetBrainGraph();
-      if (endpoint === 'brain-graph-ui' && req.method === 'GET') return handleServeBrainGraphUI(this.bearerToken);
-      if (endpoint === 'home-base-ui' && req.method === 'GET') return handleServeHomeBaseUI(this.bearerToken);
+      if (endpoint === 'brain-graph-ui' && req.method === 'GET') return handleServeBrainGraphUI(mintDaemonDeliveryToken());
+      if (endpoint === 'home-base-ui' && req.method === 'GET') return handleServeHomeBaseUI(mintDaemonDeliveryToken());
       if (endpoint === 'events' && req.method === 'GET') return handleSubscribeAssistantEvents(req, url, { authContext });
 
       // Internal OAuth callback endpoint (gateway -> runtime)

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -168,7 +168,7 @@ export interface RuntimeHttpServerOptions {
   port?: number;
   /** Hostname / IP to bind to. Defaults to '127.0.0.1' (loopback-only). */
   hostname?: string;
-  /** Bearer token required on every request (except health checks). */
+  /** Legacy shared secret for pairing routes (not used for delivery or auth). */
   bearerToken?: string;
   processMessage?: MessageProcessor;
   /** Non-blocking processor for POST /messages (persists + fires agent loop). */

--- a/assistant/src/runtime/routes/guardian-expiry-sweep.ts
+++ b/assistant/src/runtime/routes/guardian-expiry-sweep.ts
@@ -34,7 +34,7 @@ let expirySweepTimer: ReturnType<typeof setInterval> | null = null;
  */
 export function sweepExpiredGuardianApprovals(
   gatewayBaseUrl: string,
-  bearerToken?: string,
+  mintBearerToken?: () => string,
   approvalCopyGenerator?: ApprovalCopyGenerator,
 ): void {
   const expired = getExpiredPendingApprovals();
@@ -63,7 +63,7 @@ export function sweepExpiredGuardianApprovals(
         chatId: approval.requesterChatId,
         text: requesterText,
         assistantId: approval.assistantId,
-      }, bearerToken);
+      }, mintBearerToken?.());
     })().catch((err) => {
       log.error({ err, approvalId: approval.id }, 'Failed to notify requester of guardian approval expiry');
     });
@@ -80,7 +80,7 @@ export function sweepExpiredGuardianApprovals(
         chatId: approval.guardianChatId,
         text: guardianText,
         assistantId: approval.assistantId,
-      }, bearerToken);
+      }, mintBearerToken?.());
     })().catch((err) => {
       log.error({ err, approvalId: approval.id }, 'Failed to notify guardian of approval expiry');
     });
@@ -98,13 +98,13 @@ export function sweepExpiredGuardianApprovals(
  */
 export function startGuardianExpirySweep(
   gatewayBaseUrl: string,
-  bearerToken?: string,
+  mintBearerToken?: () => string,
   approvalCopyGenerator?: ApprovalCopyGenerator,
 ): void {
   if (expirySweepTimer) return;
   expirySweepTimer = setInterval(() => {
     try {
-      sweepExpiredGuardianApprovals(gatewayBaseUrl, bearerToken, approvalCopyGenerator);
+      sweepExpiredGuardianApprovals(gatewayBaseUrl, mintBearerToken, approvalCopyGenerator);
     } catch (err) {
       log.error({ err }, 'Guardian expiry sweep failed');
     }


### PR DESCRIPTION
## Summary
- Sweep functions (guardian expiry, guardian action, channel retry) now accept `() => string` token factories instead of cached `string` tokens — JWTs have 60s TTL so they must be minted fresh at each delivery call
- `config-inbox.ts` approve/deny delivery paths now use `mintDaemonDeliveryToken()` instead of the old opaque `getRuntimeProxyBearerToken()`
- `twilio-routes.ts` relay token now uses `mintEdgeRelayToken()` directly instead of falling back to the old opaque shared secret
- Brain-graph/home-base UI pages now receive a fresh JWT per page load instead of the old static opaque token

## Original prompt
Fix P0: daemon→gateway delivery paths still use old opaque bearer tokens that fail JWT validation on the gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
