### PR TITLE
fix: show thinking indicator during tool-result-to-next-event gap on iOS

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -198,6 +198,21 @@ struct ChatContentView: View {
                                 .padding(.horizontal, VSpacing.lg)
                                 .id("step-indicator")
                                 .transition(.opacity.combined(with: .move(edge: .bottom)))
+                            } else if viewModel.isThinking {
+                                // LLM is processing tool results but streaming text is
+                                // already visible — show typing dots with status text.
+                                HStack {
+                                    TypingIndicatorView()
+                                    if let statusText = viewModel.assistantStatusText, !statusText.isEmpty {
+                                        Text(statusText)
+                                            .font(VFont.caption)
+                                            .foregroundColor(VColor.textSecondary)
+                                    }
+                                    Spacer()
+                                }
+                                .padding(.horizontal, VSpacing.lg)
+                                .id("step-indicator")
+                                .transition(.opacity.combined(with: .move(edge: .bottom)))
                             }
                             // Otherwise isStreaming with text: the growing message bubble is the indicator
                         }


### PR DESCRIPTION
## Summary
- Adds a fourth branch in the iOS typing/step indicator logic for when `viewModel.isThinking` is true but the message is already streaming with text
- This covers the dead zone where the LLM is processing tool results (daemon emitted `tool_result_received` activity state) but none of the existing indicator branches match
- Shows typing dots with the daemon's status text (e.g., "Processing web search results")

## Test plan
- [ ] Trigger a multi-step tool operation on iOS (e.g., email scan across pages)
- [ ] Verify the typing indicator with status text appears between tool completions
- [ ] Verify normal streaming behavior is preserved (indicator hidden when text is actively streaming without `isThinking`)
- [ ] Build iOS target

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
