### PR TITLE
fix: add bun: prefix to eslint import sort groups

### DIFF
--- a/assistant/eslint.config.mjs
+++ b/assistant/eslint.config.mjs
@@ -14,8 +14,8 @@ const eslintConfig = defineConfig([
         "error",
         {
           groups: [
-            // Node.js builtins
-            ["^node:"],
+            // Runtime builtins (Node.js and Bun)
+            ["^node:", "^bun:"],
             // External packages
             ["^@?\\w"],
             // Internal/relative imports


### PR DESCRIPTION
## Summary
- Add `^bun:` prefix to the `simple-import-sort` groups in eslint config alongside `^node:`, so `bun:test` and `bun:sqlite` imports are properly categorized as runtime builtins
- Fixes CI lint failure where `simple-import-sort` couldn't categorize `bun:` imports, causing platform-dependent sorting behavior

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22606313079/job/65499009429

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
