### PR TITLE
fix: use last angle-bracket segment in extractEmail for RFC 5322 compliance

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts
@@ -50,11 +50,15 @@ function parseAddressList(header: string): string[] {
  *   - `<user@example.com>`
  *   - `"Display Name" <user@example.com>`
  *   - `Display Name <user@example.com>`
+ *   - `"Team <Ops>" <user@example.com>`
+ *
+ * Matches the LAST angle-bracketed segment, since RFC 5322 places the
+ * actual mailbox last — display names with angle brackets come before it.
  * Returns the lowercase bare email, or the lowercased full string as fallback.
  */
 function extractEmail(address: string): string {
-  const match = address.match(/<([^>]+)>/);
-  return (match ? match[1] : address).trim().toLowerCase();
+  const matches = address.match(/.*<([^>]+)>/);
+  return (matches ? matches[1] : address).trim().toLowerCase();
 }
 
 export async function run(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {


### PR DESCRIPTION
Fixes Codex feedback from #11492: extractEmail() now matches the last angle-bracketed segment instead of the first, correctly handling display names containing angle brackets (e.g., `"Team <Ops>" <me@example.com>`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
