### PR TITLE
feat: Account tab divider, VToggle radio switches, no Permissions dividers

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -136,6 +136,8 @@ struct SettingsAccountTab: View {
                         isPlatformUrlFocused = true
                     }
                 }
+
+                Divider().background(VColor.surfaceBorder)
             }
 
             if authManager.isLoading {
@@ -275,12 +277,7 @@ struct SettingsAccountTab: View {
                     .foregroundColor(VColor.textPrimary)
 
                 ForEach(lockfileAssistants, id: \.assistantId) { assistant in
-                    let isActive = assistant.assistantId == selectedAssistantId
                     HStack(spacing: VSpacing.sm) {
-                        Image(systemName: isActive ? "largecircle.fill.circle" : "circle")
-                            .foregroundColor(isActive ? VColor.accent : VColor.textMuted)
-                            .font(.system(size: 18))
-
                         VStack(alignment: .leading, spacing: VSpacing.xxs) {
                             Text(assistant.assistantId)
                                 .font(VFont.bodyMedium)
@@ -289,13 +286,18 @@ struct SettingsAccountTab: View {
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.textMuted)
                         }
-
                         Spacer()
+                        VToggle(isOn: Binding(
+                            get: { assistant.assistantId == selectedAssistantId },
+                            set: { isOn in
+                                if isOn { switchToAssistant(assistant) }
+                            }
+                        ))
                     }
                     .padding(.vertical, VSpacing.xs)
                     .contentShape(Rectangle())
                     .onTapGesture {
-                        if !isActive {
+                        if assistant.assistantId != selectedAssistantId {
                             switchToAssistant(assistant)
                         }
                     }


### PR DESCRIPTION
## Summary

- Add `Divider().background(VColor.surfaceBorder)` between the Platform URL setup area and the login/auth buttons area inside the Account card (dev mode only, since the Platform URL block is gated by `store.isDevMode`)
- Switch Assistant section: replace radio-circle image + text layout with `VToggle`-based rows — one toggle per assistant, acting as exclusive radio buttons (toggling on switches to that assistant)
- Permissions tab: no explicit dividers were found between the macOS System Permissions, Trust Rules, and Computer Usage cards — spacing is already handled by the outer `VStack(spacing: VSpacing.xl)` — confirming the state is correct

Part of #11676

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
