### PR TITLE
fix: Gateway button label — Set Up Tunnel → Set Up

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -32,7 +32,7 @@ struct GatewaySettingsCard: View {
             } else if tunnelSetupExpanded || !gatewayUrlText.isEmpty {
                 tunnelConfigEntry
             } else {
-                VButton(label: "Set Up Tunnel", style: .secondary, size: .large) {
+                VButton(label: "Set Up", style: .secondary, size: .large) {
                     tunnelSetupExpanded = true
                 }
             }


### PR DESCRIPTION
- Renames the Gateway card's 'Set Up Tunnel' button to 'Set Up' for consistency with other sections

Part of #11702
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
