### PR TITLE
ci: fast-fail on wrong signing identity after cert import

### DIFF
--- a/.github/workflows/ci-nightly-release.yml
+++ b/.github/workflows/ci-nightly-release.yml
@@ -79,6 +79,11 @@ jobs:
           security default-keychain -s "$KEYCHAIN_PATH"
           security find-identity -v -p codesigning "$KEYCHAIN_PATH"
 
+      - name: Verify signing identity
+        run: |
+          security find-identity -v -p codesigning | grep -q "Developer ID Application" \
+            || { echo "::error::Developer ID Application identity not found in keychain. Check the DEVID_CERTIFICATE_P12 secret."; exit 1; }
+
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -55,6 +55,11 @@ jobs:
 
           security find-identity -v -p codesigning "$KEYCHAIN_PATH"
 
+      - name: Verify signing identity
+        run: |
+          security find-identity -v -p codesigning | grep -q "Developer ID Application" \
+            || { echo "::error::Developer ID Application identity not found in keychain. Check the DEVID_CERTIFICATE_P12 secret."; exit 1; }
+
       - name: Cache SPM build artifacts
         uses: actions/cache@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -760,6 +760,11 @@ jobs:
           security default-keychain -s "$KEYCHAIN_PATH"
           security find-identity -v -p codesigning "$KEYCHAIN_PATH"
 
+      - name: Verify signing identity
+        run: |
+          security find-identity -v -p codesigning | grep -q "Developer ID Application" \
+            || { echo "::error::Developer ID Application identity not found in keychain. Check the DEVID_CERTIFICATE_P12 secret."; exit 1; }
+
       - name: Set version
         id: version
         run: |
@@ -1039,6 +1044,11 @@ jobs:
           security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
           security default-keychain -s "$KEYCHAIN_PATH"
           security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+      - name: Verify signing identity
+        run: |
+          security find-identity -v -p codesigning | grep -q "Developer ID Application" \
+            || { echo "::error::Developer ID Application identity not found in keychain. Check the DEVID_CERTIFICATE_P12 secret."; exit 1; }
 
       - name: Set version
         id: version
@@ -1422,6 +1432,11 @@ jobs:
           security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
           security default-keychain -s "$KEYCHAIN_PATH"
           security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+      - name: Verify signing identity
+        run: |
+          security find-identity -v -p codesigning | grep -q "Apple Distribution" \
+            || { echo "::error::Apple Distribution identity not found in keychain. Check the DIST_CERTIFICATE_P12 secret."; exit 1; }
 
       - name: Install provisioning profile
         env:


### PR DESCRIPTION
## Summary
Adds a verification step immediately after certificate import in all macOS and iOS CI workflows that checks for the expected signing identity before proceeding with the build.

## Why
When the wrong certificate type is uploaded to a GitHub secret (e.g., "Apple Distribution" instead of "Developer ID Application"), the build compiles for 10+ minutes before failing at the codesigning step. This happened repeatedly during recent cert migrations and was difficult to diagnose because the error appeared deep in the build logs after a long wait.

## What it does
After importing the certificate into the keychain, a new "Verify signing identity" step greps `security find-identity` output for the expected identity type:
- **macOS workflows** (`release.yml` build-macos, build-macos-split-arch, `ci-nightly-release.yml`, `pr-macos.yaml`): checks for "Developer ID Application"
- **iOS workflow** (`release.yml` release-ios): checks for "Apple Distribution"

If the wrong cert type is found, the job fails immediately with a clear error message pointing to the specific secret to check.

## Files changed
- `.github/workflows/release.yml` — 3 verification steps (2 macOS jobs, 1 iOS job)
- `.github/workflows/ci-nightly-release.yml` — 1 verification step
- `.github/workflows/pr-macos.yaml` — 1 verification step

## Testing
- If the correct cert is in the secret: no change in behavior, the grep succeeds silently
- If the wrong cert is in the secret: job fails in seconds with `::error::` annotation instead of after 10+ min of compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
