### PR TITLE
Fix lint: sort imports in config-inbox.ts

### DIFF
--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -3,7 +3,6 @@ import * as net from 'node:net';
 import type { ChannelId } from '../../channels/types.js';
 import { isChannelId, isInterfaceId } from '../../channels/types.js';
 import { getGatewayInternalBaseUrl } from '../../config/env.js';
-import { mintDaemonDeliveryToken } from '../../runtime/auth/token-service.js';
 import { getLatestStoredPayload } from '../../memory/channel-delivery-store.js';
 import type { GuardianApprovalRequest } from '../../memory/channel-guardian-store.js';
 import {
@@ -13,6 +12,7 @@ import {
 } from '../../memory/channel-guardian-store.js';
 import { addMessage, getMessages } from '../../memory/conversation-store.js';
 import { getBindingByConversation } from '../../memory/external-conversation-store.js';
+import { mintDaemonDeliveryToken } from '../../runtime/auth/token-service.js';
 import { deliverChannelReply } from '../../runtime/gateway-client.js';
 import {
   blockIngressMember,


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `assistant/src/daemon/handlers/config-inbox.ts`
- Moved `../../runtime/auth/token-service.js` import to sort correctly with other `../../runtime/` imports

## Original prompt
fix the Lint & Type check failure on https://github.com/vellum-ai/vellum-assistant/actions/runs/22605273620

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
