### PR TITLE
fix: regenerate Swift IPC contract for TableCellValue type

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -4688,6 +4688,18 @@ public struct IPCSurfaceAction: Codable, Sendable {
     }
 }
 
+public struct IPCTableCellValue: Codable, Sendable {
+    public let text: String
+    public let icon: String?
+    public let iconColor: String?
+
+    public init(text: String, icon: String? = nil, iconColor: String? = nil) {
+        self.text = text
+        self.icon = icon
+        self.iconColor = iconColor
+    }
+}
+
 public struct IPCTableColumn: Codable, Sendable {
     public let id: String
     public let label: String
@@ -4702,11 +4714,11 @@ public struct IPCTableColumn: Codable, Sendable {
 
 public struct IPCTableRow: Codable, Sendable {
     public let id: String
-    public let cells: [String: String]
+    public let cells: [String: AnyCodable]
     public let selectable: Bool?
     public let selected: Bool?
 
-    public init(id: String, cells: [String: String], selectable: Bool? = nil, selected: Bool? = nil) {
+    public init(id: String, cells: [String: AnyCodable], selectable: Bool? = nil, selected: Bool? = nil) {
         self.id = id
         self.cells = cells
         self.selectable = selectable


### PR DESCRIPTION
## Summary
- Regenerates `IPCContractGenerated.swift` to reflect the `TableCellValue` union type added in #11512
- The generated file now includes a new `IPCTableCellValue` struct with `text`, `icon`, and `iconColor` fields
- `IPCTableRow.cells` type changed from `[String: String]` to `[String: AnyCodable]` to handle the `string | TableCellValue` union type
- The `tool_result_received` activity state reason is already supported via the `String`-typed `reason` field in `IPCAssistantActivityState`

## Test plan
- [x] `bun run check:ipc-generated` passes (confirms generated file matches TypeScript source)
- [ ] CI `check:ipc-generated` check should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
