### PR TITLE
fix: pass surfaceId as activeSurfaceId in processMessage path for surface actions

### DIFF
--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -477,7 +477,7 @@ export function handleSurfaceAction(ctx: SurfaceSessionContext, surfaceId: strin
     ctx.pendingSurfaceActions.delete(surfaceId);
   }
   log.info({ surfaceId, actionId, requestId }, 'Processing surface action as follow-up');
-  ctx.processMessage(content, [], onEvent, requestId, undefined, undefined, undefined, displayContent).catch((err) => {
+  ctx.processMessage(content, [], onEvent, requestId, surfaceId, undefined, undefined, displayContent).catch((err) => {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, surfaceId, actionId }, 'Error processing surface action');
     onEvent({ type: 'error', message: `Failed to process surface action: ${message}` });


### PR DESCRIPTION
## Summary
- Fixes inconsistency where the direct `processMessage` path omitted `surfaceId` as `activeSurfaceId`, while the queued `enqueueMessage` path correctly passed it.
- This ensures surface actions processed when the session is idle retain their originating surface context.

Addresses feedback from PR #11507.

## Test plan
- [x] Verified that `enqueueMessage` (queued path) already passes `surfaceId` correctly
- [x] Updated `processMessage` (direct path) to also pass `surfaceId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
