### PR TITLE
M14: Outbound A2A delivery adapter + sendMessage()

### DIFF
--- a/assistant/src/a2a/__tests__/a2a-outbound-delivery.test.ts
+++ b/assistant/src/a2a/__tests__/a2a-outbound-delivery.test.ts
@@ -1,0 +1,379 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'a2a-outbound-delivery-test-'));
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before any import that touches mocked modules.
+// ---------------------------------------------------------------------------
+
+mock.module('../../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+mock.module('../../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Track notification signals emitted during tests
+const emittedSignals: Array<{ sourceEventName: string; contextPayload: unknown }> = [];
+mock.module('../../notifications/emit-signal.js', () => ({
+  emitNotificationSignal: async (params: { sourceEventName: string; contextPayload: unknown }) => {
+    emittedSignals.push({ sourceEventName: params.sourceEventName, contextPayload: params.contextPayload });
+    return { signalId: 'test-signal', deduplicated: false, dispatched: true, reason: 'ok', deliveryResults: [] };
+  },
+}));
+
+// Control whether scope policy flag is enabled per test
+let scopePolicyEnabled = false;
+mock.module('../../config/assistant-feature-flags.js', () => ({
+  isAssistantFeatureFlagEnabled: (key: string) => {
+    if (key === 'feature_flags.a2a-scope-policy.enabled') return scopePolicyEnabled;
+    return true;
+  },
+  loadDefaultsRegistry: () => ({}),
+}));
+
+mock.module('../../config/loader.js', () => ({
+  getConfig: () => ({
+    assistantFeatureFlagValues: {},
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import {
+  createConnection,
+  getConnection,
+  updateConnectionCredentials,
+  updateConnectionStatus,
+} from '../a2a-peer-connection-store.js';
+import { generateCredentialPair } from '../a2a-peer-auth.js';
+import {
+  sendMessage,
+  _resetHandshakeSessions,
+  _resetIdempotencyStore,
+  A2A_SOURCE_CHANNEL,
+} from '../a2a-connection-service.js';
+import { deliverMessage, MAX_RETRIES } from '../a2a-outbound-delivery.js';
+import { createTextMessage } from '../a2a-message-schema.js';
+import { getDb, initializeDb, resetDb } from '../../memory/db.js';
+import { getBindingByChannelChat } from '../../memory/external-conversation-store.js';
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run('DELETE FROM a2a_peer_connections');
+  db.run('DELETE FROM assistant_ingress_invites');
+  db.run('DELETE FROM external_conversation_bindings');
+}
+
+/** Create an active connection with valid credentials for testing. */
+function createActiveConnection(overrides?: { peerGatewayUrl?: string }) {
+  const credentials = generateCredentialPair();
+  const conn = createConnection({
+    peerGatewayUrl: overrides?.peerGatewayUrl ?? 'https://peer.example.com',
+    peerAssistantId: 'peer-001',
+    status: 'active',
+  });
+  updateConnectionCredentials(conn.id, {
+    outboundCredentialHash: credentials.outboundCredentialHash,
+    outboundCredential: credentials.outboundCredential,
+    inboundCredentialHash: credentials.inboundCredentialHash,
+    inboundCredential: credentials.inboundCredential,
+  });
+  return { connection: getConnection(conn.id)!, credentials };
+}
+
+describe('a2a-outbound-delivery', () => {
+  beforeEach(() => {
+    resetTables();
+    _resetHandshakeSessions();
+    _resetIdempotencyStore();
+    emittedSignals.length = 0;
+    scopePolicyEnabled = false;
+  });
+
+  afterAll(() => {
+    resetDb();
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  // ========================================================================
+  // sendMessage — scope gating
+  // ========================================================================
+
+  describe('sendMessage scope gating', () => {
+    test('returns not_enabled when scope policy flag is off', async () => {
+      scopePolicyEnabled = false;
+      const { connection } = createActiveConnection();
+
+      const result = await sendMessage({
+        connectionId: connection.id,
+        content: { type: 'text', text: 'hello' },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('not_enabled');
+      }
+    });
+
+    test('proceeds past scope gate when flag is on', async () => {
+      scopePolicyEnabled = true;
+      const { connection } = createActiveConnection();
+
+      // This will fail at delivery (no actual server), but it gets past the scope gate
+      const result = await sendMessage({
+        connectionId: connection.id,
+        content: { type: 'text', text: 'hello' },
+      });
+
+      // It should not be 'not_enabled' — it should proceed to delivery attempt
+      if (!result.ok) {
+        expect(result.reason).not.toBe('not_enabled');
+      }
+    });
+  });
+
+  // ========================================================================
+  // sendMessage — connection validation
+  // ========================================================================
+
+  describe('sendMessage connection validation', () => {
+    test('returns not_found for missing connection', async () => {
+      scopePolicyEnabled = true;
+
+      const result = await sendMessage({
+        connectionId: 'nonexistent-id',
+        content: { type: 'text', text: 'hello' },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('not_found');
+      }
+    });
+
+    test('returns not_active for pending connection', async () => {
+      scopePolicyEnabled = true;
+      const conn = createConnection({
+        peerGatewayUrl: 'https://peer.example.com',
+        status: 'pending',
+      });
+
+      const result = await sendMessage({
+        connectionId: conn.id,
+        content: { type: 'text', text: 'hello' },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('not_active');
+      }
+    });
+
+    test('returns not_active for revoked connection', async () => {
+      scopePolicyEnabled = true;
+      const conn = createConnection({
+        peerGatewayUrl: 'https://peer.example.com',
+        status: 'active',
+      });
+      updateConnectionStatus(conn.id, 'revoked');
+
+      const result = await sendMessage({
+        connectionId: conn.id,
+        content: { type: 'text', text: 'hello' },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('not_active');
+      }
+    });
+
+    test('returns no_credential when outbound credential is missing', async () => {
+      scopePolicyEnabled = true;
+      const conn = createConnection({
+        peerGatewayUrl: 'https://peer.example.com',
+        status: 'active',
+      });
+
+      const result = await sendMessage({
+        connectionId: conn.id,
+        content: { type: 'text', text: 'hello' },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('no_credential');
+      }
+    });
+  });
+
+  // ========================================================================
+  // sendMessage — conversation binding
+  // ========================================================================
+
+  describe('sendMessage conversation binding', () => {
+    test('creates external conversation binding on first send', async () => {
+      scopePolicyEnabled = true;
+      const { connection } = createActiveConnection();
+
+      // Verify no binding exists before send
+      const bindingBefore = getBindingByChannelChat(A2A_SOURCE_CHANNEL, connection.id);
+      expect(bindingBefore).toBeNull();
+
+      // Send will fail at delivery but should create the binding
+      await sendMessage({
+        connectionId: connection.id,
+        content: { type: 'text', text: 'hello' },
+      });
+
+      const bindingAfter = getBindingByChannelChat(A2A_SOURCE_CHANNEL, connection.id);
+      expect(bindingAfter).not.toBeNull();
+      expect(bindingAfter!.sourceChannel).toBe(A2A_SOURCE_CHANNEL);
+      expect(bindingAfter!.externalChatId).toBe(connection.id);
+    });
+  });
+
+  // ========================================================================
+  // deliverMessage — URL validation
+  // ========================================================================
+
+  describe('deliverMessage URL validation', () => {
+    test('rejects HTTP for public target', async () => {
+      const envelope = createTextMessage({
+        connectionId: 'conn-001',
+        senderAssistantId: 'self',
+        text: 'hello',
+      });
+
+      const result = await deliverMessage({
+        envelope,
+        peerGatewayUrl: 'http://public.example.com',
+        outboundCredential: 'test-credential',
+        connectionId: 'conn-001',
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('target_validation_failed');
+      }
+    });
+
+    test('allows HTTPS for public target (fails at network level)', async () => {
+      const envelope = createTextMessage({
+        connectionId: 'conn-001',
+        senderAssistantId: 'self',
+        text: 'hello',
+      });
+
+      const result = await deliverMessage({
+        envelope,
+        peerGatewayUrl: 'https://peer.example.com',
+        outboundCredential: 'test-credential',
+        connectionId: 'conn-001',
+      });
+
+      // Should pass URL validation but fail at delivery (no actual server)
+      if (!result.ok) {
+        expect(result.reason).toBe('delivery_failed');
+      }
+    });
+  });
+
+  // ========================================================================
+  // deliverMessage — dead-letter emission
+  // ========================================================================
+
+  describe('deliverMessage dead-letter', () => {
+    test('emits message_failed event after exhausting retries', async () => {
+      const envelope = createTextMessage({
+        connectionId: 'conn-dead-letter',
+        senderAssistantId: 'self',
+        text: 'hello',
+      });
+
+      const result = await deliverMessage({
+        envelope,
+        peerGatewayUrl: 'https://peer.example.com',
+        outboundCredential: 'test-credential',
+        connectionId: 'conn-dead-letter',
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('delivery_failed');
+      }
+
+      // Check that a message_failed notification was emitted
+      const failedSignal = emittedSignals.find(
+        s => s.sourceEventName === 'a2a.message_failed',
+      );
+      expect(failedSignal).toBeDefined();
+      const payload = failedSignal!.contextPayload as { connectionId: string; messageId: string };
+      expect(payload.connectionId).toBe('conn-dead-letter');
+      expect(payload.messageId).toBe(envelope.messageId);
+    });
+  });
+
+  // ========================================================================
+  // Message construction
+  // ========================================================================
+
+  describe('message construction', () => {
+    test('createTextMessage produces valid envelope', () => {
+      const envelope = createTextMessage({
+        connectionId: 'conn-001',
+        senderAssistantId: 'self',
+        text: 'hello world',
+      });
+
+      expect(envelope.messageId).toBeDefined();
+      expect(envelope.connectionId).toBe('conn-001');
+      expect(envelope.senderAssistantId).toBe('self');
+      expect(envelope.content.type).toBe('text');
+      if (envelope.content.type === 'text') {
+        expect(envelope.content.text).toBe('hello world');
+      }
+      expect(envelope.nonce).toBeDefined();
+      expect(envelope.status).toBe('pending');
+    });
+
+    test('createTextMessage with delivery metadata', () => {
+      const envelope = createTextMessage({
+        connectionId: 'conn-001',
+        senderAssistantId: 'self',
+        text: 'reply',
+        delivery: { correlationId: 'orig-msg-001' },
+      });
+
+      expect(envelope.delivery).toBeDefined();
+      expect(envelope.delivery!.correlationId).toBe('orig-msg-001');
+    });
+  });
+});

--- a/assistant/src/a2a/a2a-connection-service.ts
+++ b/assistant/src/a2a/a2a-connection-service.ts
@@ -37,6 +37,7 @@ import { generateCredentialPair } from './a2a-peer-auth.js';
 import {
   createTextMessage,
   createStructuredRequest,
+  createStructuredResponse,
   type A2AMessageContent,
   type A2ADeliveryMetadata,
 } from './a2a-message-schema.js';
@@ -970,12 +971,15 @@ export async function sendMessage(params: {
       delivery,
     });
   } else {
-    // For structured_response, build the envelope manually since the helper
-    // requires a correlationId that may come from params.correlationId
-    envelope = createTextMessage({
+    const responseContent = params.content as { action: string; result: Record<string, unknown>; success: boolean; error?: string };
+    envelope = createStructuredResponse({
       connectionId: params.connectionId,
       senderAssistantId: DAEMON_INTERNAL_ASSISTANT_ID,
-      text: JSON.stringify(params.content),
+      action: responseContent.action,
+      result: responseContent.result,
+      success: responseContent.success,
+      error: responseContent.error,
+      correlationId: params.correlationId ?? '',
       delivery,
     });
   }

--- a/assistant/src/a2a/a2a-connection-service.ts
+++ b/assistant/src/a2a/a2a-connection-service.ts
@@ -34,6 +34,13 @@ import {
 } from './a2a-handshake.js';
 
 import { generateCredentialPair } from './a2a-peer-auth.js';
+import {
+  createTextMessage,
+  createStructuredRequest,
+  type A2AMessageContent,
+  type A2ADeliveryMetadata,
+} from './a2a-message-schema.js';
+import { deliverMessage } from './a2a-outbound-delivery.js';
 
 import {
   createInvite as createIngressInvite,
@@ -42,9 +49,19 @@ import {
   markInviteExpired,
   recordInviteUse,
 } from '../memory/ingress-invite-store.js';
+import {
+  getBindingByChannelChat,
+  upsertOutboundBinding,
+} from '../memory/external-conversation-store.js';
+import { getOrCreateConversation } from '../memory/conversation-key-store.js';
+import { isAssistantFeatureFlagEnabled } from '../config/assistant-feature-flags.js';
+import { getConfig } from '../config/loader.js';
 
 import { emitNotificationSignal } from '../notifications/emit-signal.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('a2a-connection-service');
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -106,6 +123,10 @@ export type RevokeConnectionResult =
 export type ListConnectionsResult = {
   connections: A2APeerConnection[];
 };
+
+export type SendMessageResult =
+  | { ok: true; messageId: string; conversationId: string }
+  | { ok: false; reason: 'not_found' | 'not_active' | 'not_enabled' | 'no_credential' | 'delivery_failed'; detail?: string };
 
 // ---------------------------------------------------------------------------
 // Invite code encoding/decoding
@@ -750,6 +771,7 @@ export function submitVerificationCode(params: {
 
   const connectionWithCredentials = updateConnectionCredentials(params.connectionId, {
     outboundCredentialHash: credentials.outboundCredentialHash,
+    outboundCredential: credentials.outboundCredential,
     inboundCredentialHash: credentials.inboundCredentialHash,
     inboundCredential: credentials.inboundCredential,
   });
@@ -809,6 +831,7 @@ export function revokeConnection(params: {
   // Tombstone credentials
   updateConnectionCredentials(params.connectionId, {
     outboundCredentialHash: '',
+    outboundCredential: '',
     inboundCredentialHash: '',
     inboundCredential: '',
   });
@@ -853,4 +876,121 @@ export function listConnectionsFiltered(params?: {
     status: params?.status,
   });
   return { connections };
+}
+
+// ---------------------------------------------------------------------------
+// Send message
+// ---------------------------------------------------------------------------
+
+/** Canonical feature flag key for A2A scope policy. */
+const A2A_SCOPE_POLICY_FLAG = 'feature_flags.a2a-scope-policy.enabled';
+
+/**
+ * Send a message to a connected peer assistant.
+ *
+ * Validates the connection is active and the scope policy gate is enabled.
+ * Constructs an A2AMessageEnvelope, signs it, and delivers via the outbound
+ * adapter. Ensures a dedicated internal conversation binding exists for the
+ * peer connection.
+ *
+ * Returns `{ ok: false, reason: 'not_enabled' }` until M16 activates scope
+ * policy — this prevents messaging without policy enforcement.
+ */
+export async function sendMessage(params: {
+  connectionId: string;
+  content: A2AMessageContent;
+  correlationId?: string;
+}): Promise<SendMessageResult> {
+  // Scope gating: deny until scope policy is active
+  const config = getConfig();
+  if (!isAssistantFeatureFlagEnabled(A2A_SCOPE_POLICY_FLAG, config)) {
+    return { ok: false, reason: 'not_enabled', detail: 'A2A scope policy is not active' };
+  }
+
+  // Validate connection exists
+  const connection = getConnection(params.connectionId);
+  if (!connection) {
+    return { ok: false, reason: 'not_found' };
+  }
+
+  // Validate connection is active
+  if (connection.status !== 'active') {
+    return { ok: false, reason: 'not_active', detail: `Connection status is ${connection.status}` };
+  }
+
+  // Validate outbound credential is available for signing
+  if (!connection.outboundCredential) {
+    log.error(
+      { connectionId: params.connectionId },
+      'Active connection has no outbound credential for signing',
+    );
+    return { ok: false, reason: 'no_credential', detail: 'No outbound credential available for signing' };
+  }
+
+  // Ensure a conversation binding exists for this peer connection.
+  // Uses sourceChannel='a2a' and connectionId as externalChatId.
+  const existingBinding = getBindingByChannelChat(A2A_SOURCE_CHANNEL, params.connectionId);
+  let conversationId: string;
+
+  if (existingBinding) {
+    conversationId = existingBinding.conversationId;
+  } else {
+    // Create a conversation keyed by a2a:<connectionId> so the binding has a
+    // valid FK target in the conversations table.
+    const convKey = `a2a:${params.connectionId}`;
+    const { conversationId: newConvId } = getOrCreateConversation(convKey);
+    conversationId = newConvId;
+  }
+
+  upsertOutboundBinding({
+    conversationId,
+    sourceChannel: A2A_SOURCE_CHANNEL,
+    externalChatId: params.connectionId,
+  });
+
+  // Construct the message envelope
+  const delivery: A2ADeliveryMetadata | undefined = params.correlationId
+    ? { correlationId: params.correlationId }
+    : undefined;
+
+  let envelope;
+  if (params.content.type === 'text') {
+    envelope = createTextMessage({
+      connectionId: params.connectionId,
+      senderAssistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+      text: params.content.text,
+      delivery,
+    });
+  } else if (params.content.type === 'structured_request') {
+    envelope = createStructuredRequest({
+      connectionId: params.connectionId,
+      senderAssistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+      action: params.content.action,
+      requestParams: params.content.params,
+      delivery,
+    });
+  } else {
+    // For structured_response, build the envelope manually since the helper
+    // requires a correlationId that may come from params.correlationId
+    envelope = createTextMessage({
+      connectionId: params.connectionId,
+      senderAssistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+      text: JSON.stringify(params.content),
+      delivery,
+    });
+  }
+
+  // Deliver via outbound adapter with retry logic
+  const result = await deliverMessage({
+    envelope,
+    peerGatewayUrl: connection.peerGatewayUrl,
+    outboundCredential: connection.outboundCredential,
+    connectionId: params.connectionId,
+  });
+
+  if (!result.ok) {
+    return { ok: false, reason: 'delivery_failed', detail: result.error };
+  }
+
+  return { ok: true, messageId: result.messageId, conversationId };
 }

--- a/assistant/src/a2a/a2a-outbound-delivery.ts
+++ b/assistant/src/a2a/a2a-outbound-delivery.ts
@@ -1,0 +1,273 @@
+/**
+ * Outbound A2A message delivery adapter.
+ *
+ * Handles the full outbound delivery lifecycle: message construction,
+ * HMAC-SHA256 request signing, HTTP delivery to the peer's gateway,
+ * retry logic for transient failures, and dead-letter notification
+ * emission when retries are exhausted.
+ *
+ * URL validation uses the same canonical rules as a2a-connection-service.ts
+ * to ensure HTTPS for public targets and HTTP only for local/private.
+ */
+
+import { signRequest } from './a2a-peer-auth.js';
+import {
+  A2A_EVENT_NAMES,
+  type A2AMessageEnvelope,
+} from './a2a-message-schema.js';
+import { validateA2ATarget } from './a2a-connection-service.js';
+import { emitNotificationSignal } from '../notifications/emit-signal.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('a2a-outbound-delivery');
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum retry attempts for transient failures. */
+export const MAX_RETRIES = 3;
+
+/** Base delay for exponential backoff (milliseconds). */
+const BASE_RETRY_DELAY_MS = 500;
+
+/** Maximum delay cap (milliseconds). */
+const MAX_RETRY_DELAY_MS = 8_000;
+
+/** HTTP request timeout (milliseconds). */
+const DELIVERY_TIMEOUT_MS = 15_000;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type DeliveryResult =
+  | { ok: true; messageId: string }
+  | { ok: false; reason: 'target_validation_failed' | 'delivery_failed' | 'signing_failed'; error: string };
+
+export interface DeliveryParams {
+  /** The constructed message envelope to deliver. */
+  envelope: A2AMessageEnvelope;
+  /** The peer's gateway URL (delivery target). */
+  peerGatewayUrl: string;
+  /** The raw outbound credential for HMAC signing. */
+  outboundCredential: string;
+  /** The A2A connection ID. */
+  connectionId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getRetryDelay(attempt: number): number {
+  // Exponential backoff with jitter: base * 2^attempt + random jitter
+  const exponential = BASE_RETRY_DELAY_MS * Math.pow(2, attempt);
+  const jitter = Math.random() * BASE_RETRY_DELAY_MS;
+  return Math.min(exponential + jitter, MAX_RETRY_DELAY_MS);
+}
+
+/**
+ * Returns true for HTTP status codes that indicate a transient failure
+ * worth retrying (5xx server errors).
+ */
+function isTransientHttpError(status: number): boolean {
+  return status >= 500 && status < 600;
+}
+
+// ---------------------------------------------------------------------------
+// Core delivery function (single attempt)
+// ---------------------------------------------------------------------------
+
+async function deliverOnce(
+  params: DeliveryParams,
+): Promise<{ ok: true; status: number } | { ok: false; transient: boolean; error: string; status?: number }> {
+  const { envelope, peerGatewayUrl, outboundCredential, connectionId } = params;
+
+  const targetUrl = `${peerGatewayUrl.replace(/\/+$/, '')}/v1/a2a/messages/inbound`;
+
+  const bodyText = JSON.stringify(envelope);
+
+  // Sign the request with HMAC-SHA256
+  let headers: Record<string, string>;
+  try {
+    const signedHeaders = signRequest(connectionId, outboundCredential, bodyText);
+    headers = {
+      ...signedHeaders,
+      'content-type': 'application/json',
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      transient: false,
+      error: `Failed to sign request: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort(new DOMException('The operation was aborted due to timeout', 'TimeoutError'));
+  }, DELIVERY_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(targetUrl, {
+      method: 'POST',
+      headers,
+      body: bodyText,
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+
+    if (response.ok) {
+      return { ok: true, status: response.status };
+    }
+
+    const responseText = await response.text().catch(() => '');
+    const transient = isTransientHttpError(response.status);
+
+    return {
+      ok: false,
+      transient,
+      error: `HTTP ${response.status}: ${responseText.slice(0, 256)}`,
+      status: response.status,
+    };
+  } catch (err) {
+    clearTimeout(timeoutId);
+    // Network errors and timeouts are transient
+    return {
+      ok: false,
+      transient: true,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Deliver an A2A message to a peer assistant's gateway with retry logic.
+ *
+ * Flow:
+ * 1. Validate the target URL (same rules as connection service)
+ * 2. Sign the request body with HMAC-SHA256
+ * 3. POST to {peerGatewayUrl}/v1/a2a/messages/inbound
+ * 4. On transient failure (5xx, network error): retry up to MAX_RETRIES
+ *    with exponential backoff
+ * 5. On permanent failure (4xx) or retries exhausted: emit message_failed
+ *    lifecycle event via notification pipeline
+ * 6. On success: emit message_delivered lifecycle event
+ */
+export async function deliverMessage(params: DeliveryParams): Promise<DeliveryResult> {
+  const { envelope, peerGatewayUrl, connectionId } = params;
+
+  // Validate target URL before attempting delivery
+  const targetValidation = validateA2ATarget(peerGatewayUrl);
+  if (!targetValidation.ok) {
+    log.warn(
+      { connectionId, peerGatewayUrl, reason: targetValidation.reason },
+      'Target URL validation failed for outbound A2A message',
+    );
+    return {
+      ok: false,
+      reason: 'target_validation_failed',
+      error: targetValidation.reason,
+    };
+  }
+
+  let lastError = '';
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    if (attempt > 0) {
+      const retryDelayMs = getRetryDelay(attempt - 1);
+      log.info(
+        { connectionId, messageId: envelope.messageId, attempt, retryDelayMs },
+        'Retrying A2A message delivery',
+      );
+      await delay(retryDelayMs);
+    }
+
+    const result = await deliverOnce(params);
+
+    if (result.ok) {
+      log.info(
+        { connectionId, messageId: envelope.messageId, status: result.status, attempt },
+        'A2A message delivered successfully',
+      );
+
+      // Emit message_delivered lifecycle event
+      void emitNotificationSignal({
+        sourceEventName: A2A_EVENT_NAMES.MESSAGE_DELIVERED,
+        sourceChannel: 'a2a',
+        sourceSessionId: connectionId,
+        assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+        attentionHints: {
+          requiresAction: false,
+          urgency: 'low',
+          isAsyncBackground: true,
+          visibleInSourceNow: false,
+        },
+        contextPayload: {
+          connectionId,
+          messageId: envelope.messageId,
+        },
+        dedupeKey: `a2a:message-delivered:${envelope.messageId}`,
+      });
+
+      return { ok: true, messageId: envelope.messageId };
+    }
+
+    lastError = result.error;
+
+    // Non-transient failure — don't retry
+    if (!result.transient) {
+      log.warn(
+        { connectionId, messageId: envelope.messageId, error: result.error, status: result.status },
+        'A2A message delivery failed with permanent error',
+      );
+      break;
+    }
+
+    log.warn(
+      { connectionId, messageId: envelope.messageId, error: result.error, attempt, maxRetries: MAX_RETRIES },
+      'A2A message delivery failed with transient error',
+    );
+  }
+
+  // Dead-letter: emit message_failed lifecycle event
+  log.error(
+    { connectionId, messageId: envelope.messageId, error: lastError },
+    'A2A message delivery exhausted retries — dead-lettered',
+  );
+
+  void emitNotificationSignal({
+    sourceEventName: A2A_EVENT_NAMES.MESSAGE_FAILED,
+    sourceChannel: 'a2a',
+    sourceSessionId: connectionId,
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+    attentionHints: {
+      requiresAction: true,
+      urgency: 'medium',
+      isAsyncBackground: true,
+      visibleInSourceNow: false,
+    },
+    contextPayload: {
+      connectionId,
+      messageId: envelope.messageId,
+      error: lastError,
+    },
+    dedupeKey: `a2a:message-failed:${envelope.messageId}`,
+  });
+
+  return {
+    ok: false,
+    reason: 'delivery_failed',
+    error: lastError,
+  };
+}

--- a/assistant/src/a2a/a2a-peer-auth.ts
+++ b/assistant/src/a2a/a2a-peer-auth.ts
@@ -444,6 +444,7 @@ export function rotateCredentials(connectionId: string): RotateResult {
 
   const updated = updateConnectionCredentials(connectionId, {
     outboundCredentialHash: newCredentials.outboundCredentialHash,
+    outboundCredential: newCredentials.outboundCredential,
     inboundCredentialHash: newCredentials.inboundCredentialHash,
     inboundCredential: newCredentials.inboundCredential,
   });
@@ -484,6 +485,7 @@ export function revokeCredentials(connectionId: string): RevokeResult {
   // Tombstone the credentials by nullifying them
   updateConnectionCredentials(connectionId, {
     outboundCredentialHash: '',
+    outboundCredential: '',
     inboundCredentialHash: '',
     inboundCredential: '',
   });

--- a/assistant/src/a2a/a2a-peer-connection-store.ts
+++ b/assistant/src/a2a/a2a-peer-connection-store.ts
@@ -39,6 +39,7 @@ export interface A2APeerConnection {
   capabilities: string[];
   scopes: string[];
   outboundCredentialHash: string | null;
+  outboundCredential: string | null;
   inboundCredentialHash: string | null;
   inboundCredential: string | null;
   lastSeenAt: number | null;
@@ -66,6 +67,7 @@ function rowToConnection(row: typeof a2aPeerConnections.$inferSelect): A2APeerCo
     capabilities: JSON.parse(row.capabilities) as string[],
     scopes: JSON.parse(row.scopes) as string[],
     outboundCredentialHash: row.outboundCredentialHash,
+    outboundCredential: row.outboundCredential ?? null,
     inboundCredentialHash: row.inboundCredentialHash,
     inboundCredential: row.inboundCredential ?? null,
     lastSeenAt: row.lastSeenAt,
@@ -91,6 +93,7 @@ export function createConnection(params: {
   capabilities?: string[];
   scopes?: string[];
   outboundCredentialHash?: string;
+  outboundCredential?: string;
   inboundCredentialHash?: string;
   inboundCredential?: string;
   expiresAt?: number;
@@ -111,6 +114,7 @@ export function createConnection(params: {
     capabilities: JSON.stringify(params.capabilities ?? []),
     scopes: JSON.stringify(params.scopes ?? []),
     outboundCredentialHash: params.outboundCredentialHash ?? null,
+    outboundCredential: params.outboundCredential ?? null,
     inboundCredentialHash: params.inboundCredentialHash ?? null,
     inboundCredential: params.inboundCredential ?? null,
     lastSeenAt: null,
@@ -280,6 +284,7 @@ export function updateConnectionCredentials(
   connectionId: string,
   credentials: {
     outboundCredentialHash?: string;
+    outboundCredential?: string;
     inboundCredentialHash?: string;
     inboundCredential?: string;
   },
@@ -291,6 +296,9 @@ export function updateConnectionCredentials(
 
   if (credentials.outboundCredentialHash !== undefined) {
     setFields.outboundCredentialHash = credentials.outboundCredentialHash;
+  }
+  if (credentials.outboundCredential !== undefined) {
+    setFields.outboundCredential = credentials.outboundCredential;
   }
   if (credentials.inboundCredentialHash !== undefined) {
     setFields.inboundCredentialHash = credentials.inboundCredentialHash;

--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -66,6 +66,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "a2a-scope-policy",
+      "scope": "assistant",
+      "key": "feature_flags.a2a-scope-policy.enabled",
+      "label": "A2A Scope Policy",
+      "description": "Enable scoped autonomy policy for A2A messaging — required for outbound message delivery",
+      "defaultEnabled": false
+    },
+    {
       "id": "user-hosted-enabled",
       "scope": "macos",
       "key": "user_hosted_enabled",

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -2,6 +2,7 @@ import { getDb } from './db-connection.js';
 import {
   addCoreColumns,
   createA2APeerConnectionsTable,
+  migrateA2AOutboundCredential,
   createActorRefreshTokenRecordsTable,
   createActorTokenRecordsTable,
   createAssistantInboxTables,
@@ -192,6 +193,9 @@ export function initializeDb(): void {
 
   // 32. A2A peer connections (bidirectional assistant-to-assistant credentials and state)
   createA2APeerConnectionsTable(database);
+
+  // 33. A2A outbound credential column for HMAC signing of outbound messages
+  migrateA2AOutboundCredential(database);
 
   validateMigrationState(database);
 }

--- a/assistant/src/memory/migrations/129-a2a-outbound-credential.ts
+++ b/assistant/src/memory/migrations/129-a2a-outbound-credential.ts
@@ -1,0 +1,16 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Add outbound_credential column to a2a_peer_connections.
+ *
+ * Stores the raw outbound credential token that this assistant uses to
+ * HMAC-sign requests TO the peer. Previously only the hash was stored,
+ * but outbound message signing requires the raw credential.
+ */
+export function migrateA2AOutboundCredential(database: DrizzleDb): void {
+  try {
+    database.run(/*sql*/ `ALTER TABLE a2a_peer_connections ADD COLUMN outbound_credential TEXT`);
+  } catch {
+    // Column already exists — idempotent
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -70,6 +70,7 @@ export { migrateGuardianPrincipalIdColumns } from './125-guardian-principal-id-c
 export { migrateBackfillGuardianPrincipalId } from './126-backfill-guardian-principal-id.js';
 export { migrateGuardianPrincipalIdNotNull } from './127-guardian-principal-id-not-null.js';
 export { createA2APeerConnectionsTable } from './128-a2a-peer-connections.js';
+export { migrateA2AOutboundCredential } from './129-a2a-outbound-credential.js';
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -1223,6 +1223,7 @@ export const a2aPeerConnections = sqliteTable('a2a_peer_connections', {
   capabilities: text('capabilities').notNull().default('[]'),
   scopes: text('scopes').notNull().default('[]'),
   outboundCredentialHash: text('outbound_credential_hash'),
+  outboundCredential: text('outbound_credential'),
   inboundCredentialHash: text('inbound_credential_hash'),
   inboundCredential: text('inbound_credential'),
   lastSeenAt: integer('last_seen_at'),

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -184,6 +184,7 @@ import {
   handleA2AListConnections,
   handleA2ARedeem,
   handleA2ARevoke,
+  handleA2ASendMessage,
   handleA2AVerify,
 } from './routes/a2a-routes.js';
 import { handleA2AMessageInbound } from './routes/a2a-inbound-routes.js';
@@ -1346,6 +1347,12 @@ export class RuntimeHttpServer {
       const a2aConnectionStatusMatch = endpoint.match(/^a2a\/connections\/([^/]+)\/status$/);
       if (a2aConnectionStatusMatch && req.method === 'GET') {
         return handleA2AConnectionStatus(a2aConnectionStatusMatch[1]);
+      }
+
+      // A2A outbound message endpoint (assistant/skill -> runtime -> peer gateway)
+      const a2aSendMessageMatch = endpoint.match(/^a2a\/connections\/([^/]+)\/messages$/);
+      if (a2aSendMessageMatch && req.method === 'POST') {
+        return await handleA2ASendMessage(req, a2aSendMessageMatch[1]);
       }
 
       // A2A inbound message endpoint (gateway -> runtime)

--- a/assistant/src/runtime/routes/a2a-routes.ts
+++ b/assistant/src/runtime/routes/a2a-routes.ts
@@ -16,9 +16,11 @@ import {
   listConnectionsFiltered,
   redeemInvite,
   revokeConnection,
+  sendMessage,
   submitVerificationCode,
   A2A_PROTOCOL_VERSION,
 } from '../../a2a/a2a-connection-service.js';
+import type { A2AMessageContent } from '../../a2a/a2a-message-schema.js';
 import {
   a2aRateLimitResponse,
   codeVerificationLimiter,
@@ -335,4 +337,97 @@ export function handleA2AConnectionStatus(connectionId: string): Response {
     createdAt: connection.createdAt,
     updatedAt: connection.updatedAt,
   });
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/a2a/connections/:connectionId/messages — Send a message to a peer
+// ---------------------------------------------------------------------------
+
+export async function handleA2ASendMessage(req: Request, connectionId: string): Promise<Response> {
+  const body = await req.json() as Record<string, unknown>;
+
+  // Validate content
+  if (!body.content || typeof body.content !== 'object') {
+    return httpError('BAD_REQUEST', 'Missing required field: content', 400);
+  }
+
+  const content = body.content as Record<string, unknown>;
+  if (!content.type || typeof content.type !== 'string') {
+    return httpError('BAD_REQUEST', 'Missing required field: content.type', 400);
+  }
+
+  // Build the typed content object
+  let messageContent: A2AMessageContent;
+  switch (content.type) {
+    case 'text': {
+      if (typeof content.text !== 'string') {
+        return httpError('BAD_REQUEST', 'Missing required field: content.text for text content', 400);
+      }
+      messageContent = { type: 'text', text: content.text };
+      break;
+    }
+    case 'structured_request': {
+      if (typeof content.action !== 'string') {
+        return httpError('BAD_REQUEST', 'Missing required field: content.action for structured_request', 400);
+      }
+      const params = (typeof content.params === 'object' && content.params !== null)
+        ? content.params as Record<string, unknown>
+        : {};
+      messageContent = { type: 'structured_request', action: content.action, params };
+      break;
+    }
+    case 'structured_response': {
+      if (typeof content.action !== 'string') {
+        return httpError('BAD_REQUEST', 'Missing required field: content.action for structured_response', 400);
+      }
+      const result = (typeof content.result === 'object' && content.result !== null)
+        ? content.result as Record<string, unknown>
+        : {};
+      messageContent = {
+        type: 'structured_response',
+        action: content.action,
+        result,
+        success: content.success === true,
+        error: typeof content.error === 'string' ? content.error : undefined,
+      };
+      break;
+    }
+    default:
+      return httpError('BAD_REQUEST', `Unsupported content type: ${content.type}`, 400);
+  }
+
+  const correlationId = typeof body.correlationId === 'string' ? body.correlationId : undefined;
+
+  const sendResult = await sendMessage({
+    connectionId,
+    content: messageContent,
+    correlationId,
+  });
+
+  if (!sendResult.ok) {
+    const statusMap: Record<string, number> = {
+      not_found: 404,
+      not_active: 409,
+      not_enabled: 403,
+      no_credential: 500,
+      delivery_failed: 502,
+    };
+    const codeMap: Record<string, 'NOT_FOUND' | 'CONFLICT' | 'FORBIDDEN' | 'INTERNAL_ERROR' | 'SERVICE_UNAVAILABLE'> = {
+      not_found: 'NOT_FOUND',
+      not_active: 'CONFLICT',
+      not_enabled: 'FORBIDDEN',
+      no_credential: 'INTERNAL_ERROR',
+      delivery_failed: 'SERVICE_UNAVAILABLE',
+    };
+    return httpError(
+      codeMap[sendResult.reason] ?? 'INTERNAL_ERROR',
+      sendResult.detail ?? sendResult.reason,
+      statusMap[sendResult.reason] ?? 500,
+    );
+  }
+
+  return Response.json({
+    messageId: sendResult.messageId,
+    conversationId: sendResult.conversationId,
+  }, { status: 202 });
 }

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -66,6 +66,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "a2a-scope-policy",
+      "scope": "assistant",
+      "key": "feature_flags.a2a-scope-policy.enabled",
+      "label": "A2A Scope Policy",
+      "description": "Enable scoped autonomy policy for A2A messaging — required for outbound message delivery",
+      "defaultEnabled": false
+    },
+    {
       "id": "user-hosted-enabled",
       "scope": "macos",
       "key": "user_hosted_enabled",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -66,6 +66,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "a2a-scope-policy",
+      "scope": "assistant",
+      "key": "feature_flags.a2a-scope-policy.enabled",
+      "label": "A2A Scope Policy",
+      "description": "Enable scoped autonomy policy for A2A messaging — required for outbound message delivery",
+      "defaultEnabled": false
+    },
+    {
       "id": "user-hosted-enabled",
       "scope": "macos",
       "key": "user_hosted_enabled",


### PR DESCRIPTION
## Summary

- Add `sendMessage()` to `A2AConnectionService` with scope gating via `a2a-scope-policy` feature flag (returns `not_enabled` until M16 activates scope policy)
- Implement outbound delivery adapter (`a2a-outbound-delivery.ts`) with HMAC signing, exponential backoff retry (3 retries with jitter), dead-letter notification events, and URL validation
- Add conversation binding via `external_conversation_bindings` table using `getOrCreateConversation` for proper FK integrity
- Add runtime route `POST /v1/a2a/connections/:connectionId/messages` with content type validation (text, structured_request, structured_response)
- Add `a2a-scope-policy` feature flag to all three registries (meta, assistant, gateway) with `defaultEnabled: false`
- Store raw outbound credential in DB (new migration 129) for HMAC request signing
- Add comprehensive tests covering scope gating, connection validation, conversation binding, URL validation, dead-letter emission, and message construction

## Test plan

- [x] All 12 tests in `a2a-outbound-delivery.test.ts` pass
- [x] Scope gating returns `not_enabled` when `a2a-scope-policy` flag is off
- [x] Scope gating proceeds when flag is on
- [x] Connection validation rejects missing, pending, and revoked connections
- [x] Missing outbound credential returns `no_credential`
- [x] Conversation binding is created on first send with proper FK target
- [x] HTTP rejected for public targets, HTTPS allowed
- [x] Dead-letter notification emitted after retries exhausted
- [x] Pre-existing type errors on base branch are not introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
