### PR TITLE
fix: correct JWT troubleshooting guidance in gateway README

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -412,7 +412,7 @@ See [`benchmarking/gateway/README.md`](../benchmarking/gateway/README.md) for lo
 | "No route configured" replies | Add a routing entry or set `GATEWAY_UNMAPPED_POLICY=default` with a default assistant |
 | Runtime errors | Is `ASSISTANT_RUNTIME_BASE_URL` reachable? Check runtime logs. |
 | No reply from assistant | Is the assistant runtime processing messages? Check for `RUNTIME_HTTP_PORT` env var. |
-| 403 on channel inbound | The runtime rejected the request because JWT authentication failed. Ensure the gateway and runtime share the same signing key (`RUNTIME_BEARER_TOKEN` / `~/.vellum/http-token`). |
+| 403 on channel inbound | The runtime rejected the request because JWT authentication failed. Ensure the gateway and runtime share the same signing key (`~/.vellum/protected/actor-token-signing-key`). |
 
 ### Guardian-Specific Troubleshooting
 


### PR DESCRIPTION
## Summary
- Updated troubleshooting row to reference the correct signing key path instead of RUNTIME_BEARER_TOKEN/~/.vellum/http-token
- Addresses Codex P2 feedback on PR #11505

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/11505

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
