### PR TITLE
fix: prevent sonic boom crash on --help/--version

### DIFF
--- a/assistant/src/util/logger.ts
+++ b/assistant/src/util/logger.ts
@@ -156,7 +156,10 @@ function getRootLogger(): pino.Logger {
 
     try {
       const logPath = getLogPath();
-      const fileDest = pino.destination({ dest: logPath, sync: false, mkdir: true, mode: 0o600 });
+      // Use sync: true so the fd is opened immediately. This prevents
+      // "sonic boom is not ready yet" errors when commander calls
+      // process.exit(0) for --help/--version before the async fd is ready.
+      const fileDest = pino.destination({ dest: logPath, sync: true, mkdir: true, mode: 0o600 });
       // Tighten permissions on pre-existing log files that may have been created with looser modes
       try { chmodSync(logPath, 0o600); } catch { /* best-effort */ }
       const fileStream = pinoPretty(prettyOpts({ destination: fileDest, colorize: false }));


### PR DESCRIPTION
## Summary
- Change `sync: false` to `sync: true` in `getRootLogger()` fallback path so the pino file descriptor is opened immediately
- Prevents "sonic boom is not ready yet" error when commander calls `process.exit(0)` for `--help`/`--version` before the async fd is ready
- Only affects CLI commands using the fallback logger — the daemon uses `initLogger()`/`buildRotatingLogger()` which is unaffected

## Original prompt
Fix `vellum mcp --help` crashing with "sonic boom is not ready yet" error from pino's async file destination

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
