### PR TITLE
M5: A2A connection service

### DIFF
--- a/assistant/src/a2a/__tests__/a2a-connection-service.test.ts
+++ b/assistant/src/a2a/__tests__/a2a-connection-service.test.ts
@@ -1,0 +1,973 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'a2a-connection-service-test-'));
+
+mock.module('../../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+mock.module('../../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  A2A_PROTOCOL_VERSION,
+  A2A_SOURCE_CHANNEL,
+  approveConnection,
+  decodeInviteCode,
+  encodeInviteCode,
+  generateInvite,
+  initiateConnection,
+  listConnectionsFiltered,
+  redeemInvite,
+  revokeConnection,
+  submitVerificationCode,
+  validateA2ATarget,
+  _resetHandshakeSessions,
+  _resetIdempotencyStore,
+} from '../a2a-connection-service.js';
+import { getConnection } from '../a2a-peer-connection-store.js';
+import { getDb, initializeDb, resetDb } from '../../memory/db.js';
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run('DELETE FROM a2a_peer_connections');
+  db.run('DELETE FROM assistant_ingress_invites');
+}
+
+const MOCK_GATEWAY_URL = 'https://my-assistant.example.com';
+const PEER_GATEWAY_URL = 'https://peer-assistant.example.com';
+
+describe('a2a-connection-service', () => {
+  beforeEach(() => {
+    resetTables();
+    _resetHandshakeSessions();
+    _resetIdempotencyStore();
+  });
+
+  afterAll(() => {
+    resetDb();
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  // ========================================================================
+  // Invite code encoding / decoding
+  // ========================================================================
+
+  describe('encodeInviteCode / decodeInviteCode', () => {
+    test('round-trips correctly', () => {
+      const code = encodeInviteCode('https://example.com/gateway', 'test-token');
+      const decoded = decodeInviteCode(code);
+      expect(decoded).not.toBeNull();
+      expect(decoded!.g).toBe('https://example.com/gateway');
+      expect(decoded!.t).toBe('test-token');
+      expect(decoded!.v).toBe(A2A_PROTOCOL_VERSION);
+    });
+
+    test('returns null for malformed code', () => {
+      expect(decodeInviteCode('not-valid-base64url!!!')).toBeNull();
+    });
+
+    test('returns null for valid base64 but invalid JSON', () => {
+      const code = Buffer.from('not json').toString('base64url');
+      expect(decodeInviteCode(code)).toBeNull();
+    });
+
+    test('returns null for JSON missing required fields', () => {
+      const code = Buffer.from(JSON.stringify({ g: 'url' })).toString('base64url');
+      expect(decodeInviteCode(code)).toBeNull();
+    });
+
+    test('returns null for empty string fields', () => {
+      const code = Buffer.from(JSON.stringify({ g: '', t: 'token', v: '1.0.0' })).toString('base64url');
+      expect(decodeInviteCode(code)).toBeNull();
+    });
+  });
+
+  // ========================================================================
+  // Target URL validation
+  // ========================================================================
+
+  describe('validateA2ATarget', () => {
+    test('accepts HTTPS URLs', () => {
+      const result = validateA2ATarget('https://peer.example.com');
+      expect(result.ok).toBe(true);
+    });
+
+    test('accepts HTTP for localhost', () => {
+      const result = validateA2ATarget('http://localhost:7830');
+      expect(result.ok).toBe(true);
+    });
+
+    test('accepts HTTP for 127.0.0.1', () => {
+      const result = validateA2ATarget('http://127.0.0.1:7830');
+      expect(result.ok).toBe(true);
+    });
+
+    test('accepts HTTP for 10.x.x.x', () => {
+      const result = validateA2ATarget('http://10.0.1.5:7830');
+      expect(result.ok).toBe(true);
+    });
+
+    test('accepts HTTP for 172.16.x.x', () => {
+      const result = validateA2ATarget('http://172.16.0.1:7830');
+      expect(result.ok).toBe(true);
+    });
+
+    test('accepts HTTP for 192.168.x.x', () => {
+      const result = validateA2ATarget('http://192.168.1.100:7830');
+      expect(result.ok).toBe(true);
+    });
+
+    test('rejects HTTP for public addresses', () => {
+      const result = validateA2ATarget('http://peer.example.com');
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toContain('HTTPS');
+      }
+    });
+
+    test('rejects non-HTTP(S) schemes', () => {
+      const result = validateA2ATarget('ftp://peer.example.com');
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toContain('scheme');
+      }
+    });
+
+    test('rejects invalid URL format', () => {
+      const result = validateA2ATarget('not-a-url');
+      expect(result.ok).toBe(false);
+    });
+
+    test('rejects port 7821 (runtime port)', () => {
+      const result = validateA2ATarget('https://peer.example.com:7821');
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toContain('7821');
+      }
+    });
+
+    test('rejects port 7821 on localhost', () => {
+      const result = validateA2ATarget('http://localhost:7821');
+      expect(result.ok).toBe(false);
+    });
+
+    test('rejects 169.254.x.x (link-local / metadata)', () => {
+      const result = validateA2ATarget('http://169.254.169.254/metadata');
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toContain('link-local');
+      }
+    });
+
+    test('rejects fe80:: (IPv6 link-local)', () => {
+      const result = validateA2ATarget('http://[fe80::1]:7830');
+      expect(result.ok).toBe(false);
+    });
+
+    test('rejects self-loop to own gateway', () => {
+      const result = validateA2ATarget(
+        'https://my-assistant.example.com:443',
+        'https://my-assistant.example.com:443',
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toContain('self-loop');
+      }
+    });
+
+    test('accepts HTTPS for private IPs', () => {
+      const result = validateA2ATarget('https://192.168.1.100:8443');
+      expect(result.ok).toBe(true);
+    });
+
+    test('accepts HTTP for .local addresses', () => {
+      const result = validateA2ATarget('http://myhost.local:7830');
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  // ========================================================================
+  // generateInvite
+  // ========================================================================
+
+  describe('generateInvite', () => {
+    test('creates an invite and returns a decodable invite code', () => {
+      const result = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.inviteId).toBeTruthy();
+        expect(result.inviteCode).toBeTruthy();
+
+        const decoded = decodeInviteCode(result.inviteCode);
+        expect(decoded).not.toBeNull();
+        expect(decoded!.g).toBe(MOCK_GATEWAY_URL);
+        expect(decoded!.v).toBe(A2A_PROTOCOL_VERSION);
+      }
+    });
+
+    test('returns error when gateway URL is empty', () => {
+      const result = generateInvite({ gatewayUrl: '' });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('missing_gateway_url');
+      }
+    });
+
+    test('idempotent with idempotency key', () => {
+      const r1 = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL, idempotencyKey: 'key-1' });
+      const r2 = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL, idempotencyKey: 'key-1' });
+
+      expect(r1.ok).toBe(true);
+      expect(r2.ok).toBe(true);
+      if (r1.ok && r2.ok) {
+        expect(r1.inviteId).toBe(r2.inviteId);
+        expect(r1.inviteCode).toBe(r2.inviteCode);
+      }
+    });
+
+    test('different idempotency keys produce different invites', () => {
+      const r1 = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL, idempotencyKey: 'key-1' });
+      const r2 = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL, idempotencyKey: 'key-2' });
+
+      expect(r1.ok).toBe(true);
+      expect(r2.ok).toBe(true);
+      if (r1.ok && r2.ok) {
+        expect(r1.inviteId).not.toBe(r2.inviteId);
+      }
+    });
+
+    test('no idempotency key always creates new invite', () => {
+      const r1 = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      const r2 = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+
+      expect(r1.ok).toBe(true);
+      expect(r2.ok).toBe(true);
+      if (r1.ok && r2.ok) {
+        expect(r1.inviteId).not.toBe(r2.inviteId);
+      }
+    });
+
+    test('supports custom expiry and note', () => {
+      const result = generateInvite({
+        gatewayUrl: MOCK_GATEWAY_URL,
+        expiresInMs: 3600_000,
+        note: 'Test invite',
+      });
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  // ========================================================================
+  // redeemInvite
+  // ========================================================================
+
+  describe('redeemInvite', () => {
+    test('successfully redeems a valid invite', () => {
+      const genResult = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      expect(genResult.ok).toBe(true);
+      if (!genResult.ok) return;
+
+      const redeemResult = redeemInvite({ inviteCode: genResult.inviteCode });
+      expect(redeemResult.ok).toBe(true);
+      if (redeemResult.ok) {
+        expect(redeemResult.peerGatewayUrl).toBe(MOCK_GATEWAY_URL);
+        expect(redeemResult.inviteId).toBe(genResult.inviteId);
+        expect(redeemResult.tokenHash).toBeTruthy();
+      }
+    });
+
+    test('rejects malformed invite code', () => {
+      const result = redeemInvite({ inviteCode: 'garbage' });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('malformed_invite');
+      }
+    });
+
+    test('rejects invite with unknown token', () => {
+      const fakeCode = encodeInviteCode('https://fake.example.com', 'nonexistent-token');
+      const result = redeemInvite({ inviteCode: fakeCode });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('invalid_or_expired');
+      }
+    });
+
+    test('returns already_redeemed for consumed invite', () => {
+      // Generate and then consume via initiateConnection
+      const genResult = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      if (!genResult.ok) throw new Error('Failed');
+
+      const decoded = decodeInviteCode(genResult.inviteCode)!;
+
+      // Consume via initiateConnection
+      initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: decoded.t,
+        protocolVersion: A2A_PROTOCOL_VERSION,
+        capabilities: [],
+      });
+
+      // Try to redeem again
+      const redeemResult = redeemInvite({ inviteCode: genResult.inviteCode });
+      expect(redeemResult.ok).toBe(false);
+      if (!redeemResult.ok) {
+        expect(redeemResult.reason).toBe('already_redeemed');
+      }
+    });
+  });
+
+  // ========================================================================
+  // initiateConnection
+  // ========================================================================
+
+  describe('initiateConnection', () => {
+    function createValidInvite() {
+      const result = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      if (!result.ok) throw new Error('Failed to create invite');
+      const decoded = decodeInviteCode(result.inviteCode);
+      if (!decoded) throw new Error('Failed to decode invite');
+      return { ...result, token: decoded.t };
+    }
+
+    test('creates a pending connection with valid invite', () => {
+      const invite = createValidInvite();
+      const result = initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: invite.token,
+        protocolVersion: A2A_PROTOCOL_VERSION,
+        capabilities: ['scheduling:read'],
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.connectionId).toBeTruthy();
+        expect(result.handshakeSessionId).toBeTruthy();
+
+        // Verify connection in store
+        const conn = getConnection(result.connectionId);
+        expect(conn).not.toBeNull();
+        expect(conn!.status).toBe('pending');
+        expect(conn!.peerGatewayUrl).toBe(PEER_GATEWAY_URL);
+        expect(conn!.protocolVersion).toBe(A2A_PROTOCOL_VERSION);
+        expect(conn!.capabilities).toEqual(['scheduling:read']);
+      }
+    });
+
+    test('rejects invalid target URL', () => {
+      const invite = createValidInvite();
+      const result = initiateConnection({
+        peerGatewayUrl: 'http://public-host.example.com',
+        inviteToken: invite.token,
+        protocolVersion: A2A_PROTOCOL_VERSION,
+        capabilities: [],
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('invalid_target');
+      }
+    });
+
+    test('rejects protocol version mismatch', () => {
+      const invite = createValidInvite();
+      const result = initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: invite.token,
+        protocolVersion: '2.0.0',
+        capabilities: [],
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('version_mismatch');
+        expect(result.detail).toContain('major version');
+      }
+    });
+
+    test('accepts minor version difference', () => {
+      const invite = createValidInvite();
+      const result = initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: invite.token,
+        protocolVersion: '1.1.0',
+        capabilities: [],
+      });
+
+      expect(result.ok).toBe(true);
+    });
+
+    test('rejects invalid invite token', () => {
+      const result = initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: 'nonexistent-token',
+        protocolVersion: A2A_PROTOCOL_VERSION,
+        capabilities: [],
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('invite_not_found');
+      }
+    });
+
+    test('rejects already-consumed invite (one-time use)', () => {
+      const invite = createValidInvite();
+
+      // First use succeeds
+      const r1 = initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: invite.token,
+        protocolVersion: A2A_PROTOCOL_VERSION,
+        capabilities: [],
+      });
+      expect(r1.ok).toBe(true);
+
+      // Second use fails
+      const r2 = initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: invite.token,
+        protocolVersion: A2A_PROTOCOL_VERSION,
+        capabilities: [],
+      });
+      expect(r2.ok).toBe(false);
+      if (!r2.ok) {
+        expect(r2.reason).toBe('invite_consumed');
+      }
+    });
+
+    test('rejects connection to runtime port', () => {
+      const invite = createValidInvite();
+      const result = initiateConnection({
+        peerGatewayUrl: 'https://peer.example.com:7821',
+        inviteToken: invite.token,
+        protocolVersion: A2A_PROTOCOL_VERSION,
+        capabilities: [],
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('invalid_target');
+      }
+    });
+
+    test('rejects connection to link-local address', () => {
+      const invite = createValidInvite();
+      const result = initiateConnection({
+        peerGatewayUrl: 'http://169.254.169.254/metadata',
+        inviteToken: invite.token,
+        protocolVersion: A2A_PROTOCOL_VERSION,
+        capabilities: [],
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('invalid_target');
+      }
+    });
+  });
+
+  // ========================================================================
+  // approveConnection
+  // ========================================================================
+
+  describe('approveConnection', () => {
+    function createPendingConnection() {
+      const genResult = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      if (!genResult.ok) throw new Error('Failed to create invite');
+      const decoded = decodeInviteCode(genResult.inviteCode)!;
+
+      const initResult = initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: decoded.t,
+        protocolVersion: A2A_PROTOCOL_VERSION,
+        capabilities: [],
+      });
+      if (!initResult.ok) throw new Error('Failed to initiate connection');
+      return initResult;
+    }
+
+    test('approve generates verification code', () => {
+      const conn = createPendingConnection();
+      const result = approveConnection({
+        connectionId: conn.connectionId,
+        decision: 'approve',
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok && 'verificationCode' in result) {
+        expect(result.verificationCode).toBeTruthy();
+        expect(result.verificationCode).toHaveLength(6);
+        expect(result.connectionId).toBe(conn.connectionId);
+      }
+    });
+
+    test('deny revokes the connection', () => {
+      const conn = createPendingConnection();
+      const result = approveConnection({
+        connectionId: conn.connectionId,
+        decision: 'deny',
+      });
+
+      expect(result.ok).toBe(true);
+
+      const connection = getConnection(conn.connectionId);
+      expect(connection).not.toBeNull();
+      expect(connection!.status).toBe('revoked');
+    });
+
+    test('returns not_found for nonexistent connection', () => {
+      const result = approveConnection({
+        connectionId: 'nonexistent',
+        decision: 'approve',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('not_found');
+      }
+    });
+
+    test('returns already_resolved for active connection', () => {
+      const conn = createPendingConnection();
+
+      // Approve once
+      const r1 = approveConnection({
+        connectionId: conn.connectionId,
+        decision: 'approve',
+      });
+      expect(r1.ok).toBe(true);
+
+      // Submit code to activate
+      if (r1.ok && 'verificationCode' in r1) {
+        submitVerificationCode({
+          connectionId: conn.connectionId,
+          code: r1.verificationCode,
+          peerIdentity: conn.connectionId,
+        });
+      }
+
+      // Try to approve again (connection is now active)
+      const r2 = approveConnection({
+        connectionId: conn.connectionId,
+        decision: 'approve',
+      });
+      expect(r2.ok).toBe(false);
+      if (!r2.ok) {
+        expect(r2.reason).toBe('already_resolved');
+      }
+    });
+  });
+
+  // ========================================================================
+  // submitVerificationCode
+  // ========================================================================
+
+  describe('submitVerificationCode', () => {
+    function createApprovedConnection() {
+      const genResult = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      if (!genResult.ok) throw new Error('Failed to create invite');
+      const decoded = decodeInviteCode(genResult.inviteCode)!;
+
+      const initResult = initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: decoded.t,
+        protocolVersion: A2A_PROTOCOL_VERSION,
+        capabilities: ['scheduling:read'],
+      });
+      if (!initResult.ok) throw new Error('Failed to initiate connection');
+
+      const approveResult = approveConnection({
+        connectionId: initResult.connectionId,
+        decision: 'approve',
+      });
+      if (!approveResult.ok) throw new Error('Failed to approve connection');
+
+      const verificationCode = (approveResult as { ok: true; verificationCode: string }).verificationCode;
+
+      return {
+        connectionId: initResult.connectionId,
+        verificationCode,
+      };
+    }
+
+    test('valid code activates the connection', () => {
+      const { connectionId, verificationCode } = createApprovedConnection();
+
+      const result = submitVerificationCode({
+        connectionId,
+        code: verificationCode,
+        peerIdentity: connectionId,
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.connection.status).toBe('active');
+        expect(result.connection.outboundCredentialHash).toBeTruthy();
+        expect(result.connection.inboundCredentialHash).toBeTruthy();
+      }
+    });
+
+    test('invalid code returns error', () => {
+      const { connectionId } = createApprovedConnection();
+
+      const result = submitVerificationCode({
+        connectionId,
+        code: '000000',
+        peerIdentity: connectionId,
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('invalid_code');
+      }
+    });
+
+    test('returns not_found for nonexistent connection', () => {
+      const result = submitVerificationCode({
+        connectionId: 'nonexistent',
+        code: '123456',
+        peerIdentity: 'peer',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('not_found');
+      }
+    });
+
+    test('wrong peer identity returns identity_mismatch', () => {
+      const { connectionId, verificationCode } = createApprovedConnection();
+
+      const result = submitVerificationCode({
+        connectionId,
+        code: verificationCode,
+        peerIdentity: 'wrong-peer',
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('identity_mismatch');
+      }
+    });
+
+    test('max attempts exhaustion', () => {
+      const { connectionId } = createApprovedConnection();
+
+      // Submit wrong codes up to the limit
+      for (let i = 0; i < 3; i++) {
+        submitVerificationCode({
+          connectionId,
+          code: `99999${i}`,
+          peerIdentity: connectionId,
+        });
+      }
+
+      // Next attempt should fail with max_attempts
+      const result = submitVerificationCode({
+        connectionId,
+        code: '999999',
+        peerIdentity: connectionId,
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('max_attempts');
+      }
+    });
+  });
+
+  // ========================================================================
+  // revokeConnection
+  // ========================================================================
+
+  describe('revokeConnection', () => {
+    function createActiveConnection() {
+      const genResult = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      if (!genResult.ok) throw new Error('Failed to create invite');
+      const decoded = decodeInviteCode(genResult.inviteCode)!;
+
+      const initResult = initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: decoded.t,
+        protocolVersion: A2A_PROTOCOL_VERSION,
+        capabilities: [],
+      });
+      if (!initResult.ok) throw new Error('Failed to initiate connection');
+
+      const approveResult = approveConnection({
+        connectionId: initResult.connectionId,
+        decision: 'approve',
+      });
+      if (!approveResult.ok) throw new Error('Failed to approve');
+
+      const code = (approveResult as { ok: true; verificationCode: string }).verificationCode;
+
+      const verifyResult = submitVerificationCode({
+        connectionId: initResult.connectionId,
+        code,
+        peerIdentity: initResult.connectionId,
+      });
+      if (!verifyResult.ok) throw new Error('Failed to verify');
+
+      return initResult.connectionId;
+    }
+
+    test('revokes an active connection', () => {
+      const connectionId = createActiveConnection();
+      const result = revokeConnection({ connectionId });
+      expect(result.ok).toBe(true);
+
+      const conn = getConnection(connectionId);
+      expect(conn).not.toBeNull();
+      expect(conn!.status).toBe('revoked');
+      // Credentials should be tombstoned
+      expect(conn!.outboundCredentialHash).toBe('');
+      expect(conn!.inboundCredentialHash).toBe('');
+    });
+
+    test('idempotent: revoking already-revoked returns ok', () => {
+      const connectionId = createActiveConnection();
+
+      const r1 = revokeConnection({ connectionId });
+      expect(r1.ok).toBe(true);
+
+      const r2 = revokeConnection({ connectionId });
+      expect(r2.ok).toBe(true);
+    });
+
+    test('returns not_found for nonexistent connection', () => {
+      const result = revokeConnection({ connectionId: 'nonexistent' });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('not_found');
+      }
+    });
+
+    test('can revoke a pending connection', () => {
+      const genResult = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      if (!genResult.ok) throw new Error('Failed to create invite');
+      const decoded = decodeInviteCode(genResult.inviteCode)!;
+
+      const initResult = initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: decoded.t,
+        protocolVersion: A2A_PROTOCOL_VERSION,
+        capabilities: [],
+      });
+      if (!initResult.ok) throw new Error('Failed to initiate');
+
+      const result = revokeConnection({ connectionId: initResult.connectionId });
+      expect(result.ok).toBe(true);
+
+      const conn = getConnection(initResult.connectionId);
+      expect(conn!.status).toBe('revoked');
+    });
+  });
+
+  // ========================================================================
+  // listConnections
+  // ========================================================================
+
+  describe('listConnectionsFiltered', () => {
+    test('returns empty array when no connections', () => {
+      const result = listConnectionsFiltered();
+      expect(result.connections).toHaveLength(0);
+    });
+
+    test('returns all connections', () => {
+      const gen1 = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      const gen2 = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      if (!gen1.ok || !gen2.ok) throw new Error('Failed');
+
+      const d1 = decodeInviteCode(gen1.inviteCode)!;
+      const d2 = decodeInviteCode(gen2.inviteCode)!;
+
+      initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: d1.t,
+        protocolVersion: A2A_PROTOCOL_VERSION,
+        capabilities: [],
+      });
+      initiateConnection({
+        peerGatewayUrl: 'https://other-peer.example.com',
+        inviteToken: d2.t,
+        protocolVersion: A2A_PROTOCOL_VERSION,
+        capabilities: [],
+      });
+
+      const result = listConnectionsFiltered();
+      expect(result.connections).toHaveLength(2);
+    });
+
+    test('filters by status', () => {
+      const gen1 = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      const gen2 = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      if (!gen1.ok || !gen2.ok) throw new Error('Failed');
+
+      const d1 = decodeInviteCode(gen1.inviteCode)!;
+      const d2 = decodeInviteCode(gen2.inviteCode)!;
+
+      const c1 = initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: d1.t,
+        protocolVersion: A2A_PROTOCOL_VERSION,
+        capabilities: [],
+      });
+      initiateConnection({
+        peerGatewayUrl: 'https://other-peer.example.com',
+        inviteToken: d2.t,
+        protocolVersion: A2A_PROTOCOL_VERSION,
+        capabilities: [],
+      });
+
+      if (c1.ok) {
+        revokeConnection({ connectionId: c1.connectionId });
+      }
+
+      const pending = listConnectionsFiltered({ status: 'pending' });
+      expect(pending.connections).toHaveLength(1);
+
+      const revoked = listConnectionsFiltered({ status: 'revoked' });
+      expect(revoked.connections).toHaveLength(1);
+
+      const active = listConnectionsFiltered({ status: 'active' });
+      expect(active.connections).toHaveLength(0);
+    });
+  });
+
+  // ========================================================================
+  // Full lifecycle: generate -> redeem -> initiate -> approve -> verify
+  // ========================================================================
+
+  describe('full connection lifecycle', () => {
+    test('complete happy path', () => {
+      // Step 1: Generate invite
+      const genResult = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      expect(genResult.ok).toBe(true);
+      if (!genResult.ok) return;
+
+      // Step 2: Redeem invite (peer side validation)
+      const redeemResult = redeemInvite({ inviteCode: genResult.inviteCode });
+      expect(redeemResult.ok).toBe(true);
+      if (!redeemResult.ok) return;
+      expect(redeemResult.peerGatewayUrl).toBe(MOCK_GATEWAY_URL);
+
+      // Step 3: Initiate connection with the token from the invite
+      const decoded = decodeInviteCode(genResult.inviteCode)!;
+      const initResult = initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: decoded.t,
+        protocolVersion: A2A_PROTOCOL_VERSION,
+        capabilities: ['scheduling:read', 'messaging:relay'],
+      });
+      expect(initResult.ok).toBe(true);
+      if (!initResult.ok) return;
+
+      // Verify connection is pending
+      let conn = getConnection(initResult.connectionId);
+      expect(conn!.status).toBe('pending');
+
+      // Step 4: Approve the connection
+      const approveResult = approveConnection({
+        connectionId: initResult.connectionId,
+        decision: 'approve',
+      });
+      expect(approveResult.ok).toBe(true);
+      if (!approveResult.ok) return;
+      const verificationCode = (approveResult as { ok: true; verificationCode: string }).verificationCode;
+
+      // Step 5: Submit verification code
+      const verifyResult = submitVerificationCode({
+        connectionId: initResult.connectionId,
+        code: verificationCode,
+        peerIdentity: initResult.connectionId,
+      });
+      expect(verifyResult.ok).toBe(true);
+      if (!verifyResult.ok) return;
+
+      // Verify final state
+      conn = getConnection(initResult.connectionId);
+      expect(conn!.status).toBe('active');
+      expect(conn!.outboundCredentialHash).toBeTruthy();
+      expect(conn!.inboundCredentialHash).toBeTruthy();
+      expect(conn!.peerGatewayUrl).toBe(PEER_GATEWAY_URL);
+      expect(conn!.protocolVersion).toBe(A2A_PROTOCOL_VERSION);
+    });
+
+    test('lifecycle with revocation', () => {
+      // Set up an active connection
+      const genResult = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      if (!genResult.ok) throw new Error('Failed');
+      const decoded = decodeInviteCode(genResult.inviteCode)!;
+
+      const initResult = initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: decoded.t,
+        protocolVersion: A2A_PROTOCOL_VERSION,
+        capabilities: [],
+      });
+      if (!initResult.ok) throw new Error('Failed');
+
+      const approveResult = approveConnection({
+        connectionId: initResult.connectionId,
+        decision: 'approve',
+      });
+      if (!approveResult.ok) throw new Error('Failed');
+
+      const code = (approveResult as { ok: true; verificationCode: string }).verificationCode;
+      const verifyResult = submitVerificationCode({
+        connectionId: initResult.connectionId,
+        code,
+        peerIdentity: initResult.connectionId,
+      });
+      if (!verifyResult.ok) throw new Error('Failed');
+
+      // Revoke
+      const revokeResult = revokeConnection({ connectionId: initResult.connectionId });
+      expect(revokeResult.ok).toBe(true);
+
+      const conn = getConnection(initResult.connectionId);
+      expect(conn!.status).toBe('revoked');
+      expect(conn!.outboundCredentialHash).toBe('');
+      expect(conn!.inboundCredentialHash).toBe('');
+    });
+  });
+
+  // ========================================================================
+  // Protocol version constant
+  // ========================================================================
+
+  describe('constants', () => {
+    test('A2A_PROTOCOL_VERSION is semver', () => {
+      expect(A2A_PROTOCOL_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+    });
+
+    test('A2A_SOURCE_CHANNEL is assistant', () => {
+      expect(A2A_SOURCE_CHANNEL).toBe('assistant');
+    });
+  });
+});

--- a/assistant/src/a2a/__tests__/a2a-connection-service.test.ts
+++ b/assistant/src/a2a/__tests__/a2a-connection-service.test.ts
@@ -567,7 +567,7 @@ describe('a2a-connection-service', () => {
         submitVerificationCode({
           connectionId: conn.connectionId,
           code: r1.verificationCode,
-          peerIdentity: conn.connectionId,
+          peerIdentity: PEER_GATEWAY_URL,
         });
       }
 
@@ -621,7 +621,7 @@ describe('a2a-connection-service', () => {
       const result = submitVerificationCode({
         connectionId,
         code: verificationCode,
-        peerIdentity: connectionId,
+        peerIdentity: PEER_GATEWAY_URL,
       });
 
       expect(result.ok).toBe(true);
@@ -638,7 +638,7 @@ describe('a2a-connection-service', () => {
       const result = submitVerificationCode({
         connectionId,
         code: '000000',
-        peerIdentity: connectionId,
+        peerIdentity: PEER_GATEWAY_URL,
       });
 
       expect(result.ok).toBe(false);
@@ -682,7 +682,7 @@ describe('a2a-connection-service', () => {
         submitVerificationCode({
           connectionId,
           code: `99999${i}`,
-          peerIdentity: connectionId,
+          peerIdentity: PEER_GATEWAY_URL,
         });
       }
 
@@ -690,7 +690,7 @@ describe('a2a-connection-service', () => {
       const result = submitVerificationCode({
         connectionId,
         code: '999999',
-        peerIdentity: connectionId,
+        peerIdentity: PEER_GATEWAY_URL,
       });
 
       expect(result.ok).toBe(false);
@@ -729,7 +729,7 @@ describe('a2a-connection-service', () => {
       const verifyResult = submitVerificationCode({
         connectionId: initResult.connectionId,
         code,
-        peerIdentity: initResult.connectionId,
+        peerIdentity: PEER_GATEWAY_URL,
       });
       if (!verifyResult.ok) throw new Error('Failed to verify');
 
@@ -900,11 +900,12 @@ describe('a2a-connection-service', () => {
       if (!approveResult.ok) return;
       const verificationCode = (approveResult as { ok: true; verificationCode: string }).verificationCode;
 
-      // Step 5: Submit verification code
+      // Step 5: Submit verification code — peerIdentity must match the bound
+      // identity (peerAssistantId ?? peerGatewayUrl), not the connectionId
       const verifyResult = submitVerificationCode({
         connectionId: initResult.connectionId,
         code: verificationCode,
-        peerIdentity: initResult.connectionId,
+        peerIdentity: PEER_GATEWAY_URL,
       });
       expect(verifyResult.ok).toBe(true);
       if (!verifyResult.ok) return;
@@ -942,7 +943,7 @@ describe('a2a-connection-service', () => {
       const verifyResult = submitVerificationCode({
         connectionId: initResult.connectionId,
         code,
-        peerIdentity: initResult.connectionId,
+        peerIdentity: PEER_GATEWAY_URL,
       });
       if (!verifyResult.ok) throw new Error('Failed');
 

--- a/assistant/src/a2a/a2a-connection-service.ts
+++ b/assistant/src/a2a/a2a-connection-service.ts
@@ -59,6 +59,15 @@ const DEFAULT_INVITE_TTL_MS = INVITE_TOKEN_TTL_MS;
 /** Default runtime HTTP port — used for self-loop and runtime port detection. */
 const RUNTIME_PORT = 7821;
 
+/**
+ * Return the effective port for a parsed URL — the explicit port if present,
+ * otherwise the protocol default (443 for https, 80 for http).
+ */
+function getEffectivePort(parsed: URL): number {
+  if (parsed.port) return parseInt(parsed.port, 10);
+  return parsed.protocol === 'https:' ? 443 : 80;
+}
+
 // ---------------------------------------------------------------------------
 // Result types
 // ---------------------------------------------------------------------------
@@ -176,20 +185,21 @@ export function validateA2ATarget(
   }
 
   const hostname = parsed.hostname;
-  const port = parsed.port ? parseInt(parsed.port, 10) : (parsed.protocol === 'https:' ? 443 : 80);
+  const port = getEffectivePort(parsed);
 
   // Deny runtime port on any address
   if (port === RUNTIME_PORT) {
     return { ok: false, reason: `Port ${RUNTIME_PORT} is the daemon runtime port — use the gateway URL instead` };
   }
 
-  // Deny self-loop
+  // Deny self-loop — compare normalized effective ports so that implicit
+  // defaults (e.g. https://host vs https://host:443) are treated as equal.
   if (ownGatewayUrl) {
     try {
       const ownParsed = new URL(ownGatewayUrl);
       if (
         parsed.hostname === ownParsed.hostname &&
-        parsed.port === ownParsed.port &&
+        getEffectivePort(parsed) === getEffectivePort(ownParsed) &&
         parsed.protocol === ownParsed.protocol
       ) {
         return { ok: false, reason: 'Cannot connect to own gateway (self-loop)' };
@@ -245,8 +255,10 @@ function isLinkLocalAddress(hostname: string): boolean {
 function isLocalAddress(hostname: string): boolean {
   const lower = hostname.toLowerCase();
 
-  // Loopback and mDNS
-  if (lower === 'localhost' || lower === '::1' || lower.endsWith('.local')) {
+  // Loopback and mDNS — WHATWG URL parser returns bracketed hostnames for
+  // IPv6 addresses (e.g. new URL('http://[::1]:7830').hostname === '[::1]'),
+  // so we check both bare and bracketed forms.
+  if (lower === 'localhost' || lower === '::1' || lower === '[::1]' || lower.endsWith('.local')) {
     return true;
   }
 
@@ -456,6 +468,11 @@ export function initiateConnection(params: {
     return { ok: false, reason: 'invite_not_found' };
   }
 
+  // Must be an A2A invite — reject tokens created for other ingress flows
+  if (invite.sourceChannel !== A2A_SOURCE_CHANNEL) {
+    return { ok: false, reason: 'invite_not_found' };
+  }
+
   if (invite.status === 'redeemed') {
     return { ok: false, reason: 'invite_consumed' };
   }
@@ -619,19 +636,21 @@ export function submitVerificationCode(params: {
     return { ok: false, reason: 'invalid_state' };
   }
 
-  // Generate credentials
-  const credentials = generateCredentialPair();
-
-  // Update connection in store: set credentials and transition to active
-  updateConnectionCredentials(params.connectionId, {
-    outboundCredentialHash: credentials.outboundCredentialHash,
-    inboundCredentialHash: credentials.inboundCredentialHash,
-  });
-
+  // CAS transition to active FIRST — if another caller resolved/revoked the
+  // connection between verification and now, this fails and we avoid writing
+  // credentials to a non-active connection.
   const updatedConnection = updateConnectionStatus(params.connectionId, 'active', 'pending');
   if (!updatedConnection) {
     return { ok: false, reason: 'invalid_state' };
   }
+
+  // Generate and persist credentials only after successful status transition
+  const credentials = generateCredentialPair();
+
+  updateConnectionCredentials(params.connectionId, {
+    outboundCredentialHash: credentials.outboundCredentialHash,
+    inboundCredentialHash: credentials.inboundCredentialHash,
+  });
 
   // Clean up handshake session — connection is now active
   handshakeSessions.delete(params.connectionId);

--- a/assistant/src/a2a/a2a-connection-service.ts
+++ b/assistant/src/a2a/a2a-connection-service.ts
@@ -440,6 +440,7 @@ export function redeemInvite(params: {
  */
 export function initiateConnection(params: {
   peerGatewayUrl: string;
+  peerAssistantId?: string;
   inviteToken: string;
   protocolVersion: string;
   capabilities: string[];
@@ -490,6 +491,7 @@ export function initiateConnection(params: {
   // Create pending connection
   const connection = createConnection({
     peerGatewayUrl: params.peerGatewayUrl,
+    peerAssistantId: params.peerAssistantId,
     inviteId: invite.id,
     status: 'pending',
     protocolVersion: params.protocolVersion,
@@ -548,8 +550,14 @@ export function approveConnection(params: {
     return { ok: false, reason: 'not_found' };
   }
 
+  // Bind the peer's authenticated identity — peerAssistantId when available,
+  // otherwise peerGatewayUrl. Using connectionId would be meaningless because
+  // it is a generated UUID returned to the requester, so any caller who knows
+  // the ID could satisfy the anti-hijack check by echoing it back.
+  const peerIdentity = connection.peerAssistantId ?? connection.peerGatewayUrl;
+
   // Transition handshake: awaiting_request -> awaiting_approval
-  const toApproval = transitionToAwaitingApproval(session, params.connectionId);
+  const toApproval = transitionToAwaitingApproval(session, peerIdentity);
   if (!toApproval.ok) {
     return { ok: false, reason: 'invalid_state' };
   }
@@ -607,7 +615,9 @@ export function submitVerificationCode(params: {
     return { ok: false, reason: 'invalid_state' };
   }
 
-  // Verify the code via handshake state machine
+  // Verify the code via handshake state machine — the identity check inside
+  // transitionToVerified compares the caller's peerIdentity against what
+  // transitionToAwaitingApproval bound (peerAssistantId or peerGatewayUrl).
   const codeHash = hashHandshakeSecret(params.code);
   const result = transitionToVerified(session, codeHash, params.peerIdentity);
 

--- a/assistant/src/a2a/a2a-connection-service.ts
+++ b/assistant/src/a2a/a2a-connection-service.ts
@@ -1,0 +1,687 @@
+/**
+ * A2A Connection Service — surface-agnostic orchestration layer.
+ *
+ * Single API surface consumed by all interaction surfaces (chat skills,
+ * Telegram handlers, Settings UI). Every method is stateless request-in /
+ * result-out with no coupling to chat sessions, IPC, or channels.
+ *
+ * Ties together:
+ *   - a2a-peer-connection-store (M2) — connection CRUD
+ *   - a2a-handshake (M3) — handshake state machine + crypto
+ *   - a2a-peer-auth (M4) — credential generation
+ */
+
+import {
+  createConnection,
+  getConnection,
+  listConnections as storeListConnections,
+  updateConnectionCredentials,
+  updateConnectionStatus,
+  type A2APeerConnection,
+  type A2APeerConnectionStatus,
+} from './a2a-peer-connection-store.js';
+
+import {
+  createHandshakeSession,
+  generateVerificationCode,
+  hashHandshakeSecret,
+  INVITE_TOKEN_TTL_MS,
+  transitionToAwaitingApproval,
+  transitionToAwaitingVerification,
+  transitionToVerified,
+  transitionToActive,
+  type HandshakeSession,
+} from './a2a-handshake.js';
+
+import { generateCredentialPair } from './a2a-peer-auth.js';
+
+import {
+  createInvite as createIngressInvite,
+  findByTokenHash,
+  hashToken,
+  markInviteExpired,
+  recordInviteUse,
+} from '../memory/ingress-invite-store.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** v1 protocol version string. */
+export const A2A_PROTOCOL_VERSION = '1.0.0';
+
+/** Source channel discriminator for A2A invites in the ingress invite table. */
+export const A2A_SOURCE_CHANNEL = 'assistant';
+
+/** Default invite TTL: 24 hours. */
+const DEFAULT_INVITE_TTL_MS = INVITE_TOKEN_TTL_MS;
+
+/** Default runtime HTTP port — used for self-loop and runtime port detection. */
+const RUNTIME_PORT = 7821;
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+export type GenerateInviteResult =
+  | { ok: true; inviteCode: string; inviteId: string }
+  | { ok: false; reason: 'generation_failed' | 'missing_gateway_url' };
+
+export type RedeemInviteResult =
+  | { ok: true; peerGatewayUrl: string; inviteId: string; tokenHash: string }
+  | { ok: false; reason: 'invalid_or_expired' | 'already_redeemed' | 'malformed_invite' };
+
+export type InitiateConnectionResult =
+  | { ok: true; connectionId: string; handshakeSessionId: string }
+  | { ok: false; reason: 'invalid_target' | 'version_mismatch' | 'invite_not_found' | 'invite_consumed'; detail?: string };
+
+export type ApproveConnectionResult =
+  | { ok: true; verificationCode: string; connectionId: string }
+  | { ok: false; reason: 'not_found' | 'invalid_state' | 'already_resolved' };
+
+export type DenyConnectionResult =
+  | { ok: true }
+  | { ok: false; reason: 'not_found' | 'invalid_state' | 'already_resolved' };
+
+export type SubmitVerificationCodeResult =
+  | { ok: true; connection: A2APeerConnection }
+  | { ok: false; reason: 'not_found' | 'invalid_code' | 'expired' | 'max_attempts' | 'invalid_state' | 'identity_mismatch' };
+
+export type RevokeConnectionResult =
+  | { ok: true }
+  | { ok: false; reason: 'not_found' };
+
+export type ListConnectionsResult = {
+  connections: A2APeerConnection[];
+};
+
+// ---------------------------------------------------------------------------
+// Invite code encoding/decoding
+// ---------------------------------------------------------------------------
+
+interface InvitePayload {
+  /** Gateway URL of the inviting assistant. */
+  g: string;
+  /** One-time token. */
+  t: string;
+  /** Protocol version. */
+  v: string;
+}
+
+/**
+ * Encode an invite payload into a compact, URL-safe string.
+ * Uses base64url encoding of a JSON payload.
+ */
+export function encodeInviteCode(gatewayUrl: string, token: string): string {
+  const payload: InvitePayload = {
+    g: gatewayUrl,
+    t: token,
+    v: A2A_PROTOCOL_VERSION,
+  };
+  return Buffer.from(JSON.stringify(payload)).toString('base64url');
+}
+
+/**
+ * Decode an invite code back into its payload components.
+ * Returns null if the code is malformed or unparseable.
+ */
+export function decodeInviteCode(inviteCode: string): InvitePayload | null {
+  try {
+    const json = Buffer.from(inviteCode, 'base64url').toString('utf-8');
+    const payload = JSON.parse(json) as Record<string, unknown>;
+
+    if (
+      typeof payload.g !== 'string' || !payload.g ||
+      typeof payload.t !== 'string' || !payload.t ||
+      typeof payload.v !== 'string' || !payload.v
+    ) {
+      return null;
+    }
+
+    return { g: payload.g, t: payload.t, v: payload.v };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Target URL validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a peer gateway URL for outbound A2A connections. Implements
+ * the canonical target validation rule from the architecture doc.
+ *
+ * Rules:
+ *   - Only http:// and https:// schemes allowed
+ *   - HTTPS required for public addresses
+ *   - HTTP permitted only for local/private addresses (RFC 1918, loopback)
+ *   - Always deny: link-local (169.254.x.x, fe80::), runtime port 7821,
+ *     self-loop to own gateway
+ */
+export function validateA2ATarget(
+  url: string,
+  ownGatewayUrl?: string,
+): { ok: true } | { ok: false; reason: string } {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, reason: 'Invalid URL format' };
+  }
+
+  // Only HTTP(S) schemes
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { ok: false, reason: `Invalid scheme: ${parsed.protocol} — only http: and https: allowed` };
+  }
+
+  const hostname = parsed.hostname;
+  const port = parsed.port ? parseInt(parsed.port, 10) : (parsed.protocol === 'https:' ? 443 : 80);
+
+  // Deny runtime port on any address
+  if (port === RUNTIME_PORT) {
+    return { ok: false, reason: `Port ${RUNTIME_PORT} is the daemon runtime port — use the gateway URL instead` };
+  }
+
+  // Deny self-loop
+  if (ownGatewayUrl) {
+    try {
+      const ownParsed = new URL(ownGatewayUrl);
+      if (
+        parsed.hostname === ownParsed.hostname &&
+        parsed.port === ownParsed.port &&
+        parsed.protocol === ownParsed.protocol
+      ) {
+        return { ok: false, reason: 'Cannot connect to own gateway (self-loop)' };
+      }
+    } catch {
+      // If own URL is unparseable, skip self-loop check
+    }
+  }
+
+  // Check for link-local and metadata addresses
+  if (isLinkLocalAddress(hostname)) {
+    return { ok: false, reason: `Link-local/metadata address denied: ${hostname}` };
+  }
+
+  // HTTP only allowed for local/private addresses
+  if (parsed.protocol === 'http:' && !isLocalAddress(hostname)) {
+    return { ok: false, reason: 'HTTP is only allowed for local/private addresses — use HTTPS for public targets' };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Check if a hostname is a link-local or metadata address (always denied).
+ * Covers IPv4 169.254.0.0/16 and IPv6 fe80::/10.
+ */
+function isLinkLocalAddress(hostname: string): boolean {
+  const lower = hostname.toLowerCase();
+
+  // IPv6 link-local
+  if (lower.startsWith('fe80:') || lower.startsWith('[fe80:')) {
+    return true;
+  }
+
+  // IPv4 link-local (169.254.x.x) — cloud metadata endpoint SSRF vector
+  const parts = lower.split('.');
+  if (parts.length === 4) {
+    const octets = parts.map(Number);
+    if (octets.every((o) => !isNaN(o) && o >= 0 && o <= 255)) {
+      if (octets[0] === 169 && octets[1] === 254) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Check if a hostname is a local/private address where HTTP is permitted.
+ * Mirrors the Swift `LocalAddressValidator.isLocalAddress()` logic.
+ */
+function isLocalAddress(hostname: string): boolean {
+  const lower = hostname.toLowerCase();
+
+  // Loopback and mDNS
+  if (lower === 'localhost' || lower === '::1' || lower.endsWith('.local')) {
+    return true;
+  }
+
+  // IPv6 link-local (fe80::) — these are local but we deny them separately
+  // in isLinkLocalAddress; included here for completeness
+  if (lower.startsWith('fe80:') || lower.startsWith('[fe80:')) {
+    return true;
+  }
+
+  // IPv4
+  const parts = lower.split('.');
+  if (parts.length === 4) {
+    const octets = parts.map(Number);
+    if (octets.every((o) => !isNaN(o) && o >= 0 && o <= 255)) {
+      // 127.0.0.0/8 — loopback
+      if (octets[0] === 127) return true;
+      // 10.0.0.0/8 — private
+      if (octets[0] === 10) return true;
+      // 172.16.0.0/12 — private
+      if (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) return true;
+      // 192.168.0.0/16 — private
+      if (octets[0] === 192 && octets[1] === 168) return true;
+      // 169.254.0.0/16 — link-local (APIPA)
+      if (octets[0] === 169 && octets[1] === 254) return true;
+    }
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Protocol version check
+// ---------------------------------------------------------------------------
+
+/**
+ * Check major version compatibility. Returns true if the major versions match.
+ */
+function isMajorVersionCompatible(our: string, theirs: string): boolean {
+  const ourMajor = our.split('.')[0];
+  const theirMajor = theirs.split('.')[0];
+  return ourMajor === theirMajor;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory handshake session store
+// ---------------------------------------------------------------------------
+
+// Handshake sessions are short-lived (15 min TTL) and don't need persistence.
+// They are kept in-memory and keyed by connection ID.
+const handshakeSessions = new Map<string, HandshakeSession>();
+
+/** Exposed for testing — clear all in-memory handshake sessions. */
+export function _resetHandshakeSessions(): void {
+  handshakeSessions.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Idempotency key store (in-memory, bounded)
+// ---------------------------------------------------------------------------
+
+// Maps idempotency keys to invite IDs + codes for generateInvite deduplication.
+const idempotencyStore = new Map<string, { inviteId: string; inviteCode: string }>();
+
+/** Exposed for testing — clear idempotency store. */
+export function _resetIdempotencyStore(): void {
+  idempotencyStore.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Service methods
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate an invite for a peer to connect.
+ *
+ * Creates a one-time token, hashes it, stores in `assistant_ingress_invites`
+ * with `sourceChannel = 'assistant'`. Returns an invite code encoding the
+ * gateway URL + token.
+ *
+ * Idempotent when `idempotencyKey` is provided — returns the same invite
+ * if one was already created with that key.
+ */
+export function generateInvite(params: {
+  gatewayUrl: string;
+  expiresInMs?: number;
+  note?: string;
+  idempotencyKey?: string;
+}): GenerateInviteResult {
+  if (!params.gatewayUrl) {
+    return { ok: false, reason: 'missing_gateway_url' };
+  }
+
+  // Idempotency: if a key was provided and we've seen it, return the cached result
+  if (params.idempotencyKey) {
+    const cached = idempotencyStore.get(params.idempotencyKey);
+    if (cached) {
+      return { ok: true, inviteCode: cached.inviteCode, inviteId: cached.inviteId };
+    }
+  }
+
+  try {
+    const { invite, rawToken } = createIngressInvite({
+      sourceChannel: A2A_SOURCE_CHANNEL,
+      note: params.note,
+      expiresInMs: params.expiresInMs ?? DEFAULT_INVITE_TTL_MS,
+      maxUses: 1,
+    });
+
+    const inviteCode = encodeInviteCode(params.gatewayUrl, rawToken);
+
+    // Cache for idempotency
+    if (params.idempotencyKey) {
+      idempotencyStore.set(params.idempotencyKey, {
+        inviteId: invite.id,
+        inviteCode,
+      });
+    }
+
+    return { ok: true, inviteCode, inviteId: invite.id };
+  } catch {
+    return { ok: false, reason: 'generation_failed' };
+  }
+}
+
+/**
+ * Decode and validate an invite code.
+ *
+ * Parses the invite, validates the token hash against the store, checks
+ * expiry. Does NOT initiate a connection — that is a separate step.
+ */
+export function redeemInvite(params: {
+  inviteCode: string;
+}): RedeemInviteResult {
+  const payload = decodeInviteCode(params.inviteCode);
+  if (!payload) {
+    return { ok: false, reason: 'malformed_invite' };
+  }
+
+  const tokenH = hashToken(payload.t);
+  const invite = findByTokenHash(tokenH);
+
+  if (!invite) {
+    return { ok: false, reason: 'invalid_or_expired' };
+  }
+
+  // Check channel — must be an A2A invite
+  if (invite.sourceChannel !== A2A_SOURCE_CHANNEL) {
+    return { ok: false, reason: 'invalid_or_expired' };
+  }
+
+  // Check expiry
+  if (invite.expiresAt <= Date.now()) {
+    markInviteExpired(invite.id);
+    return { ok: false, reason: 'invalid_or_expired' };
+  }
+
+  // Check status
+  if (invite.status === 'redeemed') {
+    return { ok: false, reason: 'already_redeemed' };
+  }
+
+  if (invite.status !== 'active') {
+    return { ok: false, reason: 'invalid_or_expired' };
+  }
+
+  return {
+    ok: true,
+    peerGatewayUrl: payload.g,
+    inviteId: invite.id,
+    tokenHash: tokenH,
+  };
+}
+
+/**
+ * Initiate a connection request to a peer.
+ *
+ * Validates the peer URL, checks protocol version, consumes the invite,
+ * creates a pending connection, and initializes a handshake session.
+ */
+export function initiateConnection(params: {
+  peerGatewayUrl: string;
+  inviteToken: string;
+  protocolVersion: string;
+  capabilities: string[];
+  ownGatewayUrl?: string;
+}): InitiateConnectionResult {
+  // Validate target URL
+  const targetValidation = validateA2ATarget(params.peerGatewayUrl, params.ownGatewayUrl);
+  if (!targetValidation.ok) {
+    return { ok: false, reason: 'invalid_target', detail: targetValidation.reason };
+  }
+
+  // Protocol version check
+  if (!isMajorVersionCompatible(A2A_PROTOCOL_VERSION, params.protocolVersion)) {
+    return {
+      ok: false,
+      reason: 'version_mismatch',
+      detail: `Expected major version ${A2A_PROTOCOL_VERSION.split('.')[0]}, got ${params.protocolVersion.split('.')[0]}`,
+    };
+  }
+
+  // Validate invite token against store
+  const tokenH = hashToken(params.inviteToken);
+  const invite = findByTokenHash(tokenH);
+
+  if (!invite) {
+    return { ok: false, reason: 'invite_not_found' };
+  }
+
+  if (invite.status === 'redeemed') {
+    return { ok: false, reason: 'invite_consumed' };
+  }
+
+  if (invite.status !== 'active' || invite.expiresAt <= Date.now()) {
+    return { ok: false, reason: 'invite_not_found' };
+  }
+
+  // Consume the invite
+  const consumed = recordInviteUse({ inviteId: invite.id });
+  if (!consumed) {
+    return { ok: false, reason: 'invite_consumed' };
+  }
+
+  // Create pending connection
+  const connection = createConnection({
+    peerGatewayUrl: params.peerGatewayUrl,
+    inviteId: invite.id,
+    status: 'pending',
+    protocolVersion: params.protocolVersion,
+    capabilities: params.capabilities,
+  });
+
+  // Create handshake session and bind to connection
+  const inviteTokenHash = hashHandshakeSecret(params.inviteToken);
+  const session = createHandshakeSession({ inviteTokenHash });
+  handshakeSessions.set(connection.id, session);
+
+  return {
+    ok: true,
+    connectionId: connection.id,
+    handshakeSessionId: session.id,
+  };
+}
+
+/**
+ * Approve or deny a pending connection request.
+ *
+ * On approve: generates a verification code, transitions handshake to
+ * `awaiting_verification`, and returns the code for guardian to share IRL.
+ *
+ * On deny: transitions the connection to `revoked`.
+ */
+export function approveConnection(params: {
+  connectionId: string;
+  decision: 'approve' | 'deny';
+}): ApproveConnectionResult | DenyConnectionResult {
+  const connection = getConnection(params.connectionId);
+  if (!connection) {
+    return { ok: false, reason: 'not_found' };
+  }
+
+  if (connection.status !== 'pending') {
+    if (connection.status === 'active' || connection.status === 'revoked') {
+      return { ok: false, reason: 'already_resolved' };
+    }
+    return { ok: false, reason: 'invalid_state' };
+  }
+
+  if (params.decision === 'deny') {
+    const updated = updateConnectionStatus(params.connectionId, 'revoked', 'pending');
+    if (!updated) {
+      return { ok: false, reason: 'already_resolved' };
+    }
+    // Clean up handshake session
+    handshakeSessions.delete(params.connectionId);
+    return { ok: true };
+  }
+
+  // Approve flow
+  const session = handshakeSessions.get(params.connectionId);
+  if (!session) {
+    return { ok: false, reason: 'not_found' };
+  }
+
+  // Transition handshake: awaiting_request -> awaiting_approval
+  const toApproval = transitionToAwaitingApproval(session, params.connectionId);
+  if (!toApproval.ok) {
+    return { ok: false, reason: 'invalid_state' };
+  }
+
+  // Generate verification code
+  const verificationCode = generateVerificationCode();
+  const codeHash = hashHandshakeSecret(verificationCode);
+
+  // Transition handshake: awaiting_approval -> awaiting_verification
+  const toVerification = transitionToAwaitingVerification(toApproval.session, codeHash);
+  if (!toVerification.ok) {
+    return { ok: false, reason: 'invalid_state' };
+  }
+
+  // Save updated session
+  handshakeSessions.set(params.connectionId, toVerification.session);
+
+  return {
+    ok: true,
+    verificationCode,
+    connectionId: params.connectionId,
+  };
+}
+
+/**
+ * Submit the IRL verification code for a pending connection.
+ *
+ * Validates the code via handshake primitives. On success, generates
+ * credentials and transitions to `active`.
+ */
+export function submitVerificationCode(params: {
+  connectionId: string;
+  code: string;
+  peerIdentity: string;
+}): SubmitVerificationCodeResult {
+  const connection = getConnection(params.connectionId);
+  if (!connection) {
+    return { ok: false, reason: 'not_found' };
+  }
+
+  if (connection.status === 'active') {
+    return { ok: false, reason: 'invalid_state' };
+  }
+
+  if (connection.status === 'revoked' || connection.status === 'revoked_by_peer') {
+    return { ok: false, reason: 'invalid_state' };
+  }
+
+  const session = handshakeSessions.get(params.connectionId);
+  if (!session) {
+    return { ok: false, reason: 'not_found' };
+  }
+
+  if (session.state !== 'awaiting_verification') {
+    return { ok: false, reason: 'invalid_state' };
+  }
+
+  // Verify the code via handshake state machine
+  const codeHash = hashHandshakeSecret(params.code);
+  const result = transitionToVerified(session, codeHash, params.peerIdentity);
+
+  if (!result.ok) {
+    // Update session state on failure (e.g. increment attempt count)
+    if (result.reason === 'invalid_code' && 'session' in result) {
+      handshakeSessions.set(params.connectionId, result.session);
+    }
+
+    // Map handshake transition reasons to service-level reasons
+    type FailureReason = Extract<SubmitVerificationCodeResult, { ok: false }>['reason'];
+    const reasonMap: Record<string, FailureReason> = {
+      invalid_transition: 'invalid_state',
+      expired: 'expired',
+      identity_mismatch: 'identity_mismatch',
+      max_attempts: 'max_attempts',
+      invalid_code: 'invalid_code',
+    };
+
+    return { ok: false as const, reason: reasonMap[result.reason] ?? ('invalid_state' as FailureReason) };
+  }
+
+  // Transition to active
+  const activeResult = transitionToActive(result.session);
+  if (!activeResult.ok) {
+    return { ok: false, reason: 'invalid_state' };
+  }
+
+  // Generate credentials
+  const credentials = generateCredentialPair();
+
+  // Update connection in store: set credentials and transition to active
+  updateConnectionCredentials(params.connectionId, {
+    outboundCredentialHash: credentials.outboundCredentialHash,
+    inboundCredentialHash: credentials.inboundCredentialHash,
+  });
+
+  const updatedConnection = updateConnectionStatus(params.connectionId, 'active', 'pending');
+  if (!updatedConnection) {
+    return { ok: false, reason: 'invalid_state' };
+  }
+
+  // Clean up handshake session — connection is now active
+  handshakeSessions.delete(params.connectionId);
+
+  return { ok: true, connection: updatedConnection };
+}
+
+/**
+ * Revoke an active connection.
+ *
+ * Idempotent: revoking an already-revoked connection returns `{ ok: true }`.
+ * Tombstones credentials and updates status.
+ */
+export function revokeConnection(params: {
+  connectionId: string;
+}): RevokeConnectionResult {
+  const connection = getConnection(params.connectionId);
+  if (!connection) {
+    return { ok: false, reason: 'not_found' };
+  }
+
+  // Idempotent: already revoked is a success
+  if (connection.status === 'revoked' || connection.status === 'revoked_by_peer') {
+    return { ok: true };
+  }
+
+  // Tombstone credentials
+  updateConnectionCredentials(params.connectionId, {
+    outboundCredentialHash: '',
+    inboundCredentialHash: '',
+  });
+
+  // Transition to revoked
+  updateConnectionStatus(params.connectionId, 'revoked');
+
+  // Clean up any lingering handshake session
+  handshakeSessions.delete(params.connectionId);
+
+  return { ok: true };
+}
+
+/**
+ * List connections with optional status filter.
+ * Always succeeds — returns empty array when no connections exist.
+ */
+export function listConnectionsFiltered(params?: {
+  status?: A2APeerConnectionStatus;
+}): ListConnectionsResult {
+  const connections = storeListConnections({
+    status: params?.status,
+  });
+  return { connections };
+}

--- a/assistant/src/a2a/a2a-connection-service.ts
+++ b/assistant/src/a2a/a2a-connection-service.ts
@@ -647,7 +647,7 @@ export function submitVerificationCode(params: {
   // Generate and persist credentials only after successful status transition
   const credentials = generateCredentialPair();
 
-  updateConnectionCredentials(params.connectionId, {
+  const connectionWithCredentials = updateConnectionCredentials(params.connectionId, {
     outboundCredentialHash: credentials.outboundCredentialHash,
     inboundCredentialHash: credentials.inboundCredentialHash,
   });
@@ -655,7 +655,7 @@ export function submitVerificationCode(params: {
   // Clean up handshake session — connection is now active
   handshakeSessions.delete(params.connectionId);
 
-  return { ok: true, connection: updatedConnection };
+  return { ok: true, connection: connectionWithCredentials ?? updatedConnection };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `A2AConnectionService` (`assistant/src/a2a/a2a-connection-service.ts`) with seven imperative methods: `generateInvite`, `redeemInvite`, `initiateConnection`, `approveConnection`, `submitVerificationCode`, `revokeConnection`, and `listConnectionsFiltered`
- Implement target URL validation (`validateA2ATarget`) with SSRF protections: deny link-local/metadata IPs, runtime port 7821, self-loop to own gateway; HTTP only for local/private addresses
- Include invite code encoding/decoding (base64url JSON), protocol version negotiation (v1.0.0 with major version compatibility check), CAS state transitions, and idempotency key support for `generateInvite`
- Surface-agnostic — no coupling to chat, IPC, channels, or session modules

## Test plan
- [x] Invite code encoding/decoding round-trip and malformed input handling
- [x] Target URL validation covering all deny-list entries (link-local, runtime port, self-loop, non-HTTPS public, non-HTTP(S) schemes) and all accept cases (HTTPS public, HTTP local/private)
- [x] `generateInvite` with idempotency key deduplication and without
- [x] `redeemInvite` for valid, malformed, unknown, and already-redeemed invites
- [x] `initiateConnection` with valid invite, invalid target, version mismatch, minor version acceptance, consumed invite, and SSRF vectors
- [x] `approveConnection` approve/deny paths, not_found, already_resolved
- [x] `submitVerificationCode` valid code, invalid code, identity mismatch, max attempts
- [x] `revokeConnection` active connection, idempotent re-revoke, pending connection
- [x] `listConnectionsFiltered` with and without status filter
- [x] Full lifecycle integration tests (generate -> initiate -> approve -> verify -> revoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
