### PR TITLE
fix: force guardianTrustClass to 'guardian' when HTTP auth is disabled

### DIFF
--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -12,6 +12,7 @@ import { v4 as uuid } from 'uuid';
 import type { AgentEvent,AgentLoop, CheckpointDecision } from '../agent/loop.js';
 import { createAssistantMessage } from '../agent/message-types.js';
 import type { ChannelId, InterfaceId, TurnChannelContext, TurnInterfaceContext } from '../channels/types.js';
+import { isHttpAuthDisabled } from '../config/env.js';
 import { getConfig } from '../config/loader.js';
 import type { ContextWindowManager } from '../context/window-manager.js';
 import type { ToolProfiler } from '../events/tool-profiling-listener.js';
@@ -319,7 +320,7 @@ export async function runAgentLoopImpl(
         conflictGate: ctx.conflictGate,
         scopeId: ctx.memoryPolicy.scopeId,
         includeDefaultFallback: ctx.memoryPolicy.includeDefaultFallback,
-        guardianTrustClass: ctx.guardianContext?.trustClass ?? 'guardian',
+        guardianTrustClass: isHttpAuthDisabled() ? 'guardian' : (ctx.guardianContext?.trustClass ?? 'guardian'),
         isInteractive: options?.isInteractive ?? (!ctx.hasNoClient && !ctx.headlessLock),
       },
       content,

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -34,6 +34,7 @@ import type { ServerMessage, UiSurfaceShow } from "./ipc-protocol.js";
 import { runPostExecutionSideEffects } from "./tool-side-effects.js";
 
 const log = getLogger("session-tool-setup");
+import { isHttpAuthDisabled } from "../config/env.js";
 import { coreAppProxyTools } from "../tools/apps/definitions.js";
 import { registerSessionSender } from "../tools/browser/browser-screencast.js";
 import { requestComputerControlTool } from "../tools/computer-use/request-computer-control.js";
@@ -137,7 +138,7 @@ export function createToolExecutor(
       assistantId: ctx.assistantId,
       requestId: ctx.currentRequestId,
       taskRunId: ctx.taskRunId,
-      guardianTrustClass: ctx.guardianContext?.trustClass ?? "guardian",
+      guardianTrustClass: isHttpAuthDisabled() ? "guardian" : (ctx.guardianContext?.trustClass ?? "guardian"),
       executionChannel: ctx.guardianContext?.sourceChannel,
       callSessionId: ctx.callSessionId,
       triggeredBySurfaceAction:


### PR DESCRIPTION
## Summary
- When running locally with `DISABLE_HTTP_AUTH=true` and `VELLUM_UNSAFE_AUTH_BYPASS=1`, the guardian context may not be populated since there's no authenticated actor
- This causes `guardianTrustClass` to resolve to a restrictive value that blocks tool execution
- Forces `guardianTrustClass` to `'guardian'` (most permissive) when `isHttpAuthDisabled()` returns true, in both `session-tool-setup.ts` and `session-agent-loop.ts`

## Test plan
- [ ] Verify local dev with `DISABLE_HTTP_AUTH=true` no longer has tool execution restrictions
- [ ] Verify production behavior is unchanged (auth enabled → guardian context determines trust class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
