### PR TITLE
feat: settings layout — remove close button, add Back to app nav

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -87,20 +87,6 @@ struct SettingsPanel: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Header (matches VSidePanel style)
-            HStack {
-                Text("Settings")
-                    .font(VFont.panelTitle)
-                    .foregroundColor(VColor.textPrimary)
-                Spacer()
-                VIconButton(label: "Close Settings", icon: "xmark", iconOnly: true, action: onClose)
-            }
-            .padding(.horizontal, VSpacing.lg)
-            .padding(.vertical, VSpacing.lg)
-
-            Divider()
-                .background(VColor.surfaceBorder)
-
             // Two-column layout
             HStack(spacing: 0) {
                 // Left: nav sidebar
@@ -224,6 +210,24 @@ struct SettingsPanel: View {
 
     private var settingsNav: some View {
         VStack(alignment: .leading, spacing: VSpacing.xxs) {
+            // Back to app link at top of sidebar
+            Button(action: onClose) {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(VColor.textMuted)
+                    Text("Back to app")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textMuted)
+                }
+                .padding(.horizontal, VSpacing.sm)
+                .padding(.vertical, VSpacing.xs)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .padding(.bottom, VSpacing.md)
+
+            // Tab nav items
             ForEach(SettingsTab.visibleTabs(isDevMode: store.isDevMode), id: \.self) { tab in
                 SettingsNavRow(tab: tab, isSelected: selectedTab == tab) {
                     selectedTab = tab


### PR DESCRIPTION
Follow Codex Settings layout concept:
- Remove the header close (xmark) button
- Remove the header divider
- Add 'Back to app' chevron link at top of sidebar nav

Part of #11652
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
