### PR TITLE
Fix import sort order in config/schema.ts

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -1,18 +1,18 @@
-import { z } from 'zod';
+import { z } from "zod";
 
-import { getDataDir } from '../util/platform.js';
+import { getDataDir } from "../util/platform.js";
 
 // Re-export all domain schemas
 export type {
   HeartbeatConfig,
   SwarmConfig,
   WorkspaceGitConfig,
-} from './agent-schema.js';
+} from "./agent-schema.js";
 export {
   HeartbeatConfigSchema,
   SwarmConfigSchema,
   WorkspaceGitConfigSchema,
-} from './agent-schema.js';
+} from "./agent-schema.js";
 export type {
   CallerIdentityConfig,
   CallsConfig,
@@ -20,7 +20,7 @@ export type {
   CallsSafetyConfig,
   CallsVerificationConfig,
   CallsVoiceConfig,
-} from './calls-schema.js';
+} from "./calls-schema.js";
 export {
   CallerIdentityConfigSchema,
   CallsConfigSchema,
@@ -29,7 +29,7 @@ export {
   CallsVerificationConfigSchema,
   CallsVoiceConfigSchema,
   VALID_CALLER_IDENTITY_MODES,
-} from './calls-schema.js';
+} from "./calls-schema.js";
 export type {
   AuditLogConfig,
   ContextWindowConfig,
@@ -47,7 +47,7 @@ export type {
   ThinkingConfig,
   TimeoutConfig,
   UiConfig,
-} from './core-schema.js';
+} from "./core-schema.js";
 export {
   AuditLogConfigSchema,
   ContextWindowConfigSchema,
@@ -65,24 +65,18 @@ export {
   ThinkingConfigSchema,
   TimeoutConfigSchema,
   UiConfigSchema,
-} from './core-schema.js';
-export type {
-  ElevenLabsConfig,
-} from './elevenlabs-schema.js';
+} from "./core-schema.js";
+export type { ElevenLabsConfig } from "./elevenlabs-schema.js";
 export {
   DEFAULT_ELEVENLABS_VOICE_ID,
   ElevenLabsConfigSchema,
-} from './elevenlabs-schema.js';
-export type {
-  McpConfig,
-  McpServerConfig,
-  McpTransport,
-} from './mcp-schema.js';
+} from "./elevenlabs-schema.js";
+export type { McpConfig, McpServerConfig, McpTransport } from "./mcp-schema.js";
 export {
   McpConfigSchema,
   McpServerConfigSchema,
   McpTransportSchema,
-} from './mcp-schema.js';
+} from "./mcp-schema.js";
 export type {
   MemoryCleanupConfig,
   MemoryConfig,
@@ -98,7 +92,7 @@ export type {
   MemorySegmentationConfig,
   MemorySummarizationConfig,
   QdrantConfig,
-} from './memory-schema.js';
+} from "./memory-schema.js";
 export {
   MemoryCleanupConfigSchema,
   MemoryConfigSchema,
@@ -116,19 +110,11 @@ export {
   MemorySegmentationConfigSchema,
   MemorySummarizationConfigSchema,
   QdrantConfigSchema,
-} from './memory-schema.js';
-export type {
-  NotificationsConfig,
-} from './notifications-schema.js';
-export {
-  NotificationsConfigSchema,
-} from './notifications-schema.js';
-export type {
-  SandboxConfig,
-} from './sandbox-schema.js';
-export {
-  SandboxConfigSchema,
-} from './sandbox-schema.js';
+} from "./memory-schema.js";
+export type { NotificationsConfig } from "./notifications-schema.js";
+export { NotificationsConfigSchema } from "./notifications-schema.js";
+export type { SandboxConfig } from "./sandbox-schema.js";
+export { SandboxConfigSchema } from "./sandbox-schema.js";
 export type {
   RemotePolicyConfig,
   RemoteProviderConfig,
@@ -137,7 +123,7 @@ export type {
   SkillsConfig,
   SkillsInstallConfig,
   SkillsLoadConfig,
-} from './skills-schema.js';
+} from "./skills-schema.js";
 export {
   RemotePolicyConfigSchema,
   RemoteProviderConfigSchema,
@@ -146,12 +132,15 @@ export {
   SkillsConfigSchema,
   SkillsInstallConfigSchema,
   SkillsLoadConfigSchema,
-} from './skills-schema.js';
+} from "./skills-schema.js";
 
 // Imports for AssistantConfigSchema composition
-import { HeartbeatConfigSchema, SwarmConfigSchema, WorkspaceGitConfigSchema } from './agent-schema.js';
-import { CallsConfigSchema } from './calls-schema.js';
-import { ElevenLabsConfigSchema } from './elevenlabs-schema.js';
+import {
+  HeartbeatConfigSchema,
+  SwarmConfigSchema,
+  WorkspaceGitConfigSchema,
+} from "./agent-schema.js";
+import { CallsConfigSchema } from "./calls-schema.js";
 import {
   AuditLogConfigSchema,
   ContextWindowConfigSchema,
@@ -167,111 +156,161 @@ import {
   ThinkingConfigSchema,
   TimeoutConfigSchema,
   UiConfigSchema,
-} from './core-schema.js';
-import { McpConfigSchema } from './mcp-schema.js';
-import { MemoryConfigSchema } from './memory-schema.js';
-import { NotificationsConfigSchema } from './notifications-schema.js';
-import { SandboxConfigSchema } from './sandbox-schema.js';
-import { SkillsConfigSchema } from './skills-schema.js';
+} from "./core-schema.js";
+import { ElevenLabsConfigSchema } from "./elevenlabs-schema.js";
+import { McpConfigSchema } from "./mcp-schema.js";
+import { MemoryConfigSchema } from "./memory-schema.js";
+import { NotificationsConfigSchema } from "./notifications-schema.js";
+import { SandboxConfigSchema } from "./sandbox-schema.js";
+import { SkillsConfigSchema } from "./skills-schema.js";
 
-const VALID_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama', 'fireworks', 'openrouter'] as const;
-const VALID_WEB_SEARCH_PROVIDERS = ['perplexity', 'brave', 'anthropic-native'] as const;
+const VALID_PROVIDERS = [
+  "anthropic",
+  "openai",
+  "gemini",
+  "ollama",
+  "fireworks",
+  "openrouter",
+] as const;
+const VALID_WEB_SEARCH_PROVIDERS = [
+  "perplexity",
+  "brave",
+  "anthropic-native",
+] as const;
 
-export const AssistantConfigSchema = z.object({
-  provider: z
-    .enum(VALID_PROVIDERS, {
-      error: `provider must be one of: ${VALID_PROVIDERS.join(', ')}`,
-    })
-    .default('anthropic'),
-  model: z
-    .string({ error: 'model must be a string' })
-    .default('claude-opus-4-6'),
-  imageGenModel: z
-    .string({ error: 'imageGenModel must be a string' })
-    .default('gemini-2.5-flash-image'),
-  apiKeys: z
-    .record(z.string(), z.string({ error: 'Each apiKeys value must be a string' }))
-    .default({} as any),
-  webSearchProvider: z
-    .enum(VALID_WEB_SEARCH_PROVIDERS, {
-      error: `webSearchProvider must be one of: ${VALID_WEB_SEARCH_PROVIDERS.join(', ')}`,
-    })
-    .default('anthropic-native'),
-  providerOrder: z
-    .array(z.enum(VALID_PROVIDERS, {
-      error: `Each providerOrder entry must be one of: ${VALID_PROVIDERS.join(', ')}`,
-    }))
-    .default([]),
-  maxTokens: z
-    .number({ error: 'maxTokens must be a number' })
-    .int('maxTokens must be an integer')
-    .positive('maxTokens must be a positive integer')
-    .default(16000),
-  maxToolUseTurns: z
-    .number({ error: 'maxToolUseTurns must be a number' })
-    .int('maxToolUseTurns must be an integer')
-    .nonnegative('maxToolUseTurns must be a non-negative integer')
-    .default(40),
-  thinking: ThinkingConfigSchema.default(ThinkingConfigSchema.parse({})),
-  contextWindow: ContextWindowConfigSchema.default(ContextWindowConfigSchema.parse({})),
-  memory: MemoryConfigSchema.default(MemoryConfigSchema.parse({})),
-  dataDir: z
-    .string({ error: 'dataDir must be a string' })
-    .default(getDataDir()),
-  timeouts: TimeoutConfigSchema.default(TimeoutConfigSchema.parse({})),
-  sandbox: SandboxConfigSchema.default(SandboxConfigSchema.parse({})),
-  rateLimit: RateLimitConfigSchema.default(RateLimitConfigSchema.parse({})),
-  secretDetection: SecretDetectionConfigSchema.default(SecretDetectionConfigSchema.parse({})),
-  permissions: PermissionsConfigSchema.default(PermissionsConfigSchema.parse({})),
-  auditLog: AuditLogConfigSchema.default(AuditLogConfigSchema.parse({})),
-  logFile: LogFileConfigSchema.default(LogFileConfigSchema.parse({})),
-  pricingOverrides: z
-    .array(ModelPricingOverrideSchema)
-    .default([]),
-  heartbeat: HeartbeatConfigSchema.default(HeartbeatConfigSchema.parse({})),
-  swarm: SwarmConfigSchema.default(SwarmConfigSchema.parse({})),
-  mcp: McpConfigSchema.default(McpConfigSchema.parse({})),
-  skills: SkillsConfigSchema.default(SkillsConfigSchema.parse({})),
-  workspaceGit: WorkspaceGitConfigSchema.default(WorkspaceGitConfigSchema.parse({})),
-  calls: CallsConfigSchema.default(CallsConfigSchema.parse({})),
-  elevenlabs: ElevenLabsConfigSchema.default(ElevenLabsConfigSchema.parse({})),
-  sms: SmsConfigSchema.default(SmsConfigSchema.parse({})),
-  ingress: IngressConfigSchema,
-  platform: PlatformConfigSchema.default(PlatformConfigSchema.parse({})),
-  daemon: DaemonConfigSchema.default(DaemonConfigSchema.parse({})),
-  notifications: NotificationsConfigSchema.default(NotificationsConfigSchema.parse({})),
-  ui: UiConfigSchema.default(UiConfigSchema.parse({})),
-  featureFlags: z
-    .record(z.string(), z.boolean({ error: 'featureFlags values must be booleans' }))
-    .default({} as any),
-  assistantFeatureFlagValues: z
-    .record(z.string(), z.boolean({ error: 'assistantFeatureFlagValues values must be booleans' }))
-    .optional(),
-}).superRefine((config, ctx) => {
-  if (config.contextWindow?.targetInputTokens != null && config.contextWindow?.maxInputTokens != null &&
-      config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['contextWindow', 'targetInputTokens'],
-      message: 'contextWindow.targetInputTokens must be less than contextWindow.maxInputTokens',
-    });
-  }
-  const segmentation = config.memory?.segmentation;
-  if (segmentation && segmentation.overlapTokens >= segmentation.targetTokens) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['memory', 'segmentation', 'overlapTokens'],
-      message: 'memory.segmentation.overlapTokens must be less than memory.segmentation.targetTokens',
-    });
-  }
-  const dynamicBudget = config.memory?.retrieval?.dynamicBudget;
-  if (dynamicBudget && dynamicBudget.minInjectTokens > dynamicBudget.maxInjectTokens) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['memory', 'retrieval', 'dynamicBudget'],
-      message: 'memory.retrieval.dynamicBudget.minInjectTokens must be <= memory.retrieval.dynamicBudget.maxInjectTokens',
-    });
-  }
-});
+export const AssistantConfigSchema = z
+  .object({
+    provider: z
+      .enum(VALID_PROVIDERS, {
+        error: `provider must be one of: ${VALID_PROVIDERS.join(", ")}`,
+      })
+      .default("anthropic"),
+    model: z
+      .string({ error: "model must be a string" })
+      .default("claude-opus-4-6"),
+    imageGenModel: z
+      .string({ error: "imageGenModel must be a string" })
+      .default("gemini-2.5-flash-image"),
+    apiKeys: z
+      .record(
+        z.string(),
+        z.string({ error: "Each apiKeys value must be a string" }),
+      )
+      .default({} as any),
+    webSearchProvider: z
+      .enum(VALID_WEB_SEARCH_PROVIDERS, {
+        error: `webSearchProvider must be one of: ${VALID_WEB_SEARCH_PROVIDERS.join(", ")}`,
+      })
+      .default("anthropic-native"),
+    providerOrder: z
+      .array(
+        z.enum(VALID_PROVIDERS, {
+          error: `Each providerOrder entry must be one of: ${VALID_PROVIDERS.join(", ")}`,
+        }),
+      )
+      .default([]),
+    maxTokens: z
+      .number({ error: "maxTokens must be a number" })
+      .int("maxTokens must be an integer")
+      .positive("maxTokens must be a positive integer")
+      .default(16000),
+    maxToolUseTurns: z
+      .number({ error: "maxToolUseTurns must be a number" })
+      .int("maxToolUseTurns must be an integer")
+      .nonnegative("maxToolUseTurns must be a non-negative integer")
+      .default(40),
+    thinking: ThinkingConfigSchema.default(ThinkingConfigSchema.parse({})),
+    contextWindow: ContextWindowConfigSchema.default(
+      ContextWindowConfigSchema.parse({}),
+    ),
+    memory: MemoryConfigSchema.default(MemoryConfigSchema.parse({})),
+    dataDir: z
+      .string({ error: "dataDir must be a string" })
+      .default(getDataDir()),
+    timeouts: TimeoutConfigSchema.default(TimeoutConfigSchema.parse({})),
+    sandbox: SandboxConfigSchema.default(SandboxConfigSchema.parse({})),
+    rateLimit: RateLimitConfigSchema.default(RateLimitConfigSchema.parse({})),
+    secretDetection: SecretDetectionConfigSchema.default(
+      SecretDetectionConfigSchema.parse({}),
+    ),
+    permissions: PermissionsConfigSchema.default(
+      PermissionsConfigSchema.parse({}),
+    ),
+    auditLog: AuditLogConfigSchema.default(AuditLogConfigSchema.parse({})),
+    logFile: LogFileConfigSchema.default(LogFileConfigSchema.parse({})),
+    pricingOverrides: z.array(ModelPricingOverrideSchema).default([]),
+    heartbeat: HeartbeatConfigSchema.default(HeartbeatConfigSchema.parse({})),
+    swarm: SwarmConfigSchema.default(SwarmConfigSchema.parse({})),
+    mcp: McpConfigSchema.default(McpConfigSchema.parse({})),
+    skills: SkillsConfigSchema.default(SkillsConfigSchema.parse({})),
+    workspaceGit: WorkspaceGitConfigSchema.default(
+      WorkspaceGitConfigSchema.parse({}),
+    ),
+    calls: CallsConfigSchema.default(CallsConfigSchema.parse({})),
+    elevenlabs: ElevenLabsConfigSchema.default(
+      ElevenLabsConfigSchema.parse({}),
+    ),
+    sms: SmsConfigSchema.default(SmsConfigSchema.parse({})),
+    ingress: IngressConfigSchema,
+    platform: PlatformConfigSchema.default(PlatformConfigSchema.parse({})),
+    daemon: DaemonConfigSchema.default(DaemonConfigSchema.parse({})),
+    notifications: NotificationsConfigSchema.default(
+      NotificationsConfigSchema.parse({}),
+    ),
+    ui: UiConfigSchema.default(UiConfigSchema.parse({})),
+    featureFlags: z
+      .record(
+        z.string(),
+        z.boolean({ error: "featureFlags values must be booleans" }),
+      )
+      .default({} as any),
+    assistantFeatureFlagValues: z
+      .record(
+        z.string(),
+        z.boolean({
+          error: "assistantFeatureFlagValues values must be booleans",
+        }),
+      )
+      .optional(),
+  })
+  .superRefine((config, ctx) => {
+    if (
+      config.contextWindow?.targetInputTokens != null &&
+      config.contextWindow?.maxInputTokens != null &&
+      config.contextWindow.targetInputTokens >=
+        config.contextWindow.maxInputTokens
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["contextWindow", "targetInputTokens"],
+        message:
+          "contextWindow.targetInputTokens must be less than contextWindow.maxInputTokens",
+      });
+    }
+    const segmentation = config.memory?.segmentation;
+    if (
+      segmentation &&
+      segmentation.overlapTokens >= segmentation.targetTokens
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["memory", "segmentation", "overlapTokens"],
+        message:
+          "memory.segmentation.overlapTokens must be less than memory.segmentation.targetTokens",
+      });
+    }
+    const dynamicBudget = config.memory?.retrieval?.dynamicBudget;
+    if (
+      dynamicBudget &&
+      dynamicBudget.minInjectTokens > dynamicBudget.maxInjectTokens
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["memory", "retrieval", "dynamicBudget"],
+        message:
+          "memory.retrieval.dynamicBudget.minInjectTokens must be <= memory.retrieval.dynamicBudget.maxInjectTokens",
+      });
+    }
+  });
 
 export type AssistantConfig = z.infer<typeof AssistantConfigSchema>;


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error by reordering the `elevenlabs-schema.js` import alphabetically after `core-schema.js`

## Test plan
- [x] `bun run lint` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
