### PR TITLE
fix: narrow UI page token scope to least privilege

### DIFF
--- a/assistant/src/runtime/auth/token-service.ts
+++ b/assistant/src/runtime/auth/token-service.ts
@@ -309,7 +309,7 @@ export function mintUiPageToken(): string {
   return mintToken({
     aud: 'vellum-gateway',
     sub: 'svc:daemon:self',
-    scope_profile: 'gateway_service_v1',
+    scope_profile: 'actor_client_v1',
     policy_epoch: CURRENT_POLICY_EPOCH,
     ttlSeconds: 3600,
   });


### PR DESCRIPTION
## Summary
- Changed mintUiPageToken() scope_profile from gateway_service_v1 to actor_client_v1
- UI page tokens embedded in browser HTML should have minimal scope (read-only gateway access)
- Addresses Codex P1 feedback on PR #11500

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/11500

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
