### PR TITLE
fix: wrap indexMessageNow in try-catch during chatgpt import

### DIFF
--- a/assistant/src/config/bundled-skills/chatgpt-import/tools/chatgpt-import.ts
+++ b/assistant/src/config/bundled-skills/chatgpt-import/tools/chatgpt-import.ts
@@ -160,16 +160,22 @@ export async function run(
 
       // Index with the original ChatGPT timestamp so memory segments
       // reflect actual message age, not import time
-      indexMessageNow(
-        {
-          messageId: dbMessages[i].id,
-          conversationId: conversation.id,
-          role: conv.messages[i].role,
-          content: JSON.stringify(conv.messages[i].content),
-          createdAt: originalTimestamp,
-        },
-        memoryConfig,
-      );
+      try {
+        indexMessageNow(
+          {
+            messageId: dbMessages[i].id,
+            conversationId: conversation.id,
+            role: conv.messages[i].role,
+            content: JSON.stringify(conv.messages[i].content),
+            createdAt: originalTimestamp,
+          },
+          memoryConfig,
+        );
+      } catch {
+        // Indexing failure is non-fatal — the message is already persisted,
+        // and failing here would abort the loop before conversationKeys is
+        // written, causing duplicate imports on retry.
+      }
     }
 
     db.insert(conversationKeys)


### PR DESCRIPTION
Addresses review feedback from PR #11530:\n\nWraps the indexMessageNow call in a try-catch block to match the original addMessage resilience pattern. If indexing fails for a single message, the import continues rather than aborting and risking duplicate conversations on retry.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
