### PR TITLE
M19: Memory/provenance policy for A2A actors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,7 +368,14 @@ Conversational guardian verification control-plane invocation is guardian-only. 
 
 ## Memory Provenance Invariant
 
-All memory extraction and retrieval decisions must consider actor-role provenance. Untrusted actors (non-guardian, unverified_channel) must not trigger profile extraction or receive memory recall/conflict disclosures. This invariant is enforced in `indexer.ts` (write gate) and `session-memory.ts` (read gate).
+All memory extraction and retrieval decisions must consider actor-role provenance. Untrusted actors — including `non_guardian`, `unverified_channel`, and `peer_assistant` (A2A peers) — must not trigger profile extraction or receive memory recall/conflict disclosures. This invariant is enforced at four gate points:
+
+- **Write gate** (`indexer.ts`): Only `guardian` and legacy `undefined` provenance actors trigger `extract_items` and conflict resolution jobs. `peer_assistant` messages are indexed for segment search but extraction is suppressed.
+- **Read gate** (`session-memory.ts`): Only `guardian` actors receive memory recall, dynamic profile injection, and conflict gate evaluation. All other trust classes (including `peer_assistant`) get an empty recall result.
+- **History view gate** (`session-lifecycle.ts`): `peer_assistant` is treated as untrusted — only peer-provenance messages are visible, and compacted summaries (which may contain guardian-only context) are suppressed.
+- **Backfill gate** (`job-handlers/backfill.ts`): Same trust logic as the write gate — `peer_assistant` provenance is excluded from extraction during backfill.
+
+A guard test (`memory-provenance-a2a-guard.test.ts`) enforces that all four gate points correctly exclude `peer_assistant` from trusted paths.
 
 ## Guardian Privilege Isolation Invariant
 

--- a/assistant/src/__tests__/memory-provenance-a2a-guard.test.ts
+++ b/assistant/src/__tests__/memory-provenance-a2a-guard.test.ts
@@ -21,6 +21,31 @@ import { describe, expect, it } from "bun:test";
 
 const srcDir = join(import.meta.dir, "..");
 
+/**
+ * Extract the full expression surrounding an `isTrustedActor` assignment or
+ * check. Instead of inspecting a single line, this finds the line containing
+ * the identifier and then extends forward until it reaches the statement
+ * terminator (`;`). This catches multiline `||` / `&&` conditions that would
+ * slip past a single-line check.
+ */
+function extractTrustGateExpression(
+  source: string,
+  identifier: string,
+  lineFilter: (line: string) => boolean,
+): string | undefined {
+  const lines = source.split("\n");
+  const startIdx = lines.findIndex((l) => l.includes(identifier) && lineFilter(l));
+  if (startIdx === -1) return undefined;
+
+  // Accumulate lines from the match until we see a semicolon (statement end)
+  const collected: string[] = [];
+  for (let i = startIdx; i < lines.length; i++) {
+    collected.push(lines[i]);
+    if (lines[i].includes(";")) break;
+  }
+  return collected.join("\n");
+}
+
 describe("memory provenance A2A guard", () => {
   // -----------------------------------------------------------------------
   // (a) Indexer write gate — peer_assistant excluded from extraction
@@ -45,20 +70,24 @@ describe("memory provenance A2A guard", () => {
       "indexer.ts must check for undefined provenance (legacy/desktop actors) in isTrustedActor.",
     ).toBe(true);
 
-    // The indexer must NOT have peer_assistant in its trusted check
-    const trustedLine = source
-      .split("\n")
-      .find((l) => l.includes("isTrustedActor") && l.includes("="));
+    // The indexer must NOT have peer_assistant in its trust-gate expression.
+    // We extract the full multiline expression (up to the semicolon) to catch
+    // regressions where peer_assistant is added on a continuation line.
+    const trustExpr = extractTrustGateExpression(
+      source,
+      "isTrustedActor",
+      (l) => l.includes("="),
+    );
     expect(
-      trustedLine,
+      trustExpr,
       "Expected to find isTrustedActor assignment in indexer.ts",
     ).toBeDefined();
 
     expect(
-      trustedLine!.includes("peer_assistant"),
-      "indexer.ts isTrustedActor must NOT include peer_assistant. " +
+      trustExpr!.includes("peer_assistant"),
+      "indexer.ts isTrustedActor expression must NOT include peer_assistant. " +
         "A2A peers must not trigger profile extraction. " +
-        `Found: "${trustedLine!.trim()}"`,
+        `Found: "${trustExpr!.trim()}"`,
     ).toBe(false);
   });
 
@@ -88,26 +117,30 @@ describe("memory provenance A2A guard", () => {
     );
 
     // The read gate must check strictly for 'guardian' only.
-    const trustedLine = source
-      .split("\n")
-      .find((l) => l.includes("isTrustedActor") && l.includes("==="));
+    // We extract the full multiline expression (up to the semicolon) to catch
+    // regressions where peer_assistant is added on a continuation line.
+    const trustExpr = extractTrustGateExpression(
+      source,
+      "isTrustedActor",
+      (l) => l.includes("==="),
+    );
     expect(
-      trustedLine,
+      trustExpr,
       "Expected to find isTrustedActor check in session-memory.ts",
     ).toBeDefined();
 
     expect(
-      trustedLine!.includes("'guardian'"),
+      trustExpr!.includes("'guardian'"),
       "session-memory.ts isTrustedActor must check for 'guardian'. " +
-        `Found: "${trustedLine!.trim()}"`,
+        `Found: "${trustExpr!.trim()}"`,
     ).toBe(true);
 
     // Must NOT include peer_assistant as trusted
     expect(
-      trustedLine!.includes("peer_assistant"),
-      "session-memory.ts isTrustedActor must NOT include 'peer_assistant'. " +
+      trustExpr!.includes("peer_assistant"),
+      "session-memory.ts isTrustedActor expression must NOT include 'peer_assistant'. " +
         "A2A peers must not receive memory recall or conflict disclosures. " +
-        `Found: "${trustedLine!.trim()}"`,
+        `Found: "${trustExpr!.trim()}"`,
     ).toBe(false);
   });
 

--- a/assistant/src/__tests__/memory-provenance-a2a-guard.test.ts
+++ b/assistant/src/__tests__/memory-provenance-a2a-guard.test.ts
@@ -1,0 +1,271 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
+
+/**
+ * Guard tests for memory provenance gating of peer_assistant actors.
+ *
+ * These tests scan source files to enforce the Memory Provenance Invariant:
+ * peer_assistant actors (A2A peers) must NOT trigger profile extraction,
+ * receive memory recall, or receive conflict disclosures. The invariant is
+ * enforced at four gate points:
+ *
+ *   (a) indexer.ts — write gate: only guardian/undefined actors get extraction
+ *   (b) session-memory.ts — read gate: only guardian actors get recall/profile
+ *   (c) session-lifecycle.ts — history view gate: peer_assistant is untrusted
+ *   (d) backfill.ts — backfill gate: only guardian/undefined actors get extraction
+ *
+ * These guards prevent regression if someone changes the trust gating logic
+ * without updating all four gate points.
+ */
+
+const srcDir = join(import.meta.dir, "..");
+
+describe("memory provenance A2A guard", () => {
+  // -----------------------------------------------------------------------
+  // (a) Indexer write gate — peer_assistant excluded from extraction
+  // -----------------------------------------------------------------------
+
+  it("indexer isTrustedActor only trusts guardian and undefined provenance", () => {
+    const source = readFileSync(
+      join(srcDir, "memory", "indexer.ts"),
+      "utf-8",
+    );
+
+    // The indexer must define isTrustedActor as a whitelist of guardian + undefined.
+    // This ensures peer_assistant (and any other trust class) is excluded.
+    expect(
+      source.includes("provenanceTrustClass === 'guardian'"),
+      "indexer.ts must check for guardian provenance in isTrustedActor. " +
+        "Only guardian actors should trigger extraction.",
+    ).toBe(true);
+
+    expect(
+      source.includes("provenanceTrustClass === undefined"),
+      "indexer.ts must check for undefined provenance (legacy/desktop actors) in isTrustedActor.",
+    ).toBe(true);
+
+    // The indexer must NOT have peer_assistant in its trusted check
+    const trustedLine = source
+      .split("\n")
+      .find((l) => l.includes("isTrustedActor") && l.includes("="));
+    expect(
+      trustedLine,
+      "Expected to find isTrustedActor assignment in indexer.ts",
+    ).toBeDefined();
+
+    expect(
+      trustedLine!.includes("peer_assistant"),
+      "indexer.ts isTrustedActor must NOT include peer_assistant. " +
+        "A2A peers must not trigger profile extraction. " +
+        `Found: "${trustedLine!.trim()}"`,
+    ).toBe(false);
+  });
+
+  it("indexer provenanceTrustClass type includes peer_assistant", () => {
+    const source = readFileSync(
+      join(srcDir, "memory", "indexer.ts"),
+      "utf-8",
+    );
+
+    // The IndexMessageInput type must include peer_assistant in its
+    // provenanceTrustClass union so the compiler enforces coverage.
+    expect(
+      source.includes("'peer_assistant'"),
+      "indexer.ts IndexMessageInput.provenanceTrustClass must include 'peer_assistant' " +
+        "in its type union.",
+    ).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // (b) Session-memory read gate — peer_assistant excluded from recall
+  // -----------------------------------------------------------------------
+
+  it("session-memory isTrustedActor only trusts guardian for recall", () => {
+    const source = readFileSync(
+      join(srcDir, "daemon", "session-memory.ts"),
+      "utf-8",
+    );
+
+    // The read gate must check strictly for 'guardian' only.
+    const trustedLine = source
+      .split("\n")
+      .find((l) => l.includes("isTrustedActor") && l.includes("==="));
+    expect(
+      trustedLine,
+      "Expected to find isTrustedActor check in session-memory.ts",
+    ).toBeDefined();
+
+    expect(
+      trustedLine!.includes("'guardian'"),
+      "session-memory.ts isTrustedActor must check for 'guardian'. " +
+        `Found: "${trustedLine!.trim()}"`,
+    ).toBe(true);
+
+    // Must NOT include peer_assistant as trusted
+    expect(
+      trustedLine!.includes("peer_assistant"),
+      "session-memory.ts isTrustedActor must NOT include 'peer_assistant'. " +
+        "A2A peers must not receive memory recall or conflict disclosures. " +
+        `Found: "${trustedLine!.trim()}"`,
+    ).toBe(false);
+  });
+
+  it("session-memory MemoryPrepareContext accepts peer_assistant trust class", () => {
+    const source = readFileSync(
+      join(srcDir, "daemon", "session-memory.ts"),
+      "utf-8",
+    );
+
+    // The MemoryPrepareContext interface must include peer_assistant
+    // in its guardianTrustClass type.
+    expect(
+      source.includes("'peer_assistant'"),
+      "session-memory.ts MemoryPrepareContext.guardianTrustClass must include " +
+        "'peer_assistant' so the compiler enforces coverage.",
+    ).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // (c) Session-lifecycle history view gate — peer_assistant is untrusted
+  // -----------------------------------------------------------------------
+
+  it("session-lifecycle isUntrustedTrustClass includes peer_assistant", () => {
+    const source = readFileSync(
+      join(srcDir, "daemon", "session-lifecycle.ts"),
+      "utf-8",
+    );
+
+    // Find the isUntrustedTrustClass function
+    const fnStart = source.indexOf("function isUntrustedTrustClass");
+    expect(fnStart).toBeGreaterThan(-1);
+
+    // Extract the function body (until next function or export)
+    const fnBody = source.slice(fnStart);
+    const nextFn = fnBody.indexOf("\nfunction ", 1);
+    const nextExport = fnBody.indexOf("\nexport ", 1);
+    const end = Math.min(
+      nextFn > 0 ? nextFn : Infinity,
+      nextExport > 0 ? nextExport : Infinity,
+      fnBody.length,
+    );
+    const fnSource = fnBody.slice(0, end);
+
+    expect(
+      fnSource.includes("'peer_assistant'"),
+      "session-lifecycle.ts isUntrustedTrustClass must include 'peer_assistant'. " +
+        "A2A peers must be treated as untrusted for history view gating.",
+    ).toBe(true);
+  });
+
+  it("session-lifecycle filterMessagesForUntrustedActor includes peer_assistant provenance", () => {
+    const source = readFileSync(
+      join(srcDir, "daemon", "session-lifecycle.ts"),
+      "utf-8",
+    );
+
+    // Find the filterMessagesForUntrustedActor function
+    const fnStart = source.indexOf("function filterMessagesForUntrustedActor");
+    expect(fnStart).toBeGreaterThan(-1);
+
+    const fnBody = source.slice(fnStart);
+    const nextFn = fnBody.indexOf("\n\n", 1);
+    const fnSource = fnBody.slice(0, nextFn > 0 ? nextFn : fnBody.length);
+
+    expect(
+      fnSource.includes("'peer_assistant'"),
+      "session-lifecycle.ts filterMessagesForUntrustedActor must include " +
+        "'peer_assistant' in provenance filtering.",
+    ).toBe(true);
+  });
+
+  it("session-lifecycle parseProvenanceTrustClass recognizes peer_assistant", () => {
+    const source = readFileSync(
+      join(srcDir, "daemon", "session-lifecycle.ts"),
+      "utf-8",
+    );
+
+    const fnStart = source.indexOf("function parseProvenanceTrustClass");
+    expect(fnStart).toBeGreaterThan(-1);
+
+    const fnBody = source.slice(fnStart);
+    const nextFn = fnBody.indexOf("\nfunction ", 1);
+    const fnSource = fnBody.slice(0, nextFn > 0 ? nextFn : fnBody.length);
+
+    expect(
+      fnSource.includes("'peer_assistant'"),
+      "session-lifecycle.ts parseProvenanceTrustClass must recognize " +
+        "'peer_assistant' as a valid trust class.",
+    ).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // (d) Backfill gate — peer_assistant excluded from extraction on backfill
+  // -----------------------------------------------------------------------
+
+  it("backfill isTrustedTrustClass only trusts guardian and undefined", () => {
+    const source = readFileSync(
+      join(srcDir, "memory", "job-handlers", "backfill.ts"),
+      "utf-8",
+    );
+
+    // The backfill handler must define isTrustedTrustClass the same way
+    // as the indexer: guardian + undefined only.
+    const trustedFn = source
+      .split("\n")
+      .find((l) => l.includes("function isTrustedTrustClass"));
+    expect(
+      trustedFn,
+      "Expected to find isTrustedTrustClass function in backfill.ts",
+    ).toBeDefined();
+
+    // Extract the function body
+    const fnStart = source.indexOf("function isTrustedTrustClass");
+    const fnBody = source.slice(fnStart);
+    const fnEnd = fnBody.indexOf("}");
+    const fnSource = fnBody.slice(0, fnEnd + 1);
+
+    // Must trust guardian
+    expect(
+      fnSource.includes("'guardian'"),
+      "backfill.ts isTrustedTrustClass must check for 'guardian'.",
+    ).toBe(true);
+
+    // Must NOT include peer_assistant as trusted
+    expect(
+      fnSource.includes("'peer_assistant'"),
+      "backfill.ts isTrustedTrustClass must NOT include 'peer_assistant'. " +
+        "A2A peers must not trigger extraction during backfill.",
+    ).toBe(false);
+  });
+
+  it("backfill ProvenanceTrustClass type includes peer_assistant", () => {
+    const source = readFileSync(
+      join(srcDir, "memory", "job-handlers", "backfill.ts"),
+      "utf-8",
+    );
+
+    expect(
+      source.includes("'peer_assistant'"),
+      "backfill.ts ProvenanceTrustClass must include 'peer_assistant' " +
+        "so the type system tracks A2A peer provenance.",
+    ).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // (e) Conversation CRUD schema includes peer_assistant
+  // -----------------------------------------------------------------------
+
+  it("conversation-crud provenanceTrustClass schema includes peer_assistant", () => {
+    const source = readFileSync(
+      join(srcDir, "memory", "conversation-crud.ts"),
+      "utf-8",
+    );
+
+    expect(
+      source.includes("'peer_assistant'"),
+      "conversation-crud.ts provenanceTrustClass schema must include 'peer_assistant' " +
+        "so A2A peer provenance can be stored and queried.",
+    ).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/peer-assistant-trust-gates.test.ts
+++ b/assistant/src/__tests__/peer-assistant-trust-gates.test.ts
@@ -439,25 +439,125 @@ describe("peer_assistant memory extraction gate", () => {
 // =====================================================================
 
 describe("peer_assistant memory retrieval gate (session-memory)", () => {
-  // The prepareMemoryContext function in session-memory.ts checks:
-  // const isTrustedActor = ctx.guardianTrustClass === 'guardian';
-  // If not trusted, it returns early with empty recall/profile/conflict data.
-  // peer_assistant is not 'guardian', so it gets the untrusted path.
+  // Verify the session-memory.ts trust gate by scanning the source for the
+  // isTrustedActor check. This is more robust than string equality because
+  // it catches regressions in the actual source code.
 
-  // We can't easily test prepareMemoryContext directly (it has complex async deps),
-  // but we verify the trust classification logic:
+  test("session-memory.ts gates recall to guardian-only (source check)", () => {
+    const { readFileSync } = require("node:fs");
+    const { join } = require("node:path");
+    const source = readFileSync(
+      join(__dirname, "..", "daemon", "session-memory.ts"),
+      "utf-8",
+    );
 
-  test("peer_assistant is not treated as trusted for memory recall", () => {
-    // The memory gate in session-memory.ts checks:
-    // const isTrustedActor = ctx.guardianTrustClass === 'guardian';
-    // Only 'guardian' passes. peer_assistant does not.
-    const isTrustedActor = "peer_assistant" === "guardian";
-    expect(isTrustedActor).toBe(false);
+    // The isTrustedActor check must be strictly guardian-only
+    const trustedLine = source
+      .split("\n")
+      .find(
+        (l: string) => l.includes("isTrustedActor") && l.includes("==="),
+      );
+    expect(trustedLine).toBeDefined();
+    expect(trustedLine).toContain("'guardian'");
+    // Must NOT include peer_assistant as trusted
+    expect(trustedLine).not.toContain("peer_assistant");
   });
 
-  test("guardian IS treated as trusted for memory recall", () => {
-    const isTrustedActor = "guardian" === "guardian";
-    expect(isTrustedActor).toBe(true);
+  test("session-memory returns empty recall for non-guardian trust classes", () => {
+    const { readFileSync } = require("node:fs");
+    const { join } = require("node:path");
+    const source = readFileSync(
+      join(__dirname, "..", "daemon", "session-memory.ts"),
+      "utf-8",
+    );
+
+    // When isTrustedActor is false, prepareMemoryContext must return early
+    // with empty/disabled recall, profile, and conflict data.
+    const untrustedBlock = source.indexOf("if (!isTrustedActor)");
+    expect(untrustedBlock).toBeGreaterThan(-1);
+
+    // The early return must include disabled recall
+    const returnBlock = source.slice(
+      untrustedBlock,
+      source.indexOf("}", untrustedBlock + 200) + 200,
+    );
+    expect(returnBlock).toContain("enabled: false");
+    expect(returnBlock).toContain("injectedText: ''");
+    expect(returnBlock).toContain("dynamicProfile: { text: '' }");
+    expect(returnBlock).toContain("softConflictInstruction: null");
+  });
+
+  test("peer_assistant in MemoryPrepareContext guardianTrustClass type", () => {
+    const { readFileSync } = require("node:fs");
+    const { join } = require("node:path");
+    const source = readFileSync(
+      join(__dirname, "..", "daemon", "session-memory.ts"),
+      "utf-8",
+    );
+
+    // The MemoryPrepareContext interface must accept peer_assistant
+    const ifaceStart = source.indexOf(
+      "export interface MemoryPrepareContext",
+    );
+    expect(ifaceStart).toBeGreaterThan(-1);
+    const ifaceBlock = source.slice(
+      ifaceStart,
+      source.indexOf("}", ifaceStart) + 1,
+    );
+    expect(ifaceBlock).toContain("'peer_assistant'");
+  });
+});
+
+// =====================================================================
+// 5b. No Guardian Context Leakage to A2A Peers
+// =====================================================================
+
+describe("no guardian context leakage to peer_assistant actors", () => {
+  test("session-lifecycle treats peer_assistant as untrusted for history view", () => {
+    const { readFileSync } = require("node:fs");
+    const { join } = require("node:path");
+    const source = readFileSync(
+      join(__dirname, "..", "daemon", "session-lifecycle.ts"),
+      "utf-8",
+    );
+
+    // isUntrustedTrustClass must include peer_assistant
+    const fnStart = source.indexOf("function isUntrustedTrustClass");
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnBody = source.slice(fnStart, source.indexOf("}", fnStart) + 1);
+    expect(fnBody).toContain("'peer_assistant'");
+  });
+
+  test("session-lifecycle filters messages for untrusted actors including peer_assistant", () => {
+    const { readFileSync } = require("node:fs");
+    const { join } = require("node:path");
+    const source = readFileSync(
+      join(__dirname, "..", "daemon", "session-lifecycle.ts"),
+      "utf-8",
+    );
+
+    // filterMessagesForUntrustedActor must recognize peer_assistant provenance
+    const fnStart = source.indexOf(
+      "function filterMessagesForUntrustedActor",
+    );
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnBody = source.slice(fnStart, source.indexOf("}", fnStart) + 1);
+    expect(fnBody).toContain("'peer_assistant'");
+  });
+
+  test("indexer blocks extraction AND conflict resolution for peer_assistant", () => {
+    // Already tested above via indexMessageNow, but verify the dual gate:
+    // both shouldExtract && isTrustedActor and shouldResolveConflicts && isTrustedActor
+    const { readFileSync } = require("node:fs");
+    const { join } = require("node:path");
+    const source = readFileSync(
+      join(__dirname, "..", "memory", "indexer.ts"),
+      "utf-8",
+    );
+
+    // Both extraction and conflict resolution must be gated on isTrustedActor
+    expect(source).toContain("shouldExtract && isTrustedActor");
+    expect(source).toContain("shouldResolveConflicts && isTrustedActor");
   });
 });
 

--- a/assistant/src/daemon/session-memory.ts
+++ b/assistant/src/daemon/session-memory.ts
@@ -63,7 +63,16 @@ export async function prepareMemoryContext(
 ): Promise<MemoryRecallResult & { conflictClarification: string | null }> {
   // Provenance-based trust gating: untrusted actors skip all memory operations
   // (recall, dynamic profile, conflict gate) to prevent untrusted content from
-  // influencing memory-augmented responses.
+  // influencing memory-augmented responses. This includes peer_assistant (A2A)
+  // actors, who receive zero memory context by default.
+  //
+  // Extension point (scope-aware memory): When A2A scope-based access is
+  // implemented, peer_assistant actors with the `read_profile` scope could
+  // receive a limited subset of memory (e.g., timezone, display name,
+  // preferred language) via a scoped profile projection. The gate below
+  // would check `ctx.a2aScopes?.includes('read_profile')` and branch to
+  // a restricted recall path. Until then, the binary allow/block gate
+  // ensures no leakage of guardian-only context to A2A peers.
   const isTrustedActor = ctx.guardianTrustClass === 'guardian';
 
   if (!isTrustedActor) {

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -38,7 +38,16 @@ export function indexMessageNow(
   if (!config.enabled) return { indexedSegments: 0, enqueuedJobs: 0 };
 
   // Provenance-based trust gating: only guardian and legacy (undefined) actors
-  // are trusted for extraction and conflict resolution.
+  // are trusted for extraction and conflict resolution. peer_assistant (A2A)
+  // actors are explicitly excluded — their messages are indexed for segment
+  // search but never trigger profile extraction or conflict resolution.
+  //
+  // Extension point (scope-aware extraction): A future milestone could allow
+  // limited extraction from peer_assistant messages when the connection has
+  // specific scopes (e.g., `read_profile` could permit extracting the peer's
+  // timezone or language preference). The gate below would then check both
+  // trust class and granted scopes. Until then, the binary gate prevents
+  // untrusted content from polluting the guardian's memory profile.
   const isTrustedActor = input.provenanceTrustClass === 'guardian' || input.provenanceTrustClass === undefined;
 
   const text = extractTextFromStoredMessageContent(input.content);


### PR DESCRIPTION
## Summary
- Adds guard test (`memory-provenance-a2a-guard.test.ts`) enforcing that all four memory gate points (indexer, session-memory, session-lifecycle, backfill) correctly exclude `peer_assistant` from trusted paths
- Strengthens existing memory retrieval tests in `peer-assistant-trust-gates.test.ts` with source-code-level verification and guardian context leakage prevention tests
- Documents scope-aware memory extension points in both `session-memory.ts` and `indexer.ts` for future work where `read_profile` scope could allow limited memory access
- Updates AGENTS.md Memory Provenance Invariant to explicitly cover `peer_assistant` trust class with all four gate points documented

## Test plan
- [ ] Guard test verifies indexer write gate excludes `peer_assistant` from extraction
- [ ] Guard test verifies session-memory read gate is guardian-only
- [ ] Guard test verifies session-lifecycle history view gate treats `peer_assistant` as untrusted
- [ ] Guard test verifies backfill gate excludes `peer_assistant` from extraction
- [ ] Functional tests verify no guardian context leakage to A2A peers
- [ ] Existing peer_assistant trust gate tests pass with strengthened assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
