### PR TITLE
M3: Fix sidebar nav hover preview flicker

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1156,6 +1156,7 @@ struct MainWindowView: View {
                         sidebarPinnedAppRow(app)
                     }
                 }
+                .drawingGroup() // Isolate into Metal layer to prevent re-renders from sibling hover
 
                 VColor.divider
                     .frame(height: 1)
@@ -1356,6 +1357,7 @@ struct MainWindowView: View {
                         sidebarPinnedAppRow(app, isExpanded: false)
                     }
                 }
+                .drawingGroup() // Isolate into Metal layer to prevent re-renders from sibling hover
 
                 VColor.divider
                     .frame(height: 1)
@@ -1610,10 +1612,12 @@ private struct SidebarPrimaryRow: View {
             .padding(.trailing, isExpanded ? VSpacing.sm : 0)
             .padding(.vertical, VSpacing.sm)
             .frame(maxWidth: .infinity, alignment: isExpanded ? .leading : .center)
-            .background(isActive ? adaptiveColor(light: Moss._100, dark: Moss._700) : isHovered ? adaptiveColor(light: Moss._100, dark: Moss._700).opacity(0.5) : .clear)
+            .background(
+                (isActive ? adaptiveColor(light: Moss._100, dark: Moss._700) : isHovered ? adaptiveColor(light: Moss._100, dark: Moss._700).opacity(0.5) : .clear)
+                    .animation(VAnimation.fast, value: isHovered)
+            )
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())
-            .animation(VAnimation.fast, value: isHovered)
         }
         .buttonStyle(.plain)
         .padding(.horizontal, isExpanded ? VSpacing.sm : VSpacing.xs)


### PR DESCRIPTION
## Summary
- Scopes the hover animation in `SidebarPrimaryRow` to only the `.background()` modifier instead of the entire view, preventing sibling views from re-rendering when hover state changes
- Adds `.drawingGroup()` to pinned app rows in both expanded and collapsed sidebar modes, isolating them into a Metal layer so preview images don't flicker during sibling hover events

## Test plan
- [ ] Hover over Intelligence and Things nav items in the sidebar — pinned app preview cards should not flicker
- [ ] Verify hover highlight still animates smoothly on nav items
- [ ] Test in both expanded and collapsed sidebar modes
- [ ] Confirm pinned app rows still render correctly with `.drawingGroup()`

Part of #11700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
