### PR TITLE
M1: Remove automatic workspace opening from build flows

### DIFF
--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -819,6 +819,7 @@ export async function surfaceProxyResolver(
   if (toolName === 'app_open') {
     const appId = input.app_id as string;
     const preview = input.preview as DynamicPageSurfaceData['preview'];
+    const openMode = input.open_mode as string | undefined;
     const app = getApp(appId);
     if (!app) return { content: `App not found: ${appId}`, isError: true };
     const seededHomeBase = findSeededHomeBaseApp();
@@ -837,6 +838,33 @@ export async function surfaceProxyResolver(
       preview: { ...defaultPreview, ...preview, ...(storedPreview ? { previewImage: storedPreview } : {}) },
     };
     const surfaceId = uuid();
+
+    if (openMode === 'preview') {
+      // Inline-only preview card emitted during app_create — do not open a
+      // workspace panel and do not register surface state. The client renders
+      // this as a tappable inline card that opens the app on demand.
+      ctx.sendToClient({
+        type: 'ui_surface_show',
+        sessionId: ctx.conversationId,
+        surfaceId,
+        surfaceType: 'dynamic_page',
+        title: app.name,
+        data: surfaceData,
+        display: 'inline',
+      } as UiSurfaceShow);
+
+      // Track for message persistence so the inline card survives history reload.
+      ctx.currentTurnSurfaces.push({
+        surfaceId,
+        surfaceType: 'dynamic_page',
+        title: app.name,
+        data: surfaceData,
+        display: 'inline',
+      });
+
+      return { content: JSON.stringify({ surfaceId, appId }), isError: false };
+    }
+
     ctx.surfaceState.set(surfaceId, {
       surfaceType: 'dynamic_page',
       data: surfaceData,

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -10,15 +10,11 @@
 import { join } from 'node:path';
 
 import { updatePublishedAppDeployment } from '../services/published-app-updater.js';
-import { openAppViaSurface } from '../tools/apps/open-proxy.js';
 import type { ToolExecutionResult } from '../tools/types.js';
 import { getWorkspaceDir } from '../util/platform.js';
 import { isDoordashCommand, updateDoordashProgress } from './doordash-steps.js';
 import type { ServerMessage } from './ipc-protocol.js';
-import {
-  refreshSurfacesForApp,
-  surfaceProxyResolver,
-} from './session-surfaces.js';
+import { refreshSurfacesForApp } from './session-surfaces.js';
 import type { ToolSetupContext } from './session-tool-setup.js';
 
 // ── Types ────────────────────────────────────────────────────────────
@@ -37,20 +33,16 @@ export type PostExecutionHook = (
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-/** Shared logic for refreshing app surfaces, broadcasting changes, and auto-opening. */
+/** Shared logic for refreshing app surfaces, broadcasting changes, and triggering auto-deploy. */
 function handleAppChange(
   ctx: ToolSetupContext,
   appId: string,
   broadcastToAllClients: ((msg: ServerMessage) => void) | undefined,
   opts?: { fileChange?: boolean; status?: string },
 ): void {
-  const refreshed = refreshSurfacesForApp(ctx, appId, opts);
+  refreshSurfacesForApp(ctx, appId, opts);
   broadcastToAllClients?.({ type: 'app_files_changed', appId });
   void updatePublishedAppDeployment(appId);
-  if (!refreshed && !ctx.hasNoClient && !ctx.headlessLock) {
-    const resolver = (tn: string, pi: Record<string, unknown>) => surfaceProxyResolver(ctx, tn, pi);
-    void openAppViaSurface(appId, resolver);
-  }
 }
 
 // ── Registry ─────────────────────────────────────────────────────────
@@ -82,7 +74,6 @@ registerHook('app_create', (_name, _input, result, { ctx, broadcastToAllClients 
 });
 
 // Auto-refresh workspace surfaces when a persisted app is updated.
-// If no surface is currently showing the app, auto-open it.
 registerHook('app_update', (_name, input, _result, { ctx, broadcastToAllClients }) => {
   const appId = input.app_id as string | undefined;
   if (appId) {
@@ -109,7 +100,6 @@ registerHook(
 );
 
 // Auto-refresh workspace surfaces when app files are edited.
-// If no surface is currently showing the app, auto-open it.
 registerHook(
   ['app_file_edit', 'app_file_write'],
   (_name, input, _result, { ctx, broadcastToAllClients }) => {

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -11,7 +11,6 @@
 import { setHomeBaseAppLink } from '../../home-base/app-link-store.js';
 import type { AppDefinition } from '../../memory/app-store.js';
 import type { EditEngineResult } from '../../memory/app-store.js';
-import { openAppViaSurface } from './open-proxy.js';
 
 // ---------------------------------------------------------------------------
 // Shared result type
@@ -123,33 +122,16 @@ export async function executeAppCreate(
     setHomeBaseAppLink(app.id, 'personalized');
   }
 
-  // Auto-open the app via the shared open-proxy helper
+  // Emit the inline preview card via the proxy without opening a workspace panel.
+  // open_mode: "preview" signals to the client that this should be shown inline only.
   if (autoOpen && proxyToolResolver) {
     const createPreview = { ...(preview ?? {}), context: 'app_create' as const };
-    const extraInput = { preview: createPreview };
-    const openResultText = await openAppViaSurface(app.id, proxyToolResolver, extraInput);
-
-    // Determine whether the open succeeded by checking for the fallback text
-    const opened = openResultText !== 'Failed to auto-open app. Use app_open to open it manually.';
-    if (opened) {
-      return {
-        content: JSON.stringify({
-          ...app,
-          auto_opened: true,
-          open_result: openResultText,
-        }),
-        isError: false,
-      };
+    const extraInput = { preview: createPreview, open_mode: 'preview' };
+    try {
+      await proxyToolResolver('app_open', { app_id: app.id, ...extraInput });
+    } catch {
+      // Preview emission failure is non-fatal — the app was created successfully.
     }
-
-    return {
-      content: JSON.stringify({
-        ...app,
-        auto_opened: false,
-        auto_open_error: openResultText,
-      }),
-      isError: false,
-    };
   }
 
   return { content: JSON.stringify(app), isError: false };


### PR DESCRIPTION
Remove openAppViaSurface fallback from handleAppChange so apps no longer auto-open in a workspace panel on create/update. Keep refreshSurfacesForApp, app_files_changed broadcast, and published deployment updater. The inline preview card is still emitted via the app_create executor path. Part of #11589.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
