### PR TITLE
fix: skip rate limiting when HTTP auth is disabled

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -617,7 +617,8 @@ export class RuntimeHttpServer {
     // abuse surface. We key on IP rather than bearer token because the gateway
     // uses a single shared token for all proxied requests, which would collapse
     // all users into one bucket.
-    if (path.startsWith("/v1/")) {
+    // Skip rate limiting entirely when HTTP auth is disabled (local Docker dev).
+    if (path.startsWith("/v1/") && !isHttpAuthDisabled()) {
       const clientIp = extractClientIp(req, server);
       const token = extractBearerToken(req);
       const result = token


### PR DESCRIPTION
## Summary
- Skip the per-client-IP rate limiter on `/v1/*` endpoints when `DISABLE_HTTP_AUTH=true` (local Docker dev)
- In local dev, all vembda requests share the same Docker bridge IP and lack a bearer token, hitting the unauthenticated rate limiter (20 req/min) and causing 429s during normal usage
- One-line change: adds `&& !isHttpAuthDisabled()` to the rate limiting condition

## Test plan
- [ ] `vel up` and exercise `/v1/conversations` — no more 429s
- [ ] Rate limiting still applies in production (where `DISABLE_HTTP_AUTH` is not set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
