### PR TITLE
fix: section cards take full width across all settings tabs

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -897,6 +897,7 @@ struct SettingsPanel: View {
         }
         .padding(VSpacing.md)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func integrationDisplayName(_ id: String) -> String {

--- a/clients/macos/vellum-assistant/Features/Settings/ApprovedDevicesSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ApprovedDevicesSection.swift
@@ -64,6 +64,7 @@ struct ApprovedDevicesSection: View {
         }
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear {
             store.refreshApprovedDevices()
         }

--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -54,6 +54,7 @@ struct GatewaySettingsCard: View {
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear {
             store.refreshIngressConfig()
             gatewayUrlText = store.ingressPublicBaseUrl

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -196,6 +196,7 @@ struct SettingsAccountTab: View {
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Assistant Info
@@ -242,6 +243,7 @@ struct SettingsAccountTab: View {
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func infoRow(label: String, value: String, mono: Bool = false) -> some View {
@@ -330,6 +332,7 @@ struct SettingsAccountTab: View {
             .padding(VSpacing.lg)
             .frame(maxWidth: .infinity, alignment: .leading)
             .vCard(background: VColor.surfaceSubtle)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 
@@ -369,6 +372,7 @@ struct SettingsAccountTab: View {
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Hatch New Assistant
@@ -452,6 +456,7 @@ struct SettingsAccountTab: View {
             .padding(VSpacing.lg)
             .frame(maxWidth: .infinity, alignment: .leading)
             .vCard(background: VColor.surfaceSubtle)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
@@ -102,6 +102,7 @@ struct SettingsAdvancedDevTab: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func assistantFlagRow(flag: DaemonClient.AssistantFeatureFlag) -> some View {
@@ -210,6 +211,7 @@ struct SettingsAdvancedDevTab: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Developer
@@ -251,6 +253,7 @@ struct SettingsAdvancedDevTab: View {
             .padding(VSpacing.lg)
             .frame(maxWidth: .infinity, alignment: .leading)
             .vCard(background: VColor.surfaceSubtle)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -72,6 +72,7 @@ struct SettingsAppearanceTab: View {
             }
             .padding(VSpacing.lg)
             .vCard(background: VColor.surfaceSubtle)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .onAppear {
                 selectedTimezone = store.userTimezone ?? ""
             }
@@ -165,6 +166,7 @@ struct SettingsAppearanceTab: View {
             }
             .padding(VSpacing.lg)
             .vCard(background: VColor.surfaceSubtle)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .onDisappear {
                 stopRecording()
             }
@@ -237,6 +239,7 @@ struct SettingsAppearanceTab: View {
             }
             .padding(VSpacing.lg)
             .vCard(background: VColor.surfaceSubtle)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAutomationTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAutomationTab.swift
@@ -35,6 +35,7 @@ struct SettingsAutomationTab: View {
                 .padding(VSpacing.lg)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .vCard(background: VColor.surfaceSubtle)
+                .frame(maxWidth: .infinity, alignment: .leading)
 
                 VStack(alignment: .leading, spacing: VSpacing.md) {
                     Text("Scheduled Tasks")
@@ -58,6 +59,7 @@ struct SettingsAutomationTab: View {
                 .padding(VSpacing.lg)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .vCard(background: VColor.surfaceSubtle)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
 
             // Heartbeat section (checklist + runs, minus configCard)
@@ -139,6 +141,7 @@ struct HeartbeatAutomationSection: View {
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Recent Runs Card
@@ -231,6 +234,7 @@ struct HeartbeatAutomationSection: View {
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Helpers

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -256,6 +256,7 @@ struct SettingsChannelsTab: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Telegram Channel Card
@@ -310,6 +311,7 @@ struct SettingsChannelsTab: View {
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Telegram Approved Users
@@ -455,6 +457,7 @@ struct SettingsChannelsTab: View {
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Slack Channel Credential Entry
@@ -584,6 +587,7 @@ struct SettingsChannelsTab: View {
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Phone Calling Card
@@ -659,6 +663,7 @@ struct SettingsChannelsTab: View {
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Twilio Credential Entry
@@ -1519,6 +1524,7 @@ struct SettingsChannelsTab: View {
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -73,6 +73,7 @@ struct SettingsPrivacyTab: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Data Loading

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -25,6 +25,7 @@ struct ToolPermissionTesterView: View {
         }
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear {
             model.fetchToolNames()
         }

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -169,6 +169,7 @@ struct VoiceSettingsView: View {
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Custom Key Recording
@@ -368,6 +369,7 @@ struct VoiceSettingsView: View {
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func wakeWordStepCard(number: String, title: String, description: String) -> some View {
@@ -391,6 +393,7 @@ struct VoiceSettingsView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private let timeoutOptions: [(label: String, value: Int)] = [
@@ -464,5 +467,6 @@ struct VoiceSettingsView: View {
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }


### PR DESCRIPTION
Adds .frame(maxWidth: .infinity, alignment: .leading) after every .vCard(background:) modifier across all settings tab views to ensure sections stretch to full available width.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
