### PR TITLE
feat: polish Advanced settings tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
@@ -222,7 +222,7 @@ struct SettingsAdvancedDevTab: View {
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
 
-                HStack {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         Text("Environment Variables")
                             .font(VFont.body)
@@ -231,8 +231,7 @@ struct SettingsAdvancedDevTab: View {
                             .font(VFont.caption)
                             .foregroundColor(VColor.textMuted)
                     }
-                    Spacer()
-                    VButton(label: "View...", style: .tertiary) {
+                    VButton(label: "View...", style: .secondary, size: .large) {
                         appEnvVars = ProcessInfo.processInfo.environment
                             .sorted(by: { $0.key < $1.key })
                             .map { ($0.key, $0.value) }


### PR DESCRIPTION
Two improvements to Advanced tab:
- Permission Simulator: remove divider between it and next section
- Developer section: move View... button to bottom-left with large size

Part of #11652
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
