### PR TITLE
fix: extractEmail returns non-email content for trailing comment angle brackets

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts
@@ -53,18 +53,18 @@ function parseAddressList(header: string): string[] {
  *   - `"Team <Ops>" <user@example.com>`
  *   - `user@example.com (team <ops>)`
  *
- * Extracts all angle-bracketed segments and picks the last one containing `@`,
- * falling back to the last segment, then to the raw string. This handles both
- * display names with angle brackets and trailing RFC 5322 comments that may
- * contain angle brackets.
+ * Extracts all angle-bracketed segments and picks the first one containing `@`,
+ * preferring the sender mailbox over trailing comment addresses. If no segment
+ * contains `@`, strips angle-bracketed portions and returns the remaining text.
+ * This handles display names with angle brackets and trailing RFC 5322 comments.
  */
 function extractEmail(address: string): string {
   const segments = [...address.matchAll(/<([^>]+)>/g)].map((m) => m[1]);
   if (segments.length > 0) {
-    const emailSegment = [...segments].reverse().find((s) => s.includes('@'));
-    return (emailSegment ?? segments[segments.length - 1]).trim().toLowerCase();
+    const emailSegment = segments.find((s) => s.includes('@'));
+    if (emailSegment) return emailSegment.trim().toLowerCase();
   }
-  return address.trim().toLowerCase();
+  return address.replace(/<[^>]+>/g, '').trim().toLowerCase();
 }
 
 export async function run(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {

--- a/assistant/src/sequence/reply-matcher.ts
+++ b/assistant/src/sequence/reply-matcher.ts
@@ -29,11 +29,11 @@ interface WatcherEventPayload {
 function extractEmail(from: string): string | undefined {
   const segments = [...from.matchAll(/<([^>]+)>/g)].map((m) => m[1]);
   if (segments.length > 0) {
-    const emailSegment = [...segments].reverse().find((s) => s.includes('@'));
+    const emailSegment = segments.find((s) => s.includes('@'));
     if (emailSegment) return emailSegment.trim().toLowerCase();
-    return segments[segments.length - 1].trim().toLowerCase();
   }
-  if (from.includes('@')) return from.trim().toLowerCase();
+  const stripped = from.replace(/<[^>]+>/g, '').trim().toLowerCase();
+  if (stripped.includes('@')) return stripped;
   return undefined;
 }
 


### PR DESCRIPTION
Fixes extractEmail in both messaging-reply.ts and reply-matcher.ts to handle edge cases where trailing comments contain angle-bracketed non-email content (e.g., `user@example.com (team <ops>)`). Also prefers the first @-containing segment over the last to avoid selecting comment addresses over sender addresses.

Addresses feedback from PR #11501.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
