### PR TITLE
Update CODEOWNERS with domain DRI assignments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,30 +9,94 @@ assistant/src/config/templates/USER.md @awlevin @AnitaKirkovska
 assistant/src/config/templates/SOUL.md @awlevin @AnitaKirkovska
 assistant/src/config/templates/BOOTSTRAP.md @awlevin @AnitaKirkovska
 
+# Voice / calls (Alex)
+assistant/src/calls/ @alex-nork
+assistant/src/tools/calls/ @alex-nork
+assistant/src/config/calls-schema.ts @alex-nork
+assistant/src/config/bundled-skills/phone-calls/ @alex-nork
+assistant/src/config/bundled-skills/voice-setup/ @alex-nork
+assistant/src/config/bundled-skills/twilio-setup/ @alex-nork
+assistant/src/runtime/routes/call-routes.ts @alex-nork
+assistant/src/runtime/middleware/twilio-validation.ts @alex-nork
+assistant/src/runtime/channel-invite-transports/voice.ts @alex-nork
+assistant/src/tools/system/voice-config.ts @alex-nork
+assistant/src/util/voice-code.ts @alex-nork
+gateway/src/twilio/ @alex-nork
+
+# Memory system (Sidd)
+assistant/src/memory/ @siddseethepalli
+
 # Tool definitions and infrastructure
 assistant/src/tools/ @siddseethepalli
 
-# Skill system (loading, runtime, bundled skills)
-assistant/src/skills/ @siddseethepalli
-assistant/src/config/skills.ts @siddseethepalli
-assistant/src/config/skill-state.ts @siddseethepalli
-assistant/src/config/bundled-skills/ @siddseethepalli
+# Skill system (Aaron)
+assistant/src/skills/ @awlevin
+assistant/src/config/skills.ts @awlevin
+assistant/src/config/skill-state.ts @awlevin
+assistant/src/config/bundled-skills/ @awlevin
+assistant/src/tools/skills/ @awlevin
+assistant/src/daemon/handlers/skills.ts @awlevin
+assistant/src/daemon/ipc-contract/skills.ts @awlevin
+assistant/src/daemon/session-skill-tools.ts @awlevin
 
-# Memory system
-assistant/src/memory/ @siddseethepalli
-
-# Ingress / guardian / escalation domains
+# Agent-to-agent / agent-to-person interactions (Harrison)
+assistant/src/subagent/ @NgoHarrison
+assistant/src/tools/subagent/ @NgoHarrison
+assistant/src/config/bundled-skills/subagent/ @NgoHarrison
+assistant/src/channels/ @NgoHarrison
+assistant/src/messaging/ @NgoHarrison
+assistant/src/notifications/ @NgoHarrison
 assistant/src/runtime/routes/ @NgoHarrison
 assistant/src/runtime/ingress-service.ts @NgoHarrison
-assistant/src/runtime/channel-guardian-service.ts @NgoHarrison
-assistant/src/runtime/guardian-verification-templates.ts @NgoHarrison
-assistant/src/daemon/handlers/config-inbox.ts @NgoHarrison
-assistant/src/daemon/ipc-contract/inbox.ts @NgoHarrison
-assistant/src/notifications/ @NgoHarrison
-assistant/src/memory/ingress-* @NgoHarrison
-assistant/src/memory/inbox-* @NgoHarrison
-assistant/src/memory/guardian-* @NgoHarrison
-assistant/src/memory/channel-guardian-store.ts @NgoHarrison
+assistant/src/daemon/session-messaging.ts @NgoHarrison
+assistant/src/daemon/session-surfaces.ts @NgoHarrison
+gateway/src/channels/ @NgoHarrison
+gateway/src/handlers/ @NgoHarrison
+gateway/src/routing/ @NgoHarrison
+gateway/src/telegram/ @NgoHarrison
+gateway/src/slack/ @NgoHarrison
+gateway/src/whatsapp/ @NgoHarrison
+
+# MCP (Vincent)
+assistant/src/mcp/ @vincent0426
+assistant/src/tools/mcp/ @vincent0426
+assistant/src/cli/mcp.ts @vincent0426
+
+# Guardian approvals (Noa)
+assistant/src/approvals/ @noanflaherty
+assistant/src/runtime/channel-approvals.ts @noanflaherty
+assistant/src/runtime/channel-approval-parser.ts @noanflaherty
+assistant/src/runtime/channel-approval-types.ts @noanflaherty
+assistant/src/runtime/channel-guardian-service.ts @noanflaherty
+assistant/src/runtime/guardian-*.ts @noanflaherty
+assistant/src/runtime/confirmation-request-guardian-bridge.ts @noanflaherty
+assistant/src/runtime/actor-trust-resolver.ts @noanflaherty
+assistant/src/runtime/approval-*.ts @noanflaherty
+assistant/src/runtime/verification-rate-limiter.ts @noanflaherty
+assistant/src/runtime/session-approval-overrides.ts @noanflaherty
+assistant/src/runtime/routes/approval-routes.ts @noanflaherty
+assistant/src/runtime/routes/channel-guardian-routes.ts @noanflaherty
+assistant/src/runtime/routes/guardian-*.ts @noanflaherty
+assistant/src/runtime/routes/trust-rules-routes.ts @noanflaherty
+assistant/src/daemon/approval-generators.ts @noanflaherty
+assistant/src/daemon/guardian-*.ts @noanflaherty
+assistant/src/daemon/handlers/config-trust.ts @noanflaherty
+assistant/src/daemon/handlers/guardian-actions.ts @noanflaherty
+assistant/src/daemon/ipc-contract/guardian-actions.ts @noanflaherty
+assistant/src/daemon/ipc-contract/trust.ts @noanflaherty
+assistant/src/tools/guardian-control-plane-policy.ts @noanflaherty
+assistant/src/tools/tool-approval-handler.ts @noanflaherty
+assistant/src/security/tool-approval-digest.ts @noanflaherty
+assistant/src/permissions/ @noanflaherty
+assistant/src/memory/guardian-* @noanflaherty
+assistant/src/memory/channel-guardian-store.ts @noanflaherty
+assistant/src/memory/scoped-approval-grants.ts @noanflaherty
+assistant/src/memory/canonical-guardian-store.ts @noanflaherty
+assistant/src/calls/guardian-*.ts @noanflaherty
+assistant/src/config/bundled-skills/guardian-verify-setup/ @noanflaherty
+assistant/src/config/bundled-skills/trusted-contacts/ @noanflaherty
+assistant/src/notifications/guardian-question-mode.ts @noanflaherty
+gateway/src/http/routes/guardian-control-plane-proxy.ts @noanflaherty
 
 # CLI
 /cli/ @dvargas92495

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,32 +1,16 @@
-# System prompt ownership
-assistant/src/config/system-prompt.ts @awlevin @siddseethepalli @alex-nork
-assistant/src/config/computer-use-prompt.ts @awlevin @siddseethepalli @alex-nork
-assistant/src/config/templates/ @awlevin @siddseethepalli @alex-nork
+# =============================================================================
+# CODEOWNERS — ordered for last-match-wins semantics
+#
+# GitHub uses the LAST matching pattern, so broad directory rules go first
+# and specific overrides go after them.
+# =============================================================================
 
-# Default identity/personality files
-assistant/src/config/templates/IDENTITY.md @awlevin @AnitaKirkovska
-assistant/src/config/templates/USER.md @awlevin @AnitaKirkovska
-assistant/src/config/templates/SOUL.md @awlevin @AnitaKirkovska
-assistant/src/config/templates/BOOTSTRAP.md @awlevin @AnitaKirkovska
-
-# Voice / calls (Alex)
-assistant/src/calls/ @alex-nork
-assistant/src/tools/calls/ @alex-nork
-assistant/src/config/calls-schema.ts @alex-nork
-assistant/src/config/bundled-skills/phone-calls/ @alex-nork
-assistant/src/config/bundled-skills/voice-setup/ @alex-nork
-assistant/src/config/bundled-skills/twilio-setup/ @alex-nork
-assistant/src/runtime/routes/call-routes.ts @alex-nork
-assistant/src/runtime/middleware/twilio-validation.ts @alex-nork
-assistant/src/runtime/channel-invite-transports/voice.ts @alex-nork
-assistant/src/tools/system/voice-config.ts @alex-nork
-assistant/src/util/voice-code.ts @alex-nork
-gateway/src/twilio/ @alex-nork
+# --- Broad directory catch-alls (DRI defaults) ---
 
 # Memory system (Sidd)
 assistant/src/memory/ @siddseethepalli
 
-# Tool definitions and infrastructure
+# Tool definitions and infrastructure (Sidd)
 assistant/src/tools/ @siddseethepalli
 
 # Skill system (Aaron)
@@ -34,15 +18,12 @@ assistant/src/skills/ @awlevin
 assistant/src/config/skills.ts @awlevin
 assistant/src/config/skill-state.ts @awlevin
 assistant/src/config/bundled-skills/ @awlevin
-assistant/src/tools/skills/ @awlevin
 assistant/src/daemon/handlers/skills.ts @awlevin
 assistant/src/daemon/ipc-contract/skills.ts @awlevin
 assistant/src/daemon/session-skill-tools.ts @awlevin
 
 # Agent-to-agent / agent-to-person interactions (Harrison)
 assistant/src/subagent/ @NgoHarrison
-assistant/src/tools/subagent/ @NgoHarrison
-assistant/src/config/bundled-skills/subagent/ @NgoHarrison
 assistant/src/channels/ @NgoHarrison
 assistant/src/messaging/ @NgoHarrison
 assistant/src/notifications/ @NgoHarrison
@@ -57,12 +38,46 @@ gateway/src/telegram/ @NgoHarrison
 gateway/src/slack/ @NgoHarrison
 gateway/src/whatsapp/ @NgoHarrison
 
-# MCP (Vincent)
+# --- Specific overrides (must come AFTER broad rules) ---
+
+# System prompt ownership
+assistant/src/config/system-prompt.ts @awlevin @siddseethepalli @alex-nork
+assistant/src/config/computer-use-prompt.ts @awlevin @siddseethepalli @alex-nork
+assistant/src/config/templates/ @awlevin @siddseethepalli @alex-nork
+
+# Default identity/personality files
+assistant/src/config/templates/IDENTITY.md @awlevin @AnitaKirkovska
+assistant/src/config/templates/USER.md @awlevin @AnitaKirkovska
+assistant/src/config/templates/SOUL.md @awlevin @AnitaKirkovska
+assistant/src/config/templates/BOOTSTRAP.md @awlevin @AnitaKirkovska
+
+# Voice / calls (Alex) — overrides tools/, bundled-skills/, routes/
+assistant/src/calls/ @alex-nork
+assistant/src/tools/calls/ @alex-nork
+assistant/src/tools/system/voice-config.ts @alex-nork
+assistant/src/config/calls-schema.ts @alex-nork
+assistant/src/config/bundled-skills/phone-calls/ @alex-nork
+assistant/src/config/bundled-skills/voice-setup/ @alex-nork
+assistant/src/config/bundled-skills/twilio-setup/ @alex-nork
+assistant/src/runtime/routes/call-routes.ts @alex-nork
+assistant/src/runtime/middleware/twilio-validation.ts @alex-nork
+assistant/src/runtime/channel-invite-transports/voice.ts @alex-nork
+assistant/src/util/voice-code.ts @alex-nork
+gateway/src/twilio/ @alex-nork
+
+# Agent-to-agent / agent-to-person overrides (Harrison) — within tools/, bundled-skills/
+assistant/src/tools/subagent/ @NgoHarrison
+assistant/src/config/bundled-skills/subagent/ @NgoHarrison
+
+# MCP (Vincent) — overrides tools/
 assistant/src/mcp/ @vincent0426
 assistant/src/tools/mcp/ @vincent0426
 assistant/src/cli/mcp.ts @vincent0426
 
-# Guardian approvals (Noa)
+# Skill tools (Aaron) — overrides tools/
+assistant/src/tools/skills/ @awlevin
+
+# Guardian approvals (Noa) — overrides tools/, routes/, memory/, notifications/, bundled-skills/
 assistant/src/approvals/ @noanflaherty
 assistant/src/runtime/channel-approvals.ts @noanflaherty
 assistant/src/runtime/channel-approval-parser.ts @noanflaherty


### PR DESCRIPTION
## Summary
- Assigns code ownership by domain area with clear DRIs:
  - **Alex** (`@alex-nork`): voice, calls, Twilio integration
  - **Sidd** (`@siddseethepalli`): assistant memory system
  - **Aaron** (`@awlevin`): skill system (loading, runtime, bundled skills)
  - **Harrison** (`@NgoHarrison`): agent-to-agent/agent-to-person interactions, channels, gateway routing, notifications
  - **Vincent** (`@vincent0426`): MCP (Model Context Protocol)
  - **Noa** (`@noanflaherty`): guardian approvals, trust, verification, permissions
- Retains existing ownership for system prompts, identity files, CLI, and CI/CD

## Test plan
- [ ] Verify GitHub correctly parses the CODEOWNERS file (no syntax errors)
- [ ] Confirm each DRI's GitHub username resolves correctly
- [ ] Spot-check that PRs touching owned paths request reviews from the right people

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
