### PR TITLE
fix: register gmail_send_draft in bundled tool registry and fix reply-all address parsing

### DIFF
--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -86,6 +86,7 @@ import * as gmailBatchLabel from "./bundled-skills/messaging/tools/gmail-batch-l
 import * as gmailDownloadAttachment from "./bundled-skills/messaging/tools/gmail-download-attachment.js";
 import * as gmailDraft from "./bundled-skills/messaging/tools/gmail-draft.js";
 import * as gmailFilters from "./bundled-skills/messaging/tools/gmail-filters.js";
+import * as gmailSendDraft from "./bundled-skills/messaging/tools/gmail-send-draft.js";
 import * as gmailFollowUp from "./bundled-skills/messaging/tools/gmail-follow-up.js";
 import * as gmailForward from "./bundled-skills/messaging/tools/gmail-forward.js";
 import * as gmailLabel from "./bundled-skills/messaging/tools/gmail-label.js";
@@ -286,6 +287,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["messaging:tools/gmail-trash.ts", gmailTrash],
   ["messaging:tools/gmail-unsubscribe.ts", gmailUnsubscribe],
   ["messaging:tools/gmail-draft.ts", gmailDraft],
+  ["messaging:tools/gmail-send-draft.ts", gmailSendDraft],
   ["messaging:tools/gmail-list-attachments.ts", gmailListAttachments],
   ["messaging:tools/gmail-download-attachment.ts", gmailDownloadAttachment],
   ["messaging:tools/gmail-send-with-attachments.ts", gmailSendWithAttachments],


### PR DESCRIPTION
Addresses Codex feedback on #11487:

1. **Register gmail_send_draft**: Added missing entry in bundled-tool-registry.ts so the tool loads in bundled runtime mode.
2. **Fix reply-all address parsing**: Replaced naive comma-split with a quote-aware parser that handles RFC 5322 addresses like `"Doe, Jane" <jane@example.com>`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
