### PR TITLE
fix: Models & Services sections full width

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -635,6 +635,7 @@ struct SettingsPanel: View {
             // TWITTER / X section
             twitterSection
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Twitter Section


### PR DESCRIPTION
- Adds `.frame(maxWidth: .infinity, alignment: .leading)` to the outer VStack of `integrationsContent` so all section cards in the Models & Services tab stretch full width

All individual section cards (Anthropic, Perplexity, Brave Search, Image Generation, Integrations, Twitter/X) already had `.frame(maxWidth: .infinity, alignment: .leading)` applied. The outer `VStack` wrapping them all was missing the frame modifier — this PR adds it.

Part of #11702
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
