### PR TITLE
feat: table icon cells + tool_result_received activity state

### DIFF
--- a/assistant/src/daemon/ipc-contract/messages.ts
+++ b/assistant/src/daemon/ipc-contract/messages.ts
@@ -240,6 +240,7 @@ export interface AssistantActivityState {
     | 'thinking_delta'
     | 'first_text_delta'
     | 'tool_use_start'
+    | 'tool_result_received'
     | 'confirmation_requested'
     | 'confirmation_resolved'
     | 'message_complete'

--- a/assistant/src/daemon/ipc-contract/surfaces.ts
+++ b/assistant/src/daemon/ipc-contract/surfaces.ts
@@ -104,9 +104,15 @@ export interface TableColumn {
   width?: number;
 }
 
+export interface TableCellValue {
+  text: string;
+  icon?: string;       // SF Symbol name
+  iconColor?: string;  // semantic token: "success" | "warning" | "error" | "muted"
+}
+
 export interface TableRow {
   id: string;
-  cells: Record<string, string>;
+  cells: Record<string, string | TableCellValue>;
   selectable?: boolean;
   selected?: boolean;
 }

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -319,6 +319,11 @@ export function handleToolResult(
   // call re-emits the activity state transitions.
   state.firstTextDeltaEmitted = false;
   state.firstThinkingDeltaEmitted = false;
+
+  // Emit activity state immediately so clients show a thinking indicator
+  // during the gap between tool_result and the next thinking_delta/text_delta.
+  const statusText = `Processing ${friendlyToolName(state.lastCompletedToolName ?? '')} results`;
+  deps.ctx.emitActivityState('thinking', 'tool_result_received', 'assistant_turn', deps.reqId, statusText);
 }
 
 export function handleError(

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -133,7 +133,7 @@ export interface AgentLoopSessionContext {
 
   emitActivityState(
     phase: 'idle' | 'thinking' | 'streaming' | 'tool_running' | 'awaiting_confirmation',
-    reason: 'message_dequeued' | 'thinking_delta' | 'first_text_delta' | 'tool_use_start' | 'confirmation_requested' | 'confirmation_resolved' | 'message_complete' | 'generation_cancelled' | 'error_terminal',
+    reason: 'message_dequeued' | 'thinking_delta' | 'first_text_delta' | 'tool_use_start' | 'tool_result_received' | 'confirmation_requested' | 'confirmation_resolved' | 'message_complete' | 'generation_cancelled' | 'error_terminal',
     anchor?: 'assistant_turn' | 'user_turn' | 'global',
     requestId?: string,
     statusText?: string,

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -89,7 +89,7 @@ export interface ProcessSessionContext {
   setTurnInterfaceContext(ctx: TurnInterfaceContext): void;
   emitActivityState(
     phase: 'idle' | 'thinking' | 'streaming' | 'tool_running' | 'awaiting_confirmation',
-    reason: 'message_dequeued' | 'thinking_delta' | 'first_text_delta' | 'tool_use_start' | 'confirmation_requested' | 'confirmation_resolved' | 'message_complete' | 'generation_cancelled' | 'error_terminal',
+    reason: 'message_dequeued' | 'thinking_delta' | 'first_text_delta' | 'tool_use_start' | 'tool_result_received' | 'confirmation_requested' | 'confirmation_resolved' | 'message_complete' | 'generation_cancelled' | 'error_terminal',
     anchor?: 'assistant_turn' | 'user_turn' | 'global',
     requestId?: string,
     statusText?: string,

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -106,12 +106,7 @@ public struct InlineTableWidget: View {
             }
 
             ForEach(data.columns) { column in
-                Text(row.cells[column.id] ?? "")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textPrimary)
-                    .lineLimit(2)
-                    .columnFrame(column.width)
-                    .textSelection(.enabled)
+                cellView(row.cells[column.id], width: column.width)
             }
         }
         .padding(.vertical, VSpacing.xs)
@@ -124,6 +119,33 @@ public struct InlineTableWidget: View {
             if row.selectable && data.selectionMode != .none {
                 toggleSelection(row.id)
             }
+        }
+    }
+
+    @ViewBuilder
+    private func cellView(_ value: TableCellValue?, width: Int?) -> some View {
+        HStack(spacing: VSpacing.xs) {
+            if let icon = value?.icon {
+                Image(systemName: icon)
+                    .font(.system(size: 12))
+                    .foregroundColor(resolveIconColor(value?.iconColor))
+            }
+            Text(value?.text ?? "")
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .lineLimit(2)
+                .textSelection(.enabled)
+        }
+        .columnFrame(width)
+    }
+
+    private func resolveIconColor(_ token: String?) -> Color {
+        switch token {
+        case "success": return Emerald._500
+        case "warning": return Amber._500
+        case "error": return Danger._500
+        case "muted": return VColor.textMuted
+        default: return VColor.textPrimary
         }
     }
 
@@ -165,9 +187,9 @@ public struct InlineTableWidget: View {
                     TableColumn(id: "count", label: "Emails", width: nil),
                 ],
                 rows: [
-                    TableRow(id: "1", cells: ["sender": "newsletter@tech.co", "count": "47"], selectable: true, selected: false),
-                    TableRow(id: "2", cells: ["sender": "deals@store.com", "count": "32"], selectable: true, selected: false),
-                    TableRow(id: "3", cells: ["sender": "updates@social.app", "count": "28"], selectable: true, selected: false),
+                    TableRow(id: "1", cells: ["sender": TableCellValue(text: "newsletter@tech.co"), "count": TableCellValue(text: "47")], selectable: true, selected: false),
+                    TableRow(id: "2", cells: ["sender": TableCellValue(text: "deals@store.com"), "count": TableCellValue(text: "32")], selectable: true, selected: false),
+                    TableRow(id: "3", cells: ["sender": TableCellValue(text: "updates@social.app"), "count": TableCellValue(text: "28", icon: "checkmark.circle.fill", iconColor: "success")], selectable: true, selected: false),
                 ],
                 selectionMode: .multiple,
                 caption: "3 newsletters found from last 30 days"

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -420,13 +420,25 @@ public struct TableColumn: Identifiable, Sendable, Equatable {
     }
 }
 
+public struct TableCellValue: Sendable, Equatable {
+    public let text: String
+    public let icon: String?       // SF Symbol name
+    public let iconColor: String?  // "success" | "warning" | "error" | "muted"
+
+    public init(text: String, icon: String? = nil, iconColor: String? = nil) {
+        self.text = text
+        self.icon = icon
+        self.iconColor = iconColor
+    }
+}
+
 public struct TableRow: Identifiable, Sendable, Equatable {
     public let id: String
-    public let cells: [String: String]
+    public let cells: [String: TableCellValue]
     public let selectable: Bool
     public let selected: Bool
 
-    public init(id: String, cells: [String: String], selectable: Bool, selected: Bool) {
+    public init(id: String, cells: [String: TableCellValue], selectable: Bool, selected: Bool) {
         self.id = id
         self.cells = cells
         self.selectable = selectable
@@ -963,7 +975,13 @@ public extension Surface {
         let rows: [TableRow] = rowsArray.compactMap { rowDict in
             guard let id = rowDict["id"] as? String,
                   let cellsRaw = rowDict["cells"] as? [String: Any?] else { return nil }
-            let cells = cellsRaw.compactMapValues { $0 as? String }
+            let cells: [String: TableCellValue] = cellsRaw.compactMapValues { raw -> TableCellValue? in
+                if let s = raw as? String { return TableCellValue(text: s) }
+                if let d = raw as? [String: Any?], let text = d["text"] as? String {
+                    return TableCellValue(text: text, icon: d["icon"] as? String, iconColor: d["iconColor"] as? String)
+                }
+                return nil
+            }
             return TableRow(
                 id: id,
                 cells: cells,
@@ -994,7 +1012,13 @@ public extension Surface {
             rows = rowsArray.compactMap { rowDict in
                 guard let id = rowDict["id"] as? String,
                       let cellsRaw = rowDict["cells"] as? [String: Any?] else { return nil }
-                let cells = cellsRaw.compactMapValues { $0 as? String }
+                let cells: [String: TableCellValue] = cellsRaw.compactMapValues { raw -> TableCellValue? in
+                    if let s = raw as? String { return TableCellValue(text: s) }
+                    if let d = raw as? [String: Any?], let text = d["text"] as? String {
+                        return TableCellValue(text: text, icon: d["icon"] as? String, iconColor: d["iconColor"] as? String)
+                    }
+                    return nil
+                }
                 return TableRow(
                     id: id,
                     cells: cells,


### PR DESCRIPTION
## Summary
- Add `TableCellValue` type with optional `icon` (SF Symbol name) and `iconColor` (semantic token: success/warning/error/muted) to table cells
- Swift client renders icons inline with semantic color resolution; backward-compatible with plain string cells
- Emit `tool_result_received` activity state reason after tool results so clients show a thinking indicator during the gap before the next thinking/text delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
