### PR TITLE
Inline-first app preview UX: remove auto workspace opening, polish build progress

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -1323,14 +1323,16 @@ Call `app_create` with:
 - `description`: One-sentence summary
 - `schema_json`: JSON schema as string
 - `html`: Complete HTML document as string
-- `auto_open`: (optional, defaults to `true`) Opens the app immediately
-- `preview`: (optional) Inline preview card — see below
+- `auto_open`: (optional, defaults to `true`) Shows an inline preview card in chat after creation
+- `preview`: Always include this — see below
 
-Since `auto_open` defaults to `true`, you don't need to call `app_open` separately after `app_create`.
+Since `auto_open` defaults to `true`, an inline preview card is shown in chat after creation. The app is NOT opened in a workspace panel automatically — users open it explicitly if desired by clicking 'Open App' on the inline card. The app appears in Things (sidebar) immediately after creation via the `app_files_changed` broadcast.
 
 #### Preview metadata
 
-Both `ui_show` and `app_create` support a `preview` object for an inline chat preview card. Always include it so the user sees a compact summary without opening the app.
+Always include preview metadata in `app_create` calls. The app shows as an inline card in chat first — no workspace opens automatically. Users can click 'Open App' on the inline card to open the workspace.
+
+Both `ui_show` and `app_create` support a `preview` object for an inline chat preview card. Always include it so the user sees a compact summary of what was built.
 
 **With `ui_show`:**
 ```json
@@ -1387,7 +1389,7 @@ Both `ui_show` and `app_create` support a `preview` object for an inline chat pr
 }
 ```
 
-Preview fields: `title` (required), `subtitle`, `description`, `icon`, `metrics` (up to 3 key-value pills). The `icon` field accepts an emoji or an image URL. **Prefer an image URL whenever you have a relevant one** — logos, favicons, product images, headshots, flags, album art, or any image you encountered during research. The preview card renders image URLs as a thumbnail automatically. Fall back to emoji only when there is no natural image. When `app_create` is called with `auto_open: true` (the default), the preview is forwarded through `app_open` automatically.
+Preview fields: `title` (required), `subtitle`, `description`, `icon`, `metrics` (up to 3 key-value pills). The `icon` field accepts an emoji or an image URL. **Prefer an image URL whenever you have a relevant one** — logos, favicons, product images, headshots, flags, album art, or any image you encountered during research. The preview card renders image URLs as a thumbnail automatically. Fall back to emoji only when there is no natural image. When `app_create` is called with `auto_open: true` (the default), the inline preview card is shown in chat — the app is NOT automatically opened in a workspace panel.
 
 ### 6. Handle Iteration
 

--- a/assistant/src/config/bundled-skills/app-builder/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-builder/TOOLS.json
@@ -37,7 +37,7 @@
           },
           "auto_open": {
             "type": "boolean",
-            "description": "Automatically open the app after creation. Defaults to true. When true, the app is immediately displayed in a dynamic_page surface without needing a separate app_open call."
+            "description": "When true (default), an inline preview card is shown in chat after creation. The app is NOT automatically opened in a workspace panel — users can open it explicitly via the 'Open App' button on the inline card."
           },
           "set_as_home_base": {
             "type": "boolean",
@@ -45,7 +45,7 @@
           },
           "preview": {
             "type": "object",
-            "description": "Optional inline preview card shown in chat. Provides a compact summary so the user sees what was built without opening the app.",
+            "description": "Inline preview card shown in chat after creation. Always include this so users see a compact summary of what was built. Required fields: title.",
             "properties": {
               "title": { "type": "string", "description": "Preview card title" },
               "subtitle": { "type": "string", "description": "Optional subtitle" },

--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -819,6 +819,7 @@ export async function surfaceProxyResolver(
   if (toolName === 'app_open') {
     const appId = input.app_id as string;
     const preview = input.preview as DynamicPageSurfaceData['preview'];
+    const openMode = input.open_mode as string | undefined;
     const app = getApp(appId);
     if (!app) return { content: `App not found: ${appId}`, isError: true };
     const seededHomeBase = findSeededHomeBaseApp();
@@ -837,6 +838,33 @@ export async function surfaceProxyResolver(
       preview: { ...defaultPreview, ...preview, ...(storedPreview ? { previewImage: storedPreview } : {}) },
     };
     const surfaceId = uuid();
+
+    if (openMode === 'preview') {
+      // Inline-only preview card emitted during app_create — do not open a
+      // workspace panel and do not register surface state. The client renders
+      // this as a tappable inline card that opens the app on demand.
+      ctx.sendToClient({
+        type: 'ui_surface_show',
+        sessionId: ctx.conversationId,
+        surfaceId,
+        surfaceType: 'dynamic_page',
+        title: app.name,
+        data: surfaceData,
+        display: 'inline',
+      } as UiSurfaceShow);
+
+      // Track for message persistence so the inline card survives history reload.
+      ctx.currentTurnSurfaces.push({
+        surfaceId,
+        surfaceType: 'dynamic_page',
+        title: app.name,
+        data: surfaceData,
+        display: 'inline',
+      });
+
+      return { content: JSON.stringify({ surfaceId, appId }), isError: false };
+    }
+
     ctx.surfaceState.set(surfaceId, {
       surfaceType: 'dynamic_page',
       data: surfaceData,

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -10,15 +10,11 @@
 import { join } from 'node:path';
 
 import { updatePublishedAppDeployment } from '../services/published-app-updater.js';
-import { openAppViaSurface } from '../tools/apps/open-proxy.js';
 import type { ToolExecutionResult } from '../tools/types.js';
 import { getWorkspaceDir } from '../util/platform.js';
 import { isDoordashCommand, updateDoordashProgress } from './doordash-steps.js';
 import type { ServerMessage } from './ipc-protocol.js';
-import {
-  refreshSurfacesForApp,
-  surfaceProxyResolver,
-} from './session-surfaces.js';
+import { refreshSurfacesForApp } from './session-surfaces.js';
 import type { ToolSetupContext } from './session-tool-setup.js';
 
 // ── Types ────────────────────────────────────────────────────────────
@@ -37,20 +33,16 @@ export type PostExecutionHook = (
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-/** Shared logic for refreshing app surfaces, broadcasting changes, and auto-opening. */
+/** Shared logic for refreshing app surfaces, broadcasting changes, and triggering auto-deploy. */
 function handleAppChange(
   ctx: ToolSetupContext,
   appId: string,
   broadcastToAllClients: ((msg: ServerMessage) => void) | undefined,
   opts?: { fileChange?: boolean; status?: string },
 ): void {
-  const refreshed = refreshSurfacesForApp(ctx, appId, opts);
+  refreshSurfacesForApp(ctx, appId, opts);
   broadcastToAllClients?.({ type: 'app_files_changed', appId });
   void updatePublishedAppDeployment(appId);
-  if (!refreshed && !ctx.hasNoClient && !ctx.headlessLock) {
-    const resolver = (tn: string, pi: Record<string, unknown>) => surfaceProxyResolver(ctx, tn, pi);
-    void openAppViaSurface(appId, resolver);
-  }
 }
 
 // ── Registry ─────────────────────────────────────────────────────────
@@ -82,7 +74,6 @@ registerHook('app_create', (_name, _input, result, { ctx, broadcastToAllClients 
 });
 
 // Auto-refresh workspace surfaces when a persisted app is updated.
-// If no surface is currently showing the app, auto-open it.
 registerHook('app_update', (_name, input, _result, { ctx, broadcastToAllClients }) => {
   const appId = input.app_id as string | undefined;
   if (appId) {
@@ -109,7 +100,6 @@ registerHook(
 );
 
 // Auto-refresh workspace surfaces when app files are edited.
-// If no surface is currently showing the app, auto-open it.
 registerHook(
   ['app_file_edit', 'app_file_write'],
   (_name, input, _result, { ctx, broadcastToAllClients }) => {

--- a/assistant/src/tools/apps/definitions.ts
+++ b/assistant/src/tools/apps/definitions.ts
@@ -43,6 +43,11 @@ const appOpenTool: Tool = {
             type: 'string',
             description: 'The ID of the app to open',
           },
+          open_mode: {
+            type: 'string',
+            enum: ['preview', 'workspace'],
+            description: "Display mode. 'preview' shows an inline preview card in chat. 'workspace' opens the full app in a workspace panel. Defaults to 'workspace'.",
+          },
         },
         required: ['app_id'],
       },

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -129,6 +129,12 @@ export async function executeAppCreate(
     const extraInput = { preview: createPreview, open_mode: 'preview' };
     try {
       const openResult = await proxyToolResolver('app_open', { app_id: app.id, ...extraInput });
+      if (openResult.isError) {
+        return {
+          content: JSON.stringify({ ...app, auto_opened: false, auto_open_error: openResult.content }),
+          isError: false,
+        };
+      }
       return {
         content: JSON.stringify({ ...app, auto_opened: true, open_result: openResult.content }),
         isError: false,

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -128,9 +128,17 @@ export async function executeAppCreate(
     const createPreview = { ...(preview ?? {}), context: 'app_create' as const };
     const extraInput = { preview: createPreview, open_mode: 'preview' };
     try {
-      await proxyToolResolver('app_open', { app_id: app.id, ...extraInput });
+      const openResult = await proxyToolResolver('app_open', { app_id: app.id, ...extraInput });
+      return {
+        content: JSON.stringify({ ...app, auto_opened: true, open_result: openResult.content }),
+        isError: false,
+      };
     } catch {
       // Preview emission failure is non-fatal — the app was created successfully.
+      return {
+        content: JSON.stringify({ ...app, auto_opened: false, auto_open_error: 'Failed to auto-open app. Use app_open to open it manually.' }),
+        isError: false,
+      };
     }
   }
 

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -11,7 +11,6 @@
 import { setHomeBaseAppLink } from '../../home-base/app-link-store.js';
 import type { AppDefinition } from '../../memory/app-store.js';
 import type { EditEngineResult } from '../../memory/app-store.js';
-import { openAppViaSurface } from './open-proxy.js';
 
 // ---------------------------------------------------------------------------
 // Shared result type
@@ -123,33 +122,16 @@ export async function executeAppCreate(
     setHomeBaseAppLink(app.id, 'personalized');
   }
 
-  // Auto-open the app via the shared open-proxy helper
+  // Emit the inline preview card via the proxy without opening a workspace panel.
+  // open_mode: "preview" signals to the client that this should be shown inline only.
   if (autoOpen && proxyToolResolver) {
     const createPreview = { ...(preview ?? {}), context: 'app_create' as const };
-    const extraInput = { preview: createPreview };
-    const openResultText = await openAppViaSurface(app.id, proxyToolResolver, extraInput);
-
-    // Determine whether the open succeeded by checking for the fallback text
-    const opened = openResultText !== 'Failed to auto-open app. Use app_open to open it manually.';
-    if (opened) {
-      return {
-        content: JSON.stringify({
-          ...app,
-          auto_opened: true,
-          open_result: openResultText,
-        }),
-        isError: false,
-      };
+    const extraInput = { preview: createPreview, open_mode: 'preview' };
+    try {
+      await proxyToolResolver('app_open', { app_id: app.id, ...extraInput });
+    } catch {
+      // Preview emission failure is non-fatal — the app was created successfully.
     }
-
-    return {
-      content: JSON.stringify({
-        ...app,
-        auto_opened: false,
-        auto_open_error: openResultText,
-      }),
-      isError: false,
-    };
   }
 
   return { content: JSON.stringify(app), isError: false };

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolHelpers.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolHelpers.swift
@@ -103,8 +103,14 @@ extension ChatBubble {
         case "browser_screenshot":              return "Taking a screenshot"
         case "app_create":                      return "Building your app"
         case "app_update":                      return "Updating your app"
+        case "app_file_edit":                   return "Editing app files"
+        case "app_file_write":                  return "Writing app files"
         case "skill_load":
             if let name = inputSummary, !name.isEmpty {
+                // App-builder skill gets a more contextual label
+                if name.contains("app-builder") || name.contains("app_builder") {
+                    return "Using App Builder skill"
+                }
                 let display = name.replacingOccurrences(of: "-", with: " ").replacingOccurrences(of: "_", with: " ")
                 return "Loading \(display)"
             }
@@ -113,6 +119,27 @@ extension ChatBubble {
             // Convert raw snake_case name to a readable fallback
             let display = toolName.replacingOccurrences(of: "_", with: " ")
             return "Running \(display)"
+        }
+    }
+
+    /// Maps tool names to user-facing capability descriptions for completed states.
+    /// Returns nil for tools with no friendly mapping, letting callers fall back to a default.
+    /// When `buildingStatus` is present, it takes priority as it's already user-friendly.
+    static func friendlyCapabilityLabel(_ toolName: String, buildingStatus: String? = nil) -> String? {
+        if let status = buildingStatus { return status }
+        switch toolName {
+        case "app_create":                              return "Building your app"
+        case "app_update":                              return "Updating your app"
+        case "app_file_edit":                           return "Styling UI"
+        case "app_file_write":                          return "Writing interface code"
+        case "skill_load":                              return "Loading skill"
+        case "web_search":                              return "Researching"
+        case "web_fetch":                               return "Gathering information"
+        case "file_read", "host_file_read":             return "Reading files"
+        case "file_write", "host_file_write":           return "Creating files"
+        case "file_edit", "host_file_edit":             return "Editing files"
+        case "bash", "host_bash":                       return "Running commands"
+        default:                                        return nil
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -51,6 +51,21 @@ extension ChatBubble {
             // All tools done but model is still working (generating next tool call)
             LiveToolProgressView(toolCalls: message.toolCalls, isRunning: true, thinkingLabel: "Thinking")
                 .frame(maxWidth: 520, alignment: .leading)
+        } else if allToolCallsComplete && !permissionWasDenied && !message.toolCalls.isEmpty && !hideToolCalls && !message.toolCalls.contains(where: { $0.isError }) {
+            // All tools finished successfully (no errors) — show a compact completed summary with expandable steps.
+            // Also surface the approved permission chip so it isn't hidden when tools complete after approval.
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(alignment: .center, spacing: VSpacing.sm) {
+                    UsedToolsList(toolCalls: message.toolCalls, isExpanded: $stepsExpanded)
+                    Spacer()
+                    if let confirmation = decidedConfirmation, confirmation.state == .approved {
+                        compactPermissionChip(confirmation)
+                    }
+                }
+                if stepsExpanded {
+                    StepsSection(toolCalls: message.toolCalls, onRehydrate: onRehydrate)
+                }
+            }
         } else if hasPermission || (hasInProgressTools && permissionWasDenied) {
             // Completed tool steps are hidden — only show permission chip or denied tool chip.
             VStack(alignment: .leading, spacing: 0) {

--- a/clients/macos/vellum-assistant/Features/Chat/LiveToolProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/LiveToolProgressView.swift
@@ -33,6 +33,12 @@ struct LiveToolProgressView: View {
             }
             return "Working"
         }
+        // When all tools are app-building related, show a more meaningful completed label
+        let appToolNames: Set<String> = ["app_create", "app_update", "app_file_edit", "app_file_write"]
+        let appTools = toolCalls.filter { appToolNames.contains($0.toolName) }
+        if appTools.count == toolCalls.count {
+            return "Built your app"
+        }
         return "Completed \(toolCalls.count) step\(toolCalls.count == 1 ? "" : "s")"
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -13,6 +13,14 @@ struct UsedToolsList: View {
     private var pillLabel: String {
         let count = toolCalls.count
         if count == 1 { return toolCalls[0].actionDescription }
+
+        // If all tool calls are app-building related, show a friendly summary
+        let appToolNames: Set<String> = ["app_create", "app_update", "app_file_edit", "app_file_write"]
+        let appTools = toolCalls.filter { appToolNames.contains($0.toolName) }
+        if appTools.count == count {
+            return "Built your app"
+        }
+
         return "Completed \(count) steps"
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
@@ -57,6 +57,13 @@ final class AppListManager: ObservableObject {
         load()
     }
 
+    /// Test-only initializer that stores data at a custom URL instead of Application Support.
+    /// Allows unit tests to use a temporary directory without polluting real app state.
+    init(fileURL: URL) {
+        self.fileURL = fileURL
+        load()
+    }
+
     func recordAppOpen(id: String, name: String, icon: String? = nil, previewBase64: String? = nil, appType: String? = nil, description: String? = nil) {
         // Clear tombstone so an explicitly re-opened app reappears in the sidebar
         removedAppIds.remove(id)

--- a/clients/macos/vellum-assistantTests/AppListManagerSyncTests.swift
+++ b/clients/macos/vellum-assistantTests/AppListManagerSyncTests.swift
@@ -1,0 +1,225 @@
+import XCTest
+@testable import VellumAssistantLib
+
+/// Regression tests for AppListManager.syncFromDaemon().
+///
+/// These tests verify the sync chain that makes newly-created apps (e.g. from
+/// an app_create tool call) appear in the macOS "Things" sidebar after the
+/// daemon broadcasts app_files_changed, which triggers a fresh daemon sync.
+///
+/// The chain under test:
+///   app_create tool runs
+///   → handleAppChange in tool-side-effects.ts broadcasts app_files_changed
+///   → macOS client calls /v1/apps, receives updated list
+///   → AppListManager.syncFromDaemon() is called with the new list
+///   → manager.apps contains the new app
+@MainActor
+final class AppListManagerSyncTests: XCTestCase {
+
+    private var tempDir: URL!
+    private var manager: AppListManager!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let fileURL = tempDir.appendingPathComponent("app-list.json")
+        manager = AppListManager(fileURL: fileURL)
+    }
+
+    override func tearDown() {
+        manager = nil
+        try? FileManager.default.removeItem(at: tempDir)
+        tempDir = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeDaemonApp(
+        id: String = "app-1",
+        name: String = "Things",
+        description: String? = nil,
+        icon: String? = nil,
+        appType: String? = nil,
+        createdAt: Int = 1_700_000_000_000
+    ) -> AppListManager.AppItem_Daemon {
+        AppListManager.AppItem_Daemon(
+            id: id,
+            name: name,
+            description: description,
+            icon: icon,
+            appType: appType,
+            createdAt: createdAt
+        )
+    }
+
+    // MARK: - New app appears after sync
+
+    func testNewAppFromDaemonAppearsAfterSync() {
+        // Precondition: manager starts with no apps
+        XCTAssertTrue(manager.apps.isEmpty, "Manager should start empty")
+
+        let daemonApp = makeDaemonApp(id: "things-app", name: "Things")
+        manager.syncFromDaemon([daemonApp])
+
+        XCTAssertEqual(manager.apps.count, 1, "One app should appear after sync")
+        XCTAssertEqual(manager.apps.first?.id, "things-app")
+        XCTAssertEqual(manager.apps.first?.name, "Things")
+    }
+
+    func testMultipleNewAppsFromDaemonAllAppearAfterSync() {
+        let daemonApps = [
+            makeDaemonApp(id: "app-a", name: "Alpha"),
+            makeDaemonApp(id: "app-b", name: "Bravo"),
+            makeDaemonApp(id: "app-c", name: "Charlie"),
+        ]
+        manager.syncFromDaemon(daemonApps)
+
+        XCTAssertEqual(manager.apps.count, 3)
+        let ids = Set(manager.apps.map(\.id))
+        XCTAssertEqual(ids, ["app-a", "app-b", "app-c"])
+    }
+
+    func testNewAppTimestampDerivesFromDaemonCreatedAt() {
+        // createdAt is milliseconds since epoch; lastOpenedAt should reflect it
+        let createdAtMs = 1_700_000_000_000
+        let daemonApp = makeDaemonApp(id: "app-ts", name: "Timestamp App", createdAt: createdAtMs)
+        manager.syncFromDaemon([daemonApp])
+
+        let expectedDate = Date(timeIntervalSince1970: TimeInterval(createdAtMs) / 1000.0)
+        XCTAssertEqual(
+            manager.apps.first?.lastOpenedAt.timeIntervalSince1970,
+            expectedDate.timeIntervalSince1970,
+            accuracy: 0.001,
+            "lastOpenedAt should be derived from daemon's createdAt millisecond timestamp"
+        )
+    }
+
+    // MARK: - Description update
+
+    func testExistingAppDescriptionIsUpdatedOnSync() {
+        // Seed the manager with an app that has no description
+        manager.recordAppOpen(id: "app-1", name: "Things")
+        XCTAssertNil(manager.apps.first?.description, "Initial description should be nil")
+
+        // Sync from daemon with a description
+        let daemonApp = makeDaemonApp(id: "app-1", name: "Things", description: "A task manager")
+        manager.syncFromDaemon([daemonApp])
+
+        XCTAssertEqual(manager.apps.first?.description, "A task manager",
+                       "Description should be updated from daemon during sync")
+    }
+
+    func testExistingAppDescriptionIsOverwrittenWhenChanged() {
+        // Seed with a stale description
+        manager.recordAppOpen(id: "app-1", name: "Things", description: "Old description")
+
+        // Daemon reports a new description
+        let daemonApp = makeDaemonApp(id: "app-1", name: "Things", description: "New description")
+        manager.syncFromDaemon([daemonApp])
+
+        XCTAssertEqual(manager.apps.first?.description, "New description",
+                       "Daemon description should overwrite local stale description")
+    }
+
+    func testExistingAppNotDuplicatedOnSync() {
+        // Seeding an app then syncing the same app should not duplicate it
+        manager.recordAppOpen(id: "app-1", name: "Things")
+        XCTAssertEqual(manager.apps.count, 1)
+
+        let daemonApp = makeDaemonApp(id: "app-1", name: "Things", description: "Updated")
+        manager.syncFromDaemon([daemonApp])
+
+        XCTAssertEqual(manager.apps.count, 1, "Sync should not duplicate an existing app")
+    }
+
+    // MARK: - Removed app is pruned
+
+    func testAppRemovedFromDaemonIsPrunedLocally() {
+        // Seed two apps
+        manager.recordAppOpen(id: "app-keep", name: "Keep Me")
+        manager.recordAppOpen(id: "app-gone", name: "Gone App")
+        XCTAssertEqual(manager.apps.count, 2)
+
+        // Daemon only reports the first app — second has been deleted
+        let daemonApps = [makeDaemonApp(id: "app-keep", name: "Keep Me")]
+        manager.syncFromDaemon(daemonApps)
+
+        XCTAssertEqual(manager.apps.count, 1, "Pruned app should be removed")
+        XCTAssertEqual(manager.apps.first?.id, "app-keep", "Surviving app should be retained")
+        XCTAssertNil(manager.apps.first(where: { $0.id == "app-gone" }),
+                     "Removed app should not be in the list")
+    }
+
+    func testSyncWithEmptyDaemonListPrunesAllApps() {
+        manager.recordAppOpen(id: "app-1", name: "App One")
+        manager.recordAppOpen(id: "app-2", name: "App Two")
+        XCTAssertEqual(manager.apps.count, 2)
+
+        manager.syncFromDaemon([])
+
+        XCTAssertTrue(manager.apps.isEmpty, "All apps should be pruned when daemon list is empty")
+    }
+
+    // MARK: - Tombstoned apps are not re-added by sync
+
+    func testUserRemovedAppIsNotReAddedBySyncFromDaemon() {
+        // User removes an app: it is tombstoned in removedAppIds
+        manager.recordAppOpen(id: "app-tombstoned", name: "Removed App")
+        manager.removeApp(id: "app-tombstoned")
+        XCTAssertTrue(manager.apps.isEmpty, "App should be gone after user removal")
+
+        // Daemon still reports it (e.g. daemon hasn't been notified yet)
+        let daemonApp = makeDaemonApp(id: "app-tombstoned", name: "Removed App")
+        manager.syncFromDaemon([daemonApp])
+
+        XCTAssertTrue(manager.apps.isEmpty,
+                      "Tombstoned app should not reappear after daemon sync")
+    }
+
+    // MARK: - Pinned apps survive sync
+
+    func testPinnedAppSurvivesSyncAndRetainsPinnedState() {
+        manager.recordAppOpen(id: "app-pinned", name: "Pinned App")
+        manager.pinApp(id: "app-pinned")
+        XCTAssertTrue(manager.apps.first?.isPinned == true, "App should be pinned")
+
+        // Sync with the same app from daemon
+        let daemonApp = makeDaemonApp(id: "app-pinned", name: "Pinned App")
+        manager.syncFromDaemon([daemonApp])
+
+        // Pinned state is local metadata and should be preserved
+        XCTAssertTrue(manager.apps.first?.isPinned == true,
+                      "Pinned state should be preserved after sync")
+    }
+
+    // MARK: - Mixed scenario: add, update, prune in one sync
+
+    func testSyncCombinedAddUpdateAndPrune() {
+        // Seed two existing apps
+        manager.recordAppOpen(id: "app-keep", name: "Keep")
+        manager.recordAppOpen(id: "app-prune", name: "Prune Me")
+        XCTAssertEqual(manager.apps.count, 2)
+
+        // Daemon: keeps "app-keep" (with new description), removes "app-prune", adds "app-new"
+        let daemonApps = [
+            makeDaemonApp(id: "app-keep", name: "Keep", description: "I am kept"),
+            makeDaemonApp(id: "app-new", name: "New App"),
+        ]
+        manager.syncFromDaemon(daemonApps)
+
+        XCTAssertEqual(manager.apps.count, 2, "Should have kept + new = 2 apps")
+
+        let kept = manager.apps.first(where: { $0.id == "app-keep" })
+        XCTAssertNotNil(kept, "app-keep should still exist")
+        XCTAssertEqual(kept?.description, "I am kept", "Description should be updated")
+
+        let newApp = manager.apps.first(where: { $0.id == "app-new" })
+        XCTAssertNotNil(newApp, "app-new should have been added")
+
+        let pruned = manager.apps.first(where: { $0.id == "app-prune" })
+        XCTAssertNil(pruned, "app-prune should have been removed")
+    }
+}


### PR DESCRIPTION
## Summary
Restructure app creation flow so apps are previewed inline in chat (via InlineAppCreatedCard) instead of automatically jumping to a workspace panel. Polish non-technical build progress labels and ensure new apps appear in Things immediately.

## Changes
- Remove automatic workspace/panel opening on app_create — `openAppViaSurface` fallback removed from `handleAppChange`, executor uses `open_mode: 'preview'` for inline-only display
- Add `open_mode` field to `app_open` tool schema (`"preview" | "workspace"`) with handler in `session-surfaces.ts`
- Restore completed-tools summary (`UsedToolsList`) in chat bubbles with `hideToolCalls` guard, permission chip preservation, and error-case gating
- Add friendly capability labels for app-building tools ("Built your app", "Styling UI", etc.)
- Add regression tests for `AppListManager.syncFromDaemon` verifying Things sidebar visibility
- Align app-builder SKILL.md and TOOLS.json with inline-first behavior

## Milestone PRs (merged into feature branch)
- #11595: M1 — Remove automatic workspace opening from build flows
- #11596: M2 — Add preview-vs-workspace mode to app_open proxy path
- #11597: M3 — Restore and polish non-technical build progress and skill/tool visibility
- #11600: M4 — Guarantee Things visibility on app create
- #11602: M5 — Align app-builder skill contract and docs with inline-first UX

## Project issue
Closes #11589

## Test plan
- [ ] Create a new app via chat — verify inline preview card appears, no workspace panel auto-opens
- [ ] Click "Open App" on inline card — verify workspace opens correctly
- [ ] Verify new app appears in Things sidebar after creation
- [ ] Verify completed tool summary shows "Built your app" for app-building flows
- [ ] Verify permission chips still appear alongside completed tools summary
- [ ] Verify errored tools don't show success styling

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
