### PR TITLE
fix: restore monitoring after cancelled retire in macOS app

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1017,6 +1017,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 alert.addButton(withTitle: "Cancel")
                 if alert.runModal() != .alertFirstButtonReturn {
                     // Daemon is still running — user can continue using the app.
+                    // retire() already set isStopping=true and stopped monitoring;
+                    // restart monitoring so the health check remains active.
+                    assistantCli.startMonitoring()
                     return false
                 }
                 // Retire failed but user chose Force Remove — stop the daemon


### PR DESCRIPTION
Addresses feedback from Codex and Devin on #11468 (and #11470). When retire() fails and the user cancels, restore isStopping=false and restart monitoring so the app remains fully functional.

When `assistantCli.retire(name:)` throws and the user presses Cancel, the retire method has already set `isStopping = true` and called `stopMonitoring()`. The cancel path was returning without restoring these, leaving the health monitor disabled. Now calls `assistantCli.startMonitoring()` on cancel which resets `isStopping` and restarts the health check.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
