### PR TITLE
M6: Canonical guardian request kind for A2A access

### DIFF
--- a/assistant/src/__tests__/guardian-decision-primitive-canonical.test.ts
+++ b/assistant/src/__tests__/guardian-decision-primitive-canonical.test.ts
@@ -94,6 +94,9 @@ describe('guardian-request-resolvers / registry', () => {
     const kinds = getRegisteredKinds();
     expect(kinds).toContain('tool_approval');
     expect(kinds).toContain('pending_question');
+    expect(kinds).toContain('access_request');
+    expect(kinds).toContain('tool_grant_request');
+    expect(kinds).toContain('a2a_access_request');
   });
 
   test('getResolver returns undefined for unknown kind', () => {

--- a/assistant/src/a2a/__tests__/a2a-access-request-resolver.test.ts
+++ b/assistant/src/a2a/__tests__/a2a-access-request-resolver.test.ts
@@ -1,0 +1,467 @@
+/**
+ * Tests for the `a2a_access_request` canonical guardian request kind and
+ * its resolver. Covers approve, reject, stale (already-resolved), and
+ * identity mismatch paths through applyCanonicalGuardianDecision.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'a2a-access-request-resolver-test-'));
+
+mock.module('../../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+  readHttpToken: () => null,
+}));
+
+mock.module('../../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  isDebug: () => false,
+  truncateForLog: (value: string) => value,
+}));
+
+import {
+  applyCanonicalGuardianDecision,
+} from '../../approvals/guardian-decision-primitive.js';
+import type { ActorContext } from '../../approvals/guardian-request-resolvers.js';
+import { getRegisteredKinds, getResolver } from '../../approvals/guardian-request-resolvers.js';
+import {
+  createCanonicalGuardianRequest,
+  getCanonicalGuardianRequest,
+} from '../../memory/canonical-guardian-store.js';
+import { getDb, initializeDb, resetDb } from '../../memory/db.js';
+import {
+  A2A_PROTOCOL_VERSION,
+  approveConnection,
+  decodeInviteCode,
+  generateInvite,
+  initiateConnection,
+  _resetHandshakeSessions,
+  _resetIdempotencyStore,
+} from '../a2a-connection-service.js';
+import { getConnection } from '../a2a-peer-connection-store.js';
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run('DELETE FROM scoped_approval_grants');
+  db.run('DELETE FROM canonical_guardian_deliveries');
+  db.run('DELETE FROM canonical_guardian_requests');
+  db.run('DELETE FROM a2a_peer_connections');
+  db.run('DELETE FROM assistant_ingress_invites');
+}
+
+const TEST_PRINCIPAL_ID = 'test-principal-id';
+const MOCK_GATEWAY_URL = 'https://my-assistant.example.com';
+const PEER_GATEWAY_URL = 'https://peer-assistant.example.com';
+
+function guardianActor(overrides: Partial<ActorContext> = {}): ActorContext {
+  return {
+    externalUserId: 'guardian-1',
+    channel: 'telegram',
+    guardianPrincipalId: TEST_PRINCIPAL_ID,
+    ...overrides,
+  };
+}
+
+/**
+ * Helper: create a pending A2A connection and return its connectionId.
+ */
+function createPendingA2AConnection(): string {
+  const genResult = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+  if (!genResult.ok) throw new Error('Failed to generate invite');
+  const decoded = decodeInviteCode(genResult.inviteCode)!;
+
+  const initResult = initiateConnection({
+    peerGatewayUrl: PEER_GATEWAY_URL,
+    inviteToken: decoded.t,
+    protocolVersion: A2A_PROTOCOL_VERSION,
+    capabilities: ['scheduling:read'],
+  });
+  if (!initResult.ok) throw new Error('Failed to initiate connection');
+  return initResult.connectionId;
+}
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Registry tests
+// ---------------------------------------------------------------------------
+
+describe('a2a_access_request resolver registration', () => {
+  test('resolver is registered for a2a_access_request kind', () => {
+    const kinds = getRegisteredKinds();
+    expect(kinds).toContain('a2a_access_request');
+  });
+
+  test('getResolver returns the a2a_access_request resolver', () => {
+    const resolver = getResolver('a2a_access_request');
+    expect(resolver).toBeDefined();
+    expect(resolver!.kind).toBe('a2a_access_request');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Canonical decision flow tests
+// ---------------------------------------------------------------------------
+
+describe('applyCanonicalGuardianDecision with a2a_access_request', () => {
+  beforeEach(() => {
+    resetTables();
+    _resetHandshakeSessions();
+    _resetIdempotencyStore();
+  });
+
+  // ── Approve path ──────────────────────────────────────────────────────
+
+  test('approve: calls approveConnection and returns verification code in reply text', async () => {
+    const connectionId = createPendingA2AConnection();
+
+    const req = createCanonicalGuardianRequest({
+      kind: 'a2a_access_request',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      guardianExternalUserId: 'guardian-1',
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      followupState: connectionId,
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: guardianActor(),
+    });
+
+    expect(result.applied).toBe(true);
+    if (!result.applied) return;
+    expect(result.resolverFailed).toBeUndefined();
+    expect(result.resolverReplyText).toBeDefined();
+    expect(result.resolverReplyText!).toContain('Verification code:');
+
+    // Canonical request is approved
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe('approved');
+    expect(resolved!.decidedByExternalUserId).toBe('guardian-1');
+
+    // Connection is still pending (awaiting verification code submission)
+    const conn = getConnection(connectionId);
+    expect(conn).not.toBeNull();
+    expect(conn!.status).toBe('pending');
+  });
+
+  // ── Reject path ───────────────────────────────────────────────────────
+
+  test('reject: calls approveConnection with deny and revokes connection', async () => {
+    const connectionId = createPendingA2AConnection();
+
+    const req = createCanonicalGuardianRequest({
+      kind: 'a2a_access_request',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      guardianExternalUserId: 'guardian-1',
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      followupState: connectionId,
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'reject',
+      actorContext: guardianActor(),
+    });
+
+    expect(result.applied).toBe(true);
+    if (!result.applied) return;
+    expect(result.resolverFailed).toBeUndefined();
+    expect(result.resolverReplyText).toBe('A2A connection request denied.');
+
+    // Canonical request is denied
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe('denied');
+
+    // Connection is revoked
+    const conn = getConnection(connectionId);
+    expect(conn).not.toBeNull();
+    expect(conn!.status).toBe('revoked');
+  });
+
+  // ── Stale / already-resolved ──────────────────────────────────────────
+
+  test('stale: second decision fails with already_resolved', async () => {
+    const connectionId = createPendingA2AConnection();
+
+    const req = createCanonicalGuardianRequest({
+      kind: 'a2a_access_request',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      guardianExternalUserId: 'guardian-1',
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      followupState: connectionId,
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    // First decision succeeds
+    const first = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: guardianActor(),
+    });
+    expect(first.applied).toBe(true);
+
+    // Second decision fails — request is no longer pending
+    const second = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'reject',
+      actorContext: guardianActor(),
+    });
+    expect(second.applied).toBe(false);
+    if (second.applied) return;
+    expect(second.reason).toBe('already_resolved');
+
+    // First decision stuck — canonical request is approved
+    const final = getCanonicalGuardianRequest(req.id);
+    expect(final!.status).toBe('approved');
+  });
+
+  // ── Identity mismatch ─────────────────────────────────────────────────
+
+  test('identity mismatch: wrong principal is rejected', async () => {
+    const connectionId = createPendingA2AConnection();
+
+    const req = createCanonicalGuardianRequest({
+      kind: 'a2a_access_request',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      guardianExternalUserId: 'guardian-1',
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      followupState: connectionId,
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: guardianActor({ guardianPrincipalId: 'wrong-principal' }),
+    });
+
+    expect(result.applied).toBe(false);
+    if (result.applied) return;
+    expect(result.reason).toBe('identity_mismatch');
+
+    // Request remains pending
+    const unchanged = getCanonicalGuardianRequest(req.id);
+    expect(unchanged!.status).toBe('pending');
+
+    // Connection is still pending (no side effects applied)
+    const conn = getConnection(connectionId);
+    expect(conn!.status).toBe('pending');
+  });
+
+  test('identity mismatch: actor missing principal is rejected', async () => {
+    const connectionId = createPendingA2AConnection();
+
+    const req = createCanonicalGuardianRequest({
+      kind: 'a2a_access_request',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      guardianExternalUserId: 'guardian-1',
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      followupState: connectionId,
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: guardianActor({ guardianPrincipalId: undefined }),
+    });
+
+    expect(result.applied).toBe(false);
+    if (result.applied) return;
+    expect(result.reason).toBe('identity_mismatch');
+  });
+
+  // ── Missing connectionId in followupState ─────────────────────────────
+
+  test('resolver fails when followupState is missing', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'a2a_access_request',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      guardianExternalUserId: 'guardian-1',
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      // No followupState — missing connectionId
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: guardianActor(),
+    });
+
+    // CAS resolution succeeds but resolver fails
+    expect(result.applied).toBe(true);
+    if (!result.applied) return;
+    expect(result.resolverFailed).toBe(true);
+    expect(result.resolverFailureReason).toContain('missing connectionId');
+  });
+
+  // ── Invalid connectionId ──────────────────────────────────────────────
+
+  test('resolver fails when connectionId points to nonexistent connection', async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: 'a2a_access_request',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      guardianExternalUserId: 'guardian-1',
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      followupState: 'nonexistent-connection-id',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: guardianActor(),
+    });
+
+    // CAS resolution succeeds but resolver fails
+    expect(result.applied).toBe(true);
+    if (!result.applied) return;
+    expect(result.resolverFailed).toBe(true);
+    expect(result.resolverFailureReason).toContain('a2a_approve_failed');
+  });
+
+  // ── approve_always downgrade ──────────────────────────────────────────
+
+  test('approve_always is downgraded to approve_once', async () => {
+    const connectionId = createPendingA2AConnection();
+
+    const req = createCanonicalGuardianRequest({
+      kind: 'a2a_access_request',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      guardianExternalUserId: 'guardian-1',
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      followupState: connectionId,
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_always',
+      actorContext: guardianActor(),
+    });
+
+    // Should succeed — approve_always silently downgraded to approve_once
+    expect(result.applied).toBe(true);
+
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe('approved');
+  });
+
+  // ── Expired request ───────────────────────────────────────────────────
+
+  test('rejects decision on expired request', async () => {
+    const connectionId = createPendingA2AConnection();
+
+    const req = createCanonicalGuardianRequest({
+      kind: 'a2a_access_request',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      guardianExternalUserId: 'guardian-1',
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      followupState: connectionId,
+      expiresAt: new Date(Date.now() - 10_000).toISOString(), // already expired
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: guardianActor(),
+    });
+
+    expect(result.applied).toBe(false);
+    if (result.applied) return;
+    expect(result.reason).toBe('expired');
+  });
+
+  // ── Not found ─────────────────────────────────────────────────────────
+
+  test('returns not_found for nonexistent request', async () => {
+    const result = await applyCanonicalGuardianDecision({
+      requestId: 'nonexistent-id',
+      action: 'approve_once',
+      actorContext: guardianActor(),
+    });
+
+    expect(result.applied).toBe(false);
+    if (result.applied) return;
+    expect(result.reason).toBe('not_found');
+  });
+
+  // ── Decisionable guard ────────────────────────────────────────────────
+
+  test('creation requires guardianPrincipalId (decisionable kind guard)', () => {
+    expect(() => {
+      createCanonicalGuardianRequest({
+        kind: 'a2a_access_request',
+        sourceType: 'channel',
+        sourceChannel: 'telegram',
+        // No guardianPrincipalId — should throw
+      });
+    }).toThrow(/guardianPrincipalId/);
+  });
+
+  // ── No grant minted (A2A requests have no tool metadata) ──────────────
+
+  test('no grant is minted for a2a_access_request (no tool metadata)', async () => {
+    const connectionId = createPendingA2AConnection();
+
+    const req = createCanonicalGuardianRequest({
+      kind: 'a2a_access_request',
+      sourceType: 'channel',
+      sourceChannel: 'telegram',
+      guardianExternalUserId: 'guardian-1',
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      followupState: connectionId,
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: 'approve_once',
+      actorContext: guardianActor(),
+    });
+
+    expect(result.applied).toBe(true);
+    if (!result.applied) return;
+    expect(result.grantMinted).toBe(false);
+  });
+});

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -673,6 +673,118 @@ const toolGrantRequestResolver: GuardianRequestResolver = {
   },
 };
 
+/**
+ * Resolves `a2a_access_request` requests — A2A peer connection approvals.
+ *
+ * When a remote assistant initiates a connection via the A2A handshake, a
+ * canonical guardian request of kind `a2a_access_request` is created so
+ * the guardian can approve or deny the incoming peer.
+ *
+ * On approve: delegates to A2AConnectionService.approveConnection() which
+ * generates a verification code and transitions the handshake state machine.
+ *
+ * On deny: delegates to A2AConnectionService.approveConnection() with
+ * decision='deny' which revokes the connection.
+ *
+ * The connectionId is stored in the canonical request's `followupState`
+ * field so the resolver can look up the right connection.
+ */
+const a2aAccessRequestResolver: GuardianRequestResolver = {
+  kind: 'a2a_access_request',
+
+  async resolve(ctx: ResolverContext): Promise<ResolverResult> {
+    const { request, decision } = ctx;
+
+    // The connectionId is stored in followupState at request creation time.
+    const connectionId = request.followupState;
+    if (!connectionId) {
+      return { ok: false, reason: 'a2a_access_request missing connectionId in followupState' };
+    }
+
+    // Lazy import to avoid circular dependency — a2a-connection-service
+    // imports from memory/ which imports from this file's sibling modules.
+    const { approveConnection } = await import('../a2a/a2a-connection-service.js');
+
+    if (decision.action === 'reject') {
+      const denyResult = approveConnection({
+        connectionId,
+        decision: 'deny',
+      });
+
+      if (!denyResult.ok) {
+        log.warn(
+          {
+            event: 'resolver_a2a_access_request_deny_failed',
+            requestId: request.id,
+            connectionId,
+            reason: denyResult.reason,
+          },
+          'A2A access request resolver: deny failed',
+        );
+        return { ok: false, reason: `a2a_deny_failed: ${denyResult.reason}` };
+      }
+
+      log.info(
+        {
+          event: 'resolver_a2a_access_request_denied',
+          requestId: request.id,
+          connectionId,
+        },
+        'A2A access request resolver: connection denied',
+      );
+
+      return {
+        ok: true,
+        applied: true,
+        guardianReplyText: 'A2A connection request denied.',
+      };
+    }
+
+    // Approve flow — generates a verification code for IRL exchange.
+    const approveResult = approveConnection({
+      connectionId,
+      decision: 'approve',
+    });
+
+    if (!approveResult.ok) {
+      log.warn(
+        {
+          event: 'resolver_a2a_access_request_approve_failed',
+          requestId: request.id,
+          connectionId,
+          reason: approveResult.reason,
+        },
+        'A2A access request resolver: approve failed',
+      );
+      return { ok: false, reason: `a2a_approve_failed: ${approveResult.reason}` };
+    }
+
+    const verificationCode = 'verificationCode' in approveResult
+      ? approveResult.verificationCode
+      : undefined;
+
+    log.info(
+      {
+        event: 'resolver_a2a_access_request_approved',
+        requestId: request.id,
+        connectionId,
+        hasVerificationCode: !!verificationCode,
+      },
+      'A2A access request resolver: connection approved',
+    );
+
+    const replyText = verificationCode
+      ? `A2A connection approved. Verification code: ${verificationCode}. Share this code with the peer to complete the handshake.`
+      : 'A2A connection approved.';
+
+    return {
+      ok: true,
+      applied: true,
+      guardianReplyText: replyText,
+    };
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Registry
 // ---------------------------------------------------------------------------
@@ -699,3 +811,4 @@ registerResolver(pendingInteractionResolver);
 registerResolver(pendingQuestionResolver);
 registerResolver(accessRequestResolver);
 registerResolver(toolGrantRequestResolver);
+registerResolver(a2aAccessRequestResolver);

--- a/assistant/src/memory/canonical-guardian-store.ts
+++ b/assistant/src/memory/canonical-guardian-store.ts
@@ -191,6 +191,7 @@ const DECISIONABLE_KINDS = new Set([
   'tool_grant_request',
   'pending_question',
   'access_request',
+  'a2a_access_request',
 ]);
 
 export function createCanonicalGuardianRequest(params: CreateCanonicalGuardianRequestParams): CanonicalGuardianRequest {


### PR DESCRIPTION
## Summary
- Adds `a2a_access_request` as a new canonical guardian request kind in the DECISIONABLE_KINDS set
- Registers `a2aAccessRequestResolver` that delegates to `A2AConnectionService.approveConnection()` on approve (returns verification code) and deny (revokes connection)
- Stores the A2A connectionId in the canonical request's `followupState` field for resolver lookup
- All A2A guardian decisions flow through `applyCanonicalGuardianDecision` with full CAS, identity validation, and expiry checks

## Test plan
- [x] Approve path: calls approveConnection, returns verification code in reply text
- [x] Reject path: calls approveConnection with deny, revokes connection
- [x] Stale/already-resolved: second decision fails with `already_resolved`
- [x] Identity mismatch: wrong principal is rejected, actor missing principal is rejected
- [x] Missing connectionId in followupState: resolver fails gracefully
- [x] Invalid connectionId: resolver fails gracefully
- [x] approve_always downgrade to approve_once
- [x] Expired request rejection
- [x] Decisionable guard enforces guardianPrincipalId at creation time
- [x] No grant minted (A2A requests have no tool metadata)
- [x] Registry test verifies all 5 built-in resolvers

Part of #11341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
