### PR TITLE
fix: enable supportsDynamicUi for vellum web interface

### DIFF
--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -44,6 +44,14 @@ describe("resolveChannelCapabilities", () => {
     expect(caps.supportsVoiceInput).toBe(true);
   });
 
+  test("vellum channel with vellum interface supports dynamic UI", () => {
+    const caps = resolveChannelCapabilities("vellum", "vellum");
+    expect(caps.channel).toBe("vellum");
+    expect(caps.dashboardCapable).toBe(false);
+    expect(caps.supportsDynamicUi).toBe(true);
+    expect(caps.supportsVoiceInput).toBe(false);
+  });
+
   test("defaults to vellum for null source channel", () => {
     const caps = resolveChannelCapabilities(null);
     expect(caps.channel).toBe("vellum");

--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -415,6 +415,24 @@ describe("trust-gating via channel capabilities", () => {
     expect(injected).toContain("Present information as well-formatted text");
     expect(injected).toContain("desktop app");
   });
+
+  test("vellum web interface allows dynamic UI but constrains dashboard references", () => {
+    const caps = resolveChannelCapabilities("vellum", "vellum");
+    const message: Message = {
+      role: "user",
+      content: [{ type: "text", text: "Show me a form" }],
+    };
+
+    const result = injectChannelCapabilityContext(message, caps);
+    const injected = (result.content[0] as { type: "text"; text: string }).text;
+
+    expect(injected).toContain("CHANNEL CONSTRAINTS");
+    expect(injected).toContain("Do NOT reference the dashboard UI");
+    expect(injected).not.toContain("Do NOT use ui_show");
+    expect(injected).not.toContain("Present information as well-formatted text");
+    expect(injected).toContain("supports_dynamic_ui: true");
+    expect(injected).toContain("dashboard_capable: false");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -592,12 +592,14 @@ export function injectChannelCapabilityContext(
     lines.push(
       "- Do NOT reference the dashboard UI, settings panels, or visual preference pickers.",
     );
-    lines.push(
-      "- Do NOT use ui_show, ui_update, or app_create — this channel cannot render them.",
-    );
-    lines.push(
-      "- Present information as well-formatted text instead of dynamic UI.",
-    );
+    if (!caps.supportsDynamicUi) {
+      lines.push(
+        "- Do NOT use ui_show, ui_update, or app_create — this channel cannot render them.",
+      );
+      lines.push(
+        "- Present information as well-formatted text instead of dynamic UI.",
+      );
+    }
     lines.push(
       "- Defer dashboard-specific actions (e.g. accent color selection) by telling the user",
     );

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -314,7 +314,7 @@ export function resolveChannelCapabilities(
       return {
         channel,
         dashboardCapable: supportsDesktopUi,
-        supportsDynamicUi: supportsDesktopUi,
+        supportsDynamicUi: supportsDesktopUi || iface === "vellum",
         supportsVoiceInput: supportsDesktopUi,
         pttActivationKey: sanitizePttActivationKey(
           pttMetadata?.pttActivationKey,


### PR DESCRIPTION
## Summary
- The web app sends `sourceChannel: "vellum"` and `interface: "vellum"` when posting messages
- `resolveChannelCapabilities` only set `supportsDynamicUi: true` for the `"macos"` interface
- This caused the system prompt to instruct the LLM: "When `supports_dynamic_ui` is `false`, do not call `ui_show`, `ui_update`, or `app_create`"
- The LLM would then refuse to show interactive surfaces (forms, cards, tables, etc.) in the web chat UI, saying something like "there's a permission issue preventing me from showing interactive UI"
- Fix: also set `supportsDynamicUi: true` when `iface === "vellum"` (the web app)

## Test plan
- [x] Added test: `vellum channel with vellum interface supports dynamic UI`
- [ ] Verify web chat UI can display interactive surfaces (forms, cards, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
