### PR TITLE
fix: use correct experimental frontmatter key and clean up temp credential files

### DIFF
--- a/playwright/agent/tools/fill-secure-credential.ts
+++ b/playwright/agent/tools/fill-secure-credential.ts
@@ -13,7 +13,7 @@
  */
 
 import { execSync } from "child_process";
-import { writeFileSync } from "fs";
+import { unlinkSync, writeFileSync } from "fs";
 
 import type Anthropic from "@anthropic-ai/sdk";
 import type { Page } from "playwright";
@@ -263,5 +263,7 @@ end tell
         data: `Failed to fill Secure Credential: ${message}`,
       },
     };
+  } finally {
+    try { unlinkSync(scriptPath); } catch {}
   }
 }

--- a/playwright/cases/phone-setup.md
+++ b/playwright/cases/phone-setup.md
@@ -1,6 +1,6 @@
 ---
 fixture: desktop-app
-experimental: true
+status: experimental
 ---
 
 # Phone & Voice Setup


### PR DESCRIPTION
## Summary
- Change `experimental: true` to `status: experimental` in phone-setup.md so test parsers recognize the experimental gate
- Add cleanup of temp AppleScript files containing secrets in fill-secure-credential.ts via a finally block with unlinkSync

Addresses review feedback on #11498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
