### PR TITLE
fix: surface Dictation-disabled error and fix wake word restart bug

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -2297,6 +2297,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
     // MARK: - Wake Word Coordinator
 
+    private var wakeWordErrorCancellable: AnyCancellable?
+
     private func setupWakeWordCoordinator() {
         guard let mainWindow else {
             log.warning("Cannot set up wake word coordinator — main window not available")
@@ -2313,6 +2315,22 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             threadManager: mainWindow.threadManager,
             voiceInputManager: voiceInput
         )
+
+        // Show a toast when the wake word engine hits a persistent error
+        // (e.g. Dictation disabled at the OS level).
+        wakeWordErrorCancellable = audioMonitor.$persistentErrorMessage
+            .compactMap { $0 }
+            .sink { [weak self] message in
+                self?.mainWindow?.windowState.showToast(
+                    message: message,
+                    style: .warning,
+                    primaryAction: VToastAction(label: "Open Settings") {
+                        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.keyboard?Dictation") {
+                            NSWorkspace.shared.open(url)
+                        }
+                    }
+                )
+            }
 
         if UserDefaults.standard.bool(forKey: "wakeWordEnabled") {
             audioMonitor.startMonitoring()

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -926,6 +926,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             }
             voiceInput?.stop()
             voiceInput = nil
+            wakeWordErrorCancellable?.cancel()
+            wakeWordErrorCancellable = nil
             wakeWordCoordinator = nil
             ambientAgent.teardown()
 
@@ -1114,6 +1116,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         }
         voiceInput?.stop()
         voiceInput = nil
+        wakeWordErrorCancellable?.cancel()
+        wakeWordErrorCancellable = nil
         wakeWordCoordinator = nil
         ambientAgent.teardown()
 

--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/AlwaysOnAudioMonitor.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/AlwaysOnAudioMonitor.swift
@@ -32,6 +32,10 @@ final class AlwaysOnAudioMonitor: ObservableObject {
 
     @Published private(set) var isListening = false
 
+    /// Non-nil when the engine hit a persistent error that requires user action
+    /// (e.g. Dictation disabled). Cleared when monitoring restarts successfully.
+    @Published private(set) var persistentErrorMessage: String?
+
     /// Fired on the main actor when the wake word engine detects a keyword.
     var onWakeWordDetected: (() -> Void)?
 
@@ -49,6 +53,7 @@ final class AlwaysOnAudioMonitor: ObservableObject {
     init(engine: WakeWordEngine) {
         self.engine = engine
         setupEngineCallback()
+        setupPersistentErrorCallback()
         setupNotificationObservers()
         observeKeywordChanges()
     }
@@ -70,7 +75,12 @@ final class AlwaysOnAudioMonitor: ObservableObject {
 
         do {
             try engine.start()
+            guard engine.isRunning else {
+                log.warning("Engine start returned without error but is not running")
+                return
+            }
             isListening = true
+            persistentErrorMessage = nil
             log.info("Audio monitoring started")
         } catch {
             log.error("Wake word engine failed to start: \(error.localizedDescription)")
@@ -93,6 +103,17 @@ final class AlwaysOnAudioMonitor: ObservableObject {
                 guard let self, self.isListening else { return }
                 log.info("Wake word detected (confidence: \(confidence, format: .fixed(precision: 2)))")
                 self.onWakeWordDetected?()
+            }
+        }
+    }
+
+    private func setupPersistentErrorCallback() {
+        engine.onPersistentError = { [weak self] message in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                log.error("Persistent engine error: \(message, privacy: .public)")
+                self.isListening = false
+                self.persistentErrorMessage = message
             }
         }
     }
@@ -150,7 +171,12 @@ final class AlwaysOnAudioMonitor: ObservableObject {
 
         do {
             try engine.start()
-            log.info("Audio monitoring restarted after configuration change")
+            if engine.isRunning {
+                log.info("Audio monitoring restarted after configuration change")
+            } else {
+                log.warning("Engine did not restart after audio configuration change")
+                isListening = false
+            }
         } catch {
             log.error("Failed to restart audio monitoring: \(error.localizedDescription)")
             isListening = false

--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/AlwaysOnAudioMonitor.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/AlwaysOnAudioMonitor.swift
@@ -75,10 +75,11 @@ final class AlwaysOnAudioMonitor: ObservableObject {
 
         do {
             try engine.start()
-            guard engine.isRunning else {
-                log.warning("Engine start returned without error but is not running")
-                return
-            }
+            // Set isListening optimistically — engine.start() may return
+            // before the engine is fully running (e.g. when speech auth is
+            // .notDetermined and deferred to an async callback). The
+            // persistent-error callback will reset isListening if the engine
+            // hits an unrecoverable failure after starting.
             isListening = true
             persistentErrorMessage = nil
             log.info("Audio monitoring started")

--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/SpeechWakeWordEngine.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/SpeechWakeWordEngine.swift
@@ -18,6 +18,7 @@ private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "Sp
 final class SpeechWakeWordEngine: WakeWordEngine {
 
     var onWakeWordDetected: ((Float) -> Void)?
+    var onPersistentError: ((String) -> Void)?
 
     private(set) var isRunning = false
 
@@ -203,6 +204,19 @@ final class SpeechWakeWordEngine: WakeWordEngine {
                         return
                     }
                     log.error("Recognition ended after \(String(format: "%.1f", sessionDuration), privacy: .public)s: \(nsError.domain, privacy: .public)/\(nsError.code, privacy: .public) \(error.localizedDescription, privacy: .public)")
+
+                    // "Siri and Dictation are disabled" — retrying won't help.
+                    // Stop the engine and notify the caller so they can surface
+                    // a user-facing message.
+                    if nsError.domain == "kLSRErrorDomain" && nsError.code == 201 {
+                        DispatchQueue.main.async { [weak self] in
+                            guard let self, self.isRunning else { return }
+                            log.error("Dictation is disabled at the OS level — stopping wake word engine")
+                            self.stop()
+                            self.onPersistentError?("Wake word requires Dictation to be enabled. Turn it on in System Settings > Keyboard > Dictation.")
+                        }
+                        return
+                    }
                 }
 
                 DispatchQueue.main.async { [weak self] in

--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordEngine.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordEngine.swift
@@ -7,6 +7,11 @@ protocol WakeWordEngine: AnyObject {
     /// The parameter is the confidence score (0.0-1.0).
     var onWakeWordDetected: ((Float) -> Void)? { get set }
 
+    /// Called when the engine encounters a persistent error that won't resolve
+    /// by retrying (e.g. Dictation disabled at the OS level). The parameter
+    /// is a user-facing message describing what needs to be fixed.
+    var onPersistentError: ((String) -> Void)? { get set }
+
     /// Whether the engine is currently listening for the wake word.
     var isRunning: Bool { get }
 

--- a/clients/macos/vellum-assistantTests/WakeWordCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/WakeWordCoordinatorTests.swift
@@ -7,6 +7,7 @@ import Combine
 
 final class MockWakeWordEngine: WakeWordEngine {
     var onWakeWordDetected: ((Float) -> Void)?
+    var onPersistentError: ((String) -> Void)?
     private(set) var isRunning = false
     var startCalled = false
     var stopCalled = false


### PR DESCRIPTION
## Summary
- Detect `kLSRErrorDomain/201` ("Siri and Dictation are disabled") in `SpeechWakeWordEngine` and stop futile retries — instead fire a new `onPersistentError` callback
- Show a user-facing toast with "Open Settings" action that deep-links to Keyboard > Dictation
- Fix `AlwaysOnAudioMonitor.handleConfigurationChange()` not updating `isListening` when `engine.start()` returns early without throwing (causing the monitor to think it's still listening when the engine isn't running)

## Original prompt
make these fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
