### PR TITLE
fix: Settings Navigation outside Content Panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -94,22 +94,21 @@ struct SettingsPanel: View {
     @State private var selectedTab: SettingsTab = .account
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Two-column layout
-            HStack(spacing: 0) {
-                // Left: nav sidebar
-                settingsNav
-                    .frame(width: 200)
+        // Two-column layout: bare nav on window background, content in its own surface panel
+        HStack(alignment: .top, spacing: 0) {
+            // Left: nav sidebar sits directly on the window background — no card/surface wrapper
+            settingsNav
+                .frame(width: 200)
 
-                Divider()
-
-                // Right: content for selected tab
-                ScrollView {
-                    selectedTabContent
-                        .padding(VSpacing.lg)
-                        .frame(maxWidth: .infinity, alignment: .top)
-                }
+            // Right: tab content lives in its own surface panel
+            ScrollView {
+                selectedTabContent
+                    .padding(VSpacing.lg)
+                    .frame(maxWidth: .infinity, alignment: .top)
             }
+            .vCard(radius: VRadius.lg, background: VColor.surface)
+            .padding(.trailing, VSpacing.lg)
+            .padding(.vertical, VSpacing.lg)
         }
         .task {
             // Refresh permission status when the view appears


### PR DESCRIPTION
- Nav sidebar sits on window background (no card wrapper)\n- Content panel only wraps the tab settings content\n\nPart of #11702
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
