### PR TITLE
fix: guard skills_state_changed broadcast on auto-enable success

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -300,6 +300,7 @@ export async function handleSkillsInstall(
     );
     if (bundled) {
       // Auto-enable the bundled skill so it's immediately usable
+      let autoEnabled = false;
       try {
         const raw = loadRawConfig();
         ensureSkillEntry(raw, msg.slug).enabled = true;
@@ -319,6 +320,7 @@ export async function handleSkillsInstall(
           CONFIG_RELOAD_DEBOUNCE_MS,
         );
         ctx.updateConfigFingerprint();
+        autoEnabled = true;
       } catch (err) {
         log.warn(
           { err, skillId: msg.slug },
@@ -331,11 +333,13 @@ export async function handleSkillsInstall(
         operation: "install",
         success: true,
       });
-      ctx.broadcast({
-        type: "skills_state_changed",
-        name: msg.slug,
-        state: "enabled",
-      });
+      if (autoEnabled) {
+        ctx.broadcast({
+          type: "skills_state_changed",
+          name: msg.slug,
+          state: "enabled",
+        });
+      }
       return;
     }
 
@@ -357,6 +361,7 @@ export async function handleSkillsInstall(
     loadSkillCatalog();
 
     // Auto-enable the newly installed skill so it's immediately usable.
+    let autoEnabled = false;
     try {
       const raw = loadRawConfig();
       ensureSkillEntry(raw, skillId).enabled = true;
@@ -376,6 +381,7 @@ export async function handleSkillsInstall(
         CONFIG_RELOAD_DEBOUNCE_MS,
       );
       ctx.updateConfigFingerprint();
+      autoEnabled = true;
     } catch (err) {
       log.warn({ err, skillId }, "Failed to auto-enable installed skill");
     }
@@ -385,11 +391,13 @@ export async function handleSkillsInstall(
       operation: "install",
       success: true,
     });
-    ctx.broadcast({
-      type: "skills_state_changed",
-      name: skillId,
-      state: "enabled",
-    });
+    if (autoEnabled) {
+      ctx.broadcast({
+        type: "skills_state_changed",
+        name: skillId,
+        state: "enabled",
+      });
+    }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Failed to install skill");


### PR DESCRIPTION
Addresses feedback from Codex and Devin on #11473. Adds `autoEnabled` flag to gate the `skills_state_changed` broadcast on successful config save, matching the pattern in `handleSkillsCreate`. Also fixes the same issue in the clawhub install path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
