### PR TITLE
fix: remove duplicate getRootDir property in abort-cleanup test

### DIFF
--- a/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
+++ b/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
@@ -80,7 +80,6 @@ mock.module("../tools/network/script-proxy/index.js", () => ({
 mock.module("../util/platform.js", () => ({
   getRootDir: () => "/tmp",
   getDataDir: () => "/tmp",
-  getRootDir: () => "/tmp",
   getSocketPath: () => "/tmp/vellum.sock",
 }));
 


### PR DESCRIPTION
## Summary
- Removed duplicate `getRootDir` property in the platform mock object literal in `tool-execution-abort-cleanup.test.ts`
- This caused TypeScript error TS1117 ("An object literal cannot have multiple properties with the same name")

## Test plan
- [x] `bunx tsc --noEmit` passes locally
- [ ] CI type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
