### PR TITLE
fix: Permissions full width, remove Working Directory separator

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -52,8 +52,6 @@ struct ToolPermissionTesterView: View {
                     .font(VFont.mono)
             }
 
-            Divider().background(VColor.surfaceBorder)
-
             // Toggles
             HStack(spacing: VSpacing.xl) {
                 VToggle(isOn: $model.isInteractive, label: "Interactive")


### PR DESCRIPTION
- All Permissions section cards get .frame(maxWidth: .infinity)
- Removes Divider() after working directory input in Permission Simulator

Part of #11702
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
