### PR TITLE
M3: Restore and polish non-technical build progress and skill/tool visibility

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolHelpers.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolHelpers.swift
@@ -103,8 +103,14 @@ extension ChatBubble {
         case "browser_screenshot":              return "Taking a screenshot"
         case "app_create":                      return "Building your app"
         case "app_update":                      return "Updating your app"
+        case "app_file_edit":                   return "Editing app files"
+        case "app_file_write":                  return "Writing app files"
         case "skill_load":
             if let name = inputSummary, !name.isEmpty {
+                // App-builder skill gets a more contextual label
+                if name.contains("app-builder") || name.contains("app_builder") {
+                    return "Using App Builder skill"
+                }
                 let display = name.replacingOccurrences(of: "-", with: " ").replacingOccurrences(of: "_", with: " ")
                 return "Loading \(display)"
             }
@@ -113,6 +119,27 @@ extension ChatBubble {
             // Convert raw snake_case name to a readable fallback
             let display = toolName.replacingOccurrences(of: "_", with: " ")
             return "Running \(display)"
+        }
+    }
+
+    /// Maps tool names to user-facing capability descriptions for completed states.
+    /// Returns nil for tools with no friendly mapping, letting callers fall back to a default.
+    /// When `buildingStatus` is present, it takes priority as it's already user-friendly.
+    static func friendlyCapabilityLabel(_ toolName: String, buildingStatus: String? = nil) -> String? {
+        if let status = buildingStatus { return status }
+        switch toolName {
+        case "app_create":                              return "Building your app"
+        case "app_update":                              return "Updating your app"
+        case "app_file_edit":                           return "Styling UI"
+        case "app_file_write":                          return "Writing interface code"
+        case "skill_load":                              return "Loading skill"
+        case "web_search":                              return "Researching"
+        case "web_fetch":                               return "Gathering information"
+        case "file_read", "host_file_read":             return "Reading files"
+        case "file_write", "host_file_write":           return "Creating files"
+        case "file_edit", "host_file_edit":             return "Editing files"
+        case "bash", "host_bash":                       return "Running commands"
+        default:                                        return nil
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -51,6 +51,17 @@ extension ChatBubble {
             // All tools done but model is still working (generating next tool call)
             LiveToolProgressView(toolCalls: message.toolCalls, isRunning: true, thinkingLabel: "Thinking")
                 .frame(maxWidth: 520, alignment: .leading)
+        } else if allToolCallsComplete && !permissionWasDenied && !message.toolCalls.isEmpty {
+            // All tools finished successfully — show a compact completed summary with expandable steps.
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(alignment: .center, spacing: VSpacing.sm) {
+                    UsedToolsList(toolCalls: message.toolCalls, isExpanded: $stepsExpanded)
+                    Spacer()
+                }
+                if stepsExpanded {
+                    StepsSection(toolCalls: message.toolCalls, onRehydrate: onRehydrate)
+                }
+            }
         } else if hasPermission || (hasInProgressTools && permissionWasDenied) {
             // Completed tool steps are hidden — only show permission chip or denied tool chip.
             VStack(alignment: .leading, spacing: 0) {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -51,12 +51,16 @@ extension ChatBubble {
             // All tools done but model is still working (generating next tool call)
             LiveToolProgressView(toolCalls: message.toolCalls, isRunning: true, thinkingLabel: "Thinking")
                 .frame(maxWidth: 520, alignment: .leading)
-        } else if allToolCallsComplete && !permissionWasDenied && !message.toolCalls.isEmpty {
-            // All tools finished successfully — show a compact completed summary with expandable steps.
+        } else if allToolCallsComplete && !permissionWasDenied && !message.toolCalls.isEmpty && !hideToolCalls && !message.toolCalls.contains(where: { $0.isError }) {
+            // All tools finished successfully (no errors) — show a compact completed summary with expandable steps.
+            // Also surface the approved permission chip so it isn't hidden when tools complete after approval.
             VStack(alignment: .leading, spacing: 0) {
                 HStack(alignment: .center, spacing: VSpacing.sm) {
                     UsedToolsList(toolCalls: message.toolCalls, isExpanded: $stepsExpanded)
                     Spacer()
+                    if let confirmation = decidedConfirmation, confirmation.state == .approved {
+                        compactPermissionChip(confirmation)
+                    }
                 }
                 if stepsExpanded {
                     StepsSection(toolCalls: message.toolCalls, onRehydrate: onRehydrate)

--- a/clients/macos/vellum-assistant/Features/Chat/LiveToolProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/LiveToolProgressView.swift
@@ -33,6 +33,12 @@ struct LiveToolProgressView: View {
             }
             return "Working"
         }
+        // When all tools are app-building related, show a more meaningful completed label
+        let appToolNames: Set<String> = ["app_create", "app_update", "app_file_edit", "app_file_write"]
+        let appTools = toolCalls.filter { appToolNames.contains($0.toolName) }
+        if appTools.count == toolCalls.count {
+            return "Built your app"
+        }
         return "Completed \(toolCalls.count) step\(toolCalls.count == 1 ? "" : "s")"
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -13,6 +13,14 @@ struct UsedToolsList: View {
     private var pillLabel: String {
         let count = toolCalls.count
         if count == 1 { return toolCalls[0].actionDescription }
+
+        // If all tool calls are app-building related, show a friendly summary
+        let appToolNames: Set<String> = ["app_create", "app_update", "app_file_edit", "app_file_write"]
+        let appTools = toolCalls.filter { appToolNames.contains($0.toolName) }
+        if appTools.count == count {
+            return "Built your app"
+        }
+
         return "Completed \(count) steps"
     }
 


### PR DESCRIPTION
Restore UsedToolsList completed summary in ChatBubbleToolStatusView, add friendlyCapabilityLabel mapping for app-building tools, improve LiveToolProgressView and UsedToolsList completed-state labels. Part of #11589.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
