### PR TITLE
perf: pipeline list+fetch in Gmail digest and scan tools

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-outreach-scan.ts
@@ -1,6 +1,7 @@
 import type { EmailMetadata } from '../../../../messaging/email-classifier.js';
 import { classifyOutreach, type OutreachClassification } from '../../../../messaging/outreach-classifier.js';
 import { batchGetMessages,listMessages } from '../../../../messaging/providers/gmail/client.js';
+import type { GmailMessage } from '../../../../messaging/providers/gmail/types.js';
 import { getMessagingProvider } from '../../../../messaging/registry.js';
 import { withValidToken } from '../../../../security/token-manager.js';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
@@ -78,10 +79,12 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
   try {
     const provider = getMessagingProvider('gmail');
     return withValidToken(provider.credentialService, async (token) => {
-      // Paginate through listMessages to collect up to maxMessages IDs
+      // Pipeline: fire metadata fetches for each page of IDs as they arrive
       const allMessageIds: string[] = [];
+      const fetchPromises: Promise<GmailMessage[]>[] = [];
       let pageToken: string | undefined = inputPageToken;
       let truncated = false;
+      const metadataHeaders = ['From', 'Subject', 'Date'];
 
       while (allMessageIds.length < maxMessages) {
         const pageSize = Math.min(100, maxMessages - allMessageIds.length);
@@ -89,6 +92,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         const ids = (listResp.messages ?? []).map((m) => m.id);
         if (ids.length === 0) break;
         allMessageIds.push(...ids);
+        fetchPromises.push(batchGetMessages(token, ids, 'metadata', metadataHeaders));
         pageToken = listResp.nextPageToken ?? undefined;
         if (!pageToken) break;
       }
@@ -101,10 +105,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         return ok(JSON.stringify({ senders: [], total_scanned: 0, outreach_detected: 0, message: 'No emails found matching the query.' }));
       }
 
-      // Batch-fetch metadata headers
-      const messages = await batchGetMessages(token, allMessageIds, 'metadata', [
-        'From', 'Subject', 'Date',
-      ]);
+      const messages = (await Promise.all(fetchPromises)).flat();
 
       // Build EmailMetadata for the classifier
       const emailMetadata: EmailMetadata[] = messages.map((msg) => {

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
@@ -1,4 +1,5 @@
 import { batchGetMessages,listMessages } from '../../../../messaging/providers/gmail/client.js';
+import type { GmailMessage } from '../../../../messaging/providers/gmail/types.js';
 import { getMessagingProvider } from '../../../../messaging/registry.js';
 import { withValidToken } from '../../../../security/token-manager.js';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
@@ -44,10 +45,13 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
   try {
     const provider = getMessagingProvider('gmail');
     return withValidToken(provider.credentialService, async (token) => {
-      // Paginate through listMessages to collect up to maxMessages IDs
+      // Pipeline: fire metadata fetches for each page of IDs as they arrive,
+      // overlapping fetch latency with pagination latency
       const allMessageIds: string[] = [];
+      const fetchPromises: Promise<GmailMessage[]>[] = [];
       let pageToken: string | undefined = inputPageToken;
       let truncated = false;
+      const metadataHeaders = ['From', 'List-Unsubscribe', 'Subject', 'Date'];
 
       while (allMessageIds.length < maxMessages) {
         const pageSize = Math.min(100, maxMessages - allMessageIds.length);
@@ -55,6 +59,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         const ids = (listResp.messages ?? []).map((m) => m.id);
         if (ids.length === 0) break;
         allMessageIds.push(...ids);
+        fetchPromises.push(batchGetMessages(token, ids, 'metadata', metadataHeaders));
         pageToken = listResp.nextPageToken ?? undefined;
         if (!pageToken) break;
       }
@@ -68,10 +73,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         return ok(JSON.stringify({ senders: [], total_scanned: 0, message: 'No emails found matching the query. Try broadening the search (e.g. remove category filter or extend date range).' }));
       }
 
-      // Batch-fetch metadata headers
-      const messages = await batchGetMessages(token, allMessageIds, 'metadata', [
-        'From', 'List-Unsubscribe', 'Subject', 'Date',
-      ]);
+      const messages = (await Promise.all(fetchPromises)).flat();
 
       // Group by sender email
       const senderMap = new Map<string, SenderAggregation>();

--- a/assistant/src/messaging/providers/gmail/adapter.ts
+++ b/assistant/src/messaging/providers/gmail/adapter.ts
@@ -201,8 +201,10 @@ export const gmailMessagingProvider: MessagingProvider = {
     const maxIdsPerSender = 2000;
 
     const allMessageIds: string[] = [];
+    const fetchPromises: Promise<GmailMessage[]>[] = [];
     let pageToken: string | undefined = options?.pageToken;
     let truncated = false;
+    const metadataHeaders = ['From', 'List-Unsubscribe'];
 
     while (allMessageIds.length < maxMessages) {
       const pageSize = Math.min(100, maxMessages - allMessageIds.length);
@@ -210,6 +212,7 @@ export const gmailMessagingProvider: MessagingProvider = {
       const ids = (listResp.messages ?? []).map((m) => m.id);
       if (ids.length === 0) break;
       allMessageIds.push(...ids);
+      fetchPromises.push(gmail.batchGetMessages(token, ids, 'metadata', metadataHeaders));
       pageToken = listResp.nextPageToken ?? undefined;
       if (!pageToken) break;
     }
@@ -223,9 +226,7 @@ export const gmailMessagingProvider: MessagingProvider = {
       return { senders: [], totalScanned: 0, queryUsed: query };
     }
 
-    const messages = await gmail.batchGetMessages(token, allMessageIds, 'metadata', [
-      'From', 'List-Unsubscribe',
-    ]);
+    const messages = (await Promise.all(fetchPromises)).flat();
 
     const senderMap = new Map<string, {
       displayName: string; email: string; messageCount: number;


### PR DESCRIPTION
## Summary
- Start fetching message metadata for each page of IDs immediately as they arrive from `listMessages`, instead of waiting to collect all IDs first
- Overlaps fetch latency with pagination latency — while the next page of IDs is being listed, the previous page's metadata is already being fetched
- Applied to `gmail-sender-digest`, `gmail-outreach-scan`, and the Gmail adapter's `senderDigest` method

## Test plan
- [ ] Run `gmail_sender_digest` on a large inbox and verify results are identical
- [ ] Run `gmail_outreach_scan` and verify results are identical
- [ ] Test `messaging_sender_digest` (goes through adapter) and verify results

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
