### PR TITLE
fix: align tests with current BOOTSTRAP.md and system prompt builder

### DIFF
--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -14,11 +14,11 @@ describe("onboarding template contracts", () => {
       expect(lower).toContain("who am i");
     });
 
-    test("infers personality indirectly instead of asking directly", () => {
+    test("infers personality organically instead of asking directly", () => {
       const lower = bootstrap.toLowerCase();
-      // Personality step must instruct indirect/organic discovery
+      // Personality step must instruct organic discovery via conversation
       expect(lower).toContain("personality");
-      expect(lower).toContain("indirectly");
+      expect(lower).toContain("emerge");
       expect(lower).toContain("vibe");
     });
 
@@ -41,15 +41,15 @@ describe("onboarding template contracts", () => {
       const lower = bootstrap.toLowerCase();
       // The template must prompt the assistant to ask about names.
       expect(lower).toContain("name");
-      // The first step should be about locking in the assistant's name
-      expect(lower).toContain("lock in your name");
+      // The first step should be about the assistant's name
+      expect(lower).toContain("your name");
       // The conversation sequence must include identity/naming
       expect(lower).toContain("who am i");
     });
 
     test("asks user name AFTER assistant identity is established", () => {
-      // Step 1 is locking in the assistant's name, step 3 is asking the user's name
-      const assistantNameIdx = bootstrap.indexOf("Lock in your name.");
+      // Step 1 is the assistant's name, step 4 is asking the user's name
+      const assistantNameIdx = bootstrap.indexOf("Your name:");
       const userNameIdx = bootstrap.indexOf("who am I talking to?");
       expect(assistantNameIdx).toBeGreaterThan(-1);
       expect(userNameIdx).toBeGreaterThan(-1);
@@ -87,10 +87,8 @@ describe("onboarding template contracts", () => {
       expect(lower).toContain("home base");
     });
 
-    test("contains privacy/refusal policy", () => {
+    test("contains refusal policy", () => {
       const lower = bootstrap.toLowerCase();
-      // Must have a privacy section
-      expect(lower).toContain("privacy");
       // Assistant name is hard-required, user details are best-effort
       expect(lower).toContain("hard-required");
       expect(lower).toContain("best-effort");
@@ -107,16 +105,8 @@ describe("onboarding template contracts", () => {
       expect(lower).toContain("declined");
     });
 
-    test("preserves no em dashes instruction", () => {
-      const lower = bootstrap.toLowerCase();
-      expect(lower).toContain("em dashes");
-    });
-
-    test("preserves no technical jargon instruction", () => {
-      const lower = bootstrap.toLowerCase();
-      expect(lower).toContain("technical jargon");
-      expect(lower).toContain("system internals");
-    });
+    // em-dash and technical jargon instructions are now hardcoded in the system
+    // prompt builder (buildSystemPrompt) rather than in the BOOTSTRAP.md template.
 
     test("preserves comment line format instruction", () => {
       // The template must start with the comment format explanation

--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -994,12 +994,12 @@ describe("sanitizePttActivationKey", () => {
     expect(sanitizePttActivationKey("none")).toBe("none");
   });
 
-  test('returns "unknown" for invalid keys', () => {
-    expect(sanitizePttActivationKey("malicious\nprompt injection")).toBe(
-      "unknown",
-    );
-    expect(sanitizePttActivationKey("arbitrary_value")).toBe("unknown");
-    expect(sanitizePttActivationKey("")).toBe("unknown");
+  test("returns undefined for invalid keys", () => {
+    expect(
+      sanitizePttActivationKey("malicious\nprompt injection"),
+    ).toBeUndefined();
+    expect(sanitizePttActivationKey("arbitrary_value")).toBeUndefined();
+    expect(sanitizePttActivationKey("")).toBeUndefined();
   });
 });
 
@@ -1015,11 +1015,11 @@ describe("resolveChannelCapabilities with PTT metadata", () => {
     expect(caps.pttActivationKey).toBe("fn");
   });
 
-  test("sanitizes invalid pttActivationKey to unknown", () => {
+  test("sanitizes invalid pttActivationKey to undefined", () => {
     const caps = resolveChannelCapabilities("macos", "macos", {
       pttActivationKey: "evil\nprompt",
     });
-    expect(caps.pttActivationKey).toBe("unknown");
+    expect(caps.pttActivationKey).toBeUndefined();
   });
 
   test("passes through microphonePermissionGranted", () => {

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -75,9 +75,15 @@ const {
   buildPhoneCallsRoutingSection,
 } = await import("../config/system-prompt.js");
 
-/** Strip the Configuration and Skills sections so base-prompt tests stay focused. */
+/** Strip the Configuration, Skills, and hardcoded preamble sections so base-prompt tests stay focused. */
 function basePrompt(result: string): string {
   let s = result;
+  // Strip the hardcoded em-dash instruction preamble
+  const emDashLine =
+    "IMPORTANT: Never use em dashes (\u2014) in your messages. Use commas, periods, or just start a new sentence instead.";
+  if (s.startsWith(emDashLine)) {
+    s = s.slice(emDashLine.length).replace(/^\n\n/, "");
+  }
   for (const heading of [
     "## Configuration",
     "## Skills Catalog",


### PR DESCRIPTION
## Summary
- Update `basePrompt()` helper in system-prompt tests to strip the hardcoded em-dash instruction preamble
- Update onboarding template contract tests to match current BOOTSTRAP.md content (organic personality discovery, updated naming anchors, removed stale assertions for em-dash/jargon/privacy instructions)
- Fix session-runtime-assembly tests to expect `undefined` instead of `"unknown"` for invalid PTT activation keys, matching `sanitizePttActivationKey()` implementation

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22632019878/job/65584485497

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
