### PR TITLE
fix: strip parenthetical comments before email segment extraction

### DIFF
--- a/assistant/src/__tests__/extract-email.test.ts
+++ b/assistant/src/__tests__/extract-email.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'bun:test';
+import { extractEmail } from '../sequence/reply-matcher.js';
+
+describe('extractEmail', () => {
+  it('extracts from plain email', () => {
+    expect(extractEmail('user@example.com')).toBe('user@example.com');
+  });
+
+  it('extracts from angle-bracketed email', () => {
+    expect(extractEmail('<user@example.com>')).toBe('user@example.com');
+  });
+
+  it('extracts from "Name <email>" format', () => {
+    expect(extractEmail('"John Doe" <john@example.com>')).toBe('john@example.com');
+  });
+
+  it('picks actual mailbox over display-name fragment with @', () => {
+    expect(extractEmail('"Acme <support@acme.com>" <owner@example.com>')).toBe('owner@example.com');
+  });
+
+  it('strips parenthetical comments before segment extraction', () => {
+    // The parenthetical comment contains an angle-bracketed address;
+    // without stripping comments first, the code would pick ops@example.com.
+    expect(extractEmail('"Owner" <owner@example.com> (team <ops@example.com>)')).toBe('owner@example.com');
+  });
+
+  it('handles parenthetical comment with no angle brackets', () => {
+    expect(extractEmail('owner@example.com (Owner Name)')).toBe('owner@example.com');
+  });
+
+  it('lowercases the result', () => {
+    expect(extractEmail('USER@EXAMPLE.COM')).toBe('user@example.com');
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(extractEmail('')).toBeUndefined();
+  });
+
+  it('returns undefined for string with no email', () => {
+    expect(extractEmail('not an email')).toBeUndefined();
+  });
+});

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts
@@ -61,7 +61,9 @@ function parseAddressList(header: string): string[] {
  * RFC 5322 comments.
  */
 function extractEmail(address: string): string {
-  const segments = [...address.matchAll(/<([^>]+)>/g)].map((m) => m[1]);
+  // Strip parenthetical comments first to avoid matching addresses inside them
+  const cleaned = address.replace(/\(.*?\)/g, '');
+  const segments = [...cleaned.matchAll(/<([^>]+)>/g)].map((m) => m[1]);
   if (segments.length > 0) {
     const emailSegment = [...segments].reverse().find((s) => s.includes('@'));
     if (emailSegment) return emailSegment.trim().toLowerCase();

--- a/assistant/src/sequence/reply-matcher.ts
+++ b/assistant/src/sequence/reply-matcher.ts
@@ -28,8 +28,10 @@ interface WatcherEventPayload {
  * Picks the last `@`-containing segment so display-name fragments don't shadow
  * the actual mailbox. Strips parenthetical comments in the fallback path.
  */
-function extractEmail(from: string): string | undefined {
-  const segments = [...from.matchAll(/<([^>]+)>/g)].map((m) => m[1]);
+export function extractEmail(from: string): string | undefined {
+  // Strip parenthetical comments first to avoid matching addresses inside them
+  const cleaned = from.replace(/\(.*?\)/g, '');
+  const segments = [...cleaned.matchAll(/<([^>]+)>/g)].map((m) => m[1]);
   if (segments.length > 0) {
     const emailSegment = [...segments].reverse().find((s) => s.includes('@'));
     if (emailSegment) return emailSegment.trim().toLowerCase();


### PR DESCRIPTION
## Summary
- Strips RFC 5322 parenthetical comments `(...)` before extracting angle-bracketed email segments in `extractEmail()`, preventing addresses inside comments from shadowing the actual mailbox address
- Fixes both copies: `assistant/src/sequence/reply-matcher.ts` and `assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts`
- Exports `extractEmail` from `reply-matcher.ts` and adds focused unit tests covering the edge case

## Test plan
- [x] Added `extract-email.test.ts` with 9 test cases including the specific parenthetical comment edge case
- [x] All tests pass locally

Addresses feedback from Codex review on #11516.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
