### PR TITLE
Simplify guardian label fallback across all channels

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -2276,7 +2276,7 @@ describe("relay-server", () => {
         .map((raw) => JSON.parse(raw) as { type: string; token?: string })
         .filter((m) => m.type === "text");
       const promptText = textMessages.map((m) => m.token ?? "").join("");
-      expect(promptText).toContain("Hi, this is my guardian's assistant.");
+      expect(promptText).toContain("Hi, this is my human's assistant.");
       expect(promptText).not.toContain("Vellum");
       expect(promptText).toContain("don't recognize this number");
       expect(promptText).toContain("Can I get your name");
@@ -2326,13 +2326,13 @@ describe("relay-server", () => {
     // Should have transitioned to awaiting guardian decision
     expect(relay.getConnectionState()).toBe("awaiting_guardian_decision");
 
-    // Should have sent the hold message (guardian label defaults to "my guardian")
+    // Should have sent the hold message (guardian label defaults to "my human")
     const textMessages = ws.sentMessages
       .map((raw) => JSON.parse(raw) as { type: string; token?: string })
       .filter((m) => m.type === "text");
     expect(
       textMessages.some((m) =>
-        (m.token ?? "").includes("I've let my guardian know"),
+        (m.token ?? "").includes("I've let my human know"),
       ),
     ).toBe(true);
     expect(

--- a/assistant/src/__tests__/trusted-contact-approval-notifier.test.ts
+++ b/assistant/src/__tests__/trusted-contact-approval-notifier.test.ts
@@ -120,6 +120,11 @@ mock.module("../config/env.js", () => ({
   getGatewayInternalBaseUrl: () => "http://localhost:3000",
 }));
 
+// ── User reference mock ──
+mock.module("../config/user-reference.js", () => ({
+  resolveUserReference: () => "my human",
+}));
+
 // Import module under test AFTER mocks are set up
 import type { ChannelId } from "../channels/types.js";
 import type { GuardianContext } from "../runtime/guardian-context-resolver.js";

--- a/assistant/src/__tests__/trusted-contact-approval-notifier.test.ts
+++ b/assistant/src/__tests__/trusted-contact-approval-notifier.test.ts
@@ -123,6 +123,7 @@ mock.module("../config/env.js", () => ({
 // Import module under test AFTER mocks are set up
 import type { ChannelId } from "../channels/types.js";
 import type { GuardianContext } from "../runtime/guardian-context-resolver.js";
+import { resolveUserReference } from "../config/user-reference.js";
 
 // We need to test the private functions by importing the module.
 // Since startTrustedContactApprovalNotifier is not exported, we test it
@@ -220,9 +221,7 @@ async function simulateNotifierPoll(params: {
     }
   }
 
-  const waitingText = guardianName
-    ? `Waiting for ${guardianName}'s approval...`
-    : "Waiting for your guardian's approval...";
+  const waitingText = `Waiting for ${guardianName ?? resolveUserReference()}'s approval...`;
 
   try {
     await deliverChannelReply(
@@ -330,7 +329,7 @@ describe("trusted-contact pending-approval notifier", () => {
     );
   });
 
-  test("uses generic phrasing when no guardian name is available", async () => {
+  test("falls back to user reference when no guardian name is available", async () => {
     mockPendingApprovals = [
       {
         requestId: "req-3",
@@ -359,11 +358,11 @@ describe("trusted-contact pending-approval notifier", () => {
 
     expect(deliveredReplies).toHaveLength(1);
     expect(deliveredReplies[0].payload.text).toBe(
-      "Waiting for your guardian's approval...",
+      "Waiting for my human's approval...",
     );
   });
 
-  test("uses generic phrasing when no guardian binding exists", async () => {
+  test("falls back to user reference when no guardian binding exists", async () => {
     mockPendingApprovals = [
       {
         requestId: "req-4",
@@ -388,7 +387,7 @@ describe("trusted-contact pending-approval notifier", () => {
 
     expect(deliveredReplies).toHaveLength(1);
     expect(deliveredReplies[0].payload.text).toBe(
-      "Waiting for your guardian's approval...",
+      "Waiting for my human's approval...",
     );
   });
 
@@ -736,7 +735,7 @@ describe("trusted-contact pending-approval notifier", () => {
     expect(deliveredReplies).toHaveLength(1);
     // Falls back to generic phrasing
     expect(deliveredReplies[0].payload.text).toBe(
-      "Waiting for your guardian's approval...",
+      "Waiting for my human's approval...",
     );
   });
 });

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -1663,8 +1663,7 @@ export class RelayConnection {
   /**
    * Resolve a human-readable guardian label for voice wait copy.
    * Prefers displayName from the guardian binding metadata, falls back
-   * to @username, then the user's preferred name from USER.md, then
-   * "my guardian".
+   * to @username, then the user's preferred name from USER.md.
    */
   private resolveGuardianLabel(): string {
     const assistantId = this.accessRequestAssistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
@@ -1697,15 +1696,7 @@ export class RelayConnection {
       }
     }
 
-    // Fall back to the guardian's preferred name from USER.md (set during
-    // onboarding). Safe to share with unauthenticated callers — it's just
-    // a first name used in hold messages like "Still waiting on Noa".
-    const userRef = resolveUserReference();
-    if (userRef !== 'my human') {
-      return userRef;
-    }
-
-    return 'my guardian';
+    return resolveUserReference();
   }
 
   /**

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -27,6 +27,7 @@ import { canonicalizeInboundIdentity } from '../../util/canonicalize-identity.js
 import { IngressBlockedError } from '../../util/errors.js';
 import { getLogger } from '../../util/logger.js';
 import { notifyGuardianOfAccessRequest } from '../access-request-helper.js';
+import { resolveUserReference } from '../../config/user-reference.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import { mintDaemonDeliveryToken } from '../auth/token-service.js';
 import {
@@ -1577,10 +1578,8 @@ function startTrustedContactApprovalNotifier(params: {
           const guardianName = resolveGuardianDisplayName(
             assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
             sourceChannel,
-          );
-          const waitingText = guardianName
-            ? `Waiting for ${guardianName}'s approval...`
-            : 'Waiting for your guardian\'s approval...';
+          ) ?? resolveUserReference();
+          const waitingText = `Waiting for ${guardianName}'s approval...`;
           try {
             await deliverChannelReply(replyCallbackUrl, {
               chatId: externalChatId,


### PR DESCRIPTION
## Summary
- Simplify `resolveGuardianLabel()` in relay-server.ts to fall back to `resolveUserReference()` directly instead of checking against `'my human'` and then falling back to `'my guardian'`
- Add the same `resolveUserReference()` fallback to the text channel guardian name resolution in inbound-message-handler.ts
- Update test assertions to reflect the new "my human" default instead of "my guardian"

## Original prompt
Simplify guardian label fallback to just `return resolveUserReference()` since "my human" is preferable to "my guardian", and apply the same pattern to other inbound flows (Telegram).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
