### PR TITLE
Remove SMS from guardian verification, add voice guardian step to phone-calls

### DIFF
--- a/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
+++ b/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
@@ -119,13 +119,13 @@ describe("guardian-verify-setup skill — voice auto-followup", () => {
     expect(pollingSection).toContain("Non-rebind flows");
   });
 
-  test("polling is voice-only — does not apply to SMS or Telegram", () => {
+  test("polling is voice-only — does not apply to Telegram", () => {
     const pollingSection =
       skillContent
         .split("## Voice Auto-Check Polling")[1]
         ?.split("## Step 6")[0] ?? "";
     expect(pollingSection).toContain("voice-only");
-    expect(pollingSection).toContain("Do NOT poll for SMS or Telegram");
+    expect(pollingSection).toContain("Do NOT poll for Telegram");
   });
 
   test('no instruction requires waiting for user to ask "did it work?"', () => {

--- a/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "Guardian Verify Setup"
-description: "Set up guardian verification for SMS, voice, or Telegram channels via outbound verification flow"
+description: "Set up guardian verification for voice or Telegram channels via outbound verification flow"
 user-invocable: true
 metadata: {"vellum": {"emoji": "\ud83d\udd10"}}
 ---
 
-You are helping your user set up guardian verification for a messaging channel (SMS, voice, or Telegram). This links their identity as the trusted guardian for the chosen channel. All API calls go through the gateway HTTP API using `curl` with bearer auth.
+You are helping your user set up guardian verification for a messaging channel (voice or Telegram). This links their identity as the trusted guardian for the chosen channel. All API calls go through the gateway HTTP API using `curl` with bearer auth.
 
 ## Prerequisites
 
@@ -19,17 +19,16 @@ You are helping your user set up guardian verification for a messaging channel (
 
 Ask the user which channel they want to verify:
 
-- **sms** -- verify a phone number for SMS messaging
 - **voice** -- verify a phone number for voice calls
 - **telegram** -- verify a Telegram account
 
-If the user's intent already specifies a channel (e.g. "verify my phone number for SMS"), skip the prompt and proceed.
+If the user's intent already specifies a channel (e.g. "verify my phone number for voice calls"), skip the prompt and proceed.
 
 ## Step 2: Collect Destination
 
 Based on the chosen channel, ask for the required destination:
 
-- **SMS or voice**: Ask for their phone number. Accept any common format (e.g. +15551234567, (555) 123-4567, 555-123-4567). The API normalizes it to E.164.
+- **Voice**: Ask for their phone number. Accept any common format (e.g. +15551234567, (555) 123-4567, 555-123-4567). The API normalizes it to E.164.
 - **Telegram**: Ask for their Telegram chat ID (numeric) or @handle. Explain:
   - If they know their numeric chat ID, provide it directly. The bot will send the code to that chat.
   - If they only know their @handle, the flow uses a bootstrap deep-link that they must click first.
@@ -45,13 +44,12 @@ curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/outbound/st
   -d '{"channel": "<channel>", "destination": "<destination>"}'
 ```
 
-Replace `<channel>` with `sms`, `voice`, or `telegram`, and `<destination>` with the phone number or Telegram destination.
+Replace `<channel>` with `voice` or `telegram`, and `<destination>` with the phone number or Telegram destination.
 
 ### On success (`success: true`)
 
 Report the exact next action based on the channel:
 
-- **SMS**: "I've sent a 6-digit verification code to [number]. Reply with the code from that SMS conversation (not here) to complete verification — the code can only be consumed through the SMS channel."
 - **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/start` API call already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
 - **Telegram with chat ID** (no `telegramBootstrapUrl` in response): The response includes a `secret` field. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and reply with that 6-digit code to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4).
 - **Telegram with handle** (`telegramBootstrapUrl` present in response): "Tap this deep-link first: [telegramBootstrapUrl]. After Telegram binds your identity, I'll send your verification code."
@@ -68,7 +66,7 @@ Handle each error code:
 | `invalid_destination` | Tell the user the format is invalid. For phone: suggest E.164 format (+15551234567). For Telegram: explain that group chat IDs (negative numbers) are not supported. |
 | `already_bound` | Tell the user a guardian is already bound for this channel. Ask if they want to replace it. If yes, re-run the start request with `"rebind": true` added to the JSON body. |
 | `rate_limited` | Tell the user they have sent too many verification attempts to this destination. Ask them to wait and try again later. |
-| `unsupported_channel` | Tell the user the channel is not supported. Only sms, voice, and telegram are valid. |
+| `unsupported_channel` | Tell the user the channel is not supported. Only voice and telegram are valid. |
 | `no_bot_username` | Telegram bot is not configured. Load and run the `telegram-setup` skill first. |
 
 ## Step 4: Handle Resend
@@ -84,7 +82,6 @@ curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/outbound/re
 
 On success, report the next action based on the channel:
 
-- **SMS**: "I've sent a new verification code to [number]. Reply with the code from that SMS conversation to complete verification."
 - **Voice**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/resend` API call already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
 - **Telegram**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and reply with that 6-digit code to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3.
 
@@ -140,7 +137,7 @@ When in a **rebind flow** (i.e., the `start_outbound` request included `"rebind"
 - Non-rebind flows (fresh verification with no prior binding) are unaffected — the first `bound: true` is trustworthy.
 
 **Important polling rules:**
-- This polling loop is voice-only. Do NOT poll for SMS or Telegram channels (SMS codes are entered through the SMS channel itself; Telegram has its own bot-driven flow).
+- This polling loop is voice-only. Do NOT poll for Telegram channels (Telegram has its own bot-driven flow).
 - Do NOT require the user to ask "did it work?" — the whole point is proactive confirmation.
 - If the user sends a message while polling is in progress, handle their message normally. If their message is about verification status, the next poll iteration will provide the answer.
 

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -84,15 +84,13 @@ SMS messaging uses Twilio as the telephony provider. Twilio credentials and phon
 
 The sms-setup skill handles: Twilio credential storage (Account SID + Auth Token), phone number provisioning or assignment, public ingress setup, SMS compliance verification, and end-to-end test sending. Once SMS is set up, messaging is available automatically — no additional feature flag is needed.
 
-The sms-setup skill also includes optional **guardian verification** for SMS, which links your phone number as the trusted guardian.
+### Guardian Verification (Voice or Telegram)
 
-### Guardian Verification (SMS, Voice, or Telegram)
-
-If the user asks to verify their guardian identity for any channel (SMS, voice, or Telegram), load the **guardian-verify-setup** skill:
+If the user asks to verify their guardian identity for voice or Telegram, load the **guardian-verify-setup** skill:
 
 - Call `skill_load` with `skill: "guardian-verify-setup"` to load the dependency skill.
 
-The guardian-verify-setup skill handles the full outbound verification flow for all supported channels. It collects the user's destination (phone number or Telegram chat ID/handle), initiates an outbound verification session, and guides the user through entering or replying with the verification code. This is the single source of truth for guardian verification setup -- do not duplicate the verification flow inline.
+The guardian-verify-setup skill handles the full outbound verification flow for voice and Telegram channels. It collects the user's destination (phone number or Telegram chat ID/handle), initiates an outbound verification session, and guides the user through entering or replying with the verification code. This is the single source of truth for guardian verification setup -- do not duplicate the verification flow inline.
 
 ## Error Recovery
 

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -147,6 +147,29 @@ Suggest a test call to the user's own phone: **"Want to do a quick test call to 
 
 If they agree, ask for their personal phone number and place a test call with a simple task like "Introduce yourself and confirm the call system is working."
 
+## Step 5: Verify Guardian Identity (Voice)
+
+Now link the user's phone number as the trusted voice guardian. Tell the user: "Now let's verify your guardian identity for voice. This links your phone number so the assistant can verify inbound callers."
+
+Load the **guardian-verify-setup** skill to handle the verification flow:
+
+- Call `skill_load` with `skill: "guardian-verify-setup"` to load the dependency skill.
+
+When invoking the skill, indicate the channel is `voice`. The guardian-verify-setup skill manages the full outbound verification flow, including:
+
+- Collecting the user's phone number as the destination
+- Starting the outbound verification session via the gateway endpoint `POST /v1/integrations/guardian/outbound/start` with `channel: "voice"`
+- Calling the phone number and providing a code for the user to enter via their phone's keypad
+- Proactively polling for completion (voice auto-check) so the user gets instant confirmation
+- Checking guardian status to confirm the binding was created
+- Handling resend, cancel, and error cases
+
+Tell the user: _"I've loaded the guardian verification guide. It will walk you through linking your phone number as the trusted voice guardian."_
+
+After the guardian-verify-setup skill completes (or the user skips), continue to the next sections.
+
+**Note:** Guardian verification is optional but recommended. If the user declines or wants to skip, proceed without blocking. Once verified, inbound callers can be prompted for voice verification before calls proceed (see the **Guardian voice verification for inbound calls** section below).
+
 ## Caller Identity
 
 All implicit calls (calls without an explicit `caller_identity_mode`) always use the assistant's Twilio phone number. This is the number that appears on the recipient's caller ID.

--- a/assistant/src/config/bundled-skills/sms-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/sms-setup/SKILL.md
@@ -144,26 +144,6 @@ After deletion, return to Step 3b to collect information and resubmit. Warn the 
 
 **On failure:** Report the exact error message and guide the user through resolution.
 
-## Step 3.5: Guardian Verification (SMS)
-
-Now link the user's phone number as the trusted SMS guardian. Tell the user: "Now let's verify your guardian identity for SMS. This links your phone number as the trusted guardian for SMS messaging."
-
-Load the **guardian-verify-setup** skill to handle the verification flow:
-
-- Call `skill_load` with `skill: "guardian-verify-setup"` to load the dependency skill.
-
-When invoking the skill, indicate the channel is `sms`. The guardian-verify-setup skill manages the full outbound verification flow, including:
-
-- Collecting the user's phone number as the destination (accepts any common format -- the API normalizes to E.164)
-- Starting the outbound verification session via the gateway endpoint `POST /v1/integrations/guardian/outbound/start` with `channel: "sms"`
-- Sending a 6-digit code to the phone number that the user must reply with from the SMS channel
-- Checking guardian status to confirm the binding was created
-- Handling resend, cancel, and error cases
-
-Tell the user: _"I've loaded the guardian verification guide. It will walk you through linking your phone number as the trusted SMS guardian."_
-
-**Note:** Guardian verification is optional but recommended. If the user declines or wants to skip, proceed to Step 4 without blocking.
-
 ## Step 4: Test Send
 
 Run a test SMS to verify end-to-end delivery:

--- a/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
@@ -215,43 +215,35 @@ Confirm:
 
 Tell the user: **"Twilio is configured. Your assistant's phone number is {phoneNumber}. This number is used for both voice calls and SMS messaging."**
 
-## Step 5.5: Guardian Verification (SMS and Voice)
+## Step 5.5: Guardian Verification (Voice)
 
-Now link the user's phone number as the trusted guardian for SMS and/or voice channels. Tell the user: "Now let's verify your guardian identity. This links your phone number as the trusted guardian for messaging and calls."
+Now link the user's phone number as the trusted voice guardian. Tell the user: "Now let's verify your guardian identity for voice. This links your phone number so the assistant can verify inbound callers."
 
 Load the **guardian-verify-setup** skill to handle the verification flow:
 
 - Call `skill_load` with `skill: "guardian-verify-setup"` to load the dependency skill.
 
-The guardian-verify-setup skill manages the full outbound verification flow for **one channel at a time** (sms, voice, or telegram). Each invocation handles:
+When invoking the skill, indicate the channel is `voice`. The guardian-verify-setup skill manages the full outbound verification flow, including:
 
 - Collecting the user's phone number as the destination (accepts any common format -- the API normalizes to E.164)
-- Starting the outbound verification session via the gateway endpoint `POST /v1/integrations/guardian/outbound/start`
-- For **SMS**: sending a 6-digit code to the phone number that the user must reply with from the SMS channel
-- For **voice**: calling the phone number and providing a code for the user to enter via their phone's keypad
+- Starting the outbound verification session via the gateway endpoint `POST /v1/integrations/guardian/outbound/start` with `channel: "voice"`
+- Calling the phone number and providing a code for the user to enter via their phone's keypad
+- Proactively polling for completion (voice auto-check) so the user gets instant confirmation
 - Checking guardian status to confirm the binding was created
 - Handling resend, cancel, and error cases
 
-**If the user wants to verify both SMS and voice**, load the skill twice -- once for SMS and once for voice. Each channel requires its own separate verification session.
+Tell the user: _"I've loaded the guardian verification guide. It will walk you through linking your phone number as the trusted voice guardian."_
 
-Tell the user: _"I've loaded the guardian verification guide. It will walk you through linking your phone number as the trusted guardian. We'll verify one channel at a time."_
-
-After the guardian-verify-setup skill completes verification for a channel, load it again for the next channel if needed. Once all desired channels are verified (or the user skips), continue to Step 6.
+After the guardian-verify-setup skill completes (or the user skips), continue to Step 6.
 
 **Note:** Guardian verification is optional but recommended. If the user declines or wants to skip, proceed to Step 6 without blocking.
 
-To re-check guardian status later, query the channel(s) that were verified:
+To re-check guardian status later:
 
 ```bash
-# Check SMS guardian status
-curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/status?channel=sms" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
-# Check voice guardian status
 curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/status?channel=voice" \
   -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
 ```
-
-Check the status for whichever channel(s) the user actually verified (SMS, voice, or both). Report the guardian verification result per channel: **"Guardian identity — SMS: {verified | not configured}, Voice: {verified | not configured}."**
 
 ## Step 6: Enable Features
 


### PR DESCRIPTION
## Summary
- Remove SMS as a guardian verification channel from `guardian-verify-setup` skill (voice and Telegram only now)
- Add a new Step 5 (Verify Guardian Identity) to `phone-calls` skill so users are prompted to verify their voice guardian after initial phone call setup — matching how `telegram-setup` already does this
- Update `twilio-setup`, `sms-setup`, and `messaging` skills to remove SMS guardian references

## Test plan
- [x] All 12 regression tests pass (`guardian-verify-setup-skill-regression`)
- [x] Zero SMS references remain in `guardian-verify-setup/SKILL.md`
- [x] All callers of `guardian-verify-setup` are consistent across bundled skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
