### PR TITLE
fix: show active tool progress instead of stale completed count

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/LiveToolProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/LiveToolProgressView.swift
@@ -21,17 +21,17 @@ struct LiveToolProgressView: View {
         if let thinkingLabel { return thinkingLabel }
         let completedCount = toolCalls.filter(\.isComplete).count
         if isRunning {
-            if completedCount == 0 {
-                if let current = currentCall {
-                    return ChatBubble.friendlyRunningLabel(
-                        current.toolName,
-                        inputSummary: current.inputSummary,
-                        buildingStatus: current.buildingStatus
-                    )
-                }
-                return "Working"
+            if let current = currentCall {
+                return ChatBubble.friendlyRunningLabel(
+                    current.toolName,
+                    inputSummary: current.inputSummary,
+                    buildingStatus: current.buildingStatus
+                )
             }
-            return "Completed \(completedCount) step\(completedCount == 1 ? "" : "s")"
+            if completedCount > 0 {
+                return "Completed \(completedCount) step\(completedCount == 1 ? "" : "s")"
+            }
+            return "Working"
         }
         return "Completed \(toolCalls.count) step\(toolCalls.count == 1 ? "" : "s")"
     }


### PR DESCRIPTION
## Summary

- Reorder `headerLabel` logic in `LiveToolProgressView` so that an active tool call always takes priority over the "Completed X steps" label
- Previously, once any tool completed, the header would only show "Completed N steps" even while another tool was running — hiding what the assistant is currently doing
- Now the header shows the active tool's friendly label (e.g., "Running gmail sender digest") whenever a tool is in progress, falling back to completed count only when no tool is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
