### PR TITLE
fix: restore Playwright-launched browser (connectOverCDP broken under Bun)

### DIFF
--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -5,8 +5,19 @@ import { getLogger } from "../../util/logger.js";
 import { getDataDir } from "../../util/platform.js";
 import { authSessionCache } from "./auth-cache.js";
 import type { ExtractedCredential } from "./network-recording-types.js";
+import { checkBrowserRuntime } from "./runtime-check.js";
 
 const log = getLogger("browser-manager");
+
+/**
+ * Returns true when the host has a GUI capable of displaying a browser window.
+ * macOS and Windows always have a display; Linux requires DISPLAY or WAYLAND_DISPLAY.
+ */
+function canDisplayGui(): boolean {
+  if (process.platform === "darwin" || process.platform === "win32")
+    return true;
+  return !!(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
+}
 
 function getDownloadsDir(): string {
   const dir = join(getDataDir(), "browser-downloads");
@@ -116,6 +127,11 @@ let launchPersistentContext: LaunchFn | null = null;
 
 export function setLaunchFn(fn: LaunchFn | null): void {
   launchPersistentContext = fn;
+}
+
+async function getDefaultLaunchFn(): Promise<LaunchFn> {
+  const pw = await import("playwright");
+  return pw.chromium.launchPersistentContext.bind(pw.chromium);
 }
 
 function getProfileDir(): string {
@@ -232,7 +248,7 @@ class BrowserManager {
   }
 
   private async ensureContext(
-    invokingSessionId?: string,
+    _invokingSessionId?: string,
   ): Promise<BrowserContext> {
     if (this.context) return this.context;
     if (this.contextCreating) return this.contextCreating;
@@ -252,58 +268,63 @@ class BrowserManager {
         return ctx;
       }
 
-      // Try to detect an existing Chrome with --remote-debugging-port,
-      // or ask the client to launch Chrome with CDP enabled.
-      const sender = invokingSessionId
-        ? this.sessionSenders.get(invokingSessionId)
-        : undefined;
-      let cdpAvailable = await this.detectCDP();
-
-      if (!cdpAvailable && invokingSessionId && sender) {
-        log.info(
-          { sessionId: invokingSessionId },
-          "Requesting CDP from client",
-        );
-        const accepted = await this.requestCDPFromClient(
-          invokingSessionId,
-          sender,
-        );
-        if (accepted) {
-          cdpAvailable = await this.detectCDP();
-          if (!cdpAvailable) {
-            log.warn("Client accepted CDP request but CDP not detected");
-          }
-        } else {
-          log.info("Client declined CDP request");
-          throw new Error("Browser access was declined by user");
-        }
-      }
-
-      if (!cdpAvailable) {
-        throw new Error(
-          "Chrome with remote debugging is not available. Please launch Chrome with --remote-debugging-port=9222.",
-        );
-      }
-
       // Initialize auth session cache alongside browser context
       await authSessionCache.load();
 
-      try {
-        const pw = await import("playwright");
-        const browser = await pw.chromium.connectOverCDP(this.cdpUrl, {
-          timeout: 10_000,
-        });
-        this.cdpBrowser = browser;
-        this._browserLaunched = false;
-        const contexts = browser.contexts();
-        const ctx = contexts[0] || (await browser.newContext());
-        await this.initBrowserCdpSession();
-        log.info({ cdpUrl: this.cdpUrl }, "Connected to Chrome via CDP");
-        return ctx as unknown as BrowserContext;
-      } catch (err) {
-        log.warn({ err }, "CDP connectOverCDP failed");
-        throw new Error(`Failed to connect to Chrome via CDP: ${err}`);
+      // Launch browser via Playwright directly. Playwright's connectOverCDP
+      // is broken under Bun's runtime (websocket handshake times out), so we
+      // launch Playwright's own Chromium instead.
+      // Auto-install Chromium if missing.
+      if (!launchPersistentContext) {
+        const status = await checkBrowserRuntime();
+        if (status.playwrightAvailable && !status.chromiumInstalled) {
+          log.info("Chromium not installed, installing via playwright...");
+          const proc = Bun.spawn(
+            ["bunx", "playwright", "install", "chromium"],
+            {
+              stdout: "pipe",
+              stderr: "pipe",
+            },
+          );
+          const timeoutMs = 120_000;
+          let timer: ReturnType<typeof setTimeout>;
+          const exitCode = await Promise.race([
+            proc.exited.finally(() => clearTimeout(timer)),
+            new Promise<never>(
+              (_, reject) =>
+                (timer = setTimeout(() => {
+                  proc.kill();
+                  reject(
+                    new Error(
+                      `Chromium install timed out after ${timeoutMs / 1000}s`,
+                    ),
+                  );
+                }, timeoutMs)),
+            ),
+          ]);
+          if (exitCode === 0) {
+            log.info("Chromium installed successfully");
+          } else {
+            const stderr = await new Response(proc.stderr).text();
+            const msg = stderr.trim() || `exited with code ${exitCode}`;
+            throw new Error(`Failed to install Chromium: ${msg}`);
+          }
+        }
       }
+
+      const profileDir = getProfileDir();
+      mkdirSync(profileDir, { recursive: true });
+      const launch = launchPersistentContext ?? (await getDefaultLaunchFn());
+      const headless = !canDisplayGui();
+      const ctx = await launch(profileDir, { headless });
+      this._browserLaunched = true;
+      log.info(
+        { profileDir, headless },
+        headless
+          ? "Browser context created (headless)"
+          : "Browser context created (visible)",
+      );
+      return ctx;
     })();
 
     try {

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -128,9 +128,11 @@ final class AssistantCli {
         if restart {
             arguments.append("--restart")
         }
-        #if DEBUG
-        arguments.append("--watch")
-        #endif
+        // NOTE: --watch runs daemon from source via `bun --watch` which breaks
+        // Playwright's CDP websocket connection. Omit it for now.
+        // #if DEBUG
+        // arguments.append("--watch")
+        // #endif
         if let name {
             arguments += ["--name", name]
         }

--- a/clients/macos/vellum-assistant/ComputerUse/ChromeAccessibilityHelper.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ChromeAccessibilityHelper.swift
@@ -122,15 +122,19 @@ final class ChromeAccessibilityHelper {
         }
 
         // 2. Also check Playwright cache directly (bundle ID lookup can miss it)
-        let playwriteGlob = NSHomeDirectory() + "/Library/Caches/ms-playwright/chromium-*/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
+        //    Playwright uses "chrome-mac-arm64" on Apple Silicon and "chrome-mac" on Intel.
+        let archDirs = ["chrome-mac-arm64", "chrome-mac"]
         if let match = try? FileManager.default.contentsOfDirectory(atPath: NSHomeDirectory() + "/Library/Caches/ms-playwright")
             .filter({ $0.hasPrefix("chromium-") })
             .sorted()
-            .last,
-           FileManager.default.fileExists(atPath: NSHomeDirectory() + "/Library/Caches/ms-playwright/\(match)/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing") {
-            let binary = NSHomeDirectory() + "/Library/Caches/ms-playwright/\(match)/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
-            log.info("Resolved CDP binary: Chrome for Testing (Playwright cache) at \(binary, privacy: .public)")
-            return binary
+            .last {
+            for archDir in archDirs {
+                let binary = NSHomeDirectory() + "/Library/Caches/ms-playwright/\(match)/\(archDir)/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
+                if FileManager.default.fileExists(atPath: binary) {
+                    log.info("Resolved CDP binary: Chrome for Testing (Playwright cache) at \(binary, privacy: .public)")
+                    return binary
+                }
+            }
         }
 
         // 3. Fall back to regular Chrome

--- a/clients/macos/vellum-assistant/ComputerUse/ChromeAccessibilityHelper.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ChromeAccessibilityHelper.swift
@@ -107,24 +107,64 @@ final class ChromeAccessibilityHelper {
     /// Uses a dedicated user-data-dir so the user's normal Chrome is untouched.
     /// Launches via the binary directly (not NSWorkspace/Launch Services) to ensure
     /// a second instance is created instead of activating the existing one.
+    /// Resolve the Chrome binary to use for CDP automation.
+    /// Prefers Chrome for Testing (installed by Playwright) since it won't conflict
+    /// with the user's regular Chrome instance.
+    private static func resolveCDPChromeBinary() -> String? {
+        // 1. Try Chrome for Testing (Playwright-installed) — preferred because it's
+        //    a separate app that won't conflict with regular Chrome.
+        if let cftURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.google.chrome.for.testing") {
+            let binary = cftURL.appendingPathComponent("Contents/MacOS/Google Chrome for Testing").path
+            if FileManager.default.fileExists(atPath: binary) {
+                log.info("Resolved CDP binary: Chrome for Testing at \(binary, privacy: .public)")
+                return binary
+            }
+        }
+
+        // 2. Also check Playwright cache directly (bundle ID lookup can miss it)
+        let playwriteGlob = NSHomeDirectory() + "/Library/Caches/ms-playwright/chromium-*/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
+        if let match = try? FileManager.default.contentsOfDirectory(atPath: NSHomeDirectory() + "/Library/Caches/ms-playwright")
+            .filter({ $0.hasPrefix("chromium-") })
+            .sorted()
+            .last,
+           FileManager.default.fileExists(atPath: NSHomeDirectory() + "/Library/Caches/ms-playwright/\(match)/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing") {
+            let binary = NSHomeDirectory() + "/Library/Caches/ms-playwright/\(match)/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
+            log.info("Resolved CDP binary: Chrome for Testing (Playwright cache) at \(binary, privacy: .public)")
+            return binary
+        }
+
+        // 3. Fall back to regular Chrome
+        if let chromeURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.google.Chrome") {
+            let binary = chromeURL.appendingPathComponent("Contents/MacOS/Google Chrome").path
+            if FileManager.default.fileExists(atPath: binary) {
+                log.info("Resolved CDP binary: regular Chrome at \(binary, privacy: .public)")
+                return binary
+            }
+        }
+
+        log.error("No Chrome binary found for CDP")
+        return nil
+    }
+
     @MainActor
     static func launchChromeForCDP() async -> Bool {
+        // Check if CDP is already available — don't launch a duplicate
+        if let url = URL(string: "http://localhost:9222/json/version"),
+           let (_, response) = try? await URLSession.shared.data(from: url),
+           let httpResponse = response as? HTTPURLResponse,
+           httpResponse.statusCode == 200 {
+            log.info("CDP already available, skipping Chrome launch")
+            return true
+        }
+
+        guard let chromeBinary = resolveCDPChromeBinary() else {
+            return false
+        }
+
         // Chrome 145+ requires a non-default --user-data-dir for CDP to bind the debugging port.
         let chromeDataDir = NSHomeDirectory() + "/Library/Application Support/Google/Chrome-CDP"
 
-        // Resolve Chrome binary dynamically via bundle ID to support non-standard install locations
-        guard let chromeURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.google.Chrome") else {
-            log.error("Google Chrome not found via bundle ID")
-            return false
-        }
-        let chromeBinary = chromeURL.appendingPathComponent("Contents/MacOS/Google Chrome").path
-
-        guard FileManager.default.fileExists(atPath: chromeBinary) else {
-            log.error("Chrome binary not found at \(chromeBinary)")
-            return false
-        }
-
-        log.info("Launching separate Chrome instance for CDP with user-data-dir: \(chromeDataDir, privacy: .public)")
+        log.info("Launching Chrome for CDP with user-data-dir: \(chromeDataDir, privacy: .public)")
 
         do {
             let process = Process()


### PR DESCRIPTION
## Summary
- Playwright's `connectOverCDP` websocket handshake times out under Bun's runtime (both `bun run` and `bun build --compile`). PR #11624 removed the headless fallback that masked this, breaking browser automation entirely.
- Restore `launchPersistentContext` as the primary browser approach — visible on macOS, headless on headless Linux
- Prefer Chrome for Testing in `launchChromeForCDP` (won't conflict with user's regular Chrome)
- Add CDP duplicate check before launching Chrome
- Disable `--watch` in DEBUG builds (`bun --watch` also breaks Playwright)

## What was happening
1. User triggers browser tool → modal appears → Chrome opens
2. Daemon tries `connectOverCDP` → websocket hangs → 10s timeout → error
3. Before #11624, this silently fell back to Playwright's own Chromium. After #11624, it threw an error.

## Follow-up
- Dead CDP request/modal IPC code can be cleaned up in a separate PR
- Investigate Bun + Playwright websocket compatibility for future CDP support

## Test plan
- [x] Verify browser tool launches Chromium and navigates to pages
- [ ] Verify auth handoff works when login is required
- [ ] Verify headless mode works on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
