### PR TITLE
fix: add missing mock import to test files

### DIFF
--- a/assistant/src/__tests__/gmail-integration.test.ts
+++ b/assistant/src/__tests__/gmail-integration.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
 mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
 

--- a/assistant/src/__tests__/handle-user-message-secret-resume.test.ts
+++ b/assistant/src/__tests__/handle-user-message-secret-resume.test.ts
@@ -1,6 +1,6 @@
 import * as net from "node:net";
 
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
 mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
 

--- a/assistant/src/__tests__/session-approval-overrides.test.ts
+++ b/assistant/src/__tests__/session-approval-overrides.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
 


### PR DESCRIPTION
## Summary
- Added missing `mock` import from `bun:test` in `gmail-integration.test.ts`, `handle-user-message-secret-resume.test.ts`, and `session-approval-overrides.test.ts`
- These files used `mock.module()` without importing `mock`, causing `TS2304: Cannot find name 'mock'` type-check failures in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
