### PR TITLE
fix: show thinking indicator during tool-result-to-next-event gap on macOS

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -301,7 +301,7 @@ struct MessageListView: View {
                         $0.toolCalls.contains(where: { !$0.isComplete })
                     })
                     let shouldShowThinkingIndicator = isSending
-                        && !(lastVisible?.isStreaming == true)
+                        && (isThinking || !(lastVisible?.isStreaming == true))
                         && !hasActiveToolCall
                     ForEach(Array(zip(displayMessages.indices, displayMessages)), id: \.1.id) { index, message in
                         if showTimestamp.contains(index) {


### PR DESCRIPTION
## Summary
- When the daemon emits a `thinking` activity state after a `tool_result` (via the `tool_result_received` reason added in a prior PR), the macOS client now shows the thinking indicator even if the last visible message is still marked as streaming
- Previously, `shouldShowThinkingIndicator` was suppressed whenever `lastVisible?.isStreaming == true`, causing a dead zone where users saw completed tool chips but no activity indicator

## Test plan
- [ ] Trigger a multi-step tool operation (e.g., email scan across pages)
- [ ] Verify the thinking indicator appears between tool completions
- [ ] Verify normal streaming behavior is preserved (indicator hidden when text is actively streaming without `isThinking`)
- [ ] Build succeeds: `cd clients/macos && swift build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
