### PR TITLE
M2: Add preview-vs-workspace mode to app_open proxy path

### DIFF
--- a/assistant/src/tools/apps/definitions.ts
+++ b/assistant/src/tools/apps/definitions.ts
@@ -43,6 +43,11 @@ const appOpenTool: Tool = {
             type: 'string',
             description: 'The ID of the app to open',
           },
+          open_mode: {
+            type: 'string',
+            enum: ['preview', 'workspace'],
+            description: "Display mode. 'preview' shows an inline preview card in chat. 'workspace' opens the full app in a workspace panel. Defaults to 'workspace'.",
+          },
         },
         required: ['app_id'],
       },


### PR DESCRIPTION
Formalize the open_mode field in the app_open tool definition schema. M1 already added runtime handling in session-surfaces.ts and executors.ts; this milestone adds the schema so the field is documented and validated. Part of #11589.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
