### PR TITLE
fix: update config-schema test to match new guardian wait update defaults

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -658,10 +658,10 @@ describe("AssistantConfigSchema", () => {
       userConsultTimeoutSeconds: 120,
       ttsPlaybackDelayMs: 3000,
       accessRequestPollIntervalMs: 500,
-      guardianWaitUpdateInitialIntervalMs: 5000,
+      guardianWaitUpdateInitialIntervalMs: 15000,
       guardianWaitUpdateInitialWindowMs: 30000,
-      guardianWaitUpdateSteadyMinIntervalMs: 7000,
-      guardianWaitUpdateSteadyMaxIntervalMs: 10000,
+      guardianWaitUpdateSteadyMinIntervalMs: 20000,
+      guardianWaitUpdateSteadyMaxIntervalMs: 30000,
       disclosure: {
         enabled: true,
         text: 'At the very beginning of the call, introduce yourself as an assistant calling on behalf of the person you represent. Do not say "AI assistant".',


### PR DESCRIPTION
## Summary
- Updated `config-schema.test.ts` to match the new default values for guardian wait update intervals in `calls-schema.ts`
- `guardianWaitUpdateInitialIntervalMs`: 5000 → 15000
- `guardianWaitUpdateSteadyMinIntervalMs`: 7000 → 20000
- `guardianWaitUpdateSteadyMaxIntervalMs`: 10000 → 30000

## Original prompt
fix the CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22637227921

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
