### PR TITLE
feat: polish Account settings tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -12,16 +12,74 @@ struct GatewaySettingsCard: View {
     @State private var gatewayUrlText: String = ""
     @State private var isGatewayUrlFocused: Bool = false
     @State private var gatewayTargetCopied: Bool = false
+    @State private var tunnelSetupExpanded: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Gateway")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.textPrimary)
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Gateway")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+                Text("Local gateway that forwards requests to this assistant")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            }
 
-            gatewayContent
+            // Gateway running status row
+            if store.gatewayReachable == true {
+                HStack(spacing: VSpacing.sm) {
+                    VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success, size: .large) {}
+
+                    // Copy the local gateway target address
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(store.localGatewayTarget, forType: .string)
+                        gatewayTargetCopied = true
+                        Task {
+                            try? await Task.sleep(nanoseconds: 2_000_000_000)
+                            gatewayTargetCopied = false
+                        }
+                    } label: {
+                        Image(systemName: gatewayTargetCopied ? "checkmark" : "doc.on.doc")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(gatewayTargetCopied ? VColor.success : VColor.textSecondary)
+                            .frame(width: 28, height: 28)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Copy gateway address")
+                    .help("Copy local gateway address: \(store.localGatewayTarget)")
+                }
+
+                // Show the local gateway target as a readable label
+                Text(store.localGatewayTarget)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.textMuted)
+                    .textSelection(.enabled)
+            } else if tunnelSetupExpanded {
+                tunnelConfigEntry
+            } else {
+                VButton(label: "Set Up Tunnel", style: .secondary, size: .large) {
+                    tunnelSetupExpanded = true
+                }
+            }
+
+            // Diagnostic message when gateway is up but tunnel is down
+            if store.gatewayReachable == true,
+               !store.ingressPublicBaseUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+               store.ingressReachable == false {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(VColor.warning)
+                        .font(.system(size: 12))
+                    Text("Gateway is running but tunnel is unreachable. Check your tunnel configuration.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.warning)
+                }
+            }
         }
         .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
         .onAppear {
             store.refreshIngressConfig()
@@ -44,144 +102,59 @@ struct GatewaySettingsCard: View {
         }
     }
 
-    // MARK: - Gateway Content
+    // MARK: - Tunnel Configuration Entry
 
-    private var gatewayContent: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            // Local Gateway Target (read-only)
-            HStack(spacing: VSpacing.xs) {
+    private var tunnelConfigEntry: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
                 Text("Local Gateway Target")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+                HStack(spacing: VSpacing.sm) {
+                    Text(store.localGatewayTarget)
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textPrimary)
+                        .textSelection(.enabled)
+                        .padding(VSpacing.md)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(VColor.surface.opacity(0.5))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .stroke(VColor.surfaceBorder.opacity(0.3), lineWidth: 1)
+                        )
+
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(store.localGatewayTarget, forType: .string)
+                        gatewayTargetCopied = true
+                        Task {
+                            try? await Task.sleep(nanoseconds: 2_000_000_000)
+                            gatewayTargetCopied = false
+                        }
+                    } label: {
+                        Image(systemName: gatewayTargetCopied ? "checkmark" : "doc.on.doc")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(gatewayTargetCopied ? VColor.success : VColor.textSecondary)
+                            .frame(width: 28, height: 28)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Copy gateway address")
+                    .help("Copy address")
+                }
+                Text("Point your tunnel (ngrok, Cloudflare, etc.) to this address.")
                     .font(VFont.caption)
                     .foregroundColor(VColor.textSecondary)
             }
 
-            HStack(spacing: VSpacing.sm) {
-                Text(store.localGatewayTarget)
-                    .font(VFont.mono)
-                    .foregroundColor(VColor.textPrimary)
-                    .textSelection(.enabled)
-                    .padding(VSpacing.md)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(VColor.surface.opacity(0.5))
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.md)
-                            .stroke(VColor.surfaceBorder.opacity(0.3), lineWidth: 1)
-                    )
-
-                Button {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(store.localGatewayTarget, forType: .string)
-                    gatewayTargetCopied = true
-                    Task {
-                        try? await Task.sleep(nanoseconds: 2_000_000_000)
-                        gatewayTargetCopied = false
-                    }
-                } label: {
-                    Image(systemName: gatewayTargetCopied ? "checkmark" : "doc.on.doc")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(gatewayTargetCopied ? VColor.success : VColor.textSecondary)
-                        .frame(width: 28, height: 28)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Copy gateway address")
-                .help("Copy address")
-
-                InlineConnectionStatus(
-                    status: gatewayStatusInfo,
-                    isRefreshing: store.isCheckingGateway,
-                    lastChecked: store.gatewayLastChecked,
-                    accessibilityLabel: "gateway"
-                ) {
-                    Task { await store.testGatewayOnly() }
-                }
-            }
-
-            Text("Point your tunnel (ngrok, Cloudflare, etc.) to this address.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textSecondary)
-
-            // Gateway URL field
             Text("Gateway URL")
                 .font(VFont.caption)
                 .foregroundColor(VColor.textSecondary)
 
-            HStack(spacing: VSpacing.sm) {
-                VInlineActionField(text: $gatewayUrlText, placeholder: "https://your-tunnel.example.com", allowEmpty: true, isFocused: $isGatewayUrlFocused) {
-                    store.saveIngressPublicBaseUrl(gatewayUrlText)
-                }
-
-                InlineConnectionStatus(
-                    status: tunnelStatusInfo,
-                    isRefreshing: store.isCheckingTunnel,
-                    lastChecked: store.tunnelLastChecked,
-                    accessibilityLabel: "tunnel"
-                ) {
-                    Task { await store.testTunnelOnly() }
-                }
+            VInlineActionField(text: $gatewayUrlText, placeholder: "https://your-tunnel.example.com", allowEmpty: true, isFocused: $isGatewayUrlFocused) {
+                store.saveIngressPublicBaseUrl(gatewayUrlText)
             }
-
-            // Diagnostic message when gateway is up but tunnel is down
-            if store.gatewayReachable == true,
-               !store.ingressPublicBaseUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-               store.ingressReachable == false {
-                HStack(spacing: VSpacing.sm) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundColor(VColor.warning)
-                        .font(.system(size: 12))
-                    Text("Gateway is running but tunnel is unreachable. Check your tunnel configuration.")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.warning)
-                }
-            }
-
         }
     }
-
-    // MARK: - Connection Status Helpers
-
-    private var gatewayStatusInfo: ConnectionStatusInfo {
-        guard let reachable = store.gatewayReachable else {
-            return ConnectionStatusInfo(label: "Unknown", color: VColor.textMuted, icon: "questionmark.circle.fill")
-        }
-        if reachable {
-            return ConnectionStatusInfo(label: "Running", color: VColor.success, icon: "checkmark.circle.fill")
-        } else {
-            return ConnectionStatusInfo(label: "Stopped", color: VColor.error, icon: "xmark.circle.fill")
-        }
-    }
-
-    private var tunnelStatusInfo: ConnectionStatusInfo {
-        let trimmedUrl = store.ingressPublicBaseUrl.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        // No URL configured
-        if trimmedUrl.isEmpty {
-            return ConnectionStatusInfo(label: "Not configured", color: VColor.textMuted, icon: "minus.circle.fill")
-        }
-
-        // URL is non-empty but not a valid absolute HTTP(S) URL
-        if let parsed = URL(string: trimmedUrl), let scheme = parsed.scheme, ["http", "https"].contains(scheme.lowercased()) {
-            // valid — fall through to further checks below
-        } else {
-            return ConnectionStatusInfo(label: "Invalid URL format", color: VColor.error, icon: "exclamationmark.circle.fill")
-        }
-
-        // URL is set but ingress is disabled
-        if !store.ingressEnabled {
-            return ConnectionStatusInfo(label: "URL set but gateway not active", color: VColor.warning, icon: "exclamationmark.triangle.fill")
-        }
-
-        // Haven't tested yet
-        guard let reachable = store.ingressReachable else {
-            return ConnectionStatusInfo(label: "Unknown", color: VColor.textMuted, icon: "questionmark.circle.fill")
-        }
-
-        if reachable {
-            return ConnectionStatusInfo(label: "Reachable", color: VColor.success, icon: "checkmark.circle.fill")
-        } else {
-            return ConnectionStatusInfo(label: "Unreachable", color: VColor.error, icon: "xmark.circle.fill")
-        }
-    }
-
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -117,81 +117,43 @@ struct SettingsAccountTab: View {
                     .font(VFont.caption)
                     .foregroundColor(VColor.textSecondary)
 
-                HStack(spacing: VSpacing.sm) {
+                // When platform is reachable, show a Connected badge and hide the input field.
+                // When not reachable/configured, show the inline field for editing.
+                if store.vellumPlatformReachable == true {
+                    VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success, size: .large) {}
+                } else if isPlatformUrlFocused || !platformUrlText.isEmpty {
                     VInlineActionField(text: $platformUrlText, placeholder: "https://platform.vellum.ai", isFocused: $isPlatformUrlFocused) {
                         store.savePlatformBaseUrl(platformUrlText)
                         Task { await store.checkVellumPlatform() }
                     }
-
-                    InlineConnectionStatus(
-                        status: platformStatusInfo,
-                        isRefreshing: store.isCheckingVellumPlatform,
-                        lastChecked: store.platformLastChecked,
-                        accessibilityLabel: "platform"
-                    ) {
-                        Task { await store.checkVellumPlatform() }
+                } else {
+                    VButton(label: "Set Up", style: .secondary, size: .large) {
+                        isPlatformUrlFocused = true
                     }
-                }
-            } else {
-                HStack(spacing: VSpacing.sm) {
-                    InlineConnectionStatus(
-                        status: platformStatusInfo,
-                        isRefreshing: store.isCheckingVellumPlatform,
-                        lastChecked: store.platformLastChecked,
-                        accessibilityLabel: "platform"
-                    ) {
-                        Task { await store.checkVellumPlatform() }
-                    }
-                    Spacer()
                 }
             }
 
-            Divider().background(VColor.surfaceBorder)
-
             if authManager.isLoading {
                 HStack(spacing: VSpacing.sm) {
-                    Image(systemName: "arrow.triangle.2.circlepath")
-                        .foregroundColor(VColor.textMuted)
-                        .font(.system(size: 14))
+                    ProgressView()
+                        .controlSize(.small)
                     Text("Checking...")
                         .font(VFont.body)
                         .foregroundColor(VColor.textSecondary)
                 }
-            } else if let user = authManager.currentUser {
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    HStack(spacing: VSpacing.sm) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(VColor.success)
-                            .font(.system(size: 14))
-                        Text(user.email ?? user.display ?? "Signed in")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textSecondary)
-                        Spacer()
-                    }
-                    VButton(label: "Log Out", style: .danger, size: .large) {
-                        Task { await authManager.logout() }
-                    }
+            } else if authManager.currentUser != nil {
+                VButton(label: "Log Out", style: .danger, size: .large) {
+                    Task { await authManager.logout() }
                 }
             } else {
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    HStack(spacing: VSpacing.sm) {
-                        Image(systemName: "xmark.circle")
-                            .foregroundColor(VColor.textMuted)
-                            .font(.system(size: 14))
-                        Text("Not signed in")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textSecondary)
-                        Spacer()
-                    }
-                    VButton(
-                        label: authManager.isSubmitting ? "Signing in..." : "Log In",
-                        style: .primary,
-                        size: .large
-                    ) {
-                        Task { await authManager.startWorkOSLogin() }
-                    }
-                    .disabled(authManager.isSubmitting)
+                VButton(
+                    label: authManager.isSubmitting ? "Signing in..." : "Log In",
+                    style: .primary,
+                    size: .large
+                ) {
+                    Task { await authManager.startWorkOSLogin() }
                 }
+                .disabled(authManager.isSubmitting)
             }
 
             if let error = authManager.errorMessage {
@@ -203,19 +165,6 @@ struct SettingsAccountTab: View {
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
-    }
-
-    // MARK: - Platform Status
-
-    private var platformStatusInfo: ConnectionStatusInfo {
-        guard let reachable = store.vellumPlatformReachable else {
-            return ConnectionStatusInfo(label: "Unknown", color: VColor.textMuted, icon: "questionmark.circle.fill")
-        }
-        if reachable {
-            return ConnectionStatusInfo(label: "Reachable", color: VColor.success, icon: "checkmark.circle.fill")
-        } else {
-            return ConnectionStatusInfo(label: store.vellumPlatformError ?? "Unreachable", color: VColor.error, icon: "xmark.circle.fill")
-        }
     }
 
     // MARK: - Assistant Info
@@ -321,12 +270,11 @@ struct SettingsAccountTab: View {
                     .foregroundColor(VColor.textPrimary)
 
                 ForEach(lockfileAssistants, id: \.assistantId) { assistant in
+                    let isActive = assistant.assistantId == selectedAssistantId
                     HStack(spacing: VSpacing.sm) {
-                        Image(systemName: assistant.assistantId == selectedAssistantId
-                              ? "checkmark.circle.fill" : "circle")
-                            .foregroundColor(assistant.assistantId == selectedAssistantId
-                                             ? VColor.accent : VColor.textMuted)
-                            .font(.system(size: 16))
+                        Image(systemName: isActive ? "largecircle.fill.circle" : "circle")
+                            .foregroundColor(isActive ? VColor.accent : VColor.textMuted)
+                            .font(.system(size: 18))
 
                         VStack(alignment: .leading, spacing: VSpacing.xxs) {
                             Text(assistant.assistantId)
@@ -338,18 +286,14 @@ struct SettingsAccountTab: View {
                         }
 
                         Spacer()
-
-                        if assistant.assistantId != selectedAssistantId {
-                            VButton(label: "Switch", style: .primary) {
-                                switchToAssistant(assistant)
-                            }
-                        } else {
-                            Text("Active")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textMuted)
-                        }
                     }
                     .padding(.vertical, VSpacing.xs)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        if !isActive {
+                            switchToAssistant(assistant)
+                        }
+                    }
                 }
             }
             .padding(VSpacing.lg)


### PR DESCRIPTION
Polish the Account tab in Settings:
- Remove divider between platform URL area and auth section
- Remove sign-in status text rows — Login/Logout button is enough indicator
- Platform URL (dev mode): adopt Telegram/Slack Connected-button pattern
- Gateway card: restyle to match Channels card pattern
- Switch Assistant: convert to radio-toggle rows

Part of #11652
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
