### PR TITLE
fix: preserve keychain fallback on macOS by marking backend as downgraded

### DIFF
--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -6,14 +6,14 @@
  * Backend selection is cached after the first call for the process lifetime.
  */
 
-import { getLogger } from '../util/logger.js';
-import { isMacOS } from '../util/platform.js';
-import * as encryptedStore from './encrypted-store.js';
-import * as keychain from './keychain.js';
+import { getLogger } from "../util/logger.js";
+import { isMacOS } from "../util/platform.js";
+import * as encryptedStore from "./encrypted-store.js";
+import * as keychain from "./keychain.js";
 
-const log = getLogger('secure-keys');
+const log = getLogger("secure-keys");
 
-type Backend = 'keychain' | 'encrypted' | null;
+type Backend = "keychain" | "encrypted" | null;
 let resolvedBackend: Backend | undefined;
 /** True when backend was downgraded from keychain to encrypted at runtime. */
 let downgradedFromKeychain = false;
@@ -22,19 +22,24 @@ function getBackend(): Backend {
   if (resolvedBackend !== undefined) return resolvedBackend;
 
   // On macOS, skip keychain probing and use encrypted file storage directly
-  // to avoid repeated Keychain Access authorization prompts.
+  // to avoid repeated Keychain Access authorization prompts. Mark as
+  // downgraded so getSecureKey/getSecureKeyAsync still check keychain as a
+  // fallback for secrets stored before this switch.
   if (isMacOS()) {
-    log.debug('macOS detected, using encrypted file storage (skipping keychain)');
-    resolvedBackend = 'encrypted';
+    log.debug(
+      "macOS detected, using encrypted file storage (skipping keychain)",
+    );
+    resolvedBackend = "encrypted";
+    downgradedFromKeychain = true;
     return resolvedBackend;
   }
 
   if (keychain.isKeychainAvailable()) {
-    log.debug('Using OS keychain for secure key storage');
-    resolvedBackend = 'keychain';
+    log.debug("Using OS keychain for secure key storage");
+    resolvedBackend = "keychain";
   } else {
-    log.debug('OS keychain unavailable, using encrypted file storage');
-    resolvedBackend = 'encrypted';
+    log.debug("OS keychain unavailable, using encrypted file storage");
+    resolvedBackend = "encrypted";
   }
   return resolvedBackend;
 }
@@ -43,19 +48,24 @@ async function getBackendAsync(): Promise<Backend> {
   if (resolvedBackend !== undefined) return resolvedBackend;
 
   // On macOS, skip keychain probing and use encrypted file storage directly
-  // to avoid repeated Keychain Access authorization prompts.
+  // to avoid repeated Keychain Access authorization prompts. Mark as
+  // downgraded so getSecureKey/getSecureKeyAsync still check keychain as a
+  // fallback for secrets stored before this switch.
   if (isMacOS()) {
-    log.debug('macOS detected, using encrypted file storage (skipping keychain)');
-    resolvedBackend = 'encrypted';
+    log.debug(
+      "macOS detected, using encrypted file storage (skipping keychain)",
+    );
+    resolvedBackend = "encrypted";
+    downgradedFromKeychain = true;
     return resolvedBackend;
   }
 
   if (await keychain.isKeychainAvailableAsync()) {
-    log.debug('Using OS keychain for secure key storage');
-    resolvedBackend = 'keychain';
+    log.debug("Using OS keychain for secure key storage");
+    resolvedBackend = "keychain";
   } else {
-    log.debug('OS keychain unavailable, using encrypted file storage');
-    resolvedBackend = 'encrypted';
+    log.debug("OS keychain unavailable, using encrypted file storage");
+    resolvedBackend = "encrypted";
   }
   return resolvedBackend;
 }
@@ -71,15 +81,17 @@ function withKeychainFallback<T>(
   fallbackValue: T,
 ): T {
   const backend = getBackend();
-  if (backend === 'encrypted') return encryptedFn();
-  if (backend !== 'keychain') return fallbackValue;
+  if (backend === "encrypted") return encryptedFn();
+  if (backend !== "keychain") return fallbackValue;
 
   const result = keychainFn();
   // keychain.setKey/deleteKey return false on failure.
   // We downgrade on failures (false) to switch to encrypted backend.
   if (result === false) {
-    log.warn('Keychain operation failed at runtime, falling back to encrypted file storage');
-    resolvedBackend = 'encrypted';
+    log.warn(
+      "Keychain operation failed at runtime, falling back to encrypted file storage",
+    );
+    resolvedBackend = "encrypted";
     downgradedFromKeychain = true;
     return encryptedFn();
   }
@@ -92,18 +104,20 @@ function withKeychainFallback<T>(
  */
 export function getSecureKey(account: string): string | undefined {
   const backend = getBackend();
-  if (backend === 'keychain') {
+  if (backend === "keychain") {
     try {
       return keychain.getKey(account) ?? undefined;
     } catch {
       // Keychain runtime error on read — downgrade to encrypted store
-      log.warn('Keychain read failed at runtime, falling back to encrypted file storage');
-      resolvedBackend = 'encrypted';
+      log.warn(
+        "Keychain read failed at runtime, falling back to encrypted file storage",
+      );
+      resolvedBackend = "encrypted";
       downgradedFromKeychain = true;
       return encryptedStore.getKey(account);
     }
   }
-  if (backend === 'encrypted') {
+  if (backend === "encrypted") {
     const value = encryptedStore.getKey(account);
     // After a runtime downgrade, keys may still exist in the keychain.
     // Try keychain read as fallback so pre-downgrade keys remain accessible.
@@ -137,7 +151,7 @@ export function setSecureKey(account: string, value: string): boolean {
  */
 export function deleteSecureKey(account: string): boolean {
   const backend = getBackend();
-  if (backend === 'encrypted') {
+  if (backend === "encrypted") {
     const result = encryptedStore.deleteKey(account);
     // After a runtime downgrade, keys may still exist in the keychain.
     // Attempt best-effort cleanup so stale credentials don't linger.
@@ -146,7 +160,7 @@ export function deleteSecureKey(account: string): boolean {
     }
     return result;
   }
-  if (backend !== 'keychain') return false;
+  if (backend !== "keychain") return false;
 
   // keychain.deleteKey returns false for both "not found" and "runtime error".
   // Check existence first so a missing key doesn't spuriously downgrade the
@@ -175,7 +189,7 @@ export function deleteSecureKey(account: string): boolean {
  */
 export function listSecureKeys(): string[] {
   const backend = getBackend();
-  if (backend === 'encrypted') return encryptedStore.listKeys();
+  if (backend === "encrypted") return encryptedStore.listKeys();
   // OS keychains don't provide a list API scoped to our service
   return [];
 }
@@ -184,7 +198,7 @@ export function listSecureKeys(): string[] {
  * Return the currently resolved backend type.
  * Useful for feature-gating behaviour that only works on certain backends.
  */
-export function getBackendType(): 'keychain' | 'encrypted' | null {
+export function getBackendType(): "keychain" | "encrypted" | null {
   return getBackend();
 }
 
@@ -205,19 +219,23 @@ export function isDowngradedFromKeychain(): boolean {
 /**
  * Async version of `getSecureKey` — retrieve a secret without blocking.
  */
-export async function getSecureKeyAsync(account: string): Promise<string | undefined> {
+export async function getSecureKeyAsync(
+  account: string,
+): Promise<string | undefined> {
   const backend = await getBackendAsync();
-  if (backend === 'keychain') {
+  if (backend === "keychain") {
     try {
       return (await keychain.getKeyAsync(account)) ?? undefined;
     } catch {
-      log.warn('Keychain read failed at runtime, falling back to encrypted file storage');
-      resolvedBackend = 'encrypted';
+      log.warn(
+        "Keychain read failed at runtime, falling back to encrypted file storage",
+      );
+      resolvedBackend = "encrypted";
       downgradedFromKeychain = true;
       return encryptedStore.getKey(account);
     }
   }
-  if (backend === 'encrypted') {
+  if (backend === "encrypted") {
     const value = encryptedStore.getKey(account);
     if (value === undefined && downgradedFromKeychain) {
       try {
@@ -234,15 +252,20 @@ export async function getSecureKeyAsync(account: string): Promise<string | undef
 /**
  * Async version of `setSecureKey` — store a secret without blocking.
  */
-export async function setSecureKeyAsync(account: string, value: string): Promise<boolean> {
+export async function setSecureKeyAsync(
+  account: string,
+  value: string,
+): Promise<boolean> {
   const backend = await getBackendAsync();
-  if (backend === 'encrypted') return encryptedStore.setKey(account, value);
-  if (backend !== 'keychain') return false;
+  if (backend === "encrypted") return encryptedStore.setKey(account, value);
+  if (backend !== "keychain") return false;
 
   const result = await keychain.setKeyAsync(account, value);
   if (result === false) {
-    log.warn('Keychain operation failed at runtime, falling back to encrypted file storage');
-    resolvedBackend = 'encrypted';
+    log.warn(
+      "Keychain operation failed at runtime, falling back to encrypted file storage",
+    );
+    resolvedBackend = "encrypted";
     downgradedFromKeychain = true;
     return encryptedStore.setKey(account, value);
   }
@@ -254,14 +277,14 @@ export async function setSecureKeyAsync(account: string, value: string): Promise
  */
 export async function deleteSecureKeyAsync(account: string): Promise<boolean> {
   const backend = await getBackendAsync();
-  if (backend === 'encrypted') {
+  if (backend === "encrypted") {
     const result = encryptedStore.deleteKey(account);
     if (downgradedFromKeychain) {
       await keychain.deleteKeyAsync(account); // best-effort
     }
     return result;
   }
-  if (backend !== 'keychain') return false;
+  if (backend !== "keychain") return false;
 
   try {
     if ((await keychain.getKeyAsync(account)) == null) {
@@ -273,8 +296,10 @@ export async function deleteSecureKeyAsync(account: string): Promise<boolean> {
 
   const result = await keychain.deleteKeyAsync(account);
   if (result === false) {
-    log.warn('Keychain operation failed at runtime, falling back to encrypted file storage');
-    resolvedBackend = 'encrypted';
+    log.warn(
+      "Keychain operation failed at runtime, falling back to encrypted file storage",
+    );
+    resolvedBackend = "encrypted";
     downgradedFromKeychain = true;
     return encryptedStore.deleteKey(account);
   }


### PR DESCRIPTION
## Summary

Addresses Codex review feedback from PR #11332.

- When macOS skips keychain and uses encrypted file storage directly, the `downgradedFromKeychain` flag was not being set. This meant `getSecureKey`/`getSecureKeyAsync` would not check keychain as a fallback for pre-existing secrets, causing credentials stored before the switch to appear missing after restart.
- Sets `downgradedFromKeychain = true` in both `getBackend()` and `getBackendAsync()` when macOS bypasses keychain, so the existing fallback path reads pre-migration keychain secrets.

Note: The Devin feedback about `assertMetadataWritable()` in `handleDeleteSecret` was already addressed in PR #11466.

## Test plan

- [x] Existing `secure-keys.test.ts` tests continue to pass — the macOS test verifies encrypted store is used
- [x] The keychain fallback path (guarded by `downgradedFromKeychain`) is now active on macOS, matching the runtime-downgrade behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
