### PR TITLE
fix: only sync present keys to daemon on reconnect, don't delete missing ones

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1021,7 +1021,9 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    /// Re-sync all keys to daemon on reconnect, including deletions for cleared keys.
+    /// Re-sync locally-known keys to daemon on reconnect.
+    /// Only pushes keys that are present in the macOS keychain — never deletes,
+    /// because the daemon may hold keys set through other flows (e.g. CLI).
     private func syncAllKeysToDaemon() {
         let apiKeyProviders: [(String, String?)] = [
             ("anthropic", APIKeyManager.getKey()),
@@ -1032,16 +1034,12 @@ public final class SettingsStore: ObservableObject {
         for (provider, value) in apiKeyProviders {
             if let key = value {
                 syncKeyToDaemon(provider: provider, value: key)
-            } else {
-                deleteKeyFromDaemon(provider: provider)
             }
         }
 
         // ElevenLabs uses the credential type, not api_key
         if let key = APIKeyManager.getKey(for: "elevenlabs") {
             syncCredentialToDaemon(name: "elevenlabs:api_key", value: key)
-        } else {
-            deleteCredentialFromDaemon(name: "elevenlabs:api_key")
         }
     }
 


### PR DESCRIPTION
Addresses Codex feedback on #11469. Removes DELETE calls from syncAllKeysToDaemon() to prevent erasing daemon-side keys that were set via CLI. Deletions are only triggered by explicit user clear actions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
