### PR TITLE
refactor: move heartbeat runs into modal with icon controls

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -66,6 +66,7 @@ struct SettingsPanel: View {
     @State private var showingReminders = false
     @State private var showingScheduledTasks = false
     @State private var showingHeartbeatConfig = false
+    @State private var showingHeartbeatRuns = false
     @State private var twitterClientId: String = ""
     @State private var twitterClientSecret: String = ""
     @State private var integrations: [IPCIntegrationListResponseIntegration] = []
@@ -218,6 +219,11 @@ struct SettingsPanel: View {
                 HeartbeatConfigView(daemonClient: daemonClient)
             }
         }
+        .sheet(isPresented: $showingHeartbeatRuns) {
+            if let daemonClient {
+                HeartbeatRunsView(daemonClient: daemonClient)
+            }
+        }
     }
 
     // MARK: - Nav Sidebar
@@ -250,7 +256,7 @@ struct SettingsPanel: View {
         case .permissions:
             permissionsContent
         case .automation:
-            SettingsAutomationTab(daemonClient: daemonClient, showingReminders: $showingReminders, showingScheduledTasks: $showingScheduledTasks, showingHeartbeatConfig: $showingHeartbeatConfig)
+            SettingsAutomationTab(daemonClient: daemonClient, showingReminders: $showingReminders, showingScheduledTasks: $showingScheduledTasks, showingHeartbeatConfig: $showingHeartbeatConfig, showingHeartbeatRuns: $showingHeartbeatRuns)
         case .appearance:
             SettingsAppearanceTab(store: store)
         case .privacy:

--- a/clients/macos/vellum-assistant/Features/Settings/HeartbeatRunsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/HeartbeatRunsView.swift
@@ -9,6 +9,8 @@ struct HeartbeatRunsView: View {
     @State private var isRunning: Bool = false
     @State private var runError: String?
     @State private var expandedRunId: String?
+    @State private var previousRunNowCallback: ((IPCHeartbeatRunNowResponse) -> Void)?
+    @State private var previousRunsListCallback: ((IPCHeartbeatRunsListResponse) -> Void)?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -181,6 +183,9 @@ struct HeartbeatRunsView: View {
     }
 
     private func setupCallbacks() {
+        previousRunsListCallback = daemonClient.onHeartbeatRunsListResponse
+        previousRunNowCallback = daemonClient.onHeartbeatRunNowResponse
+
         daemonClient.onHeartbeatRunsListResponse = { response in
             Task { @MainActor in
                 self.runs = response.runs
@@ -199,7 +204,7 @@ struct HeartbeatRunsView: View {
     }
 
     private func clearCallbacks() {
-        daemonClient.onHeartbeatRunsListResponse = nil
-        daemonClient.onHeartbeatRunNowResponse = nil
+        daemonClient.onHeartbeatRunsListResponse = previousRunsListCallback
+        daemonClient.onHeartbeatRunNowResponse = previousRunNowCallback
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/HeartbeatRunsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/HeartbeatRunsView.swift
@@ -1,0 +1,205 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct HeartbeatRunsView: View {
+    let daemonClient: DaemonClient
+    @Environment(\.dismiss) var dismiss
+
+    @State private var runs: [IPCHeartbeatRunsListResponseRun] = []
+    @State private var isRunning: Bool = false
+    @State private var runError: String?
+    @State private var expandedRunId: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("Heartbeat Runs")
+                    .font(VFont.headline)
+                    .foregroundColor(VColor.textPrimary)
+                Spacer()
+                if isRunning {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Running...")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                } else {
+                    VIconButton(label: "Run Now", icon: "play.fill", tooltip: "Run Now") {
+                        triggerRun()
+                    }
+                }
+                VButton(label: "Done", style: .tertiary) { dismiss() }
+            }
+            .padding(VSpacing.lg)
+
+            Divider().background(VColor.surfaceBorder)
+
+            if let error = runError {
+                Text(error)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
+                    .padding(.horizontal, VSpacing.lg)
+                    .padding(.top, VSpacing.sm)
+            }
+
+            if runs.isEmpty {
+                Spacer()
+                VStack(spacing: VSpacing.sm) {
+                    Image(systemName: "clock.arrow.circlepath")
+                        .font(.largeTitle)
+                        .foregroundColor(VColor.textMuted)
+                    Text("No heartbeat runs yet")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textMuted)
+                }
+                Spacer()
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        ForEach(runs, id: \.id) { run in
+                            VStack(alignment: .leading, spacing: 0) {
+                                Button {
+                                    withAnimation(VAnimation.fast) {
+                                        expandedRunId = expandedRunId == run.id ? nil : run.id
+                                    }
+                                } label: {
+                                    HStack(spacing: VSpacing.md) {
+                                        resultBadge(run.result)
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            Text(run.title)
+                                                .font(VFont.body)
+                                                .foregroundColor(VColor.textPrimary)
+                                                .lineLimit(1)
+                                            Text(formatTimestamp(run.createdAt))
+                                                .font(VFont.caption)
+                                                .foregroundColor(VColor.textMuted)
+                                        }
+                                        Spacer()
+                                        Image(systemName: expandedRunId == run.id ? "chevron.down" : "chevron.right")
+                                            .font(.system(size: 10, weight: .semibold))
+                                            .foregroundColor(VColor.textMuted)
+                                    }
+                                    .padding(VSpacing.sm)
+                                    .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+
+                                if expandedRunId == run.id {
+                                    Text(run.summary?.isEmpty == false ? run.summary! : "No summary available")
+                                        .font(VFont.mono)
+                                        .foregroundColor(VColor.textSecondary)
+                                        .textSelection(.enabled)
+                                        .padding(VSpacing.sm)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .background(VColor.surface)
+                                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                                        .overlay(
+                                            RoundedRectangle(cornerRadius: VRadius.md)
+                                                .stroke(VColor.surfaceBorder, lineWidth: 1)
+                                        )
+                                        .padding(.horizontal, VSpacing.sm)
+                                        .padding(.bottom, VSpacing.sm)
+                                }
+                            }
+
+                            if run.id != runs.last?.id {
+                                Divider().background(VColor.surfaceBorder)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, VSpacing.lg)
+                    .padding(.vertical, VSpacing.sm)
+                }
+            }
+        }
+        .frame(width: 500, height: 450)
+        .background(VColor.background)
+        .onAppear { setupCallbacks(); loadRuns() }
+        .onDisappear { clearCallbacks() }
+    }
+
+    // MARK: - Helpers
+
+    private func resultBadge(_ result: String) -> some View {
+        Group {
+            switch result {
+            case "ok":
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(VColor.success)
+                    Text("OK")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.success)
+                }
+            case "alert":
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(VColor.warning)
+                    Text("ALERT")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.warning)
+                }
+            default:
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "questionmark.circle")
+                        .foregroundColor(VColor.textMuted)
+                    Text("--")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
+        }
+        .frame(width: 70, alignment: .leading)
+    }
+
+    private func formatTimestamp(_ ms: Int) -> String {
+        let date = Date(timeIntervalSince1970: Double(ms) / 1000.0)
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+
+    // MARK: - Actions
+
+    private func triggerRun() {
+        isRunning = true
+        runError = nil
+        do {
+            try daemonClient.sendHeartbeatRunNow()
+        } catch {
+            isRunning = false
+            runError = "Failed to send run request"
+        }
+    }
+
+    // MARK: - Data Loading
+
+    private func loadRuns() {
+        try? daemonClient.sendHeartbeatRunsList(limit: 20)
+    }
+
+    private func setupCallbacks() {
+        daemonClient.onHeartbeatRunsListResponse = { response in
+            Task { @MainActor in
+                self.runs = response.runs
+            }
+        }
+        daemonClient.onHeartbeatRunNowResponse = { response in
+            Task { @MainActor in
+                self.isRunning = false
+                if !response.success {
+                    self.runError = response.error ?? "Run failed"
+                } else {
+                    try? self.daemonClient.sendHeartbeatRunsList(limit: 20)
+                }
+            }
+        }
+    }
+
+    private func clearCallbacks() {
+        daemonClient.onHeartbeatRunsListResponse = nil
+        daemonClient.onHeartbeatRunNowResponse = nil
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAutomationTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAutomationTab.swift
@@ -8,6 +8,7 @@ struct SettingsAutomationTab: View {
     @Binding var showingReminders: Bool
     @Binding var showingScheduledTasks: Bool
     @Binding var showingHeartbeatConfig: Bool
+    @Binding var showingHeartbeatRuns: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
@@ -61,7 +62,7 @@ struct SettingsAutomationTab: View {
             }
 
             // Heartbeat section (checklist + runs, minus configCard)
-            HeartbeatAutomationSection(daemonClient: daemonClient, showingHeartbeatConfig: $showingHeartbeatConfig)
+            HeartbeatAutomationSection(daemonClient: daemonClient, showingHeartbeatConfig: $showingHeartbeatConfig, showingHeartbeatRuns: $showingHeartbeatRuns)
         }
     }
 }
@@ -75,23 +76,19 @@ struct SettingsAutomationTab: View {
 struct HeartbeatAutomationSection: View {
     var daemonClient: DaemonClient?
     @Binding var showingHeartbeatConfig: Bool
+    @Binding var showingHeartbeatRuns: Bool
 
     // -- Checklist state --
     @State private var checklistContent: String = ""
     @State private var isDefaultChecklist: Bool = true
 
-    // -- Runs state --
-    @State private var runs: [IPCHeartbeatRunsListResponseRun] = []
+    // -- Run now state --
     @State private var isRunning: Bool = false
     @State private var runError: String?
-
-    // -- Expansion state --
-    @State private var expandedRunId: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
             checklistCard
-            runsCard
         }
         .onAppear { setupCallbacks(); loadAll() }
         .onDisappear { clearCallbacks() }
@@ -111,9 +108,26 @@ struct HeartbeatAutomationSection: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.textMuted)
                 }
-                VIconButton(label: "Config", icon: "gearshape", iconOnly: true) {
+                if isRunning {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    VIconButton(label: "Run Now", icon: "play.fill", iconOnly: true, tooltip: "Run Now") {
+                        triggerRun()
+                    }
+                }
+                VIconButton(label: "History", icon: "clock.arrow.circlepath", iconOnly: true, tooltip: "History") {
+                    showingHeartbeatRuns = true
+                }
+                VIconButton(label: "Config", icon: "gearshape", iconOnly: true, tooltip: "Config") {
                     showingHeartbeatConfig = true
                 }
+            }
+
+            if let error = runError {
+                Text(error)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
             }
 
             Text("Items the heartbeat checks on each run")
@@ -141,157 +155,28 @@ struct HeartbeatAutomationSection: View {
         .vCard(background: VColor.surfaceSubtle)
     }
 
-    // MARK: - Recent Runs Card
+    // MARK: - Actions
 
-    private var runsCard: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            HStack {
-                Text("Heartbeat Runs")
-                    .font(VFont.sectionTitle)
-                    .foregroundColor(VColor.textPrimary)
-                Spacer()
-                if isRunning {
-                    ProgressView()
-                        .controlSize(.small)
-                    Text("Running...")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                } else {
-                    VButton(label: "Run Now", style: .primary, size: .large) {
-                        isRunning = true
-                        runError = nil
-                        guard let client = daemonClient else {
-                            isRunning = false
-                            runError = "Daemon not available"
-                            return
-                        }
-                        do {
-                            try client.sendHeartbeatRunNow()
-                        } catch {
-                            isRunning = false
-                            runError = "Failed to send run request"
-                        }
-                    }
-                }
-            }
-
-            if let error = runError {
-                Text(error)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.error)
-            }
-
-            if runs.isEmpty {
-                Text("No heartbeat runs yet")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .padding(.vertical, VSpacing.lg)
-            } else {
-                ForEach(runs, id: \.id) { run in
-                    VStack(alignment: .leading, spacing: 0) {
-                        Button {
-                            withAnimation(VAnimation.fast) {
-                                expandedRunId = expandedRunId == run.id ? nil : run.id
-                            }
-                        } label: {
-                            HStack(spacing: VSpacing.md) {
-                                resultBadge(run.result)
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(run.title)
-                                        .font(VFont.body)
-                                        .foregroundColor(VColor.textPrimary)
-                                        .lineLimit(1)
-                                    Text(formatTimestamp(run.createdAt))
-                                        .font(VFont.caption)
-                                        .foregroundColor(VColor.textMuted)
-                                }
-                                Spacer()
-                                Image(systemName: expandedRunId == run.id ? "chevron.down" : "chevron.right")
-                                    .font(.system(size: 10, weight: .semibold))
-                                    .foregroundColor(VColor.textMuted)
-                            }
-                            .padding(VSpacing.sm)
-                            .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-
-                        if expandedRunId == run.id {
-                            Text(run.summary?.isEmpty == false ? run.summary! : "No summary available")
-                                .font(VFont.mono)
-                                .foregroundColor(VColor.textSecondary)
-                                .textSelection(.enabled)
-                                .padding(VSpacing.sm)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .background(VColor.surface)
-                                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: VRadius.md)
-                                        .stroke(VColor.surfaceBorder, lineWidth: 1)
-                                )
-                                .padding(.horizontal, VSpacing.sm)
-                                .padding(.bottom, VSpacing.sm)
-                        }
-                    }
-
-                    if run.id != runs.last?.id {
-                        Divider().background(VColor.surfaceBorder)
-                    }
-                }
-            }
+    private func triggerRun() {
+        isRunning = true
+        runError = nil
+        guard let client = daemonClient else {
+            isRunning = false
+            runError = "Daemon not available"
+            return
         }
-        .padding(VSpacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceSubtle)
-    }
-
-    // MARK: - Helpers
-
-    private func resultBadge(_ result: String) -> some View {
-        Group {
-            switch result {
-            case "ok":
-                HStack(spacing: VSpacing.xs) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(VColor.success)
-                    Text("OK")
-                        .font(VFont.captionMedium)
-                        .foregroundColor(VColor.success)
-                }
-            case "alert":
-                HStack(spacing: VSpacing.xs) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundColor(VColor.warning)
-                    Text("ALERT")
-                        .font(VFont.captionMedium)
-                        .foregroundColor(VColor.warning)
-                }
-            default:
-                HStack(spacing: VSpacing.xs) {
-                    Image(systemName: "questionmark.circle")
-                        .foregroundColor(VColor.textMuted)
-                    Text("--")
-                        .font(VFont.captionMedium)
-                        .foregroundColor(VColor.textMuted)
-                }
-            }
+        do {
+            try client.sendHeartbeatRunNow()
+        } catch {
+            isRunning = false
+            runError = "Failed to send run request"
         }
-        .frame(width: 70, alignment: .leading)
-    }
-
-    private func formatTimestamp(_ ms: Int) -> String {
-        let date = Date(timeIntervalSince1970: Double(ms) / 1000.0)
-        let formatter = DateFormatter()
-        formatter.dateStyle = .short
-        formatter.timeStyle = .short
-        return formatter.string(from: date)
     }
 
     // MARK: - Data Loading
 
     private func loadAll() {
         try? daemonClient?.sendHeartbeatChecklistRead()
-        try? daemonClient?.sendHeartbeatRunsList(limit: 20)
     }
 
     private func setupCallbacks() {
@@ -301,19 +186,11 @@ struct HeartbeatAutomationSection: View {
                 self.isDefaultChecklist = response.isDefault
             }
         }
-        daemonClient?.onHeartbeatRunsListResponse = { response in
-            Task { @MainActor in
-                self.runs = response.runs
-            }
-        }
         daemonClient?.onHeartbeatRunNowResponse = { response in
             Task { @MainActor in
                 self.isRunning = false
                 if !response.success {
                     self.runError = response.error ?? "Run failed"
-                } else {
-                    // Refresh the runs list after a successful run
-                    try? self.daemonClient?.sendHeartbeatRunsList(limit: 20)
                 }
             }
         }
@@ -321,7 +198,6 @@ struct HeartbeatAutomationSection: View {
 
     private func clearCallbacks() {
         daemonClient?.onHeartbeatChecklistResponse = nil
-        daemonClient?.onHeartbeatRunsListResponse = nil
         daemonClient?.onHeartbeatRunNowResponse = nil
     }
 }


### PR DESCRIPTION
## Summary
- Moved the inline Heartbeat Runs list into a dedicated `HeartbeatRunsView` sheet modal (consistent with `HeartbeatConfigView`)
- Replaced the "Run Now" button with a play icon in the checklist card header
- Added a history (clock) icon to open the runs modal
- The checklist card header now has 3 icons: play, history, config (gear)

## Test plan
- [ ] Verify the 3 icons appear in the Heartbeat Checklist card header
- [ ] Verify clicking the play icon triggers a heartbeat run
- [ ] Verify clicking the clock icon opens the Heartbeat Runs modal
- [ ] Verify clicking the gear icon still opens the config modal
- [ ] Verify the runs modal shows run history with expandable details

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
