### PR TITLE
refactor: remove daemon CLI commands from assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ Over SSH-forwarded sockets, the probe fails automatically (the filesystems don't
 | CLI: "could not connect to daemon socket" | Is the SSH socket tunnel active? Check `VELLUM_DAEMON_SOCKET` path |
 | CLI: daemon starts locally despite socket override | Check that `VELLUM_DAEMON_AUTOSTART` is not set to `1` |
 | macOS: not connecting | Verify socket path in `VELLUM_DAEMON_SOCKET` exists and is writable |
-| Any: "connection refused" | Is the remote daemon running? (`vellum daemon status` on remote) |
+| Any: "connection refused" | Is the remote daemon running? (`vellum ps` on remote) |
 
 Run `vellum doctor` for a full diagnostic check including socket path and autostart policy.
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -87,7 +87,6 @@ bun run src/index.ts dev            # dev mode (auto-restart on file changes)
 | `vellum sleep` | Stop daemon + gateway processes |
 | `vellum ps` | List assistants and per-assistant process status |
 | `vellum` | Launch interactive CLI session |
-| `vellum daemon start\|stop\|restart\|status` | Manage the daemon process (low-level) |
 | `vellum dev` | Run daemon with auto-restart on file changes |
 | `vellum sessions list\|new\|export\|clear` | Manage conversation sessions |
 | `vellum config set\|get\|list` | Manage configuration |

--- a/assistant/src/cli/core-commands.ts
+++ b/assistant/src/cli/core-commands.ts
@@ -14,7 +14,6 @@ import { hasSocketOverride,shouldAutoStartDaemon } from '../daemon/connection-po
 import {
   ensureDaemonRunning,
   getDaemonStatus,
-  startDaemon,
   stopDaemon,
 } from '../daemon/lifecycle.js';
 import { formatJson,formatMarkdown } from '../export/formatter.js';
@@ -42,66 +41,6 @@ export function registerDefaultAction(program: Command): void {
     }
     await startCli();
   });
-}
-
-export function registerDaemonCommand(program: Command): void {
-  const daemon = program.command('daemon').description('Manage the daemon process');
-
-  daemon
-    .command('start')
-    .description('Start the daemon')
-    .action(async () => {
-      const result = await startDaemon();
-      if (result.alreadyRunning) {
-        log.info(`Daemon already running (pid ${result.pid})`);
-      } else {
-        log.info(`Daemon started (pid ${result.pid})`);
-      }
-    });
-
-  daemon
-    .command('stop')
-    .description('Stop the daemon')
-    .action(async () => {
-      const result = await stopDaemon();
-      if (result.stopped) {
-        log.info('Daemon stopped');
-      } else if (result.reason === 'stop_failed') {
-        log.error('Failed to stop daemon — process survived SIGKILL');
-        process.exit(1);
-      } else {
-        log.info('Daemon is not running');
-      }
-    });
-
-  daemon
-    .command('restart')
-    .description('Restart the daemon')
-    .action(async () => {
-      const stopResult = await stopDaemon();
-      if (stopResult.stopped) {
-        log.info('Daemon stopped');
-      } else if (stopResult.reason === 'stop_failed') {
-        log.error('Failed to stop daemon — process survived SIGKILL, cannot restart');
-        process.exit(1);
-      }
-      const startResult = await startDaemon();
-      log.info(`Daemon started (pid ${startResult.pid})`);
-    });
-
-  daemon
-    .command('status')
-    .description('Show daemon status')
-    .action(async () => {
-      const status = await getDaemonStatus();
-      if (status.running) {
-        log.info(`Daemon is running (pid ${status.pid})`);
-      } else {
-        log.info('Daemon is not running');
-      }
-      log.info(`Socket path: ${getSocketPath()}${hasSocketOverride() ? ' (override)' : ''}`);
-      log.info(`Autostart: ${shouldAutoStartDaemon() ? 'enabled' : 'disabled'}`);
-    });
 }
 
 export function registerDevCommand(program: Command): void {
@@ -671,7 +610,6 @@ export function registerCompletionsCommand(program: Command): void {
     .description('Generate shell completion script (e.g. vellum completions bash >> ~/.bashrc)')
     .action((shell: string) => {
       const subcommands: Record<string, string[]> = {
-        daemon: ['start', 'stop', 'restart', 'status'],
         sessions: ['list', 'new', 'export', 'clear'],
         config: ['set', 'get', 'list', 'validate-allowlist'],
         keys: ['list', 'set', 'delete'],
@@ -682,7 +620,7 @@ export function registerCompletionsCommand(program: Command): void {
         autonomy: ['get', 'set'],
       };
       const topLevel = [
-        'daemon', 'dev', 'sessions', 'config', 'keys', 'trust', 'memory',
+        'dev', 'sessions', 'config', 'keys', 'trust', 'memory',
         'hooks', 'contacts', 'autonomy', 'audit', 'doctor', 'completions', 'help',
       ];
 
@@ -746,7 +684,6 @@ function generateZshCompletion(
 _vellum() {
     local -a commands
     commands=(
-        'daemon:Manage the daemon process'
         'dev:Run daemon in dev mode with auto-restart'
         'sessions:Manage sessions'
         'config:Manage configuration'
@@ -789,7 +726,6 @@ function generateFishCompletion(
   script += `complete -c vellum -f\n`;
 
   const descriptions: Record<string, string> = {
-    daemon: 'Manage the daemon process',
     dev: 'Run daemon in dev mode with auto-restart',
     sessions: 'Manage sessions',
     config: 'Manage configuration',

--- a/assistant/src/cli/mcp.ts
+++ b/assistant/src/cli/mcp.ts
@@ -230,7 +230,7 @@ export function registerMcpCommand(program: Command): void {
 
       saveRawConfig(raw);
       log.info(`Added MCP server "${name}" (${opts.transportType})`);
-      log.info('Restart the daemon for changes to take effect: vellum daemon restart');
+      log.info('Restart the daemon for changes to take effect: vellum sleep && vellum wake');
     });
 
   mcp
@@ -351,7 +351,7 @@ export function registerMcpCommand(program: Command): void {
       provider.stopCallbackServer();
 
       log.info(`Authentication successful for "${name}".`);
-      log.info('Restart the daemon for changes to take effect: vellum daemon restart');
+      log.info('Restart the daemon for changes to take effect: vellum sleep && vellum wake');
       process.exit(0);
     });
 
@@ -383,6 +383,6 @@ export function registerMcpCommand(program: Command): void {
       delete servers[name];
       saveRawConfig(raw);
       log.info(`Removed MCP server "${name}".`);
-      log.info('Restart the daemon for changes to take effect: vellum daemon restart');
+      log.info('Restart the daemon for changes to take effect: vellum sleep && vellum wake');
     });
 }

--- a/assistant/src/config/bundled-skills/self-upgrade/SKILL.md
+++ b/assistant/src/config/bundled-skills/self-upgrade/SKILL.md
@@ -45,16 +45,16 @@ Then start the gateway again using whatever method the user's deployment uses (e
 
 ## Step 4: Restart the daemon
 
-Use `vellum daemon restart` which stops the old daemon and starts a new one from the updated binary in a single command:
+Use `vellum sleep` to stop the running daemon and gateway, then `vellum wake` to start them again from the updated binary:
 
 ```bash
-vellum daemon restart
+vellum sleep && vellum wake
 ```
 
 Verify it is running:
 
 ```bash
-vellum daemon status
+vellum ps
 ```
 
 **Important:** This is the last step because the current daemon process is the one executing this conversation. After the restart, the new daemon takes over and this session ends gracefully.

--- a/assistant/src/config/bundled-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/telegram-setup/SKILL.md
@@ -12,7 +12,7 @@ You are helping your user connect a Telegram bot to the Vellum Assistant gateway
 
 Before beginning setup, verify these conditions are met:
 
-1. **Gateway API base URL is set and reachable:** Use the injected `INTERNAL_GATEWAY_BASE_URL`, then run `curl -sf "$INTERNAL_GATEWAY_BASE_URL/healthz"` — it should return gateway health JSON (for example `{"status":"ok"}`). If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
+1. **Gateway API base URL is set and reachable:** Use the injected `INTERNAL_GATEWAY_BASE_URL`, then run `curl -sf "$INTERNAL_GATEWAY_BASE_URL/healthz"` — it should return gateway health JSON (for example `{"status":"ok"}`). If it fails, tell the user to start the daemon with `vellum wake` and wait for it to become healthy before continuing.
 2. **Public ingress URL is configured.** The gateway webhook URL is derived from `${ingress.publicBaseUrl}/webhooks/telegram`. If the ingress URL is not configured, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the URL before continuing.
 3. **Use gateway control-plane routes only.** Telegram setup/config actions in this skill must call gateway endpoints under `/v1/integrations/telegram/*` — never call the daemon runtime port directly.
 

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -17,7 +17,6 @@ import {
 import {
   registerAuditCommand,
   registerCompletionsCommand,
-  registerDaemonCommand,
   registerDefaultAction,
   registerDevCommand,
   registerDoctorCommand,
@@ -39,7 +38,6 @@ program
   .version(version);
 
 registerDefaultAction(program);
-registerDaemonCommand(program);
 registerDevCommand(program);
 registerSessionsCommand(program);
 registerConfigCommand(program);

--- a/cli/README.md
+++ b/cli/README.md
@@ -111,7 +111,7 @@ The CLI looks up the instance by name in `~/.vellum.lock.json` and determines ho
 
 - **`gcp`** -- Deletes the GCP Compute Engine instance via `gcloud compute instances delete`.
 - **`aws`** -- Terminates the AWS EC2 instance by looking up the instance ID from its Name tag.
-- **`local`** -- Stops the local daemon (`bunx vellum daemon stop`) and removes the `~/.vellum` directory.
+- **`local`** -- Stops the local daemon (`vellum sleep`) and removes the `~/.vellum` directory.
 - **`custom`** -- SSHs to the remote host to stop the daemon/gateway and remove the `~/.vellum` directory.
 
 #### Examples

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -96,7 +96,7 @@ async function retireCustom(entry: AssistantEntry): Promise<void> {
   console.log(`\u{1F5D1}\ufe0f  Retiring custom instance on ${sshHost}...\n`);
 
   const remoteCmd = [
-    "bunx vellum daemon stop 2>/dev/null || true",
+    "bunx vellum sleep 2>/dev/null || true",
     "pkill -f gateway 2>/dev/null || true",
     "rm -rf ~/.vellum",
   ].join(" && ");

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -1,7 +1,9 @@
 import { execFileSync, spawn } from "child_process";
 import {
+  closeSync,
   existsSync,
   mkdirSync,
+  openSync,
   readFileSync,
   unlinkSync,
   writeFileSync,
@@ -155,6 +157,43 @@ function resolveDaemonMainPath(assistantIndex: string): string {
 async function startDaemonFromSource(assistantIndex: string): Promise<void> {
   const daemonMainPath = resolveDaemonMainPath(assistantIndex);
 
+  const vellumDir = join(homedir(), ".vellum");
+  mkdirSync(vellumDir, { recursive: true });
+
+  const pidFile = join(vellumDir, "vellum.pid");
+  const socketFile = join(vellumDir, "vellum.sock");
+
+  // --- Lifecycle guard: prevent split-brain daemon state ---
+  if (existsSync(pidFile)) {
+    try {
+      const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+      if (!isNaN(pid)) {
+        try {
+          process.kill(pid, 0);
+          console.log(`   Daemon already running (pid ${pid})\n`);
+          return;
+        } catch {
+          try { unlinkSync(pidFile); } catch {}
+        }
+      }
+    } catch {}
+  }
+
+  if (await isSocketResponsive(socketFile)) {
+    const ownerPid = findSocketOwnerPid(socketFile);
+    if (ownerPid) {
+      writeFileSync(pidFile, String(ownerPid), "utf-8");
+      console.log(
+        `   Daemon socket is responsive (pid ${ownerPid}) — skipping restart\n`,
+      );
+    } else {
+      console.log("   Daemon socket is responsive — skipping restart\n");
+    }
+    return;
+  }
+
+  try { unlinkSync(socketFile); } catch {}
+
   const env: Record<string, string | undefined> = {
     ...process.env,
     RUNTIME_HTTP_PORT: process.env.RUNTIME_HTTP_PORT || "7821",
@@ -165,20 +204,19 @@ async function startDaemonFromSource(assistantIndex: string): Promise<void> {
       process.env.VELLUM_DAEMON_TCP_ENABLED || "1";
   }
 
-  const vellumDir = join(homedir(), ".vellum");
-  mkdirSync(vellumDir, { recursive: true });
-
+  // Use fd inheritance instead of pipes so the daemon's stdout/stderr survive
+  // after the parent (hatch) exits. Bun does not ignore SIGPIPE, so piped
+  // stdio would kill the daemon on its first write after the parent closes.
   const logFd = openLogFile("hatch.log");
   const child = spawn("bun", ["run", daemonMainPath], {
     detached: true,
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio: ["ignore", logFd, logFd],
     env,
   });
-  pipeToLogFile(child, logFd, "daemon");
+  if (typeof logFd === "number") closeSync(logFd);
   child.unref();
 
   if (child.pid) {
-    const pidFile = join(vellumDir, "vellum.pid");
     writeFileSync(pidFile, String(child.pid), "utf-8");
   }
 }

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -153,6 +153,8 @@ function resolveDaemonMainPath(assistantIndex: string): string {
 }
 
 async function startDaemonFromSource(assistantIndex: string): Promise<void> {
+  const daemonMainPath = resolveDaemonMainPath(assistantIndex);
+
   const env: Record<string, string | undefined> = {
     ...process.env,
     RUNTIME_HTTP_PORT: process.env.RUNTIME_HTTP_PORT || "7821",
@@ -163,21 +165,22 @@ async function startDaemonFromSource(assistantIndex: string): Promise<void> {
       process.env.VELLUM_DAEMON_TCP_ENABLED || "1";
   }
 
-  const child = spawn("bun", ["run", assistantIndex, "daemon", "start"], {
-    stdio: "inherit",
+  const vellumDir = join(homedir(), ".vellum");
+  mkdirSync(vellumDir, { recursive: true });
+
+  const logFd = openLogFile("hatch.log");
+  const child = spawn("bun", ["run", daemonMainPath], {
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
     env,
   });
+  pipeToLogFile(child, logFd, "daemon");
+  child.unref();
 
-  await new Promise<void>((resolve, reject) => {
-    child.on("close", (code) => {
-      if (code === 0) {
-        resolve();
-      } else {
-        reject(new Error(`Daemon start exited with code ${code}`));
-      }
-    });
-    child.on("error", reject);
-  });
+  if (child.pid) {
+    const pidFile = join(vellumDir, "vellum.pid");
+    writeFileSync(pidFile, String(child.pid), "utf-8");
+  }
 }
 
 // NOTE: startDaemonWatchFromSource() is the CLI-side watch-mode daemon
@@ -668,6 +671,17 @@ export async function startLocalDaemon(watch: boolean = false): Promise<void> {
       }
     } else {
       await startDaemonFromSource(assistantIndex);
+
+      const vellumDir = join(homedir(), ".vellum");
+      const socketFile = join(vellumDir, "vellum.sock");
+      const socketReady = await waitForSocketFile(socketFile, 60000);
+      if (socketReady) {
+        console.log("   Daemon socket ready\n");
+      } else {
+        console.log(
+          "   ⚠️  Daemon socket did not appear within 60s — continuing anyway\n",
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Removes `vellum daemon start|stop|restart|status` CLI commands from the assistant package, consolidating daemon lifecycle management into the CLI package (`hatch`, `wake`, `sleep`, `ps`, `retire`)
- Rewrites `startDaemonFromSource()` in `cli/src/lib/local.ts` to spawn `daemon/main.ts` directly as a detached process, eliminating the two-layer spawn indirection
- Adds socket wait on the non-desktop-app path since the function is now non-blocking
- Removes daemon from all shell completions (bash, zsh, fish)

## Test plan
- [ ] `vellum daemon start` shows "unknown command" (removed)
- [ ] `vellum dev` still works (kept)
- [ ] `vellum` (no args) still auto-starts daemon via `ensureDaemonRunning()`
- [ ] `vellum-cli hatch` starts daemon (now spawns `daemon/main.ts` directly)
- [ ] Shell completions no longer include `daemon` subcommands
- [ ] `bun run tsc --noEmit` passes in both `assistant/` and `cli/`
- [ ] `bun run lint` passes in both packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)