### PR TITLE
feat: set schedule_job_id on conversations created by schedules

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1,22 +1,34 @@
-import { and, asc,count, eq, inArray, isNull, sql } from 'drizzle-orm';
-import { v4 as uuid } from 'uuid';
-import { z } from 'zod';
+import { and, asc, count, eq, inArray, isNull, sql } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+import { z } from "zod";
 
-import type { ChannelId, InterfaceId } from '../channels/types.js';
-import { parseChannelId, parseInterfaceId } from '../channels/types.js';
-import { CHANNEL_IDS, INTERFACE_IDS, isChannelId } from '../channels/types.js';
-import { getConfig } from '../config/loader.js';
-import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
-import { getLogger } from '../util/logger.js';
-import { createRowMapper } from '../util/row-mapper.js';
-import { deleteOrphanAttachments } from './attachments-store.js';
-import { projectAssistantMessage } from './conversation-attention-store.js';
-import { getDb, rawExec, rawGet } from './db.js';
-import { indexMessageNow } from './indexer.js';
-import { channelInboundEvents, conversations, llmRequestLogs, memoryEmbeddings, memoryItemEntities, memoryItems, memoryItemSources, memorySegments, messageAttachments, messages, toolInvocations } from './schema.js';
+import type { ChannelId, InterfaceId } from "../channels/types.js";
+import { parseChannelId, parseInterfaceId } from "../channels/types.js";
+import { CHANNEL_IDS, INTERFACE_IDS, isChannelId } from "../channels/types.js";
+import { getConfig } from "../config/loader.js";
+import type { GuardianRuntimeContext } from "../daemon/session-runtime-assembly.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import { getLogger } from "../util/logger.js";
+import { createRowMapper } from "../util/row-mapper.js";
+import { deleteOrphanAttachments } from "./attachments-store.js";
+import { projectAssistantMessage } from "./conversation-attention-store.js";
+import { getDb, rawExec, rawGet } from "./db.js";
+import { indexMessageNow } from "./indexer.js";
+import {
+  channelInboundEvents,
+  conversations,
+  llmRequestLogs,
+  memoryEmbeddings,
+  memoryItemEntities,
+  memoryItems,
+  memoryItemSources,
+  memorySegments,
+  messageAttachments,
+  messages,
+  toolInvocations,
+} from "./schema.js";
 
-const log = getLogger('conversation-store');
+const log = getLogger("conversation-store");
 
 // ── Message metadata Zod schema ──────────────────────────────────────
 // Validates the JSON stored in messages.metadata. Known fields are typed;
@@ -28,23 +40,27 @@ const interfaceIdSchema = z.enum(INTERFACE_IDS);
 const subagentNotificationSchema = z.object({
   subagentId: z.string(),
   label: z.string(),
-  status: z.enum(['completed', 'failed', 'aborted']),
+  status: z.enum(["completed", "failed", "aborted"]),
   error: z.string().optional(),
   conversationId: z.string().optional(),
 });
 
-export const messageMetadataSchema = z.object({
-  userMessageChannel: channelIdSchema.optional(),
-  assistantMessageChannel: channelIdSchema.optional(),
-  userMessageInterface: interfaceIdSchema.optional(),
-  assistantMessageInterface: interfaceIdSchema.optional(),
-  subagentNotification: subagentNotificationSchema.optional(),
-  // Provenance fields for trust-aware memory gating (M3)
-  provenanceTrustClass: z.enum(['guardian', 'trusted_contact', 'unknown']).optional(),
-  provenanceSourceChannel: channelIdSchema.optional(),
-  provenanceGuardianExternalUserId: z.string().optional(),
-  provenanceRequesterIdentifier: z.string().optional(),
-}).passthrough();
+export const messageMetadataSchema = z
+  .object({
+    userMessageChannel: channelIdSchema.optional(),
+    assistantMessageChannel: channelIdSchema.optional(),
+    userMessageInterface: interfaceIdSchema.optional(),
+    assistantMessageInterface: interfaceIdSchema.optional(),
+    subagentNotification: subagentNotificationSchema.optional(),
+    // Provenance fields for trust-aware memory gating (M3)
+    provenanceTrustClass: z
+      .enum(["guardian", "trusted_contact", "unknown"])
+      .optional(),
+    provenanceSourceChannel: channelIdSchema.optional(),
+    provenanceGuardianExternalUserId: z.string().optional(),
+    provenanceRequesterIdentifier: z.string().optional(),
+  })
+  .passthrough();
 
 export type MessageMetadata = z.infer<typeof messageMetadataSchema>;
 
@@ -54,8 +70,10 @@ export type MessageMetadata = z.infer<typeof messageMetadataSchema>;
  * absence of trust context means we cannot verify trust —
  * callers with actual guardian trust should always supply a real context.
  */
-export function provenanceFromGuardianContext(ctx: GuardianRuntimeContext | null | undefined): Record<string, unknown> {
-  if (!ctx) return { provenanceTrustClass: 'unknown' };
+export function provenanceFromGuardianContext(
+  ctx: GuardianRuntimeContext | null | undefined,
+): Record<string, unknown> {
+  if (!ctx) return { provenanceTrustClass: "unknown" };
   return {
     provenanceTrustClass: ctx.trustClass,
     provenanceSourceChannel: ctx.sourceChannel,
@@ -83,23 +101,26 @@ export interface ConversationRow {
   isAutoTitle: number;
 }
 
-export const parseConversation = createRowMapper<typeof conversations.$inferSelect, ConversationRow>({
-  id: 'id',
-  title: 'title',
-  createdAt: 'createdAt',
-  updatedAt: 'updatedAt',
-  totalInputTokens: 'totalInputTokens',
-  totalOutputTokens: 'totalOutputTokens',
-  totalEstimatedCost: 'totalEstimatedCost',
-  contextSummary: 'contextSummary',
-  contextCompactedMessageCount: 'contextCompactedMessageCount',
-  contextCompactedAt: 'contextCompactedAt',
-  threadType: 'threadType',
-  source: 'source',
-  memoryScopeId: 'memoryScopeId',
-  originChannel: 'originChannel',
-  originInterface: 'originInterface',
-  isAutoTitle: 'isAutoTitle',
+export const parseConversation = createRowMapper<
+  typeof conversations.$inferSelect,
+  ConversationRow
+>({
+  id: "id",
+  title: "title",
+  createdAt: "createdAt",
+  updatedAt: "updatedAt",
+  totalInputTokens: "totalInputTokens",
+  totalOutputTokens: "totalOutputTokens",
+  totalEstimatedCost: "totalEstimatedCost",
+  contextSummary: "contextSummary",
+  contextCompactedMessageCount: "contextCompactedMessageCount",
+  contextCompactedAt: "contextCompactedAt",
+  threadType: "threadType",
+  source: "source",
+  memoryScopeId: "memoryScopeId",
+  originChannel: "originChannel",
+  originInterface: "originInterface",
+  isAutoTitle: "isAutoTitle",
 });
 
 export interface MessageRow {
@@ -111,13 +132,16 @@ export interface MessageRow {
   metadata: string | null;
 }
 
-export const parseMessage = createRowMapper<typeof messages.$inferSelect, MessageRow>({
-  id: 'id',
-  conversationId: 'conversationId',
-  role: 'role',
-  content: 'content',
-  createdAt: 'createdAt',
-  metadata: 'metadata',
+export const parseMessage = createRowMapper<
+  typeof messages.$inferSelect,
+  MessageRow
+>({
+  id: "id",
+  conversationId: "conversationId",
+  role: "role",
+  content: "content",
+  createdAt: "createdAt",
+  metadata: "metadata",
 });
 
 /**
@@ -134,14 +158,26 @@ function monotonicNow(): number {
   return lastTimestamp;
 }
 
-export function createConversation(titleOrOpts?: string | { title?: string; threadType?: 'standard' | 'private' | 'background'; source?: string }) {
+export function createConversation(
+  titleOrOpts?:
+    | string
+    | {
+        title?: string;
+        threadType?: "standard" | "private" | "background";
+        source?: string;
+        scheduleJobId?: string;
+      },
+) {
   const db = getDb();
   const now = Date.now();
-  const opts = typeof titleOrOpts === 'string' ? { title: titleOrOpts } : (titleOrOpts ?? {});
-  const threadType = opts.threadType ?? 'standard';
-  const source = opts.source ?? 'user';
+  const opts =
+    typeof titleOrOpts === "string"
+      ? { title: titleOrOpts }
+      : (titleOrOpts ?? {});
+  const threadType = opts.threadType ?? "standard";
+  const source = opts.source ?? "user";
   const id = uuid();
-  const memoryScopeId = threadType === 'private' ? `private:${id}` : 'default';
+  const memoryScopeId = threadType === "private" ? `private:${id}` : "default";
   const conversation = {
     id,
     title: opts.title ?? null,
@@ -156,6 +192,7 @@ export function createConversation(titleOrOpts?: string | { title?: string; thre
     threadType,
     source,
     memoryScopeId,
+    scheduleJobId: opts.scheduleJobId ?? null,
   };
 
   // Retry on SQLITE_BUSY and SQLITE_IOERR — transient disk I/O errors or WAL
@@ -166,9 +203,15 @@ export function createConversation(titleOrOpts?: string | { title?: string; thre
       db.insert(conversations).values(conversation).run();
       break;
     } catch (err) {
-      const code = (err as { code?: string }).code ?? '';
-      if (attempt < MAX_RETRIES && (code.startsWith('SQLITE_BUSY') || code.startsWith('SQLITE_IOERR'))) {
-        log.warn({ attempt, conversationId: id, code }, 'createConversation: transient SQLite error, retrying');
+      const code = (err as { code?: string }).code ?? "";
+      if (
+        attempt < MAX_RETRIES &&
+        (code.startsWith("SQLITE_BUSY") || code.startsWith("SQLITE_IOERR"))
+      ) {
+        log.warn(
+          { attempt, conversationId: id, code },
+          "createConversation: transient SQLite error, retrying",
+        );
         // Synchronous sleep — createConversation is synchronous and the
         // retry window is short (50-150ms), so Bun.sleepSync is appropriate.
         Bun.sleepSync(50 * (attempt + 1));
@@ -191,15 +234,17 @@ export function getConversation(id: string): ConversationRow | null {
   return row ? parseConversation(row) : null;
 }
 
-export function getConversationThreadType(conversationId: string): 'standard' | 'private' {
+export function getConversationThreadType(
+  conversationId: string,
+): "standard" | "private" {
   const conv = getConversation(conversationId);
   const raw = conv?.threadType;
-  return raw === 'private' ? 'private' : 'standard';
+  return raw === "private" ? "private" : "standard";
 }
 
 export function getConversationMemoryScopeId(conversationId: string): string {
   const conv = getConversation(conversationId);
-  return conv?.memoryScopeId ?? 'default';
+  return conv?.memoryScopeId ?? "default";
 }
 
 /**
@@ -210,21 +255,34 @@ export function getConversationMemoryScopeId(conversationId: string): string {
 export function deleteConversation(id: string): void {
   const db = getDb();
   db.transaction((tx) => {
-    tx.delete(llmRequestLogs).where(eq(llmRequestLogs.conversationId, id)).run();
-    tx.delete(toolInvocations).where(eq(toolInvocations.conversationId, id)).run();
+    tx.delete(llmRequestLogs)
+      .where(eq(llmRequestLogs.conversationId, id))
+      .run();
+    tx.delete(toolInvocations)
+      .where(eq(toolInvocations.conversationId, id))
+      .run();
     tx.delete(messages).where(eq(messages.conversationId, id)).run();
     tx.delete(conversations).where(eq(conversations.id, id)).run();
   });
 }
 
-export async function addMessage(conversationId: string, role: string, content: string, metadata?: Record<string, unknown>, opts?: { skipIndexing?: boolean }) {
+export async function addMessage(
+  conversationId: string,
+  role: string,
+  content: string,
+  metadata?: Record<string, unknown>,
+  opts?: { skipIndexing?: boolean },
+) {
   const db = getDb();
   const messageId = uuid();
 
   if (metadata) {
     const result = messageMetadataSchema.safeParse(metadata);
     if (!result.success) {
-      log.warn({ conversationId, messageId, issues: result.error.issues }, 'Invalid message metadata, storing as-is');
+      log.warn(
+        { conversationId, messageId, issues: result.error.issues },
+        "Invalid message metadata, storing as-is",
+      );
     }
   }
 
@@ -255,7 +313,12 @@ export async function addMessage(conversationId: string, role: string, content: 
         if (originChannelCandidate) {
           tx.update(conversations)
             .set({ originChannel: originChannelCandidate })
-            .where(and(eq(conversations.id, conversationId), isNull(conversations.originChannel)))
+            .where(
+              and(
+                eq(conversations.id, conversationId),
+                isNull(conversations.originChannel),
+              ),
+            )
             .run();
         }
         tx.update(conversations)
@@ -265,38 +328,62 @@ export async function addMessage(conversationId: string, role: string, content: 
       });
       break;
     } catch (err) {
-      const errCode = (err as { code?: string }).code ?? '';
-      if (attempt < MAX_RETRIES && (errCode.startsWith('SQLITE_BUSY') || errCode.startsWith('SQLITE_IOERR'))) {
-        log.warn({ attempt, conversationId, code: errCode }, 'addMessage: transient SQLite error, retrying');
+      const errCode = (err as { code?: string }).code ?? "";
+      if (
+        attempt < MAX_RETRIES &&
+        (errCode.startsWith("SQLITE_BUSY") ||
+          errCode.startsWith("SQLITE_IOERR"))
+      ) {
+        log.warn(
+          { attempt, conversationId, code: errCode },
+          "addMessage: transient SQLite error, retrying",
+        );
         await Bun.sleep(50 * (attempt + 1));
         continue;
       }
       throw err;
     }
   }
-  const message = { id: messageId, conversationId, role, content, createdAt: now, ...(metadataStr ? { metadata: metadataStr } : {}) };
+  const message = {
+    id: messageId,
+    conversationId,
+    role,
+    content,
+    createdAt: now,
+    ...(metadataStr ? { metadata: metadataStr } : {}),
+  };
 
   if (!opts?.skipIndexing) {
     try {
       const config = getConfig();
       const scopeId = getConversationMemoryScopeId(conversationId);
-      const parsed = metadata ? messageMetadataSchema.safeParse(metadata) : null;
-      const provenanceTrustClass = parsed?.success ? parsed.data.provenanceTrustClass : undefined;
-      indexMessageNow({
-        messageId: message.id,
-        conversationId: message.conversationId,
-        role: message.role,
-        content: message.content,
-        createdAt: message.createdAt,
-        scopeId,
-        provenanceTrustClass,
-      }, config.memory);
+      const parsed = metadata
+        ? messageMetadataSchema.safeParse(metadata)
+        : null;
+      const provenanceTrustClass = parsed?.success
+        ? parsed.data.provenanceTrustClass
+        : undefined;
+      indexMessageNow(
+        {
+          messageId: message.id,
+          conversationId: message.conversationId,
+          role: message.role,
+          content: message.content,
+          createdAt: message.createdAt,
+          scopeId,
+          provenanceTrustClass,
+        },
+        config.memory,
+      );
     } catch (err) {
-      log.warn({ err, conversationId, messageId: message.id }, 'Failed to index message for memory');
+      log.warn(
+        { err, conversationId, messageId: message.id },
+        "Failed to index message for memory",
+      );
     }
   }
 
-  if (role === 'assistant') {
+  if (role === "assistant") {
     try {
       projectAssistantMessage({
         conversationId,
@@ -305,7 +392,10 @@ export async function addMessage(conversationId: string, role: string, content: 
         messageAt: message.createdAt,
       });
     } catch (err) {
-      log.warn({ err, conversationId, messageId: message.id }, 'Failed to project assistant message for attention tracking');
+      log.warn(
+        { err, conversationId, messageId: message.id },
+        "Failed to project assistant message for attention tracking",
+      );
     }
   }
 
@@ -324,7 +414,10 @@ export function getMessages(conversationId: string): MessageRow[] {
 }
 
 /** Fetch a single message by ID, optionally scoped to a specific conversation. */
-export function getMessageById(messageId: string, conversationId?: string): MessageRow | null {
+export function getMessageById(
+  messageId: string,
+  conversationId?: string,
+): MessageRow | null {
   const db = getDb();
   const conditions = [eq(messages.id, messageId)];
   if (conversationId) {
@@ -338,14 +431,15 @@ export function getMessageById(messageId: string, conversationId?: string): Mess
   return row ? parseMessage(row) : null;
 }
 
-export function updateConversationTitle(id: string, title: string, isAutoTitle?: number): void {
+export function updateConversationTitle(
+  id: string,
+  title: string,
+  isAutoTitle?: number,
+): void {
   const db = getDb();
   const set: Record<string, unknown> = { title, updatedAt: Date.now() };
   if (isAutoTitle !== undefined) set.isAutoTitle = isAutoTitle;
-  db.update(conversations)
-    .set(set)
-    .where(eq(conversations.id, id))
-    .run();
+  db.update(conversations).set(set).where(eq(conversations.id, id)).run();
 }
 
 export function updateConversationUsage(
@@ -356,7 +450,12 @@ export function updateConversationUsage(
 ): void {
   const db = getDb();
   db.update(conversations)
-    .set({ totalInputTokens, totalOutputTokens, totalEstimatedCost, updatedAt: Date.now() })
+    .set({
+      totalInputTokens,
+      totalOutputTokens,
+      totalEstimatedCost,
+      updatedAt: Date.now(),
+    })
     .where(eq(conversations.id, id))
     .run();
 }
@@ -384,8 +483,10 @@ export function updateConversationContextWindow(
  * Returns { conversations, messages } counts.
  */
 export function clearAll(): { conversations: number; messages: number } {
-  const msgCount = rawGet<{ c: number }>('SELECT COUNT(*) AS c FROM messages')?.c ?? 0;
-  const convCount = rawGet<{ c: number }>('SELECT COUNT(*) AS c FROM conversations')?.c ?? 0;
+  const msgCount =
+    rawGet<{ c: number }>("SELECT COUNT(*) AS c FROM messages")?.c ?? 0;
+  const convCount =
+    rawGet<{ c: number }>("SELECT COUNT(*) AS c FROM conversations")?.c ?? 0;
 
   // Delete in dependency order. Cascades handle memory_segments,
   // memory_item_sources, and tool_invocations, but we explicitly
@@ -398,56 +499,78 @@ export function clearAll(): { conversations: number; messages: number } {
   // corrupted FTS table would roll back every base-table DELETE).
   let segmentFtsCorrupted = false;
   try {
-    rawExec('DELETE FROM memory_segment_fts');
+    rawExec("DELETE FROM memory_segment_fts");
   } catch (err) {
-    log.warn({ err }, 'clearAll: failed to clear memory_segment_fts — dropping triggers so base-table cleanup can proceed');
-    rawExec('DROP TRIGGER IF EXISTS memory_segments_ai');
-    rawExec('DROP TRIGGER IF EXISTS memory_segments_ad');
-    rawExec('DROP TRIGGER IF EXISTS memory_segments_au');
+    log.warn(
+      { err },
+      "clearAll: failed to clear memory_segment_fts — dropping triggers so base-table cleanup can proceed",
+    );
+    rawExec("DROP TRIGGER IF EXISTS memory_segments_ai");
+    rawExec("DROP TRIGGER IF EXISTS memory_segments_ad");
+    rawExec("DROP TRIGGER IF EXISTS memory_segments_au");
     segmentFtsCorrupted = true;
   }
-  rawExec('DELETE FROM memory_item_sources');
-  rawExec('DELETE FROM memory_segments');
-  rawExec('DELETE FROM memory_items');
-  rawExec('DELETE FROM memory_summaries');
-  rawExec('DELETE FROM memory_embeddings');
-  rawExec('DELETE FROM memory_jobs');
-  rawExec('DELETE FROM memory_checkpoints');
-  rawExec('DELETE FROM llm_request_logs');
-  rawExec('DELETE FROM llm_usage_events');
-  rawExec('DELETE FROM message_attachments');
-  rawExec('DELETE FROM attachments');
-  rawExec('DELETE FROM tool_invocations');
+  rawExec("DELETE FROM memory_item_sources");
+  rawExec("DELETE FROM memory_segments");
+  rawExec("DELETE FROM memory_items");
+  rawExec("DELETE FROM memory_summaries");
+  rawExec("DELETE FROM memory_embeddings");
+  rawExec("DELETE FROM memory_jobs");
+  rawExec("DELETE FROM memory_checkpoints");
+  rawExec("DELETE FROM llm_request_logs");
+  rawExec("DELETE FROM llm_usage_events");
+  rawExec("DELETE FROM message_attachments");
+  rawExec("DELETE FROM attachments");
+  rawExec("DELETE FROM tool_invocations");
   let messagesFtsCorrupted = false;
   try {
-    rawExec('DELETE FROM messages_fts');
+    rawExec("DELETE FROM messages_fts");
   } catch (err) {
-    log.warn({ err }, 'clearAll: failed to clear messages_fts — dropping triggers so base-table cleanup can proceed');
-    rawExec('DROP TRIGGER IF EXISTS messages_fts_ai');
-    rawExec('DROP TRIGGER IF EXISTS messages_fts_ad');
-    rawExec('DROP TRIGGER IF EXISTS messages_fts_au');
+    log.warn(
+      { err },
+      "clearAll: failed to clear messages_fts — dropping triggers so base-table cleanup can proceed",
+    );
+    rawExec("DROP TRIGGER IF EXISTS messages_fts_ai");
+    rawExec("DROP TRIGGER IF EXISTS messages_fts_ad");
+    rawExec("DROP TRIGGER IF EXISTS messages_fts_au");
     messagesFtsCorrupted = true;
   }
-  rawExec('DELETE FROM messages');
-  rawExec('DELETE FROM conversations');
+  rawExec("DELETE FROM messages");
+  rawExec("DELETE FROM conversations");
 
   // Rebuild corrupted FTS tables and restore triggers after all base-table
   // DELETEs have completed. Dropping the virtual table clears the corruption,
   // and recreating it + triggers means subsequent writes maintain FTS
   // consistency without requiring a daemon restart.
   if (segmentFtsCorrupted) {
-    rawExec('DROP TABLE IF EXISTS memory_segment_fts');
-    rawExec(`CREATE VIRTUAL TABLE IF NOT EXISTS memory_segment_fts USING fts5(segment_id UNINDEXED, text)`);
-    rawExec(`CREATE TRIGGER IF NOT EXISTS memory_segments_ai AFTER INSERT ON memory_segments BEGIN INSERT INTO memory_segment_fts(segment_id, text) VALUES (new.id, new.text); END`);
-    rawExec(`CREATE TRIGGER IF NOT EXISTS memory_segments_ad AFTER DELETE ON memory_segments BEGIN DELETE FROM memory_segment_fts WHERE segment_id = old.id; END`);
-    rawExec(`CREATE TRIGGER IF NOT EXISTS memory_segments_au AFTER UPDATE ON memory_segments BEGIN DELETE FROM memory_segment_fts WHERE segment_id = old.id; INSERT INTO memory_segment_fts(segment_id, text) VALUES (new.id, new.text); END`);
+    rawExec("DROP TABLE IF EXISTS memory_segment_fts");
+    rawExec(
+      `CREATE VIRTUAL TABLE IF NOT EXISTS memory_segment_fts USING fts5(segment_id UNINDEXED, text)`,
+    );
+    rawExec(
+      `CREATE TRIGGER IF NOT EXISTS memory_segments_ai AFTER INSERT ON memory_segments BEGIN INSERT INTO memory_segment_fts(segment_id, text) VALUES (new.id, new.text); END`,
+    );
+    rawExec(
+      `CREATE TRIGGER IF NOT EXISTS memory_segments_ad AFTER DELETE ON memory_segments BEGIN DELETE FROM memory_segment_fts WHERE segment_id = old.id; END`,
+    );
+    rawExec(
+      `CREATE TRIGGER IF NOT EXISTS memory_segments_au AFTER UPDATE ON memory_segments BEGIN DELETE FROM memory_segment_fts WHERE segment_id = old.id; INSERT INTO memory_segment_fts(segment_id, text) VALUES (new.id, new.text); END`,
+    );
   }
   if (messagesFtsCorrupted) {
-    rawExec('DROP TABLE IF EXISTS messages_fts');
-    rawExec(`CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(message_id UNINDEXED, content)`);
-    rawExec(`CREATE TRIGGER IF NOT EXISTS messages_fts_ai AFTER INSERT ON messages BEGIN INSERT INTO messages_fts(message_id, content) VALUES (new.id, new.content); END`);
-    rawExec(`CREATE TRIGGER IF NOT EXISTS messages_fts_ad AFTER DELETE ON messages BEGIN DELETE FROM messages_fts WHERE message_id = old.id; END`);
-    rawExec(`CREATE TRIGGER IF NOT EXISTS messages_fts_au AFTER UPDATE ON messages BEGIN DELETE FROM messages_fts WHERE message_id = old.id; INSERT INTO messages_fts(message_id, content) VALUES (new.id, new.content); END`);
+    rawExec("DROP TABLE IF EXISTS messages_fts");
+    rawExec(
+      `CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(message_id UNINDEXED, content)`,
+    );
+    rawExec(
+      `CREATE TRIGGER IF NOT EXISTS messages_fts_ai AFTER INSERT ON messages BEGIN INSERT INTO messages_fts(message_id, content) VALUES (new.id, new.content); END`,
+    );
+    rawExec(
+      `CREATE TRIGGER IF NOT EXISTS messages_fts_ad AFTER DELETE ON messages BEGIN DELETE FROM messages_fts WHERE message_id = old.id; END`,
+    );
+    rawExec(
+      `CREATE TRIGGER IF NOT EXISTS messages_fts_au AFTER UPDATE ON messages BEGIN DELETE FROM messages_fts WHERE message_id = old.id; INSERT INTO messages_fts(message_id, content) VALUES (new.id, new.content); END`,
+    );
   }
 
   return { conversations: convCount, messages: msgCount };
@@ -460,7 +583,12 @@ export function deleteLastExchange(conversationId: string): number {
   const lastUserMsg = db
     .select({ id: messages.id })
     .from(messages)
-    .where(and(eq(messages.conversationId, conversationId), eq(messages.role, 'user')))
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        eq(messages.role, "user"),
+      ),
+    )
     .orderBy(sql`rowid DESC`)
     .limit(1)
     .get();
@@ -476,20 +604,31 @@ export function deleteLastExchange(conversationId: string): number {
     sql`rowid >= ${rowidSubquery}`,
   );
 
-  const [{ deleted }] = db.select({ deleted: count() }).from(messages).where(condition).all();
+  const [{ deleted }] = db
+    .select({ deleted: count() })
+    .from(messages)
+    .where(condition)
+    .all();
   if (deleted === 0) return 0;
 
   // Collect attachment IDs linked to the messages being deleted so we can
   // scope orphan cleanup to only those candidates (not freshly uploaded ones).
-  const messageIds = db.select({ id: messages.id }).from(messages).where(condition).all().map((r) => r.id);
-  const candidateAttachmentIds = messageIds.length > 0
-    ? db.select({ attachmentId: messageAttachments.attachmentId })
-      .from(messageAttachments)
-      .where(inArray(messageAttachments.messageId, messageIds))
-      .all()
-      .map((r) => r.attachmentId)
-      .filter((id): id is string => id != null)
-    : [];
+  const messageIds = db
+    .select({ id: messages.id })
+    .from(messages)
+    .where(condition)
+    .all()
+    .map((r) => r.id);
+  const candidateAttachmentIds =
+    messageIds.length > 0
+      ? db
+          .select({ attachmentId: messageAttachments.attachmentId })
+          .from(messageAttachments)
+          .where(inArray(messageAttachments.messageId, messageIds))
+          .all()
+          .map((r) => r.attachmentId)
+          .filter((id): id is string => id != null)
+      : [];
 
   db.transaction((tx) => {
     tx.delete(messages).where(condition).run();
@@ -518,7 +657,10 @@ export interface DeletedMemoryIds {
  * Update the content of an existing message. Used when consolidating
  * multiple assistant messages into one.
  */
-export function updateMessageContent(messageId: string, newContent: string): void {
+export function updateMessageContent(
+  messageId: string,
+  newContent: string,
+): void {
   const db = getDb();
   db.update(messages)
     .set({ content: newContent })
@@ -531,7 +673,10 @@ export function updateMessageContent(messageId: string, newContent: string): voi
  * Used during message consolidation so that attachments linked to deleted
  * messages survive the ON DELETE CASCADE on message_attachments.
  */
-export function relinkAttachments(fromMessageIds: string[], toMessageId: string): number {
+export function relinkAttachments(
+  fromMessageIds: string[],
+  toMessageId: string,
+): number {
   if (fromMessageIds.length === 0) return 0;
   const db = getDb();
 
@@ -612,10 +757,12 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
     // Clean up segment embeddings from SQLite (Qdrant cleanup is the caller's job).
     if (result.segmentIds.length > 0) {
       tx.delete(memoryEmbeddings)
-        .where(and(
-          eq(memoryEmbeddings.targetType, 'segment'),
-          inArray(memoryEmbeddings.targetId, result.segmentIds),
-        ))
+        .where(
+          and(
+            eq(memoryEmbeddings.targetType, "segment"),
+            inArray(memoryEmbeddings.targetId, result.segmentIds),
+          ),
+        )
         .run();
     }
 
@@ -628,7 +775,9 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
         .where(inArray(memoryItemSources.memoryItemId, candidateItemIds))
         .all();
       const survivingIds = new Set(surviving.map((r) => r.memoryItemId));
-      const orphanedIds = candidateItemIds.filter((id) => !survivingIds.has(id));
+      const orphanedIds = candidateItemIds.filter(
+        (id) => !survivingIds.has(id),
+      );
       result.orphanedItemIds = orphanedIds;
 
       if (orphanedIds.length > 0) {
@@ -638,10 +787,12 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
           .run();
         // Delete embeddings referencing these items.
         tx.delete(memoryEmbeddings)
-          .where(and(
-            eq(memoryEmbeddings.targetType, 'item'),
-            inArray(memoryEmbeddings.targetId, orphanedIds),
-          ))
+          .where(
+            and(
+              eq(memoryEmbeddings.targetType, "item"),
+              inArray(memoryEmbeddings.targetId, orphanedIds),
+            ),
+          )
           .run();
         // Delete the orphaned memory items themselves.
         tx.delete(memoryItems)
@@ -656,34 +807,56 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
   return result;
 }
 
-export function setConversationOriginChannelIfUnset(conversationId: string, channel: ChannelId): void {
+export function setConversationOriginChannelIfUnset(
+  conversationId: string,
+  channel: ChannelId,
+): void {
   const db = getDb();
   db.update(conversations)
     .set({ originChannel: channel })
-    .where(and(eq(conversations.id, conversationId), isNull(conversations.originChannel)))
+    .where(
+      and(
+        eq(conversations.id, conversationId),
+        isNull(conversations.originChannel),
+      ),
+    )
     .run();
 }
 
-export function getConversationOriginChannel(conversationId: string): ChannelId | null {
+export function getConversationOriginChannel(
+  conversationId: string,
+): ChannelId | null {
   const db = getDb();
-  const row = db.select({ originChannel: conversations.originChannel })
+  const row = db
+    .select({ originChannel: conversations.originChannel })
     .from(conversations)
     .where(eq(conversations.id, conversationId))
     .get();
   return parseChannelId(row?.originChannel) ?? null;
 }
 
-export function setConversationOriginInterfaceIfUnset(conversationId: string, interfaceId: InterfaceId): void {
+export function setConversationOriginInterfaceIfUnset(
+  conversationId: string,
+  interfaceId: InterfaceId,
+): void {
   const db = getDb();
   db.update(conversations)
     .set({ originInterface: interfaceId })
-    .where(and(eq(conversations.id, conversationId), isNull(conversations.originInterface)))
+    .where(
+      and(
+        eq(conversations.id, conversationId),
+        isNull(conversations.originInterface),
+      ),
+    )
     .run();
 }
 
-export function getConversationOriginInterface(conversationId: string): InterfaceId | null {
+export function getConversationOriginInterface(
+  conversationId: string,
+): InterfaceId | null {
   const db = getDb();
-  const row = db.select({ originInterface: conversations.originInterface })
+  const row = db
+    .select({ originInterface: conversations.originInterface })
     .from(conversations)
     .where(eq(conversations.id, conversationId))
     .get();
@@ -700,7 +873,7 @@ export function getConversationOriginInterface(conversationId: string): Interfac
  */
 export function getConversationRecentProvenanceTrustClass(
   conversationId: string,
-): 'guardian' | 'trusted_contact' | 'unknown' | undefined {
+): "guardian" | "trusted_contact" | "unknown" | undefined {
   const row = rawGet<{ metadata: string | null }>(
     `SELECT metadata FROM messages
      WHERE conversation_id = ? AND role = 'user' AND metadata IS NOT NULL

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -1,18 +1,31 @@
-import { createConversation } from '../memory/conversation-store.js';
-import { GENERATING_TITLE, queueGenerateConversationTitle } from '../memory/conversation-title-service.js';
-import { invalidateAssistantInferredItemsForConversation } from '../memory/task-memory-cleanup.js';
-import { runSequencesOnce } from '../sequence/engine.js';
-import { claimDueReminders, completeReminder, failReminder, type RoutingIntent,setReminderConversationId } from '../tools/reminder/reminder-store.js';
-import { getLogger } from '../util/logger.js';
-import { runWatchersOnce, type WatcherEscalator,type WatcherNotifier } from '../watcher/engine.js';
-import { hasSetConstructs } from './recurrence-engine.js';
+import { createConversation } from "../memory/conversation-store.js";
+import {
+  GENERATING_TITLE,
+  queueGenerateConversationTitle,
+} from "../memory/conversation-title-service.js";
+import { invalidateAssistantInferredItemsForConversation } from "../memory/task-memory-cleanup.js";
+import { runSequencesOnce } from "../sequence/engine.js";
+import {
+  claimDueReminders,
+  completeReminder,
+  failReminder,
+  type RoutingIntent,
+  setReminderConversationId,
+} from "../tools/reminder/reminder-store.js";
+import { getLogger } from "../util/logger.js";
+import {
+  runWatchersOnce,
+  type WatcherEscalator,
+  type WatcherNotifier,
+} from "../watcher/engine.js";
+import { hasSetConstructs } from "./recurrence-engine.js";
 import {
   claimDueSchedules,
   completeScheduleRun,
   createScheduleRun,
-} from './schedule-store.js';
+} from "./schedule-store.js";
 
-const log = getLogger('scheduler');
+const log = getLogger("scheduler");
 
 export type ScheduleMessageProcessor = (
   conversationId: string,
@@ -50,21 +63,35 @@ export function startScheduler(
     if (stopped || tickRunning) return;
     tickRunning = true;
     try {
-      await runScheduleOnce(processMessage, notifyReminder, notifySchedule, watcherNotifier, watcherEscalator);
+      await runScheduleOnce(
+        processMessage,
+        notifyReminder,
+        notifySchedule,
+        watcherNotifier,
+        watcherEscalator,
+      );
     } catch (err) {
-      log.error({ err }, 'Schedule tick failed');
+      log.error({ err }, "Schedule tick failed");
     } finally {
       tickRunning = false;
     }
   };
 
-  const timer = setInterval(() => { void tick(); }, TICK_INTERVAL_MS);
+  const timer = setInterval(() => {
+    void tick();
+  }, TICK_INTERVAL_MS);
   timer.unref();
   void tick();
 
   return {
     async runOnce(): Promise<number> {
-      return runScheduleOnce(processMessage, notifyReminder, notifySchedule, watcherNotifier, watcherEscalator);
+      return runScheduleOnce(
+        processMessage,
+        notifyReminder,
+        notifySchedule,
+        watcherNotifier,
+        watcherEscalator,
+      );
     },
     stop(): void {
       stopped = true;
@@ -90,62 +117,123 @@ async function runScheduleOnce(
     const taskMatch = job.message.match(/^run_task:(\S+)$/);
     if (taskMatch) {
       const taskId = taskMatch[1];
-      const isRruleSet = job.syntax === 'rrule' && hasSetConstructs(job.expression);
+      const isRruleSet =
+        job.syntax === "rrule" && hasSetConstructs(job.expression);
       try {
-        log.info({ jobId: job.id, name: job.name, taskId, syntax: job.syntax, expression: job.expression, isRruleSet }, 'Executing scheduled task');
-        const { runTask } = await import('../tasks/task-runner.js');
+        log.info(
+          {
+            jobId: job.id,
+            name: job.name,
+            taskId,
+            syntax: job.syntax,
+            expression: job.expression,
+            isRruleSet,
+          },
+          "Executing scheduled task",
+        );
+        const { runTask } = await import("../tasks/task-runner.js");
         const result = await runTask(
-          { taskId, workingDir: process.cwd(), source: 'schedule' },
-          processMessage as (conversationId: string, message: string, taskRunId: string) => Promise<void>,
+          { taskId, workingDir: process.cwd(), source: "schedule" },
+          processMessage as (
+            conversationId: string,
+            message: string,
+            taskRunId: string,
+          ) => Promise<void>,
         );
 
         // Track the schedule run using the task's conversation
         const runId = createScheduleRun(job.id, result.conversationId);
-        if (result.status === 'failed') {
-          completeScheduleRun(runId, { status: 'error', error: result.error ?? 'Task run failed' });
+        if (result.status === "failed") {
+          completeScheduleRun(runId, {
+            status: "error",
+            error: result.error ?? "Task run failed",
+          });
         } else {
-          completeScheduleRun(runId, { status: 'ok' });
+          completeScheduleRun(runId, { status: "ok" });
           notifySchedule({ id: job.id, name: job.name });
         }
         processed += 1;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        log.warn({ err, jobId: job.id, name: job.name, taskId, syntax: job.syntax, expression: job.expression, isRruleSet }, 'Scheduled task execution failed');
+        log.warn(
+          {
+            err,
+            jobId: job.id,
+            name: job.name,
+            taskId,
+            syntax: job.syntax,
+            expression: job.expression,
+            isRruleSet,
+          },
+          "Scheduled task execution failed",
+        );
         // Create a fallback conversation for the schedule run record
-        const fallbackConversation = createConversation({ title: GENERATING_TITLE, source: 'schedule' });
+        const fallbackConversation = createConversation({
+          title: GENERATING_TITLE,
+          source: "schedule",
+          scheduleJobId: job.id,
+        });
         queueGenerateConversationTitle({
           conversationId: fallbackConversation.id,
-          context: { origin: 'schedule', systemHint: `Schedule: ${job.name}` },
+          context: { origin: "schedule", systemHint: `Schedule: ${job.name}` },
         });
         const runId = createScheduleRun(job.id, fallbackConversation.id);
-        completeScheduleRun(runId, { status: 'error', error: message });
+        completeScheduleRun(runId, { status: "error", error: message });
       }
       continue;
     }
 
-    const conversation = createConversation({ title: GENERATING_TITLE, source: 'schedule' });
+    const conversation = createConversation({
+      title: GENERATING_TITLE,
+      source: "schedule",
+      scheduleJobId: job.id,
+    });
     queueGenerateConversationTitle({
       conversationId: conversation.id,
-      context: { origin: 'schedule', systemHint: `Schedule: ${job.name}` },
+      context: { origin: "schedule", systemHint: `Schedule: ${job.name}` },
     });
     const runId = createScheduleRun(job.id, conversation.id);
-    const isRruleSetMsg = job.syntax === 'rrule' && hasSetConstructs(job.expression);
+    const isRruleSetMsg =
+      job.syntax === "rrule" && hasSetConstructs(job.expression);
 
     try {
-      log.info({ jobId: job.id, name: job.name, syntax: job.syntax, expression: job.expression, isRruleSet: isRruleSetMsg, conversationId: conversation.id }, 'Executing schedule');
+      log.info(
+        {
+          jobId: job.id,
+          name: job.name,
+          syntax: job.syntax,
+          expression: job.expression,
+          isRruleSet: isRruleSetMsg,
+          conversationId: conversation.id,
+        },
+        "Executing schedule",
+      );
       await processMessage(conversation.id, job.message);
-      completeScheduleRun(runId, { status: 'ok' });
+      completeScheduleRun(runId, { status: "ok" });
       notifySchedule({ id: job.id, name: job.name });
       processed += 1;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      log.warn({ err, jobId: job.id, name: job.name, syntax: job.syntax, expression: job.expression, isRruleSet: isRruleSetMsg }, 'Schedule execution failed');
-      completeScheduleRun(runId, { status: 'error', error: message });
+      log.warn(
+        {
+          err,
+          jobId: job.id,
+          name: job.name,
+          syntax: job.syntax,
+          expression: job.expression,
+          isRruleSet: isRruleSetMsg,
+        },
+        "Schedule execution failed",
+      );
+      completeScheduleRun(runId, { status: "error", error: message });
 
       try {
         invalidateAssistantInferredItemsForConversation(conversation.id);
       } catch (cleanupErr) {
-        log.warn({ err: cleanupErr, conversationId: conversation.id }, 'Failed to invalidate assistant-inferred memory items');
+        log.warn(
+          { err: cleanupErr, conversationId: conversation.id },
+          "Failed to invalidate assistant-inferred memory items",
+        );
       }
     }
   }
@@ -153,24 +241,43 @@ async function runScheduleOnce(
   // ── One-shot reminders ──────────────────────────────────────────────
   const dueReminders = claimDueReminders(now);
   for (const reminder of dueReminders) {
-    if (reminder.mode === 'execute') {
-      const conversation = createConversation({ title: GENERATING_TITLE, source: 'reminder' });
+    if (reminder.mode === "execute") {
+      const conversation = createConversation({
+        title: GENERATING_TITLE,
+        source: "reminder",
+      });
       queueGenerateConversationTitle({
         conversationId: conversation.id,
-        context: { origin: 'reminder', systemHint: `Reminder: ${reminder.label}` },
+        context: {
+          origin: "reminder",
+          systemHint: `Reminder: ${reminder.label}`,
+        },
       });
       setReminderConversationId(reminder.id, conversation.id);
       try {
-        log.info({ reminderId: reminder.id, label: reminder.label, conversationId: conversation.id }, 'Executing reminder');
+        log.info(
+          {
+            reminderId: reminder.id,
+            label: reminder.label,
+            conversationId: conversation.id,
+          },
+          "Executing reminder",
+        );
         await processMessage(conversation.id, reminder.message);
         completeReminder(reminder.id);
       } catch (err) {
-        log.warn({ err, reminderId: reminder.id }, 'Reminder execution failed, reverting to pending');
+        log.warn(
+          { err, reminderId: reminder.id },
+          "Reminder execution failed, reverting to pending",
+        );
         failReminder(reminder.id);
       }
     } else {
       try {
-        log.info({ reminderId: reminder.id, label: reminder.label }, 'Firing reminder notification');
+        log.info(
+          { reminderId: reminder.id, label: reminder.label },
+          "Firing reminder notification",
+        );
         notifyReminder({
           id: reminder.id,
           label: reminder.label,
@@ -180,7 +287,10 @@ async function runScheduleOnce(
         });
         completeReminder(reminder.id);
       } catch (err) {
-        log.warn({ err, reminderId: reminder.id }, 'Reminder notification failed, reverting to pending');
+        log.warn(
+          { err, reminderId: reminder.id },
+          "Reminder notification failed, reverting to pending",
+        );
         failReminder(reminder.id);
       }
     }
@@ -190,10 +300,14 @@ async function runScheduleOnce(
   // ── Watchers (event-driven polling) ────────────────────────────────
   if (watcherNotifier && watcherEscalator) {
     try {
-      const watcherProcessed = await runWatchersOnce(processMessage, watcherNotifier, watcherEscalator);
+      const watcherProcessed = await runWatchersOnce(
+        processMessage,
+        watcherNotifier,
+        watcherEscalator,
+      );
       processed += watcherProcessed;
     } catch (err) {
-      log.error({ err }, 'Watcher tick failed');
+      log.error({ err }, "Watcher tick failed");
     }
   }
 
@@ -202,11 +316,11 @@ async function runScheduleOnce(
     const sequenceProcessed = await runSequencesOnce(processMessage);
     processed += sequenceProcessed;
   } catch (err) {
-    log.error({ err }, 'Sequence engine tick failed');
+    log.error({ err }, "Sequence engine tick failed");
   }
 
   if (processed > 0) {
-    log.info({ processed }, 'Schedule tick complete');
+    log.info({ processed }, "Schedule tick complete");
   }
   return processed;
 }


### PR DESCRIPTION
## Summary
- Add `scheduleJobId` option to `createConversation()` to persist the originating schedule job ID
- Pass `job.id` as `scheduleJobId` at both schedule-triggered conversation creation sites in the scheduler (regular messages and task-failure fallbacks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
