### PR TITLE
fix: sort gmail-send-draft import in bundled-tool-registry

### DIFF
--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -86,12 +86,12 @@ import * as gmailBatchLabel from "./bundled-skills/messaging/tools/gmail-batch-l
 import * as gmailDownloadAttachment from "./bundled-skills/messaging/tools/gmail-download-attachment.js";
 import * as gmailDraft from "./bundled-skills/messaging/tools/gmail-draft.js";
 import * as gmailFilters from "./bundled-skills/messaging/tools/gmail-filters.js";
-import * as gmailSendDraft from "./bundled-skills/messaging/tools/gmail-send-draft.js";
 import * as gmailFollowUp from "./bundled-skills/messaging/tools/gmail-follow-up.js";
 import * as gmailForward from "./bundled-skills/messaging/tools/gmail-forward.js";
 import * as gmailLabel from "./bundled-skills/messaging/tools/gmail-label.js";
 import * as gmailListAttachments from "./bundled-skills/messaging/tools/gmail-list-attachments.js";
 import * as gmailOutreachScan from "./bundled-skills/messaging/tools/gmail-outreach-scan.js";
+import * as gmailSendDraft from "./bundled-skills/messaging/tools/gmail-send-draft.js";
 import * as gmailSendWithAttachments from "./bundled-skills/messaging/tools/gmail-send-with-attachments.js";
 import * as gmailSenderDigest from "./bundled-skills/messaging/tools/gmail-sender-digest.js";
 import * as gmailSummarizeThread from "./bundled-skills/messaging/tools/gmail-summarize-thread.js";


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `bundled-tool-registry.ts` by moving the `gmailSendDraft` import to its correct alphabetical position

## Original prompt
fix this ci issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22606699219/job/65500281533

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
