### PR TITLE
fix: Cancel buttons → .tertiary variant across all settings views

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -313,7 +313,7 @@ struct SettingsPanel: View {
                                 anthropicSetupExpanded = false
                             }
                             .disabled(apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                            VButton(label: "Cancel", style: .secondary, size: .large) {
+                            VButton(label: "Cancel", style: .tertiary, size: .large) {
                                 apiKeyText = ""
                                 anthropicSetupExpanded = false
                             }
@@ -379,7 +379,7 @@ struct SettingsPanel: View {
                                 perplexitySetupExpanded = false
                             }
                             .disabled(perplexityKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                            VButton(label: "Cancel", style: .secondary, size: .large) {
+                            VButton(label: "Cancel", style: .tertiary, size: .large) {
                                 perplexityKeyText = ""
                                 perplexitySetupExpanded = false
                             }
@@ -445,7 +445,7 @@ struct SettingsPanel: View {
                                 braveSetupExpanded = false
                             }
                             .disabled(braveKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                            VButton(label: "Cancel", style: .secondary, size: .large) {
+                            VButton(label: "Cancel", style: .tertiary, size: .large) {
                                 braveKeyText = ""
                                 braveSetupExpanded = false
                             }
@@ -532,7 +532,7 @@ struct SettingsPanel: View {
                                 imageGenSetupExpanded = false
                             }
                             .disabled(imageGenKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                            VButton(label: "Cancel", style: .secondary, size: .large) {
+                            VButton(label: "Cancel", style: .tertiary, size: .large) {
                                 imageGenKeyText = ""
                                 imageGenSetupExpanded = false
                             }

--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -137,7 +137,7 @@ struct GatewaySettingsCard: View {
                     tunnelSetupExpanded = false
                 }
                 // No .disabled() — empty URL is valid (clears the tunnel target)
-                VButton(label: "Cancel", style: .secondary, size: .large) {
+                VButton(label: "Cancel", style: .tertiary, size: .large) {
                     gatewayUrlText = store.ingressPublicBaseUrl
                     isGatewayUrlFocused = false
                     tunnelSetupExpanded = false

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -133,7 +133,7 @@ struct SettingsAccountTab: View {
                             isPlatformUrlFocused = false
                         }
                         .disabled(platformUrlText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                        VButton(label: "Cancel", style: .secondary, size: .large) {
+                        VButton(label: "Cancel", style: .tertiary, size: .large) {
                             platformUrlText = store.platformBaseUrl
                             isPlatformUrlFocused = false
                         }
@@ -150,7 +150,7 @@ struct SettingsAccountTab: View {
                             isPlatformUrlFocused = false
                         }
                         .disabled(platformUrlText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                        VButton(label: "Cancel", style: .secondary, size: .large) {
+                        VButton(label: "Cancel", style: .tertiary, size: .large) {
                             platformUrlText = ""
                             isPlatformUrlFocused = false
                         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -1429,7 +1429,7 @@ struct SettingsChannelsTab: View {
                     .padding(.leading, labelColumnWidth + VSpacing.sm)
             }
 
-            VButton(label: "Cancel", style: .secondary, size: .large) {
+            VButton(label: "Cancel", style: .tertiary, size: .large) {
                 store.cancelGuardianChallenge(channel: channel)
             }
         }


### PR DESCRIPTION
## Summary

- Changes all `VButton(label: "Cancel", style: .secondary)` instances to `style: .tertiary` across all settings views
- Covers `SettingsPanel.swift` (4 instances: Anthropic, Perplexity, Brave Search, Image Gen sections), `GatewaySettingsCard.swift` (1 instance), `SettingsAccountTab.swift` (2 instances), and `SettingsChannelsTab.swift` (1 instance)
- Leaves all already-`.tertiary` Cancel buttons untouched, and does not change any "Set Up" or "Save" buttons

## Test plan

- [ ] Open Settings → Models & Services: verify Cancel buttons in Anthropic, Perplexity, Brave Search, and Image Gen sections render as tertiary style
- [ ] Open Settings → Account: verify both Cancel buttons render as tertiary style
- [ ] Open Settings → Channels: verify Cancel button in guardian challenge section renders as tertiary style
- [ ] Open Gateway settings card: verify Cancel button renders as tertiary style

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
