### PR TITLE
fix: resolve TS2339 guardianContext type error in test mock

### DIFF
--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -239,7 +239,7 @@ function makePendingApprovalSession(
     setChannelCapabilities: () => {},
     setAssistantId: () => {},
     guardianContext: undefined as unknown,
-    setGuardianContext(ctx: unknown) {
+    setGuardianContext(this: { guardianContext: unknown }, ctx: unknown) {
       this.guardianContext = ctx;
     },
     setAuthContext: () => {},


### PR DESCRIPTION
## Summary
- Add explicit `this` parameter type to `setGuardianContext` method in the `send-endpoint-busy.test.ts` mock session object, fixing `TS2339: Property 'guardianContext' does not exist on type '{}'`.

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22607301714/job/65502039568

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
