### PR TITLE
feat: polish Permissions tab — Trust Rules button layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -779,7 +779,7 @@ struct SettingsPanel: View {
                         .font(VFont.sectionTitle)
                         .foregroundColor(VColor.textPrimary)
 
-                    HStack {
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
                             Text("Manage Trust Rules")
                                 .font(VFont.body)
@@ -788,8 +788,7 @@ struct SettingsPanel: View {
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.textMuted)
                         }
-                        Spacer()
-                        VButton(label: "Manage...", style: .tertiary) {
+                        VButton(label: "Manage...", style: .secondary, size: .large) {
                             daemonClient?.isTrustRulesSheetOpen = true
                             showingTrustRules = true
                         }


### PR DESCRIPTION
Move the Manage... button in the Trust Rules section to a bottom row aligned left, with large size.

Part of #11652
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
