### PR TITLE
feat: consolidate hatch logs into single tagged file

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -14,7 +14,7 @@ import { dirname, join } from "path";
 import { loadLatestAssistant } from "./assistant-config.js";
 import { GATEWAY_PORT } from "./constants.js";
 import { stopProcessByPidFile } from "./process.js";
-import { openLogFile, closeLogFile } from "./xdg-log.js";
+import { openLogFile, pipeToLogFile } from "./xdg-log.js";
 
 const _require = createRequire(import.meta.url);
 
@@ -513,20 +513,16 @@ export async function startLocalDaemon(): Promise<void> {
         }
       }
 
-      const daemonLogFd = openLogFile("daemon.log");
-      let daemonPid: number | undefined;
-      try {
-        const child = spawn(daemonBinary, [], {
-          cwd: dirname(daemonBinary),
-          detached: true,
-          stdio: ["ignore", daemonLogFd, daemonLogFd],
-          env: daemonEnv,
-        });
-        child.unref();
-        daemonPid = child.pid;
-      } finally {
-        closeLogFile(daemonLogFd);
-      }
+      const daemonLogFd = openLogFile("hatch.log");
+      const child = spawn(daemonBinary, [], {
+        cwd: dirname(daemonBinary),
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: daemonEnv,
+      });
+      pipeToLogFile(child, daemonLogFd, "daemon");
+      child.unref();
+      const daemonPid = child.pid;
 
       // Write PID file immediately so the health monitor can find the process
       // and concurrent hatch() calls see it as alive.
@@ -691,30 +687,24 @@ export async function startGateway(assistantId?: string): Promise<string> {
       );
     }
 
-    const gatewayLogFd = openLogFile("gateway.log");
-    try {
-      gateway = spawn(gatewayBinary, [], {
-        detached: true,
-        stdio: ["ignore", gatewayLogFd, gatewayLogFd],
-        env: gatewayEnv,
-      });
-    } finally {
-      closeLogFile(gatewayLogFd);
-    }
+    const gatewayLogFd = openLogFile("hatch.log");
+    gateway = spawn(gatewayBinary, [], {
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: gatewayEnv,
+    });
+    pipeToLogFile(gateway, gatewayLogFd, "gateway");
   } else {
     // Source tree / bunx: resolve the gateway source directory and run via bun.
     const gatewayDir = resolveGatewayDir();
-    const gwLogFd = openLogFile("gateway.log");
-    try {
-      gateway = spawn("bun", ["run", "src/index.ts", "--vellum-gateway"], {
-        cwd: gatewayDir,
-        detached: true,
-        stdio: ["ignore", gwLogFd, gwLogFd],
-        env: gatewayEnv,
-      });
-    } finally {
-      closeLogFile(gwLogFd);
-    }
+    const gwLogFd = openLogFile("hatch.log");
+    gateway = spawn("bun", ["run", "src/index.ts", "--vellum-gateway"], {
+      cwd: gatewayDir,
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: gatewayEnv,
+    });
+    pipeToLogFile(gateway, gwLogFd, "gateway");
   }
 
   gateway.unref();

--- a/cli/src/lib/xdg-log.ts
+++ b/cli/src/lib/xdg-log.ts
@@ -1,4 +1,5 @@
 import { closeSync, mkdirSync, openSync, writeSync } from "fs";
+import type { ChildProcess } from "child_process";
 import { homedir } from "os";
 import { join } from "path";
 
@@ -33,5 +34,40 @@ export function closeLogFile(fd: number | "ignore"): void {
 export function writeToLogFile(fd: number | "ignore", msg: string): void {
   if (typeof fd === "number") {
     try { writeSync(fd, msg); } catch { /* best-effort */ }
+  }
+}
+
+/** Pipe a child process's stdout/stderr to a shared log file descriptor,
+ *  prefixing each line with a tag (e.g. "[daemon]" or "[gateway]").
+ *  Streams are unref'd so they don't prevent the parent from exiting.
+ *  The fd is closed automatically when both streams end. */
+export function pipeToLogFile(child: ChildProcess, fd: number | "ignore", tag: string): void {
+  if (fd === "ignore") return;
+  const numFd: number = fd;
+  const prefix = `[${tag}] `;
+  const streams = [child.stdout, child.stderr].filter(Boolean);
+  let ended = 0;
+
+  function onDone() {
+    ended++;
+    if (ended >= streams.length) {
+      try { closeSync(numFd); } catch { /* best-effort */ }
+    }
+  }
+
+  for (const stream of streams) {
+    if (!stream) continue;
+    (stream as NodeJS.ReadableStream & { unref?: () => void }).unref?.();
+    stream.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      const lines = text.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        if (i === lines.length - 1 && lines[i] === "") break;
+        const nl = i < lines.length - 1 ? "\n" : "";
+        try { writeSync(numFd, prefix + lines[i] + nl); } catch { /* best-effort */ }
+      }
+    });
+    stream.on("end", onDone);
+    stream.on("error", onDone);
   }
 }

--- a/cli/src/lib/xdg-log.ts
+++ b/cli/src/lib/xdg-log.ts
@@ -44,7 +44,7 @@ export function writeToLogFile(fd: number | "ignore", msg: string): void {
 export function pipeToLogFile(child: ChildProcess, fd: number | "ignore", tag: string): void {
   if (fd === "ignore") return;
   const numFd: number = fd;
-  const prefix = `[${tag}] `;
+  const tagLabel = `[${tag}]`;
   const streams = [child.stdout, child.stderr].filter(Boolean);
   let ended = 0;
 
@@ -64,6 +64,7 @@ export function pipeToLogFile(child: ChildProcess, fd: number | "ignore", tag: s
       for (let i = 0; i < lines.length; i++) {
         if (i === lines.length - 1 && lines[i] === "") break;
         const nl = i < lines.length - 1 ? "\n" : "";
+        const prefix = `${new Date().toISOString()} ${tagLabel} `;
         try { writeSync(numFd, prefix + lines[i] + nl); } catch { /* best-effort */ }
       }
     });


### PR DESCRIPTION
## Summary
- Merges separate `daemon.log` and `gateway.log` into a single `~/.config/vellum/logs/hatch.log`
- Each line is prefixed with `[daemon]` or `[gateway]` for easy filtering (`grep '\[daemon\]' hatch.log`)
- Uses pipe-based stdio so the parent can read, tag, and write each line to the shared fd
- The fd is closed automatically when both child stdout/stderr streams end (no leaked descriptors)

## Test plan
- [ ] Run `vellum hatch` locally and verify `~/.config/vellum/logs/hatch.log` is created
- [ ] Verify log lines are prefixed with `[daemon]` or `[gateway]`
- [ ] Verify no separate `daemon.log` or `gateway.log` files are created
- [ ] Verify hatch completes successfully with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
