### PR TITLE
fix: remove unused imports and variables in gateway

### DIFF
--- a/gateway/src/__tests__/config.test.ts
+++ b/gateway/src/__tests__/config.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync, unlinkSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { describe, test, expect } from "bun:test";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/gateway/src/__tests__/runtime-proxy-auth.test.ts
+++ b/gateway/src/__tests__/runtime-proxy-auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, afterEach, beforeAll } from "bun:test";
+import { describe, test, expect, mock, afterEach } from "bun:test";
 import type { GatewayConfig } from "../config.js";
 import { initSigningKey, mintToken } from "../auth/token-service.js";
 import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";

--- a/gateway/src/__tests__/slack-deliver.test.ts
+++ b/gateway/src/__tests__/slack-deliver.test.ts
@@ -57,8 +57,6 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return merged;
 }
 
-const TOKEN = "test-deliver-token";
-
 function makeRequest(
   body: unknown,
   headers?: Record<string, string>,

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -2,12 +2,12 @@ process.title = "vellum-gateway";
 
 import { randomBytes } from "node:crypto";
 import { AuthRateLimiter } from "./auth-rate-limiter.js";
-import { loadOrCreateSigningKey, initSigningKey, verifyToken } from "./auth/token-service.js";
+import { loadOrCreateSigningKey, initSigningKey } from "./auth/token-service.js";
 import { validateEdgeToken } from "./auth/token-exchange.js";
 import { resolveScopeProfile } from "./auth/scopes.js";
 import type { Scope } from "./auth/types.js";
 import { ConfigFileWatcher } from "./config-file-watcher.js";
-import { loadConfig, isSlackChannelConfigured, type GatewayConfig } from "./config.js";
+import { loadConfig, isSlackChannelConfigured } from "./config.js";
 import { CredentialWatcher } from "./credential-watcher.js";
 import { createRuntimeProxyHandler } from "./http/routes/runtime-proxy.js";
 import {


### PR DESCRIPTION
## Summary
- Remove unused `unlinkSync` import from `config.test.ts`
- Remove unused `beforeAll` import from `runtime-proxy-auth.test.ts`
- Remove unused `TOKEN` variable from `slack-deliver.test.ts`
- Remove unused `verifyToken` and `GatewayConfig` imports from `index.ts`

## Original prompt
help me fix CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22605700364

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
