### PR TITLE
fix: respect TableColumn width in InlineTableWidget to prevent text overflow

### DIFF
--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -39,7 +39,8 @@ export const uiShowTool: Tool = {
     'templateData shape: { title: string, status: "in_progress"|"completed"|"failed", ' +
     'steps: Array<{ label: string, status: "pending"|"in_progress"|"completed"|"failed", detail?: string }> }\n' +
     '- table: Data table with columns, selectable rows, and action buttons. ' +
-    'data shape: { columns: Array<{ id: string, label: string }>, rows: Array<{ id: string, cells: Record<string, string>, selectable?: boolean, selected?: boolean }>, selectionMode?: "none"|"single"|"multiple", caption?: string }\n' +
+    'data shape: { columns: Array<{ id: string, label: string, width?: number }>, rows: Array<{ id: string, cells: Record<string, string>, selectable?: boolean, selected?: boolean }>, selectionMode?: "none"|"single"|"multiple", caption?: string }. ' +
+    'Column width is in points — use it for narrow columns (e.g. counts, short labels) so flexible columns get more space. Omit width for columns that should expand.\n' +
     '- form: Input form with typed fields. ' +
     'data shape: { description?: string, fields: Array<{ id: string, type: "text"|"textarea"|"select"|"toggle"|"number"|"password", label: string, placeholder?: string, required?: boolean, defaultValue?: string|number|boolean, options?: Array<{ label: string, value: string }> }>, submitLabel?: string }. ' +
     'For multi-page forms, use pages array instead of top-level fields: { pages: [{ id: string, title: string, description?: string, fields: [...] }], pageLabels?: { next?: string, back?: string, submit?: string }, submitLabel?: string }\n' +

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -1,5 +1,16 @@
 import SwiftUI
 
+private extension View {
+    @ViewBuilder
+    func columnFrame(_ width: Int?) -> some View {
+        if let w = width {
+            self.frame(width: CGFloat(w), alignment: .leading)
+        } else {
+            self.frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
 /// Inline table widget with selectable rows and action support.
 public struct InlineTableWidget: View {
     public let data: TableSurfaceData
@@ -44,7 +55,7 @@ public struct InlineTableWidget: View {
                     Text(column.label)
                         .font(VFont.captionMedium)
                         .foregroundColor(VColor.textMuted)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .columnFrame(column.width)
                         .textSelection(.enabled)
                 }
             }
@@ -99,7 +110,7 @@ public struct InlineTableWidget: View {
                     .font(VFont.body)
                     .foregroundColor(VColor.textPrimary)
                     .lineLimit(2)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .columnFrame(column.width)
                     .textSelection(.enabled)
             }
         }


### PR DESCRIPTION
## Summary
- **InlineTableWidget.swift**: Add `columnFrame(_:)` helper that uses fixed `frame(width:)` when a column specifies a `width`, and `frame(maxWidth: .infinity)` otherwise — applied to both header and data cells
- **ui-surface/definitions.ts**: Document `width?: number` on table column schema so the LLM knows to use it for narrow columns

## Original prompt
small UI bug with overflow text (screenshot of table with clipped rightmost column)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
