### PR TITLE
feat: add phone-calls routing section to system prompt

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -72,6 +72,7 @@ const {
   ensurePromptFiles,
   stripCommentLines,
   buildExternalCommsIdentitySection,
+  buildPhoneCallsRoutingSection,
 } = await import("../config/system-prompt.js");
 
 /** Strip the Configuration and Skills sections so base-prompt tests stay focused. */
@@ -222,6 +223,26 @@ describe("buildSystemPrompt", () => {
       "Do not volunteer that you are an AI unless directly asked",
     );
     expect(section).toContain("Occasional variations are acceptable");
+  });
+
+  test("includes phone calls routing section", () => {
+    const result = buildSystemPrompt();
+    expect(result).toContain("## Routing: Phone Calls");
+    expect(result).toContain('skill: "phone-calls"');
+  });
+
+  test("buildPhoneCallsRoutingSection returns section with expected content", () => {
+    const section = buildPhoneCallsRoutingSection();
+    expect(section).toContain("## Routing: Phone Calls");
+    expect(section).toContain("Trigger phrases");
+    expect(section).toContain("Exclusivity rules");
+    expect(section).toContain("phone-calls");
+    expect(section).toContain("Do NOT improvise Twilio setup instructions");
+  });
+
+  test("phone calls routing section excluded from low tier", () => {
+    const result = buildSystemPrompt("low");
+    expect(result).not.toContain("## Routing: Phone Calls");
   });
 
   test("includes memory persistence section in high tier", () => {

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -145,6 +145,7 @@ export function buildSystemPrompt(tier: ResponseTier = 'high'): string {
     parts.push(buildAttachmentSection());
     parts.push(buildInChatConfigurationSection());
     parts.push(buildVoiceSetupRoutingSection());
+    parts.push(buildPhoneCallsRoutingSection());
     parts.push(buildChannelCommandIntentSection());
   }
 
@@ -370,6 +371,37 @@ export function buildVoiceSetupRoutingSection(): string {
     '- Voice setup (this skill) = **local PTT, wake word, microphone permissions** on the Mac desktop app.',
     '- Phone calls skill = **Twilio-powered voice calls** over the phone network. Completely separate.',
     '- If the user says "voice" in the context of phone calls or Twilio, load `phone-calls` instead.',
+  ].join('\n');
+}
+
+export function buildPhoneCallsRoutingSection(): string {
+  return [
+    '## Routing: Phone Calls',
+    '',
+    'When the user asks to set up phone calling, place a call, configure Twilio for voice, or anything related to outbound/inbound phone calls, load the **Phone Calls** skill.',
+    '',
+    '### Trigger phrases',
+    '- "Set up phone calling" / "enable calls"',
+    '- "Make a call to..." / "call [number/business]"',
+    '- "Configure Twilio" (in context of voice calls, not SMS)',
+    '- "Can you make phone calls?"',
+    '- "Set up my phone number" (for calling, not SMS)',
+    '',
+    '### What it does',
+    'The skill handles the full phone calling lifecycle:',
+    '1. Twilio credential setup (delegates to twilio-setup skill)',
+    '2. Public ingress configuration (delegates to public-ingress skill)',
+    '3. Enabling the calls feature',
+    '4. Placing outbound calls and receiving inbound calls',
+    '5. Voice quality configuration (standard Twilio TTS or ElevenLabs)',
+    '',
+    'Load with: `skill_load` using `skill: "phone-calls"`',
+    '',
+    '### Exclusivity rules',
+    '- Do NOT improvise Twilio setup instructions from general knowledge — always load the skill first.',
+    '- Do NOT confuse with voice-setup (local PTT/wake word/microphone) or guardian-verify-setup (channel verification).',
+    '- If the user says "voice" in the context of phone calls or Twilio, load phone-calls, not voice-setup.',
+    '- For guardian voice verification specifically, load guardian-verify-setup instead.',
   ].join('\n');
 }
 


### PR DESCRIPTION
## Summary
- Add dedicated `buildPhoneCallsRoutingSection()` with trigger phrases, skill description, and exclusivity rules so the assistant auto-loads the phone-calls skill instead of improvising Twilio setup advice
- Wire the section into `buildSystemPrompt()` for medium+high tiers, placed after voice-setup routing
- Add tests for section presence, content, and low-tier exclusion

## Original prompt
Bug Report: Phone Calls Skill Missing from System Prompt Routing — the assistant doesn't auto-load the phone-calls skill when users ask about phone calling, Twilio setup, or placing calls. Added a routing section following the same pattern as guardian-verify and voice-setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
