### PR TITLE
Fix guardian wait heartbeat timing

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -1214,10 +1214,14 @@ export class RelayConnection {
 
     updateCallSession(this.callSessionId, { status: 'waiting_on_user' });
 
-    // Start the heartbeat timer for periodic progress updates
-    this.accessRequestWaitStartedAt = Date.now();
+    // Start the heartbeat timer for periodic progress updates.
+    // Delay the first heartbeat by the estimated TTS playback duration so
+    // the initial hold message finishes before any heartbeat fires.
     this.heartbeatSequence = 0;
-    this.scheduleNextHeartbeat();
+    this.accessRequestHeartbeatTimer = setTimeout(() => {
+      this.accessRequestWaitStartedAt = Date.now();
+      this.scheduleNextHeartbeat();
+    }, getTtsPlaybackDelayMs());
 
     // Poll the canonical request status
     this.accessRequestPollTimer = setInterval(() => {

--- a/assistant/src/config/calls-schema.ts
+++ b/assistant/src/config/calls-schema.ts
@@ -93,7 +93,7 @@ export const CallsConfigSchema = z.object({
     .int('calls.guardianWaitUpdateInitialIntervalMs must be an integer')
     .min(1000, 'calls.guardianWaitUpdateInitialIntervalMs must be >= 1000')
     .max(60_000, 'calls.guardianWaitUpdateInitialIntervalMs must be at most 60000')
-    .default(5000),
+    .default(15_000),
   guardianWaitUpdateInitialWindowMs: z
     .number({ error: 'calls.guardianWaitUpdateInitialWindowMs must be a number' })
     .int('calls.guardianWaitUpdateInitialWindowMs must be an integer')
@@ -105,13 +105,13 @@ export const CallsConfigSchema = z.object({
     .int('calls.guardianWaitUpdateSteadyMinIntervalMs must be an integer')
     .min(1000, 'calls.guardianWaitUpdateSteadyMinIntervalMs must be >= 1000')
     .max(60_000, 'calls.guardianWaitUpdateSteadyMinIntervalMs must be at most 60000')
-    .default(7000),
+    .default(20_000),
   guardianWaitUpdateSteadyMaxIntervalMs: z
     .number({ error: 'calls.guardianWaitUpdateSteadyMaxIntervalMs must be a number' })
     .int('calls.guardianWaitUpdateSteadyMaxIntervalMs must be an integer')
     .min(1000, 'calls.guardianWaitUpdateSteadyMaxIntervalMs must be >= 1000')
     .max(60_000, 'calls.guardianWaitUpdateSteadyMaxIntervalMs must be at most 60000')
-    .default(10_000),
+    .default(30_000),
   disclosure: CallsDisclosureConfigSchema.default(CallsDisclosureConfigSchema.parse({})),
   safety: CallsSafetyConfigSchema.default(CallsSafetyConfigSchema.parse({})),
   voice: CallsVoiceConfigSchema.default(CallsVoiceConfigSchema.parse({})),


### PR DESCRIPTION
## Summary
- Delay heartbeat timer start by `ttsPlaybackDelayMs` so the initial hold message finishes playing before any heartbeat fires
- Increase default heartbeat intervals: 5s→15s initial, 7s→20s steady min, 10s→30s steady max
- Anchor `accessRequestWaitStartedAt` to TTS completion rather than TTS initiation

## Original prompt
Fix guardian wait heartbeat timing bug — messages fire too rapidly and overlap with TTS playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
