### PR TITLE
fix: add 90-second time budget to Gmail scan tools

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-outreach-scan.ts
@@ -84,9 +84,17 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
       const fetchPromises: Promise<GmailMessage[]>[] = [];
       let pageToken: string | undefined = inputPageToken;
       let truncated = false;
+      let timeBudgetExceeded = false;
       const metadataHeaders = ['From', 'Subject', 'Date'];
+      const startTime = Date.now();
+      const TIME_BUDGET_MS = 90_000;
 
       while (allMessageIds.length < maxMessages) {
+        if (Date.now() - startTime > TIME_BUDGET_MS) {
+          timeBudgetExceeded = true;
+          truncated = true;
+          break;
+        }
         const pageSize = Math.min(100, maxMessages - allMessageIds.length);
         const listResp = await listMessages(token, query, pageSize, pageToken);
         const ids = (listResp.messages ?? []).map((m) => m.id);
@@ -231,6 +239,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         total_scanned: allMessageIds.length,
         outreach_detected: totalOutreachDetected,
         ...(truncated ? { truncated: true, next_page_token: pageToken } : {}),
+        ...(timeBudgetExceeded ? { time_budget_exceeded: true } : {}),
       }));
     });
   } catch (e) {

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
@@ -51,9 +51,17 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
       const fetchPromises: Promise<GmailMessage[]>[] = [];
       let pageToken: string | undefined = inputPageToken;
       let truncated = false;
+      let timeBudgetExceeded = false;
       const metadataHeaders = ['From', 'List-Unsubscribe', 'Subject', 'Date'];
+      const startTime = Date.now();
+      const TIME_BUDGET_MS = 90_000;
 
       while (allMessageIds.length < maxMessages) {
+        if (Date.now() - startTime > TIME_BUDGET_MS) {
+          timeBudgetExceeded = true;
+          truncated = true;
+          break;
+        }
         const pageSize = Math.min(100, maxMessages - allMessageIds.length);
         const listResp = await listMessages(token, query, pageSize, pageToken);
         const ids = (listResp.messages ?? []).map((m) => m.id);
@@ -183,6 +191,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         total_scanned: allMessageIds.length,
         query_used: query,
         ...(truncated ? { truncated: true, next_page_token: pageToken } : {}),
+        ...(timeBudgetExceeded ? { time_budget_exceeded: true } : {}),
         note: `message_count reflects emails found per sender within the ${allMessageIds.length} messages scanned. Use scan_id with gmail_batch_archive to archive messages (pass scan_id + sender_ids instead of message_ids).`,
       }));
     });

--- a/assistant/src/messaging/providers/gmail/adapter.ts
+++ b/assistant/src/messaging/providers/gmail/adapter.ts
@@ -205,8 +205,14 @@ export const gmailMessagingProvider: MessagingProvider = {
     let pageToken: string | undefined = options?.pageToken;
     let truncated = false;
     const metadataHeaders = ['From', 'List-Unsubscribe'];
+    const startTime = Date.now();
+    const TIME_BUDGET_MS = 90_000;
 
     while (allMessageIds.length < maxMessages) {
+      if (Date.now() - startTime > TIME_BUDGET_MS) {
+        truncated = true;
+        break;
+      }
       const pageSize = Math.min(100, maxMessages - allMessageIds.length);
       const listResp = await gmail.listMessages(token, query, pageSize, pageToken);
       const ids = (listResp.messages ?? []).map((m) => m.id);


### PR DESCRIPTION
## Summary

- Adds a cooperative 90-second time budget to all three Gmail scan loops (`gmail-sender-digest.ts`, `gmail-outreach-scan.ts`, `adapter.ts` `senderDigest()`)
- When the budget is exceeded, the loop breaks and returns partial results with `time_budget_exceeded: true` (skill tools) or `truncated: true` (adapter)
- Prevents unbounded scanning that caused 5+ minute runtimes when processing large inboxes (4000+ messages across multiple page token passes)

Token safety: Google access tokens last 3600s and `withValidToken` proactively refreshes 5 min before expiry. With batch API + pipelining, 2000 messages complete in ~10-20s — the 90s budget ensures we never approach page token expiry (~5-10 min).

## Test plan

- [x] `bunx tsc --noEmit` passes
- [ ] Manual test: run "Declutter Your Email Inbox" on a large inbox — verify scan completes within ~90s and returns partial results if budget is hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
