### PR TITLE
fix: create dedicated least-privilege scope profile for UI page tokens

### DIFF
--- a/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
+++ b/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
@@ -249,6 +249,7 @@ describe("scope profile contract", () => {
       "internal.write",
     ],
     ipc_v1: ["ipc.all"],
+    ui_page_v1: ["settings.read"],
   };
 
   for (const [profile, expectedScopes] of Object.entries(EXPECTED_PROFILES)) {
@@ -271,6 +272,7 @@ describe("scope profile contract", () => {
       "gateway_ingress_v1",
       "gateway_service_v1",
       "ipc_v1",
+      "ui_page_v1",
     ];
 
     for (const profile of profiles) {

--- a/assistant/src/runtime/auth/scopes.ts
+++ b/assistant/src/runtime/auth/scopes.ts
@@ -42,6 +42,9 @@ const PROFILE_SCOPES: Record<ScopeProfile, ReadonlySet<Scope>> = {
   ipc_v1: new Set<Scope>([
     'ipc.all',
   ]),
+  ui_page_v1: new Set<Scope>([
+    'settings.read',
+  ]),
 };
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/auth/token-service.ts
+++ b/assistant/src/runtime/auth/token-service.ts
@@ -304,12 +304,15 @@ export function mintEdgeRelayToken(): string {
  * tokens with validateEdgeToken() expecting aud=vellum-gateway. A 1-hour TTL
  * gives users enough time to interact with the page (including using Refresh
  * buttons) without the token expiring mid-session.
+ *
+ * Uses the dedicated ui_page_v1 scope profile which grants only settings.read
+ * — the minimum needed for the brain-graph data endpoint those pages call.
  */
 export function mintUiPageToken(): string {
   return mintToken({
     aud: 'vellum-gateway',
     sub: 'svc:daemon:self',
-    scope_profile: 'actor_client_v1',
+    scope_profile: 'ui_page_v1',
     policy_epoch: CURRENT_POLICY_EPOCH,
     ttlSeconds: 3600,
   });

--- a/assistant/src/runtime/auth/types.ts
+++ b/assistant/src/runtime/auth/types.ts
@@ -13,7 +13,8 @@ export type ScopeProfile =
   | 'actor_client_v1'
   | 'gateway_ingress_v1'
   | 'gateway_service_v1'
-  | 'ipc_v1';
+  | 'ipc_v1'
+  | 'ui_page_v1';
 
 // ---------------------------------------------------------------------------
 // Individual scope strings

--- a/gateway/src/auth/scopes.ts
+++ b/gateway/src/auth/scopes.ts
@@ -42,6 +42,9 @@ const PROFILE_SCOPES: Record<ScopeProfile, ReadonlySet<Scope>> = {
   ipc_v1: new Set<Scope>([
     'ipc.all',
   ]),
+  ui_page_v1: new Set<Scope>([
+    'settings.read',
+  ]),
 };
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/auth/types.ts
+++ b/gateway/src/auth/types.ts
@@ -13,7 +13,8 @@ export type ScopeProfile =
   | 'actor_client_v1'
   | 'gateway_ingress_v1'
   | 'gateway_service_v1'
-  | 'ipc_v1';
+  | 'ipc_v1'
+  | 'ui_page_v1';
 
 // ---------------------------------------------------------------------------
 // Individual scope strings


### PR DESCRIPTION
## Summary
- Create a new `ui_page_v1` scope profile with minimal read-only scopes for browser-embedded UI pages
- Revert `mintUiPageToken()` from `actor_client_v1` back to the new dedicated profile
- Addresses Codex feedback on PR #11545 which correctly identified that switching to `actor_client_v1` broadened scope rather than narrowing it

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/11545

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
