### PR TITLE
perf: parallelize Slack user name resolution in scan-digest

### DIFF
--- a/assistant/src/config/bundled-skills/slack/tools/slack-scan-digest.ts
+++ b/assistant/src/config/bundled-skills/slack/tools/slack-scan-digest.ts
@@ -70,47 +70,49 @@ async function scanChannel(
       if (msg.user) participantIds.add(msg.user);
     }
 
-    const keyParticipants: string[] = [];
-    for (const uid of participantIds) {
-      keyParticipants.push(await resolveUserName(token, uid));
-    }
+    const keyParticipants = await Promise.all(
+      [...participantIds].map((uid) => resolveUserName(token, uid)),
+    );
 
     const threadMessages = messages
       .filter((m) => (m.reply_count ?? 0) > 0)
       .sort((a, b) => (b.reply_count ?? 0) - (a.reply_count ?? 0))
       .slice(0, 3);
 
-    const topThreads: ThreadSummary[] = [];
-    for (const msg of threadMessages) {
-      let participants: string[] = [];
+    const topThreads: ThreadSummary[] = await Promise.all(
+      threadMessages.map(async (msg) => {
+        let participants: string[] = [];
 
-      if (includeThreads) {
-        try {
-          const replies = await slack.conversationReplies(
-            token,
-            channelId,
-            msg.ts,
-            10,
-          );
-          const threadParticipantIds = new Set<string>();
-          for (const reply of replies.messages) {
-            if (reply.user) threadParticipantIds.add(reply.user);
+        if (includeThreads) {
+          try {
+            const replies = await slack.conversationReplies(
+              token,
+              channelId,
+              msg.ts,
+              10,
+            );
+            const threadParticipantIds = new Set<string>();
+            for (const reply of replies.messages) {
+              if (reply.user) threadParticipantIds.add(reply.user);
+            }
+            participants = await Promise.all(
+              [...threadParticipantIds].map((uid) =>
+                resolveUserName(token, uid),
+              ),
+            );
+          } catch {
+            participants = [await resolveUserName(token, msg.user ?? "")];
           }
-          for (const uid of threadParticipantIds) {
-            participants.push(await resolveUserName(token, uid));
-          }
-        } catch {
-          participants = [await resolveUserName(token, msg.user ?? "")];
         }
-      }
 
-      topThreads.push({
-        threadTs: msg.ts,
-        previewText: truncate(msg.text, 150),
-        replyCount: msg.reply_count ?? 0,
-        participants,
-      });
-    }
+        return {
+          threadTs: msg.ts,
+          previewText: truncate(msg.text, 150),
+          replyCount: msg.reply_count ?? 0,
+          participants,
+        };
+      }),
+    );
 
     return {
       channelId,


### PR DESCRIPTION
## Summary
- Replace sequential `for...of` loops with `Promise.all` for Slack user name resolution in `slack-scan-digest`
- Parallelize both channel-level participant resolution and thread participant resolution
- Also parallelize thread reply fetching (up to 3 threads fetched concurrently instead of sequentially)
- The existing `userNameCache` prevents duplicate API calls for the same user

## Test plan
- [ ] Run `slack_scan_digest` and verify results are identical (same channels, participants, thread summaries)
- [ ] Verify user names resolve correctly with the cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
