### PR TITLE
M5: Align app-builder skill contract and docs with inline-first UX

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -1323,14 +1323,16 @@ Call `app_create` with:
 - `description`: One-sentence summary
 - `schema_json`: JSON schema as string
 - `html`: Complete HTML document as string
-- `auto_open`: (optional, defaults to `true`) Opens the app immediately
-- `preview`: (optional) Inline preview card — see below
+- `auto_open`: (optional, defaults to `true`) Shows an inline preview card in chat after creation
+- `preview`: Always include this — see below
 
-Since `auto_open` defaults to `true`, you don't need to call `app_open` separately after `app_create`.
+Since `auto_open` defaults to `true`, an inline preview card is shown in chat after creation. The app is NOT opened in a workspace panel automatically — users open it explicitly if desired by clicking 'Open App' on the inline card. The app appears in Things (sidebar) immediately after creation via the `app_files_changed` broadcast.
 
 #### Preview metadata
 
-Both `ui_show` and `app_create` support a `preview` object for an inline chat preview card. Always include it so the user sees a compact summary without opening the app.
+Always include preview metadata in `app_create` calls. The app shows as an inline card in chat first — no workspace opens automatically. Users can click 'Open App' on the inline card to open the workspace.
+
+Both `ui_show` and `app_create` support a `preview` object for an inline chat preview card. Always include it so the user sees a compact summary of what was built.
 
 **With `ui_show`:**
 ```json
@@ -1387,7 +1389,7 @@ Both `ui_show` and `app_create` support a `preview` object for an inline chat pr
 }
 ```
 
-Preview fields: `title` (required), `subtitle`, `description`, `icon`, `metrics` (up to 3 key-value pills). The `icon` field accepts an emoji or an image URL. **Prefer an image URL whenever you have a relevant one** — logos, favicons, product images, headshots, flags, album art, or any image you encountered during research. The preview card renders image URLs as a thumbnail automatically. Fall back to emoji only when there is no natural image. When `app_create` is called with `auto_open: true` (the default), the preview is forwarded through `app_open` automatically.
+Preview fields: `title` (required), `subtitle`, `description`, `icon`, `metrics` (up to 3 key-value pills). The `icon` field accepts an emoji or an image URL. **Prefer an image URL whenever you have a relevant one** — logos, favicons, product images, headshots, flags, album art, or any image you encountered during research. The preview card renders image URLs as a thumbnail automatically. Fall back to emoji only when there is no natural image. When `app_create` is called with `auto_open: true` (the default), the inline preview card is shown in chat — the app is NOT automatically opened in a workspace panel.
 
 ### 6. Handle Iteration
 

--- a/assistant/src/config/bundled-skills/app-builder/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-builder/TOOLS.json
@@ -37,7 +37,7 @@
           },
           "auto_open": {
             "type": "boolean",
-            "description": "Automatically open the app after creation. Defaults to true. When true, the app is immediately displayed in a dynamic_page surface without needing a separate app_open call."
+            "description": "When true (default), an inline preview card is shown in chat after creation. The app is NOT automatically opened in a workspace panel — users can open it explicitly via the 'Open App' button on the inline card."
           },
           "set_as_home_base": {
             "type": "boolean",
@@ -45,7 +45,7 @@
           },
           "preview": {
             "type": "object",
-            "description": "Optional inline preview card shown in chat. Provides a compact summary so the user sees what was built without opening the app.",
+            "description": "Inline preview card shown in chat after creation. Always include this so users see a compact summary of what was built. Required fields: title.",
             "properties": {
               "title": { "type": "string", "description": "Preview card title" },
               "subtitle": { "type": "string", "description": "Optional subtitle" },


### PR DESCRIPTION
Update TOOLS.json auto_open and preview descriptions to reflect inline-first behavior. Update SKILL.md to emphasize inline preview cards, explicit user-initiated workspace opening, and Things visibility. Part of #11589.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
