### PR TITLE
fix: log indexing failures in ChatGPT import instead of silently swallowing

### DIFF
--- a/assistant/src/config/bundled-skills/chatgpt-import/tools/chatgpt-import.ts
+++ b/assistant/src/config/bundled-skills/chatgpt-import/tools/chatgpt-import.ts
@@ -20,6 +20,9 @@ import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { getLogger } from "../../../../util/logger.js";
+
+const log = getLogger("chatgpt-import");
 
 // -- ChatGPT export format types --
 
@@ -171,10 +174,16 @@ export async function run(
           },
           memoryConfig,
         );
-      } catch {
+      } catch (err) {
         // Indexing failure is non-fatal — the message is already persisted,
         // and failing here would abort the loop before conversationKeys is
         // written, causing duplicate imports on retry.
+        log.warn(
+          "Failed to index imported message %s in conversation %s: %s",
+          dbMessages[i].id,
+          conversation.id,
+          err instanceof Error ? err.message : String(err),
+        );
       }
     }
 


### PR DESCRIPTION
The catch block around indexMessageNow in chatgpt-import.ts was silently swallowing exceptions. Added error logging so indexing failures are visible for debugging while keeping the non-fatal behavior that prevents duplicate imports.

Addresses feedback from PR #11537.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
