### PR TITLE
fix: update test mocks to match production code changes

### DIFF
--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -132,9 +132,11 @@ describe("getChannelApprovalPrompt", () => {
     const result = getChannelApprovalPrompt("conv-1");
     expect(result).not.toBeNull();
     expect(result!.promptText).toContain("shell");
-    expect(result!.actions).toHaveLength(3);
+    expect(result!.actions).toHaveLength(5);
     expect(result!.actions.map((a) => a.id)).toEqual([
       "approve_once",
+      "approve_10m",
+      "approve_thread",
       "approve_always",
       "reject",
     ]);
@@ -174,6 +176,8 @@ describe("getChannelApprovalPrompt", () => {
     expect(result).not.toBeNull();
     expect(result!.actions.map((a) => a.id)).toEqual([
       "approve_once",
+      "approve_10m",
+      "approve_thread",
       "approve_always",
       "reject",
     ]);
@@ -189,6 +193,8 @@ describe("getChannelApprovalPrompt", () => {
     expect(result).not.toBeNull();
     expect(result!.actions.map((a) => a.id)).toEqual([
       "approve_once",
+      "approve_10m",
+      "approve_thread",
       "approve_always",
       "reject",
     ]);

--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -79,6 +79,14 @@ mock.module("../runtime/local-actor-identity.js", () => ({
   }),
 }));
 
+mock.module("../runtime/guardian-context-resolver.js", () => ({
+  resolveGuardianContext: () => ({
+    trustClass: "guardian",
+    sourceChannel: "vellum",
+  }),
+  toGuardianRuntimeContext: (ctx: unknown) => ctx,
+}));
+
 import type { AuthContext } from "../runtime/auth/types.js";
 import { handleSendMessage } from "../runtime/routes/conversation-routes.js";
 

--- a/assistant/src/__tests__/daemon-server-session-init.test.ts
+++ b/assistant/src/__tests__/daemon-server-session-init.test.ts
@@ -131,6 +131,8 @@ class MockSession {
     this.guardianContext = ctx;
   }
 
+  setAuthContext(): void {}
+
   setChannelCapabilities(): void {}
 
   setCommandIntent(): void {}

--- a/assistant/src/__tests__/gmail-integration.test.ts
+++ b/assistant/src/__tests__/gmail-integration.test.ts
@@ -11,6 +11,13 @@ const toolsManifestPath = resolve(
   "../config/bundled-skills/messaging/TOOLS.json",
 );
 const toolsManifest = JSON.parse(readFileSync(toolsManifestPath, "utf-8"));
+const slackToolsManifestPath = resolve(
+  __dirname,
+  "../config/bundled-skills/slack/TOOLS.json",
+);
+const slackToolsManifest = JSON.parse(
+  readFileSync(slackToolsManifestPath, "utf-8"),
+);
 
 describe("Messaging tool contract", () => {
   const expectedGmailToolNames = [
@@ -70,19 +77,21 @@ describe("Messaging tool contract", () => {
   });
 
   test("TOOLS.json manifest contains all expected slack_* tool names", () => {
-    const manifestToolNames: string[] = toolsManifest.tools.map(
+    const slackToolNames: string[] = slackToolsManifest.tools.map(
       (t: { name: string }) => t.name,
     );
     for (const name of expectedSlackToolNames) {
-      expect(manifestToolNames).toContain(name);
+      expect(slackToolNames).toContain(name);
     }
   });
 
-  test("TOOLS.json manifest contains at least the expected number of tools", () => {
+  test("TOOLS.json manifests contain at least the expected number of tools", () => {
     const expectedMinimum =
       expectedGmailToolNames.length +
       expectedMessagingToolNames.length +
       expectedSlackToolNames.length;
-    expect(toolsManifest.tools.length).toBeGreaterThanOrEqual(expectedMinimum);
+    const totalTools =
+      toolsManifest.tools.length + slackToolsManifest.tools.length;
+    expect(totalTools).toBeGreaterThanOrEqual(expectedMinimum);
   });
 });

--- a/assistant/src/__tests__/handle-user-message-secret-resume.test.ts
+++ b/assistant/src/__tests__/handle-user-message-secret-resume.test.ts
@@ -1,7 +1,12 @@
 import * as net from "node:net";
 import { describe, expect, mock, test } from "bun:test";
 
-mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
+const actualEnv = await import("../config/env.js");
+mock.module("../config/env.js", () => ({
+  ...actualEnv,
+  isHttpAuthDisabled: () => true,
+  isMonitoringEnabled: () => false,
+}));
 
 const { handleUserMessage } = await import("../daemon/handlers/sessions.js");
 
@@ -47,6 +52,7 @@ describe("handleUserMessage secret redirect continuation", () => {
       setAssistantId: () => {},
       setChannelCapabilities: () => {},
       setGuardianContext: () => {},
+      setAuthContext: () => {},
       setCommandIntent: () => {},
       updateClient: () => {},
       emitActivityState: () => {},

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -116,6 +116,7 @@ interface TestSession {
   setTurnInterfaceContext: (ctx: unknown) => void;
   setAssistantId: (assistantId: string) => void;
   setGuardianContext: (ctx: unknown) => void;
+  setAuthContext: (ctx: unknown) => void;
   setCommandIntent: (intent: unknown) => void;
   updateClient: (
     sendToClient: (msg: ServerMessage) => void,
@@ -180,6 +181,7 @@ function makeSession(overrides: Partial<TestSession> = {}): TestSession {
     setTurnInterfaceContext: () => {},
     setAssistantId: () => {},
     setGuardianContext: () => {},
+    setAuthContext: () => {},
     setCommandIntent: () => {},
     updateClient: () => {},
     emitActivityState: () => {},

--- a/assistant/src/__tests__/ingress-reconcile.test.ts
+++ b/assistant/src/__tests__/ingress-reconcile.test.ts
@@ -66,6 +66,13 @@ mock.module("../providers/registry.js", () => ({
   initializeProviders: () => {},
 }));
 
+// Mock token service — triggerGatewayReconcile now uses mintDaemonDeliveryToken
+// instead of readHttpToken for the Bearer token.
+let mintedToken: string | null = null;
+mock.module("../runtime/auth/token-service.js", () => ({
+  mintDaemonDeliveryToken: () => mintedToken ?? "test-delivery-token",
+}));
+
 import { handleIngressConfig } from "../daemon/handlers/config.js";
 import type { HandlerContext } from "../daemon/handlers/shared.js";
 import type {
@@ -121,6 +128,7 @@ describe("Ingress reconcile trigger in handleIngressConfig", () => {
   beforeEach(() => {
     rawConfigStore = {};
     httpTokenValue = null;
+    mintedToken = null;
     reconcileCalls = [];
     fetchShouldFail = false;
 
@@ -186,7 +194,7 @@ describe("Ingress reconcile trigger in handleIngressConfig", () => {
 
   // ── Token present/missing behavior ──────────────────────────────────────
 
-  test("skips reconcile trigger when no HTTP bearer token is available", async () => {
+  test("always triggers reconcile even when readHttpToken returns null (uses mintDaemonDeliveryToken)", async () => {
     httpTokenValue = null;
 
     const msg: IngressConfigRequest = {
@@ -206,12 +214,12 @@ describe("Ingress reconcile trigger in handleIngressConfig", () => {
     const res = sent[0] as { type: string; success: boolean };
     expect(res.success).toBe(true);
 
-    // No reconcile call should have been made
-    expect(reconcileCalls).toHaveLength(0);
+    // Reconcile is always triggered using mintDaemonDeliveryToken
+    expect(reconcileCalls).toHaveLength(1);
   });
 
-  test("triggers reconcile when HTTP bearer token is available", async () => {
-    httpTokenValue = "test-bearer-token";
+  test("triggers reconcile with mintDaemonDeliveryToken bearer token", async () => {
+    mintedToken = "test-bearer-token";
 
     const msg: IngressConfigRequest = {
       type: "ingress_config",

--- a/assistant/src/__tests__/mcp-cli.test.ts
+++ b/assistant/src/__tests__/mcp-cli.test.ts
@@ -144,7 +144,7 @@ describe("vellum mcp list", () => {
     expect(stdout).toContain("stdio");
     expect(stdout).toContain("npx -y some-mcp-server");
     expect(stdout).toContain("low");
-  });
+  }, 15_000);
 
   test("--json outputs valid JSON", () => {
     writeConfig({

--- a/assistant/src/__tests__/recording-intent-handler.test.ts
+++ b/assistant/src/__tests__/recording-intent-handler.test.ts
@@ -1,7 +1,12 @@
 import * as net from "node:net";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
+const actualEnv = await import("../config/env.js");
+mock.module("../config/env.js", () => ({
+  ...actualEnv,
+  isHttpAuthDisabled: () => true,
+  isMonitoringEnabled: () => false,
+}));
 
 // ─── Mocks (must be before any imports that depend on them) ─────────────────
 
@@ -351,7 +356,9 @@ mock.module("../subagent/index.js", () => ({
 
 // ── Mock IPC protocol helpers ──────────────────────────────────────────────
 
+const actualIpcProtocol = await import("../daemon/ipc-protocol.js");
 mock.module("../daemon/ipc-protocol.js", () => ({
+  ...actualIpcProtocol,
   normalizeThreadType: (t: string) => t ?? "primary",
 }));
 
@@ -414,6 +421,7 @@ function createCtx(overrides?: Partial<HandlerContext>): {
     setAssistantId: noop,
     setChannelCapabilities: noop,
     setGuardianContext: noop,
+    setAuthContext: noop,
     setCommandIntent: noop,
     updateClient: noop,
     processMessage: async () => {},

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -108,6 +108,7 @@ function makeCompletingSession(): Session {
     setChannelCapabilities: () => {},
     setAssistantId: () => {},
     setGuardianContext: () => {},
+    setAuthContext: () => {},
     setCommandIntent: () => {},
     setTurnChannelContext: () => {},
     setTurnInterfaceContext: () => {},
@@ -160,6 +161,7 @@ function makeHangingSession(): Session {
     setChannelCapabilities: () => {},
     setAssistantId: () => {},
     setGuardianContext: () => {},
+    setAuthContext: () => {},
     setCommandIntent: () => {},
     setTurnChannelContext: () => {},
     setTurnInterfaceContext: () => {},
@@ -236,7 +238,11 @@ function makePendingApprovalSession(
     },
     setChannelCapabilities: () => {},
     setAssistantId: () => {},
-    setGuardianContext: () => {},
+    guardianContext: undefined as unknown,
+    setGuardianContext(ctx: unknown) {
+      this.guardianContext = ctx;
+    },
+    setAuthContext: () => {},
     setCommandIntent: () => {},
     setTurnChannelContext: () => {},
     setTurnInterfaceContext: () => {},
@@ -290,7 +296,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
     createBinding({
       assistantId: "self",
       channel: "vellum",
-      guardianExternalUserId: "guardian-vellum",
+      guardianExternalUserId: "dev-bypass",
       guardianDeliveryChatId: "vellum",
       guardianPrincipalId: "test-principal-id",
     });

--- a/assistant/src/__tests__/sms-messaging-provider.test.ts
+++ b/assistant/src/__tests__/sms-messaging-provider.test.ts
@@ -37,6 +37,10 @@ mock.module("../util/platform.js", () => ({
   readHttpToken: () => "runtime-token",
 }));
 
+mock.module("../runtime/auth/token-service.js", () => ({
+  mintDaemonDeliveryToken: () => "runtime-token",
+}));
+
 mock.module("../config/loader.js", () => ({
   loadConfig: () => configState,
 }));


### PR DESCRIPTION
## Summary
- Updated 11 test files to match recent production code changes
- Added `setAuthContext` mock to all test session objects (new Session method)
- Added `isMonitoringEnabled` and `getLogfireToken` to env.js mocks (spread actual module)
- Updated channel-approvals expectations for new `approve_10m` and `approve_thread` actions
- Added `mintDaemonDeliveryToken` mock to SMS and ingress-reconcile tests (token service migration)
- Fixed gmail-integration test to load slack tools from separate `slack/TOOLS.json` manifest
- Added `guardian-context-resolver.js` mock for conversation-routes-guardian-reply test
- Made `setGuardianContext` store context in send-endpoint-busy test sessions
- Updated guardian binding identity to match dev-bypass auth context
- Spread actual `ipc-protocol.js` module in recording-intent-handler test
- Increased mcp-cli test timeout for stdio test

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22606860532/job/65500771322

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
