### PR TITLE
fix: optimize keychain cleanup and add async downgrade path coverage in secure-keys

### DIFF
--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -158,7 +158,13 @@ export function setSecureKey(account: string, value: string): boolean {
   // keychain first) does not read an outdated value.
   if (result && downgradedFromKeychain && getBackend() === "encrypted") {
     keychainMissCache.delete(account);
-    try { keychain.deleteKey(account); } catch { /* best-effort */ }
+    try {
+      // Only attempt deletion if the key actually exists in keychain to
+      // avoid spawning a subprocess on every write.
+      if (keychain.getKey(account) !== undefined) {
+        keychain.deleteKey(account);
+      }
+    } catch { /* best-effort */ }
   }
   return result;
 }
@@ -291,7 +297,14 @@ export async function setSecureKeyAsync(
     // Clean up stale keychain entry (mirrors setSecureKey logic).
     if (result && downgradedFromKeychain) {
       keychainMissCache.delete(account);
-      try { await keychain.deleteKeyAsync(account); } catch { /* best-effort */ }
+      try {
+        // Only attempt deletion if the key actually exists in keychain to
+        // avoid spawning a subprocess on every write.
+        const exists = await keychain.getKeyAsync(account);
+        if (exists !== undefined) {
+          await keychain.deleteKeyAsync(account);
+        }
+      } catch { /* best-effort */ }
     }
     return result;
   }
@@ -304,7 +317,18 @@ export async function setSecureKeyAsync(
     );
     resolvedBackend = "encrypted";
     downgradedFromKeychain = true;
-    return encryptedStore.setKey(account, value);
+    const fallbackResult = encryptedStore.setKey(account, value);
+    // Clean up stale keychain entry after runtime downgrade
+    if (fallbackResult) {
+      keychainMissCache.delete(account);
+      try {
+        const exists = await keychain.getKeyAsync(account);
+        if (exists !== undefined) {
+          await keychain.deleteKeyAsync(account);
+        }
+      } catch { /* best-effort */ }
+    }
+    return fallbackResult;
   }
   return result;
 }


### PR DESCRIPTION
## Summary
- Check keychain key existence before attempting deletion to avoid spawning a subprocess on every write after downgrade
- Add stale keychain cleanup in the async runtime downgrade fallback path (when backend starts as keychain, fails mid-call, and falls back to encrypted store)

Addresses review feedback on #11607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
