### PR TITLE
M4: Peer identity/auth model

### DIFF
--- a/assistant/src/a2a/__tests__/a2a-peer-auth.test.ts
+++ b/assistant/src/a2a/__tests__/a2a-peer-auth.test.ts
@@ -1,0 +1,935 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'a2a-peer-auth-test-'));
+
+mock.module('../../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+mock.module('../../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  CREDENTIAL_BYTE_LENGTH,
+  DEFAULT_REPLAY_WINDOW_MS,
+  HEADER_CONNECTION_ID,
+  HEADER_NONCE,
+  HEADER_SIGNATURE,
+  HEADER_TIMESTAMP,
+  NonceStore,
+  buildSigningPayload,
+  computeHmac,
+  generateCredentialPair,
+  generateCredentialToken,
+  revokeCredentials,
+  rotateCredentials,
+  signRequest,
+  verifyRequest,
+  verifySignature,
+} from '../a2a-peer-auth.js';
+import { hashHandshakeSecret } from '../a2a-handshake.js';
+import {
+  createConnection,
+  getConnection,
+  updateConnectionStatus,
+} from '../a2a-peer-connection-store.js';
+import { getDb, initializeDb, resetDb } from '../../memory/db.js';
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run('DELETE FROM a2a_peer_connections');
+}
+
+// ---------------------------------------------------------------------------
+// Credential generation
+// ---------------------------------------------------------------------------
+
+describe('generateCredentialToken', () => {
+  test('produces a hex string of expected length', () => {
+    const token = generateCredentialToken();
+    // 32 bytes = 64 hex characters
+    expect(token).toHaveLength(CREDENTIAL_BYTE_LENGTH * 2);
+    expect(token).toMatch(/^[0-9a-f]+$/);
+  });
+
+  test('generates unique tokens on successive calls', () => {
+    const tokens = new Set<string>();
+    for (let i = 0; i < 50; i++) {
+      tokens.add(generateCredentialToken());
+    }
+    expect(tokens.size).toBe(50);
+  });
+});
+
+describe('generateCredentialPair', () => {
+  test('returns inbound and outbound credentials with their hashes', () => {
+    const pair = generateCredentialPair();
+
+    expect(pair.inboundCredential).toHaveLength(CREDENTIAL_BYTE_LENGTH * 2);
+    expect(pair.outboundCredential).toHaveLength(CREDENTIAL_BYTE_LENGTH * 2);
+    expect(pair.inboundCredentialHash).toHaveLength(64); // SHA-256 hex
+    expect(pair.outboundCredentialHash).toHaveLength(64);
+  });
+
+  test('hashes match the raw credentials', () => {
+    const pair = generateCredentialPair();
+
+    expect(pair.inboundCredentialHash).toBe(hashHandshakeSecret(pair.inboundCredential));
+    expect(pair.outboundCredentialHash).toBe(hashHandshakeSecret(pair.outboundCredential));
+  });
+
+  test('inbound and outbound credentials are different', () => {
+    const pair = generateCredentialPair();
+    expect(pair.inboundCredential).not.toBe(pair.outboundCredential);
+  });
+
+  test('successive pairs are unique', () => {
+    const pair1 = generateCredentialPair();
+    const pair2 = generateCredentialPair();
+
+    expect(pair1.inboundCredential).not.toBe(pair2.inboundCredential);
+    expect(pair1.outboundCredential).not.toBe(pair2.outboundCredential);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HMAC signing primitives
+// ---------------------------------------------------------------------------
+
+describe('buildSigningPayload', () => {
+  test('concatenates timestamp, nonce, and body with colons', () => {
+    const payload = buildSigningPayload('1700000000000', 'nonce-abc', '{"hello":"world"}');
+    expect(payload).toBe('1700000000000:nonce-abc:{"hello":"world"}');
+  });
+
+  test('handles empty body', () => {
+    const payload = buildSigningPayload('123', 'n', '');
+    expect(payload).toBe('123:n:');
+  });
+});
+
+describe('computeHmac', () => {
+  test('produces a hex string', () => {
+    const hmac = computeHmac('secret-key', 'some payload');
+    expect(hmac).toMatch(/^[0-9a-f]+$/);
+    // HMAC-SHA256 produces 32 bytes = 64 hex chars
+    expect(hmac).toHaveLength(64);
+  });
+
+  test('same inputs produce same output (deterministic)', () => {
+    const a = computeHmac('key', 'data');
+    const b = computeHmac('key', 'data');
+    expect(a).toBe(b);
+  });
+
+  test('different keys produce different signatures', () => {
+    const a = computeHmac('key-1', 'data');
+    const b = computeHmac('key-2', 'data');
+    expect(a).not.toBe(b);
+  });
+
+  test('different data produces different signatures', () => {
+    const a = computeHmac('key', 'data-1');
+    const b = computeHmac('key', 'data-2');
+    expect(a).not.toBe(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Request signing
+// ---------------------------------------------------------------------------
+
+describe('signRequest', () => {
+  test('returns all required headers', () => {
+    const headers = signRequest('conn-1', 'my-credential', '{"test":true}');
+
+    expect(headers[HEADER_SIGNATURE]).toBeTruthy();
+    expect(headers[HEADER_TIMESTAMP]).toBeTruthy();
+    expect(headers[HEADER_NONCE]).toBeTruthy();
+    expect(headers[HEADER_CONNECTION_ID]).toBe('conn-1');
+  });
+
+  test('signature is a valid HMAC-SHA256 hex string', () => {
+    const headers = signRequest('conn-1', 'cred', 'body');
+    expect(headers[HEADER_SIGNATURE]).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test('nonce is a UUID', () => {
+    const headers = signRequest('conn-1', 'cred', 'body');
+    expect(headers[HEADER_NONCE]).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  test('uses provided timestamp when given', () => {
+    const headers = signRequest('conn-1', 'cred', 'body', 1700000000000);
+    expect(headers[HEADER_TIMESTAMP]).toBe('1700000000000');
+  });
+
+  test('signature is verifiable', () => {
+    const credential = generateCredentialToken();
+    const body = '{"message":"hello"}';
+    const now = Date.now();
+
+    const headers = signRequest('conn-1', credential, body, now);
+
+    // Manually verify the signature
+    const payload = buildSigningPayload(headers[HEADER_TIMESTAMP], headers[HEADER_NONCE], body);
+    const expectedSig = computeHmac(credential, payload);
+    expect(headers[HEADER_SIGNATURE]).toBe(expectedSig);
+  });
+
+  test('different calls produce different nonces', () => {
+    const nonces = new Set<string>();
+    for (let i = 0; i < 20; i++) {
+      const headers = signRequest('conn-1', 'cred', 'body');
+      nonces.add(headers[HEADER_NONCE]);
+    }
+    expect(nonces.size).toBe(20);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NonceStore
+// ---------------------------------------------------------------------------
+
+describe('NonceStore', () => {
+  test('new nonce returns false (not seen)', () => {
+    const store = new NonceStore();
+    expect(store.hasBeenSeen('nonce-1')).toBe(false);
+  });
+
+  test('repeated nonce returns true (seen)', () => {
+    const store = new NonceStore();
+    store.hasBeenSeen('nonce-1');
+    expect(store.hasBeenSeen('nonce-1')).toBe(true);
+  });
+
+  test('different nonces are tracked independently', () => {
+    const store = new NonceStore();
+    expect(store.hasBeenSeen('a')).toBe(false);
+    expect(store.hasBeenSeen('b')).toBe(false);
+    expect(store.hasBeenSeen('a')).toBe(true);
+    expect(store.hasBeenSeen('b')).toBe(true);
+    expect(store.hasBeenSeen('c')).toBe(false);
+  });
+
+  test('size tracks the number of stored nonces', () => {
+    const store = new NonceStore();
+    expect(store.size).toBe(0);
+
+    store.hasBeenSeen('a');
+    expect(store.size).toBe(1);
+
+    store.hasBeenSeen('b');
+    expect(store.size).toBe(2);
+
+    // Duplicate does not increase size
+    store.hasBeenSeen('a');
+    expect(store.size).toBe(2);
+  });
+
+  test('sweep evicts nonces older than the replay window', () => {
+    const store = new NonceStore(1000); // 1-second window
+    const baseTime = 1000000;
+
+    store.hasBeenSeen('old-nonce', baseTime);
+    store.hasBeenSeen('new-nonce', baseTime + 1500);
+    expect(store.size).toBe(2);
+
+    // Sweep at time where old-nonce is expired but new-nonce is not
+    const evicted = store.sweep(baseTime + 2000);
+    expect(evicted).toBe(1);
+    expect(store.size).toBe(1);
+
+    // Verify old-nonce was evicted (can be re-used)
+    expect(store.hasBeenSeen('old-nonce', baseTime + 2000)).toBe(false);
+    // new-nonce is still tracked
+    expect(store.hasBeenSeen('new-nonce', baseTime + 2000)).toBe(true);
+  });
+
+  test('opportunistic sweep triggers after replay window interval', () => {
+    const store = new NonceStore(1000); // 1-second window
+    const baseTime = 1000000;
+
+    store.hasBeenSeen('old', baseTime);
+    expect(store.size).toBe(1);
+
+    // This call triggers an opportunistic sweep because enough time has passed
+    store.hasBeenSeen('new', baseTime + 2000);
+    // old should have been evicted, new is added
+    expect(store.size).toBe(1);
+  });
+
+  test('clear resets the store', () => {
+    const store = new NonceStore();
+    store.hasBeenSeen('a');
+    store.hasBeenSeen('b');
+    expect(store.size).toBe(2);
+
+    store.clear();
+    expect(store.size).toBe(0);
+    expect(store.hasBeenSeen('a')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifySignature (stateless — no DB)
+// ---------------------------------------------------------------------------
+
+describe('verifySignature', () => {
+  test('valid signature passes', () => {
+    const credential = generateCredentialToken();
+    const body = '{"test":true}';
+    const now = Date.now();
+    const nonceStore = new NonceStore();
+
+    const headers = signRequest('conn-1', credential, body, now);
+
+    const result = verifySignature({
+      signature: headers[HEADER_SIGNATURE],
+      timestamp: headers[HEADER_TIMESTAMP],
+      nonce: headers[HEADER_NONCE],
+      body,
+      credential,
+      nonceStore,
+      now,
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  test('tampered body fails verification', () => {
+    const credential = generateCredentialToken();
+    const body = '{"test":true}';
+    const now = Date.now();
+    const nonceStore = new NonceStore();
+
+    const headers = signRequest('conn-1', credential, body, now);
+
+    const result = verifySignature({
+      signature: headers[HEADER_SIGNATURE],
+      timestamp: headers[HEADER_TIMESTAMP],
+      nonce: headers[HEADER_NONCE],
+      body: '{"test":false}', // tampered
+      credential,
+      nonceStore,
+      now,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('invalid_signature');
+  });
+
+  test('wrong credential fails verification', () => {
+    const realCredential = generateCredentialToken();
+    const wrongCredential = generateCredentialToken();
+    const body = '{"data":"hello"}';
+    const now = Date.now();
+    const nonceStore = new NonceStore();
+
+    const headers = signRequest('conn-1', realCredential, body, now);
+
+    const result = verifySignature({
+      signature: headers[HEADER_SIGNATURE],
+      timestamp: headers[HEADER_TIMESTAMP],
+      nonce: headers[HEADER_NONCE],
+      body,
+      credential: wrongCredential,
+      nonceStore,
+      now,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('invalid_signature');
+  });
+
+  test('expired timestamp rejected', () => {
+    const credential = generateCredentialToken();
+    const body = 'body';
+    const oldTime = Date.now() - DEFAULT_REPLAY_WINDOW_MS - 1000;
+    const nonceStore = new NonceStore();
+
+    const headers = signRequest('conn-1', credential, body, oldTime);
+
+    const result = verifySignature({
+      signature: headers[HEADER_SIGNATURE],
+      timestamp: headers[HEADER_TIMESTAMP],
+      nonce: headers[HEADER_NONCE],
+      body,
+      credential,
+      nonceStore,
+      now: Date.now(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('timestamp_expired');
+  });
+
+  test('future timestamp beyond replay window rejected', () => {
+    const credential = generateCredentialToken();
+    const body = 'body';
+    const futureTime = Date.now() + DEFAULT_REPLAY_WINDOW_MS + 1000;
+    const nonceStore = new NonceStore();
+
+    const headers = signRequest('conn-1', credential, body, futureTime);
+
+    const result = verifySignature({
+      signature: headers[HEADER_SIGNATURE],
+      timestamp: headers[HEADER_TIMESTAMP],
+      nonce: headers[HEADER_NONCE],
+      body,
+      credential,
+      nonceStore,
+      now: Date.now(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('timestamp_expired');
+  });
+
+  test('duplicate nonce rejected', () => {
+    const credential = generateCredentialToken();
+    const body = 'body';
+    const now = Date.now();
+    const nonceStore = new NonceStore();
+
+    const headers = signRequest('conn-1', credential, body, now);
+
+    // First verification succeeds
+    const result1 = verifySignature({
+      signature: headers[HEADER_SIGNATURE],
+      timestamp: headers[HEADER_TIMESTAMP],
+      nonce: headers[HEADER_NONCE],
+      body,
+      credential,
+      nonceStore,
+      now,
+    });
+    expect(result1.ok).toBe(true);
+
+    // Replay with same nonce fails
+    const result2 = verifySignature({
+      signature: headers[HEADER_SIGNATURE],
+      timestamp: headers[HEADER_TIMESTAMP],
+      nonce: headers[HEADER_NONCE],
+      body,
+      credential,
+      nonceStore,
+      now,
+    });
+    expect(result2.ok).toBe(false);
+    if (!result2.ok) expect(result2.reason).toBe('nonce_replayed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyRequest (full — with DB lookup)
+// ---------------------------------------------------------------------------
+
+describe('verifyRequest', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  afterAll(() => {
+    resetDb();
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  function createActiveConnection(inboundCredential: string): { connection: ReturnType<typeof createConnection>; inboundCredential: string } {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://peer.example.com',
+      status: 'active',
+      inboundCredentialHash: hashHandshakeSecret(inboundCredential),
+      outboundCredentialHash: hashHandshakeSecret(generateCredentialToken()),
+    });
+    return { connection: conn, inboundCredential };
+  }
+
+  test('valid request passes full verification', () => {
+    const inboundCred = generateCredentialToken();
+    const { connection } = createActiveConnection(inboundCred);
+    const body = '{"action":"ping"}';
+    const now = Date.now();
+    const nonceStore = new NonceStore();
+
+    // The peer signs with the inbound credential (from our perspective)
+    const headers = signRequest(connection.id, inboundCred, body, now);
+
+    const result = verifyRequest({
+      headers: {
+        [HEADER_SIGNATURE]: headers[HEADER_SIGNATURE],
+        [HEADER_TIMESTAMP]: headers[HEADER_TIMESTAMP],
+        [HEADER_NONCE]: headers[HEADER_NONCE],
+        [HEADER_CONNECTION_ID]: headers[HEADER_CONNECTION_ID],
+      },
+      body,
+      inboundCredential: inboundCred,
+      nonceStore,
+      now,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.connectionId).toBe(connection.id);
+  });
+
+  test('missing headers rejected', () => {
+    const nonceStore = new NonceStore();
+
+    const result = verifyRequest({
+      headers: {},
+      body: 'body',
+      inboundCredential: 'cred',
+      nonceStore,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('missing_headers');
+  });
+
+  test('partial headers rejected', () => {
+    const nonceStore = new NonceStore();
+
+    const result = verifyRequest({
+      headers: {
+        [HEADER_SIGNATURE]: 'sig',
+        [HEADER_TIMESTAMP]: '123',
+        // missing nonce and connection-id
+      },
+      body: 'body',
+      inboundCredential: 'cred',
+      nonceStore,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('missing_headers');
+  });
+
+  test('nonexistent connection rejected', () => {
+    const nonceStore = new NonceStore();
+    const now = Date.now();
+    const cred = generateCredentialToken();
+    const headers = signRequest('nonexistent-id', cred, 'body', now);
+
+    const result = verifyRequest({
+      headers: {
+        [HEADER_SIGNATURE]: headers[HEADER_SIGNATURE],
+        [HEADER_TIMESTAMP]: headers[HEADER_TIMESTAMP],
+        [HEADER_NONCE]: headers[HEADER_NONCE],
+        [HEADER_CONNECTION_ID]: 'nonexistent-id',
+      },
+      body: 'body',
+      inboundCredential: cred,
+      nonceStore,
+      now,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('connection_not_found');
+  });
+
+  test('pending connection rejected', () => {
+    const inboundCred = generateCredentialToken();
+    const conn = createConnection({
+      peerGatewayUrl: 'https://peer.example.com',
+      status: 'pending',
+      inboundCredentialHash: hashHandshakeSecret(inboundCred),
+    });
+    const nonceStore = new NonceStore();
+    const now = Date.now();
+    const headers = signRequest(conn.id, inboundCred, 'body', now);
+
+    const result = verifyRequest({
+      headers: {
+        [HEADER_SIGNATURE]: headers[HEADER_SIGNATURE],
+        [HEADER_TIMESTAMP]: headers[HEADER_TIMESTAMP],
+        [HEADER_NONCE]: headers[HEADER_NONCE],
+        [HEADER_CONNECTION_ID]: conn.id,
+      },
+      body: 'body',
+      inboundCredential: inboundCred,
+      nonceStore,
+      now,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('connection_not_active');
+  });
+
+  test('revoked connection rejected with credential_revoked', () => {
+    const inboundCred = generateCredentialToken();
+    const conn = createConnection({
+      peerGatewayUrl: 'https://peer.example.com',
+      status: 'revoked',
+      inboundCredentialHash: hashHandshakeSecret(inboundCred),
+    });
+    const nonceStore = new NonceStore();
+    const now = Date.now();
+    const headers = signRequest(conn.id, inboundCred, 'body', now);
+
+    const result = verifyRequest({
+      headers: {
+        [HEADER_SIGNATURE]: headers[HEADER_SIGNATURE],
+        [HEADER_TIMESTAMP]: headers[HEADER_TIMESTAMP],
+        [HEADER_NONCE]: headers[HEADER_NONCE],
+        [HEADER_CONNECTION_ID]: conn.id,
+      },
+      body: 'body',
+      inboundCredential: inboundCred,
+      nonceStore,
+      now,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('credential_revoked');
+  });
+
+  test('expired timestamp rejected', () => {
+    const inboundCred = generateCredentialToken();
+    const { connection } = createActiveConnection(inboundCred);
+    const nonceStore = new NonceStore();
+    const now = Date.now();
+    const oldTime = now - DEFAULT_REPLAY_WINDOW_MS - 1000;
+
+    const headers = signRequest(connection.id, inboundCred, 'body', oldTime);
+
+    const result = verifyRequest({
+      headers: {
+        [HEADER_SIGNATURE]: headers[HEADER_SIGNATURE],
+        [HEADER_TIMESTAMP]: headers[HEADER_TIMESTAMP],
+        [HEADER_NONCE]: headers[HEADER_NONCE],
+        [HEADER_CONNECTION_ID]: connection.id,
+      },
+      body: 'body',
+      inboundCredential: inboundCred,
+      nonceStore,
+      now,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('timestamp_expired');
+  });
+
+  test('replayed nonce rejected', () => {
+    const inboundCred = generateCredentialToken();
+    const { connection } = createActiveConnection(inboundCred);
+    const body = '{"test":true}';
+    const now = Date.now();
+    const nonceStore = new NonceStore();
+
+    const headers = signRequest(connection.id, inboundCred, body, now);
+    const headerObj = {
+      [HEADER_SIGNATURE]: headers[HEADER_SIGNATURE],
+      [HEADER_TIMESTAMP]: headers[HEADER_TIMESTAMP],
+      [HEADER_NONCE]: headers[HEADER_NONCE],
+      [HEADER_CONNECTION_ID]: connection.id,
+    };
+
+    // First request succeeds
+    const result1 = verifyRequest({
+      headers: headerObj,
+      body,
+      inboundCredential: inboundCred,
+      nonceStore,
+      now,
+    });
+    expect(result1.ok).toBe(true);
+
+    // Replay with same nonce fails
+    const result2 = verifyRequest({
+      headers: headerObj,
+      body,
+      inboundCredential: inboundCred,
+      nonceStore,
+      now,
+    });
+    expect(result2.ok).toBe(false);
+    if (!result2.ok) expect(result2.reason).toBe('nonce_replayed');
+  });
+
+  test('tampered body fails signature verification', () => {
+    const inboundCred = generateCredentialToken();
+    const { connection } = createActiveConnection(inboundCred);
+    const now = Date.now();
+    const nonceStore = new NonceStore();
+
+    const headers = signRequest(connection.id, inboundCred, '{"original":true}', now);
+
+    const result = verifyRequest({
+      headers: {
+        [HEADER_SIGNATURE]: headers[HEADER_SIGNATURE],
+        [HEADER_TIMESTAMP]: headers[HEADER_TIMESTAMP],
+        [HEADER_NONCE]: headers[HEADER_NONCE],
+        [HEADER_CONNECTION_ID]: connection.id,
+      },
+      body: '{"tampered":true}',
+      inboundCredential: inboundCred,
+      nonceStore,
+      now,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('invalid_signature');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Credential rotation
+// ---------------------------------------------------------------------------
+
+describe('rotateCredentials', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test('generates new credentials and updates the connection', () => {
+    const oldPair = generateCredentialPair();
+    const conn = createConnection({
+      peerGatewayUrl: 'https://peer.example.com',
+      status: 'active',
+      outboundCredentialHash: oldPair.outboundCredentialHash,
+      inboundCredentialHash: oldPair.inboundCredentialHash,
+    });
+
+    const result = rotateCredentials(conn.id);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+
+    // New credentials are different from old ones
+    expect(result.newCredentials.outboundCredential).not.toBe(oldPair.outboundCredential);
+    expect(result.newCredentials.inboundCredential).not.toBe(oldPair.inboundCredential);
+
+    // Connection store is updated
+    const updated = getConnection(conn.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.outboundCredentialHash).toBe(result.newCredentials.outboundCredentialHash);
+    expect(updated!.inboundCredentialHash).toBe(result.newCredentials.inboundCredentialHash);
+  });
+
+  test('new credentials work for signing/verification', () => {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://peer.example.com',
+      status: 'active',
+      outboundCredentialHash: hashHandshakeSecret('old-outbound'),
+      inboundCredentialHash: hashHandshakeSecret('old-inbound'),
+    });
+
+    const result = rotateCredentials(conn.id);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+
+    // Sign with new outbound credential
+    const body = '{"after":"rotation"}';
+    const now = Date.now();
+    const headers = signRequest(conn.id, result.newCredentials.outboundCredential, body, now);
+
+    // Verify with new outbound credential
+    const nonceStore = new NonceStore();
+    const verifyResult = verifySignature({
+      signature: headers[HEADER_SIGNATURE],
+      timestamp: headers[HEADER_TIMESTAMP],
+      nonce: headers[HEADER_NONCE],
+      body,
+      credential: result.newCredentials.outboundCredential,
+      nonceStore,
+      now,
+    });
+    expect(verifyResult.ok).toBe(true);
+  });
+
+  test('old credentials fail after rotation', () => {
+    const oldOutbound = generateCredentialToken();
+    const conn = createConnection({
+      peerGatewayUrl: 'https://peer.example.com',
+      status: 'active',
+      outboundCredentialHash: hashHandshakeSecret(oldOutbound),
+      inboundCredentialHash: hashHandshakeSecret('old-inbound'),
+    });
+
+    const result = rotateCredentials(conn.id);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+
+    // Sign with OLD outbound credential
+    const body = '{"old":"credential"}';
+    const now = Date.now();
+    const headers = signRequest(conn.id, oldOutbound, body, now);
+
+    // Verify with NEW outbound credential should fail
+    const nonceStore = new NonceStore();
+    const verifyResult = verifySignature({
+      signature: headers[HEADER_SIGNATURE],
+      timestamp: headers[HEADER_TIMESTAMP],
+      nonce: headers[HEADER_NONCE],
+      body,
+      credential: result.newCredentials.outboundCredential,
+      nonceStore,
+      now,
+    });
+    expect(verifyResult.ok).toBe(false);
+    if (!verifyResult.ok) expect(verifyResult.reason).toBe('invalid_signature');
+  });
+
+  test('rotation fails for non-active connection', () => {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://peer.example.com',
+      status: 'pending',
+    });
+
+    const result = rotateCredentials(conn.id);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('connection_not_active');
+  });
+
+  test('rotation fails for nonexistent connection', () => {
+    const result = rotateCredentials('nonexistent');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('connection_not_found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Credential revocation
+// ---------------------------------------------------------------------------
+
+describe('revokeCredentials', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test('revokes an active connection', () => {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://peer.example.com',
+      status: 'active',
+      outboundCredentialHash: hashHandshakeSecret('out'),
+      inboundCredentialHash: hashHandshakeSecret('in'),
+    });
+
+    const result = revokeCredentials(conn.id);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(result.connection.status).toBe('revoked');
+  });
+
+  test('credentials are tombstoned after revocation', () => {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://peer.example.com',
+      status: 'active',
+      outboundCredentialHash: hashHandshakeSecret('out'),
+      inboundCredentialHash: hashHandshakeSecret('in'),
+    });
+
+    revokeCredentials(conn.id);
+
+    const updated = getConnection(conn.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.outboundCredentialHash).toBe('');
+    expect(updated!.inboundCredentialHash).toBe('');
+  });
+
+  test('revoked connection rejects new requests via verifyRequest', () => {
+    const inboundCred = generateCredentialToken();
+    const conn = createConnection({
+      peerGatewayUrl: 'https://peer.example.com',
+      status: 'active',
+      inboundCredentialHash: hashHandshakeSecret(inboundCred),
+      outboundCredentialHash: hashHandshakeSecret(generateCredentialToken()),
+    });
+
+    // Revoke
+    revokeCredentials(conn.id);
+
+    // Try to make a request with the old credential
+    const body = '{"after":"revocation"}';
+    const now = Date.now();
+    const nonceStore = new NonceStore();
+    const headers = signRequest(conn.id, inboundCred, body, now);
+
+    const result = verifyRequest({
+      headers: {
+        [HEADER_SIGNATURE]: headers[HEADER_SIGNATURE],
+        [HEADER_TIMESTAMP]: headers[HEADER_TIMESTAMP],
+        [HEADER_NONCE]: headers[HEADER_NONCE],
+        [HEADER_CONNECTION_ID]: conn.id,
+      },
+      body,
+      inboundCredential: inboundCred,
+      nonceStore,
+      now,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('credential_revoked');
+  });
+
+  test('cannot revoke an already-revoked connection', () => {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://peer.example.com',
+      status: 'active',
+    });
+
+    const first = revokeCredentials(conn.id);
+    expect(first.ok).toBe(true);
+
+    const second = revokeCredentials(conn.id);
+    expect(second.ok).toBe(false);
+    if (!second.ok) expect(second.reason).toBe('already_revoked');
+  });
+
+  test('cannot revoke a nonexistent connection', () => {
+    const result = revokeCredentials('nonexistent');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('connection_not_found');
+  });
+
+  test('can revoke a pending connection', () => {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://peer.example.com',
+      status: 'pending',
+    });
+
+    const result = revokeCredentials(conn.id);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(result.connection.status).toBe('revoked');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+describe('constants', () => {
+  test('DEFAULT_REPLAY_WINDOW_MS is 5 minutes', () => {
+    expect(DEFAULT_REPLAY_WINDOW_MS).toBe(5 * 60 * 1000);
+  });
+
+  test('CREDENTIAL_BYTE_LENGTH is 32', () => {
+    expect(CREDENTIAL_BYTE_LENGTH).toBe(32);
+  });
+});

--- a/assistant/src/a2a/__tests__/a2a-peer-auth.test.ts
+++ b/assistant/src/a2a/__tests__/a2a-peer-auth.test.ts
@@ -672,6 +672,35 @@ describe('verifyRequest', () => {
     if (!result2.ok) expect(result2.reason).toBe('nonce_replayed');
   });
 
+  test('wrong inbound credential rejected with credential_mismatch', () => {
+    const realCred = generateCredentialToken();
+    const wrongCred = generateCredentialToken();
+    const { connection } = createActiveConnection(realCred);
+    const body = '{"test":"credential_mismatch"}';
+    const now = Date.now();
+    const nonceStore = new NonceStore();
+
+    // Sign with the wrong credential (which also means the HMAC would fail,
+    // but the credential hash check should reject it first)
+    const headers = signRequest(connection.id, wrongCred, body, now);
+
+    const result = verifyRequest({
+      headers: {
+        [HEADER_SIGNATURE]: headers[HEADER_SIGNATURE],
+        [HEADER_TIMESTAMP]: headers[HEADER_TIMESTAMP],
+        [HEADER_NONCE]: headers[HEADER_NONCE],
+        [HEADER_CONNECTION_ID]: connection.id,
+      },
+      body,
+      inboundCredential: wrongCred,
+      nonceStore,
+      now,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('credential_mismatch');
+  });
+
   test('tampered body fails signature verification', () => {
     const inboundCred = generateCredentialToken();
     const { connection } = createActiveConnection(inboundCred);

--- a/assistant/src/a2a/__tests__/a2a-peer-auth.test.ts
+++ b/assistant/src/a2a/__tests__/a2a-peer-auth.test.ts
@@ -251,10 +251,11 @@ describe('NonceStore', () => {
 
   test('sweep evicts nonces older than the replay window', () => {
     const store = new NonceStore(1000); // 1-second window
-    const baseTime = 1000000;
 
-    store.hasBeenSeen('old-nonce', baseTime);
-    store.hasBeenSeen('new-nonce', baseTime + 1500);
+    // Use record() to add nonces without triggering opportunistic sweep
+    const baseTime = 1000000;
+    store.record('old-nonce', baseTime);
+    store.record('new-nonce', baseTime + 1500);
     expect(store.size).toBe(2);
 
     // Sweep at time where old-nonce is expired but new-nonce is not
@@ -263,22 +264,25 @@ describe('NonceStore', () => {
     expect(store.size).toBe(1);
 
     // Verify old-nonce was evicted (can be re-used)
-    expect(store.hasBeenSeen('old-nonce', baseTime + 2000)).toBe(false);
+    expect(store.isKnown('old-nonce', baseTime + 2000)).toBe(false);
     // new-nonce is still tracked
-    expect(store.hasBeenSeen('new-nonce', baseTime + 2000)).toBe(true);
+    expect(store.isKnown('new-nonce', baseTime + 2000)).toBe(true);
   });
 
   test('opportunistic sweep triggers after replay window interval', () => {
     const store = new NonceStore(1000); // 1-second window
     const baseTime = 1000000;
 
-    store.hasBeenSeen('old', baseTime);
+    store.record('old', baseTime);
+    // Reset lastSweep so the next isKnown with enough time elapsed triggers sweep
+    store.sweep(baseTime);
     expect(store.size).toBe(1);
 
-    // This call triggers an opportunistic sweep because enough time has passed
-    store.hasBeenSeen('new', baseTime + 2000);
-    // old should have been evicted, new is added
-    expect(store.size).toBe(1);
+    // isKnown at baseTime + 2000 triggers opportunistic sweep (2000 >= 1000)
+    // old was recorded at baseTime, cutoff is (baseTime+2000) - 1000 = baseTime+1000
+    // baseTime < baseTime+1000 -> evicted
+    store.isKnown('new', baseTime + 2000);
+    expect(store.size).toBe(0);
   });
 
   test('clear resets the store', () => {
@@ -290,6 +294,75 @@ describe('NonceStore', () => {
     store.clear();
     expect(store.size).toBe(0);
     expect(store.hasBeenSeen('a')).toBe(false);
+  });
+
+  test('isKnown returns false for unseen nonce without recording it', () => {
+    const store = new NonceStore();
+    expect(store.isKnown('nonce-1')).toBe(false);
+    expect(store.size).toBe(0);
+    // Still unknown because isKnown does not record
+    expect(store.isKnown('nonce-1')).toBe(false);
+  });
+
+  test('isKnown returns true for a previously recorded nonce', () => {
+    const store = new NonceStore();
+    store.record('nonce-1');
+    expect(store.isKnown('nonce-1')).toBe(true);
+  });
+
+  test('record adds a nonce to the store', () => {
+    const store = new NonceStore();
+    expect(store.size).toBe(0);
+    store.record('nonce-1');
+    expect(store.size).toBe(1);
+    expect(store.isKnown('nonce-1')).toBe(true);
+  });
+
+  test('record with explicit timestamp', () => {
+    const store = new NonceStore(1000);
+    const baseTime = 1000000;
+    store.record('nonce-1', baseTime);
+    expect(store.isKnown('nonce-1', baseTime)).toBe(true);
+    expect(store.size).toBe(1);
+  });
+
+  test('isKnown triggers opportunistic sweep', () => {
+    const store = new NonceStore(1000);
+    const baseTime = 1000000;
+    store.record('old', baseTime);
+    expect(store.size).toBe(1);
+
+    // isKnown at a later time triggers sweep and evicts 'old'
+    expect(store.isKnown('new', baseTime + 2000)).toBe(false);
+    expect(store.size).toBe(0);
+  });
+
+  test('lastSweep initialized to 0 so first sweep triggers with explicit now', () => {
+    const store = new NonceStore(1000);
+    store.record('old', 500);
+    expect(store.size).toBe(1);
+
+    // At time 1000: lastSweep is 0, so 1000 - 0 >= 1000 triggers sweep.
+    // cutoff = 1000 - 1000 = 0, 'old' recorded at 500 > 0, not evicted. lastSweep = 1000.
+    store.isKnown('check', 1000);
+    expect(store.size).toBe(1);
+
+    // At time 2000: lastSweep is 1000, so 2000 - 1000 >= 1000 triggers sweep.
+    // cutoff = 2000 - 1000 = 1000, 'old' recorded at 500 < 1000 -> evicted.
+    store.isKnown('check2', 2000);
+    expect(store.size).toBe(0);
+  });
+
+  test('unauthenticated nonces do not pollute the store via isKnown', () => {
+    const store = new NonceStore();
+    // Simulate an unauthenticated request: isKnown check without record
+    expect(store.isKnown('attacker-nonce')).toBe(false);
+    expect(store.size).toBe(0);
+
+    // A legitimate request with the same nonce should still succeed
+    expect(store.isKnown('attacker-nonce')).toBe(false);
+    store.record('attacker-nonce');
+    expect(store.isKnown('attacker-nonce')).toBe(true);
   });
 });
 
@@ -440,6 +513,43 @@ describe('verifySignature', () => {
     });
     expect(result2.ok).toBe(false);
     if (!result2.ok) expect(result2.reason).toBe('nonce_replayed');
+  });
+
+  test('failed HMAC does not pollute the nonce store', () => {
+    const realCredential = generateCredentialToken();
+    const wrongCredential = generateCredentialToken();
+    const body = '{"data":"test"}';
+    const now = Date.now();
+    const nonceStore = new NonceStore();
+
+    const headers = signRequest('conn-1', realCredential, body, now);
+
+    // First attempt: wrong credential -> invalid_signature, nonce NOT recorded
+    const result1 = verifySignature({
+      signature: headers[HEADER_SIGNATURE],
+      timestamp: headers[HEADER_TIMESTAMP],
+      nonce: headers[HEADER_NONCE],
+      body,
+      credential: wrongCredential,
+      nonceStore,
+      now,
+    });
+    expect(result1.ok).toBe(false);
+    if (!result1.ok) expect(result1.reason).toBe('invalid_signature');
+    expect(nonceStore.size).toBe(0);
+
+    // Second attempt: correct credential -> should succeed (nonce was not recorded)
+    const result2 = verifySignature({
+      signature: headers[HEADER_SIGNATURE],
+      timestamp: headers[HEADER_TIMESTAMP],
+      nonce: headers[HEADER_NONCE],
+      body,
+      credential: realCredential,
+      nonceStore,
+      now,
+    });
+    expect(result2.ok).toBe(true);
+    expect(nonceStore.size).toBe(1);
   });
 });
 

--- a/assistant/src/a2a/a2a-peer-auth.ts
+++ b/assistant/src/a2a/a2a-peer-auth.ts
@@ -1,0 +1,465 @@
+/**
+ * A2A peer authentication primitives.
+ *
+ * Provides credential generation, HMAC-SHA256 request signing/verification,
+ * replay protection (timestamp window + nonce tracking), and credential
+ * rotation/revocation for peer-to-peer assistant communication.
+ *
+ * Intentionally independent of the runtime bearer token used for local
+ * client auth -- A2A connections use their own credential model as described
+ * in the architecture doc (section "4. Peer Identity & Auth Model").
+ */
+
+import { createHmac, randomBytes, randomUUID } from 'node:crypto';
+
+import { hashHandshakeSecret, timingSafeCompare } from './a2a-handshake.js';
+import {
+  getConnection,
+  updateConnectionCredentials,
+  updateConnectionStatus,
+  type A2APeerConnection,
+} from './a2a-peer-connection-store.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Credential token length in bytes (32 bytes = 64 hex chars). */
+export const CREDENTIAL_BYTE_LENGTH = 32;
+
+/** Default replay window: requests with timestamps older than this are rejected. */
+export const DEFAULT_REPLAY_WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+
+/** HMAC algorithm used for request signing. */
+export const HMAC_ALGORITHM = 'sha256';
+
+/** Header names for signed request metadata. */
+export const HEADER_SIGNATURE = 'x-a2a-signature';
+export const HEADER_TIMESTAMP = 'x-a2a-timestamp';
+export const HEADER_NONCE = 'x-a2a-nonce';
+export const HEADER_CONNECTION_ID = 'x-a2a-connection-id';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CredentialPair {
+  /** Raw credential token we give to the peer (they use it to auth to us). */
+  inboundCredential: string;
+  /** SHA-256 hash of inboundCredential (what we store). */
+  inboundCredentialHash: string;
+  /** Raw credential token the peer gives us (we use it to auth to them). */
+  outboundCredential: string;
+  /** SHA-256 hash of outboundCredential (what we store). */
+  outboundCredentialHash: string;
+}
+
+export interface SignedRequestHeaders {
+  [HEADER_SIGNATURE]: string;
+  [HEADER_TIMESTAMP]: string;
+  [HEADER_NONCE]: string;
+  [HEADER_CONNECTION_ID]: string;
+}
+
+export type VerifyResult =
+  | { ok: true; connectionId: string }
+  | { ok: false; reason: 'missing_headers' | 'connection_not_found' | 'connection_not_active' | 'invalid_signature' | 'timestamp_expired' | 'nonce_replayed' | 'credential_revoked' };
+
+export type RotateResult =
+  | { ok: true; newCredentials: CredentialPair; connection: A2APeerConnection }
+  | { ok: false; reason: 'connection_not_found' | 'connection_not_active' };
+
+export type RevokeResult =
+  | { ok: true; connection: A2APeerConnection }
+  | { ok: false; reason: 'connection_not_found' | 'already_revoked' };
+
+// ---------------------------------------------------------------------------
+// Credential generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a cryptographically secure credential token.
+ * Returns a hex-encoded random string of `CREDENTIAL_BYTE_LENGTH` bytes.
+ */
+export function generateCredentialToken(): string {
+  return randomBytes(CREDENTIAL_BYTE_LENGTH).toString('hex');
+}
+
+/**
+ * Generate a full credential pair for a new peer connection.
+ * Returns both raw tokens (to exchange with the peer) and their hashes
+ * (what gets persisted in the connection store).
+ */
+export function generateCredentialPair(): CredentialPair {
+  const inboundCredential = generateCredentialToken();
+  const outboundCredential = generateCredentialToken();
+
+  return {
+    inboundCredential,
+    inboundCredentialHash: hashHandshakeSecret(inboundCredential),
+    outboundCredential,
+    outboundCredentialHash: hashHandshakeSecret(outboundCredential),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HMAC-SHA256 request signing
+// ---------------------------------------------------------------------------
+
+/**
+ * Construct the canonical string that gets signed.
+ * Format: `${timestamp}:${nonce}:${body}`
+ *
+ * The ordering is deterministic -- timestamp and nonce come first so the
+ * verifier can reject expired/replayed requests before touching the body.
+ */
+export function buildSigningPayload(timestamp: string, nonce: string, body: string): string {
+  return `${timestamp}:${nonce}:${body}`;
+}
+
+/**
+ * Compute an HMAC-SHA256 signature over the given payload using the
+ * provided credential as the key.
+ */
+export function computeHmac(credential: string, payload: string): string {
+  return createHmac(HMAC_ALGORITHM, credential).update(payload).digest('hex');
+}
+
+/**
+ * Sign an outbound request. Returns headers that must be attached to the
+ * HTTP request for the peer to verify authenticity.
+ *
+ * @param connectionId - The A2A connection ID this request belongs to.
+ * @param outboundCredential - The raw credential token for signing (our outbound credential).
+ * @param body - The serialized request body.
+ * @param now - Optional timestamp override for testing.
+ */
+export function signRequest(
+  connectionId: string,
+  outboundCredential: string,
+  body: string,
+  now?: number,
+): SignedRequestHeaders {
+  const timestamp = String(now ?? Date.now());
+  const nonce = randomUUID();
+  const payload = buildSigningPayload(timestamp, nonce, body);
+  const signature = computeHmac(outboundCredential, payload);
+
+  return {
+    [HEADER_SIGNATURE]: signature,
+    [HEADER_TIMESTAMP]: timestamp,
+    [HEADER_NONCE]: nonce,
+    [HEADER_CONNECTION_ID]: connectionId,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Nonce store (in-memory, TTL-based cleanup)
+// ---------------------------------------------------------------------------
+
+/**
+ * In-memory nonce store for replay protection. Tracks seen nonces with
+ * their timestamps. Nonces older than the replay window are periodically
+ * evicted.
+ *
+ * Exported as a class so tests can create isolated instances. The module
+ * also exports a default singleton for production use.
+ */
+export class NonceStore {
+  private readonly seen = new Map<string, number>();
+  private readonly replayWindowMs: number;
+  private lastSweep: number;
+
+  constructor(replayWindowMs: number = DEFAULT_REPLAY_WINDOW_MS) {
+    this.replayWindowMs = replayWindowMs;
+    this.lastSweep = Date.now();
+  }
+
+  /**
+   * Check if a nonce has been seen. If not, record it and return false.
+   * If it has been seen (replay), return true.
+   *
+   * Also performs opportunistic sweep of expired nonces.
+   */
+  hasBeenSeen(nonce: string, now?: number): boolean {
+    const currentTime = now ?? Date.now();
+
+    // Opportunistic sweep: clean up every replay window interval
+    if (currentTime - this.lastSweep >= this.replayWindowMs) {
+      this.sweep(currentTime);
+    }
+
+    if (this.seen.has(nonce)) {
+      return true;
+    }
+
+    this.seen.set(nonce, currentTime);
+    return false;
+  }
+
+  /**
+   * Evict nonces older than the replay window.
+   */
+  sweep(now?: number): number {
+    const currentTime = now ?? Date.now();
+    const cutoff = currentTime - this.replayWindowMs;
+    let evicted = 0;
+
+    for (const [nonce, timestamp] of this.seen) {
+      if (timestamp < cutoff) {
+        this.seen.delete(nonce);
+        evicted++;
+      }
+    }
+
+    this.lastSweep = currentTime;
+    return evicted;
+  }
+
+  /** Current number of tracked nonces. */
+  get size(): number {
+    return this.seen.size;
+  }
+
+  /** Reset the store (for testing). */
+  clear(): void {
+    this.seen.clear();
+  }
+}
+
+/** Default singleton nonce store for production use. */
+export const defaultNonceStore = new NonceStore();
+
+// ---------------------------------------------------------------------------
+// Request verification
+// ---------------------------------------------------------------------------
+
+export interface VerifyRequestParams {
+  headers: Record<string, string | undefined>;
+  body: string;
+  nonceStore?: NonceStore;
+  replayWindowMs?: number;
+  now?: number;
+}
+
+/**
+ * Verify an inbound request from a peer assistant.
+ *
+ * Checks (in order):
+ * 1. Required headers are present.
+ * 2. The connection exists and is active.
+ * 3. The timestamp is within the replay window.
+ * 4. The nonce has not been seen before.
+ * 5. The HMAC signature matches using the stored inbound credential hash
+ *    (re-derived by comparing against the stored hash).
+ *
+ * The inbound credential hash in the connection store is the SHA-256 hash
+ * of the raw credential the peer uses to sign. We cannot reverse the hash,
+ * so the peer's raw credential is used as the HMAC key. We verify by
+ * looking up the connection, then using the stored `inboundCredentialHash`
+ * to look up the raw credential -- but since we only store hashes, the
+ * verification works differently:
+ *
+ * Actually, for HMAC verification, we need the raw credential. The peer
+ * signs with their outbound credential (which is our inbound credential).
+ * We store only the hash. So at verification time, we need an alternative
+ * approach: we store a separate HMAC verification key alongside the hash.
+ *
+ * **Design decision**: The connection store's `inboundCredentialHash` is
+ * the SHA-256 hash of the raw credential for identification/lookup. For
+ * HMAC verification, we use the raw credential directly as the HMAC key.
+ * This means the verifier needs access to the raw inbound credential.
+ *
+ * To support this without storing raw credentials in the DB, we use a
+ * different approach: the inbound credential IS the HMAC key, and we
+ * store its hash for revocation checks. The raw credential is exchanged
+ * during the handshake and must be available to the verifier at runtime.
+ *
+ * For the v1 implementation, we accept the raw inbound credential as a
+ * parameter for verification. The caller (gateway) maintains a secure
+ * mapping of connectionId -> raw inbound credential in memory.
+ */
+export function verifyRequest(
+  params: VerifyRequestParams & { inboundCredential: string },
+): VerifyResult {
+  const { headers, body, inboundCredential, now } = params;
+  const nonceStore = params.nonceStore ?? defaultNonceStore;
+  const replayWindowMs = params.replayWindowMs ?? DEFAULT_REPLAY_WINDOW_MS;
+  const currentTime = now ?? Date.now();
+
+  // 1. Check required headers
+  const signature = headers[HEADER_SIGNATURE];
+  const timestamp = headers[HEADER_TIMESTAMP];
+  const nonce = headers[HEADER_NONCE];
+  const connectionId = headers[HEADER_CONNECTION_ID];
+
+  if (!signature || !timestamp || !nonce || !connectionId) {
+    return { ok: false, reason: 'missing_headers' };
+  }
+
+  // 2. Check connection exists and is active
+  const connection = getConnection(connectionId);
+  if (!connection) {
+    return { ok: false, reason: 'connection_not_found' };
+  }
+
+  if (connection.status === 'revoked' || connection.status === 'revoked_by_peer') {
+    return { ok: false, reason: 'credential_revoked' };
+  }
+
+  if (connection.status !== 'active') {
+    return { ok: false, reason: 'connection_not_active' };
+  }
+
+  // 3. Check timestamp within replay window
+  const requestTime = parseInt(timestamp, 10);
+  if (isNaN(requestTime) || Math.abs(currentTime - requestTime) > replayWindowMs) {
+    return { ok: false, reason: 'timestamp_expired' };
+  }
+
+  // 4. Check nonce not replayed
+  if (nonceStore.hasBeenSeen(nonce, currentTime)) {
+    return { ok: false, reason: 'nonce_replayed' };
+  }
+
+  // 5. Verify HMAC signature
+  const payload = buildSigningPayload(timestamp, nonce, body);
+  const expectedSignature = computeHmac(inboundCredential, payload);
+
+  if (!timingSafeCompare(signature, expectedSignature)) {
+    return { ok: false, reason: 'invalid_signature' };
+  }
+
+  return { ok: true, connectionId };
+}
+
+// ---------------------------------------------------------------------------
+// Stateless verification (no DB lookup)
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify a request signature without looking up the connection in the DB.
+ * Useful when the caller has already resolved the connection and credential.
+ *
+ * Performs: timestamp check, nonce check, HMAC verification.
+ */
+export function verifySignature(params: {
+  signature: string;
+  timestamp: string;
+  nonce: string;
+  body: string;
+  credential: string;
+  nonceStore?: NonceStore;
+  replayWindowMs?: number;
+  now?: number;
+}): { ok: true } | { ok: false; reason: 'timestamp_expired' | 'nonce_replayed' | 'invalid_signature' } {
+  const {
+    signature,
+    timestamp,
+    nonce,
+    body,
+    credential,
+  } = params;
+  const nonceStore = params.nonceStore ?? defaultNonceStore;
+  const replayWindowMs = params.replayWindowMs ?? DEFAULT_REPLAY_WINDOW_MS;
+  const currentTime = params.now ?? Date.now();
+
+  // Timestamp check
+  const requestTime = parseInt(timestamp, 10);
+  if (isNaN(requestTime) || Math.abs(currentTime - requestTime) > replayWindowMs) {
+    return { ok: false, reason: 'timestamp_expired' };
+  }
+
+  // Nonce check
+  if (nonceStore.hasBeenSeen(nonce, currentTime)) {
+    return { ok: false, reason: 'nonce_replayed' };
+  }
+
+  // HMAC check
+  const payload = buildSigningPayload(timestamp, nonce, body);
+  const expectedSignature = computeHmac(credential, payload);
+
+  if (!timingSafeCompare(signature, expectedSignature)) {
+    return { ok: false, reason: 'invalid_signature' };
+  }
+
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Credential rotation
+// ---------------------------------------------------------------------------
+
+/**
+ * Rotate credentials for an active connection. Generates a new credential
+ * pair, updates the connection store, and returns both the new credentials
+ * (for exchange with the peer) and the updated connection.
+ *
+ * The old credentials are invalidated immediately -- any subsequent request
+ * using the old credentials will fail verification because the stored hashes
+ * no longer match.
+ */
+export function rotateCredentials(connectionId: string): RotateResult {
+  const connection = getConnection(connectionId);
+  if (!connection) {
+    return { ok: false, reason: 'connection_not_found' };
+  }
+
+  if (connection.status !== 'active') {
+    return { ok: false, reason: 'connection_not_active' };
+  }
+
+  const newCredentials = generateCredentialPair();
+
+  const updated = updateConnectionCredentials(connectionId, {
+    outboundCredentialHash: newCredentials.outboundCredentialHash,
+    inboundCredentialHash: newCredentials.inboundCredentialHash,
+  });
+
+  if (!updated) {
+    return { ok: false, reason: 'connection_not_found' };
+  }
+
+  return {
+    ok: true,
+    newCredentials,
+    connection: updated,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Credential revocation
+// ---------------------------------------------------------------------------
+
+/**
+ * Revoke credentials for a connection. Transitions the connection to
+ * 'revoked' status and tombstones the credential hashes.
+ *
+ * After revocation, any request using the old credentials will be rejected
+ * because `verifyRequest` checks connection status before signature
+ * verification.
+ */
+export function revokeCredentials(connectionId: string, reason?: string): RevokeResult {
+  const connection = getConnection(connectionId);
+  if (!connection) {
+    return { ok: false, reason: 'connection_not_found' };
+  }
+
+  if (connection.status === 'revoked' || connection.status === 'revoked_by_peer') {
+    return { ok: false, reason: 'already_revoked' };
+  }
+
+  // Tombstone the credentials by nullifying them
+  updateConnectionCredentials(connectionId, {
+    outboundCredentialHash: '',
+    inboundCredentialHash: '',
+  });
+
+  // Transition to revoked status
+  const updated = updateConnectionStatus(connectionId, 'revoked');
+  if (!updated) {
+    return { ok: false, reason: 'connection_not_found' };
+  }
+
+  return { ok: true, connection: updated };
+}

--- a/assistant/src/a2a/a2a-peer-auth.ts
+++ b/assistant/src/a2a/a2a-peer-auth.ts
@@ -172,7 +172,33 @@ export class NonceStore {
 
   constructor(replayWindowMs: number = DEFAULT_REPLAY_WINDOW_MS) {
     this.replayWindowMs = replayWindowMs;
-    this.lastSweep = Date.now();
+    this.lastSweep = 0;
+  }
+
+  /**
+   * Check whether a nonce is already tracked (read-only, no side effects).
+   * Use this before HMAC verification to avoid polluting the store with
+   * unauthenticated nonces.
+   */
+  isKnown(nonce: string, now?: number): boolean {
+    const currentTime = now ?? Date.now();
+
+    // Opportunistic sweep: clean up every replay window interval
+    if (currentTime - this.lastSweep >= this.replayWindowMs) {
+      this.sweep(currentTime);
+    }
+
+    return this.seen.has(nonce);
+  }
+
+  /**
+   * Record a nonce after the request has been authenticated. Call this
+   * only after HMAC verification succeeds to prevent unauthenticated
+   * requests from polluting the nonce store.
+   */
+  record(nonce: string, now?: number): void {
+    const currentTime = now ?? Date.now();
+    this.seen.set(nonce, currentTime);
   }
 
   /**
@@ -180,6 +206,9 @@ export class NonceStore {
    * If it has been seen (replay), return true.
    *
    * Also performs opportunistic sweep of expired nonces.
+   *
+   * @deprecated Use `isKnown()` + `record()` instead to avoid polluting
+   * the store with unauthenticated nonces.
    */
   hasBeenSeen(nonce: string, now?: number): boolean {
     const currentTime = now ?? Date.now();
@@ -323,8 +352,8 @@ export function verifyRequest(
     return { ok: false, reason: 'timestamp_expired' };
   }
 
-  // 5. Check nonce not replayed
-  if (nonceStore.hasBeenSeen(nonce, currentTime)) {
+  // 5. Check nonce not replayed (read-only check before HMAC)
+  if (nonceStore.isKnown(nonce, currentTime)) {
     return { ok: false, reason: 'nonce_replayed' };
   }
 
@@ -335,6 +364,9 @@ export function verifyRequest(
   if (!timingSafeCompare(signature, expectedSignature)) {
     return { ok: false, reason: 'invalid_signature' };
   }
+
+  // Record nonce only after authentication succeeds
+  nonceStore.record(nonce, currentTime);
 
   return { ok: true, connectionId };
 }
@@ -376,8 +408,8 @@ export function verifySignature(params: {
     return { ok: false, reason: 'timestamp_expired' };
   }
 
-  // Nonce check
-  if (nonceStore.hasBeenSeen(nonce, currentTime)) {
+  // Nonce check (read-only before HMAC)
+  if (nonceStore.isKnown(nonce, currentTime)) {
     return { ok: false, reason: 'nonce_replayed' };
   }
 
@@ -388,6 +420,9 @@ export function verifySignature(params: {
   if (!timingSafeCompare(signature, expectedSignature)) {
     return { ok: false, reason: 'invalid_signature' };
   }
+
+  // Record nonce only after authentication succeeds
+  nonceStore.record(nonce, currentTime);
 
   return { ok: true };
 }
@@ -445,7 +480,7 @@ export function rotateCredentials(connectionId: string): RotateResult {
  * because `verifyRequest` checks connection status before signature
  * verification.
  */
-export function revokeCredentials(connectionId: string, reason?: string): RevokeResult {
+export function revokeCredentials(connectionId: string): RevokeResult {
   const connection = getConnection(connectionId);
   if (!connection) {
     return { ok: false, reason: 'connection_not_found' };

--- a/assistant/src/a2a/a2a-peer-auth.ts
+++ b/assistant/src/a2a/a2a-peer-auth.ts
@@ -365,8 +365,10 @@ export function verifyRequest(
     return { ok: false, reason: 'invalid_signature' };
   }
 
-  // Record nonce only after authentication succeeds
-  nonceStore.record(nonce, currentTime);
+  // Record nonce only after authentication succeeds.
+  // Anchor retention to the later of currentTime and requestTime so that
+  // a valid request near the replay-window limit isn't evicted prematurely.
+  nonceStore.record(nonce, Math.max(currentTime, requestTime));
 
   return { ok: true, connectionId };
 }
@@ -421,8 +423,10 @@ export function verifySignature(params: {
     return { ok: false, reason: 'invalid_signature' };
   }
 
-  // Record nonce only after authentication succeeds
-  nonceStore.record(nonce, currentTime);
+  // Record nonce only after authentication succeeds.
+  // Anchor retention to the later of currentTime and requestTime so that
+  // a valid request near the replay-window limit isn't evicted prematurely.
+  nonceStore.record(nonce, Math.max(currentTime, requestTime));
 
   return { ok: true };
 }

--- a/assistant/src/a2a/a2a-peer-auth.ts
+++ b/assistant/src/a2a/a2a-peer-auth.ts
@@ -63,7 +63,7 @@ export interface SignedRequestHeaders {
 
 export type VerifyResult =
   | { ok: true; connectionId: string }
-  | { ok: false; reason: 'missing_headers' | 'connection_not_found' | 'connection_not_active' | 'invalid_signature' | 'timestamp_expired' | 'nonce_replayed' | 'credential_revoked' };
+  | { ok: false; reason: 'missing_headers' | 'connection_not_found' | 'connection_not_active' | 'invalid_signature' | 'timestamp_expired' | 'nonce_replayed' | 'credential_revoked' | 'credential_mismatch' };
 
 export type RotateResult =
   | { ok: true; newCredentials: CredentialPair; connection: A2APeerConnection }
@@ -248,10 +248,10 @@ export interface VerifyRequestParams {
  * Checks (in order):
  * 1. Required headers are present.
  * 2. The connection exists and is active.
- * 3. The timestamp is within the replay window.
- * 4. The nonce has not been seen before.
- * 5. The HMAC signature matches using the stored inbound credential hash
- *    (re-derived by comparing against the stored hash).
+ * 3. The caller-supplied inbound credential matches the connection's stored hash.
+ * 4. The timestamp is within the replay window.
+ * 5. The nonce has not been seen before.
+ * 6. The HMAC signature matches.
  *
  * The inbound credential hash in the connection store is the SHA-256 hash
  * of the raw credential the peer uses to sign. We cannot reverse the hash,
@@ -311,18 +311,24 @@ export function verifyRequest(
     return { ok: false, reason: 'connection_not_active' };
   }
 
-  // 3. Check timestamp within replay window
+  // 3. Validate the caller-supplied credential matches the stored hash
+  const inboundCredentialHash = hashHandshakeSecret(inboundCredential);
+  if (!connection.inboundCredentialHash || !timingSafeCompare(inboundCredentialHash, connection.inboundCredentialHash)) {
+    return { ok: false, reason: 'credential_mismatch' };
+  }
+
+  // 4. Check timestamp within replay window
   const requestTime = parseInt(timestamp, 10);
   if (isNaN(requestTime) || Math.abs(currentTime - requestTime) > replayWindowMs) {
     return { ok: false, reason: 'timestamp_expired' };
   }
 
-  // 4. Check nonce not replayed
+  // 5. Check nonce not replayed
   if (nonceStore.hasBeenSeen(nonce, currentTime)) {
     return { ok: false, reason: 'nonce_replayed' };
   }
 
-  // 5. Verify HMAC signature
+  // 6. Verify HMAC signature
   const payload = buildSigningPayload(timestamp, nonce, body);
   const expectedSignature = computeHmac(inboundCredential, payload);
 


### PR DESCRIPTION
## Summary
- Add peer-assistant credential generation (32-byte hex tokens, SHA-256 hashed for storage)
- Implement HMAC-SHA256 request signing/verification with canonical signing payload format
- Add replay protection via timestamp window (configurable, default 5min) and in-memory nonce tracking with TTL-based cleanup
- Credential rotation: generates new pair, atomically updates connection store, old credentials immediately invalid
- Credential revocation: tombstones credentials and transitions connection to revoked status

Separate from runtime bearer tokens per architecture design constraints.

Closes #11345

## Test plan
- [x] Credential generation tests (format, uniqueness, hash consistency)
- [x] HMAC signing primitive tests (determinism, key/data sensitivity)
- [x] Request signing tests (header format, signature verifiability)
- [x] NonceStore tests (tracking, eviction, opportunistic sweep)
- [x] Stateless signature verification (valid passes, tampered/wrong-key/expired/replayed rejected)
- [x] Full request verification with DB (active connection passes, missing headers/nonexistent/pending/revoked rejected)
- [x] Credential rotation (new creds work, old creds fail, non-active rejected)
- [x] Credential revocation (tombstoned creds, status change, idempotency, post-revocation request rejection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
