### PR TITLE
feat: settings setup sections — Save/Cancel row below input field

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -319,11 +319,10 @@ struct SettingsPanel: View {
                             .font(VFont.caption)
                             .foregroundColor(VColor.textSecondary)
 
-                        VInlineActionField(text: $apiKeyText, placeholder: "This is your private generated key", isSecure: true) {
-                            store.saveAPIKey(apiKeyText)
-                            apiKeyText = ""
-                            anthropicSetupExpanded = false
-                        }
+                        SecureField("This is your private generated key", text: $apiKeyText)
+                            .vInputStyle()
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
 
                         HStack(spacing: 0) {
                             Text("Get your API key at ")
@@ -337,9 +336,17 @@ struct SettingsPanel: View {
                                 }
                         }
 
-                        VButton(label: "Cancel", style: .tertiary, size: .large) {
-                            anthropicSetupExpanded = false
-                            apiKeyText = ""
+                        HStack(spacing: VSpacing.sm) {
+                            VButton(label: "Save", style: .primary, size: .large) {
+                                store.saveAPIKey(apiKeyText)
+                                apiKeyText = ""
+                                anthropicSetupExpanded = false
+                            }
+                            .disabled(apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                            VButton(label: "Cancel", style: .secondary, size: .large) {
+                                apiKeyText = ""
+                                anthropicSetupExpanded = false
+                            }
                         }
                     }
                 } else {
@@ -417,11 +424,10 @@ struct SettingsPanel: View {
                             .font(VFont.caption)
                             .foregroundColor(VColor.textSecondary)
 
-                        VInlineActionField(text: $perplexityKeyText, placeholder: "Your Perplexity API key", isSecure: true) {
-                            store.savePerplexityKey(perplexityKeyText)
-                            perplexityKeyText = ""
-                            perplexitySetupExpanded = false
-                        }
+                        SecureField("Your Perplexity API key", text: $perplexityKeyText)
+                            .vInputStyle()
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
 
                         HStack(spacing: 0) {
                             Text("Get your API key at ")
@@ -435,9 +441,17 @@ struct SettingsPanel: View {
                                 }
                         }
 
-                        VButton(label: "Cancel", style: .tertiary, size: .large) {
-                            perplexitySetupExpanded = false
-                            perplexityKeyText = ""
+                        HStack(spacing: VSpacing.sm) {
+                            VButton(label: "Save", style: .primary, size: .large) {
+                                store.savePerplexityKey(perplexityKeyText)
+                                perplexityKeyText = ""
+                                perplexitySetupExpanded = false
+                            }
+                            .disabled(perplexityKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                            VButton(label: "Cancel", style: .secondary, size: .large) {
+                                perplexityKeyText = ""
+                                perplexitySetupExpanded = false
+                            }
                         }
                     }
                 } else {
@@ -475,11 +489,10 @@ struct SettingsPanel: View {
                             .font(VFont.caption)
                             .foregroundColor(VColor.textSecondary)
 
-                        VInlineActionField(text: $braveKeyText, placeholder: "Your Brave Search API key", isSecure: true) {
-                            store.saveBraveKey(braveKeyText)
-                            braveKeyText = ""
-                            braveSetupExpanded = false
-                        }
+                        SecureField("Your Brave Search API key", text: $braveKeyText)
+                            .vInputStyle()
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
 
                         HStack(spacing: 0) {
                             Text("Get your API key at ")
@@ -493,9 +506,17 @@ struct SettingsPanel: View {
                                 }
                         }
 
-                        VButton(label: "Cancel", style: .tertiary, size: .large) {
-                            braveSetupExpanded = false
-                            braveKeyText = ""
+                        HStack(spacing: VSpacing.sm) {
+                            VButton(label: "Save", style: .primary, size: .large) {
+                                store.saveBraveKey(braveKeyText)
+                                braveKeyText = ""
+                                braveSetupExpanded = false
+                            }
+                            .disabled(braveKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                            VButton(label: "Cancel", style: .secondary, size: .large) {
+                                braveKeyText = ""
+                                braveSetupExpanded = false
+                            }
                         }
                     }
                 } else {
@@ -554,11 +575,10 @@ struct SettingsPanel: View {
                             .font(VFont.caption)
                             .foregroundColor(VColor.textSecondary)
 
-                        VInlineActionField(text: $imageGenKeyText, placeholder: "Your Gemini API key", isSecure: true) {
-                            store.saveImageGenKey(imageGenKeyText)
-                            imageGenKeyText = ""
-                            imageGenSetupExpanded = false
-                        }
+                        SecureField("Your Gemini API key", text: $imageGenKeyText)
+                            .vInputStyle()
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
 
                         HStack(spacing: 0) {
                             Text("Get your API key at ")
@@ -572,9 +592,17 @@ struct SettingsPanel: View {
                                 }
                         }
 
-                        VButton(label: "Cancel", style: .tertiary, size: .large) {
-                            imageGenSetupExpanded = false
-                            imageGenKeyText = ""
+                        HStack(spacing: VSpacing.sm) {
+                            VButton(label: "Save", style: .primary, size: .large) {
+                                store.saveImageGenKey(imageGenKeyText)
+                                imageGenKeyText = ""
+                                imageGenSetupExpanded = false
+                            }
+                            .disabled(imageGenKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                            VButton(label: "Cancel", style: .secondary, size: .large) {
+                                imageGenKeyText = ""
+                                imageGenSetupExpanded = false
+                            }
                         }
                     }
                 } else {

--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -125,8 +125,23 @@ struct GatewaySettingsCard: View {
                 .font(VFont.caption)
                 .foregroundColor(VColor.textSecondary)
 
-            VInlineActionField(text: $gatewayUrlText, placeholder: "https://your-tunnel.example.com", allowEmpty: true, isFocused: $isGatewayUrlFocused) {
-                store.saveIngressPublicBaseUrl(gatewayUrlText)
+            TextField("https://your-tunnel.example.com", text: $gatewayUrlText)
+                .vInputStyle()
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+
+            HStack(spacing: VSpacing.sm) {
+                VButton(label: "Save", style: .primary, size: .large) {
+                    store.saveIngressPublicBaseUrl(gatewayUrlText)
+                    isGatewayUrlFocused = false
+                    tunnelSetupExpanded = false
+                }
+                // No .disabled() — empty URL is valid (clears the tunnel target)
+                VButton(label: "Cancel", style: .secondary, size: .large) {
+                    gatewayUrlText = store.ingressPublicBaseUrl
+                    isGatewayUrlFocused = false
+                    tunnelSetupExpanded = false
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -122,14 +122,38 @@ struct SettingsAccountTab: View {
                 // When not reachable/configured, show the inline field or a Set Up prompt.
                 if store.vellumPlatformReachable == true {
                     VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success, size: .large) {}
-                    VInlineActionField(text: $platformUrlText, placeholder: "https://platform.vellum.ai", isFocused: $isPlatformUrlFocused) {
-                        store.savePlatformBaseUrl(platformUrlText)
-                        Task { await store.checkVellumPlatform() }
+                    TextField("https://platform.vellum.ai", text: $platformUrlText)
+                        .vInputStyle()
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                    HStack(spacing: VSpacing.sm) {
+                        VButton(label: "Save", style: .primary, size: .large) {
+                            store.savePlatformBaseUrl(platformUrlText)
+                            Task { await store.checkVellumPlatform() }
+                            isPlatformUrlFocused = false
+                        }
+                        .disabled(platformUrlText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        VButton(label: "Cancel", style: .secondary, size: .large) {
+                            platformUrlText = store.platformBaseUrl
+                            isPlatformUrlFocused = false
+                        }
                     }
                 } else if isPlatformUrlFocused || !platformUrlText.isEmpty {
-                    VInlineActionField(text: $platformUrlText, placeholder: "https://platform.vellum.ai", isFocused: $isPlatformUrlFocused) {
-                        store.savePlatformBaseUrl(platformUrlText)
-                        Task { await store.checkVellumPlatform() }
+                    TextField("https://platform.vellum.ai", text: $platformUrlText)
+                        .vInputStyle()
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                    HStack(spacing: VSpacing.sm) {
+                        VButton(label: "Save", style: .primary, size: .large) {
+                            store.savePlatformBaseUrl(platformUrlText)
+                            Task { await store.checkVellumPlatform() }
+                            isPlatformUrlFocused = false
+                        }
+                        .disabled(platformUrlText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        VButton(label: "Cancel", style: .secondary, size: .large) {
+                            platformUrlText = ""
+                            isPlatformUrlFocused = false
+                        }
                     }
                 } else {
                     VButton(label: "Set Up", style: .secondary, size: .large) {


### PR DESCRIPTION
Replace VInlineActionField with stacked pattern: input field on top, Save + Cancel buttons on the row below. Matches Telegram/Slack Channels pattern.

Applies to: Anthropic, Perplexity, Brave, ImageGen (SettingsPanel), Platform URL (AccountTab), Gateway URL (GatewaySettingsCard), Telegram/Slack/Twilio (ChannelsTab).

Part of #11676
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
