### PR TITLE
fix: chain previous callback in HeartbeatRunsView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/HeartbeatRunsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/HeartbeatRunsView.swift
@@ -192,6 +192,7 @@ struct HeartbeatRunsView: View {
             }
         }
         daemonClient.onHeartbeatRunNowResponse = { response in
+            self.previousRunNowCallback?(response)
             Task { @MainActor in
                 self.isRunning = false
                 if !response.success {


### PR DESCRIPTION
## Summary
- Forward `onHeartbeatRunNowResponse` to saved `previousRunNowCallback` in `HeartbeatRunsView` so the automation tab's handler still fires while the modal is open
- Fixes the "Run Now" spinner getting permanently stuck after opening and closing the heartbeat runs modal
- Addresses unresolved review feedback from #11580

## Test plan
- [ ] Open Automation tab, click Run Now play icon — spinner resets when done
- [ ] Open Heartbeat Runs modal, close it, click Run Now — spinner still resets
- [ ] Open Heartbeat Runs modal, click Run Now from automation tab behind modal — both views update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
