### PR TITLE
M2: Add 3-dot hover menu overlay on app cards

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -176,6 +176,8 @@ struct AppsGridView: View {
                             Label(app.isPinned ? "Unpin" : "Pin", systemImage: app.isPinned ? "pin.slash" : "pin")
                         }
                         Button(role: .destructive) {
+                            hoveredAppId = nil
+                            NSCursor.pop()
                             appListManager.removeApp(id: app.id)
                         } label: {
                             Label("Delete", systemImage: "trash")

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -164,6 +164,36 @@ struct AppsGridView: View {
                     RoundedRectangle(cornerRadius: VRadius.lg)
                         .stroke(VColor.surfaceBorder, lineWidth: 1)
                 )
+                .overlay(alignment: .topTrailing) {
+                    Menu {
+                        Button {
+                            if app.isPinned {
+                                appListManager.unpinApp(id: app.id)
+                            } else {
+                                appListManager.pinApp(id: app.id)
+                            }
+                        } label: {
+                            Label(app.isPinned ? "Unpin" : "Pin", systemImage: app.isPinned ? "pin.slash" : "pin")
+                        }
+                        Button(role: .destructive) {
+                            appListManager.removeApp(id: app.id)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis")
+                            .font(.system(size: 14, weight: .bold))
+                            .foregroundColor(.white)
+                            .frame(width: 28, height: 28)
+                            .background(Circle().fill(Color(hex: 0x4B6845)))
+                    }
+                    .menuStyle(.borderlessButton)
+                    .menuIndicator(.hidden)
+                    .fixedSize()
+                    .padding(VSpacing.sm)
+                    .opacity(isHovered ? 1 : 0)
+                    .animation(VAnimation.fast, value: isHovered)
+                }
                 .shadow(color: .black.opacity(0.06), radius: 4, y: 2)
 
                 // Name + date below the image

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -192,6 +192,7 @@ struct AppsGridView: View {
                     .fixedSize()
                     .padding(VSpacing.sm)
                     .opacity(isHovered ? 1 : 0)
+                    .allowsHitTesting(isHovered)
                     .animation(VAnimation.fast, value: isHovered)
                 }
                 .shadow(color: .black.opacity(0.06), radius: 4, y: 2)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -189,6 +189,7 @@ struct AppsGridView: View {
                     }
                     .menuStyle(.borderlessButton)
                     .menuIndicator(.hidden)
+                    .accessibilityLabel("App actions")
                     .fixedSize()
                     .padding(VSpacing.sm)
                     .opacity(isHovered ? 1 : 0)


### PR DESCRIPTION
Adds a circular dark green 3-dot menu button in the top-right corner of app card previews on hover. Menu contains Pin/Unpin and Delete actions. Keeps existing right-click context menu. Part of #11700.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
