### PR TITLE
fix: detect StreamableHTTPError.code for MCP auth error handling

### DIFF
--- a/assistant/src/mcp/client.ts
+++ b/assistant/src/mcp/client.ts
@@ -75,7 +75,8 @@ export class McpClient {
 
       if (isHttpTransport) {
         const isAuthError = err instanceof UnauthorizedError
-          || (err instanceof Error && /\b(401|403|unauthorized|forbidden)\b/i.test(err.message));
+          || (err instanceof Error && /\b(401|403|unauthorized|forbidden)\b/i.test(err.message))
+          || (err != null && typeof err === 'object' && 'code' in err && (err.code === 401 || err.code === 403));
 
         if (isAuthError) {
           // Auth-related — user can run `vellum mcp auth <name>` to authenticate.


### PR DESCRIPTION
## Summary
- The MCP SDK's `StreamableHTTPError` puts the HTTP status code in `.code` but not in `.message`, so our regex-only check on `err.message` missed 401/403 errors when no OAuth provider was attached
- This caused auth-required servers to show `✗ Error: Streamable HTTP error...` instead of `! Needs authentication`
- Added a check for `err.code === 401 || err.code === 403` alongside the existing regex and `UnauthorizedError` checks

## Test plan
- [ ] Configure an MCP server that requires OAuth (e.g. Linear) without authenticating first
- [ ] Run `vellum mcp list` — should show `! Needs authentication` instead of `✗ Error: Streamable HTTP error...`
- [ ] Restart daemon — server should log auth guidance instead of connection failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
