### PR TITLE
fix: reorder forceStop before disconnect in performSwitchAssistant

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -970,8 +970,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     ///
     /// The sequence is intentionally ordered to avoid stale references:
     /// 1. Stop lifecycle monitoring and daemon processes
-    /// 2. Disconnect daemon transport
-    /// 3. Clear assistant-scoped runtime state (threads, sessions, callbacks)
+    /// 2. Clear assistant-scoped runtime state (recording, windows, callbacks)
+    /// 3. Disconnect daemon transport
     /// 4. Persist the new assistant selection
     /// 5. Reconfigure daemon transport and reconnect
     /// 6. Resume monitoring and credential bootstrap
@@ -980,13 +980,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         assistantCli.stopMonitoring()
         assistantCli.stop()
 
-        // 2. Disconnect daemon transport (handled by reconfigure in step 5)
-        daemonClient.disconnect()
-
-        // 3. Clear assistant-scoped runtime state
-        // Force-stop any active recording to avoid stale session references
+        // 2. Clear assistant-scoped runtime state before disconnecting
+        // so forceStop can send a recording_status to the daemon.
         recordingManager.forceStop()
         recordingHUDWindow?.dismiss()
+
+        // 3. Disconnect daemon transport (reconfigure in step 5 also disconnects)
+        daemonClient.disconnect()
         // Close and recreate the main window to reset thread/session state
         mainWindow?.close()
         mainWindow = nil


### PR DESCRIPTION
## Summary
- Move recordingManager.forceStop() and recordingHUDWindow?.dismiss() before daemonClient.disconnect() so the recording cancellation status message can reach the daemon
- Update doc comment step numbering to reflect the new ordering

Addresses review feedback on #11564.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
