### PR TITLE
fix: properly clean up SSE state on managed-mode 401

### DIFF
--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -422,6 +422,8 @@ public final class HTTPTransport {
                         if self.isManagedMode {
                             // In managed mode, 401 means the session token expired.
                             // Don't reconnect — it would loop indefinitely.
+                            self.shouldReconnect = false
+                            self.sseTask = nil
                             self.setSSEConnected(false)
                             return
                         }


### PR DESCRIPTION
Addresses feedback from Codex and Devin on #11485. Adds shouldReconnect=false to stop health-check loop, and clears sseTask so startSSE() can restart after re-auth.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
