### PR TITLE
fix: add missing getRootDir mock to abort-cleanup test

### DIFF
--- a/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
+++ b/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
@@ -78,6 +78,7 @@ mock.module("../tools/network/script-proxy/index.js", () => ({
 }));
 
 mock.module("../util/platform.js", () => ({
+  getRootDir: () => "/tmp",
   getDataDir: () => "/tmp",
   getSocketPath: () => "/tmp/vellum.sock",
 }));


### PR DESCRIPTION
## Summary
- Added `getRootDir` to the `platform.js` mock in `tool-execution-abort-cleanup.test.ts`
- Commit `547e4f8e8` introduced an import of `token-service.js` in `safe-env.ts`, which transitively requires `getRootDir` from `platform.ts`
- This has been causing 4 consecutive CI failures on main

## Original prompt
Help get these CI checks passing: https://github.com/vellum-ai/vellum-assistant/actions/runs/22612865559/job/65518811339

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
