### PR TITLE
perf: add fields parameter to Gmail metadata fetches

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-outreach-scan.ts
@@ -92,7 +92,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         const ids = (listResp.messages ?? []).map((m) => m.id);
         if (ids.length === 0) break;
         allMessageIds.push(...ids);
-        fetchPromises.push(batchGetMessages(token, ids, 'metadata', metadataHeaders));
+        fetchPromises.push(batchGetMessages(token, ids, 'metadata', metadataHeaders, 'id,internalDate,payload/headers'));
         pageToken = listResp.nextPageToken ?? undefined;
         if (!pageToken) break;
       }

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
@@ -59,7 +59,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         const ids = (listResp.messages ?? []).map((m) => m.id);
         if (ids.length === 0) break;
         allMessageIds.push(...ids);
-        fetchPromises.push(batchGetMessages(token, ids, 'metadata', metadataHeaders));
+        fetchPromises.push(batchGetMessages(token, ids, 'metadata', metadataHeaders, 'id,internalDate,payload/headers'));
         pageToken = listResp.nextPageToken ?? undefined;
         if (!pageToken) break;
       }

--- a/assistant/src/messaging/providers/gmail/adapter.ts
+++ b/assistant/src/messaging/providers/gmail/adapter.ts
@@ -212,7 +212,7 @@ export const gmailMessagingProvider: MessagingProvider = {
       const ids = (listResp.messages ?? []).map((m) => m.id);
       if (ids.length === 0) break;
       allMessageIds.push(...ids);
-      fetchPromises.push(gmail.batchGetMessages(token, ids, 'metadata', metadataHeaders));
+      fetchPromises.push(gmail.batchGetMessages(token, ids, 'metadata', metadataHeaders, 'id,internalDate,payload/headers'));
       pageToken = listResp.nextPageToken ?? undefined;
       if (!pageToken) break;
     }

--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -120,11 +120,13 @@ export async function getMessage(
   messageId: string,
   format: GmailMessageFormat = 'full',
   metadataHeaders?: string[],
+  fields?: string,
 ): Promise<GmailMessage> {
   const params = new URLSearchParams({ format });
   if (format === 'metadata' && metadataHeaders) {
     for (const h of metadataHeaders) params.append('metadataHeaders', h);
   }
+  if (fields) params.set('fields', fields);
   return request<GmailMessage>(token, `/messages/${messageId}?${params}`);
 }
 
@@ -162,6 +164,7 @@ async function executeBatchCall(
   messageIds: string[],
   format: GmailMessageFormat,
   metadataHeaders: string[] | undefined,
+  fields?: string,
 ): Promise<{ messages: Array<{ index: number; msg: GmailMessage }>; failedIds: Array<{ index: number; id: string }> }> {
   const boundary = `batch_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
 
@@ -170,6 +173,7 @@ async function executeBatchCall(
   if (format === 'metadata' && metadataHeaders) {
     for (const h of metadataHeaders) params.append('metadataHeaders', h);
   }
+  if (fields) params.set('fields', fields);
   const qs = params.toString();
 
   // Build multipart request body
@@ -244,12 +248,13 @@ export async function batchGetMessages(
   messageIds: string[],
   format: GmailMessageFormat = 'full',
   metadataHeaders?: string[],
+  fields?: string,
 ): Promise<GmailMessage[]> {
   if (messageIds.length === 0) return [];
 
   // Single message — just use getMessage directly
   if (messageIds.length === 1) {
-    return [await getMessage(token, messageIds[0], format, metadataHeaders)];
+    return [await getMessage(token, messageIds[0], format, metadataHeaders, fields)];
   }
 
   const results = new Array<GmailMessage | null>(messageIds.length).fill(null);
@@ -263,7 +268,7 @@ export async function batchGetMessages(
   for (let i = 0; i < chunks.length; i += BATCH_CONCURRENCY) {
     const wave = chunks.slice(i, i + BATCH_CONCURRENCY);
     const waveResults = await Promise.all(
-      wave.map((chunk) => executeBatchCall(token, chunk.ids, format, metadataHeaders)),
+      wave.map((chunk) => executeBatchCall(token, chunk.ids, format, metadataHeaders, fields)),
     );
 
     // Place successful messages into the result array
@@ -278,7 +283,7 @@ export async function batchGetMessages(
       // Retry failed sub-requests individually
       if (failedIds.length > 0) {
         const retried = await Promise.all(
-          failedIds.map(({ id }) => getMessage(token, id, format, metadataHeaders)),
+          failedIds.map(({ id }) => getMessage(token, id, format, metadataHeaders, fields)),
         );
         for (let r = 0; r < failedIds.length; r++) {
           results[baseIndex + failedIds[r].index] = retried[r];


### PR DESCRIPTION
## Summary
- Add optional `fields` parameter to `getMessage()` and `batchGetMessages()` to request only needed response fields via the Google API `fields` query parameter
- Applied to `gmail-sender-digest`, `gmail-outreach-scan`, and adapter `senderDigest` with `fields=id,internalDate,payload/headers` — excludes unused `threadId`, `labelIds`, `snippet`, `historyId`, `sizeEstimate` from each response
- Callers that need other fields (like `gmail-triage` which uses `snippet` and `labelIds`) are unaffected — they don't pass `fields`

## Test plan
- [ ] Run `gmail_sender_digest` and verify results are identical
- [ ] Run `gmail_outreach_scan` and verify results are identical
- [ ] Run `gmail_triage` and verify it still works (doesn't pass `fields`, should be unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
