### PR TITLE
fix: use JSON-aware trailing comma cleanup in frontmatter parser

### DIFF
--- a/assistant/src/skills/frontmatter.ts
+++ b/assistant/src/skills/frontmatter.ts
@@ -41,12 +41,15 @@ export function parseFrontmatterFields(
   function flushContinuation() {
     if (currentKey !== undefined) {
       if (continuationLines.length > 0) {
-        // Join continuation lines, then strip trailing commas before closing
-        // braces/brackets so that prettier-formatted JSON remains valid for JSON.parse.
-        fields[currentKey] = continuationLines
-          .map((l) => l.trim())
-          .join(" ")
-          .replace(/,\s*([}\]])/g, "$1");
+        const joined = continuationLines.map((l) => l.trim()).join(" ");
+        // Try parsing as-is first to avoid corrupting commas inside quoted strings.
+        // Only apply trailing-comma cleanup if the raw text isn't valid JSON.
+        try {
+          JSON.parse(joined);
+          fields[currentKey] = joined;
+        } catch {
+          fields[currentKey] = joined.replace(/,\s*([}\]])/g, "$1");
+        }
       } else {
         fields[currentKey] = "";
       }


### PR DESCRIPTION
Addresses Codex feedback on #11464. The multiline frontmatter parser now tries JSON.parse first before applying trailing comma regex cleanup, preventing corruption of commas inside quoted strings.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
