### PR TITLE
feat: hide sidebar when Settings is open, full-width sections

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -495,12 +495,19 @@ struct MainWindowView: View {
             }
     }
 
+    private var isSettingsOpen: Bool {
+        if case .panel(.settings) = windowState.selection { return true }
+        return false
+    }
+
     /// Top bar extracted to break up type-checker complexity.
     private var topBarView: some View {
         HStack(spacing: VSpacing.sm) {
-            VIconButton(label: "Sidebar", icon: "sidebar.left", isActive: sidebarExpanded, iconOnly: true, tooltip: sidebarExpanded ? "Collapse sidebar" : "Expand sidebar") {
-                withAnimation(VAnimation.panel) {
-                    sidebarExpanded.toggle()
+            if !isSettingsOpen {
+                VIconButton(label: "Sidebar", icon: "sidebar.left", isActive: sidebarExpanded, iconOnly: true, tooltip: sidebarExpanded ? "Collapse sidebar" : "Expand sidebar") {
+                    withAnimation(VAnimation.panel) {
+                        sidebarExpanded.toggle()
+                    }
                 }
             }
             Spacer()
@@ -578,7 +585,9 @@ struct MainWindowView: View {
 
                     // Main container: sidebar + content with uniform padding
                     HStack(spacing: 16) {
-                        sidebarView
+                        if !isSettingsOpen {
+                            sidebarView
+                        }
 
                         chatContentView(geometry: geometry)
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -390,6 +390,7 @@ struct SettingsPanel: View {
             }
             .animation(VAnimation.fast, value: showModelDropdown)
             .zIndex(showModelDropdown ? 1 : 0)
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             // PERPLEXITY SEARCH section
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -448,6 +449,7 @@ struct SettingsPanel: View {
             }
             .padding(VSpacing.lg)
             .vCard(background: VColor.surfaceSubtle)
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             // BRAVE SEARCH section
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -506,6 +508,7 @@ struct SettingsPanel: View {
             }
             .padding(VSpacing.lg)
             .vCard(background: VColor.surfaceSubtle)
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             // IMAGE GENERATION section
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -585,6 +588,7 @@ struct SettingsPanel: View {
             }
             .padding(VSpacing.lg)
             .vCard(background: VColor.surfaceSubtle)
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             // INTEGRATIONS section (hidden when empty)
             if daemonClient != nil && !integrations.isEmpty {
@@ -599,6 +603,7 @@ struct SettingsPanel: View {
                 }
                 .padding(VSpacing.lg)
                 .vCard(background: VColor.surfaceSubtle)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
 
             // TWITTER / X section
@@ -752,6 +757,7 @@ struct SettingsPanel: View {
         }
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Permissions Tab
@@ -820,6 +826,7 @@ struct SettingsPanel: View {
             }
             .padding(VSpacing.lg)
             .vCard(background: VColor.surfaceSubtle)
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             // TRUST RULES section
             if daemonClient != nil {
@@ -846,6 +853,7 @@ struct SettingsPanel: View {
                 }
                 .padding(VSpacing.lg)
                 .vCard(background: VColor.surfaceSubtle)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
 
             // COMPUTER USAGE section (moved from Advanced)
@@ -869,6 +877,7 @@ struct SettingsPanel: View {
             }
             .padding(VSpacing.lg)
             .vCard(background: VColor.surfaceSubtle)
+            .frame(maxWidth: .infinity, alignment: .leading)
 
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
@@ -249,6 +249,7 @@ struct SettingsAdvancedDevTab: View {
                 }
             }
             .padding(VSpacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .vCard(background: VColor.surfaceSubtle)
         }
     }


### PR DESCRIPTION
- Hide sidebar and toggle button when Settings panel is active
- Settings content expands to full width
- All settings section cards use frame(maxWidth: .infinity)

Part of #11676
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
