### PR TITLE
fix: clean up stale keychain entries when writing to encrypted store

### DIFF
--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -148,11 +148,19 @@ export function getSecureKey(account: string): string | undefined {
  * Returns `true` on success, `false` on failure.
  */
 export function setSecureKey(account: string, value: string): boolean {
-  return withKeychainFallback(
+  const result = withKeychainFallback(
     () => keychain.setKey(account, value),
     () => encryptedStore.setKey(account, value),
     false,
   );
+  // When writing to the encrypted store after a keychain downgrade, clean up
+  // any stale keychain entry so the gateway's credential-reader (which tries
+  // keychain first) does not read an outdated value.
+  if (result && downgradedFromKeychain && getBackend() === "encrypted") {
+    keychainMissCache.delete(account);
+    try { keychain.deleteKey(account); } catch { /* best-effort */ }
+  }
+  return result;
 }
 
 /**
@@ -278,7 +286,15 @@ export async function setSecureKeyAsync(
   value: string,
 ): Promise<boolean> {
   const backend = await getBackendAsync();
-  if (backend === "encrypted") return encryptedStore.setKey(account, value);
+  if (backend === "encrypted") {
+    const result = encryptedStore.setKey(account, value);
+    // Clean up stale keychain entry (mirrors setSecureKey logic).
+    if (result && downgradedFromKeychain) {
+      keychainMissCache.delete(account);
+      try { await keychain.deleteKeyAsync(account); } catch { /* best-effort */ }
+    }
+    return result;
+  }
   if (backend !== "keychain") return false;
 
   const result = await keychain.setKeyAsync(account, value);


### PR DESCRIPTION
## Summary
- On macOS the daemon uses the encrypted file backend, but `setSecureKey`/`setSecureKeyAsync` didn't clean up stale keychain entries when writing new values
- The gateway's `credential-reader` tries keychain first, so it would read outdated credentials — causing Twilio webhook signature validation failures
- Now both set functions delete the stale keychain entry (best-effort) after a successful encrypted-store write, mirroring what `deleteSecureKey` already does

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
