### PR TITLE
fix: make extractEmail robust against trailing comment angle brackets

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts
@@ -51,14 +51,20 @@ function parseAddressList(header: string): string[] {
  *   - `"Display Name" <user@example.com>`
  *   - `Display Name <user@example.com>`
  *   - `"Team <Ops>" <user@example.com>`
+ *   - `user@example.com (team <ops>)`
  *
- * Matches the LAST angle-bracketed segment, since RFC 5322 places the
- * actual mailbox last — display names with angle brackets come before it.
- * Returns the lowercase bare email, or the lowercased full string as fallback.
+ * Extracts all angle-bracketed segments and picks the last one containing `@`,
+ * falling back to the last segment, then to the raw string. This handles both
+ * display names with angle brackets and trailing RFC 5322 comments that may
+ * contain angle brackets.
  */
 function extractEmail(address: string): string {
-  const matches = address.match(/.*<([^>]+)>/);
-  return (matches ? matches[1] : address).trim().toLowerCase();
+  const segments = [...address.matchAll(/<([^>]+)>/g)].map((m) => m[1]);
+  if (segments.length > 0) {
+    const emailSegment = segments.findLast((s) => s.includes('@'));
+    return (emailSegment ?? segments[segments.length - 1]).trim().toLowerCase();
+  }
+  return address.trim().toLowerCase();
 }
 
 export async function run(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {

--- a/assistant/src/sequence/reply-matcher.ts
+++ b/assistant/src/sequence/reply-matcher.ts
@@ -23,10 +23,16 @@ interface WatcherEventPayload {
 
 /**
  * Extract a bare email address from a "Name <email>" or plain "email" string.
+ * Handles RFC 5322 addresses where display names or trailing comments may
+ * contain angle brackets (e.g., `"Team <Ops>" <user@example.com>`).
  */
 function extractEmail(from: string): string | undefined {
-  const match = from.match(/<([^>]+)>/);
-  if (match) return match[1].toLowerCase();
+  const segments = [...from.matchAll(/<([^>]+)>/g)].map((m) => m[1]);
+  if (segments.length > 0) {
+    const emailSegment = segments.findLast((s) => s.includes('@'));
+    if (emailSegment) return emailSegment.trim().toLowerCase();
+    return segments[segments.length - 1].trim().toLowerCase();
+  }
   if (from.includes('@')) return from.trim().toLowerCase();
   return undefined;
 }


### PR DESCRIPTION
Addresses reviewer feedback on #11497:

1. **Codex**: The greedy regex `.*<([^>]+)>` could extract text from trailing RFC 5322 comments containing angle brackets (e.g., `(team <ops>)`) instead of the actual email. Fixed by extracting all angle-bracketed segments and picking the last one containing `@`.

2. **Devin**: Applied the same fix to `reply-matcher.ts` which still had the old first-match regex.

Fixes both `messaging-reply.ts` and `reply-matcher.ts` to use a shared robust email extraction pattern.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
