### PR TITLE
ci: remove continue-on-error from build-ios, gate release-ios on tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1356,9 +1356,6 @@ jobs:
     needs: [bump-and-tag, ci-assistant, ci-cli, ci-gateway]
     runs-on: macos-14
     timeout-minutes: 15
-    continue-on-error: true
-    outputs:
-      actual_result: ${{ steps.report.outputs.status }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1381,13 +1378,8 @@ jobs:
         working-directory: clients/ios
         run: ./build.sh test
 
-      - name: Report actual result
-        id: report
-        if: always()
-        run: echo "status=${{ job.status }}" >> "$GITHUB_OUTPUT"
-
   release-ios:
-    needs: [bump-and-tag, ci-assistant, ci-cli, ci-gateway]
+    needs: [bump-and-tag, build-ios, ci-assistant, ci-cli, ci-gateway]
     runs-on: macos-14
     timeout-minutes: 30
     env:
@@ -1629,6 +1621,7 @@ jobs:
             "${{ needs.publish-npm.result }}" \
             "${{ needs.publish-meta.result }}" \
             "${{ needs.build-macos.result }}" \
+            "${{ needs.build-ios.result }}" \
             "${{ needs.push-assistant-manifest.result }}" \
             "${{ needs.push-gateway-manifest.result }}" \
             "${{ needs.release.result }}" \
@@ -1659,7 +1652,7 @@ jobs:
           G=$(ci_icon "${{ needs.ci-gateway.result }}")
           P=$(ci_icon "${{ needs.ci-playwright.result }}")
           D=$(ci_icon "${{ needs.build-macos.result }}")
-          I=$(ci_icon "${{ needs.build-ios.outputs.actual_result }}")
+          I=$(ci_icon "${{ needs.build-ios.result }}")
           RI=$(ci_icon "${{ needs.release-ios.result }}")
           AI=$(ci_icon "${{ needs.push-assistant-manifest.result }}")
           GI=$(ci_icon "${{ needs.push-gateway-manifest.result }}")


### PR DESCRIPTION
## Summary
Follows up on #11539 to apply the same treatment to `build-ios`. Removes `continue-on-error: true` so `build-ios` failures properly block downstream jobs, and makes `release-ios` depend on `build-ios` so TestFlight uploads don't proceed when iOS tests fail.

## What changed
- **Removed `continue-on-error: true` from `build-ios`:** Previously, `build-ios` failures were silently ignored by GitHub Actions (reported as "success"). Now failures propagate normally.
- **`release-ios` depends on `build-ios`:** TestFlight upload no longer proceeds if iOS simulator build or tests fail.
- **Cleaned up `actual_result` workaround:** Removed the "Report actual result" step and `outputs.actual_result`. The notify job now uses `needs.build-ios.result` directly.
- **Added `build-ios` to failure detection:** The notify job's failure loop now includes `build-ios` so Slack notifications correctly reflect iOS build failures.

## Why
`build-ios` had the same `continue-on-error` issue that `ci-assistant` had (fixed in #11539). With `continue-on-error: true`, adding it to any job's `needs:` list only adds wait time without actually gating — GitHub Actions always reports the job as "success." This also meant `release-ios` would upload to TestFlight even when iOS tests were failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
