### PR TITLE
fix: Appearance Theme Tabs move to bottom-left under label

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -24,11 +24,10 @@ struct SettingsAppearanceTab: View {
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
 
-                HStack {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text("Theme")
                         .font(VFont.body)
                         .foregroundColor(VColor.textSecondary)
-                    Spacer()
                     VSegmentedControl(
                         items: [
                             (label: "System", tag: "system"),
@@ -44,7 +43,7 @@ struct SettingsAppearanceTab: View {
                         ),
                         style: .pill
                     )
-                    .frame(width: 220)
+                    .fixedSize()
                 }
 
                 VStack(alignment: .leading, spacing: VSpacing.xs) {


### PR DESCRIPTION
- Changes Theme row from inline HStack to VStack
- Picker sits below label, left-aligned

Part of #11702
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
