### PR TITLE
fix: merge duplicate shared.js imports in config-inbox.ts

### DIFF
--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -25,8 +25,7 @@ import {
   upsertIngressMember,
 } from '../../runtime/ingress-service.js';
 import type { AssistantInboxEscalationRequest, IngressInviteRequest, IngressMemberRequest } from '../ipc-protocol.js';
-import { defineHandlers, type HandlerContext, log } from './shared.js';
-import { renderHistoryContent } from './shared.js';
+import { defineHandlers, type HandlerContext, log, renderHistoryContent } from './shared.js';
 
 export function handleIngressInvite(
   msg: IngressInviteRequest,


### PR DESCRIPTION
## Summary
- Merges two separate imports from `./shared.js` into a single import statement to fix the `simple-import-sort/imports` lint error

## Original prompt
fix lint error on main [ bun run lint
$ eslint

/home/runner/work/vellum-assistant/vellum-assistant/assistant/src/daemon/handlers/config-inbox.ts
  1:1  error  Run autofix to sort these imports!  simple-import-sort/imports

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
