### PR TITLE
fix: replace Array.findLast with reverse().find() for ES2022 compat

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts
@@ -61,7 +61,7 @@ function parseAddressList(header: string): string[] {
 function extractEmail(address: string): string {
   const segments = [...address.matchAll(/<([^>]+)>/g)].map((m) => m[1]);
   if (segments.length > 0) {
-    const emailSegment = segments.findLast((s) => s.includes('@'));
+    const emailSegment = [...segments].reverse().find((s) => s.includes('@'));
     return (emailSegment ?? segments[segments.length - 1]).trim().toLowerCase();
   }
   return address.trim().toLowerCase();

--- a/assistant/src/sequence/reply-matcher.ts
+++ b/assistant/src/sequence/reply-matcher.ts
@@ -29,7 +29,7 @@ interface WatcherEventPayload {
 function extractEmail(from: string): string | undefined {
   const segments = [...from.matchAll(/<([^>]+)>/g)].map((m) => m[1]);
   if (segments.length > 0) {
-    const emailSegment = segments.findLast((s) => s.includes('@'));
+    const emailSegment = [...segments].reverse().find((s) => s.includes('@'));
     if (emailSegment) return emailSegment.trim().toLowerCase();
     return segments[segments.length - 1].trim().toLowerCase();
   }


### PR DESCRIPTION
## Summary
- Replaces `Array.findLast()` (ES2023) with `[...arr].reverse().find()` (ES2022) in two files to fix TS2550 type errors
- Affected files: `messaging-reply.ts` and `reply-matcher.ts`

## Original prompt
fix type check failures on main in separate worktree pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
