### PR TITLE
fix: index chatgpt-import messages with original timestamps

### DIFF
--- a/assistant/src/config/bundled-skills/chatgpt-import/tools/chatgpt-import.ts
+++ b/assistant/src/config/bundled-skills/chatgpt-import/tools/chatgpt-import.ts
@@ -4,11 +4,13 @@ import { inflateRawSync } from "node:zlib";
 import { eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { getConfig } from "../../../../config/loader.js";
 import {
   addMessage,
   createConversation,
 } from "../../../../memory/conversation-store.js";
 import { getDb } from "../../../../memory/db.js";
+import { indexMessageNow } from "../../../../memory/indexer.js";
 import {
   conversationKeys,
   conversations,
@@ -88,7 +90,9 @@ export async function run(
     imported = parseChatGPTExport(filePath);
   } catch (err) {
     return {
-      content: `Error parsing export file: ${err instanceof Error ? err.message : String(err)}`,
+      content: `Error parsing export file: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
       isError: true,
     };
   }
@@ -121,9 +125,15 @@ export async function run(
 
     const conversation = createConversation(conv.title);
 
+    // Skip indexing during insert so we can backfill original timestamps first
     for (const msg of conv.messages) {
-      // Uses the daemon's addMessage which triggers memory indexing
-      await addMessage(conversation.id, msg.role, JSON.stringify(msg.content));
+      await addMessage(
+        conversation.id,
+        msg.role,
+        JSON.stringify(msg.content),
+        undefined,
+        { skipIndexing: true },
+      );
     }
 
     // Override timestamps to match ChatGPT originals
@@ -140,11 +150,26 @@ export async function run(
       .orderBy(messagesTable.createdAt)
       .all();
 
+    const memoryConfig = getConfig().memory;
     for (let i = 0; i < dbMessages.length && i < conv.messages.length; i++) {
+      const originalTimestamp = conv.messages[i].createdAt;
       db.update(messagesTable)
-        .set({ createdAt: conv.messages[i].createdAt })
+        .set({ createdAt: originalTimestamp })
         .where(eq(messagesTable.id, dbMessages[i].id))
         .run();
+
+      // Index with the original ChatGPT timestamp so memory segments
+      // reflect actual message age, not import time
+      indexMessageNow(
+        {
+          messageId: dbMessages[i].id,
+          conversationId: conversation.id,
+          role: conv.messages[i].role,
+          content: JSON.stringify(conv.messages[i].content),
+          createdAt: originalTimestamp,
+        },
+        memoryConfig,
+      );
     }
 
     db.insert(conversationKeys)


### PR DESCRIPTION
Addresses Codex feedback on #11465. Reorders the import flow to backfill original ChatGPT timestamps before memory indexing, preventing old archived messages from being ranked as brand-new in memory retrieval.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
