### PR TITLE
fix: use != null for keychain key existence checks in secure-keys

### DIFF
--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -161,7 +161,7 @@ export function setSecureKey(account: string, value: string): boolean {
     try {
       // Only attempt deletion if the key actually exists in keychain to
       // avoid spawning a subprocess on every write.
-      if (keychain.getKey(account) !== undefined) {
+      if (keychain.getKey(account) != null) {
         keychain.deleteKey(account);
       }
     } catch { /* best-effort */ }
@@ -301,7 +301,7 @@ export async function setSecureKeyAsync(
         // Only attempt deletion if the key actually exists in keychain to
         // avoid spawning a subprocess on every write.
         const exists = await keychain.getKeyAsync(account);
-        if (exists !== undefined) {
+        if (exists != null) {
           await keychain.deleteKeyAsync(account);
         }
       } catch { /* best-effort */ }
@@ -323,7 +323,7 @@ export async function setSecureKeyAsync(
       keychainMissCache.delete(account);
       try {
         const exists = await keychain.getKeyAsync(account);
-        if (exists !== undefined) {
+        if (exists != null) {
           await keychain.deleteKeyAsync(account);
         }
       } catch { /* best-effort */ }


### PR DESCRIPTION
The keychain getKey/getKeyAsync methods return null (not undefined) for missing keys, so the !== undefined checks were always true, defeating the optimization added in PR #11616. Changed to != null at all three locations.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
