### PR TITLE
M7: A2A handshake endpoints (runtime + gateway proxy)

### DIFF
--- a/assistant/src/a2a/__tests__/a2a-rate-limiter.test.ts
+++ b/assistant/src/a2a/__tests__/a2a-rate-limiter.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'bun:test';
+
+import { A2ARateLimiter, a2aRateLimitResponse, a2aRateLimitHeaders } from '../a2a-rate-limiter.js';
+
+describe('A2ARateLimiter', () => {
+  test('allows requests within the limit', () => {
+    const limiter = new A2ARateLimiter({ maxAttempts: 3, windowMs: 60_000 });
+
+    const r1 = limiter.check('key-1');
+    expect(r1.allowed).toBe(true);
+    expect(r1.remaining).toBe(2);
+
+    const r2 = limiter.check('key-1');
+    expect(r2.allowed).toBe(true);
+    expect(r2.remaining).toBe(1);
+
+    const r3 = limiter.check('key-1');
+    expect(r3.allowed).toBe(true);
+    expect(r3.remaining).toBe(0);
+  });
+
+  test('blocks requests after limit is reached', () => {
+    const limiter = new A2ARateLimiter({ maxAttempts: 2, windowMs: 60_000 });
+
+    limiter.check('key-1');
+    limiter.check('key-1');
+
+    const result = limiter.check('key-1');
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+  });
+
+  test('separate keys are tracked independently', () => {
+    const limiter = new A2ARateLimiter({ maxAttempts: 1, windowMs: 60_000 });
+
+    const r1 = limiter.check('key-a');
+    expect(r1.allowed).toBe(true);
+
+    const r2 = limiter.check('key-b');
+    expect(r2.allowed).toBe(true);
+
+    const r3 = limiter.check('key-a');
+    expect(r3.allowed).toBe(false);
+  });
+
+  test('clear resets all state', () => {
+    const limiter = new A2ARateLimiter({ maxAttempts: 1, windowMs: 60_000 });
+
+    limiter.check('key-1');
+    const blocked = limiter.check('key-1');
+    expect(blocked.allowed).toBe(false);
+
+    limiter.clear();
+
+    const afterClear = limiter.check('key-1');
+    expect(afterClear.allowed).toBe(true);
+  });
+
+  test('resetAt is a valid Unix timestamp in seconds', () => {
+    const limiter = new A2ARateLimiter({ maxAttempts: 5, windowMs: 60_000 });
+    const result = limiter.check('key-1');
+    expect(result.resetAt).toBeGreaterThan(Date.now() / 1000 - 10);
+    expect(result.resetAt).toBeLessThan(Date.now() / 1000 + 120);
+  });
+
+  test('evicts stale entries when maxTrackedKeys is reached', () => {
+    const limiter = new A2ARateLimiter({
+      maxAttempts: 10,
+      windowMs: 1, // 1ms window — all entries expire instantly
+      maxTrackedKeys: 2,
+    });
+
+    limiter.check('key-a');
+    limiter.check('key-b');
+
+    // Small delay to let the 1ms window expire
+    const start = Date.now();
+    while (Date.now() - start < 5) {
+      // busy-wait
+    }
+
+    // This should trigger eviction of stale keys
+    const result = limiter.check('key-c');
+    expect(result.allowed).toBe(true);
+  });
+});
+
+describe('a2aRateLimitHeaders', () => {
+  test('returns correct header keys', () => {
+    const headers = a2aRateLimitHeaders({
+      allowed: true,
+      limit: 5,
+      remaining: 3,
+      resetAt: 1234567890,
+    });
+    expect(headers['X-RateLimit-Limit']).toBe('5');
+    expect(headers['X-RateLimit-Remaining']).toBe('3');
+    expect(headers['X-RateLimit-Reset']).toBe('1234567890');
+  });
+});
+
+describe('a2aRateLimitResponse', () => {
+  test('returns 429 with Retry-After header', async () => {
+    const result = {
+      allowed: false,
+      limit: 5,
+      remaining: 0,
+      resetAt: Math.ceil(Date.now() / 1000) + 60,
+    };
+    const response = a2aRateLimitResponse(result);
+    expect(response.status).toBe(429);
+    expect(response.headers.get('Retry-After')).toBeTruthy();
+    expect(response.headers.get('X-RateLimit-Limit')).toBe('5');
+
+    const body = await response.json() as { error: { code: string; message: string } };
+    expect(body.error.code).toBe('RATE_LIMITED');
+  });
+});

--- a/assistant/src/a2a/__tests__/a2a-routes.test.ts
+++ b/assistant/src/a2a/__tests__/a2a-routes.test.ts
@@ -1,0 +1,591 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'a2a-routes-test-'));
+
+mock.module('../../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+mock.module('../../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  handleA2AInvite,
+  handleA2ARedeem,
+  handleA2AConnect,
+  handleA2AApprove,
+  handleA2AVerify,
+  handleA2ARevoke,
+  handleA2AListConnections,
+  handleA2AConnectionStatus,
+} from '../../runtime/routes/a2a-routes.js';
+import {
+  generateInvite,
+  decodeInviteCode,
+  initiateConnection,
+  approveConnection,
+  _resetHandshakeSessions,
+  _resetIdempotencyStore,
+} from '../a2a-connection-service.js';
+import {
+  inviteRedemptionLimiter,
+  codeVerificationLimiter,
+  statusPollingLimiter,
+} from '../a2a-rate-limiter.js';
+import { getDb, initializeDb, resetDb } from '../../memory/db.js';
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run('DELETE FROM a2a_peer_connections');
+  db.run('DELETE FROM assistant_ingress_invites');
+}
+
+const MOCK_GATEWAY_URL = 'https://my-assistant.example.com';
+const PEER_GATEWAY_URL = 'https://peer-assistant.example.com';
+
+function jsonReq(body: unknown): Request {
+  return new Request('http://localhost/test', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('a2a-routes', () => {
+  beforeEach(() => {
+    resetTables();
+    _resetHandshakeSessions();
+    _resetIdempotencyStore();
+    inviteRedemptionLimiter.clear();
+    codeVerificationLimiter.clear();
+    statusPollingLimiter.clear();
+  });
+
+  afterAll(() => {
+    resetDb();
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  // ========================================================================
+  // POST /v1/a2a/invite
+  // ========================================================================
+
+  describe('handleA2AInvite', () => {
+    test('happy path — generates an invite', async () => {
+      const res = await handleA2AInvite(jsonReq({ gatewayUrl: MOCK_GATEWAY_URL }));
+      expect(res.status).toBe(200);
+      const body = await res.json() as { inviteCode: string; inviteId: string };
+      expect(body.inviteCode).toBeTruthy();
+      expect(body.inviteId).toBeTruthy();
+    });
+
+    test('missing gatewayUrl returns 400', async () => {
+      const res = await handleA2AInvite(jsonReq({}));
+      expect(res.status).toBe(400);
+    });
+
+    test('empty gatewayUrl returns 400', async () => {
+      const res = await handleA2AInvite(jsonReq({ gatewayUrl: '' }));
+      expect(res.status).toBe(400);
+    });
+
+    test('idempotent invite generation', async () => {
+      const req1 = jsonReq({ gatewayUrl: MOCK_GATEWAY_URL, idempotencyKey: 'test-key' });
+      const res1 = await handleA2AInvite(req1);
+      const body1 = await res1.json() as { inviteCode: string; inviteId: string };
+
+      const req2 = jsonReq({ gatewayUrl: MOCK_GATEWAY_URL, idempotencyKey: 'test-key' });
+      const res2 = await handleA2AInvite(req2);
+      const body2 = await res2.json() as { inviteCode: string; inviteId: string };
+
+      expect(body1.inviteCode).toBe(body2.inviteCode);
+      expect(body1.inviteId).toBe(body2.inviteId);
+    });
+  });
+
+  // ========================================================================
+  // POST /v1/a2a/redeem
+  // ========================================================================
+
+  describe('handleA2ARedeem', () => {
+    test('happy path — redeems a valid invite', async () => {
+      const inviteResult = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      if (!inviteResult.ok) throw new Error('Failed to generate invite');
+
+      const res = await handleA2ARedeem(jsonReq({ inviteCode: inviteResult.inviteCode }));
+      expect(res.status).toBe(200);
+      const body = await res.json() as { peerGatewayUrl: string; inviteId: string };
+      expect(body.peerGatewayUrl).toBe(MOCK_GATEWAY_URL);
+      expect(body.inviteId).toBe(inviteResult.inviteId);
+    });
+
+    test('missing inviteCode returns 400', async () => {
+      const res = await handleA2ARedeem(jsonReq({}));
+      expect(res.status).toBe(400);
+    });
+
+    test('malformed invite returns 400', async () => {
+      const res = await handleA2ARedeem(jsonReq({ inviteCode: 'not-valid-base64' }));
+      expect(res.status).toBe(400);
+    });
+
+    test('invalid token returns 404', async () => {
+      // Create a well-formed but unknown invite code
+      const fakeCode = Buffer.from(JSON.stringify({
+        g: 'https://fake.example.com',
+        t: 'nonexistent-token',
+        v: '1.0.0',
+      })).toString('base64url');
+      const res = await handleA2ARedeem(jsonReq({ inviteCode: fakeCode }));
+      expect(res.status).toBe(404);
+    });
+
+    test('rate limit enforcement — returns 429 after 5 attempts', async () => {
+      const inviteCode = 'rate-limit-test-code';
+      for (let i = 0; i < 5; i++) {
+        await handleA2ARedeem(jsonReq({ inviteCode }));
+      }
+
+      const res = await handleA2ARedeem(jsonReq({ inviteCode }));
+      expect(res.status).toBe(429);
+      expect(res.headers.get('Retry-After')).toBeTruthy();
+    });
+  });
+
+  // ========================================================================
+  // POST /v1/a2a/connect
+  // ========================================================================
+
+  describe('handleA2AConnect', () => {
+    test('happy path — initiates connection with valid invite token', async () => {
+      const inviteResult = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      if (!inviteResult.ok) throw new Error('Failed to generate invite');
+
+      const payload = decodeInviteCode(inviteResult.inviteCode);
+      if (!payload) throw new Error('Failed to decode invite code');
+
+      const res = await handleA2AConnect(jsonReq({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: payload.t,
+        protocolVersion: '1.0.0',
+        capabilities: [],
+      }));
+      expect(res.status).toBe(201);
+      const body = await res.json() as { connectionId: string; handshakeSessionId: string };
+      expect(body.connectionId).toBeTruthy();
+      expect(body.handshakeSessionId).toBeTruthy();
+    });
+
+    test('missing peerGatewayUrl returns 400', async () => {
+      const res = await handleA2AConnect(jsonReq({ inviteToken: 'some-token' }));
+      expect(res.status).toBe(400);
+    });
+
+    test('missing inviteToken returns 400', async () => {
+      const res = await handleA2AConnect(jsonReq({ peerGatewayUrl: PEER_GATEWAY_URL }));
+      expect(res.status).toBe(400);
+    });
+
+    test('invalid invite token returns 404', async () => {
+      const res = await handleA2AConnect(jsonReq({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: 'nonexistent-token',
+        protocolVersion: '1.0.0',
+        capabilities: [],
+      }));
+      expect(res.status).toBe(404);
+    });
+
+    test('consumed invite returns 409', async () => {
+      const inviteResult = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      if (!inviteResult.ok) throw new Error('Failed to generate invite');
+      const payload = decodeInviteCode(inviteResult.inviteCode);
+      if (!payload) throw new Error('Failed to decode invite code');
+
+      // First connect consumes the invite
+      await handleA2AConnect(jsonReq({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: payload.t,
+        protocolVersion: '1.0.0',
+        capabilities: [],
+      }));
+
+      // Second connect should fail
+      const res = await handleA2AConnect(jsonReq({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: payload.t,
+        protocolVersion: '1.0.0',
+        capabilities: [],
+      }));
+      expect(res.status).toBe(409);
+    });
+  });
+
+  // ========================================================================
+  // POST /v1/a2a/approve
+  // ========================================================================
+
+  describe('handleA2AApprove', () => {
+    function createPendingConnection(): { connectionId: string } {
+      const inviteResult = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      if (!inviteResult.ok) throw new Error('Failed to generate invite');
+      const payload = decodeInviteCode(inviteResult.inviteCode);
+      if (!payload) throw new Error('Failed to decode invite code');
+
+      const connectResult = initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: payload.t,
+        protocolVersion: '1.0.0',
+        capabilities: [],
+      });
+      if (!connectResult.ok) throw new Error('Failed to initiate connection');
+      return { connectionId: connectResult.connectionId };
+    }
+
+    test('happy path — approve returns verification code', async () => {
+      const { connectionId } = createPendingConnection();
+
+      const res = await handleA2AApprove(jsonReq({
+        connectionId,
+        decision: 'approve',
+      }));
+      expect(res.status).toBe(200);
+      const body = await res.json() as { verificationCode: string; connectionId: string };
+      expect(body.verificationCode).toBeTruthy();
+      expect(body.connectionId).toBe(connectionId);
+    });
+
+    test('deny returns ok', async () => {
+      const { connectionId } = createPendingConnection();
+
+      const res = await handleA2AApprove(jsonReq({
+        connectionId,
+        decision: 'deny',
+      }));
+      expect(res.status).toBe(200);
+      const body = await res.json() as { ok: boolean };
+      expect(body.ok).toBe(true);
+    });
+
+    test('missing connectionId returns 400', async () => {
+      const res = await handleA2AApprove(jsonReq({ decision: 'approve' }));
+      expect(res.status).toBe(400);
+    });
+
+    test('invalid decision returns 400', async () => {
+      const res = await handleA2AApprove(jsonReq({
+        connectionId: 'some-id',
+        decision: 'invalid',
+      }));
+      expect(res.status).toBe(400);
+    });
+
+    test('nonexistent connection returns 404', async () => {
+      const res = await handleA2AApprove(jsonReq({
+        connectionId: 'nonexistent',
+        decision: 'approve',
+      }));
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // ========================================================================
+  // POST /v1/a2a/verify
+  // ========================================================================
+
+  describe('handleA2AVerify', () => {
+    function createApprovedConnection(): { connectionId: string; verificationCode: string } {
+      const inviteResult = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      if (!inviteResult.ok) throw new Error('Failed to generate invite');
+      const payload = decodeInviteCode(inviteResult.inviteCode);
+      if (!payload) throw new Error('Failed to decode invite code');
+
+      const connectResult = initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: payload.t,
+        protocolVersion: '1.0.0',
+        capabilities: [],
+      });
+      if (!connectResult.ok) throw new Error('Failed to initiate connection');
+
+      const approveResult = approveConnection({
+        connectionId: connectResult.connectionId,
+        decision: 'approve',
+      });
+      if (!approveResult.ok || !('verificationCode' in approveResult)) {
+        throw new Error('Failed to approve connection');
+      }
+
+      return {
+        connectionId: connectResult.connectionId,
+        verificationCode: approveResult.verificationCode,
+      };
+    }
+
+    test('happy path — valid code transitions to active', async () => {
+      const { connectionId, verificationCode } = createApprovedConnection();
+
+      const res = await handleA2AVerify(jsonReq({
+        connectionId,
+        code: verificationCode,
+        peerIdentity: PEER_GATEWAY_URL,
+      }));
+      expect(res.status).toBe(200);
+      const body = await res.json() as { connectionId: string; status: string };
+      expect(body.connectionId).toBe(connectionId);
+      expect(body.status).toBe('active');
+    });
+
+    test('missing connectionId returns 400', async () => {
+      const res = await handleA2AVerify(jsonReq({ code: '123456', peerIdentity: 'test' }));
+      expect(res.status).toBe(400);
+    });
+
+    test('missing code returns 400', async () => {
+      const res = await handleA2AVerify(jsonReq({ connectionId: 'some-id', peerIdentity: 'test' }));
+      expect(res.status).toBe(400);
+    });
+
+    test('missing peerIdentity returns 400', async () => {
+      const res = await handleA2AVerify(jsonReq({ connectionId: 'some-id', code: '123456' }));
+      expect(res.status).toBe(400);
+    });
+
+    test('invalid code returns 403', async () => {
+      const { connectionId } = createApprovedConnection();
+
+      const res = await handleA2AVerify(jsonReq({
+        connectionId,
+        code: 'wrong-code',
+        peerIdentity: PEER_GATEWAY_URL,
+      }));
+      expect(res.status).toBe(403);
+    });
+
+    test('nonexistent connection returns 404', async () => {
+      const res = await handleA2AVerify(jsonReq({
+        connectionId: 'nonexistent',
+        code: '123456',
+        peerIdentity: 'test',
+      }));
+      expect(res.status).toBe(404);
+    });
+
+    test('rate limit enforcement — returns 429 after 5 attempts', async () => {
+      const { connectionId } = createApprovedConnection();
+
+      for (let i = 0; i < 5; i++) {
+        await handleA2AVerify(jsonReq({
+          connectionId,
+          code: 'wrong-code',
+          peerIdentity: PEER_GATEWAY_URL,
+        }));
+      }
+
+      const res = await handleA2AVerify(jsonReq({
+        connectionId,
+        code: 'wrong-code',
+        peerIdentity: PEER_GATEWAY_URL,
+      }));
+      expect(res.status).toBe(429);
+      expect(res.headers.get('Retry-After')).toBeTruthy();
+    });
+  });
+
+  // ========================================================================
+  // POST /v1/a2a/revoke
+  // ========================================================================
+
+  describe('handleA2ARevoke', () => {
+    test('missing connectionId returns 400', async () => {
+      const res = await handleA2ARevoke(jsonReq({}));
+      expect(res.status).toBe(400);
+    });
+
+    test('nonexistent connection returns 404', async () => {
+      const res = await handleA2ARevoke(jsonReq({ connectionId: 'nonexistent' }));
+      expect(res.status).toBe(404);
+    });
+
+    test('happy path — revoke an active connection', async () => {
+      // Create a full connection cycle to get to active state
+      const inviteResult = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      if (!inviteResult.ok) throw new Error('Failed to generate invite');
+      const payload = decodeInviteCode(inviteResult.inviteCode);
+      if (!payload) throw new Error('Failed to decode invite code');
+
+      const connectResult = initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: payload.t,
+        protocolVersion: '1.0.0',
+        capabilities: [],
+      });
+      if (!connectResult.ok) throw new Error('Failed to initiate connection');
+
+      const approveResult = approveConnection({
+        connectionId: connectResult.connectionId,
+        decision: 'approve',
+      });
+      if (!approveResult.ok || !('verificationCode' in approveResult)) {
+        throw new Error('Failed to approve connection');
+      }
+
+      // Use the route handler for the revoke step
+      const res = await handleA2ARevoke(jsonReq({
+        connectionId: connectResult.connectionId,
+      }));
+      expect(res.status).toBe(200);
+      const body = await res.json() as { ok: boolean };
+      expect(body.ok).toBe(true);
+    });
+  });
+
+  // ========================================================================
+  // GET /v1/a2a/connections
+  // ========================================================================
+
+  describe('handleA2AListConnections', () => {
+    test('returns empty array when no connections', () => {
+      const url = new URL('http://localhost/v1/a2a/connections');
+      const res = handleA2AListConnections(url);
+      expect(res.status).toBe(200);
+    });
+
+    test('returns connections after creating one', async () => {
+      const inviteResult = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      if (!inviteResult.ok) throw new Error('Failed to generate invite');
+      const payload = decodeInviteCode(inviteResult.inviteCode);
+      if (!payload) throw new Error('Failed to decode invite code');
+
+      initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: payload.t,
+        protocolVersion: '1.0.0',
+        capabilities: [],
+      });
+
+      const url = new URL('http://localhost/v1/a2a/connections');
+      const res = handleA2AListConnections(url);
+      expect(res.status).toBe(200);
+      const body = await res.json() as { connections: unknown[] };
+      expect(body.connections.length).toBeGreaterThan(0);
+    });
+
+    test('filters by status', async () => {
+      const inviteResult = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      if (!inviteResult.ok) throw new Error('Failed to generate invite');
+      const payload = decodeInviteCode(inviteResult.inviteCode);
+      if (!payload) throw new Error('Failed to decode invite code');
+
+      initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: payload.t,
+        protocolVersion: '1.0.0',
+        capabilities: [],
+      });
+
+      const url = new URL('http://localhost/v1/a2a/connections?status=active');
+      const res = handleA2AListConnections(url);
+      const body = await res.json() as { connections: unknown[] };
+      expect(body.connections.length).toBe(0);
+
+      const url2 = new URL('http://localhost/v1/a2a/connections?status=pending');
+      const res2 = handleA2AListConnections(url2);
+      const body2 = await res2.json() as { connections: unknown[] };
+      expect(body2.connections.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ========================================================================
+  // GET /v1/a2a/connections/:connectionId/status
+  // ========================================================================
+
+  describe('handleA2AConnectionStatus', () => {
+    test('nonexistent connection returns 404', () => {
+      const res = handleA2AConnectionStatus('nonexistent');
+      expect(res.status).toBe(404);
+    });
+
+    test('happy path — returns connection status', async () => {
+      const inviteResult = generateInvite({ gatewayUrl: MOCK_GATEWAY_URL });
+      if (!inviteResult.ok) throw new Error('Failed to generate invite');
+      const payload = decodeInviteCode(inviteResult.inviteCode);
+      if (!payload) throw new Error('Failed to decode invite code');
+
+      const connectResult = initiateConnection({
+        peerGatewayUrl: PEER_GATEWAY_URL,
+        inviteToken: payload.t,
+        protocolVersion: '1.0.0',
+        capabilities: [],
+      });
+      if (!connectResult.ok) throw new Error('Failed to initiate connection');
+
+      const res = handleA2AConnectionStatus(connectResult.connectionId);
+      expect(res.status).toBe(200);
+      const body = await res.json() as { connectionId: string; status: string };
+      expect(body.connectionId).toBe(connectResult.connectionId);
+      expect(body.status).toBe('pending');
+    });
+
+    test('rate limit enforcement — returns 429 after 60 requests', () => {
+      const connectionId = 'rate-limit-test-id';
+      for (let i = 0; i < 60; i++) {
+        handleA2AConnectionStatus(connectionId);
+      }
+
+      const res = handleA2AConnectionStatus(connectionId);
+      expect(res.status).toBe(429);
+      expect(res.headers.get('Retry-After')).toBeTruthy();
+    });
+  });
+
+  // ========================================================================
+  // Authentication (401)
+  // ========================================================================
+
+  describe('authentication', () => {
+    // Note: Auth enforcement happens at the HTTP server level, not in the route
+    // handlers. These tests verify the route handlers themselves work with valid
+    // requests. The HTTP server tests would cover auth enforcement.
+
+    test('all POST endpoints reject empty JSON gracefully', async () => {
+      const endpoints = [
+        handleA2AInvite,
+        handleA2ARedeem,
+        handleA2AConnect,
+        handleA2AApprove,
+        handleA2AVerify,
+        handleA2ARevoke,
+      ];
+
+      for (const handler of endpoints) {
+        const res = await handler(jsonReq({}));
+        expect(res.status).toBe(400);
+      }
+    });
+  });
+});

--- a/assistant/src/a2a/a2a-rate-limiter.ts
+++ b/assistant/src/a2a/a2a-rate-limiter.ts
@@ -1,0 +1,181 @@
+/**
+ * In-memory rate limiter for A2A handshake endpoints.
+ *
+ * Uses a sliding-window approach keyed by a string identifier (token, session
+ * ID, IP, etc.). Each limiter instance tracks attempts per key and rejects
+ * requests once the cap is hit within the window.
+ *
+ * All limiters are independent — instantiate one per concern (invite
+ * redemption, code verification, status polling, connect requests).
+ */
+
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('a2a-rate-limiter');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface A2ARateLimitResult {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  /** Unix timestamp (seconds) when the current window resets. */
+  resetAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Limiter
+// ---------------------------------------------------------------------------
+
+export class A2ARateLimiter {
+  private readonly requests = new Map<string, number[]>();
+  private readonly maxAttempts: number;
+  private readonly windowMs: number;
+  private readonly maxTrackedKeys: number;
+  private readonly label: string;
+
+  constructor(opts: {
+    maxAttempts: number;
+    windowMs: number;
+    maxTrackedKeys?: number;
+    /** Human-readable label for log messages. */
+    label?: string;
+  }) {
+    this.maxAttempts = opts.maxAttempts;
+    this.windowMs = opts.windowMs;
+    this.maxTrackedKeys = opts.maxTrackedKeys ?? 10_000;
+    this.label = opts.label ?? 'a2a';
+  }
+
+  /**
+   * Check whether a request for `key` should be allowed.
+   * Records the attempt and returns rate-limit metadata.
+   */
+  check(key: string): A2ARateLimitResult {
+    const now = Date.now();
+    let timestamps = this.requests.get(key);
+
+    if (!timestamps) {
+      if (this.requests.size >= this.maxTrackedKeys) {
+        this.evictStale(now);
+        if (this.requests.size >= this.maxTrackedKeys) {
+          const oldest = this.requests.keys().next().value;
+          if (oldest !== undefined) this.requests.delete(oldest);
+        }
+      }
+      timestamps = [];
+      this.requests.set(key, timestamps);
+    }
+
+    const cutoff = now - this.windowMs;
+
+    // Remove expired timestamps from the front
+    while (timestamps.length > 0 && timestamps[0] <= cutoff) {
+      timestamps.shift();
+    }
+
+    const remaining = Math.max(0, this.maxAttempts - timestamps.length);
+    const resetAt = timestamps.length > 0
+      ? Math.ceil((timestamps[0] + this.windowMs) / 1000)
+      : Math.ceil((now + this.windowMs) / 1000);
+
+    if (timestamps.length >= this.maxAttempts) {
+      log.warn({ key: key.slice(0, 8) + '...', label: this.label }, 'Rate limit exceeded');
+      return {
+        allowed: false,
+        limit: this.maxAttempts,
+        remaining: 0,
+        resetAt,
+      };
+    }
+
+    timestamps.push(now);
+
+    return {
+      allowed: true,
+      limit: this.maxAttempts,
+      remaining: remaining - 1,
+      resetAt,
+    };
+  }
+
+  /** Evict entries whose timestamps have all expired. */
+  private evictStale(now: number): void {
+    const cutoff = now - this.windowMs;
+    for (const [key, timestamps] of this.requests) {
+      while (timestamps.length > 0 && timestamps[0] <= cutoff) {
+        timestamps.shift();
+      }
+      if (timestamps.length === 0) {
+        this.requests.delete(key);
+      }
+    }
+  }
+
+  /** Reset all tracked state (for testing). */
+  clear(): void {
+    this.requests.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton instances
+// ---------------------------------------------------------------------------
+
+/** Invite redemption: max 5 attempts per invite token per 15-minute window. */
+export const inviteRedemptionLimiter = new A2ARateLimiter({
+  maxAttempts: 5,
+  windowMs: 15 * 60 * 1000,
+  label: 'invite-redemption',
+});
+
+/** Code verification: max 5 attempts per handshake session per 15-minute window. */
+export const codeVerificationLimiter = new A2ARateLimiter({
+  maxAttempts: 5,
+  windowMs: 15 * 60 * 1000,
+  label: 'code-verification',
+});
+
+/** Status polling: max 60 requests/minute per handshake ID. */
+export const statusPollingLimiter = new A2ARateLimiter({
+  maxAttempts: 60,
+  windowMs: 60 * 1000,
+  label: 'status-polling',
+});
+
+/** Connect requests: max 10 inbound requests per source IP per minute. */
+export const connectRequestLimiter = new A2ARateLimiter({
+  maxAttempts: 10,
+  windowMs: 60 * 1000,
+  label: 'connect-request',
+});
+
+// ---------------------------------------------------------------------------
+// Response helpers
+// ---------------------------------------------------------------------------
+
+/** Build standard rate limit headers from a check result. */
+export function a2aRateLimitHeaders(result: A2ARateLimitResult): Record<string, string> {
+  return {
+    'X-RateLimit-Limit': String(result.limit),
+    'X-RateLimit-Remaining': String(result.remaining),
+    'X-RateLimit-Reset': String(result.resetAt),
+  };
+}
+
+/** Return a 429 response with rate limit headers and a Retry-After hint. */
+export function a2aRateLimitResponse(result: A2ARateLimitResult): Response {
+  const retryAfter = Math.max(1, result.resetAt - Math.ceil(Date.now() / 1000));
+  return Response.json(
+    { error: { code: 'RATE_LIMITED', message: 'Too Many Requests' } },
+    {
+      status: 429,
+      headers: {
+        ...a2aRateLimitHeaders(result),
+        'Retry-After': String(retryAfter),
+      },
+    },
+  );
+}

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -176,6 +176,16 @@ import {
   handlePairingRequest,
   handlePairingStatus,
 } from "./routes/pairing-routes.js";
+import {
+  handleA2AApprove,
+  handleA2AConnect,
+  handleA2AConnectionStatus,
+  handleA2AInvite,
+  handleA2AListConnections,
+  handleA2ARedeem,
+  handleA2ARevoke,
+  handleA2AVerify,
+} from './routes/a2a-routes.js';
 import { handleAddSecret, handleDeleteSecret } from "./routes/secret-routes.js";
 import { handleSurfaceAction } from "./routes/surface-action-routes.js";
 import {
@@ -1322,6 +1332,20 @@ export class RuntimeHttpServer {
       if (endpoint === 'brain-graph-ui' && req.method === 'GET') return handleServeBrainGraphUI(mintUiPageToken());
       if (endpoint === 'home-base-ui' && req.method === 'GET') return handleServeHomeBaseUI(mintUiPageToken());
       if (endpoint === 'events' && req.method === 'GET') return handleSubscribeAssistantEvents(req, url, { authContext });
+
+      // A2A connection management endpoints
+      if (endpoint === 'a2a/invite' && req.method === 'POST') return await handleA2AInvite(req);
+      if (endpoint === 'a2a/redeem' && req.method === 'POST') return await handleA2ARedeem(req);
+      if (endpoint === 'a2a/connect' && req.method === 'POST') return await handleA2AConnect(req);
+      if (endpoint === 'a2a/approve' && req.method === 'POST') return await handleA2AApprove(req);
+      if (endpoint === 'a2a/verify' && req.method === 'POST') return await handleA2AVerify(req);
+      if (endpoint === 'a2a/revoke' && req.method === 'POST') return await handleA2ARevoke(req);
+      if (endpoint === 'a2a/connections' && req.method === 'GET') return handleA2AListConnections(url);
+
+      const a2aConnectionStatusMatch = endpoint.match(/^a2a\/connections\/([^/]+)\/status$/);
+      if (a2aConnectionStatusMatch && req.method === 'GET') {
+        return handleA2AConnectionStatus(a2aConnectionStatusMatch[1]);
+      }
 
       // Internal OAuth callback endpoint (gateway -> runtime)
       if (endpoint === 'internal/oauth/callback' && req.method === 'POST') {

--- a/assistant/src/runtime/routes/a2a-routes.ts
+++ b/assistant/src/runtime/routes/a2a-routes.ts
@@ -22,6 +22,7 @@ import {
 import {
   a2aRateLimitResponse,
   codeVerificationLimiter,
+  connectRequestLimiter,
   inviteRedemptionLimiter,
   statusPollingLimiter,
 } from '../../a2a/a2a-rate-limiter.js';
@@ -127,6 +128,14 @@ export async function handleA2AConnect(req: Request): Promise<Response> {
   }
   if (!inviteToken) {
     return httpError('BAD_REQUEST', 'Missing required field: inviteToken', 400);
+  }
+
+  // Rate limit by source IP (set by gateway proxy via X-Forwarded-For)
+  const clientIp = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown';
+  const rlResult = connectRequestLimiter.check(clientIp);
+  if (!rlResult.allowed) {
+    log.warn({ clientIp }, 'Connect request rate limit hit');
+    return a2aRateLimitResponse(rlResult);
   }
 
   const result = initiateConnection({

--- a/assistant/src/runtime/routes/a2a-routes.ts
+++ b/assistant/src/runtime/routes/a2a-routes.ts
@@ -1,0 +1,325 @@
+/**
+ * Runtime HTTP route handlers for A2A connection management.
+ *
+ * Exposes the A2A connection service methods as REST endpoints. All endpoints
+ * accept explicit parameters in the request body/query — no session coupling.
+ *
+ * Internal endpoints (invite, redeem, approve, revoke, list connections) use
+ * the existing runtime bearer auth. External endpoints (connect, verify,
+ * status) are designed for peer-to-peer access and have their own auth model.
+ */
+
+import {
+  approveConnection,
+  generateInvite,
+  initiateConnection,
+  listConnectionsFiltered,
+  redeemInvite,
+  revokeConnection,
+  submitVerificationCode,
+  A2A_PROTOCOL_VERSION,
+} from '../../a2a/a2a-connection-service.js';
+import {
+  a2aRateLimitResponse,
+  codeVerificationLimiter,
+  inviteRedemptionLimiter,
+  statusPollingLimiter,
+} from '../../a2a/a2a-rate-limiter.js';
+import { getConnection } from '../../a2a/a2a-peer-connection-store.js';
+import { getLogger } from '../../util/logger.js';
+import { httpError } from '../http-errors.js';
+
+import type { A2APeerConnectionStatus } from '../../a2a/a2a-peer-connection-store.js';
+
+const log = getLogger('a2a-routes');
+
+// ---------------------------------------------------------------------------
+// POST /v1/a2a/invite — Generate an invite for a peer
+// ---------------------------------------------------------------------------
+
+export async function handleA2AInvite(req: Request): Promise<Response> {
+  const body = await req.json() as Record<string, unknown>;
+
+  const gatewayUrl = typeof body.gatewayUrl === 'string' ? body.gatewayUrl : '';
+  if (!gatewayUrl) {
+    return httpError('BAD_REQUEST', 'Missing required field: gatewayUrl', 400);
+  }
+
+  const expiresInMs = typeof body.expiresInMs === 'number' ? body.expiresInMs : undefined;
+  const note = typeof body.note === 'string' ? body.note : undefined;
+  const idempotencyKey = typeof body.idempotencyKey === 'string' ? body.idempotencyKey : undefined;
+
+  const result = generateInvite({ gatewayUrl, expiresInMs, note, idempotencyKey });
+
+  if (!result.ok) {
+    if (result.reason === 'missing_gateway_url') {
+      return httpError('BAD_REQUEST', 'Missing gateway URL', 400);
+    }
+    return httpError('INTERNAL_ERROR', 'Failed to generate invite', 500);
+  }
+
+  return Response.json({
+    inviteCode: result.inviteCode,
+    inviteId: result.inviteId,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/a2a/redeem — Validate and decode an invite code
+// ---------------------------------------------------------------------------
+
+export async function handleA2ARedeem(req: Request): Promise<Response> {
+  const body = await req.json() as Record<string, unknown>;
+
+  const inviteCode = typeof body.inviteCode === 'string' ? body.inviteCode : '';
+  if (!inviteCode) {
+    return httpError('BAD_REQUEST', 'Missing required field: inviteCode', 400);
+  }
+
+  // Rate limit by invite code (truncated for privacy in logs)
+  const rlResult = inviteRedemptionLimiter.check(inviteCode);
+  if (!rlResult.allowed) {
+    log.warn({ inviteCode: inviteCode.slice(0, 8) + '...' }, 'Invite redemption rate limit hit');
+    return a2aRateLimitResponse(rlResult);
+  }
+
+  const result = redeemInvite({ inviteCode });
+
+  if (!result.ok) {
+    const statusMap: Record<string, number> = {
+      malformed_invite: 400,
+      invalid_or_expired: 404,
+      already_redeemed: 409,
+    };
+    return httpError(
+      result.reason === 'malformed_invite' ? 'BAD_REQUEST' : result.reason === 'already_redeemed' ? 'CONFLICT' : 'NOT_FOUND',
+      result.reason,
+      statusMap[result.reason] ?? 400,
+    );
+  }
+
+  return Response.json({
+    peerGatewayUrl: result.peerGatewayUrl,
+    inviteId: result.inviteId,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/a2a/connect — Initiate a connection request (peer-facing)
+// ---------------------------------------------------------------------------
+
+export async function handleA2AConnect(req: Request): Promise<Response> {
+  const body = await req.json() as Record<string, unknown>;
+
+  const peerGatewayUrl = typeof body.peerGatewayUrl === 'string' ? body.peerGatewayUrl : '';
+  const inviteToken = typeof body.inviteToken === 'string' ? body.inviteToken : '';
+  const protocolVersion = typeof body.protocolVersion === 'string' ? body.protocolVersion : A2A_PROTOCOL_VERSION;
+  const capabilities = Array.isArray(body.capabilities) ? body.capabilities.filter((c): c is string => typeof c === 'string') : [];
+  const peerAssistantId = typeof body.peerAssistantId === 'string' ? body.peerAssistantId : undefined;
+  const ownGatewayUrl = typeof body.ownGatewayUrl === 'string' ? body.ownGatewayUrl : undefined;
+
+  if (!peerGatewayUrl) {
+    return httpError('BAD_REQUEST', 'Missing required field: peerGatewayUrl', 400);
+  }
+  if (!inviteToken) {
+    return httpError('BAD_REQUEST', 'Missing required field: inviteToken', 400);
+  }
+
+  const result = initiateConnection({
+    peerGatewayUrl,
+    peerAssistantId,
+    inviteToken,
+    protocolVersion,
+    capabilities,
+    ownGatewayUrl,
+  });
+
+  if (!result.ok) {
+    const statusMap: Record<string, number> = {
+      invalid_target: 400,
+      version_mismatch: 400,
+      invite_not_found: 404,
+      invite_consumed: 409,
+    };
+    const codeMap: Record<string, 'BAD_REQUEST' | 'NOT_FOUND' | 'CONFLICT'> = {
+      invalid_target: 'BAD_REQUEST',
+      version_mismatch: 'BAD_REQUEST',
+      invite_not_found: 'NOT_FOUND',
+      invite_consumed: 'CONFLICT',
+    };
+    return httpError(
+      codeMap[result.reason] ?? 'BAD_REQUEST',
+      result.detail ?? result.reason,
+      statusMap[result.reason] ?? 400,
+    );
+  }
+
+  return Response.json({
+    connectionId: result.connectionId,
+    handshakeSessionId: result.handshakeSessionId,
+  }, { status: 201 });
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/a2a/approve — Approve or deny a pending connection
+// ---------------------------------------------------------------------------
+
+export async function handleA2AApprove(req: Request): Promise<Response> {
+  const body = await req.json() as Record<string, unknown>;
+
+  const connectionId = typeof body.connectionId === 'string' ? body.connectionId : '';
+  const decision = typeof body.decision === 'string' ? body.decision : '';
+
+  if (!connectionId) {
+    return httpError('BAD_REQUEST', 'Missing required field: connectionId', 400);
+  }
+  if (decision !== 'approve' && decision !== 'deny') {
+    return httpError('BAD_REQUEST', 'decision must be "approve" or "deny"', 400);
+  }
+
+  const result = approveConnection({ connectionId, decision });
+
+  if (!result.ok) {
+    const statusMap: Record<string, number> = {
+      not_found: 404,
+      invalid_state: 409,
+      already_resolved: 409,
+    };
+    return httpError(
+      result.reason === 'not_found' ? 'NOT_FOUND' : 'CONFLICT',
+      result.reason,
+      statusMap[result.reason] ?? 400,
+    );
+  }
+
+  if (decision === 'approve' && 'verificationCode' in result) {
+    return Response.json({
+      verificationCode: result.verificationCode,
+      connectionId: result.connectionId,
+    });
+  }
+
+  return Response.json({ ok: true });
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/a2a/verify — Submit verification code (peer-facing)
+// ---------------------------------------------------------------------------
+
+export async function handleA2AVerify(req: Request): Promise<Response> {
+  const body = await req.json() as Record<string, unknown>;
+
+  const connectionId = typeof body.connectionId === 'string' ? body.connectionId : '';
+  const code = typeof body.code === 'string' ? body.code : '';
+  const peerIdentity = typeof body.peerIdentity === 'string' ? body.peerIdentity : '';
+
+  if (!connectionId) {
+    return httpError('BAD_REQUEST', 'Missing required field: connectionId', 400);
+  }
+  if (!code) {
+    return httpError('BAD_REQUEST', 'Missing required field: code', 400);
+  }
+  if (!peerIdentity) {
+    return httpError('BAD_REQUEST', 'Missing required field: peerIdentity', 400);
+  }
+
+  // Rate limit by connection ID
+  const rlResult = codeVerificationLimiter.check(connectionId);
+  if (!rlResult.allowed) {
+    log.warn({ connectionId }, 'Code verification rate limit hit');
+    return a2aRateLimitResponse(rlResult);
+  }
+
+  const result = submitVerificationCode({ connectionId, code, peerIdentity });
+
+  if (!result.ok) {
+    const statusMap: Record<string, number> = {
+      not_found: 404,
+      invalid_code: 403,
+      expired: 410,
+      max_attempts: 429,
+      invalid_state: 409,
+      identity_mismatch: 403,
+    };
+    const codeMap: Record<string, 'NOT_FOUND' | 'FORBIDDEN' | 'GONE' | 'RATE_LIMITED' | 'CONFLICT'> = {
+      not_found: 'NOT_FOUND',
+      invalid_code: 'FORBIDDEN',
+      expired: 'GONE',
+      max_attempts: 'RATE_LIMITED',
+      invalid_state: 'CONFLICT',
+      identity_mismatch: 'FORBIDDEN',
+    };
+    return httpError(
+      codeMap[result.reason] ?? 'BAD_REQUEST',
+      result.reason,
+      statusMap[result.reason] ?? 400,
+    );
+  }
+
+  return Response.json({
+    connectionId: result.connection.id,
+    status: result.connection.status,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/a2a/revoke — Revoke a connection
+// ---------------------------------------------------------------------------
+
+export async function handleA2ARevoke(req: Request): Promise<Response> {
+  const body = await req.json() as Record<string, unknown>;
+
+  const connectionId = typeof body.connectionId === 'string' ? body.connectionId : '';
+  if (!connectionId) {
+    return httpError('BAD_REQUEST', 'Missing required field: connectionId', 400);
+  }
+
+  const result = revokeConnection({ connectionId });
+
+  if (!result.ok) {
+    return httpError('NOT_FOUND', result.reason, 404);
+  }
+
+  return Response.json({ ok: true });
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/a2a/connections — List connections
+// ---------------------------------------------------------------------------
+
+export function handleA2AListConnections(url: URL): Response {
+  const statusParam = url.searchParams.get('status') as A2APeerConnectionStatus | null;
+
+  const result = listConnectionsFiltered({
+    status: statusParam ?? undefined,
+  });
+
+  return Response.json({ connections: result.connections });
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/a2a/connections/:connectionId/status — Poll connection status
+// ---------------------------------------------------------------------------
+
+export function handleA2AConnectionStatus(connectionId: string): Response {
+  // Rate limit by connection ID
+  const rlResult = statusPollingLimiter.check(connectionId);
+  if (!rlResult.allowed) {
+    log.warn({ connectionId }, 'Status polling rate limit hit');
+    return a2aRateLimitResponse(rlResult);
+  }
+
+  const connection = getConnection(connectionId);
+  if (!connection) {
+    return httpError('NOT_FOUND', 'Connection not found', 404);
+  }
+
+  return Response.json({
+    connectionId: connection.id,
+    status: connection.status,
+    peerGatewayUrl: connection.peerGatewayUrl,
+    protocolVersion: connection.protocolVersion,
+    createdAt: connection.createdAt,
+    updatedAt: connection.updatedAt,
+  });
+}

--- a/assistant/src/runtime/routes/a2a-routes.ts
+++ b/assistant/src/runtime/routes/a2a-routes.ts
@@ -26,6 +26,7 @@ import {
   statusPollingLimiter,
 } from '../../a2a/a2a-rate-limiter.js';
 import { getConnection } from '../../a2a/a2a-peer-connection-store.js';
+import { getIngressPublicBaseUrl } from '../../config/env.js';
 import { getLogger } from '../../util/logger.js';
 import { httpError } from '../http-errors.js';
 
@@ -116,7 +117,10 @@ export async function handleA2AConnect(req: Request): Promise<Response> {
   const protocolVersion = typeof body.protocolVersion === 'string' ? body.protocolVersion : A2A_PROTOCOL_VERSION;
   const capabilities = Array.isArray(body.capabilities) ? body.capabilities.filter((c): c is string => typeof c === 'string') : [];
   const peerAssistantId = typeof body.peerAssistantId === 'string' ? body.peerAssistantId : undefined;
-  const ownGatewayUrl = typeof body.ownGatewayUrl === 'string' ? body.ownGatewayUrl : undefined;
+
+  // Derive ownGatewayUrl server-side from config instead of trusting the
+  // request body, so peers cannot forge it to bypass the self-loop guard.
+  const ownGatewayUrl = getIngressPublicBaseUrl();
 
   if (!peerGatewayUrl) {
     return httpError('BAD_REQUEST', 'Missing required field: peerGatewayUrl', 400);

--- a/gateway/src/http/routes/a2a-proxy.ts
+++ b/gateway/src/http/routes/a2a-proxy.ts
@@ -32,6 +32,7 @@ export function createA2AProxyHandler(config: GatewayConfig) {
     req: Request,
     upstreamPath: string,
     upstreamSearch: string,
+    clientIp?: string,
   ): Promise<Response> {
     const start = performance.now();
     const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${upstreamSearch}`;
@@ -39,6 +40,12 @@ export function createA2AProxyHandler(config: GatewayConfig) {
     const reqHeaders = stripHopByHop(new Headers(req.headers));
     reqHeaders.delete("host");
     reqHeaders.delete("authorization");
+
+    // Overwrite X-Forwarded-For with the actual client IP to prevent spoofing,
+    // matching the pattern used by the runtime proxy.
+    if (clientIp) {
+      reqHeaders.set("x-forwarded-for", clientIp);
+    }
 
     // Add the runtime's bearer token for daemon auth
     if (config.runtimeBearerToken) {
@@ -108,18 +115,18 @@ export function createA2AProxyHandler(config: GatewayConfig) {
 
   return {
     /** POST /v1/a2a/connect — proxy to daemon (unauthenticated, invite-token-gated) */
-    async handleConnect(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/a2a/connect", "");
+    async handleConnect(req: Request, clientIp?: string): Promise<Response> {
+      return proxyToRuntime(req, "/v1/a2a/connect", "", clientIp);
     },
 
     /** POST /v1/a2a/verify — proxy to daemon (unauthenticated during handshake) */
-    async handleVerify(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/a2a/verify", "");
+    async handleVerify(req: Request, clientIp?: string): Promise<Response> {
+      return proxyToRuntime(req, "/v1/a2a/verify", "", clientIp);
     },
 
     /** GET /v1/a2a/connections/:connectionId/status — proxy to daemon */
-    async handleConnectionStatus(req: Request, connectionId: string): Promise<Response> {
-      return proxyToRuntime(req, `/v1/a2a/connections/${encodeURIComponent(connectionId)}/status`, "");
+    async handleConnectionStatus(req: Request, connectionId: string, clientIp?: string): Promise<Response> {
+      return proxyToRuntime(req, `/v1/a2a/connections/${encodeURIComponent(connectionId)}/status`, "", clientIp);
     },
   };
 }

--- a/gateway/src/http/routes/a2a-proxy.ts
+++ b/gateway/src/http/routes/a2a-proxy.ts
@@ -1,0 +1,125 @@
+/**
+ * Gateway proxy endpoints for A2A peer-to-peer handshake requests.
+ *
+ * These routes are the public-facing surface for inbound A2A connections from
+ * other assistants. They proxy to the daemon runtime's internal A2A endpoints.
+ *
+ * Public (unauthenticated / invite-token-gated) routes:
+ *   - POST /v1/a2a/connect — Peer initiates a connection with an invite token
+ *   - POST /v1/a2a/verify — Peer submits a verification code
+ *   - GET /v1/a2a/connections/:connectionId/status — Peer polls connection status
+ *
+ * The connect endpoint is unauthenticated because the peer doesn't have
+ * credentials yet — they present an invite token instead. The verify and
+ * status endpoints are also unauthenticated at the gateway level because
+ * they occur during the handshake before credentials are exchanged.
+ */
+
+import type { GatewayConfig } from "../../config.js";
+import { fetchImpl } from "../../fetch.js";
+import { getLogger } from "../../logger.js";
+import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
+
+const log = getLogger("a2a-proxy");
+
+/** 64 KB — A2A handshake payloads are small JSON. */
+const MAX_A2A_PAYLOAD_BYTES = 64 * 1024;
+
+const TIMEOUT_MS = 15_000;
+
+export function createA2AProxyHandler(config: GatewayConfig) {
+  async function proxyToRuntime(
+    req: Request,
+    upstreamPath: string,
+    upstreamSearch: string,
+  ): Promise<Response> {
+    const start = performance.now();
+    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${upstreamSearch}`;
+
+    const reqHeaders = stripHopByHop(new Headers(req.headers));
+    reqHeaders.delete("host");
+    reqHeaders.delete("authorization");
+
+    // Add the runtime's bearer token for daemon auth
+    if (config.runtimeBearerToken) {
+      reqHeaders.set("authorization", `Bearer ${config.runtimeBearerToken}`);
+    }
+
+    const hasBody = req.method !== "GET" && req.method !== "HEAD";
+
+    // Payload size guard
+    if (hasBody) {
+      const contentLength = req.headers.get("content-length");
+      if (contentLength) {
+        const declared = Number(contentLength);
+        if (declared > MAX_A2A_PAYLOAD_BYTES || Number.isNaN(declared)) {
+          log.warn({ contentLength }, "A2A proxy payload too large (content-length)");
+          return Response.json({ error: "Payload too large" }, { status: 413 });
+        }
+      }
+    }
+
+    const bodyBuffer = hasBody ? await req.arrayBuffer() : null;
+    if (bodyBuffer !== null) {
+      if (bodyBuffer.byteLength > MAX_A2A_PAYLOAD_BYTES) {
+        log.warn({ bodyLength: bodyBuffer.byteLength }, "A2A proxy payload too large");
+        return Response.json({ error: "Payload too large" }, { status: 413 });
+      }
+      reqHeaders.set("content-length", String(bodyBuffer.byteLength));
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(new DOMException("The operation was aborted due to timeout", "TimeoutError"));
+    }, TIMEOUT_MS);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(upstream, {
+        method: req.method,
+        headers: reqHeaders,
+        body: bodyBuffer,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const duration = Math.round(performance.now() - start);
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        log.error({ path: upstreamPath, duration }, "A2A proxy upstream timed out");
+        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+      }
+      log.error({ err, path: upstreamPath, duration }, "A2A proxy upstream connection failed");
+      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    }
+
+    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const duration = Math.round(performance.now() - start);
+
+    if (response.status >= 400) {
+      const body = await response.text();
+      log.warn({ path: upstreamPath, status: response.status, duration }, "A2A proxy upstream error");
+      return new Response(body, { status: response.status, headers: resHeaders });
+    }
+
+    log.info({ path: upstreamPath, status: response.status, duration }, "A2A proxy completed");
+    return new Response(response.body, { status: response.status, headers: resHeaders });
+  }
+
+  return {
+    /** POST /v1/a2a/connect — proxy to daemon (unauthenticated, invite-token-gated) */
+    async handleConnect(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/a2a/connect", "");
+    },
+
+    /** POST /v1/a2a/verify — proxy to daemon (unauthenticated during handshake) */
+    async handleVerify(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/a2a/verify", "");
+    },
+
+    /** GET /v1/a2a/connections/:connectionId/status — proxy to daemon */
+    async handleConnectionStatus(req: Request, connectionId: string): Promise<Response> {
+      return proxyToRuntime(req, `/v1/a2a/connections/${encodeURIComponent(connectionId)}/status`, "");
+    },
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -28,6 +28,7 @@ import { createWhatsAppWebhookHandler } from "./http/routes/whatsapp-webhook.js"
 import { createWhatsAppDeliverHandler } from "./http/routes/whatsapp-deliver.js";
 import { createSlackDeliverHandler } from "./http/routes/slack-deliver.js";
 import { createOAuthCallbackHandler } from "./http/routes/oauth-callback.js";
+import { createA2AProxyHandler } from "./http/routes/a2a-proxy.js";
 import { createPairingProxyHandler } from "./http/routes/pairing-proxy.js";
 import { createFeatureFlagsGetHandler, createFeatureFlagsPatchHandler } from "./http/routes/feature-flags.js";
 import { createGuardianControlPlaneProxyHandler } from "./http/routes/guardian-control-plane-proxy.js";
@@ -56,6 +57,9 @@ let draining = false;
 
 // Shared rate limiter for auth failures and unauthenticated endpoints
 const authRateLimiter = new AuthRateLimiter();
+
+// Per-IP rate limiter for A2A connect requests (10 per minute)
+const a2aConnectRateLimiter = new AuthRateLimiter(10, 60_000);
 
 function isBrowserRelaySocketData(data: unknown): data is BrowserRelaySocketData {
   return !!data && typeof data === "object" && (data as { wsType?: unknown }).wsType === "browser-relay";
@@ -108,6 +112,7 @@ function main() {
   const handleWhatsAppDeliver = createWhatsAppDeliverHandler(config);
   const handleSlackDeliver = createSlackDeliverHandler(config);
   const handleOAuthCallback = createOAuthCallbackHandler(config);
+  const a2aProxy = createA2AProxyHandler(config);
   const pairingProxy = createPairingProxyHandler(config);
   const guardianControlPlaneProxy = createGuardianControlPlaneProxyHandler(config);
   const telegramControlPlaneProxy = createTelegramControlPlaneProxyHandler(config);
@@ -616,6 +621,38 @@ function main() {
           authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
         }
         return res;
+      }
+
+      // ── A2A peer handshake proxy ──
+      // These endpoints are public-facing (unauthenticated at gateway level).
+      // The connect endpoint is invite-token-gated; verify/status occur during
+      // the handshake before credentials are exchanged.
+      if (url.pathname === "/v1/a2a/connect" && tracedReq.method === "POST") {
+        const connectClientIp = getClientIp(req, svr, config.trustProxy);
+        if (a2aConnectRateLimiter.isBlocked(connectClientIp)) {
+          log.warn({ ip: connectClientIp }, "A2A connect rate limit exceeded");
+          return Response.json(
+            { error: { code: "RATE_LIMITED", message: "Too Many Requests" } },
+            { status: 429, headers: { "Retry-After": "60" } },
+          );
+        }
+        a2aConnectRateLimiter.recordFailure(connectClientIp);
+        const res = await a2aProxy.handleConnect(tracedReq);
+        if (res.status === 401 || res.status === 403) {
+          authRateLimiter.recordFailure(connectClientIp);
+        }
+        return res;
+      }
+      if (url.pathname === "/v1/a2a/verify" && tracedReq.method === "POST") {
+        const res = await a2aProxy.handleVerify(tracedReq);
+        if (res.status === 401 || res.status === 403) {
+          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+        }
+        return res;
+      }
+      const a2aStatusMatch = url.pathname.match(/^\/v1\/a2a\/connections\/([^/]+)\/status$/);
+      if (a2aStatusMatch && tracedReq.method === "GET") {
+        return a2aProxy.handleConnectionStatus(tracedReq, decodeURIComponent(a2aStatusMatch[1]));
       }
 
       // ── Feature flags API ──

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -637,22 +637,24 @@ function main() {
           );
         }
         a2aConnectRateLimiter.recordFailure(connectClientIp);
-        const res = await a2aProxy.handleConnect(tracedReq);
+        const res = await a2aProxy.handleConnect(tracedReq, connectClientIp);
         if (res.status === 401 || res.status === 403) {
           authRateLimiter.recordFailure(connectClientIp);
         }
         return res;
       }
       if (url.pathname === "/v1/a2a/verify" && tracedReq.method === "POST") {
-        const res = await a2aProxy.handleVerify(tracedReq);
+        const verifyClientIp = getClientIp(req, svr, config.trustProxy);
+        const res = await a2aProxy.handleVerify(tracedReq, verifyClientIp);
         if (res.status === 401 || res.status === 403) {
-          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+          authRateLimiter.recordFailure(verifyClientIp);
         }
         return res;
       }
       const a2aStatusMatch = url.pathname.match(/^\/v1\/a2a\/connections\/([^/]+)\/status$/);
       if (a2aStatusMatch && tracedReq.method === "GET") {
-        return a2aProxy.handleConnectionStatus(tracedReq, decodeURIComponent(a2aStatusMatch[1]));
+        const statusClientIp = getClientIp(req, svr, config.trustProxy);
+        return a2aProxy.handleConnectionStatus(tracedReq, decodeURIComponent(a2aStatusMatch[1]), statusClientIp);
       }
 
       // ── Feature flags API ──


### PR DESCRIPTION
## Summary

- Adds runtime HTTP routes for all A2A connection service methods (`/v1/a2a/invite`, `/v1/a2a/redeem`, `/v1/a2a/connect`, `/v1/a2a/approve`, `/v1/a2a/verify`, `/v1/a2a/revoke`, `/v1/a2a/connections`, `/v1/a2a/connections/:id/status`)
- Adds gateway proxy routes for public-facing endpoints (`/v1/a2a/connect`, `/v1/a2a/verify`, `/v1/a2a/connections/:id/status`)
- Implements in-memory rate limiting with configurable windows and attempt caps for invite redemption, code verification, status polling, and gateway connect requests
- Comprehensive test coverage for route handlers, rate limit enforcement, and parameter validation

## Test plan

- [ ] Verify all runtime A2A endpoints return correct HTTP status codes for happy path and error cases
- [ ] Verify rate limiting returns 429 with Retry-After header after threshold is exceeded
- [ ] Verify gateway proxy routes forward to runtime correctly
- [ ] Verify authentication is enforced on internal endpoints (invite, redeem, approve, revoke, list connections)
- [ ] Verify external endpoints (connect, verify, status) are accessible through the gateway without bearer auth

Part of #11341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
