### PR TITLE
fix: section spacing = content padding (VSpacing.lg) across settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -242,7 +242,7 @@ struct SettingsPanel: View {
     // MARK: - Integrations Tab
 
     private var integrationsContent: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xl) {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
             // ANTHROPIC section
             VStack(alignment: .leading, spacing: VSpacing.md) {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
@@ -709,7 +709,7 @@ struct SettingsPanel: View {
     // MARK: - Permissions Tab
 
     private var permissionsContent: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xl) {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
             // PERMISSIONS section (OS permissions)
             VStack(alignment: .leading, spacing: VSpacing.md) {
                 Text("macOS System Permissions")

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAutomationTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAutomationTab.swift
@@ -89,7 +89,7 @@ struct HeartbeatAutomationSection: View {
     @State private var expandedRunId: String?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xl) {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
             checklistCard
             runsCard
         }


### PR DESCRIPTION
Changes the top-level section VStack spacing to VSpacing.lg (16pt) across all settings views, matching the .padding(VSpacing.lg) used on the content area. Previously some used VSpacing.xl (24pt).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
