### PR TITLE
fix: remove console.log from McpClient, use structured logger

### DIFF
--- a/assistant/src/cli/mcp.ts
+++ b/assistant/src/cli/mcp.ts
@@ -15,7 +15,7 @@ const log = getCliLogger('cli');
 export const HEALTH_CHECK_TIMEOUT_MS = 10_000;
 
 export async function checkServerHealth(serverId: string, config: McpServerConfig, timeoutMs = HEALTH_CHECK_TIMEOUT_MS): Promise<string> {
-  const client = new McpClient(serverId, { quiet: true });
+  const client = new McpClient(serverId);
   try {
     await Promise.race([
       client.connect(config.transport),

--- a/assistant/src/mcp/client.ts
+++ b/assistant/src/mcp/client.ts
@@ -30,15 +30,13 @@ export class McpClient {
   private transport: StdioClientTransport | SSEClientTransport | StreamableHTTPClientTransport | null = null;
   private connected = false;
   private oauthProvider: McpOAuthProvider | null = null;
-  private quiet: boolean;
 
   get isConnected(): boolean {
     return this.connected;
   }
 
-  constructor(serverId: string, opts?: { quiet?: boolean }) {
+  constructor(serverId: string) {
     this.serverId = serverId;
-    this.quiet = opts?.quiet ?? false;
     this.client = new Client({
       name: 'vellum-assistant',
       version: '1.0.0',
@@ -61,7 +59,7 @@ export class McpClient {
       }
     }
 
-    if (!this.quiet) console.log(`[MCP] Connecting to server "${this.serverId}"...`);
+    log.info({ serverId: this.serverId }, 'Connecting to MCP server');
     this.transport = this.createTransport(transportConfig);
 
     try {
@@ -82,13 +80,11 @@ export class McpClient {
         if (isAuthError) {
           // Auth-related — user can run `vellum mcp auth <name>` to authenticate.
           log.info({ serverId: this.serverId, err }, 'MCP server requires authentication');
-          if (!this.quiet) console.log(`[MCP] Server "${this.serverId}" requires authentication. Run "vellum mcp auth ${this.serverId}" to authenticate.`);
           return;
         }
 
         // Non-auth error (DNS, TLS, timeout, etc.) — log and re-throw
         log.error({ serverId: this.serverId, err }, 'MCP server connection failed');
-        if (!this.quiet) console.error(`[MCP] Server "${this.serverId}" connection failed: ${err instanceof Error ? err.message : err}`);
         throw err;
       }
 
@@ -96,7 +92,6 @@ export class McpClient {
     }
 
     this.connected = true;
-    if (!this.quiet) console.log(`[MCP] Server "${this.serverId}" connected successfully`);
     log.info({ serverId: this.serverId }, 'MCP client connected');
   }
 


### PR DESCRIPTION
## Summary
- Remove `console.log`/`console.error` calls from `McpClient.connect()` — these were duplicating existing structured `log.info`/`log.error` calls
- Remove the now-unused `quiet` constructor option and its single caller in `checkServerHealth`

## Original prompt
remove console.log here assistant/src/mcp/client.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
