### PR TITLE
Fix import sort lint errors

### DIFF
--- a/assistant/src/__tests__/trusted-contact-approval-notifier.test.ts
+++ b/assistant/src/__tests__/trusted-contact-approval-notifier.test.ts
@@ -127,8 +127,8 @@ mock.module("../config/user-reference.js", () => ({
 
 // Import module under test AFTER mocks are set up
 import type { ChannelId } from "../channels/types.js";
-import type { GuardianContext } from "../runtime/guardian-context-resolver.js";
 import { resolveUserReference } from "../config/user-reference.js";
+import type { GuardianContext } from "../runtime/guardian-context-resolver.js";
 
 // We need to test the private functions by importing the module.
 // Since startTrustedContactApprovalNotifier is not exported, we test it

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -9,6 +9,7 @@
 import type { ChannelId, InterfaceId } from '../../channels/types.js';
 import { CHANNEL_IDS, INTERFACE_IDS, isChannelId, parseInterfaceId } from '../../channels/types.js';
 import { getGatewayInternalBaseUrl } from '../../config/env.js';
+import { resolveUserReference } from '../../config/user-reference.js';
 import { RESEND_COOLDOWN_MS } from '../../daemon/handlers/config-channels.js';
 import * as attachmentsStore from '../../memory/attachments-store.js';
 import {
@@ -27,7 +28,6 @@ import { canonicalizeInboundIdentity } from '../../util/canonicalize-identity.js
 import { IngressBlockedError } from '../../util/errors.js';
 import { getLogger } from '../../util/logger.js';
 import { notifyGuardianOfAccessRequest } from '../access-request-helper.js';
-import { resolveUserReference } from '../../config/user-reference.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import { mintDaemonDeliveryToken } from '../auth/token-service.js';
 import {


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint errors in `trusted-contact-approval-notifier.test.ts` and `inbound-message-handler.ts`
- Just import reordering, no logic changes

## Original prompt
fix the errors in CI here: https://github.com/vellum-ai/vellum-assistant/actions/runs/22638267369

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
