### PR TITLE
feat: bypass guardian trust gate when auth disabled

### DIFF
--- a/assistant/src/__tests__/resolve-guardian-trust-class.test.ts
+++ b/assistant/src/__tests__/resolve-guardian-trust-class.test.ts
@@ -1,0 +1,61 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GuardianRuntimeContext } from "../daemon/session-runtime-assembly.js";
+
+// ── Module mocks ─────────────────────────────────────────────────────
+
+let fakeHttpAuthDisabled = false;
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => fakeHttpAuthDisabled,
+  hasUngatedHttpAuthDisabled: () => false,
+}));
+
+// ── Real imports (after mocks) ───────────────────────────────────────
+
+import { resolveGuardianTrustClass } from "../daemon/session-tool-setup.js";
+
+afterAll(() => {
+  mock.restore();
+});
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("resolveGuardianTrustClass", () => {
+  beforeEach(() => {
+    fakeHttpAuthDisabled = false;
+  });
+
+  test("returns guardian context trust class when auth is enabled", () => {
+    const ctx: Pick<GuardianRuntimeContext, "trustClass"> = {
+      trustClass: "trusted_contact",
+    };
+    expect(resolveGuardianTrustClass(ctx as GuardianRuntimeContext)).toBe(
+      "trusted_contact",
+    );
+  });
+
+  test("defaults to guardian when no guardian context and auth is enabled", () => {
+    expect(resolveGuardianTrustClass(undefined)).toBe("guardian");
+  });
+
+  test("forces guardian when HTTP auth is disabled, regardless of context trust class", () => {
+    fakeHttpAuthDisabled = true;
+    const ctx: Pick<GuardianRuntimeContext, "trustClass"> = {
+      trustClass: "trusted_contact",
+    };
+    expect(resolveGuardianTrustClass(ctx as GuardianRuntimeContext)).toBe(
+      "guardian",
+    );
+  });
+
+  test("forces guardian for unknown trust class when HTTP auth is disabled", () => {
+    fakeHttpAuthDisabled = true;
+    const ctx: Pick<GuardianRuntimeContext, "trustClass"> = {
+      trustClass: "unknown",
+    };
+    expect(resolveGuardianTrustClass(ctx as GuardianRuntimeContext)).toBe(
+      "guardian",
+    );
+  });
+});

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -65,6 +65,7 @@ import {
   stripInjectedContext,
 } from './session-runtime-assembly.js';
 import type { SkillProjectionCache } from './session-skill-tools.js';
+import { resolveGuardianTrustClass } from './session-tool-setup.js';
 import { recordUsage } from './session-usage.js';
 import type { TraceEmitter } from './trace-emitter.js';
 
@@ -319,7 +320,7 @@ export async function runAgentLoopImpl(
         conflictGate: ctx.conflictGate,
         scopeId: ctx.memoryPolicy.scopeId,
         includeDefaultFallback: ctx.memoryPolicy.includeDefaultFallback,
-        guardianTrustClass: ctx.guardianContext?.trustClass ?? 'guardian',
+        guardianTrustClass: resolveGuardianTrustClass(ctx.guardianContext),
         isInteractive: options?.isInteractive ?? (!ctx.hasNoClient && !ctx.headlessLock),
       },
       content,

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -18,6 +18,7 @@ import {
   findHighestPriorityRule,
 } from "../permissions/trust-store.js";
 import { isAllowDecision } from "../permissions/types.js";
+import { isHttpAuthDisabled } from "../config/env.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import { getEffectiveMode } from "../runtime/session-approval-overrides.js";
 import type { ToolExecutor } from "../tools/executor.js";
@@ -44,12 +45,25 @@ import type {
 import { getAllToolDefinitions } from "../tools/registry.js";
 import { allUiSurfaceTools } from "../tools/ui-surface/definitions.js";
 import type { GuardianRuntimeContext } from "./session-runtime-assembly.js";
+import type { TrustClass } from "../runtime/actor-trust-resolver.js";
 import {
   projectSkillTools,
   type SkillProjectionCache,
 } from "./session-skill-tools.js";
 import type { SurfaceSessionContext } from "./session-surfaces.js";
 import { surfaceProxyResolver } from "./session-surfaces.js";
+
+/**
+ * Resolve the effective guardian trust class for tool execution.
+ * When HTTP auth is disabled (dev bypass), always treat the actor as
+ * guardian so that control-plane gates don't block local development.
+ */
+export function resolveGuardianTrustClass(
+  guardianContext: GuardianRuntimeContext | undefined,
+): TrustClass {
+  if (isHttpAuthDisabled()) return "guardian";
+  return guardianContext?.trustClass ?? "guardian";
+}
 
 // ── Context Interface ────────────────────────────────────────────────
 
@@ -137,7 +151,7 @@ export function createToolExecutor(
       assistantId: ctx.assistantId,
       requestId: ctx.currentRequestId,
       taskRunId: ctx.taskRunId,
-      guardianTrustClass: ctx.guardianContext?.trustClass ?? "guardian",
+      guardianTrustClass: resolveGuardianTrustClass(ctx.guardianContext),
       executionChannel: ctx.guardianContext?.sourceChannel,
       callSessionId: ctx.callSessionId,
       triggeredBySurfaceAction:


### PR DESCRIPTION
## Summary
- When `DISABLE_HTTP_AUTH` is enabled (with `VELLUM_UNSAFE_AUTH_BYPASS=1`), force `guardianTrustClass` to `"guardian"` so control-plane gates and tool approval checks don't block local development
- Extracts `resolveGuardianTrustClass()` helper used by both `session-tool-setup.ts` and `session-agent-loop.ts`
- Previously, `DISABLE_HTTP_AUTH` bypassed JWT verification at the HTTP layer but guardian trust class was resolved independently, causing guardian-only endpoints to still be blocked

## Test plan
- [x] Unit test: `resolve-guardian-trust-class.test.ts` verifies trust class is forced to `"guardian"` when auth is disabled, regardless of the actual context trust class
- [ ] Manual: enable `DISABLE_HTTP_AUTH=true` + `VELLUM_UNSAFE_AUTH_BYPASS=1` and verify guardian control-plane endpoints are accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
