### PR TITLE
feat: Appearance timezone VDropdown stacked below label, no stray dividers

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -47,39 +47,35 @@ struct SettingsAppearanceTab: View {
                     .frame(width: 220)
                 }
 
-                HStack(alignment: .center, spacing: VSpacing.sm) {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        Text("User timezone")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textSecondary)
-                        Text("Timezone used for time-aware responses.")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-                    }
-                    Spacer()
-                    Picker("", selection: $selectedTimezone) {
-                        Text("Not Set").tag("")
-                        ForEach(Self.knownTimezones, id: \.self) { identifier in
-                            Text(identifier).tag(identifier)
-                        }
-                    }
-                    .pickerStyle(.menu)
-                    .labelsHidden()
-                    .onChange(of: selectedTimezone) { newValue in
-                        if newValue.isEmpty {
-                            store.clearUserTimezone()
-                        } else {
-                            store.saveUserTimezone(newValue)
-                        }
-                    }
-                    .onAppear {
-                        selectedTimezone = store.userTimezone ?? ""
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("User timezone")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Text("Timezone used for time-aware responses.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    VDropdown(
+                        placeholder: "Not Set",
+                        selection: $selectedTimezone,
+                        options: [(label: "Not Set", value: "")] + Self.knownTimezones.map { (label: $0, value: $0) },
+                        emptyValue: ""
+                    )
+                    .frame(width: 360)
+                }
+                .onChange(of: selectedTimezone) { _, newValue in
+                    if newValue.isEmpty {
+                        store.clearUserTimezone()
+                    } else {
+                        store.saveUserTimezone(newValue)
                     }
                 }
 
             }
             .padding(VSpacing.lg)
             .vCard(background: VColor.surfaceSubtle)
+            .onAppear {
+                selectedTimezone = store.userTimezone ?? ""
+            }
 
             // KEYBOARD SHORTCUTS section
             VStack(alignment: .leading, spacing: 0) {


### PR DESCRIPTION
- Display section: replace inline Picker with VDropdown below label+description, 360pt wide
- Permission Simulator: verify and ensure no divider after the section

Part of #11676
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
