### PR TITLE
fix: correct isHttpAuthDisabled docstring to match implementation

### DIFF
--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -39,7 +39,9 @@ function int(name: string, fallback?: number): number | undefined {
   const n = parseInt(raw, 10);
   if (isNaN(n)) {
     throw new Error(
-      `Invalid integer for ${name}: "${raw}"${fallback !== undefined ? ` (fallback: ${fallback})` : ""}`,
+      `Invalid integer for ${name}: "${raw}"${
+        fallback !== undefined ? ` (fallback: ${fallback})` : ""
+      }`,
     );
   }
   return n;
@@ -101,9 +103,6 @@ export function getRuntimeGatewayOriginSecret(): string | undefined {
  * True when HTTP API auth is disabled via DISABLE_HTTP_AUTH=true AND the
  * safety gate VELLUM_UNSAFE_AUTH_BYPASS=1 is also set. Without the safety
  * gate, the bypass is ignored.
- *
- * Also returns true in test environments (bun test sets NODE_ENV=test)
- * so that tests don't need to initialize the JWT signing key.
  */
 export function isHttpAuthDisabled(): boolean {
   if (str("DISABLE_HTTP_AUTH")?.toLowerCase() !== "true") return false;


### PR DESCRIPTION
The docstring on isHttpAuthDisabled() incorrectly claimed the function returns true in test environments via NODE_ENV detection. The implementation only checks DISABLE_HTTP_AUTH + VELLUM_UNSAFE_AUTH_BYPASS. Updated the docstring to accurately describe the actual behavior.

Addresses feedback from PR #11520.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
