### PR TITLE
Fix guardian label falling back to 'my guardian'

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -11,6 +11,7 @@ import { randomInt } from 'node:crypto';
 import type { ServerWebSocket } from 'bun';
 
 import { getConfig } from '../config/loader.js';
+import { resolveUserReference } from '../config/user-reference.js';
 import { getAssistantName } from '../daemon/identity-helpers.js';
 import { getCanonicalGuardianRequest } from '../memory/canonical-guardian-store.js';
 import { listActiveBindingsByAssistant } from '../memory/channel-guardian-store.js';
@@ -1662,7 +1663,8 @@ export class RelayConnection {
   /**
    * Resolve a human-readable guardian label for voice wait copy.
    * Prefers displayName from the guardian binding metadata, falls back
-   * to @username, then "my guardian".
+   * to @username, then the user's preferred name from USER.md, then
+   * "my guardian".
    */
   private resolveGuardianLabel(): string {
     const assistantId = this.accessRequestAssistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
@@ -1694,6 +1696,15 @@ export class RelayConnection {
         // ignore malformed metadata
       }
     }
+
+    // Fall back to the guardian's preferred name from USER.md (set during
+    // onboarding). Safe to share with unauthenticated callers — it's just
+    // a first name used in hold messages like "Still waiting on Noa".
+    const userRef = resolveUserReference();
+    if (userRef !== 'my human') {
+      return userRef;
+    }
+
     return 'my guardian';
   }
 


### PR DESCRIPTION
## Summary
- Add USER.md preferred name as fallback in `resolveGuardianLabel()` before "my guardian"
- The vellum channel bootstrap doesn't capture displayName, so hold messages said "my guardian" instead of the user's name
- Now reads the "Preferred name/reference" from USER.md (set during onboarding) as a fallback

## Original prompt
Fix guardian label bug — heartbeat messages say "my guardian" instead of the guardian's actual name

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
