### PR TITLE
fix: correct toGuardianRuntimeContext mock arity

### DIFF
--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -84,7 +84,10 @@ mock.module("../runtime/guardian-context-resolver.js", () => ({
     trustClass: "guardian",
     sourceChannel: "vellum",
   }),
-  toGuardianRuntimeContext: (ctx: unknown) => ctx,
+  toGuardianRuntimeContext: (sourceChannel: unknown, ctx: unknown) => ({
+    ...(ctx as Record<string, unknown>),
+    sourceChannel,
+  }),
 }));
 
 import type { AuthContext } from "../runtime/auth/types.js";


### PR DESCRIPTION
## Summary

- Fixes `toGuardianRuntimeContext` mock in guardian reply test to match the real function's 2-param signature `(sourceChannel, ctx)` instead of incorrect 1-param `(ctx)`
- The mock was returning the channel string `"vellum"` instead of a guardian context object

Addresses review feedback from Devin and Codex on PR #11563.

## Test plan

- [x] `bun test conversation-routes-guardian-reply.test.ts` passes

> **Prompt:** `Address the feedback on PR #11563: Fix toGuardianRuntimeContext mock arity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
