### PR TITLE
fix: extend isVellumProcess to recognize bun-launched gateway

### DIFF
--- a/cli/src/lib/process.ts
+++ b/cli/src/lib/process.ts
@@ -13,8 +13,11 @@ function isVellumProcess(pid: number): boolean {
       timeout: 3000,
       stdio: ["ignore", "pipe", "ignore"],
     }).trim();
-    // Match daemon binary, gateway binary, or bun-run source invocations
-    return /vellum|@vellumai/.test(output);
+    // Match daemon/gateway binaries (vellum-daemon, vellum-gateway), npm
+    // package names (@vellumai/*), or bun-run source invocations where the
+    // command line may only show "bun run src/index.ts" without any
+    // vellum-specific path component (e.g. gateway launched from its cwd).
+    return /vellum|@vellumai|bun\s+(run\s+)?src\/index\.ts/.test(output);
   } catch {
     return false;
   }


### PR DESCRIPTION
Addresses Codex feedback on #11472. Extends the isVellumProcess() regex to also match bun-launched gateway/daemon processes (bun run src/index.ts), preventing misclassification as stale PIDs when running in source/non-desktop mode.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
