### PR TITLE
feat: skip assistant onboarding in desktop-app-hatched fixture

### DIFF
--- a/playwright/agent/fixtures.ts
+++ b/playwright/agent/fixtures.ts
@@ -7,7 +7,8 @@
  */
 
 import { execSync } from "child_process";
-import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "fs";
+import os from "os";
 import path from "path";
 
 // ── Types ───────────────────────────────────────────────────────────
@@ -89,6 +90,7 @@ async function createDesktopAppHatchedFixture(options: FixtureOptions): Promise<
   verifyAppExists(appDisplayName);
   ensureVellumInPath(appDisplayName);
   ensureAssistantHatched();
+  skipAssistantOnboarding();
 
   return {
     teardown: async () => {
@@ -226,6 +228,17 @@ function ensureAssistantHatched(): void {
   }
 
   logVellumPs();
+}
+
+/**
+ * Deletes BOOTSTRAP.md from the assistant workspace so the assistant
+ * skips its first-run acclimation flow (name, personality, etc.).
+ */
+function skipAssistantOnboarding(): void {
+  const bootstrapPath = path.join(os.homedir(), ".vellum", "workspace", "BOOTSTRAP.md");
+  if (existsSync(bootstrapPath)) {
+    unlinkSync(bootstrapPath);
+  }
 }
 
 function retireAssistant(): void {

--- a/playwright/agent/fixtures.ts
+++ b/playwright/agent/fixtures.ts
@@ -100,6 +100,13 @@ async function createDesktopAppHatchedFixture(options: FixtureOptions): Promise<
   };
 }
 
+// ── Path Helpers ────────────────────────────────────────────────────
+
+/** Resolves the base data directory, respecting the BASE_DATA_DIR env var. */
+function getBaseDir(): string {
+  return process.env.BASE_DATA_DIR?.trim() || os.homedir();
+}
+
 // ── Shared Helpers ──────────────────────────────────────────────────
 
 function verifyAppExists(appDisplayName: string): void {
@@ -268,7 +275,7 @@ async function ensureAssistantHatched(): Promise<void> {
  * Throws if the lockfile is missing or has no assistant entries.
  */
 function readRuntimeUrlFromLockfile(): string {
-  const lockfilePath = path.join(os.homedir(), ".vellum.lock.json");
+  const lockfilePath = path.join(getBaseDir(), ".vellum.lock.json");
   if (!existsSync(lockfilePath)) {
     throw new Error("Lockfile (~/.vellum.lock.json) not found after hatching");
   }
@@ -294,7 +301,7 @@ function readRuntimeUrlFromLockfile(): string {
  * skips its first-run acclimation flow (name, personality, etc.).
  */
 function skipAssistantOnboarding(): void {
-  const bootstrapPath = path.join(os.homedir(), ".vellum", "workspace", "BOOTSTRAP.md");
+  const bootstrapPath = path.join(getBaseDir(), ".vellum", "workspace", "BOOTSTRAP.md");
   if (existsSync(bootstrapPath)) {
     unlinkSync(bootstrapPath);
   }

--- a/playwright/agent/fixtures.ts
+++ b/playwright/agent/fixtures.ts
@@ -7,7 +7,7 @@
  */
 
 import { execSync } from "child_process";
-import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import os from "os";
 import path from "path";
 
@@ -89,7 +89,7 @@ async function createDesktopAppHatchedFixture(options: FixtureOptions): Promise<
 
   verifyAppExists(appDisplayName);
   ensureVellumInPath(appDisplayName);
-  ensureAssistantHatched();
+  await ensureAssistantHatched();
   skipAssistantOnboarding();
 
   return {
@@ -188,12 +188,14 @@ function ensureVellumInPath(appDisplayName: string): void {
 }
 
 /**
- * Ensures an assistant is hatched.
+ * Ensures an assistant is hatched, the lockfile is populated, and the
+ * assistant is healthy before returning.
  *
  * Checks `vellum ps` for an existing assistant. If none is found,
- * runs `vellum hatch` to create one.
+ * runs `vellum hatch` to create one. Then verifies the lockfile has
+ * an assistant entry and polls `/healthz` until it reports healthy.
  */
-function ensureAssistantHatched(): void {
+async function ensureAssistantHatched(): Promise<void> {
   let psOutput: string;
   try {
     psOutput = execSync("vellum ps", {
@@ -210,24 +212,81 @@ function ensureAssistantHatched(): void {
     .split("\n")
     .filter((l) => l.trim() && !l.includes("NAME") && !l.startsWith("  -"));
 
-  if (lines.length > 0) {
-    logVellumPs();
-    return;
-  }
-
-  // No assistant found — hatch one
-  try {
-    execSync("vellum hatch", {
-      stdio: "inherit",
-      timeout: 300_000,
-      shell: "/bin/bash",
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw new Error(`Failed to hatch assistant: ${message}`);
+  if (lines.length === 0) {
+    // No assistant found — hatch one
+    try {
+      execSync("vellum hatch", {
+        stdio: "inherit",
+        timeout: 300_000,
+        shell: "/bin/bash",
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to hatch assistant: ${message}`);
+    }
   }
 
   logVellumPs();
+
+  // Verify the lockfile was updated with an assistant entry
+  const runtimeUrl = readRuntimeUrlFromLockfile();
+
+  // Poll health endpoint until the assistant is ready
+  const maxWaitMs = 60_000;
+  const pollIntervalMs = 1_000;
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < maxWaitMs) {
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 1_500);
+      const response = await fetch(`${runtimeUrl}/healthz`, {
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+
+      if (response.ok) {
+        const body = (await response.json()) as { status?: string };
+        if (body.status === "healthy") {
+          return;
+        }
+      }
+    } catch {
+      // Not ready yet — keep polling
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  throw new Error(
+    `Assistant at ${runtimeUrl} did not become healthy within ${maxWaitMs / 1_000}s`,
+  );
+}
+
+/**
+ * Reads the latest assistant's runtimeUrl from ~/.vellum.lock.json.
+ * Throws if the lockfile is missing or has no assistant entries.
+ */
+function readRuntimeUrlFromLockfile(): string {
+  const lockfilePath = path.join(os.homedir(), ".vellum.lock.json");
+  if (!existsSync(lockfilePath)) {
+    throw new Error("Lockfile (~/.vellum.lock.json) not found after hatching");
+  }
+
+  const raw = readFileSync(lockfilePath, "utf-8");
+  const data = JSON.parse(raw) as { assistants?: { runtimeUrl?: string }[] };
+  const assistants = data.assistants;
+
+  if (!Array.isArray(assistants) || assistants.length === 0) {
+    throw new Error("No assistant entries in lockfile after hatching");
+  }
+
+  const runtimeUrl = assistants[0].runtimeUrl;
+  if (!runtimeUrl) {
+    throw new Error("Assistant entry missing runtimeUrl in lockfile");
+  }
+
+  return runtimeUrl;
 }
 
 /**

--- a/playwright/agent/fixtures.ts
+++ b/playwright/agent/fixtures.ts
@@ -144,39 +144,51 @@ function logVellumPs(): void {
 }
 
 /**
- * Resolves the path to the bundled `vellum-cli` binary inside the
- * desktop app and creates a `vellum` symlink in a temporary bin
- * directory that is prepended to PATH. This ensures all subsequent
- * `vellum` commands use the CLI that ships with the app under test.
+ * Resolves the bundled binaries inside the desktop app and symlinks them
+ * into a temporary bin directory prepended to PATH. Symlinks vellum-cli
+ * as `vellum`, plus vellum-daemon and vellum-gateway so the CLI can find
+ * sibling binaries when hatching. Sets VELLUM_DESKTOP_APP so the CLI
+ * uses the bundled-binary code path instead of looking for source files.
  */
 function ensureVellumInPath(appDisplayName: string): void {
   const appDir = path.resolve(__dirname, "../../clients/macos/dist");
-  const cliBinary = path.join(appDir, `${appDisplayName}.app`, "Contents", "MacOS", "vellum-cli");
+  const macosDir = path.join(appDir, `${appDisplayName}.app`, "Contents", "MacOS");
+  const cliBinary = path.join(macosDir, "vellum-cli");
 
   if (!existsSync(cliBinary)) {
     throw new Error(`Bundled CLI not found at: ${cliBinary}`);
   }
 
-  // Create a temp bin dir with a `vellum` symlink pointing to the bundled CLI
+  // Create a temp bin dir with symlinks for all bundled binaries
   const tmpBin = path.join(__dirname, "../.vellum-bin");
   mkdirSync(tmpBin, { recursive: true });
-  const symlinkPath = path.join(tmpBin, "vellum");
 
-  try {
-    // Remove stale symlink if it exists
-    if (existsSync(symlinkPath)) {
-      execSync(`rm -f ${JSON.stringify(symlinkPath)}`);
+  const symlinks: Array<[string, string]> = [
+    [cliBinary, path.join(tmpBin, "vellum")],
+    [path.join(macosDir, "vellum-daemon"), path.join(tmpBin, "vellum-daemon")],
+    [path.join(macosDir, "vellum-gateway"), path.join(tmpBin, "vellum-gateway")],
+  ];
+
+  for (const [target, link] of symlinks) {
+    if (!existsSync(target)) continue;
+    try {
+      if (existsSync(link)) {
+        execSync(`rm -f ${JSON.stringify(link)}`);
+      }
+      execSync(`ln -s ${JSON.stringify(target)} ${JSON.stringify(link)}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to create symlink ${link}: ${message}`);
     }
-    execSync(`ln -s ${JSON.stringify(cliBinary)} ${JSON.stringify(symlinkPath)}`);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw new Error(`Failed to create vellum symlink: ${message}`);
   }
 
   // Prepend the temp bin dir to PATH
   if (!process.env.PATH?.includes(tmpBin)) {
     process.env.PATH = `${tmpBin}:${process.env.PATH ?? ""}`;
   }
+
+  // Tell the CLI to use the bundled-binary code path
+  process.env.VELLUM_DESKTOP_APP = "1";
 
   // Verify it works
   try {

--- a/playwright/agent/fixtures.ts
+++ b/playwright/agent/fixtures.ts
@@ -267,8 +267,23 @@ async function ensureAssistantHatched(): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
   }
 
+  // Collect diagnostics: vellum ps, hatch.log, and last health response
+  let psInfo = "";
+  try {
+    psInfo = execSync("vellum ps 2>&1", {
+      encoding: "utf-8",
+      timeout: 30_000,
+      shell: "/bin/bash",
+    });
+  } catch (err: unknown) {
+    psInfo = (err as { stdout?: string }).stdout || "vellum ps failed";
+  }
+
+  const diagnostics = buildDiagnostics(hatchOutput);
+
   throw new Error(
-    `Assistant at ${runtimeUrl} did not become healthy within ${maxWaitMs / 1_000}s`,
+    `Assistant at ${runtimeUrl} did not become healthy within ${maxWaitMs / 1_000}s\n` +
+      `--- vellum ps ---\n${psInfo}\n\n${diagnostics}`,
   );
 }
 

--- a/playwright/agent/fixtures.ts
+++ b/playwright/agent/fixtures.ts
@@ -238,18 +238,22 @@ async function ensureAssistantHatched(): Promise<void> {
   logVellumPs();
 
   // Verify the lockfile was updated with an assistant entry
-  const runtimeUrl = readRuntimeUrlFromLockfile(hatchOutput);
+  const { runtimeUrl, assistantId } = readAssistantFromLockfile(hatchOutput);
 
-  // Poll health endpoint until the assistant is ready
+  // Poll the daemon directly (port 7821) rather than through the gateway,
+  // since the gateway may require auth for proxied health checks.
+  const daemonUrl = "http://localhost:7821";
+
   const maxWaitMs = 60_000;
   const pollIntervalMs = 1_000;
   const startTime = Date.now();
+  let lastHealthError = "";
 
   while (Date.now() - startTime < maxWaitMs) {
     try {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), 1_500);
-      const response = await fetch(`${runtimeUrl}/healthz`, {
+      const response = await fetch(`${daemonUrl}/healthz`, {
         signal: controller.signal,
       });
       clearTimeout(timeoutId);
@@ -259,31 +263,59 @@ async function ensureAssistantHatched(): Promise<void> {
         if (body.status === "healthy") {
           return;
         }
+        lastHealthError = `status=${response.status} body=${JSON.stringify(body)}`;
+      } else {
+        lastHealthError = `status=${response.status}`;
       }
-    } catch {
-      // Not ready yet — keep polling
+    } catch (err) {
+      lastHealthError =
+        err instanceof Error ? `${err.name}: ${err.message}` : String(err);
     }
 
     await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
   }
 
-  // Collect diagnostics: vellum ps, hatch.log, and last health response
-  let psInfo = "";
+  // Collect diagnostics
+  const diagParts: string[] = [];
+
+  diagParts.push(`Last health check error: ${lastHealthError}`);
+
+  // vellum ps (overview)
   try {
-    psInfo = execSync("vellum ps 2>&1", {
+    const ps = execSync("vellum ps 2>&1", {
       encoding: "utf-8",
       timeout: 30_000,
       shell: "/bin/bash",
     });
+    diagParts.push(`--- vellum ps ---\n${ps.trim()}`);
   } catch (err: unknown) {
-    psInfo = (err as { stdout?: string }).stdout || "vellum ps failed";
+    diagParts.push(
+      `--- vellum ps ---\n${(err as { stdout?: string }).stdout || "failed"}`,
+    );
   }
 
-  const diagnostics = buildDiagnostics(hatchOutput);
+  // vellum ps <name> (subprocess details)
+  if (assistantId) {
+    try {
+      const psDetail = execSync(
+        `vellum ps ${JSON.stringify(assistantId)} 2>&1`,
+        { encoding: "utf-8", timeout: 30_000, shell: "/bin/bash" },
+      );
+      diagParts.push(
+        `--- vellum ps ${assistantId} ---\n${psDetail.trim()}`,
+      );
+    } catch (err: unknown) {
+      diagParts.push(
+        `--- vellum ps ${assistantId} ---\n${(err as { stdout?: string }).stdout || "failed"}`,
+      );
+    }
+  }
+
+  diagParts.push(buildDiagnostics(hatchOutput));
 
   throw new Error(
-    `Assistant at ${runtimeUrl} did not become healthy within ${maxWaitMs / 1_000}s\n` +
-      `--- vellum ps ---\n${psInfo}\n\n${diagnostics}`,
+    `Assistant daemon at ${daemonUrl} did not become healthy within ${maxWaitMs / 1_000}s ` +
+      `(gateway: ${runtimeUrl})\n\n${diagParts.join("\n\n")}`,
   );
 }
 
@@ -301,10 +333,13 @@ function hasAssistantInLockfile(): boolean {
 }
 
 /**
- * Reads the latest assistant's runtimeUrl from ~/.vellum.lock.json.
+ * Reads the latest assistant's runtimeUrl and assistantId from ~/.vellum.lock.json.
  * Throws if the lockfile is missing or has no assistant entries.
  */
-function readRuntimeUrlFromLockfile(hatchOutput: string): string {
+function readAssistantFromLockfile(hatchOutput: string): {
+  runtimeUrl: string;
+  assistantId: string;
+} {
   const diagnostics = buildDiagnostics(hatchOutput);
   const lockfilePath = path.join(getBaseDir(), ".vellum.lock.json");
 
@@ -315,7 +350,9 @@ function readRuntimeUrlFromLockfile(hatchOutput: string): string {
   }
 
   const raw = readFileSync(lockfilePath, "utf-8");
-  const data = JSON.parse(raw) as { assistants?: { runtimeUrl?: string }[] };
+  const data = JSON.parse(raw) as {
+    assistants?: { runtimeUrl?: string; assistantId?: string }[];
+  };
   const assistants = data.assistants;
 
   if (!Array.isArray(assistants) || assistants.length === 0) {
@@ -324,14 +361,17 @@ function readRuntimeUrlFromLockfile(hatchOutput: string): string {
     );
   }
 
-  const runtimeUrl = assistants[0].runtimeUrl;
-  if (!runtimeUrl) {
+  const entry = assistants[0];
+  if (!entry.runtimeUrl) {
     throw new Error(
       `Assistant entry missing runtimeUrl in lockfile.\n${diagnostics}`,
     );
   }
 
-  return runtimeUrl;
+  return {
+    runtimeUrl: entry.runtimeUrl,
+    assistantId: entry.assistantId || "",
+  };
 }
 
 /** Collects hatch CLI output and hatch.log into a single diagnostic string. */
@@ -348,8 +388,8 @@ function buildDiagnostics(hatchOutput: string): string {
     try {
       const contents = readFileSync(logPath, "utf-8");
       const lines = contents.split("\n");
-      const tail = lines.slice(-50).join("\n");
-      parts.push(`--- hatch.log (last 50 lines) ---\n${tail}`);
+      const tail = lines.slice(-200).join("\n");
+      parts.push(`--- hatch.log (last 200 lines) ---\n${tail}`);
     } catch {
       parts.push(`Failed to read hatch.log at ${logPath}`);
     }

--- a/playwright/agent/fixtures.ts
+++ b/playwright/agent/fixtures.ts
@@ -211,9 +211,15 @@ async function ensureAssistantHatched(): Promise<void> {
         timeout: 300_000,
         shell: "/bin/bash",
       });
-    } catch (err) {
+    } catch (err: unknown) {
+      const output =
+        (err as { stdout?: string }).stdout ||
+        (err as { stderr?: string }).stderr ||
+        "";
       const message = err instanceof Error ? err.message : String(err);
-      throw new Error(`Failed to hatch assistant: ${message}`);
+      throw new Error(
+        `Failed to hatch assistant: ${message}${output ? `\n--- vellum hatch output ---\n${output}` : ""}`,
+      );
     }
   }
 

--- a/playwright/agent/fixtures.ts
+++ b/playwright/agent/fixtures.ts
@@ -198,32 +198,15 @@ function ensureVellumInPath(appDisplayName: string): void {
  * Ensures an assistant is hatched, the lockfile is populated, and the
  * assistant is healthy before returning.
  *
- * Checks `vellum ps` for an existing assistant. If none is found,
- * runs `vellum hatch` to create one. Then verifies the lockfile has
- * an assistant entry and polls `/healthz` until it reports healthy.
+ * Checks the lockfile for an existing assistant. If none is found,
+ * runs `vellum hatch` to create one. Then polls `/healthz` until
+ * the assistant reports healthy.
  */
 async function ensureAssistantHatched(): Promise<void> {
-  let psOutput: string;
-  try {
-    psOutput = execSync("vellum ps", {
-      encoding: "utf-8",
-      timeout: 30_000,
-      shell: "/bin/bash",
-    });
-  } catch {
-    // vellum ps failed — try hatching
-    psOutput = "";
-  }
-
-  const lines = psOutput
-    .split("\n")
-    .filter((l) => l.trim() && !l.includes("NAME") && !l.startsWith("  -"));
-
   let hatchOutput = "";
-  if (lines.length === 0) {
-    // No assistant found — hatch one
+  if (!hasAssistantInLockfile()) {
     try {
-      hatchOutput = execSync("vellum hatch", {
+      hatchOutput = execSync("vellum hatch 2>&1", {
         encoding: "utf-8",
         timeout: 300_000,
         shell: "/bin/bash",
@@ -269,6 +252,19 @@ async function ensureAssistantHatched(): Promise<void> {
   throw new Error(
     `Assistant at ${runtimeUrl} did not become healthy within ${maxWaitMs / 1_000}s`,
   );
+}
+
+/** Returns true if the lockfile exists and contains at least one assistant. */
+function hasAssistantInLockfile(): boolean {
+  const lockfilePath = path.join(getBaseDir(), ".vellum.lock.json");
+  if (!existsSync(lockfilePath)) return false;
+  try {
+    const raw = readFileSync(lockfilePath, "utf-8");
+    const data = JSON.parse(raw) as { assistants?: unknown[] };
+    return Array.isArray(data.assistants) && data.assistants.length > 0;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/playwright/agent/fixtures.ts
+++ b/playwright/agent/fixtures.ts
@@ -219,11 +219,12 @@ async function ensureAssistantHatched(): Promise<void> {
     .split("\n")
     .filter((l) => l.trim() && !l.includes("NAME") && !l.startsWith("  -"));
 
+  let hatchOutput = "";
   if (lines.length === 0) {
     // No assistant found — hatch one
     try {
-      execSync("vellum hatch", {
-        stdio: "inherit",
+      hatchOutput = execSync("vellum hatch", {
+        encoding: "utf-8",
         timeout: 300_000,
         shell: "/bin/bash",
       });
@@ -236,7 +237,7 @@ async function ensureAssistantHatched(): Promise<void> {
   logVellumPs();
 
   // Verify the lockfile was updated with an assistant entry
-  const runtimeUrl = readRuntimeUrlFromLockfile();
+  const runtimeUrl = readRuntimeUrlFromLockfile(hatchOutput);
 
   // Poll health endpoint until the assistant is ready
   const maxWaitMs = 60_000;
@@ -274,11 +275,13 @@ async function ensureAssistantHatched(): Promise<void> {
  * Reads the latest assistant's runtimeUrl from ~/.vellum.lock.json.
  * Throws if the lockfile is missing or has no assistant entries.
  */
-function readRuntimeUrlFromLockfile(): string {
+function readRuntimeUrlFromLockfile(hatchOutput: string): string {
+  const diagnostics = buildDiagnostics(hatchOutput);
   const lockfilePath = path.join(getBaseDir(), ".vellum.lock.json");
+
   if (!existsSync(lockfilePath)) {
     throw new Error(
-      `Lockfile not found at ${lockfilePath} after hatching.\n${readHatchLog()}`,
+      `Lockfile not found at ${lockfilePath} after hatching.\n${diagnostics}`,
     );
   }
 
@@ -288,35 +291,44 @@ function readRuntimeUrlFromLockfile(): string {
 
   if (!Array.isArray(assistants) || assistants.length === 0) {
     throw new Error(
-      `No assistant entries in lockfile after hatching.\n${readHatchLog()}`,
+      `No assistant entries in lockfile after hatching.\n${diagnostics}`,
     );
   }
 
   const runtimeUrl = assistants[0].runtimeUrl;
   if (!runtimeUrl) {
     throw new Error(
-      `Assistant entry missing runtimeUrl in lockfile.\n${readHatchLog()}`,
+      `Assistant entry missing runtimeUrl in lockfile.\n${diagnostics}`,
     );
   }
 
   return runtimeUrl;
 }
 
-/** Returns the tail of hatch.log for diagnostic error messages. */
-function readHatchLog(): string {
+/** Collects hatch CLI output and hatch.log into a single diagnostic string. */
+function buildDiagnostics(hatchOutput: string): string {
+  const parts: string[] = [];
+
+  if (hatchOutput.trim()) {
+    parts.push(`--- vellum hatch output ---\n${hatchOutput.trim()}`);
+  }
+
   const configHome = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
   const logPath = path.join(configHome, "vellum", "logs", "hatch.log");
-  if (!existsSync(logPath)) {
-    return `hatch.log not found at ${logPath}`;
+  if (existsSync(logPath)) {
+    try {
+      const contents = readFileSync(logPath, "utf-8");
+      const lines = contents.split("\n");
+      const tail = lines.slice(-50).join("\n");
+      parts.push(`--- hatch.log (last 50 lines) ---\n${tail}`);
+    } catch {
+      parts.push(`Failed to read hatch.log at ${logPath}`);
+    }
+  } else {
+    parts.push(`hatch.log not found at ${logPath}`);
   }
-  try {
-    const contents = readFileSync(logPath, "utf-8");
-    const lines = contents.split("\n");
-    const tail = lines.slice(-50).join("\n");
-    return `--- hatch.log (last 50 lines) ---\n${tail}`;
-  } catch {
-    return `Failed to read hatch.log at ${logPath}`;
-  }
+
+  return parts.join("\n\n");
 }
 
 /**

--- a/playwright/agent/fixtures.ts
+++ b/playwright/agent/fixtures.ts
@@ -91,6 +91,7 @@ async function createDesktopAppHatchedFixture(options: FixtureOptions): Promise<
   ensureVellumInPath(appDisplayName);
   await ensureAssistantHatched();
   skipAssistantOnboarding();
+  ensureApiKeyInDefaults();
 
   return {
     teardown: async () => {
@@ -408,6 +409,26 @@ function skipAssistantOnboarding(): void {
   const bootstrapPath = path.join(getBaseDir(), ".vellum", "workspace", "BOOTSTRAP.md");
   if (existsSync(bootstrapPath)) {
     unlinkSync(bootstrapPath);
+  }
+}
+
+/**
+ * Writes the ANTHROPIC_API_KEY from the environment into the app's
+ * UserDefaults so the macOS app sees a valid key and skips the auth
+ * setup screen.
+ */
+function ensureApiKeyInDefaults(): void {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) return;
+
+  const domain = "com.vellum.vellum-assistant";
+  try {
+    execSync(
+      `defaults write ${domain} vellum_provider_anthropic ${JSON.stringify(apiKey)}`,
+      { timeout: 5_000 },
+    );
+  } catch {
+    // Best-effort — tests may still work if auth is handled differently
   }
 }
 

--- a/playwright/agent/fixtures.ts
+++ b/playwright/agent/fixtures.ts
@@ -277,7 +277,9 @@ async function ensureAssistantHatched(): Promise<void> {
 function readRuntimeUrlFromLockfile(): string {
   const lockfilePath = path.join(getBaseDir(), ".vellum.lock.json");
   if (!existsSync(lockfilePath)) {
-    throw new Error("Lockfile (~/.vellum.lock.json) not found after hatching");
+    throw new Error(
+      `Lockfile not found at ${lockfilePath} after hatching.\n${readHatchLog()}`,
+    );
   }
 
   const raw = readFileSync(lockfilePath, "utf-8");
@@ -285,15 +287,36 @@ function readRuntimeUrlFromLockfile(): string {
   const assistants = data.assistants;
 
   if (!Array.isArray(assistants) || assistants.length === 0) {
-    throw new Error("No assistant entries in lockfile after hatching");
+    throw new Error(
+      `No assistant entries in lockfile after hatching.\n${readHatchLog()}`,
+    );
   }
 
   const runtimeUrl = assistants[0].runtimeUrl;
   if (!runtimeUrl) {
-    throw new Error("Assistant entry missing runtimeUrl in lockfile");
+    throw new Error(
+      `Assistant entry missing runtimeUrl in lockfile.\n${readHatchLog()}`,
+    );
   }
 
   return runtimeUrl;
+}
+
+/** Returns the tail of hatch.log for diagnostic error messages. */
+function readHatchLog(): string {
+  const configHome = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
+  const logPath = path.join(configHome, "vellum", "logs", "hatch.log");
+  if (!existsSync(logPath)) {
+    return `hatch.log not found at ${logPath}`;
+  }
+  try {
+    const contents = readFileSync(logPath, "utf-8");
+    const lines = contents.split("\n");
+    const tail = lines.slice(-50).join("\n");
+    return `--- hatch.log (last 50 lines) ---\n${tail}`;
+  } catch {
+    return `Failed to read hatch.log at ${logPath}`;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Deletes `BOOTSTRAP.md` from the assistant workspace after hatching in the `desktop-app-hatched` fixture
- This signals to the daemon that the first-run acclimation flow (name, personality, etc.) is complete, so tests skip it

## Test plan
- [ ] Verify tests using `desktop-app-hatched` fixture no longer trigger the assistant onboarding flow
- [ ] Verify tests using `desktop-app` fixture still trigger onboarding as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
