### PR TITLE
fix: settings content on plain background (remove vCard)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -97,13 +97,12 @@ struct SettingsPanel: View {
             settingsNav
                 .frame(width: 200)
 
-            // Right: tab content lives in its own surface panel
+            // Right: tab content on plain window background
             ScrollView {
                 selectedTabContent
                     .padding(VSpacing.lg)
                     .frame(maxWidth: .infinity, alignment: .top)
             }
-            .vCard(radius: VRadius.lg, background: VColor.surface)
             .padding(.trailing, VSpacing.lg)
             .padding(.vertical, VSpacing.lg)
         }


### PR DESCRIPTION
Removes the .vCard(radius:background:) modifier from the settings tab content ScrollView. The bright white VColor.surface card was added in the previous pass but the user wants the content to sit on the plain window background (gray).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
