### PR TITLE
fix: use long-lived edge token for brain-graph/home-base UI pages

### DIFF
--- a/assistant/src/runtime/auth/token-service.ts
+++ b/assistant/src/runtime/auth/token-service.ts
@@ -266,6 +266,29 @@ export function mintEdgeRelayToken(): string {
 }
 
 // ---------------------------------------------------------------------------
+// UI page token
+// ---------------------------------------------------------------------------
+
+/**
+ * Mint a long-lived JWT for embedding in browser-served UI pages
+ * (brain-graph, home-base).
+ *
+ * These pages make API calls that route through the gateway, which validates
+ * tokens with validateEdgeToken() expecting aud=vellum-gateway. A 1-hour TTL
+ * gives users enough time to interact with the page (including using Refresh
+ * buttons) without the token expiring mid-session.
+ */
+export function mintUiPageToken(): string {
+  return mintToken({
+    aud: 'vellum-gateway',
+    sub: 'svc:daemon:self',
+    scope_profile: 'gateway_service_v1',
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 3600,
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Hash
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -46,7 +46,7 @@ import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
 // Auth
 import { authenticateRequest } from './auth/middleware.js';
 import { enforcePolicy, getPolicy } from './auth/route-policy.js';
-import { mintDaemonDeliveryToken, verifyToken } from './auth/token-service.js';
+import { mintDaemonDeliveryToken, mintUiPageToken, verifyToken } from './auth/token-service.js';
 import type { AuthContext } from './auth/types.js';
 import { sweepFailedEvents } from './channel-retry-sweep.js';
 import { httpError } from './http-errors.js';
@@ -1318,8 +1318,8 @@ export class RuntimeHttpServer {
 
       if (endpoint === 'identity' && req.method === 'GET') return handleGetIdentity();
       if (endpoint === 'brain-graph' && req.method === 'GET') return handleGetBrainGraph();
-      if (endpoint === 'brain-graph-ui' && req.method === 'GET') return handleServeBrainGraphUI(mintDaemonDeliveryToken());
-      if (endpoint === 'home-base-ui' && req.method === 'GET') return handleServeHomeBaseUI(mintDaemonDeliveryToken());
+      if (endpoint === 'brain-graph-ui' && req.method === 'GET') return handleServeBrainGraphUI(mintUiPageToken());
+      if (endpoint === 'home-base-ui' && req.method === 'GET') return handleServeHomeBaseUI(mintUiPageToken());
       if (endpoint === 'events' && req.method === 'GET') return handleSubscribeAssistantEvents(req, url, { authContext });
 
       // Internal OAuth callback endpoint (gateway -> runtime)


### PR DESCRIPTION
Addresses review feedback on #11495. The brain-graph and home-base UI pages were embedding a 60-second daemon delivery JWT that (1) expired before interactive use and (2) had the wrong audience for gateway edge auth. Now uses a dedicated UI page token with longer TTL and correct edge audience.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
