### PR TITLE
M17: Guardian scope management + revocation flows

### DIFF
--- a/assistant/src/a2a/__tests__/a2a-scope-management.test.ts
+++ b/assistant/src/a2a/__tests__/a2a-scope-management.test.ts
@@ -1,0 +1,481 @@
+/**
+ * Tests for A2A scope management via A2AConnectionService:
+ *   - updateScopes() with valid/invalid scopes
+ *   - getScopes() returns current scopes
+ *   - Notification signal emission on scope changes
+ *   - Immediate enforcement after scope update
+ *   - Audit logging on scope changes
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'a2a-scope-management-test-'));
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before any import that touches mocked modules.
+// ---------------------------------------------------------------------------
+
+mock.module('../../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+// Capture log calls for audit verification
+const logCalls: Array<{ level: string; args: unknown[] }> = [];
+
+mock.module('../../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: (_target, prop) => (...args: unknown[]) => {
+        logCalls.push({ level: String(prop), args });
+      },
+    }),
+}));
+
+// Capture notification signals for verification
+const emittedSignals: Array<Record<string, unknown>> = [];
+
+mock.module('../../notifications/emit-signal.js', () => ({
+  emitNotificationSignal: async (params: Record<string, unknown>) => {
+    emittedSignals.push(params);
+    return {
+      signalId: 'test-signal',
+      deduplicated: false,
+      dispatched: true,
+      reason: 'ok',
+      deliveryResults: [],
+    };
+  },
+}));
+
+// Control scope policy flag per test
+let scopePolicyEnabled = true;
+mock.module('../../config/assistant-feature-flags.js', () => ({
+  isAssistantFeatureFlagEnabled: (key: string) => {
+    if (key === 'feature_flags.a2a-scope-policy.enabled') return scopePolicyEnabled;
+    return true;
+  },
+  loadDefaultsRegistry: () => ({}),
+}));
+
+mock.module('../../config/loader.js', () => ({
+  getConfig: () => ({
+    assistantFeatureFlagValues: {},
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import {
+  updateScopes,
+  getScopes,
+  sendMessage,
+  _resetHandshakeSessions,
+  _resetIdempotencyStore,
+} from '../a2a-connection-service.js';
+
+import {
+  createConnection,
+  getConnection,
+  updateConnectionCredentials,
+} from '../a2a-peer-connection-store.js';
+
+import { generateCredentialPair } from '../a2a-peer-auth.js';
+import { evaluateScope } from '../a2a-scope-policy.js';
+import { getDb, initializeDb, resetDb } from '../../memory/db.js';
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run('DELETE FROM a2a_peer_connections');
+  db.run('DELETE FROM assistant_ingress_invites');
+  db.run('DELETE FROM external_conversation_bindings');
+}
+
+/** Create an active connection with valid credentials and optionally granted scopes. */
+function createActiveConnection(overrides?: { scopes?: string[]; peerGatewayUrl?: string; peerAssistantId?: string }) {
+  const credentials = generateCredentialPair();
+  const conn = createConnection({
+    peerGatewayUrl: overrides?.peerGatewayUrl ?? 'https://peer.example.com',
+    peerAssistantId: overrides?.peerAssistantId ?? 'peer-001',
+    status: 'active',
+    scopes: overrides?.scopes,
+  });
+  updateConnectionCredentials(conn.id, {
+    outboundCredentialHash: credentials.outboundCredentialHash,
+    outboundCredential: credentials.outboundCredential,
+    inboundCredentialHash: credentials.inboundCredentialHash,
+    inboundCredential: credentials.inboundCredential,
+  });
+  return { connection: getConnection(conn.id)!, credentials };
+}
+
+// ===========================================================================
+// updateScopes Tests
+// ===========================================================================
+
+describe('updateScopes', () => {
+  beforeEach(() => {
+    resetTables();
+    _resetHandshakeSessions();
+    _resetIdempotencyStore();
+    emittedSignals.length = 0;
+    logCalls.length = 0;
+    scopePolicyEnabled = true;
+  });
+
+  afterAll(() => {
+    resetDb();
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  test('updates scopes with valid scope IDs', () => {
+    const { connection } = createActiveConnection({ scopes: ['message'] });
+
+    const result = updateScopes({
+      connectionId: connection.id,
+      scopes: ['message', 'read_profile', 'read_availability'],
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.previousScopes).toEqual(['message']);
+      expect(result.newScopes).toEqual(['message', 'read_profile', 'read_availability']);
+      expect(result.connection.scopes).toEqual(['message', 'read_profile', 'read_availability']);
+    }
+  });
+
+  test('rejects invalid/undeclared scope IDs', () => {
+    const { connection } = createActiveConnection({ scopes: ['message'] });
+
+    const result = updateScopes({
+      connectionId: connection.id,
+      scopes: ['message', 'fake_scope', 'another_fake'],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('invalid_scopes');
+      expect(result.detail).toContain('fake_scope');
+      expect(result.detail).toContain('another_fake');
+    }
+
+    // Original scopes unchanged
+    const current = getConnection(connection.id);
+    expect(current!.scopes).toEqual(['message']);
+  });
+
+  test('returns not_found for nonexistent connection', () => {
+    const result = updateScopes({
+      connectionId: 'nonexistent-id',
+      scopes: ['message'],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('not_found');
+    }
+  });
+
+  test('returns not_active for revoked connection', () => {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://peer.example.com',
+      status: 'revoked',
+    });
+
+    const result = updateScopes({
+      connectionId: conn.id,
+      scopes: ['message'],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('not_active');
+    }
+  });
+
+  test('returns not_active for pending connection', () => {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://peer.example.com',
+      status: 'pending',
+    });
+
+    const result = updateScopes({
+      connectionId: conn.id,
+      scopes: ['message'],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('not_active');
+    }
+  });
+
+  test('allows setting empty scopes (revoke all)', () => {
+    const { connection } = createActiveConnection({ scopes: ['message', 'read_profile'] });
+
+    const result = updateScopes({
+      connectionId: connection.id,
+      scopes: [],
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.previousScopes).toEqual(['message', 'read_profile']);
+      expect(result.newScopes).toEqual([]);
+      expect(result.connection.scopes).toEqual([]);
+    }
+  });
+
+  test('allows setting all 5 catalog scopes', () => {
+    const { connection } = createActiveConnection({ scopes: [] });
+
+    const allScopes = ['message', 'read_availability', 'create_events', 'read_profile', 'execute_requests'];
+    const result = updateScopes({
+      connectionId: connection.id,
+      scopes: allScopes,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.newScopes).toEqual(allScopes);
+    }
+  });
+
+  // ---- Notification signal emission ----
+
+  test('emits a2a.scopes_changed notification signal', () => {
+    const { connection } = createActiveConnection({ scopes: ['message'] });
+
+    updateScopes({
+      connectionId: connection.id,
+      scopes: ['message', 'read_profile'],
+    });
+
+    const scopeSignal = emittedSignals.find(
+      (s) => s.sourceEventName === 'a2a.scopes_changed',
+    );
+    expect(scopeSignal).toBeDefined();
+    expect(scopeSignal!.sourceChannel).toBe('a2a');
+    expect(scopeSignal!.sourceSessionId).toBe(connection.id);
+
+    const payload = scopeSignal!.contextPayload as Record<string, unknown>;
+    expect(payload.connectionId).toBe(connection.id);
+    expect(payload.previousScopes).toEqual(['message']);
+    expect(payload.newScopes).toEqual(['message', 'read_profile']);
+    expect(payload.peerAssistantId).toBe('peer-001');
+    expect(typeof payload.timestamp).toBe('number');
+  });
+
+  test('does not emit notification signal on failure', () => {
+    emittedSignals.length = 0;
+
+    updateScopes({
+      connectionId: 'nonexistent-id',
+      scopes: ['message'],
+    });
+
+    const scopeSignal = emittedSignals.find(
+      (s) => s.sourceEventName === 'a2a.scopes_changed',
+    );
+    expect(scopeSignal).toBeUndefined();
+  });
+
+  // ---- Audit logging ----
+
+  test('logs scope change for audit', () => {
+    const { connection } = createActiveConnection({
+      scopes: ['message'],
+      peerAssistantId: 'peer-audit-test',
+    });
+    logCalls.length = 0;
+
+    updateScopes({
+      connectionId: connection.id,
+      scopes: ['message', 'read_profile'],
+    });
+
+    const infoLogs = logCalls.filter((c) => c.level === 'info');
+    const auditLog = infoLogs.find((c) => {
+      const msg = c.args[1];
+      return typeof msg === 'string' && msg.includes('scope change');
+    });
+    expect(auditLog).toBeDefined();
+
+    const logData = auditLog!.args[0] as Record<string, unknown>;
+    expect(logData.connectionId).toBe(connection.id);
+    expect(logData.peerAssistantId).toBe('peer-audit-test');
+    expect(logData.previousScopes).toEqual(['message']);
+    expect(logData.newScopes).toEqual(['message', 'read_profile']);
+    expect(typeof logData.timestamp).toBe('number');
+  });
+
+  // ---- Immediate enforcement ----
+
+  test('scope narrowing is immediately enforced on next scope check', () => {
+    const { connection } = createActiveConnection({ scopes: ['message', 'read_profile'] });
+
+    // Before narrowing: message scope is allowed
+    let evalResult = evaluateScope(getConnection(connection.id)!.scopes, 'sendMessage');
+    expect(evalResult.allowed).toBe(true);
+
+    // Narrow scopes: remove message
+    const result = updateScopes({
+      connectionId: connection.id,
+      scopes: ['read_profile'],
+    });
+    expect(result.ok).toBe(true);
+
+    // After narrowing: message scope is denied (read from store)
+    evalResult = evaluateScope(getConnection(connection.id)!.scopes, 'sendMessage');
+    expect(evalResult.allowed).toBe(false);
+  });
+
+  test('scope widening is immediately enforced on next scope check', () => {
+    const { connection } = createActiveConnection({ scopes: ['read_profile'] });
+
+    // Before widening: message scope is denied
+    let evalResult = evaluateScope(getConnection(connection.id)!.scopes, 'sendMessage');
+    expect(evalResult.allowed).toBe(false);
+
+    // Widen scopes: add message
+    const result = updateScopes({
+      connectionId: connection.id,
+      scopes: ['read_profile', 'message'],
+    });
+    expect(result.ok).toBe(true);
+
+    // After widening: message scope is allowed
+    evalResult = evaluateScope(getConnection(connection.id)!.scopes, 'sendMessage');
+    expect(evalResult.allowed).toBe(true);
+  });
+
+  test('revoking all scopes immediately blocks sendMessage', async () => {
+    scopePolicyEnabled = true;
+    const { connection } = createActiveConnection({ scopes: ['message'] });
+
+    // Revoke all scopes
+    const result = updateScopes({
+      connectionId: connection.id,
+      scopes: [],
+    });
+    expect(result.ok).toBe(true);
+
+    // sendMessage should fail with scope_denied
+    const sendResult = await sendMessage({
+      connectionId: connection.id,
+      content: { type: 'text', text: 'should be blocked' },
+    });
+
+    expect(sendResult.ok).toBe(false);
+    if (!sendResult.ok) {
+      expect(sendResult.reason).toBe('scope_denied');
+    }
+  });
+});
+
+// ===========================================================================
+// getScopes Tests
+// ===========================================================================
+
+describe('getScopes', () => {
+  beforeEach(() => {
+    resetTables();
+    _resetHandshakeSessions();
+    _resetIdempotencyStore();
+  });
+
+  afterAll(() => {
+    resetDb();
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  test('returns current scopes for active connection', () => {
+    const { connection } = createActiveConnection({ scopes: ['message', 'read_profile'] });
+
+    const result = getScopes({ connectionId: connection.id });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.scopes).toEqual(['message', 'read_profile']);
+      expect(result.connectionId).toBe(connection.id);
+    }
+  });
+
+  test('returns empty array when no scopes are set', () => {
+    const { connection } = createActiveConnection({ scopes: [] });
+
+    const result = getScopes({ connectionId: connection.id });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.scopes).toEqual([]);
+    }
+  });
+
+  test('returns not_found for nonexistent connection', () => {
+    const result = getScopes({ connectionId: 'nonexistent-id' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('not_found');
+    }
+  });
+
+  test('returns not_active for non-active connection', () => {
+    const conn = createConnection({
+      peerGatewayUrl: 'https://peer.example.com',
+      status: 'revoked',
+      scopes: ['message'],
+    });
+
+    const result = getScopes({ connectionId: conn.id });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('not_active');
+    }
+  });
+
+  test('reflects updated scopes after updateScopes()', () => {
+    const { connection } = createActiveConnection({ scopes: ['message'] });
+
+    // Update scopes
+    updateScopes({
+      connectionId: connection.id,
+      scopes: ['message', 'create_events'],
+    });
+
+    // getScopes should reflect the change
+    const result = getScopes({ connectionId: connection.id });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.scopes).toEqual(['message', 'create_events']);
+    }
+  });
+});

--- a/assistant/src/a2a/a2a-connection-service.ts
+++ b/assistant/src/a2a/a2a-connection-service.ts
@@ -16,6 +16,7 @@ import {
   getConnection,
   listConnections as storeListConnections,
   updateConnectionCredentials,
+  updateConnectionScopes as storeUpdateConnectionScopes,
   updateConnectionStatus,
   type A2APeerConnection,
   type A2APeerConnectionStatus,
@@ -129,6 +130,14 @@ export type ListConnectionsResult = {
 export type SendMessageResult =
   | { ok: true; messageId: string; conversationId: string }
   | { ok: false; reason: 'not_found' | 'not_active' | 'not_enabled' | 'no_credential' | 'delivery_failed' | 'scope_denied'; detail?: string };
+
+export type UpdateScopesResult =
+  | { ok: true; previousScopes: string[]; newScopes: string[]; connection: A2APeerConnection }
+  | { ok: false; reason: 'not_found' | 'not_active' | 'invalid_scopes'; detail?: string };
+
+export type GetScopesResult =
+  | { ok: true; scopes: string[]; connectionId: string }
+  | { ok: false; reason: 'not_found' | 'not_active' };
 
 // ---------------------------------------------------------------------------
 // Invite code encoding/decoding
@@ -1004,4 +1013,112 @@ export async function sendMessage(params: {
   }
 
   return { ok: true, messageId: result.messageId, conversationId };
+}
+
+// ---------------------------------------------------------------------------
+// Scope management
+// ---------------------------------------------------------------------------
+
+/**
+ * Update the granted scopes for an A2A connection.
+ *
+ * Validates the connection exists and is active, validates all scope IDs
+ * against the catalog, updates the store, emits an `a2a.scopes_changed`
+ * lifecycle event, and logs the change for audit.
+ *
+ * Scope narrowing (removing a scope) takes effect immediately — the next
+ * inbound request from the peer is evaluated against the new scopes because
+ * the policy engine reads from the store on each request.
+ */
+export function updateScopes(params: {
+  connectionId: string;
+  scopes: string[];
+}): UpdateScopesResult {
+  const connection = getConnection(params.connectionId);
+  if (!connection) {
+    return { ok: false, reason: 'not_found' };
+  }
+
+  if (connection.status !== 'active') {
+    return { ok: false, reason: 'not_active', detail: `Connection status is ${connection.status}` };
+  }
+
+  const previousScopes = [...connection.scopes];
+
+  const storeResult = storeUpdateConnectionScopes(params.connectionId, params.scopes);
+
+  if (!storeResult.ok) {
+    if (storeResult.reason === 'invalid_scopes') {
+      return { ok: false, reason: 'invalid_scopes', detail: storeResult.detail };
+    }
+    return { ok: false, reason: 'not_found' };
+  }
+
+  const now = Date.now();
+
+  // Audit log: record the scope change with before/after state
+  log.info(
+    {
+      connectionId: params.connectionId,
+      peerAssistantId: connection.peerAssistantId,
+      previousScopes,
+      newScopes: params.scopes,
+      timestamp: now,
+    },
+    'A2A scope change applied',
+  );
+
+  // Emit lifecycle event so surfaces (macOS client, Telegram, etc.) can
+  // observe scope changes in real-time
+  void emitNotificationSignal({
+    sourceEventName: 'a2a.scopes_changed',
+    sourceChannel: 'a2a',
+    sourceSessionId: params.connectionId,
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+    attentionHints: {
+      requiresAction: false,
+      urgency: 'low',
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
+    contextPayload: {
+      connectionId: params.connectionId,
+      peerAssistantId: connection.peerAssistantId ?? null,
+      previousScopes,
+      newScopes: params.scopes,
+      timestamp: now,
+    },
+    dedupeKey: `a2a:scopes-changed:${params.connectionId}:${now}`,
+  });
+
+  return {
+    ok: true,
+    previousScopes,
+    newScopes: params.scopes,
+    connection: storeResult.connection,
+  };
+}
+
+/**
+ * Get the current granted scopes for an A2A connection.
+ *
+ * Validates the connection exists and is active.
+ */
+export function getScopes(params: {
+  connectionId: string;
+}): GetScopesResult {
+  const connection = getConnection(params.connectionId);
+  if (!connection) {
+    return { ok: false, reason: 'not_found' };
+  }
+
+  if (connection.status !== 'active') {
+    return { ok: false, reason: 'not_active' };
+  }
+
+  return {
+    ok: true,
+    scopes: connection.scopes,
+    connectionId: connection.id,
+  };
 }

--- a/assistant/src/a2a/a2a-message-schema.ts
+++ b/assistant/src/a2a/a2a-message-schema.ts
@@ -182,6 +182,7 @@ export const A2A_EVENT_NAMES = {
   VERIFICATION_CODE_READY: 'a2a.verification_code_ready',
   CONNECTION_ESTABLISHED: 'a2a.connection_established',
   CONNECTION_REVOKED: 'a2a.connection_revoked',
+  SCOPES_CHANGED: 'a2a.scopes_changed',
   MESSAGE_RECEIVED: 'a2a.message_received',
   MESSAGE_DELIVERED: 'a2a.message_delivered',
   MESSAGE_FAILED: 'a2a.message_failed',
@@ -239,6 +240,15 @@ export interface A2AConnectionRevokedPayload {
   peerAssistantId: string | null;
 }
 
+/** Payload for `a2a.scopes_changed`. */
+export interface A2AScopesChangedPayload {
+  connectionId: string;
+  peerAssistantId: string | null;
+  previousScopes: string[];
+  newScopes: string[];
+  timestamp: number;
+}
+
 /** Payload for `a2a.message_received`. */
 export interface A2AMessageReceivedPayload {
   connectionId: string;
@@ -277,6 +287,7 @@ export interface A2AEventPayloadMap {
   'a2a.verification_code_ready': A2AVerificationCodeReadyPayload;
   'a2a.connection_established': A2AConnectionEstablishedPayload;
   'a2a.connection_revoked': A2AConnectionRevokedPayload;
+  'a2a.scopes_changed': A2AScopesChangedPayload;
   'a2a.message_received': A2AMessageReceivedPayload;
   'a2a.message_delivered': A2AMessageDeliveredPayload;
   'a2a.message_failed': A2AMessageFailedPayload;

--- a/assistant/src/config/bundled-skills/a2a-connections/SKILL.md
+++ b/assistant/src/config/bundled-skills/a2a-connections/SKILL.md
@@ -213,7 +213,52 @@ curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/a2a/connections/<connection_id>/status" \
 
 The response contains `{ connectionId, status, peerGatewayUrl, protocolVersion, createdAt, updatedAt }`.
 
-### 8. Revoke a connection
+### 8. View connection scopes
+
+Use this to show the user what scopes (permissions) are granted to a specific A2A connection. Scopes control what actions a peer assistant can perform.
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/a2a/connections/<connection_id>/scopes" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+The response contains `{ connectionId, scopes }` where `scopes` is an array of scope IDs.
+
+Available scope IDs and their meanings:
+- `message` -- Send and receive text messages
+- `read_availability` -- Read calendar free/busy information
+- `create_events` -- Create calendar events (medium risk)
+- `read_profile` -- Read basic profile info (name, timezone)
+- `execute_requests` -- Execute structured A2A requests (high risk)
+
+**Presenting results**: Show the scopes as a readable list with their descriptions. If no scopes are granted, tell the user no permissions are currently set for this connection.
+
+### 9. Update connection scopes
+
+Use this when the user wants to grant or revoke specific permissions for a peer connection. **Scope changes take effect immediately** -- the peer's next request will be evaluated against the updated scopes.
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+curl -s -X PUT "$INTERNAL_GATEWAY_BASE_URL/v1/a2a/connections/<connection_id>/scopes" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "{\"scopes\": [\"message\", \"read_profile\"]}"
+```
+
+The `scopes` array replaces the existing scopes entirely. To add a scope, include it alongside existing ones. To remove a scope, omit it from the array.
+
+The response contains `{ connectionId, previousScopes, newScopes }`.
+
+**Presenting results**: Show what changed clearly:
+> Updated scopes for [peer name or URL]:
+> - Added: `read_profile`
+> - Removed: `create_events`
+> - Current scopes: `message`, `read_profile`
+
+**Confirmation**: Granting high-risk scopes (`execute_requests`, `create_events`) should be confirmed with the user before proceeding. Revoking scopes or granting low-risk scopes (`message`, `read_profile`, `read_availability`) does not require extra confirmation.
+
+### 10. Revoke a connection
 
 Use this when the user wants to disconnect from a peer. **Always confirm with the user before revoking.**
 
@@ -232,6 +277,8 @@ On success, the response is `{ ok: true }`.
 ## Confirmation Requirements
 
 **Revoking a connection requires explicit user confirmation before execution.** Modifying who can communicate with the assistant should always be a deliberate choice.
+
+**Granting high-risk scopes** (`execute_requests`, `create_events`) requires explicit user confirmation. Granting low-risk scopes or revoking any scope does not require extra confirmation.
 
 Generating invites, redeeming invites, and approving/denying connections do not require additional confirmation since the user is explicitly initiating those actions.
 
@@ -256,6 +303,8 @@ If a request returns an error JSON (typically `{ error: { code, message } }`), r
 | `expired` (410) | The verification code or handshake session expired | The handshake timed out. The peer needs to send a new connect request. |
 | `max_attempts` (429) | Too many incorrect code attempts | Rate limited. Wait and try again, or revoke and start fresh. |
 | `identity_mismatch` (403) | The peer identity does not match the connection | The verification is being attempted from the wrong peer. |
+| `invalid_scopes` (400) | One or more scope IDs are not recognized | Check the scope IDs against the available list: `message`, `read_availability`, `create_events`, `read_profile`, `execute_requests`. |
+| `not_active` (409) | Connection is not active (scopes can only be managed on active connections) | The connection must be fully established before managing scopes. |
 | HTTP 429 (rate limited) | Too many requests | Tell the user to wait a moment before retrying. The response includes a `Retry-After` header. |
 | HTTP 502/504 (gateway error) | Peer assistant unreachable | The peer's gateway may be offline. Ask the user to confirm the peer is running and try again later. |
 
@@ -281,7 +330,24 @@ If a request returns an error JSON (typically `{ error: { code, message } }`), r
 **"Disconnect from [name/URL]"** / **"Revoke connection to [name]"**:
 1. List connections to identify the target
 2. Confirm with the user
-3. Revoke the connection (Action 8)
+3. Revoke the connection (Action 10)
+
+**"Allow messaging with [connection]"** / **"Grant message scope to [name]"**:
+1. List connections to identify the target (Action 6)
+2. Get current scopes (Action 8)
+3. Add the requested scope to the existing list
+4. Update scopes (Action 9)
+
+**"Revoke calendar access from [connection]"** / **"Remove create_events scope"**:
+1. List connections to identify the target (Action 6)
+2. Get current scopes (Action 8)
+3. Remove the specified scope from the list
+4. Update scopes (Action 9)
+
+**"Show scopes for [connection]"** / **"What can [name] do?"**:
+1. List connections to identify the target (Action 6)
+2. Get scopes (Action 8)
+3. Present the scopes with descriptions
 
 **Incoming connection request (notification)**:
 When the assistant receives a notification about a pending connection request from a peer, present it to the guardian and ask whether to approve or deny. If approved, display the verification code with out-of-band sharing instructions.

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -231,6 +231,19 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
 
   // Delivery ack
   { endpoint: 'channels/delivery-ack', scopes: ['internal.write'] },
+
+  // A2A connection management
+  { endpoint: 'a2a/invite', scopes: ['settings.write'] },
+  { endpoint: 'a2a/redeem', scopes: ['settings.write'] },
+  { endpoint: 'a2a/connect', scopes: ['settings.write'] },
+  { endpoint: 'a2a/approve', scopes: ['settings.write'] },
+  { endpoint: 'a2a/verify', scopes: ['settings.write'] },
+  { endpoint: 'a2a/revoke', scopes: ['settings.write'] },
+  { endpoint: 'a2a/connections', scopes: ['settings.read'] },
+  { endpoint: 'a2a/connections/status:GET', scopes: ['settings.read'] },
+  { endpoint: 'a2a/connections/messages:POST', scopes: ['settings.write'] },
+  { endpoint: 'a2a/connections/scopes:PUT', scopes: ['settings.write'] },
+  { endpoint: 'a2a/connections/scopes:GET', scopes: ['settings.read'] },
 ];
 
 for (const { endpoint, scopes } of ACTOR_ENDPOINTS) {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -180,11 +180,13 @@ import {
   handleA2AApprove,
   handleA2AConnect,
   handleA2AConnectionStatus,
+  handleA2AGetScopes,
   handleA2AInvite,
   handleA2AListConnections,
   handleA2ARedeem,
   handleA2ARevoke,
   handleA2ASendMessage,
+  handleA2AUpdateScopes,
   handleA2AVerify,
 } from './routes/a2a-routes.js';
 import { handleA2AMessageInbound } from './routes/a2a-inbound-routes.js';
@@ -1353,6 +1355,15 @@ export class RuntimeHttpServer {
       const a2aSendMessageMatch = endpoint.match(/^a2a\/connections\/([^/]+)\/messages$/);
       if (a2aSendMessageMatch && req.method === 'POST') {
         return await handleA2ASendMessage(req, a2aSendMessageMatch[1]);
+      }
+
+      // A2A scope management endpoints
+      const a2aScopesMatch = endpoint.match(/^a2a\/connections\/([^/]+)\/scopes$/);
+      if (a2aScopesMatch && req.method === 'PUT') {
+        return await handleA2AUpdateScopes(req, a2aScopesMatch[1]);
+      }
+      if (a2aScopesMatch && req.method === 'GET') {
+        return handleA2AGetScopes(a2aScopesMatch[1]);
       }
 
       // A2A inbound message endpoint (gateway -> runtime)

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -282,6 +282,12 @@ const PARAMETERIZED_ROUTE_PATTERNS: Array<{ re: RegExp; policyBase: string }> = 
   { re: /^trust-rules\/manage\/[^/]+$/, policyBase: 'trust-rules/manage' },
   // interfaces/{path}
   { re: /^interfaces\/.+$/, policyBase: 'interfaces' },
+  // a2a/connections/{id}/status
+  { re: /^a2a\/connections\/[^/]+\/status$/, policyBase: 'a2a/connections/status' },
+  // a2a/connections/{id}/messages
+  { re: /^a2a\/connections\/[^/]+\/messages$/, policyBase: 'a2a/connections/messages' },
+  // a2a/connections/{id}/scopes
+  { re: /^a2a\/connections\/[^/]+\/scopes$/, policyBase: 'a2a/connections/scopes' },
 ];
 
 /**

--- a/assistant/src/runtime/routes/a2a-routes.ts
+++ b/assistant/src/runtime/routes/a2a-routes.ts
@@ -447,7 +447,11 @@ export async function handleA2AUpdateScopes(req: Request, connectionId: string):
     return httpError('BAD_REQUEST', 'Missing required field: scopes (array of scope IDs)', 400);
   }
 
-  const scopes = body.scopes.filter((s): s is string => typeof s === 'string');
+  if (!body.scopes.every((s: unknown) => typeof s === 'string')) {
+    return httpError('BAD_REQUEST', 'All scope IDs must be strings', 400);
+  }
+
+  const scopes = body.scopes as string[];
 
   const result = updateScopes({ connectionId, scopes });
 

--- a/assistant/src/runtime/routes/a2a-routes.ts
+++ b/assistant/src/runtime/routes/a2a-routes.ts
@@ -12,12 +12,14 @@
 import {
   approveConnection,
   generateInvite,
+  getScopes,
   initiateConnection,
   listConnectionsFiltered,
   redeemInvite,
   revokeConnection,
   sendMessage,
   submitVerificationCode,
+  updateScopes,
   A2A_PROTOCOL_VERSION,
 } from '../../a2a/a2a-connection-service.js';
 import type { A2AMessageContent } from '../../a2a/a2a-message-schema.js';
@@ -432,4 +434,69 @@ export async function handleA2ASendMessage(req: Request, connectionId: string): 
     messageId: sendResult.messageId,
     conversationId: sendResult.conversationId,
   }, { status: 202 });
+}
+
+// ---------------------------------------------------------------------------
+// PUT /v1/a2a/connections/:connectionId/scopes — Update connection scopes
+// ---------------------------------------------------------------------------
+
+export async function handleA2AUpdateScopes(req: Request, connectionId: string): Promise<Response> {
+  const body = await req.json() as Record<string, unknown>;
+
+  if (!Array.isArray(body.scopes)) {
+    return httpError('BAD_REQUEST', 'Missing required field: scopes (array of scope IDs)', 400);
+  }
+
+  const scopes = body.scopes.filter((s): s is string => typeof s === 'string');
+
+  const result = updateScopes({ connectionId, scopes });
+
+  if (!result.ok) {
+    const statusMap: Record<string, number> = {
+      not_found: 404,
+      not_active: 409,
+      invalid_scopes: 400,
+    };
+    const codeMap: Record<string, 'NOT_FOUND' | 'CONFLICT' | 'BAD_REQUEST'> = {
+      not_found: 'NOT_FOUND',
+      not_active: 'CONFLICT',
+      invalid_scopes: 'BAD_REQUEST',
+    };
+    return httpError(
+      codeMap[result.reason] ?? 'BAD_REQUEST',
+      result.detail ?? result.reason,
+      statusMap[result.reason] ?? 400,
+    );
+  }
+
+  return Response.json({
+    connectionId,
+    previousScopes: result.previousScopes,
+    newScopes: result.newScopes,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/a2a/connections/:connectionId/scopes — Get connection scopes
+// ---------------------------------------------------------------------------
+
+export function handleA2AGetScopes(connectionId: string): Response {
+  const result = getScopes({ connectionId });
+
+  if (!result.ok) {
+    const statusMap: Record<string, number> = {
+      not_found: 404,
+      not_active: 409,
+    };
+    return httpError(
+      result.reason === 'not_found' ? 'NOT_FOUND' : 'CONFLICT',
+      result.reason,
+      statusMap[result.reason] ?? 400,
+    );
+  }
+
+  return Response.json({
+    connectionId: result.connectionId,
+    scopes: result.scopes,
+  });
 }


### PR DESCRIPTION
## Summary

- Add `updateScopes()` and `getScopes()` methods to `A2AConnectionService` with scope catalog validation, audit logging, and `a2a.scopes_changed` lifecycle event emission
- Add `PUT /v1/a2a/connections/:connectionId/scopes` and `GET /v1/a2a/connections/:connectionId/scopes` HTTP endpoints with bearer auth (proxied through gateway catch-all)
- Add `a2a.scopes_changed` event name, typed payload (`A2AScopesChangedPayload`), and event payload map entry to `a2a-message-schema.ts`
- Update A2A connections skill (`SKILL.md`) with scope management actions (view scopes, update scopes), workflows, confirmation requirements, and error table entries
- Add comprehensive test suite covering: valid/invalid scope updates, notification signal emission, audit logging, immediate enforcement after scope changes, and getScopes behavior

## Test plan

- [ ] `updateScopes()` accepts valid scope IDs and updates the store
- [ ] `updateScopes()` rejects invalid/undeclared scope IDs with detail message
- [ ] `updateScopes()` returns `not_found` for nonexistent connections
- [ ] `updateScopes()` returns `not_active` for non-active connections
- [ ] `updateScopes()` emits `a2a.scopes_changed` notification signal with correct payload
- [ ] `updateScopes()` logs scope change for audit with connectionId, peerAssistantId, before/after scopes
- [ ] Scope narrowing is immediately enforced (next evaluateScope check reflects new scopes)
- [ ] Scope widening is immediately enforced
- [ ] Revoking all scopes immediately blocks `sendMessage`
- [ ] `getScopes()` returns current scopes for active connections
- [ ] `getScopes()` returns `not_found`/`not_active` for missing/inactive connections
- [ ] `getScopes()` reflects updates made by `updateScopes()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
