### PR TITLE
fix: move forceStop before assistantCli.stop so recording status reaches the daemon

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -969,23 +969,23 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     /// restarts with the new assistant.
     ///
     /// The sequence is intentionally ordered to avoid stale references:
-    /// 1. Stop lifecycle monitoring and daemon processes
+    /// 1. Stop lifecycle monitoring
     /// 2. Clear assistant-scoped runtime state (recording, windows, callbacks)
-    /// 3. Disconnect daemon transport
+    /// 3. Stop daemon processes and disconnect transport
     /// 4. Persist the new assistant selection
     /// 5. Reconfigure daemon transport and reconnect
     /// 6. Resume monitoring and credential bootstrap
     func performSwitchAssistant(to assistant: LockfileAssistant) {
-        // 1. Stop lifecycle monitoring and daemon processes
+        // 1. Stop lifecycle monitoring
         assistantCli.stopMonitoring()
-        assistantCli.stop()
 
-        // 2. Clear assistant-scoped runtime state before disconnecting
-        // so forceStop can send a recording_status to the daemon.
+        // 2. Clear assistant-scoped runtime state while the daemon is still
+        // running so forceStop can deliver a recording_status IPC message.
         recordingManager.forceStop()
         recordingHUDWindow?.dismiss()
 
-        // 3. Disconnect daemon transport (reconfigure in step 5 also disconnects)
+        // 3. Stop daemon processes and disconnect transport
+        assistantCli.stop()
         daemonClient.disconnect()
         // Close and recreate the main window to reset thread/session state
         mainWindow?.close()


### PR DESCRIPTION
## Summary
- Move recordingManager.forceStop() and recordingHUDWindow?.dismiss() before assistantCli.stop() so the recording cancellation IPC message can reach the still-running daemon
- Previously, assistantCli.stop() killed the daemon process synchronously before forceStop could send the status message

Addresses review feedback on #11613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
