### PR TITLE
feat: add bundled mcp-setup skill with dynamic description

### DIFF
--- a/assistant/src/config/bundled-skills/mcp-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/mcp-setup/SKILL.md
@@ -9,7 +9,7 @@ Help users configure MCP servers so external tools (e.g. Linear, GitHub, Notion)
 
 ## CLI Commands
 
-All commands use `vellum mcp`. Run them via `host_shell`.
+All commands use `vellum mcp`. Run them via `host_bash`.
 
 ### List servers
 

--- a/assistant/src/config/bundled-skills/mcp-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/mcp-setup/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: "MCP Setup"
+description: "Add, authenticate, list, and remove MCP (Model Context Protocol) servers"
+user-invocable: false
+metadata: {"vellum": {"emoji": "🔌"}}
+---
+
+Help users configure MCP servers so external tools (e.g. Linear, GitHub, Notion) become available in conversations.
+
+## CLI Commands
+
+All commands use `vellum mcp`. Run them via `host_shell`.
+
+### List servers
+
+```
+vellum mcp list
+```
+
+Shows all configured servers with connection status, transport type, and URL.
+
+### Add a server
+
+```
+vellum mcp add <name> -t <transport-type> -u <url> [-r <risk>] [--disabled]
+```
+
+- `<name>` — unique identifier (e.g. `linear`, `github`)
+- `-t` — transport type: `stdio`, `sse`, or `streamable-http`
+- `-u` — server URL (required for `sse`/`streamable-http`)
+- `-c` — command (required for `stdio`), `-a` for args
+- `-r` — risk level: `low`, `medium`, or `high` (default: `high`)
+
+Examples:
+```
+vellum mcp add linear -t streamable-http -u https://mcp.linear.app/mcp
+vellum mcp add context7 -t streamable-http -u https://mcp.context7.com/mcp -r low
+vellum mcp add local-db -t stdio -c npx -a -y @my/mcp-server
+```
+
+### Authenticate (OAuth)
+
+```
+vellum mcp auth <name>
+```
+
+Opens the user's browser for OAuth authorization. Only works for `sse`/`streamable-http` servers that require authentication. After the user completes login in the browser, tokens are saved automatically.
+
+Use this when:
+- A server shows `! Needs authentication` in `vellum mcp list`
+- An MCP tool call fails with an auth/token error
+- Setting up a new OAuth-protected server for the first time
+
+### Remove a server
+
+```
+vellum mcp remove <name>
+```
+
+Removes the server config and cleans up any stored OAuth credentials.
+
+## After Changes
+
+After adding, removing, or authenticating a server, the user must **quit and relaunch the Vellum app** for changes to take effect. The app runs its own daemon — `vellum daemon restart` only restarts the CLI daemon, which is a separate process.
+
+Tell the user: "Please quit and relaunch the Vellum app, then start a new conversation."
+
+## When to Use
+
+- User asks to connect/set up an external service via MCP
+- User asks "what MCP servers do I have?"
+- An MCP tool returns an auth error — offer to run `vellum mcp auth <name>`
+- User wants to remove an MCP integration

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -894,6 +894,21 @@ function escapeXml(str: string): string {
     .replace(/'/g, "&apos;");
 }
 
+/**
+ * Build a dynamic description for the mcp-setup skill that includes
+ * configured MCP server names, so the model knows which servers exist.
+ */
+function getMcpSetupDescription(): string {
+  const config = getConfig();
+  const servers = config.mcp?.servers;
+  if (!servers || Object.keys(servers).length === 0) {
+    return "Add, authenticate, list, and remove MCP (Model Context Protocol) servers";
+  }
+
+  const serverNames = Object.keys(servers);
+  return `Manage MCP servers. Configured: ${serverNames.join(", ")}. Load this skill to check status, authenticate, or add/remove servers.`;
+}
+
 function formatSkillsCatalog(skills: SkillSummary[]): string {
   // Filter out skills with disableModelInvocation or unsupported OS
   const visible = skills.filter((s) => {
@@ -908,7 +923,9 @@ function formatSkillsCatalog(skills: SkillSummary[]): string {
   for (const skill of visible) {
     const idAttr = escapeXml(skill.id);
     const nameAttr = escapeXml(skill.name);
-    const descAttr = escapeXml(skill.description);
+    const descAttr = skill.id === "mcp-setup"
+      ? escapeXml(getMcpSetupDescription())
+      : escapeXml(skill.description);
     const locAttr = escapeXml(skill.directoryPath);
     const credAttr = skill.credentialSetupFor
       ? ` credential-setup-for="${escapeXml(skill.credentialSetupFor)}"`


### PR DESCRIPTION
## Summary
- Adds a bundled `mcp-setup` skill that teaches the assistant how to use `vellum mcp` CLI commands (add, auth, list, remove)
- Dynamically generates the skill description in the system prompt to include configured MCP server names (e.g. `Configured: context7, linear`), so the model knows which servers exist and loads the skill when relevant
- Instructs users to quit/relaunch the app after auth changes (since the app runs its own daemon separate from the CLI daemon)

## Test plan
- [ ] With MCP servers configured, verify system prompt shows `mcp-setup` skill with server names in description
- [ ] Ask "what are my issues in linear" — model should load mcp-setup skill and offer to run `vellum mcp auth linear`
- [ ] With no MCP servers configured, verify mcp-setup skill shows generic description

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
