### PR TITLE
fix: update gateway tests for JWT auth model

### DIFF
--- a/gateway/src/__tests__/browser-relay-websocket.test.ts
+++ b/gateway/src/__tests__/browser-relay-websocket.test.ts
@@ -1,9 +1,25 @@
 import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
 import type { GatewayConfig } from "../config.js";
+import { initSigningKey, mintToken } from "../auth/token-service.js";
+import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
 import {
   createBrowserRelayWebsocketHandler,
   getBrowserRelayWebsocketHandlers,
 } from "../http/routes/browser-relay-websocket.js";
+
+const TEST_SIGNING_KEY = Buffer.from('test-signing-key-at-least-32-bytes-long');
+initSigningKey(TEST_SIGNING_KEY);
+
+/** Mint a valid edge JWT for browser relay auth. */
+function mintEdgeToken(): string {
+  return mintToken({
+    aud: 'vellum-gateway',
+    sub: 'actor:test-assistant:test-user',
+    scope_profile: 'actor_client_v1',
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 300,
+  });
+}
 
 const WS_CONNECTING = WebSocket.CONNECTING; // 0
 const WS_OPEN = WebSocket.OPEN; // 1
@@ -95,7 +111,7 @@ function createFakeUpstreamWs() {
 }
 
 describe("createBrowserRelayWebsocketHandler", () => {
-  const TEST_TOKEN = "relay-token-abc123";
+  const TEST_TOKEN = mintEdgeToken();
 
   test("upgrades when token query parameter is valid", () => {
     const config = makeConfig({});
@@ -238,7 +254,8 @@ describe("getBrowserRelayWebsocketHandlers", () => {
     handlers.message(ws as never, "hello-before-open");
 
     const MockWS = globalThis.WebSocket as unknown as ReturnType<typeof mock>;
-    expect(MockWS).toHaveBeenCalledWith("ws://runtime.internal:7821/v1/browser-relay?token=runtime-token");
+    const calledUrl = (MockWS.mock.calls[0] as unknown[])[0] as string;
+    expect(calledUrl).toMatch(/^ws:\/\/runtime\.internal:7821\/v1\/browser-relay\?token=ey/);
 
     fakeUpstream.readyState = WS_OPEN;
     fakeUpstream.emit("open");

--- a/gateway/src/__tests__/guardian-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/guardian-control-plane-proxy.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
 import type { GatewayConfig } from "../config.js";
+import { initSigningKey } from "../auth/token-service.js";
+
+const TEST_SIGNING_KEY = Buffer.from('test-signing-key-at-least-32-bytes-long');
+initSigningKey(TEST_SIGNING_KEY);
 
 type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
@@ -127,7 +131,7 @@ describe("guardian control-plane proxy", () => {
 
     expect(res.status).toBe(200);
     expect(capturedBody).toBe('{"channel":"voice","destination":"+15551234567"}');
-    expect(capturedHeaders?.get("authorization")).toBe("Bearer runtime-token");
+    expect(capturedHeaders?.get("authorization")).toMatch(/^Bearer ey/);
     expect(capturedHeaders?.has("host")).toBe(false);
   });
 

--- a/gateway/src/__tests__/ingress-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/ingress-control-plane-proxy.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
 import type { GatewayConfig } from "../config.js";
+import { initSigningKey } from "../auth/token-service.js";
+
+const TEST_SIGNING_KEY = Buffer.from('test-signing-key-at-least-32-bytes-long');
+initSigningKey(TEST_SIGNING_KEY);
 
 type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
@@ -136,7 +140,7 @@ describe("ingress control-plane proxy", () => {
     );
 
     expect(res.status).toBe(200);
-    expect(capturedHeaders?.get("authorization")).toBe("Bearer runtime-token");
+    expect(capturedHeaders?.get("authorization")).toMatch(/^Bearer ey/);
     expect(capturedHeaders?.has("host")).toBe(false);
   });
 

--- a/gateway/src/__tests__/oauth-callback.test.ts
+++ b/gateway/src/__tests__/oauth-callback.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
 import type { GatewayConfig } from "../config.js";
+import { initSigningKey } from "../auth/token-service.js";
+
+const TEST_SIGNING_KEY = Buffer.from('test-signing-key-at-least-32-bytes-long');
+initSigningKey(TEST_SIGNING_KEY);
 
 type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
@@ -96,7 +100,7 @@ describe("OAuth callback handler", () => {
     expect(sentBody.error).toBeUndefined();
 
     const headers = calledInit.headers as Record<string, string>;
-    expect(headers["Authorization"]).toBe("Bearer rt-token");
+    expect(headers["Authorization"]).toMatch(/^Bearer ey/);
   });
 
   test("missing state parameter returns 400 error page", async () => {
@@ -317,7 +321,7 @@ describe("OAuth callback handler", () => {
     expect(fetchMock.mock.calls.length).toBe(MAX_CONSUMED_STATES + 1);
   });
 
-  test("omits Authorization header when runtimeBearerToken is undefined", async () => {
+  test("always sends JWT Authorization header to runtime", async () => {
     fetchMock = mock(async () =>
       Response.json({ ok: true }, { status: 200 }),
     );
@@ -334,6 +338,6 @@ describe("OAuth callback handler", () => {
 
     const calledInit = (fetchMock.mock.calls[0] as unknown[])[1] as RequestInit;
     const headers = calledInit.headers as Record<string, string>;
-    expect(headers["Authorization"]).toBeUndefined();
+    expect(headers["Authorization"]).toMatch(/^Bearer ey/);
   });
 });

--- a/gateway/src/__tests__/runtime-client.test.ts
+++ b/gateway/src/__tests__/runtime-client.test.ts
@@ -1,6 +1,10 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
 import type { RuntimeAttachmentMeta, RuntimeInboundPayload } from "../runtime/client.js";
 import type { GatewayConfig } from "../config.js";
+import { initSigningKey } from "../auth/token-service.js";
+
+const TEST_SIGNING_KEY = Buffer.from('test-signing-key-at-least-32-bytes-long');
+initSigningKey(TEST_SIGNING_KEY);
 
 type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
@@ -182,7 +186,7 @@ describe("forwardToRuntime", () => {
     expect(attachments[0].kind).toBe("generated_image");
   });
 
-  test("sends Authorization header when runtimeBearerToken is configured", async () => {
+  test("sends JWT Authorization header to runtime", async () => {
     fetchMock = mock(async () =>
       new Response(JSON.stringify(successBody), { status: 200 }),
     );
@@ -192,20 +196,7 @@ describe("forwardToRuntime", () => {
 
     const calledInit = (fetchMock.mock.calls[0] as unknown[])[1] as RequestInit;
     const headers = calledInit.headers as Record<string, string>;
-    expect(headers["Authorization"]).toBe("Bearer my-secret-token");
-  });
-
-  test("omits Authorization header when runtimeBearerToken is undefined", async () => {
-    fetchMock = mock(async () =>
-      new Response(JSON.stringify(successBody), { status: 200 }),
-    );
-
-    const config = makeConfig();
-    await forwardToRuntime(config, payload);
-
-    const calledInit = (fetchMock.mock.calls[0] as unknown[])[1] as RequestInit;
-    const headers = calledInit.headers as Record<string, string>;
-    expect(headers["Authorization"]).toBeUndefined();
+    expect(headers["Authorization"]).toMatch(/^Bearer ey/);
   });
 });
 
@@ -282,7 +273,7 @@ describe("forwardTwilioVoiceWebhook", () => {
     expect(sentBody.originalUrl).toBe(originalUrl);
 
     const headers = calledInit.headers as Record<string, string>;
-    expect(headers["Authorization"]).toBe("Bearer rt-tok");
+    expect(headers["Authorization"]).toMatch(/^Bearer ey/);
   });
 });
 

--- a/gateway/src/__tests__/runtime-health-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-health-proxy.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
 import type { GatewayConfig } from "../config.js";
+import { initSigningKey } from "../auth/token-service.js";
+
+const TEST_SIGNING_KEY = Buffer.from('test-signing-key-at-least-32-bytes-long');
+initSigningKey(TEST_SIGNING_KEY);
 
 type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
@@ -102,7 +106,7 @@ describe("runtime health proxy", () => {
     );
 
     expect(res.status).toBe(200);
-    expect(capturedHeaders?.get("authorization")).toBe("Bearer runtime-token");
+    expect(capturedHeaders?.get("authorization")).toMatch(/^Bearer ey/);
     expect(capturedHeaders?.has("host")).toBe(false);
   });
 

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
 import type { GatewayConfig } from "../config.js";
+import { initSigningKey } from "../auth/token-service.js";
+
+const TEST_SIGNING_KEY = Buffer.from('test-signing-key-at-least-32-bytes-long');
+initSigningKey(TEST_SIGNING_KEY);
 
 type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
@@ -223,7 +227,7 @@ describe("runtime proxy handler", () => {
     expect(capturedSignal).toBeInstanceOf(AbortSignal);
   });
 
-  test("forwards authorization header when auth is not required", async () => {
+  test("replaces client authorization with JWT service token when auth is not required", async () => {
     let capturedHeaders: Headers | undefined;
     fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
       capturedHeaders = init?.headers as unknown as Headers;
@@ -236,10 +240,11 @@ describe("runtime proxy handler", () => {
     });
     await handler(req);
 
-    expect(capturedHeaders!.get("authorization")).toBe("Bearer upstream-token");
+    // When auth is not required, gateway still mints a JWT service token for the runtime
+    expect(capturedHeaders!.get("authorization")).toMatch(/^Bearer ey/);
   });
 
-  test("replaces client authorization with configured bearer token for upstream", async () => {
+  test("replaces client authorization with JWT token for upstream", async () => {
     let capturedHeaders: Headers | undefined;
     fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
       capturedHeaders = init?.headers as unknown as Headers;
@@ -254,7 +259,7 @@ describe("runtime proxy handler", () => {
     });
     await handler(req);
 
-    expect(capturedHeaders!.get("authorization")).toBe("Bearer daemon-token");
+    expect(capturedHeaders!.get("authorization")).toMatch(/^Bearer ey/);
   });
 
   test("truncates long upstream error bodies in logs", async () => {

--- a/gateway/src/__tests__/telegram-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/telegram-control-plane-proxy.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
 import type { GatewayConfig } from "../config.js";
+import { initSigningKey } from "../auth/token-service.js";
+
+const TEST_SIGNING_KEY = Buffer.from('test-signing-key-at-least-32-bytes-long');
+initSigningKey(TEST_SIGNING_KEY);
 
 type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
@@ -122,7 +126,7 @@ describe("telegram control-plane proxy", () => {
     );
 
     expect(res.status).toBe(200);
-    expect(capturedHeaders?.get("authorization")).toBe("Bearer runtime-token");
+    expect(capturedHeaders?.get("authorization")).toMatch(/^Bearer ey/);
     expect(capturedHeaders?.has("host")).toBe(false);
   });
 

--- a/gateway/src/__tests__/telegram-deliver-auth.test.ts
+++ b/gateway/src/__tests__/telegram-deliver-auth.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
 import type { GatewayConfig } from "../config.js";
+import { initSigningKey, mintToken } from "../auth/token-service.js";
+import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
+
+const TEST_SIGNING_KEY = Buffer.from('test-signing-key-at-least-32-bytes-long');
+initSigningKey(TEST_SIGNING_KEY);
 
 type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
@@ -10,7 +15,18 @@ mock.module("../fetch.js", () => ({
 
 const { createTelegramDeliverHandler } = await import("../http/routes/telegram-deliver.js");
 
-const TOKEN = "test-deliver-token";
+/** Mint a valid daemon JWT for deliver auth. */
+function mintDeliverToken(): string {
+  return mintToken({
+    aud: 'vellum-daemon',
+    sub: 'svc:gateway:self',
+    scope_profile: 'gateway_service_v1',
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 300,
+  });
+}
+
+const TOKEN = mintDeliverToken();
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -354,22 +370,6 @@ describe("/deliver/telegram bearer auth enforcement", () => {
     expect(body.ok).toBe(true);
   });
 
-  test("returns 503 when no token is configured and bypass is not set", async () => {
-    const handler = createTelegramDeliverHandler(
-      makeConfig({}),
-    );
-    const req = new Request("http://localhost:7830/deliver/telegram", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ chatId: "123", text: "hello" }),
-    });
-    const res = await handler(req);
-
-    expect(res.status).toBe(503);
-    const body = await res.json();
-    expect(body.error).toBe("Service not configured: bearer token required");
-  });
-
   test("allows unauthenticated access when bypass flag is set and no token configured", async () => {
     mockTelegramApi();
     const handler = createTelegramDeliverHandler(
@@ -385,23 +385,6 @@ describe("/deliver/telegram bearer auth enforcement", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.ok).toBe(true);
-  });
-
-  test("bypass flag is ignored when a bearer token is configured (auth still required)", async () => {
-    const handler = createTelegramDeliverHandler(
-      makeConfig({ telegramDeliverAuthBypass: true }),
-    );
-    const req = new Request("http://localhost:7830/deliver/telegram", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ chatId: "123", text: "hello" }),
-    });
-    const res = await handler(req);
-
-    // Token is configured, so missing Authorization header is still rejected
-    expect(res.status).toBe(401);
-    const body = await res.json();
-    expect(body.error).toBe("Unauthorized");
   });
 
   test("still rejects non-POST methods before auth check", async () => {

--- a/gateway/src/__tests__/telegram-reconcile-route.test.ts
+++ b/gateway/src/__tests__/telegram-reconcile-route.test.ts
@@ -1,5 +1,23 @@
 import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import type { GatewayConfig } from "../config.js";
+import { initSigningKey, mintToken } from "../auth/token-service.js";
+import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
+
+const TEST_SIGNING_KEY = Buffer.from('test-signing-key-at-least-32-bytes-long');
+initSigningKey(TEST_SIGNING_KEY);
+
+/** Mint a valid daemon JWT for reconcile auth. */
+function mintDaemonToken(): string {
+  return mintToken({
+    aud: 'vellum-daemon',
+    sub: 'svc:gateway:self',
+    scope_profile: 'gateway_service_v1',
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 300,
+  });
+}
+
+const TOKEN = mintDaemonToken();
 
 type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
@@ -125,15 +143,6 @@ describe("POST /internal/telegram/reconcile", () => {
     expect(res.status).toBe(405);
   });
 
-  test("returns 503 when no bearer token is configured", async () => {
-    const config = makeConfig({});
-    const handler = createTelegramReconcileHandler(config);
-    const res = await handler(makeRequest("POST", "any-token"));
-    expect(res.status).toBe(503);
-    const body = await res.json();
-    expect(body.error).toContain("bearer token required");
-  });
-
   test("returns 401 for missing auth header", async () => {
     const config = makeConfig();
     const handler = createTelegramReconcileHandler(config);
@@ -151,7 +160,7 @@ describe("POST /internal/telegram/reconcile", () => {
   test("triggers reconcile with correct auth", async () => {
     const config = makeConfig();
     const handler = createTelegramReconcileHandler(config);
-    const res = await handler(makeRequest("POST", "test-token"));
+    const res = await handler(makeRequest("POST", TOKEN));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.ok).toBe(true);
@@ -163,7 +172,7 @@ describe("POST /internal/telegram/reconcile", () => {
     const config = makeConfig({ ingressPublicBaseUrl: "https://old.example.com" });
     const handler = createTelegramReconcileHandler(config);
     const res = await handler(
-      makeRequest("POST", "test-token", {
+      makeRequest("POST", TOKEN, {
         ingressPublicBaseUrl: "https://new.example.com/",
       }),
     );
@@ -176,7 +185,7 @@ describe("POST /internal/telegram/reconcile", () => {
     const config = makeConfig({ ingressPublicBaseUrl: "https://old.example.com" });
     const handler = createTelegramReconcileHandler(config);
     const res = await handler(
-      makeRequest("POST", "test-token", {
+      makeRequest("POST", TOKEN, {
         ingressPublicBaseUrl: "",
       }),
     );
@@ -190,7 +199,7 @@ describe("POST /internal/telegram/reconcile", () => {
     const req = new Request("http://localhost:7830/internal/telegram/reconcile", {
       method: "POST",
       headers: {
-        authorization: "Bearer test-token",
+        authorization: `Bearer ${TOKEN}`,
       },
     });
     const res = await handler(req);
@@ -204,7 +213,7 @@ describe("POST /internal/telegram/reconcile", () => {
     });
     const config = makeConfig();
     const handler = createTelegramReconcileHandler(config);
-    const res = await handler(makeRequest("POST", "test-token"));
+    const res = await handler(makeRequest("POST", TOKEN));
     expect(res.status).toBe(502);
     const body = await res.json();
     expect(body.error).toBe("Reconciliation failed");
@@ -216,7 +225,7 @@ describe("POST /internal/telegram/reconcile", () => {
     const req = new Request("http://localhost:7830/internal/telegram/reconcile", {
       method: "POST",
       headers: {
-        authorization: "Bearer test-token",
+        authorization: `Bearer ${TOKEN}`,
         "content-type": "application/json",
       },
       body: "not-json{",
@@ -263,12 +272,12 @@ describe("POST /internal/telegram/reconcile", () => {
     // is still running, leaving Telegram pointed at the first URL.
     const [res1, res2] = await Promise.all([
       handler(
-        makeRequest("POST", "test-token", {
+        makeRequest("POST", TOKEN, {
           ingressPublicBaseUrl: "https://first.com",
         }),
       ),
       handler(
-        makeRequest("POST", "test-token", {
+        makeRequest("POST", TOKEN, {
           ingressPublicBaseUrl: "https://second.com",
         }),
       ),

--- a/gateway/src/__tests__/telegram-send-attachments.test.ts
+++ b/gateway/src/__tests__/telegram-send-attachments.test.ts
@@ -1,6 +1,10 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
 import type { RuntimeAttachmentMeta } from "../runtime/client.js";
 import type { GatewayConfig } from "../config.js";
+import { initSigningKey } from "../auth/token-service.js";
+
+const TEST_SIGNING_KEY = Buffer.from('test-signing-key-at-least-32-bytes-long');
+initSigningKey(TEST_SIGNING_KEY);
 
 type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());

--- a/gateway/src/__tests__/telegram-webhook-handler.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-handler.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect, mock, afterEach, beforeEach } from "bun:test";
 import type { GatewayConfig } from "../config.js";
+import { initSigningKey } from "../auth/token-service.js";
+
+const TEST_SIGNING_KEY = Buffer.from('test-signing-key-at-least-32-bytes-long');
+initSigningKey(TEST_SIGNING_KEY);
 
 type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());

--- a/gateway/src/__tests__/twilio-webhooks.test.ts
+++ b/gateway/src/__tests__/twilio-webhooks.test.ts
@@ -1,6 +1,10 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
 import { createHmac } from "node:crypto";
 import type { GatewayConfig } from "../config.js";
+import { initSigningKey } from "../auth/token-service.js";
+
+const TEST_SIGNING_KEY = Buffer.from('test-signing-key-at-least-32-bytes-long');
+initSigningKey(TEST_SIGNING_KEY);
 
 type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());

--- a/gateway/src/http/routes/sms-deliver.test.ts
+++ b/gateway/src/http/routes/sms-deliver.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, mock, afterEach } from "bun:test";
 import type { GatewayConfig } from "../../config.js";
+import { initSigningKey, mintToken } from "../../auth/token-service.js";
+import { CURRENT_POLICY_EPOCH } from "../../auth/policy.js";
+
+const TEST_SIGNING_KEY = Buffer.from('test-signing-key-at-least-32-bytes-long');
+initSigningKey(TEST_SIGNING_KEY);
 
 type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
@@ -12,7 +17,18 @@ const { createSmsDeliverHandler } = await import("./sms-deliver.js");
 
 // --- Helpers ---------------------------------------------------------------
 
-const TOKEN = "test-deliver-token";
+/** Mint a valid daemon JWT for deliver auth. */
+function mintDeliverToken(): string {
+  return mintToken({
+    aud: 'vellum-daemon',
+    sub: 'svc:gateway:self',
+    scope_profile: 'gateway_service_v1',
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 300,
+  });
+}
+
+const TOKEN = mintDeliverToken();
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -95,17 +111,6 @@ describe("/deliver/sms", () => {
     });
     const res = await handler(req);
     expect(res.status).toBe(405);
-  });
-
-  it("rejects when no bearer token and bypass not set with 503", async () => {
-    const handler = createSmsDeliverHandler(
-      makeConfig({}),
-    );
-    const req = makeRequest({ to: "+15559876543", text: "hello" });
-    const res = await handler(req);
-    expect(res.status).toBe(503);
-    const body = await res.json();
-    expect(body.error).toBe("Service not configured: bearer token required");
   });
 
   it("rejects request without Authorization header with 401", async () => {

--- a/gateway/src/http/routes/telegram-deliver.test.ts
+++ b/gateway/src/http/routes/telegram-deliver.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
 import type { GatewayConfig } from "../../config.js";
+import { initSigningKey, mintToken } from "../../auth/token-service.js";
+import { CURRENT_POLICY_EPOCH } from "../../auth/policy.js";
 import { createTelegramDeliverHandler } from "./telegram-deliver.js";
+
+const TEST_SIGNING_KEY = Buffer.from('test-signing-key-at-least-32-bytes-long');
+initSigningKey(TEST_SIGNING_KEY);
 
 // ---- Mocks ----
 
@@ -68,7 +73,18 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return merged;
 }
 
-const TOKEN = "test-deliver-token";
+/** Mint a valid daemon JWT for deliver auth. */
+function mintDeliverToken(): string {
+  return mintToken({
+    aud: 'vellum-daemon',
+    sub: 'svc:gateway:self',
+    scope_profile: 'gateway_service_v1',
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 300,
+  });
+}
+
+const TOKEN = mintDeliverToken();
 
 function makeRequest(body: unknown, headers?: Record<string, string>): Request {
   return new Request("http://localhost:7830/deliver/telegram", {
@@ -95,17 +111,6 @@ describe("telegram-deliver endpoint basics", () => {
     expect(res.status).toBe(405);
     const body = await res.json();
     expect(body.error).toBe("Method not allowed");
-  });
-
-  it("rejects when no bearer token and bypass not set with 503", async () => {
-    const handler = createTelegramDeliverHandler(
-      makeConfig({ telegramDeliverAuthBypass: false }),
-    );
-    const req = makeRequest({ chatId: "123", text: "hello" });
-    const res = await handler(req);
-    expect(res.status).toBe(503);
-    const body = await res.json();
-    expect(body.error).toBe("Service not configured: bearer token required");
   });
 
   it("rejects request without Authorization header with 401", async () => {

--- a/gateway/src/http/routes/whatsapp-deliver.test.ts
+++ b/gateway/src/http/routes/whatsapp-deliver.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
 import type { GatewayConfig } from "../../config.js";
+import { initSigningKey, mintToken } from "../../auth/token-service.js";
+import { CURRENT_POLICY_EPOCH } from "../../auth/policy.js";
+
+const TEST_SIGNING_KEY = Buffer.from('test-signing-key-at-least-32-bytes-long');
+initSigningKey(TEST_SIGNING_KEY);
 
 // ---- Mocks ----
 
@@ -16,7 +21,18 @@ const { createWhatsAppDeliverHandler } = await import("./whatsapp-deliver.js");
 
 // ---- Helpers ----
 
-const TOKEN = "test-deliver-token";
+/** Mint a valid daemon JWT for deliver auth. */
+function mintDeliverToken(): string {
+  return mintToken({
+    aud: 'vellum-daemon',
+    sub: 'svc:gateway:self',
+    scope_profile: 'gateway_service_v1',
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 300,
+  });
+}
+
+const TOKEN = mintDeliverToken();
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -94,22 +110,9 @@ describe("/deliver/whatsapp", () => {
     expect(body.error).toBe("Method not allowed");
   });
 
-  it("rejects when no bearer token and bypass not set with 503", async () => {
-    const handler = createWhatsAppDeliverHandler(
-      makeConfig({
-        whatsappDeliverAuthBypass: false,
-      }),
-    );
-    const req = makeRequest({ to: "+15559876543", text: "hello" });
-    const res = await handler(req);
-    expect(res.status).toBe(503);
-    const body = await res.json();
-    expect(body.error).toBe("Service not configured: bearer token required");
-  });
-
   it("rejects request without Authorization header with 401", async () => {
     const handler = createWhatsAppDeliverHandler(
-      makeConfig({}),
+      makeConfig({ whatsappDeliverAuthBypass: false }),
     );
     const req = makeRequest({ to: "+15559876543", text: "hello" });
     const res = await handler(req);
@@ -120,7 +123,7 @@ describe("/deliver/whatsapp", () => {
 
   it("rejects request with wrong bearer token with 401", async () => {
     const handler = createWhatsAppDeliverHandler(
-      makeConfig({}),
+      makeConfig({ whatsappDeliverAuthBypass: false }),
     );
     const req = makeRequest({ to: "+15559876543", text: "hello" }, {
       authorization: "Bearer wrong-token",
@@ -133,7 +136,7 @@ describe("/deliver/whatsapp", () => {
 
   it("accepts request with correct bearer token", async () => {
     const handler = createWhatsAppDeliverHandler(
-      makeConfig({}),
+      makeConfig({ whatsappDeliverAuthBypass: false }),
     );
     const req = makeRequest({ to: "+15559876543", text: "hello" }, {
       authorization: `Bearer ${TOKEN}`,


### PR DESCRIPTION
## Summary
- Initialize signing key (`initSigningKey()`) in all gateway test files that mint tokens or call handlers using JWT auth
- Replace hardcoded static token assertions (e.g. `"Bearer runtime-token"`, `"Bearer test-token"`) with JWT pattern checks (`/^Bearer ey/`)
- Mint proper JWTs via `mintToken()` in deliver and reconcile test files instead of using static string tokens
- Remove stale tests that expected 503 "Service not configured: bearer token required" (old config-based auth model concept)

## Original prompt
fix the errors in https://github.com/vellum-ai/vellum-assistant/actions/runs/22605700354/job/65497154610

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
