### PR TITLE
test: add unit tests for MCP client auth error detection

### DIFF
--- a/assistant/src/__tests__/mcp-client-auth.test.ts
+++ b/assistant/src/__tests__/mcp-client-auth.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, jest, mock, test } from "bun:test";
+
+// Mock secure-keys so McpOAuthProvider doesn't try to access the keychain
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: jest.fn().mockResolvedValue(null),
+  setSecureKeyAsync: jest.fn().mockResolvedValue(undefined),
+  deleteSecureKeyAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
+const { McpClient } = await import("../mcp/client.js");
+
+/**
+ * Mimics the SDK's StreamableHTTPError which has a `.code` property
+ * containing the HTTP status code, but doesn't include it in `.message`.
+ */
+class FakeStreamableHTTPError extends Error {
+  code: number;
+  constructor(code: number, message: string) {
+    super(`Streamable HTTP error: ${message}`);
+    this.code = code;
+  }
+}
+
+const httpTransport = {
+  type: "streamable-http" as const,
+  url: "https://example.com/mcp",
+};
+
+describe("McpClient auth error detection", () => {
+  test("treats StreamableHTTPError with code 401 as auth error (does not throw)", async () => {
+    const client = new McpClient("test-server", { quiet: true });
+
+    // Monkey-patch createTransport to throw a 401 StreamableHTTPError
+    (client as any).createTransport = () => ({});
+    (client as any).client = {
+      connect: () => {
+        throw new FakeStreamableHTTPError(401, 'Error POSTing to endpoint: {"error":"invalid_token"}');
+      },
+      close: async () => {},
+    };
+
+    // Should NOT throw — auth errors are swallowed, isConnected stays false
+    await client.connect(httpTransport);
+    expect(client.isConnected).toBe(false);
+  });
+
+  test("treats StreamableHTTPError with code 403 as auth error (does not throw)", async () => {
+    const client = new McpClient("test-server", { quiet: true });
+
+    (client as any).createTransport = () => ({});
+    (client as any).client = {
+      connect: () => {
+        throw new FakeStreamableHTTPError(403, "Forbidden");
+      },
+      close: async () => {},
+    };
+
+    await client.connect(httpTransport);
+    expect(client.isConnected).toBe(false);
+  });
+
+  test("rethrows non-auth StreamableHTTPError for HTTP transports", async () => {
+    const client = new McpClient("test-server", { quiet: true });
+
+    (client as any).createTransport = () => ({});
+    (client as any).client = {
+      connect: () => {
+        throw new FakeStreamableHTTPError(500, "Internal Server Error");
+      },
+      close: async () => {},
+    };
+
+    await expect(client.connect(httpTransport)).rejects.toThrow("Internal Server Error");
+  });
+
+  test("treats error message containing 'unauthorized' as auth error", async () => {
+    const client = new McpClient("test-server", { quiet: true });
+
+    (client as any).createTransport = () => ({});
+    (client as any).client = {
+      connect: () => {
+        throw new Error("unauthorized request");
+      },
+      close: async () => {},
+    };
+
+    await client.connect(httpTransport);
+    expect(client.isConnected).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds unit tests for `McpClient.connect()` auth error detection logic
- Tests cover: `StreamableHTTPError` with `.code` 401/403, error message regex matching, and non-auth error rethrow
- Covers the fix from #11693

## Test plan
- [x] `bun test src/__tests__/mcp-client-auth.test.ts` — 4 tests pass (240ms)
- [x] `bun test src/__tests__/mcp-health-check.test.ts` — existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
