### PR TITLE
fix: gate ANSI status updates behind isTTY in mcp list

### DIFF
--- a/assistant/src/cli/mcp.ts
+++ b/assistant/src/cli/mcp.ts
@@ -73,55 +73,90 @@ export function registerMcpCommand(program: Command): void {
 
       log.info(`${entries.length} MCP server(s) configured:\n`);
 
-      // First pass: print all server blocks with placeholder status, track line positions
-      let lineCount = 0;
-      const healthChecks: { id: string; cfg: McpServerConfig; statusLine: number }[] = [];
+      const isTTY = process.stdout.isTTY;
 
-      for (const [id, cfg] of entries) {
-        if (!cfg || typeof cfg !== 'object') {
-          log.info(`  ${id} (invalid config — skipped)\n`);
-          lineCount += 2;
-          continue;
-        }
-        const enabled = cfg.enabled !== false;
-        const transport = cfg.transport;
-        const risk = cfg.defaultRiskLevel ?? 'high';
-        const statusText = !enabled ? '✗ disabled' : '⏳ Checking...';
+      if (isTTY) {
+        // TTY path: print placeholders, run health checks in parallel, update in-place with ANSI codes
+        let lineCount = 0;
+        const healthChecks: { id: string; cfg: McpServerConfig; statusLine: number }[] = [];
 
-        log.info(`  ${id}`);
-        lineCount++;
-        const statusLine = lineCount;
-        log.info(`    Status:    ${statusText}`);
-        lineCount++;
-        log.info(`    Transport: ${transport?.type ?? 'unknown'}`);
-        lineCount++;
-        if (transport?.type === 'stdio') {
-          log.info(`    Command:   ${transport.command} ${(transport.args ?? []).join(' ')}`);
+        for (const [id, cfg] of entries) {
+          if (!cfg || typeof cfg !== 'object') {
+            log.info(`  ${id} (invalid config — skipped)\n`);
+            lineCount += 2;
+            continue;
+          }
+          const enabled = cfg.enabled !== false;
+          const transport = cfg.transport;
+          const risk = cfg.defaultRiskLevel ?? 'high';
+          const statusText = !enabled ? '✗ disabled' : '⏳ Checking...';
+
+          log.info(`  ${id}`);
           lineCount++;
-        } else if (transport && 'url' in transport) {
-          log.info(`    URL:       ${transport.url}`);
+          const statusLine = lineCount;
+          log.info(`    Status:    ${statusText}`);
           lineCount++;
-        }
-        log.info(`    Risk:      ${risk}`);
-        lineCount++;
-        if (cfg.allowedTools) { log.info(`    Allowed:   ${cfg.allowedTools.join(', ')}`); lineCount++; }
-        if (cfg.blockedTools) { log.info(`    Blocked:   ${cfg.blockedTools.join(', ')}`); lineCount++; }
-        log.info('');
-        lineCount++;
+          log.info(`    Transport: ${transport?.type ?? 'unknown'}`);
+          lineCount++;
+          if (transport?.type === 'stdio') {
+            log.info(`    Command:   ${transport.command} ${(transport.args ?? []).join(' ')}`);
+            lineCount++;
+          } else if (transport && 'url' in transport) {
+            log.info(`    URL:       ${transport.url}`);
+            lineCount++;
+          }
+          log.info(`    Risk:      ${risk}`);
+          lineCount++;
+          if (cfg.allowedTools) { log.info(`    Allowed:   ${cfg.allowedTools.join(', ')}`); lineCount++; }
+          if (cfg.blockedTools) { log.info(`    Blocked:   ${cfg.blockedTools.join(', ')}`); lineCount++; }
+          log.info('');
+          lineCount++;
 
-        if (enabled) {
-          healthChecks.push({ id, cfg, statusLine });
+          if (enabled) {
+            healthChecks.push({ id, cfg, statusLine });
+          }
+        }
+
+        if (healthChecks.length === 0) return;
+
+        // Run health checks in parallel, update status lines in-place with ANSI codes
+        await Promise.all(healthChecks.map(async ({ id, cfg, statusLine }) => {
+          const health = await checkServerHealth(id, cfg);
+          const up = lineCount - statusLine;
+          process.stdout.write(`\x1b[${up}A\r\x1b[2K    Status:    ${health}\x1b[${up}B\r`);
+        }));
+      } else {
+        // Non-TTY path: run health checks sequentially, print final status directly (no ANSI codes)
+        for (const [id, cfg] of entries) {
+          if (!cfg || typeof cfg !== 'object') {
+            log.info(`  ${id} (invalid config — skipped)\n`);
+            continue;
+          }
+          const enabled = cfg.enabled !== false;
+          const transport = cfg.transport;
+          const risk = cfg.defaultRiskLevel ?? 'high';
+
+          let statusText: string;
+          if (!enabled) {
+            statusText = '✗ disabled';
+          } else {
+            statusText = await checkServerHealth(id, cfg);
+          }
+
+          log.info(`  ${id}`);
+          log.info(`    Status:    ${statusText}`);
+          log.info(`    Transport: ${transport?.type ?? 'unknown'}`);
+          if (transport?.type === 'stdio') {
+            log.info(`    Command:   ${transport.command} ${(transport.args ?? []).join(' ')}`);
+          } else if (transport && 'url' in transport) {
+            log.info(`    URL:       ${transport.url}`);
+          }
+          log.info(`    Risk:      ${risk}`);
+          if (cfg.allowedTools) { log.info(`    Allowed:   ${cfg.allowedTools.join(', ')}`); }
+          if (cfg.blockedTools) { log.info(`    Blocked:   ${cfg.blockedTools.join(', ')}`); }
+          log.info('');
         }
       }
-
-      if (healthChecks.length === 0) return;
-
-      // Second pass: run health checks in parallel, update status lines in-place
-      await Promise.all(healthChecks.map(async ({ id, cfg, statusLine }) => {
-        const health = await checkServerHealth(id, cfg);
-        const up = lineCount - statusLine;
-        process.stdout.write(`\x1b[${up}A\r\x1b[2K    Status:    ${health}\x1b[${up}B\r`);
-      }));
 
       // Health checks may leave MCP transports alive — force exit
       process.exit(0);


### PR DESCRIPTION
## Summary
- Gate ANSI cursor-movement escape codes behind `process.stdout.isTTY` in `vellum mcp list`
- When stdout is not a TTY (piped, redirected, CI), fall back to sequential health checks with direct status output — no placeholders, no ANSI codes
- Fixes garbled output when running `vellum mcp list | cat` or `vellum mcp list > out.txt`
- Addresses unresolved review feedback from #11572

## Test plan
- [x] `bun test src/__tests__/mcp-health-check.test.ts` — all pass
- [x] `bun test src/__tests__/mcp-cli.test.ts` — all pass
- [ ] Manual: `vellum mcp list | cat` produces clean output without ANSI codes
- [ ] Manual: `vellum mcp list` in terminal still shows parallel status updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
