### PR TITLE
feat: parallel health checks with inline status in mcp list

### DIFF
--- a/assistant/src/cli/mcp.ts
+++ b/assistant/src/cli/mcp.ts
@@ -73,40 +73,58 @@ export function registerMcpCommand(program: Command): void {
 
       log.info(`${entries.length} MCP server(s) configured:\n`);
 
-      let didHealthCheck = false;
+      // First pass: print all server blocks with placeholder status, track line positions
+      let lineCount = 0;
+      const healthChecks: { id: string; cfg: McpServerConfig; statusLine: number }[] = [];
+
       for (const [id, cfg] of entries) {
         if (!cfg || typeof cfg !== 'object') {
           log.info(`  ${id} (invalid config — skipped)\n`);
+          lineCount += 2;
           continue;
         }
         const enabled = cfg.enabled !== false;
         const transport = cfg.transport;
         const risk = cfg.defaultRiskLevel ?? 'high';
-
-        let status: string;
-        if (!enabled) {
-          status = '✗ disabled';
-        } else {
-          status = await checkServerHealth(id, cfg);
-          didHealthCheck = true;
-        }
+        const statusText = !enabled ? '✗ disabled' : '⏳ Checking...';
 
         log.info(`  ${id}`);
-        log.info(`    Status:    ${status}`);
+        lineCount++;
+        const statusLine = lineCount;
+        log.info(`    Status:    ${statusText}`);
+        lineCount++;
         log.info(`    Transport: ${transport?.type ?? 'unknown'}`);
+        lineCount++;
         if (transport?.type === 'stdio') {
           log.info(`    Command:   ${transport.command} ${(transport.args ?? []).join(' ')}`);
+          lineCount++;
         } else if (transport && 'url' in transport) {
           log.info(`    URL:       ${transport.url}`);
+          lineCount++;
         }
         log.info(`    Risk:      ${risk}`);
-        if (cfg.allowedTools) log.info(`    Allowed:   ${cfg.allowedTools.join(', ')}`);
-        if (cfg.blockedTools) log.info(`    Blocked:   ${cfg.blockedTools.join(', ')}`);
+        lineCount++;
+        if (cfg.allowedTools) { log.info(`    Allowed:   ${cfg.allowedTools.join(', ')}`); lineCount++; }
+        if (cfg.blockedTools) { log.info(`    Blocked:   ${cfg.blockedTools.join(', ')}`); lineCount++; }
         log.info('');
+        lineCount++;
+
+        if (enabled) {
+          healthChecks.push({ id, cfg, statusLine });
+        }
       }
 
+      if (healthChecks.length === 0) return;
+
+      // Second pass: run health checks in parallel, update status lines in-place
+      await Promise.all(healthChecks.map(async ({ id, cfg, statusLine }) => {
+        const health = await checkServerHealth(id, cfg);
+        const up = lineCount - statusLine;
+        process.stdout.write(`\x1b[${up}A\r\x1b[2K    Status:    ${health}\x1b[${up}B\r`);
+      }));
+
       // Health checks may leave MCP transports alive — force exit
-      if (didHealthCheck) process.exit(0);
+      process.exit(0);
     });
 
   mcp


### PR DESCRIPTION
## Summary
- Print all server blocks immediately with `⏳ Checking...` placeholder status
- Run health checks in parallel instead of sequentially
- Update each Status line in-place using ANSI escape codes (`\x1b[<N>A` cursor up, `\x1b[2K` clear line)
- Faster completion when multiple servers are configured

## Test plan
- [x] `bun test src/__tests__/mcp-health-check.test.ts` — 4 pass
- [x] `bun test src/__tests__/mcp-cli.test.ts` — 16 pass
- [ ] Manual: `vellum mcp list` with multiple servers — verify all blocks appear instantly, status updates in-place

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
