### PR TITLE
fix: extractEmail prefers last @-segment and strips parenthetical comments

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts
@@ -53,18 +53,20 @@ function parseAddressList(header: string): string[] {
  *   - `"Team <Ops>" <user@example.com>`
  *   - `user@example.com (team <ops>)`
  *
- * Extracts all angle-bracketed segments and picks the first one containing `@`,
- * preferring the sender mailbox over trailing comment addresses. If no segment
- * contains `@`, strips angle-bracketed portions and returns the remaining text.
- * This handles display names with angle brackets and trailing RFC 5322 comments.
+ * Extracts all angle-bracketed segments and picks the last one containing `@`,
+ * preferring the actual mailbox over display-name fragments like
+ * `"Acme <support@acme.com>" <owner@example.com>`. If no segment contains `@`,
+ * strips angle-bracketed portions and parenthetical comments, returning the
+ * remaining text. This handles display names with angle brackets and trailing
+ * RFC 5322 comments.
  */
 function extractEmail(address: string): string {
   const segments = [...address.matchAll(/<([^>]+)>/g)].map((m) => m[1]);
   if (segments.length > 0) {
-    const emailSegment = segments.find((s) => s.includes('@'));
+    const emailSegment = [...segments].reverse().find((s) => s.includes('@'));
     if (emailSegment) return emailSegment.trim().toLowerCase();
   }
-  return address.replace(/<[^>]+>/g, '').trim().toLowerCase();
+  return address.replace(/<[^>]+>/g, '').replace(/\(.*?\)/g, '').trim().toLowerCase();
 }
 
 export async function run(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {

--- a/assistant/src/sequence/reply-matcher.ts
+++ b/assistant/src/sequence/reply-matcher.ts
@@ -24,15 +24,17 @@ interface WatcherEventPayload {
 /**
  * Extract a bare email address from a "Name <email>" or plain "email" string.
  * Handles RFC 5322 addresses where display names or trailing comments may
- * contain angle brackets (e.g., `"Team <Ops>" <user@example.com>`).
+ * contain angle brackets (e.g., `"Acme <support@acme.com>" <owner@example.com>`).
+ * Picks the last `@`-containing segment so display-name fragments don't shadow
+ * the actual mailbox. Strips parenthetical comments in the fallback path.
  */
 function extractEmail(from: string): string | undefined {
   const segments = [...from.matchAll(/<([^>]+)>/g)].map((m) => m[1]);
   if (segments.length > 0) {
-    const emailSegment = segments.find((s) => s.includes('@'));
+    const emailSegment = [...segments].reverse().find((s) => s.includes('@'));
     if (emailSegment) return emailSegment.trim().toLowerCase();
   }
-  const stripped = from.replace(/<[^>]+>/g, '').trim().toLowerCase();
+  const stripped = from.replace(/<[^>]+>/g, '').replace(/\(.*?\)/g, '').trim().toLowerCase();
   if (stripped.includes('@')) return stripped;
   return undefined;
 }


### PR DESCRIPTION
Addresses review feedback on #11514:

- Reverts first-match to last-match for @-containing angle-bracket segments, fixing regression for quoted display names like `"Acme <support@acme.com>" <owner@example.com>`
- Strips RFC 5322 parenthetical comments in fallback path so `user@example.com (team <ops>)` returns clean `user@example.com` instead of `user@example.com (team )`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
