### PR TITLE
M13: Add assistant channel type and inbound event variant

### DIFF
--- a/assistant/src/a2a/__tests__/a2a-inbound-trust.test.ts
+++ b/assistant/src/a2a/__tests__/a2a-inbound-trust.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for A2A assistant channel trust classification.
+ *
+ * Verifies that:
+ * - Messages from the 'assistant' channel are classified as peer_assistant trust
+ * - Trust classification is fail-closed (no identity -> unknown, not peer_assistant)
+ * - The assistant channel type is recognized by the channel type system
+ * - Existing channels are not affected by the addition
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { resolveActorTrust } from '../../runtime/actor-trust-resolver.js';
+import { CHANNEL_IDS, isChannelId, INTERFACE_IDS, isInterfaceId } from '../../channels/types.js';
+
+describe('assistant channel trust classification', () => {
+  test('assistant channel with valid actor ID is classified as peer_assistant', () => {
+    const result = resolveActorTrust({
+      assistantId: 'self',
+      sourceChannel: 'assistant',
+      conversationExternalId: 'conn-123',
+      actorExternalId: 'peer-assistant-001',
+    });
+
+    expect(result.trustClass).toBe('peer_assistant');
+    expect(result.canonicalSenderId).toBe('peer-assistant-001');
+    expect(result.actorMetadata.channel).toBe('assistant');
+    expect(result.actorMetadata.trustStatus).toBe('peer_assistant');
+  });
+
+  test('assistant channel without actor ID is classified as unknown (fail-closed)', () => {
+    const result = resolveActorTrust({
+      assistantId: 'self',
+      sourceChannel: 'assistant',
+      conversationExternalId: 'conn-123',
+      actorExternalId: undefined,
+    });
+
+    expect(result.trustClass).toBe('unknown');
+    expect(result.canonicalSenderId).toBeNull();
+    expect(result.denialReason).toBe('no_identity');
+  });
+
+  test('assistant channel with empty actor ID is classified as unknown', () => {
+    const result = resolveActorTrust({
+      assistantId: 'self',
+      sourceChannel: 'assistant',
+      conversationExternalId: 'conn-123',
+      actorExternalId: '   ',
+    });
+
+    expect(result.trustClass).toBe('unknown');
+    expect(result.canonicalSenderId).toBeNull();
+  });
+
+  test('assistant channel does not check guardian bindings', () => {
+    const result = resolveActorTrust({
+      assistantId: 'self',
+      sourceChannel: 'assistant',
+      conversationExternalId: 'conn-123',
+      actorExternalId: 'peer-assistant-001',
+    });
+
+    expect(result.guardianBindingMatch).toBeNull();
+    expect(result.guardianPrincipalId).toBeUndefined();
+    expect(result.memberRecord).toBeNull();
+  });
+
+  test('assistant channel preserves display name', () => {
+    const result = resolveActorTrust({
+      assistantId: 'self',
+      sourceChannel: 'assistant',
+      conversationExternalId: 'conn-123',
+      actorExternalId: 'peer-assistant-001',
+      actorDisplayName: 'Friendly Bot',
+    });
+
+    expect(result.actorMetadata.displayName).toBe('Friendly Bot');
+    expect(result.actorMetadata.senderDisplayName).toBe('Friendly Bot');
+  });
+
+  test('assistant channel preserves username', () => {
+    const result = resolveActorTrust({
+      assistantId: 'self',
+      sourceChannel: 'assistant',
+      conversationExternalId: 'conn-123',
+      actorExternalId: 'peer-assistant-001',
+      actorUsername: 'friendly_bot',
+    });
+
+    expect(result.actorMetadata.username).toBe('friendly_bot');
+    expect(result.actorMetadata.identifier).toBe('@friendly_bot');
+  });
+});
+
+describe('assistant channel type in channel ID system', () => {
+  test('CHANNEL_IDS includes assistant', () => {
+    expect(CHANNEL_IDS).toContain('assistant');
+  });
+
+  test('isChannelId recognizes assistant', () => {
+    expect(isChannelId('assistant')).toBe(true);
+  });
+
+  test('INTERFACE_IDS includes assistant', () => {
+    expect(INTERFACE_IDS).toContain('assistant');
+  });
+
+  test('isInterfaceId recognizes assistant', () => {
+    expect(isInterfaceId('assistant')).toBe(true);
+  });
+});
+
+describe('existing channels are not affected', () => {
+  const existingChannels = ['telegram', 'sms', 'voice', 'vellum', 'whatsapp', 'slack', 'email'] as const;
+
+  for (const channel of existingChannels) {
+    test(`${channel} channel is still recognized`, () => {
+      expect(isChannelId(channel)).toBe(true);
+    });
+  }
+
+  test('telegram channel does not resolve as peer_assistant', () => {
+    const result = resolveActorTrust({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      conversationExternalId: 'chat-123',
+      actorExternalId: '55001',
+    });
+
+    // Telegram actors without a guardian binding should be 'unknown', not 'peer_assistant'
+    expect(result.trustClass).not.toBe('peer_assistant');
+  });
+
+  test('sms channel does not resolve as peer_assistant', () => {
+    const result = resolveActorTrust({
+      assistantId: 'self',
+      sourceChannel: 'sms',
+      conversationExternalId: '+1234567890',
+      actorExternalId: '+1234567890',
+    });
+
+    expect(result.trustClass).not.toBe('peer_assistant');
+  });
+});

--- a/assistant/src/a2a/a2a-connection-service.ts
+++ b/assistant/src/a2a/a2a-connection-service.ts
@@ -743,12 +743,15 @@ export function submitVerificationCode(params: {
     return { ok: false, reason: 'invalid_state' };
   }
 
-  // Generate and persist credentials only after successful status transition
+  // Generate and persist credentials only after successful status transition.
+  // The raw inbound credential is stored alongside its hash so the runtime
+  // can verify HMAC-SHA256 signatures on inbound A2A messages.
   const credentials = generateCredentialPair();
 
   const connectionWithCredentials = updateConnectionCredentials(params.connectionId, {
     outboundCredentialHash: credentials.outboundCredentialHash,
     inboundCredentialHash: credentials.inboundCredentialHash,
+    inboundCredential: credentials.inboundCredential,
   });
 
   // Clean up handshake session — connection is now active
@@ -807,6 +810,7 @@ export function revokeConnection(params: {
   updateConnectionCredentials(params.connectionId, {
     outboundCredentialHash: '',
     inboundCredentialHash: '',
+    inboundCredential: '',
   });
 
   // Transition to revoked

--- a/assistant/src/a2a/a2a-peer-auth.ts
+++ b/assistant/src/a2a/a2a-peer-auth.ts
@@ -282,31 +282,17 @@ export interface VerifyRequestParams {
  * 5. The nonce has not been seen before.
  * 6. The HMAC signature matches.
  *
- * The inbound credential hash in the connection store is the SHA-256 hash
- * of the raw credential the peer uses to sign. We cannot reverse the hash,
- * so the peer's raw credential is used as the HMAC key. We verify by
- * looking up the connection, then using the stored `inboundCredentialHash`
- * to look up the raw credential -- but since we only store hashes, the
- * verification works differently:
+ * The connection store persists both the raw `inboundCredential` and its
+ * SHA-256 hash (`inboundCredentialHash`). The hash is used for
+ * identification/revocation checks; the raw credential is the HMAC key
+ * used for signature verification.
  *
- * Actually, for HMAC verification, we need the raw credential. The peer
- * signs with their outbound credential (which is our inbound credential).
- * We store only the hash. So at verification time, we need an alternative
- * approach: we store a separate HMAC verification key alongside the hash.
+ * This function accepts the raw inbound credential as a parameter so it
+ * can validate (step 3) that the caller-supplied credential matches the
+ * stored hash before using it for HMAC verification (step 6).
  *
- * **Design decision**: The connection store's `inboundCredentialHash` is
- * the SHA-256 hash of the raw credential for identification/lookup. For
- * HMAC verification, we use the raw credential directly as the HMAC key.
- * This means the verifier needs access to the raw inbound credential.
- *
- * To support this without storing raw credentials in the DB, we use a
- * different approach: the inbound credential IS the HMAC key, and we
- * store its hash for revocation checks. The raw credential is exchanged
- * during the handshake and must be available to the verifier at runtime.
- *
- * For the v1 implementation, we accept the raw inbound credential as a
- * parameter for verification. The caller (gateway) maintains a secure
- * mapping of connectionId -> raw inbound credential in memory.
+ * For simpler verification where the caller has already resolved the
+ * connection and credential, use `verifySignature()` instead.
  */
 export function verifyRequest(
   params: VerifyRequestParams & { inboundCredential: string },
@@ -459,6 +445,7 @@ export function rotateCredentials(connectionId: string): RotateResult {
   const updated = updateConnectionCredentials(connectionId, {
     outboundCredentialHash: newCredentials.outboundCredentialHash,
     inboundCredentialHash: newCredentials.inboundCredentialHash,
+    inboundCredential: newCredentials.inboundCredential,
   });
 
   if (!updated) {
@@ -498,6 +485,7 @@ export function revokeCredentials(connectionId: string): RevokeResult {
   updateConnectionCredentials(connectionId, {
     outboundCredentialHash: '',
     inboundCredentialHash: '',
+    inboundCredential: '',
   });
 
   // Transition to revoked status

--- a/assistant/src/a2a/a2a-peer-connection-store.ts
+++ b/assistant/src/a2a/a2a-peer-connection-store.ts
@@ -40,6 +40,7 @@ export interface A2APeerConnection {
   scopes: string[];
   outboundCredentialHash: string | null;
   inboundCredentialHash: string | null;
+  inboundCredential: string | null;
   lastSeenAt: number | null;
   createdAt: number;
   updatedAt: number;
@@ -66,6 +67,7 @@ function rowToConnection(row: typeof a2aPeerConnections.$inferSelect): A2APeerCo
     scopes: JSON.parse(row.scopes) as string[],
     outboundCredentialHash: row.outboundCredentialHash,
     inboundCredentialHash: row.inboundCredentialHash,
+    inboundCredential: row.inboundCredential ?? null,
     lastSeenAt: row.lastSeenAt,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
@@ -90,6 +92,7 @@ export function createConnection(params: {
   scopes?: string[];
   outboundCredentialHash?: string;
   inboundCredentialHash?: string;
+  inboundCredential?: string;
   expiresAt?: number;
 }): A2APeerConnection {
   const db = getDb();
@@ -109,6 +112,7 @@ export function createConnection(params: {
     scopes: JSON.stringify(params.scopes ?? []),
     outboundCredentialHash: params.outboundCredentialHash ?? null,
     inboundCredentialHash: params.inboundCredentialHash ?? null,
+    inboundCredential: params.inboundCredential ?? null,
     lastSeenAt: null,
     createdAt: now,
     updatedAt: now,
@@ -277,6 +281,7 @@ export function updateConnectionCredentials(
   credentials: {
     outboundCredentialHash?: string;
     inboundCredentialHash?: string;
+    inboundCredential?: string;
   },
 ): A2APeerConnection | null {
   const db = getDb();
@@ -289,6 +294,9 @@ export function updateConnectionCredentials(
   }
   if (credentials.inboundCredentialHash !== undefined) {
     setFields.inboundCredentialHash = credentials.inboundCredentialHash;
+  }
+  if (credentials.inboundCredential !== undefined) {
+    setFields.inboundCredential = credentials.inboundCredential;
   }
 
   db.update(a2aPeerConnections)

--- a/assistant/src/channels/config.ts
+++ b/assistant/src/channels/config.ts
@@ -63,6 +63,12 @@ const CHANNEL_POLICIES = {
       conversationStrategy: 'not_deliverable',
     },
   },
+  assistant: {
+    notification: {
+      deliveryEnabled: false,
+      conversationStrategy: 'continue_existing_conversation',
+    },
+  },
 } as const satisfies Record<ChannelId, ChannelNotificationPolicy>;
 
 export type ChannelPolicies = typeof CHANNEL_POLICIES;

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -1,5 +1,5 @@
 export const CHANNEL_IDS = [
-  'telegram', 'sms', 'voice', 'vellum', 'whatsapp', 'slack', 'email',
+  'telegram', 'sms', 'voice', 'vellum', 'whatsapp', 'slack', 'email', 'assistant',
 ] as const;
 
 export type ChannelId = (typeof CHANNEL_IDS)[number];
@@ -37,7 +37,7 @@ export interface TurnChannelContext {
 
 export const INTERFACE_IDS = [
   'macos', 'ios', 'cli',
-  'telegram', 'sms', 'voice', 'vellum', 'whatsapp', 'slack', 'email',
+  'telegram', 'sms', 'voice', 'vellum', 'whatsapp', 'slack', 'email', 'assistant',
 ] as const;
 
 export type InterfaceId = (typeof INTERFACE_IDS)[number];

--- a/assistant/src/memory/migrations/128-a2a-peer-connections.ts
+++ b/assistant/src/memory/migrations/128-a2a-peer-connections.ts
@@ -6,6 +6,11 @@ import type { DrizzleDb } from '../db-connection.js';
  * Stores the persistent connection state between two assistants: credential pairs,
  * peer gateway URL, protocol version, negotiated capabilities, granted scopes,
  * and lifecycle timestamps.
+ *
+ * The `inbound_credential` column stores the raw credential token that peer
+ * assistants use to sign inbound requests. It is required for HMAC-SHA256
+ * signature verification at the runtime layer. The `inbound_credential_hash`
+ * column stores its SHA-256 hash for identification/revocation checks.
  */
 export function createA2APeerConnectionsTable(database: DrizzleDb): void {
   database.run(/*sql*/ `
@@ -22,6 +27,7 @@ export function createA2APeerConnectionsTable(database: DrizzleDb): void {
       scopes TEXT NOT NULL DEFAULT '[]',
       outbound_credential_hash TEXT,
       inbound_credential_hash TEXT,
+      inbound_credential TEXT,
       last_seen_at INTEGER,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL,
@@ -30,6 +36,15 @@ export function createA2APeerConnectionsTable(database: DrizzleDb): void {
       expires_at INTEGER
     )
   `);
+
+  // For databases that already have the table from a prior migration run,
+  // add the inbound_credential column if it doesn't exist.
+  try {
+    database.run(/*sql*/ `ALTER TABLE a2a_peer_connections ADD COLUMN inbound_credential TEXT`);
+  } catch {
+    // Column already exists — expected for fresh databases where CREATE TABLE
+    // included it, or for databases that already ran this migration.
+  }
 
   database.run(
     /*sql*/ `CREATE INDEX IF NOT EXISTS idx_a2a_peer_connections_status

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -1224,6 +1224,7 @@ export const a2aPeerConnections = sqliteTable('a2a_peer_connections', {
   scopes: text('scopes').notNull().default('[]'),
   outboundCredentialHash: text('outbound_credential_hash'),
   inboundCredentialHash: text('inbound_credential_hash'),
+  inboundCredential: text('inbound_credential'),
   lastSeenAt: integer('last_seen_at'),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -101,6 +101,30 @@ export function resolveActorTrust(input: ResolveActorTrustInput): ActorTrustCont
 
   const identifier = senderUsername ? `@${senderUsername}` : canonicalSenderId ?? undefined;
 
+  // Assistant channel actors are always classified as peer_assistant.
+  // This is a fail-closed classification: if identity cannot be established,
+  // the message is rejected as unknown rather than falling through to a
+  // more permissive trust class.
+  if (input.sourceChannel === 'assistant') {
+    return {
+      canonicalSenderId,
+      guardianBindingMatch: null,
+      guardianPrincipalId: undefined,
+      memberRecord: null,
+      trustClass: canonicalSenderId ? 'peer_assistant' : 'unknown',
+      actorMetadata: {
+        identifier,
+        displayName: senderDisplayName,
+        senderDisplayName,
+        memberDisplayName: undefined,
+        username: senderUsername,
+        channel: input.sourceChannel,
+        trustStatus: canonicalSenderId ? 'peer_assistant' : 'unknown',
+      },
+      denialReason: canonicalSenderId ? undefined : 'no_identity',
+    };
+  }
+
   // No identity at all => unknown
   if (!canonicalSenderId) {
     return {

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -246,6 +246,12 @@ registerPolicy('channels/inbound', {
   allowedPrincipalTypes: ['svc_gateway'],
 });
 
+// A2A inbound messages: gateway-only
+registerPolicy('a2a/messages/inbound', {
+  requiredScopes: ['ingress.write'],
+  allowedPrincipalTypes: ['svc_gateway'],
+});
+
 // Internal forwarding endpoints: gateway-only
 const INTERNAL_ENDPOINTS = [
   'internal/twilio/voice-webhook',

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -186,6 +186,7 @@ import {
   handleA2ARevoke,
   handleA2AVerify,
 } from './routes/a2a-routes.js';
+import { handleA2AMessageInbound } from './routes/a2a-inbound-routes.js';
 import { handleAddSecret, handleDeleteSecret } from "./routes/secret-routes.js";
 import { handleSurfaceAction } from "./routes/surface-action-routes.js";
 import {
@@ -1345,6 +1346,11 @@ export class RuntimeHttpServer {
       const a2aConnectionStatusMatch = endpoint.match(/^a2a\/connections\/([^/]+)\/status$/);
       if (a2aConnectionStatusMatch && req.method === 'GET') {
         return handleA2AConnectionStatus(a2aConnectionStatusMatch[1]);
+      }
+
+      // A2A inbound message endpoint (gateway -> runtime)
+      if (endpoint === 'a2a/messages/inbound' && req.method === 'POST') {
+        return await handleA2AMessageInbound(req, this.processMessage);
       }
 
       // Internal OAuth callback endpoint (gateway -> runtime)

--- a/assistant/src/runtime/routes/a2a-inbound-routes.ts
+++ b/assistant/src/runtime/routes/a2a-inbound-routes.ts
@@ -130,8 +130,9 @@ export async function handleA2AMessageInbound(
     return httpError('UNAUTHORIZED', 'Invalid signature', 401);
   }
 
-  // Message deduplication: check (connectionId, nonce) before processing
-  if (defaultMessageDedupStore.isDuplicate(envelope.connectionId, envelope.nonce)) {
+  // Message deduplication: check-only (don't record yet — record after successful processing
+  // so that transient failures allow the peer to retry delivery)
+  if (defaultMessageDedupStore.isKnown(envelope.connectionId, envelope.nonce)) {
     log.info(
       { connectionId: envelope.connectionId, messageId: envelope.messageId },
       'Duplicate A2A message, returning accepted',
@@ -197,6 +198,10 @@ export async function handleA2AMessageInbound(
       'assistant',             // sourceChannel
       'assistant',             // sourceInterface
     );
+
+    // Record the nonce only after successful processing so transient failures
+    // don't permanently mark the message as "seen" (allowing peer retries).
+    defaultMessageDedupStore.record(envelope.connectionId, envelope.nonce);
 
     log.info(
       {

--- a/assistant/src/runtime/routes/a2a-inbound-routes.ts
+++ b/assistant/src/runtime/routes/a2a-inbound-routes.ts
@@ -1,15 +1,13 @@
 /**
  * Runtime route handler for inbound A2A messages from peer assistants.
  *
- * Handles message deduplication, connection validation, and routing through
- * the standard inbound message pipeline with peer_assistant trust
- * classification applied from the start.
+ * Handles HMAC-SHA256 peer auth verification, message deduplication,
+ * connection validation, and routing through the standard inbound message
+ * pipeline with peer_assistant trust classification applied from the start.
  *
- * HMAC-SHA256 peer auth verification is expected to be handled at the
- * gateway/proxy level using the A2A auth headers. The runtime validates
- * the connection is active and the envelope is well-formed.
- *
- * The gateway proxies POST /v1/a2a/messages/inbound to this handler.
+ * The gateway proxies POST /v1/a2a/messages/inbound to this handler,
+ * forwarding the A2A auth headers. The runtime performs the actual HMAC
+ * signature verification against the connection's stored inbound credential.
  */
 
 import {
@@ -17,6 +15,8 @@ import {
   HEADER_TIMESTAMP,
   HEADER_NONCE,
   HEADER_CONNECTION_ID,
+  verifySignature,
+  defaultNonceStore,
 } from '../../a2a/a2a-peer-auth.js';
 import { getConnection } from '../../a2a/a2a-peer-connection-store.js';
 import { defaultMessageDedupStore } from '../../a2a/a2a-message-dedup.js';
@@ -33,9 +33,10 @@ const log = getLogger('a2a-inbound');
  * Flow:
  * 1. Parse the A2A message envelope from the request body
  * 2. Validate A2A auth headers are present and connection ID matches
- * 3. Check the connection is active
- * 4. Check message deduplication via (connectionId, nonce)
- * 5. Route through processMessage with peer_assistant trust context
+ * 3. Look up the connection and verify it is active
+ * 4. Verify the HMAC-SHA256 signature against the stored inbound credential
+ * 5. Check message deduplication via (connectionId, nonce)
+ * 6. Route through processMessage with peer_assistant trust context
  */
 export async function handleA2AMessageInbound(
   req: Request,
@@ -69,19 +70,17 @@ export async function handleA2AMessageInbound(
   }
 
   // Validate A2A auth headers are present
-  const hasA2AAuth = !!(
-    req.headers.get(HEADER_SIGNATURE) &&
-    req.headers.get(HEADER_TIMESTAMP) &&
-    req.headers.get(HEADER_NONCE) &&
-    req.headers.get(HEADER_CONNECTION_ID)
-  );
+  const signature = req.headers.get(HEADER_SIGNATURE);
+  const timestamp = req.headers.get(HEADER_TIMESTAMP);
+  const nonce = req.headers.get(HEADER_NONCE);
+  const connectionIdHeader = req.headers.get(HEADER_CONNECTION_ID);
 
-  if (!hasA2AAuth) {
+  if (!signature || !timestamp || !nonce || !connectionIdHeader) {
     return httpError('UNAUTHORIZED', 'Missing A2A authentication headers', 401);
   }
 
   // Verify the connection ID in the header matches the envelope
-  if (req.headers.get(HEADER_CONNECTION_ID) !== envelope.connectionId) {
+  if (connectionIdHeader !== envelope.connectionId) {
     return httpError('BAD_REQUEST', 'Connection ID mismatch between header and envelope', 400);
   }
 
@@ -93,6 +92,42 @@ export async function handleA2AMessageInbound(
 
   if (connection.status !== 'active') {
     return httpError('FORBIDDEN', 'Connection is not active', 403);
+  }
+
+  // The raw inbound credential is required for HMAC verification.
+  // It is stored alongside the hash when credentials are generated during
+  // the handshake (submitVerificationCode) or rotation (rotateCredentials).
+  if (!connection.inboundCredential) {
+    log.error(
+      { connectionId: envelope.connectionId },
+      'Connection is active but has no stored inbound credential for HMAC verification',
+    );
+    return httpError('INTERNAL_ERROR', 'Connection credential not available', 500);
+  }
+
+  // Verify the HMAC-SHA256 signature using the stored inbound credential.
+  // This checks timestamp freshness, nonce replay, and signature correctness.
+  const verifyResult = verifySignature({
+    signature,
+    timestamp,
+    nonce,
+    body: bodyText,
+    credential: connection.inboundCredential,
+    nonceStore: defaultNonceStore,
+  });
+
+  if (!verifyResult.ok) {
+    log.warn(
+      { connectionId: envelope.connectionId, reason: verifyResult.reason },
+      'A2A inbound message failed HMAC verification',
+    );
+    if (verifyResult.reason === 'timestamp_expired') {
+      return httpError('UNAUTHORIZED', 'Request timestamp outside replay window', 401);
+    }
+    if (verifyResult.reason === 'nonce_replayed') {
+      return httpError('UNAUTHORIZED', 'Nonce has already been used', 401);
+    }
+    return httpError('UNAUTHORIZED', 'Invalid signature', 401);
   }
 
   // Message deduplication: check (connectionId, nonce) before processing

--- a/assistant/src/runtime/routes/a2a-inbound-routes.ts
+++ b/assistant/src/runtime/routes/a2a-inbound-routes.ts
@@ -149,7 +149,7 @@ export async function handleA2AMessageInbound(
   const content = envelope.content;
   switch (content.type) {
     case 'text':
-      textContent = content.text;
+      textContent = content.text ?? '';
       break;
     case 'structured_request':
       textContent = JSON.stringify({

--- a/assistant/src/runtime/routes/a2a-inbound-routes.ts
+++ b/assistant/src/runtime/routes/a2a-inbound-routes.ts
@@ -1,0 +1,187 @@
+/**
+ * Runtime route handler for inbound A2A messages from peer assistants.
+ *
+ * Handles message deduplication, connection validation, and routing through
+ * the standard inbound message pipeline with peer_assistant trust
+ * classification applied from the start.
+ *
+ * HMAC-SHA256 peer auth verification is expected to be handled at the
+ * gateway/proxy level using the A2A auth headers. The runtime validates
+ * the connection is active and the envelope is well-formed.
+ *
+ * The gateway proxies POST /v1/a2a/messages/inbound to this handler.
+ */
+
+import {
+  HEADER_SIGNATURE,
+  HEADER_TIMESTAMP,
+  HEADER_NONCE,
+  HEADER_CONNECTION_ID,
+} from '../../a2a/a2a-peer-auth.js';
+import { getConnection } from '../../a2a/a2a-peer-connection-store.js';
+import { defaultMessageDedupStore } from '../../a2a/a2a-message-dedup.js';
+import type { A2AMessageEnvelope } from '../../a2a/a2a-message-schema.js';
+import { getLogger } from '../../util/logger.js';
+import { httpError } from '../http-errors.js';
+import type { MessageProcessor } from '../http-types.js';
+
+const log = getLogger('a2a-inbound');
+
+/**
+ * Handle an inbound A2A message from a peer assistant.
+ *
+ * Flow:
+ * 1. Parse the A2A message envelope from the request body
+ * 2. Validate A2A auth headers are present and connection ID matches
+ * 3. Check the connection is active
+ * 4. Check message deduplication via (connectionId, nonce)
+ * 5. Route through processMessage with peer_assistant trust context
+ */
+export async function handleA2AMessageInbound(
+  req: Request,
+  processMessage?: MessageProcessor,
+): Promise<Response> {
+  let bodyText: string;
+  try {
+    bodyText = await req.text();
+  } catch {
+    return httpError('BAD_REQUEST', 'Failed to read request body', 400);
+  }
+
+  let envelope: A2AMessageEnvelope;
+  try {
+    envelope = JSON.parse(bodyText) as A2AMessageEnvelope;
+  } catch {
+    return httpError('BAD_REQUEST', 'Invalid JSON', 400);
+  }
+
+  // Validate required fields
+  if (!envelope.messageId || !envelope.connectionId || !envelope.senderAssistantId) {
+    return httpError('BAD_REQUEST', 'Missing required fields: messageId, connectionId, senderAssistantId', 400);
+  }
+
+  if (!envelope.content || !envelope.content.type) {
+    return httpError('BAD_REQUEST', 'Missing required field: content.type', 400);
+  }
+
+  if (!envelope.nonce) {
+    return httpError('BAD_REQUEST', 'Missing required field: nonce', 400);
+  }
+
+  // Validate A2A auth headers are present
+  const hasA2AAuth = !!(
+    req.headers.get(HEADER_SIGNATURE) &&
+    req.headers.get(HEADER_TIMESTAMP) &&
+    req.headers.get(HEADER_NONCE) &&
+    req.headers.get(HEADER_CONNECTION_ID)
+  );
+
+  if (!hasA2AAuth) {
+    return httpError('UNAUTHORIZED', 'Missing A2A authentication headers', 401);
+  }
+
+  // Verify the connection ID in the header matches the envelope
+  if (req.headers.get(HEADER_CONNECTION_ID) !== envelope.connectionId) {
+    return httpError('BAD_REQUEST', 'Connection ID mismatch between header and envelope', 400);
+  }
+
+  // Look up and validate the connection
+  const connection = getConnection(envelope.connectionId);
+  if (!connection) {
+    return httpError('NOT_FOUND', 'Connection not found', 404);
+  }
+
+  if (connection.status !== 'active') {
+    return httpError('FORBIDDEN', 'Connection is not active', 403);
+  }
+
+  // Message deduplication: check (connectionId, nonce) before processing
+  if (defaultMessageDedupStore.isDuplicate(envelope.connectionId, envelope.nonce)) {
+    log.info(
+      { connectionId: envelope.connectionId, messageId: envelope.messageId },
+      'Duplicate A2A message, returning accepted',
+    );
+    return Response.json({
+      accepted: true,
+      duplicate: true,
+      messageId: envelope.messageId,
+    });
+  }
+
+  // Extract text content from the envelope based on content type
+  let textContent: string;
+  const content = envelope.content;
+  switch (content.type) {
+    case 'text':
+      textContent = content.text;
+      break;
+    case 'structured_request':
+      textContent = JSON.stringify({
+        type: 'structured_request',
+        action: content.action,
+        params: content.params,
+      });
+      break;
+    case 'structured_response':
+      textContent = JSON.stringify({
+        type: 'structured_response',
+        action: content.action,
+        result: content.result,
+        success: content.success,
+        error: content.error,
+      });
+      break;
+    default:
+      textContent = '';
+  }
+
+  if (!processMessage) {
+    return httpError('INTERNAL_ERROR', 'Message processor not available', 500);
+  }
+
+  try {
+    // Use the connection ID as the conversation ID so messages from the
+    // same peer connection are grouped in the same conversation thread.
+    // The guardianContext carries peer_assistant trust from the start --
+    // there is no window where this message could be processed without
+    // proper trust classification.
+    const result = await processMessage(
+      envelope.connectionId,   // conversationId: use connection ID for conversation grouping
+      textContent,
+      undefined,               // no attachments
+      {
+        guardianContext: {
+          sourceChannel: 'assistant',
+          trustClass: 'peer_assistant',
+          requesterExternalUserId: envelope.senderAssistantId,
+          requesterChatId: envelope.connectionId,
+          requesterIdentifier: envelope.senderAssistantId,
+          requesterDisplayName: connection.peerDisplayName ?? envelope.senderAssistantId,
+        },
+      },
+      'assistant',             // sourceChannel
+      'assistant',             // sourceInterface
+    );
+
+    log.info(
+      {
+        connectionId: envelope.connectionId,
+        messageId: envelope.messageId,
+        senderAssistantId: envelope.senderAssistantId,
+      },
+      'A2A inbound message processed',
+    );
+
+    return Response.json({
+      accepted: true,
+      duplicate: false,
+      messageId: envelope.messageId,
+    });
+  } catch (err) {
+    log.error(
+      { err, connectionId: envelope.connectionId, messageId: envelope.messageId },
+      'Failed to process A2A inbound message',
+    );
+    return httpError('INTERNAL_ERROR', 'Failed to process message', 500);
+  }
+}

--- a/gateway/src/__tests__/a2a-channel-type.test.ts
+++ b/gateway/src/__tests__/a2a-channel-type.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect } from 'bun:test';
+import { CHANNEL_IDS, isChannelId, parseChannelId, assertChannelId, INTERFACE_IDS, isInterfaceId } from '../channels/types.js';
+import type { InboundChannelId, GatewayInboundEvent, AssistantInboundEvent } from '../channels/inbound-event.js';
+
+describe('assistant channel type recognition', () => {
+  test('CHANNEL_IDS includes assistant', () => {
+    expect(CHANNEL_IDS).toContain('assistant');
+  });
+
+  test('isChannelId recognizes assistant', () => {
+    expect(isChannelId('assistant')).toBe(true);
+  });
+
+  test('parseChannelId parses assistant', () => {
+    expect(parseChannelId('assistant')).toBe('assistant');
+  });
+
+  test('assertChannelId accepts assistant', () => {
+    expect(() => assertChannelId('assistant', 'test')).not.toThrow();
+    expect(assertChannelId('assistant', 'test')).toBe('assistant');
+  });
+
+  test('INTERFACE_IDS includes assistant', () => {
+    expect(INTERFACE_IDS).toContain('assistant');
+  });
+
+  test('isInterfaceId recognizes assistant', () => {
+    expect(isInterfaceId('assistant')).toBe(true);
+  });
+
+  test('existing channels are not affected by the addition', () => {
+    const existingChannels = ['telegram', 'sms', 'voice', 'vellum', 'whatsapp', 'slack', 'email'];
+    for (const ch of existingChannels) {
+      expect(isChannelId(ch)).toBe(true);
+      expect(parseChannelId(ch)).toBe(ch);
+    }
+  });
+
+  test('invalid channel IDs are still rejected', () => {
+    expect(isChannelId('invalid')).toBe(false);
+    expect(parseChannelId('invalid')).toBeNull();
+    expect(() => assertChannelId('invalid', 'test')).toThrow();
+  });
+});
+
+describe('AssistantInboundEvent type', () => {
+  test('can create a valid assistant inbound event', () => {
+    const event: AssistantInboundEvent = {
+      version: 'v1',
+      sourceChannel: 'assistant',
+      receivedAt: new Date().toISOString(),
+      message: {
+        content: 'Hello from peer',
+        conversationExternalId: 'conn-123',
+        externalMessageId: 'msg-456',
+      },
+      actor: {
+        actorExternalId: 'peer-assistant-id',
+        displayName: 'Peer Assistant',
+      },
+      source: {
+        updateId: 'nonce-789',
+      },
+      raw: {},
+    };
+
+    expect(event.sourceChannel).toBe('assistant');
+  });
+
+  test('assistant event is part of GatewayInboundEvent union', () => {
+    const event: GatewayInboundEvent = {
+      version: 'v1',
+      sourceChannel: 'assistant',
+      receivedAt: new Date().toISOString(),
+      message: {
+        content: 'test',
+        conversationExternalId: 'conn-1',
+        externalMessageId: 'msg-1',
+      },
+      actor: {
+        actorExternalId: 'peer-1',
+      },
+      source: {
+        updateId: 'nonce-1',
+      },
+      raw: {},
+    };
+
+    // Type system ensures this compiles — sourceChannel discrimination works
+    if (event.sourceChannel === 'assistant') {
+      expect(event.sourceChannel).toBe('assistant');
+    }
+  });
+});

--- a/gateway/src/__tests__/a2a-normalize.test.ts
+++ b/gateway/src/__tests__/a2a-normalize.test.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect } from 'bun:test';
+import { normalizeA2AInbound, type A2AInboundEnvelope } from '../a2a/normalize.js';
+
+describe('normalizeA2AInbound', () => {
+  const validEnvelope: A2AInboundEnvelope = {
+    messageId: 'msg-001',
+    connectionId: 'conn-abc',
+    senderAssistantId: 'peer-assistant-1',
+    nonce: 'nonce-xyz',
+    timestamp: 1700000000000,
+    content: {
+      type: 'text',
+      text: 'Hello from peer assistant',
+    },
+    status: 'pending',
+  };
+
+  test('normalizes a valid text message into GatewayInboundEvent', () => {
+    const result = normalizeA2AInbound(validEnvelope);
+
+    expect(result).not.toBeNull();
+    expect(result!.version).toBe('v1');
+    expect(result!.sourceChannel).toBe('assistant');
+    expect(result!.message.content).toBe('Hello from peer assistant');
+    expect(result!.message.conversationExternalId).toBe('conn-abc');
+    expect(result!.message.externalMessageId).toBe('msg-001');
+    expect(result!.actor.actorExternalId).toBe('peer-assistant-1');
+    expect(result!.actor.displayName).toBe('peer-assistant-1');
+    expect(result!.source.updateId).toBe('nonce-xyz');
+    expect(result!.source.messageId).toBe('msg-001');
+    expect(result!.raw).toEqual(validEnvelope as unknown as Record<string, unknown>);
+  });
+
+  test('normalizes a structured request message', () => {
+    const envelope: A2AInboundEnvelope = {
+      ...validEnvelope,
+      content: {
+        type: 'structured_request',
+        action: 'search',
+        params: { query: 'test' },
+      },
+    };
+
+    const result = normalizeA2AInbound(envelope);
+
+    expect(result).not.toBeNull();
+    expect(result!.sourceChannel).toBe('assistant');
+    const parsed = JSON.parse(result!.message.content);
+    expect(parsed.type).toBe('structured_request');
+    expect(parsed.action).toBe('search');
+    expect(parsed.params).toEqual({ query: 'test' });
+  });
+
+  test('normalizes a structured response message', () => {
+    const envelope: A2AInboundEnvelope = {
+      ...validEnvelope,
+      content: {
+        type: 'structured_response',
+        action: 'search',
+        result: { items: [] },
+        success: true,
+      },
+    };
+
+    const result = normalizeA2AInbound(envelope);
+
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!.message.content);
+    expect(parsed.type).toBe('structured_response');
+    expect(parsed.action).toBe('search');
+    expect(parsed.success).toBe(true);
+  });
+
+  test('returns null when messageId is missing', () => {
+    const envelope = { ...validEnvelope, messageId: '' };
+    expect(normalizeA2AInbound(envelope)).toBeNull();
+  });
+
+  test('returns null when connectionId is missing', () => {
+    const envelope = { ...validEnvelope, connectionId: '' };
+    expect(normalizeA2AInbound(envelope)).toBeNull();
+  });
+
+  test('returns null when senderAssistantId is missing', () => {
+    const envelope = { ...validEnvelope, senderAssistantId: '' };
+    expect(normalizeA2AInbound(envelope)).toBeNull();
+  });
+
+  test('returns null when content is missing', () => {
+    const envelope = { ...validEnvelope, content: undefined as unknown as A2AInboundEnvelope['content'] };
+    expect(normalizeA2AInbound(envelope)).toBeNull();
+  });
+
+  test('maps conversationExternalId to connectionId', () => {
+    const result = normalizeA2AInbound(validEnvelope);
+    expect(result).not.toBeNull();
+    expect(result!.message.conversationExternalId).toBe(validEnvelope.connectionId);
+  });
+
+  test('maps actorExternalId to senderAssistantId', () => {
+    const result = normalizeA2AInbound(validEnvelope);
+    expect(result).not.toBeNull();
+    expect(result!.actor.actorExternalId).toBe(validEnvelope.senderAssistantId);
+  });
+
+  test('handles unknown content type gracefully', () => {
+    const envelope: A2AInboundEnvelope = {
+      ...validEnvelope,
+      content: { type: 'unknown_type' as string },
+    };
+
+    const result = normalizeA2AInbound(envelope);
+    expect(result).not.toBeNull();
+    expect(result!.message.content).toBe('');
+  });
+});

--- a/gateway/src/a2a/normalize.ts
+++ b/gateway/src/a2a/normalize.ts
@@ -1,0 +1,96 @@
+/**
+ * Normalize an A2A message envelope into a GatewayInboundEvent.
+ *
+ * Maps:
+ *   - conversationExternalId -> connectionId (peer connection ID)
+ *   - actorExternalId -> senderAssistantId (peer assistant's identifier)
+ *   - sourceChannel -> 'assistant'
+ *
+ * Returns null if the envelope is missing required fields.
+ */
+
+import type { GatewayInboundEvent } from '../types.js';
+
+export interface A2AInboundEnvelope {
+  messageId: string;
+  connectionId: string;
+  senderAssistantId: string;
+  nonce: string;
+  timestamp: number;
+  content: {
+    type: string;
+    text?: string;
+    action?: string;
+    params?: Record<string, unknown>;
+    result?: Record<string, unknown>;
+    success?: boolean;
+    error?: string;
+  };
+  delivery?: {
+    correlationId?: string;
+    replyTo?: string;
+  };
+  status: string;
+}
+
+/**
+ * Normalize an A2A message envelope into a GatewayInboundEvent for the
+ * assistant channel. Returns null when required fields are missing.
+ */
+export function normalizeA2AInbound(
+  envelope: A2AInboundEnvelope,
+): GatewayInboundEvent | null {
+  if (!envelope.messageId || !envelope.connectionId || !envelope.senderAssistantId) {
+    return null;
+  }
+
+  if (!envelope.content) {
+    return null;
+  }
+
+  // Extract text content from the envelope based on content type
+  let textContent: string;
+  switch (envelope.content.type) {
+    case 'text':
+      textContent = envelope.content.text ?? '';
+      break;
+    case 'structured_request':
+      textContent = JSON.stringify({
+        type: 'structured_request',
+        action: envelope.content.action,
+        params: envelope.content.params,
+      });
+      break;
+    case 'structured_response':
+      textContent = JSON.stringify({
+        type: 'structured_response',
+        action: envelope.content.action,
+        result: envelope.content.result,
+        success: envelope.content.success,
+        error: envelope.content.error,
+      });
+      break;
+    default:
+      textContent = '';
+  }
+
+  return {
+    version: 'v1',
+    sourceChannel: 'assistant',
+    receivedAt: new Date(envelope.timestamp).toISOString(),
+    message: {
+      content: textContent,
+      conversationExternalId: envelope.connectionId,
+      externalMessageId: envelope.messageId,
+    },
+    actor: {
+      actorExternalId: envelope.senderAssistantId,
+      displayName: envelope.senderAssistantId,
+    },
+    source: {
+      updateId: envelope.nonce,
+      messageId: envelope.messageId,
+    },
+    raw: envelope as unknown as Record<string, unknown>,
+  };
+}

--- a/gateway/src/channels/inbound-event.ts
+++ b/gateway/src/channels/inbound-event.ts
@@ -8,7 +8,7 @@ import type { ChannelId } from './types.js';
  * The discriminated union is keyed by `sourceChannel`.
  */
 
-export type InboundChannelId = Extract<ChannelId, 'telegram' | 'sms' | 'whatsapp' | 'slack'>;
+export type InboundChannelId = Extract<ChannelId, 'telegram' | 'sms' | 'whatsapp' | 'slack' | 'assistant'>;
 
 interface InboundEventBase<C extends InboundChannelId> {
   version: 'v1';
@@ -50,9 +50,11 @@ export type TelegramInboundEvent = InboundEventBase<'telegram'>;
 export type SmsInboundEvent = InboundEventBase<'sms'>;
 export type WhatsAppInboundEvent = InboundEventBase<'whatsapp'>;
 export type SlackInboundEvent = InboundEventBase<'slack'>;
+export type AssistantInboundEvent = InboundEventBase<'assistant'>;
 
 export type GatewayInboundEvent =
   | TelegramInboundEvent
   | SmsInboundEvent
   | WhatsAppInboundEvent
-  | SlackInboundEvent;
+  | SlackInboundEvent
+  | AssistantInboundEvent;

--- a/gateway/src/channels/types.ts
+++ b/gateway/src/channels/types.ts
@@ -1,5 +1,5 @@
 export const CHANNEL_IDS = [
-  'telegram', 'sms', 'voice', 'vellum', 'whatsapp', 'slack', 'email',
+  'telegram', 'sms', 'voice', 'vellum', 'whatsapp', 'slack', 'email', 'assistant',
 ] as const;
 
 export type ChannelId = (typeof CHANNEL_IDS)[number];
@@ -21,7 +21,7 @@ export function assertChannelId(value: unknown, field: string): ChannelId {
 
 export const INTERFACE_IDS = [
   'macos', 'ios', 'cli',
-  'telegram', 'sms', 'voice', 'vellum', 'whatsapp', 'slack', 'email',
+  'telegram', 'sms', 'voice', 'vellum', 'whatsapp', 'slack', 'email', 'assistant',
 ] as const;
 
 export type InterfaceId = (typeof INTERFACE_IDS)[number];

--- a/gateway/src/http/routes/a2a-inbound.ts
+++ b/gateway/src/http/routes/a2a-inbound.ts
@@ -2,17 +2,17 @@
  * Gateway route for inbound A2A messages from peer assistants.
  *
  * This is the endpoint that a peer assistant's outbound delivery adapter
- * calls to send messages. The route:
+ * calls to send messages. The gateway acts as a transparent proxy:
  *
- * 1. Extracts the A2A auth headers (signature, timestamp, nonce, connection ID)
- * 2. Proxies the request to the runtime's /v1/a2a/messages/inbound endpoint
- *    which handles peer auth verification, dedup, and message routing
- * 3. The runtime normalizes the message into a GatewayInboundEvent and
- *    processes it through the standard inbound pipeline with peer_assistant trust
+ * 1. Validates payload size and basic envelope structure
+ * 2. Forwards the request (including all A2A auth headers) to the runtime's
+ *    /v1/a2a/messages/inbound endpoint
+ * 3. The runtime performs HMAC-SHA256 signature verification, connection
+ *    validation, dedup, trust classification, and message routing
  *
- * Auth is handled by HMAC-SHA256 signatures on the A2A headers, not by
- * gateway-level JWT auth. The gateway passes all A2A headers through to the
- * runtime for verification.
+ * The gateway does NOT verify A2A signatures — it passes the x-a2a-* headers
+ * through to the runtime, which has access to the stored inbound credentials
+ * needed for HMAC verification.
  */
 
 import type { GatewayConfig } from '../../config.js';
@@ -33,8 +33,8 @@ export function createA2AInboundHandler(config: GatewayConfig) {
    * POST /v1/a2a/messages/inbound
    *
    * Accepts an A2A message envelope with HMAC-SHA256 auth headers.
-   * The runtime handles peer auth verification and forwards the message
-   * through the standard inbound pipeline with peer_assistant trust.
+   * Proxies to the runtime which verifies the signature, then routes
+   * the message through the inbound pipeline with peer_assistant trust.
    */
   async function handleA2AInbound(req: Request, clientIp?: string): Promise<Response> {
     // Payload size guard
@@ -89,8 +89,9 @@ export function createA2AInboundHandler(config: GatewayConfig) {
     }
 
     // Forward to runtime's A2A inbound endpoint with all A2A auth headers.
-    // The runtime handles peer auth verification (HMAC-SHA256), dedup,
-    // connection lookup, trust classification, and message routing.
+    // The runtime verifies the HMAC-SHA256 signature against the stored
+    // inbound credential, then handles dedup, trust classification, and
+    // message routing.
     const upstream = `${config.assistantRuntimeBaseUrl}/v1/a2a/messages/inbound`;
 
     const headers: Record<string, string> = {

--- a/gateway/src/http/routes/a2a-inbound.ts
+++ b/gateway/src/http/routes/a2a-inbound.ts
@@ -1,0 +1,156 @@
+/**
+ * Gateway route for inbound A2A messages from peer assistants.
+ *
+ * This is the endpoint that a peer assistant's outbound delivery adapter
+ * calls to send messages. The route:
+ *
+ * 1. Extracts the A2A auth headers (signature, timestamp, nonce, connection ID)
+ * 2. Proxies the request to the runtime's /v1/a2a/messages/inbound endpoint
+ *    which handles peer auth verification, dedup, and message routing
+ * 3. The runtime normalizes the message into a GatewayInboundEvent and
+ *    processes it through the standard inbound pipeline with peer_assistant trust
+ *
+ * Auth is handled by HMAC-SHA256 signatures on the A2A headers, not by
+ * gateway-level JWT auth. The gateway passes all A2A headers through to the
+ * runtime for verification.
+ */
+
+import type { GatewayConfig } from '../../config.js';
+import { getLogger } from '../../logger.js';
+import type { A2AInboundEnvelope } from '../../a2a/normalize.js';
+import { mintIngressToken } from '../../auth/token-exchange.js';
+import { fetchImpl } from '../../fetch.js';
+
+const log = getLogger('a2a-inbound');
+
+/** Maximum payload size for A2A messages: 256 KB. */
+const MAX_A2A_MESSAGE_BYTES = 256 * 1024;
+
+const TIMEOUT_MS = 15_000;
+
+export function createA2AInboundHandler(config: GatewayConfig) {
+  /**
+   * POST /v1/a2a/messages/inbound
+   *
+   * Accepts an A2A message envelope with HMAC-SHA256 auth headers.
+   * The runtime handles peer auth verification and forwards the message
+   * through the standard inbound pipeline with peer_assistant trust.
+   */
+  async function handleA2AInbound(req: Request, clientIp?: string): Promise<Response> {
+    // Payload size guard
+    const contentLength = req.headers.get('content-length');
+    if (contentLength) {
+      const declared = Number(contentLength);
+      if (declared > MAX_A2A_MESSAGE_BYTES || Number.isNaN(declared)) {
+        log.warn({ contentLength }, 'A2A inbound payload too large');
+        return Response.json({ error: 'Payload too large' }, { status: 413 });
+      }
+    }
+
+    let bodyText: string;
+    try {
+      bodyText = await req.text();
+    } catch {
+      return Response.json({ error: 'Failed to read request body' }, { status: 400 });
+    }
+
+    if (bodyText.length > MAX_A2A_MESSAGE_BYTES) {
+      log.warn({ bodyLength: bodyText.length }, 'A2A inbound payload too large');
+      return Response.json({ error: 'Payload too large' }, { status: 413 });
+    }
+
+    let envelope: A2AInboundEnvelope;
+    try {
+      envelope = JSON.parse(bodyText) as A2AInboundEnvelope;
+    } catch {
+      return Response.json({ error: 'Invalid JSON' }, { status: 400 });
+    }
+
+    // Basic envelope validation
+    if (!envelope.messageId || !envelope.connectionId || !envelope.senderAssistantId) {
+      return Response.json(
+        { error: 'Missing required fields: messageId, connectionId, senderAssistantId' },
+        { status: 400 },
+      );
+    }
+
+    if (!envelope.content || !envelope.content.type) {
+      return Response.json(
+        { error: 'Missing required field: content.type' },
+        { status: 400 },
+      );
+    }
+
+    if (!envelope.nonce) {
+      return Response.json(
+        { error: 'Missing required field: nonce' },
+        { status: 400 },
+      );
+    }
+
+    // Forward to runtime's A2A inbound endpoint with all A2A auth headers.
+    // The runtime handles peer auth verification (HMAC-SHA256), dedup,
+    // connection lookup, trust classification, and message routing.
+    const upstream = `${config.assistantRuntimeBaseUrl}/v1/a2a/messages/inbound`;
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${mintIngressToken()}`,
+    };
+
+    // Pass through A2A auth headers for the runtime to verify
+    const a2aHeaders = [
+      'x-a2a-signature',
+      'x-a2a-timestamp',
+      'x-a2a-nonce',
+      'x-a2a-connection-id',
+    ];
+    for (const header of a2aHeaders) {
+      const value = req.headers.get(header);
+      if (value) {
+        headers[header] = value;
+      }
+    }
+
+    if (clientIp) {
+      headers['x-forwarded-for'] = clientIp;
+    }
+
+    try {
+      const response = await fetchImpl(upstream, {
+        method: 'POST',
+        headers,
+        body: bodyText,
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+      });
+
+      const resBody = await response.text();
+
+      if (response.status >= 400) {
+        log.warn(
+          { status: response.status, connectionId: envelope.connectionId },
+          'A2A inbound upstream error',
+        );
+      } else {
+        log.info(
+          { connectionId: envelope.connectionId, messageId: envelope.messageId },
+          'A2A inbound message forwarded to runtime',
+        );
+      }
+
+      return new Response(resBody, {
+        status: response.status,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'TimeoutError') {
+        log.error({ connectionId: envelope.connectionId }, 'A2A inbound upstream timed out');
+        return Response.json({ error: 'Gateway Timeout' }, { status: 504 });
+      }
+      log.error({ err, connectionId: envelope.connectionId }, 'A2A inbound upstream connection failed');
+      return Response.json({ error: 'Bad Gateway' }, { status: 502 });
+    }
+  }
+
+  return { handleA2AInbound };
+}

--- a/gateway/src/http/routes/a2a-inbound.ts
+++ b/gateway/src/http/routes/a2a-inbound.ts
@@ -49,14 +49,14 @@ export function createA2AInboundHandler(config: GatewayConfig) {
 
     let bodyText: string;
     try {
-      bodyText = await req.text();
+      const bodyBuffer = await req.arrayBuffer();
+      if (bodyBuffer.byteLength > MAX_A2A_MESSAGE_BYTES) {
+        log.warn({ bodyBytes: bodyBuffer.byteLength }, 'A2A inbound payload too large');
+        return Response.json({ error: 'Payload too large' }, { status: 413 });
+      }
+      bodyText = new TextDecoder().decode(bodyBuffer);
     } catch {
       return Response.json({ error: 'Failed to read request body' }, { status: 400 });
-    }
-
-    if (bodyText.length > MAX_A2A_MESSAGE_BYTES) {
-      log.warn({ bodyLength: bodyText.length }, 'A2A inbound payload too large');
-      return Response.json({ error: 'Payload too large' }, { status: 413 });
     }
 
     let envelope: A2AInboundEnvelope;

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -29,6 +29,7 @@ import { createWhatsAppDeliverHandler } from "./http/routes/whatsapp-deliver.js"
 import { createSlackDeliverHandler } from "./http/routes/slack-deliver.js";
 import { createOAuthCallbackHandler } from "./http/routes/oauth-callback.js";
 import { createA2AProxyHandler } from "./http/routes/a2a-proxy.js";
+import { createA2AInboundHandler } from "./http/routes/a2a-inbound.js";
 import { createPairingProxyHandler } from "./http/routes/pairing-proxy.js";
 import { createFeatureFlagsGetHandler, createFeatureFlagsPatchHandler } from "./http/routes/feature-flags.js";
 import { createGuardianControlPlaneProxyHandler } from "./http/routes/guardian-control-plane-proxy.js";
@@ -113,6 +114,7 @@ function main() {
   const handleSlackDeliver = createSlackDeliverHandler(config);
   const handleOAuthCallback = createOAuthCallbackHandler(config);
   const a2aProxy = createA2AProxyHandler(config);
+  const a2aInbound = createA2AInboundHandler(config);
   const pairingProxy = createPairingProxyHandler(config);
   const guardianControlPlaneProxy = createGuardianControlPlaneProxyHandler(config);
   const telegramControlPlaneProxy = createTelegramControlPlaneProxyHandler(config);
@@ -655,6 +657,12 @@ function main() {
       if (a2aStatusMatch && tracedReq.method === "GET") {
         const statusClientIp = getClientIp(req, svr, config.trustProxy);
         return a2aProxy.handleConnectionStatus(tracedReq, decodeURIComponent(a2aStatusMatch[1]), statusClientIp);
+      }
+      // A2A inbound message endpoint (peer assistant -> gateway -> runtime).
+      // Authenticated via HMAC-SHA256 A2A headers (not gateway JWT).
+      if (url.pathname === "/v1/a2a/messages/inbound" && tracedReq.method === "POST") {
+        const inboundClientIp = getClientIp(req, svr, config.trustProxy);
+        return a2aInbound.handleA2AInbound(tracedReq, inboundClientIp);
       }
 
       // ── Feature flags API ──

--- a/gateway/src/types.ts
+++ b/gateway/src/types.ts
@@ -1,1 +1,1 @@
-export type { GatewayInboundEvent, GatewayInboundEvent as GatewayInboundEventV1, InboundChannelId, TelegramInboundEvent, SmsInboundEvent, WhatsAppInboundEvent, SlackInboundEvent } from './channels/inbound-event.js';
+export type { GatewayInboundEvent, GatewayInboundEvent as GatewayInboundEventV1, InboundChannelId, TelegramInboundEvent, SmsInboundEvent, WhatsAppInboundEvent, SlackInboundEvent, AssistantInboundEvent } from './channels/inbound-event.js';


### PR DESCRIPTION
## Summary
- Add `assistant` to `CHANNEL_IDS`, `INTERFACE_IDS`, and `InboundChannelId` in both assistant and gateway packages
- Add `AssistantInboundEvent` variant to the `GatewayInboundEvent` discriminated union
- Add `assistant` channel notification policy (non-deliverable, continue existing conversation)
- Add `peer_assistant` trust classification in `resolveActorTrust` for the `assistant` channel (fail-closed: no identity = unknown)
- Add gateway route `POST /v1/a2a/messages/inbound` that proxies A2A messages to the runtime
- Add runtime handler that validates connection, deduplicates messages, and routes through `processMessage` with `peer_assistant` trust context pre-set
- Add `a2a/messages/inbound` route policy (gateway-only, ingress.write scope)
- Add A2A inbound normalizer in gateway for converting message envelopes to `GatewayInboundEvent`

## Field Mappings
- `conversationExternalId` → peer connection ID (from `a2a_peer_connections` table)
- `actorExternalId` → peer assistant ID (remote assistant's identifier)
- `sourceChannel` → `'assistant'`

## Trust Classification
Peer assistant trust is applied at the ingress boundary with no unguarded window:
- In the runtime handler: `guardianContext.trustClass` is set to `'peer_assistant'` before `processMessage` is called
- In `resolveActorTrust`: the `assistant` channel short-circuits to `peer_assistant` trust when identity is present, `unknown` when not (fail-closed)

## Test plan
- [x] `a2a-channel-type.test.ts` — assistant channel type recognized by CHANNEL_IDS, isChannelId, parseChannelId, INTERFACE_IDS
- [x] `a2a-normalize.test.ts` — A2A envelope normalization (text, structured request/response, missing fields, field mappings)
- [x] `a2a-inbound-trust.test.ts` — peer_assistant trust classification, fail-closed for missing identity, no guardian binding lookup, existing channels unaffected
- [x] Regression: existing channels (telegram, sms, whatsapp, etc.) still recognized and not classified as peer_assistant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
