### PR TITLE
fix: inline thinking indicator to prevent duplicate avatar stacking

### DIFF
--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -150,6 +150,9 @@ const TOOL_FRIENDLY_NAMES: Record<string, string> = {
   browser_wait: 'browser',
   app_create: 'app',
   app_update: 'app',
+  skill_load: 'skill',
+  app_file_edit: 'app file',
+  app_file_write: 'app file',
 };
 
 function friendlyToolName(name: string): string {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -21,6 +21,12 @@ struct ChatBubble: View {
     var resolveHttpPort: (() -> Int?) = { nil }
     var showAvatar: Bool = true
     var isLatestAssistantMessage: Bool = false
+    /// When true, the assistant is still processing after tool calls completed.
+    /// Renders an inline loading indicator in trailingStatus to avoid a separate
+    /// standalone thinking row (which would stack a duplicate avatar).
+    var isProcessingAfterTools: Bool = false
+    /// Status text from the assistant activity state, forwarded for inline display.
+    var processingStatusText: String?
 
     @State private var appearance = AvatarAppearanceManager.shared
     @State private var isHovered = false

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -65,6 +65,12 @@ extension ChatBubble {
                 if stepsExpanded {
                     StepsSection(toolCalls: message.toolCalls, onRehydrate: onRehydrate)
                 }
+                // Inline processing indicator — shown when assistant is still working
+                // after tool calls completed, preventing a duplicate avatar row.
+                if isProcessingAfterTools {
+                    inlineProcessingIndicator
+                        .padding(.top, VSpacing.xs)
+                }
             }
         } else if hasPermission || (hasInProgressTools && permissionWasDenied) {
             // Completed tool steps are hidden — only show permission chip or denied tool chip.
@@ -78,9 +84,40 @@ extension ChatBubble {
                     }
                     Spacer()
                 }
+                if isProcessingAfterTools {
+                    inlineProcessingIndicator
+                        .padding(.top, VSpacing.xs)
+                }
             }
             .padding(.top, VSpacing.xxs)
+        } else if isProcessingAfterTools {
+            // Fallback: no tool status to show but assistant is still processing.
+            inlineProcessingIndicator
         }
+    }
+
+    /// Inline processing indicator with staged friendly labels for long waits.
+    var inlineProcessingIndicator: some View {
+        let initialLabel = Self.friendlyProcessingLabel(processingStatusText)
+        return RunningIndicator(
+            label: initialLabel,
+            showIcon: false,
+            progressiveLabels: [
+                initialLabel,
+                "Putting this together",
+                "Finalizing your response",
+            ],
+            labelInterval: 8
+        )
+    }
+
+    /// Maps raw daemon status text to a friendlier label for the inline indicator.
+    static func friendlyProcessingLabel(_ statusText: String?) -> String {
+        guard let text = statusText else { return "Thinking" }
+        let lower = text.lowercased()
+        if lower.contains("skill") { return "Applying capabilities" }
+        if lower.contains("processing") { return "Processing results" }
+        return text
     }
 
     /// Failed/denied tool chip — shown when the user denied permission.

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -300,9 +300,17 @@ struct MessageListView: View {
                     let hasActiveToolCall = currentTurnMessages.contains(where: {
                         $0.toolCalls.contains(where: { !$0.isComplete })
                     })
-                    let shouldShowThinkingIndicator = isSending
+                    // Determine whether a standalone thinking row would be shown
+                    // (before considering inlining).
+                    let wouldShowThinking = isSending
                         && (isThinking || !(lastVisible?.isStreaming == true))
                         && !hasActiveToolCall
+                    // When the last visible message is an assistant bubble, render
+                    // the indicator inline inside that bubble's trailingStatus
+                    // instead of spawning a standalone row (duplicate avatar).
+                    let lastVisibleIsAssistant = lastVisible?.role == .assistant
+                    let canInlineProcessing = wouldShowThinking && lastVisibleIsAssistant
+                    let shouldShowThinkingIndicator = wouldShowThinking && !canInlineProcessing
                     ForEach(Array(zip(displayMessages.indices, displayMessages)), id: \.1.id) { index, message in
                         if showTimestamp.contains(index) {
                             TimestampDivider(date: message.timestamp)
@@ -387,6 +395,8 @@ struct MessageListView: View {
                                 resolveHttpPort: resolveHttpPort,
                                 showAvatar: !previousIsAssistant,
                                 isLatestAssistantMessage: message.role == .assistant && message.id == latestAssistantId,
+                                isProcessingAfterTools: canInlineProcessing && message.id == latestAssistantId,
+                                processingStatusText: canInlineProcessing && message.id == latestAssistantId ? assistantStatusText : nil,
                                 activeSurfaceId: activeSurfaceId
                             )
                                 .id(message.id)


### PR DESCRIPTION
## Summary
- Renders the "Thinking" indicator inline inside the last assistant bubble's `trailingStatus` instead of spawning a standalone `thinkingIndicatorRow` with its own avatar, preventing duplicate avatar stacking
- Adds friendly tool name labels for `skill_load`, `app_file_edit`, `app_file_write` and staged progressive copy for long processing waits ("Thinking" → "Putting this together" → "Finalizing your response")

## Test plan
- [ ] Send a message that triggers tool use — verify no duplicate avatars appear during the thinking gap between tool completion and response
- [ ] Send a plain message (no tools) — verify the thinking indicator appears inline below the assistant bubble content, not as a separate row
- [ ] Verify the standalone thinking row still appears when the last message is from the user (first response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
