### PR TITLE
Add package-level unit tests independent of runtime app

### DIFF
--- a/proxy-sidecar/src/__tests__/certs.test.ts
+++ b/proxy-sidecar/src/__tests__/certs.test.ts
@@ -1,0 +1,170 @@
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+
+import {
+  ensureCombinedCABundle,
+  ensureLocalCA,
+  getCAPath,
+  getCombinedCAPath,
+  issueLeafCert,
+} from '../certs.js';
+
+let dataDir: string;
+
+beforeAll(async () => {
+  dataDir = await mkdtemp(join(tmpdir(), 'proxy-sidecar-certs-test-'));
+});
+
+afterAll(async () => {
+  await rm(dataDir, { recursive: true, force: true });
+});
+
+describe('ensureLocalCA', () => {
+  test('creates CA cert and key with correct permissions', async () => {
+    await ensureLocalCA(dataDir);
+
+    const caDir = join(dataDir, 'proxy-ca');
+    const certStat = await stat(join(caDir, 'ca.pem'));
+    const keyStat = await stat(join(caDir, 'ca-key.pem'));
+
+    expect(certStat.isFile()).toBe(true);
+    expect(keyStat.isFile()).toBe(true);
+
+    // Check permissions (mask with 0o777 to get just the permission bits)
+    expect(keyStat.mode & 0o777).toBe(0o600);
+    expect(certStat.mode & 0o777).toBe(0o644);
+  });
+
+  test('is idempotent -- repeated calls do not regenerate', async () => {
+    const caDir = join(dataDir, 'proxy-ca');
+    const certBefore = await readFile(join(caDir, 'ca.pem'), 'utf-8');
+    const keyBefore = await readFile(join(caDir, 'ca-key.pem'), 'utf-8');
+
+    await ensureLocalCA(dataDir);
+
+    const certAfter = await readFile(join(caDir, 'ca.pem'), 'utf-8');
+    const keyAfter = await readFile(join(caDir, 'ca-key.pem'), 'utf-8');
+
+    expect(certAfter).toBe(certBefore);
+    expect(keyAfter).toBe(keyBefore);
+  });
+
+  test('CA cert is a valid PEM certificate', async () => {
+    const caDir = join(dataDir, 'proxy-ca');
+    const cert = await readFile(join(caDir, 'ca.pem'), 'utf-8');
+    expect(cert).toContain('BEGIN CERTIFICATE');
+    expect(cert).toContain('END CERTIFICATE');
+  });
+
+  test('CA key is a valid PEM private key', async () => {
+    const caDir = join(dataDir, 'proxy-ca');
+    const key = await readFile(join(caDir, 'ca-key.pem'), 'utf-8');
+    expect(key).toContain('BEGIN');
+    expect(key).toContain('END');
+  });
+});
+
+describe('issueLeafCert', () => {
+  const HOSTNAME = 'example.com';
+
+  test('generates a leaf cert for a hostname', async () => {
+    const caDir = join(dataDir, 'proxy-ca');
+    const result = await issueLeafCert(caDir, HOSTNAME);
+
+    expect(result.cert).toContain('BEGIN CERTIFICATE');
+    expect(result.key).toContain('BEGIN');
+
+    // Verify the issued files exist on disk
+    const issuedDir = join(caDir, 'issued');
+    const certStat_ = await stat(join(issuedDir, `${HOSTNAME}.pem`));
+    const keyStat_ = await stat(join(issuedDir, `${HOSTNAME}-key.pem`));
+    expect(certStat_.isFile()).toBe(true);
+    expect(keyStat_.isFile()).toBe(true);
+  });
+
+  test('returns cached cert on repeated calls', async () => {
+    const caDir = join(dataDir, 'proxy-ca');
+    const first = await issueLeafCert(caDir, HOSTNAME);
+    const second = await issueLeafCert(caDir, HOSTNAME);
+
+    expect(second.cert).toBe(first.cert);
+    expect(second.key).toBe(first.key);
+  });
+
+  test('generates different certs for different hostnames', async () => {
+    const caDir = join(dataDir, 'proxy-ca');
+    const certA = await issueLeafCert(caDir, 'a.example.com');
+    const certB = await issueLeafCert(caDir, 'b.example.com');
+
+    expect(certA.cert).not.toBe(certB.cert);
+    expect(certA.key).not.toBe(certB.key);
+  });
+
+  test('rejects invalid hostname characters', async () => {
+    const caDir = join(dataDir, 'proxy-ca');
+    await expect(issueLeafCert(caDir, 'host name with spaces')).rejects.toThrow(
+      'Invalid hostname',
+    );
+  });
+
+  test('rejects hostname with path traversal characters', async () => {
+    const caDir = join(dataDir, 'proxy-ca');
+    await expect(issueLeafCert(caDir, '../etc/passwd')).rejects.toThrow(
+      'Invalid hostname',
+    );
+  });
+
+  test('rejects hostname with special characters', async () => {
+    const caDir = join(dataDir, 'proxy-ca');
+    await expect(issueLeafCert(caDir, 'host;rm -rf /')).rejects.toThrow(
+      'Invalid hostname',
+    );
+  });
+
+  test('allows wildcard hostnames', async () => {
+    const caDir = join(dataDir, 'proxy-ca');
+    const result = await issueLeafCert(caDir, '*.example.com');
+    expect(result.cert).toContain('BEGIN CERTIFICATE');
+    expect(result.key).toContain('BEGIN');
+  });
+});
+
+describe('getCAPath', () => {
+  test('returns the correct path to the CA cert', () => {
+    const result = getCAPath('/some/data/dir');
+    expect(result).toBe('/some/data/dir/proxy-ca/ca.pem');
+  });
+});
+
+describe('getCombinedCAPath', () => {
+  test('returns the correct path to the combined CA bundle', () => {
+    const result = getCombinedCAPath('/some/data/dir');
+    expect(result).toBe('/some/data/dir/proxy-ca/combined-ca-bundle.pem');
+  });
+});
+
+describe('ensureCombinedCABundle', () => {
+  test('creates combined bundle when system CA exists', async () => {
+    // This test may return null if no system CA bundle is found on the machine
+    const result = await ensureCombinedCABundle(dataDir);
+    if (result !== null) {
+      const bundleContent = await readFile(result, 'utf-8');
+      // Should contain the proxy CA cert
+      const proxyCert = await readFile(
+        join(dataDir, 'proxy-ca', 'ca.pem'),
+        'utf-8',
+      );
+      expect(bundleContent).toContain(proxyCert.trim());
+    }
+    // If result is null, system has no CA bundle at known paths -- that's ok
+  });
+
+  test('is idempotent when combined bundle is fresh', async () => {
+    const first = await ensureCombinedCABundle(dataDir);
+    const second = await ensureCombinedCABundle(dataDir);
+    // Both should return the same result
+    expect(second).toBe(first);
+  });
+});

--- a/proxy-sidecar/src/__tests__/connect-tunnel.test.ts
+++ b/proxy-sidecar/src/__tests__/connect-tunnel.test.ts
@@ -1,0 +1,263 @@
+import { type Server } from 'node:http';
+import { createServer as createTcpServer, connect } from 'node:net';
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { createProxyServer } from '../server.js';
+
+/** Start an HTTP server and return its address + cleanup handle. */
+function listenEphemeral(
+  server: Server,
+): Promise<{ port: number; close: () => Promise<void> }> {
+  return new Promise((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('Failed to get address'));
+        return;
+      }
+      resolve({
+        port: addr.port,
+        close: () =>
+          new Promise<void>((r, j) => server.close((e) => (e ? j(e) : r()))),
+      });
+    });
+    server.on('error', reject);
+  });
+}
+
+/** Start a raw TCP echo server. */
+function listenTcpEcho(): Promise<{
+  port: number;
+  close: () => Promise<void>;
+}> {
+  return new Promise((resolve, reject) => {
+    const server = createTcpServer((socket) => {
+      socket.pipe(socket);
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('Failed to get address'));
+        return;
+      }
+      resolve({
+        port: addr.port,
+        close: () =>
+          new Promise<void>((r, j) => server.close((e) => (e ? j(e) : r()))),
+      });
+    });
+    server.on('error', reject);
+  });
+}
+
+/**
+ * Send an HTTP CONNECT request to the proxy and return the raw socket
+ * once the tunnel is established (or an error status).
+ */
+function sendConnect(
+  proxyPort: number,
+  target: string,
+): Promise<{ statusCode: number; socket: import('node:net').Socket }> {
+  return new Promise((resolve, reject) => {
+    const socket = connect(proxyPort, '127.0.0.1', () => {
+      socket.write(`CONNECT ${target} HTTP/1.1\r\nHost: ${target}\r\n\r\n`);
+    });
+
+    let headerBuf = '';
+    const onData = (chunk: Buffer) => {
+      headerBuf += chunk.toString();
+      const endIdx = headerBuf.indexOf('\r\n\r\n');
+      if (endIdx !== -1) {
+        socket.removeListener('data', onData);
+        const statusLine = headerBuf.slice(0, headerBuf.indexOf('\r\n'));
+        const statusCode = Number(statusLine.split(' ')[1]);
+        const remaining = headerBuf.slice(endIdx + 4);
+        if (remaining.length > 0) {
+          socket.unshift(Buffer.from(remaining));
+        }
+        resolve({ statusCode, socket });
+      }
+    };
+
+    socket.on('data', onData);
+    socket.on('error', reject);
+  });
+}
+
+describe('CONNECT tunnel', () => {
+  const cleanups: Array<{ close: () => Promise<void> }> = [];
+
+  afterEach(async () => {
+    await Promise.all(cleanups.map((c) => c.close().catch(() => {})));
+    cleanups.length = 0;
+  });
+
+  test('successful CONNECT tunnel establishment', async () => {
+    const echo = await listenTcpEcho();
+    cleanups.push(echo);
+
+    const proxy = createProxyServer();
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px);
+
+    const { statusCode, socket } = await sendConnect(
+      px.port,
+      `127.0.0.1:${echo.port}`,
+    );
+    cleanups.push({
+      close: () => {
+        socket.destroy();
+        return Promise.resolve();
+      },
+    });
+
+    expect(statusCode).toBe(200);
+    socket.destroy();
+  });
+
+  test('bidirectional data flow through tunnel', async () => {
+    const echo = await listenTcpEcho();
+    cleanups.push(echo);
+
+    const proxy = createProxyServer();
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px);
+
+    const { statusCode, socket } = await sendConnect(
+      px.port,
+      `127.0.0.1:${echo.port}`,
+    );
+    cleanups.push({
+      close: () => {
+        socket.destroy();
+        return Promise.resolve();
+      },
+    });
+
+    expect(statusCode).toBe(200);
+
+    // Write through the tunnel and read back
+    const received = await new Promise<string>((resolve, reject) => {
+      socket.once('data', (chunk: Buffer) => resolve(chunk.toString()));
+      socket.on('error', reject);
+      socket.write('hello tunnel');
+    });
+
+    expect(received).toBe('hello tunnel');
+    socket.destroy();
+  });
+
+  test('malformed target (no port) rejected with 400', async () => {
+    const proxy = createProxyServer();
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px);
+
+    const { statusCode, socket } = await sendConnect(px.port, 'example.com');
+    expect(statusCode).toBe(400);
+    socket.destroy();
+  });
+
+  test('malformed target (empty host) rejected with 400', async () => {
+    const proxy = createProxyServer();
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px);
+
+    const { statusCode, socket } = await sendConnect(px.port, ':443');
+    expect(statusCode).toBe(400);
+    socket.destroy();
+  });
+
+  test('upstream connection failure returns 502', async () => {
+    const proxy = createProxyServer();
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px);
+
+    // Port 1 should be unreachable
+    const { statusCode, socket } = await sendConnect(px.port, '127.0.0.1:1');
+    expect(statusCode).toBe(502);
+    socket.destroy();
+  });
+
+  test('socket cleanup on client disconnect', async () => {
+    const echo = await listenTcpEcho();
+    cleanups.push(echo);
+
+    const proxy = createProxyServer();
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px);
+
+    const { statusCode, socket } = await sendConnect(
+      px.port,
+      `127.0.0.1:${echo.port}`,
+    );
+    expect(statusCode).toBe(200);
+
+    // Destroy client side -- upstream should clean up without crashing
+    socket.destroy();
+
+    // Give a moment for cleanup to propagate
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  test('policyCallback can reject CONNECT with 403', async () => {
+    const echo = await listenTcpEcho();
+    cleanups.push(echo);
+
+    const proxy = createProxyServer({
+      policyCallback: async () => null,
+    });
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px);
+
+    const { statusCode, socket } = await sendConnect(
+      px.port,
+      `127.0.0.1:${echo.port}`,
+    );
+    expect(statusCode).toBe(403);
+    socket.destroy();
+  });
+
+  test('policyCallback can allow CONNECT', async () => {
+    const echo = await listenTcpEcho();
+    cleanups.push(echo);
+
+    const proxy = createProxyServer({
+      policyCallback: async () => ({}),
+    });
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px);
+
+    const { statusCode, socket } = await sendConnect(
+      px.port,
+      `127.0.0.1:${echo.port}`,
+    );
+    cleanups.push({
+      close: () => {
+        socket.destroy();
+        return Promise.resolve();
+      },
+    });
+    expect(statusCode).toBe(200);
+    socket.destroy();
+  });
+
+  test('policyCallback error returns 502', async () => {
+    const echo = await listenTcpEcho();
+    cleanups.push(echo);
+
+    const proxy = createProxyServer({
+      policyCallback: async () => {
+        throw new Error('policy error');
+      },
+    });
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px);
+
+    const { statusCode, socket } = await sendConnect(
+      px.port,
+      `127.0.0.1:${echo.port}`,
+    );
+    expect(statusCode).toBe(502);
+    socket.destroy();
+  });
+});

--- a/proxy-sidecar/src/__tests__/host-pattern-match.test.ts
+++ b/proxy-sidecar/src/__tests__/host-pattern-match.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  compareMatchSpecificity,
+  type HostMatchKind,
+  matchHostPattern,
+} from '../host-pattern-match.js';
+
+describe('matchHostPattern', () => {
+  // -- Exact matches --------------------------------------------------------
+
+  test('exact match returns "exact"', () => {
+    expect(matchHostPattern('api.fal.ai', 'api.fal.ai')).toBe('exact');
+  });
+
+  test('exact match is case-insensitive', () => {
+    expect(matchHostPattern('API.FAL.AI', 'api.fal.ai')).toBe('exact');
+    expect(matchHostPattern('api.fal.ai', 'API.FAL.AI')).toBe('exact');
+    expect(matchHostPattern('Api.Fal.Ai', 'api.fal.ai')).toBe('exact');
+  });
+
+  // -- Wildcard matches -----------------------------------------------------
+
+  test('wildcard pattern matches subdomain', () => {
+    expect(matchHostPattern('api.fal.ai', '*.fal.ai')).toBe('wildcard');
+  });
+
+  test('wildcard pattern matches deeply nested subdomain', () => {
+    expect(matchHostPattern('deep.sub.fal.ai', '*.fal.ai')).toBe('wildcard');
+  });
+
+  test('wildcard match is case-insensitive', () => {
+    expect(matchHostPattern('API.FAL.AI', '*.fal.ai')).toBe('wildcard');
+    expect(matchHostPattern('api.fal.ai', '*.FAL.AI')).toBe('wildcard');
+  });
+
+  test('wildcard pattern does not match apex by default', () => {
+    expect(matchHostPattern('fal.ai', '*.fal.ai')).toBe('none');
+  });
+
+  test('wildcard pattern matches apex with includeApexForWildcard', () => {
+    expect(
+      matchHostPattern('fal.ai', '*.fal.ai', { includeApexForWildcard: true }),
+    ).toBe('wildcard');
+  });
+
+  test('wildcard apex match is case-insensitive', () => {
+    expect(
+      matchHostPattern('FAL.AI', '*.fal.ai', { includeApexForWildcard: true }),
+    ).toBe('wildcard');
+  });
+
+  // -- No match -------------------------------------------------------------
+
+  test('returns "none" for non-matching hostname', () => {
+    expect(matchHostPattern('api.openai.com', '*.fal.ai')).toBe('none');
+  });
+
+  test('returns "none" for partial suffix match that is not a subdomain', () => {
+    // "notfal.ai" ends with "fal.ai" but is not ".fal.ai"
+    expect(matchHostPattern('notfal.ai', '*.fal.ai')).toBe('none');
+  });
+
+  test('returns "none" for completely different domain', () => {
+    expect(matchHostPattern('example.com', 'api.fal.ai')).toBe('none');
+  });
+
+  test('returns "none" for empty pattern', () => {
+    expect(matchHostPattern('api.fal.ai', '')).toBe('none');
+  });
+
+  test('returns "none" for non-wildcard non-exact pattern', () => {
+    expect(matchHostPattern('api.fal.ai', 'fal.ai')).toBe('none');
+  });
+
+  // -- Edge cases -----------------------------------------------------------
+
+  test('single-label hostname with exact pattern', () => {
+    expect(matchHostPattern('localhost', 'localhost')).toBe('exact');
+  });
+
+  test('wildcard pattern with single-label suffix', () => {
+    expect(matchHostPattern('sub.localhost', '*.localhost')).toBe('wildcard');
+  });
+
+  test('pattern starting with *. but host is just the dot-suffix', () => {
+    // "*.com" should not match "com" without apex inclusion
+    expect(matchHostPattern('com', '*.com')).toBe('none');
+    // But it should with apex inclusion
+    expect(
+      matchHostPattern('com', '*.com', { includeApexForWildcard: true }),
+    ).toBe('wildcard');
+  });
+
+  test('includeApexForWildcard defaults to false', () => {
+    expect(matchHostPattern('fal.ai', '*.fal.ai')).toBe('none');
+    expect(matchHostPattern('fal.ai', '*.fal.ai', {})).toBe('none');
+    expect(
+      matchHostPattern('fal.ai', '*.fal.ai', { includeApexForWildcard: false }),
+    ).toBe('none');
+  });
+
+  test('fal.run with *.fal.run pattern and apex inclusion', () => {
+    expect(
+      matchHostPattern('fal.run', '*.fal.run', { includeApexForWildcard: true }),
+    ).toBe('wildcard');
+  });
+});
+
+describe('compareMatchSpecificity', () => {
+  test('exact is more specific than wildcard', () => {
+    expect(compareMatchSpecificity('exact', 'wildcard')).toBeLessThan(0);
+  });
+
+  test('wildcard is more specific than none', () => {
+    expect(compareMatchSpecificity('wildcard', 'none')).toBeLessThan(0);
+  });
+
+  test('exact is more specific than none', () => {
+    expect(compareMatchSpecificity('exact', 'none')).toBeLessThan(0);
+  });
+
+  test('none is less specific than exact', () => {
+    expect(compareMatchSpecificity('none', 'exact')).toBeGreaterThan(0);
+  });
+
+  test('none is less specific than wildcard', () => {
+    expect(compareMatchSpecificity('none', 'wildcard')).toBeGreaterThan(0);
+  });
+
+  test('wildcard is less specific than exact', () => {
+    expect(compareMatchSpecificity('wildcard', 'exact')).toBeGreaterThan(0);
+  });
+
+  test('equal specificities return zero', () => {
+    const kinds: HostMatchKind[] = ['exact', 'wildcard', 'none'];
+    for (const k of kinds) {
+      expect(compareMatchSpecificity(k, k)).toBe(0);
+    }
+  });
+});

--- a/proxy-sidecar/src/__tests__/http-forwarder.test.ts
+++ b/proxy-sidecar/src/__tests__/http-forwarder.test.ts
@@ -1,0 +1,316 @@
+import http, {
+  createServer,
+  type IncomingMessage,
+  type Server,
+} from 'node:http';
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { createProxyServer } from '../server.js';
+
+/** Shape of the JSON body echoed by the upstream test server. */
+interface EchoBody {
+  method: string;
+  url: string;
+  headers: Record<string, string | string[] | undefined>;
+  body: string;
+}
+
+/** Start an HTTP server and return its URL + cleanup handle. */
+function listenEphemeral(
+  server: Server,
+): Promise<{ url: string; close: () => Promise<void> }> {
+  return new Promise((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('Failed to get address'));
+        return;
+      }
+      resolve({
+        url: `http://127.0.0.1:${addr.port}`,
+        close: () =>
+          new Promise<void>((r, j) => server.close((e) => (e ? j(e) : r()))),
+      });
+    });
+    server.on('error', reject);
+  });
+}
+
+/** Collect the full body of an IncomingMessage. */
+function readBody(msg: IncomingMessage): Promise<string> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    msg.on('data', (c: Buffer) => chunks.push(c));
+    msg.on('end', () => resolve(Buffer.concat(chunks).toString()));
+  });
+}
+
+/**
+ * Send an HTTP proxy request (absolute-URL form) and return the response.
+ */
+function proxyRequest(
+  proxyUrl: string,
+  targetUrl: string,
+  method: string,
+  headers: Record<string, string> = {},
+  body?: string,
+): Promise<{ status: number; body: string; headers: Record<string, string | string[] | undefined> }> {
+  return new Promise((resolve, reject) => {
+    const { hostname, port } = new URL(proxyUrl);
+    const req = http.request(
+      {
+        hostname,
+        port: Number(port),
+        path: targetUrl,
+        method,
+        headers,
+      },
+      (res: IncomingMessage) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode!,
+            body: Buffer.concat(chunks).toString(),
+            headers: res.headers,
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    if (body) {
+      req.write(body);
+    }
+    req.end();
+  });
+}
+
+describe('http-forwarder', () => {
+  const servers: Array<{ close: () => Promise<void> }> = [];
+
+  afterEach(async () => {
+    await Promise.all(servers.map((s) => s.close().catch(() => {})));
+    servers.length = 0;
+  });
+
+  async function setupPair(policyCallback?: Parameters<typeof createProxyServer>[0] extends infer T ? T extends { policyCallback?: infer P } ? P : never : never) {
+    // Upstream echo server
+    const upstream = createServer(async (req, res) => {
+      const body = await readBody(req);
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'X-Echo': 'true',
+      });
+      res.end(
+        JSON.stringify({
+          method: req.method,
+          url: req.url,
+          headers: req.headers,
+          body,
+        }),
+      );
+    });
+    const up = await listenEphemeral(upstream);
+    servers.push(up);
+
+    // Proxy
+    const proxy = createProxyServer({ policyCallback });
+    const px = await listenEphemeral(proxy);
+    servers.push(px);
+
+    return { upstreamUrl: up.url, proxyUrl: px.url };
+  }
+
+  test('simple GET forwarded correctly', async () => {
+    const { upstreamUrl, proxyUrl } = await setupPair();
+
+    const response = await proxyRequest(
+      proxyUrl,
+      `${upstreamUrl}/hello?a=1`,
+      'GET',
+      { 'X-Custom': 'test-value' },
+    );
+
+    expect(response.status).toBe(200);
+    const data = JSON.parse(response.body) as EchoBody;
+    expect(data.method).toBe('GET');
+    expect(data.url).toBe('/hello?a=1');
+    expect(data.headers['x-custom']).toBe('test-value');
+  });
+
+  test('POST with body forwarded correctly', async () => {
+    const { upstreamUrl, proxyUrl } = await setupPair();
+
+    const response = await proxyRequest(
+      proxyUrl,
+      `${upstreamUrl}/submit`,
+      'POST',
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({ key: 'value' }),
+    );
+
+    expect(response.status).toBe(200);
+    const data = JSON.parse(response.body) as EchoBody;
+    expect(data.method).toBe('POST');
+    expect(data.url).toBe('/submit');
+    expect(data.body).toBe('{"key":"value"}');
+  });
+
+  test('error response forwarded correctly', async () => {
+    // Upstream that returns 404
+    const upstream = createServer((_req, res) => {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Not Found');
+    });
+    const up = await listenEphemeral(upstream);
+    servers.push(up);
+
+    const proxy = createProxyServer();
+    const px = await listenEphemeral(proxy);
+    servers.push(px);
+
+    const response = await proxyRequest(
+      px.url,
+      `${up.url}/missing`,
+      'GET',
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body).toBe('Not Found');
+  });
+
+  test('upstream connection failure returns 502', async () => {
+    const proxy = createProxyServer();
+    const px = await listenEphemeral(proxy);
+    servers.push(px);
+
+    const response = await proxyRequest(
+      px.url,
+      'http://127.0.0.1:1/unreachable',
+      'GET',
+    );
+
+    expect(response.status).toBe(502);
+    expect(response.body).toBe('Bad Gateway');
+  });
+
+  test('hop-by-hop headers are stripped from forwarded request', async () => {
+    const { upstreamUrl, proxyUrl } = await setupPair();
+
+    const response = await proxyRequest(
+      proxyUrl,
+      `${upstreamUrl}/headers`,
+      'GET',
+      {
+        'X-Custom': 'keep-me',
+        'Proxy-Authorization': 'secret',
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const data = JSON.parse(response.body) as EchoBody;
+    expect(data.headers['x-custom']).toBe('keep-me');
+    expect(data.headers['proxy-authorization']).toBeUndefined();
+  });
+
+  test('non-HTTP protocol rejected with 400', async () => {
+    const proxy = createProxyServer();
+    const px = await listenEphemeral(proxy);
+    servers.push(px);
+
+    // Use raw http.request to send a HTTPS URL as the path,
+    // which the forwarder should reject since only HTTP is supported.
+    const { hostname, port } = new URL(px.url);
+    const response = await new Promise<{ status: number; body: string }>(
+      (resolve, reject) => {
+        const socket = new (require('node:net').Socket)();
+        socket.connect(Number(port), hostname, () => {
+          socket.write(
+            'GET https://example.com/path HTTP/1.1\r\nHost: example.com\r\n\r\n',
+          );
+        });
+        let buf = '';
+        socket.on('data', (chunk: Buffer) => {
+          buf += chunk.toString();
+          const endIdx = buf.indexOf('\r\n\r\n');
+          if (endIdx !== -1) {
+            const statusLine = buf.slice(0, buf.indexOf('\r\n'));
+            const status = Number(statusLine.split(' ')[1]);
+            const body = buf.slice(endIdx + 4);
+            socket.destroy();
+            resolve({ status, body });
+          }
+        });
+        socket.on('error', reject);
+      },
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  test('policyCallback can inject extra headers', async () => {
+    const { upstreamUrl, proxyUrl } = await setupPair(
+      async () => ({ 'X-Injected': 'policy-value' }),
+    );
+
+    const response = await proxyRequest(
+      proxyUrl,
+      `${upstreamUrl}/inject-test`,
+      'GET',
+    );
+
+    expect(response.status).toBe(200);
+    const data = JSON.parse(response.body) as EchoBody;
+    expect(data.headers['x-injected']).toBe('policy-value');
+  });
+
+  test('policyCallback returning null rejects with 403', async () => {
+    const { upstreamUrl, proxyUrl } = await setupPair(async () => null);
+
+    const response = await proxyRequest(
+      proxyUrl,
+      `${upstreamUrl}/blocked`,
+      'GET',
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body).toBe('Forbidden');
+  });
+
+  test('policyCallback error returns 502', async () => {
+    const { upstreamUrl, proxyUrl } = await setupPair(async () => {
+      throw new Error('policy failure');
+    });
+
+    const response = await proxyRequest(
+      proxyUrl,
+      `${upstreamUrl}/error`,
+      'GET',
+    );
+
+    expect(response.status).toBe(502);
+    expect(response.body).toBe('Bad Gateway');
+  });
+
+  test('onRequest callback is called for HTTP requests', async () => {
+    const upstream = createServer(async (req, res) => {
+      res.writeHead(200);
+      res.end('ok');
+    });
+    const up = await listenEphemeral(upstream);
+    servers.push(up);
+
+    const requestLog: Array<{ method: string; url: string }> = [];
+    const proxy = createProxyServer({
+      onRequest: (method, url) => requestLog.push({ method, url }),
+    });
+    const px = await listenEphemeral(proxy);
+    servers.push(px);
+
+    await proxyRequest(px.url, `${up.url}/test`, 'GET');
+
+    expect(requestLog).toHaveLength(1);
+    expect(requestLog[0].method).toBe('GET');
+    expect(requestLog[0].url).toContain('/test');
+  });
+});

--- a/proxy-sidecar/src/__tests__/logging.test.ts
+++ b/proxy-sidecar/src/__tests__/logging.test.ts
@@ -1,0 +1,400 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  buildCredentialRefTrace,
+  buildDecisionTrace,
+  createSafeLogEntry,
+  type CredentialRefTrace,
+  type ProxyDecisionTrace,
+  sanitizeHeaders,
+  sanitizeUrl,
+  stripQueryString,
+} from '../logging.js';
+import type { PolicyDecision } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// sanitizeHeaders
+// ---------------------------------------------------------------------------
+
+describe('sanitizeHeaders', () => {
+  test('redacts sensitive header values', () => {
+    const headers = {
+      Authorization: 'Bearer sk-secret',
+      'Content-Type': 'application/json',
+      'X-Api-Key': 'my-api-key',
+    };
+    const result = sanitizeHeaders(headers, ['Authorization', 'X-Api-Key']);
+    expect(result).toEqual({
+      Authorization: '[REDACTED]',
+      'Content-Type': 'application/json',
+      'X-Api-Key': '[REDACTED]',
+    });
+  });
+
+  test('is case-insensitive for key matching', () => {
+    const headers = {
+      authorization: 'Bearer token',
+      AUTHORIZATION: 'Bearer token2',
+    };
+    const result = sanitizeHeaders(headers, ['Authorization']);
+    expect(result.authorization).toBe('[REDACTED]');
+    expect(result.AUTHORIZATION).toBe('[REDACTED]');
+  });
+
+  test('preserves non-sensitive headers', () => {
+    const headers = {
+      'Content-Type': 'text/plain',
+      Host: 'example.com',
+    };
+    const result = sanitizeHeaders(headers, ['Authorization']);
+    expect(result).toEqual(headers);
+  });
+
+  test('handles empty sensitive keys list', () => {
+    const headers = { Authorization: 'secret' };
+    const result = sanitizeHeaders(headers, []);
+    expect(result).toEqual(headers);
+  });
+
+  test('handles empty headers', () => {
+    const result = sanitizeHeaders({}, ['Authorization']);
+    expect(result).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeUrl
+// ---------------------------------------------------------------------------
+
+describe('sanitizeUrl', () => {
+  test('redacts sensitive query parameters', () => {
+    const result = sanitizeUrl(
+      'http://example.com/api?api_key=secret123&format=json',
+      ['api_key'],
+    );
+    // URL.searchParams.set encodes brackets, so [REDACTED] becomes %5BREDACTED%5D
+    expect(result).toContain('REDACTED');
+    expect(result).not.toContain('secret123');
+    expect(result).toContain('format=json');
+  });
+
+  test('returns URL unchanged when no sensitive params specified', () => {
+    const url = 'http://example.com/api?key=value';
+    expect(sanitizeUrl(url, [])).toBe(url);
+  });
+
+  test('handles relative paths with query parameters', () => {
+    const result = sanitizeUrl('/api/v1?token=secret&page=1', ['token']);
+    expect(result).not.toContain('secret');
+    expect(result).toContain('page=1');
+    // URL.searchParams.set encodes brackets
+    expect(result).toContain('REDACTED');
+  });
+
+  test('returns URL unchanged when no query string present', () => {
+    const url = 'http://example.com/api';
+    expect(sanitizeUrl(url, ['api_key'])).toBe(url);
+  });
+
+  test('is case-insensitive for param matching', () => {
+    const result = sanitizeUrl(
+      'http://example.com/api?API_KEY=secret',
+      ['api_key'],
+    );
+    expect(result).not.toContain('secret');
+  });
+
+  test('handles malformed URLs by stripping query string', () => {
+    // A URL that can't be parsed
+    const result = sanitizeUrl('://invalid?secret=value', ['secret']);
+    expect(result).not.toContain('value');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createSafeLogEntry
+// ---------------------------------------------------------------------------
+
+describe('createSafeLogEntry', () => {
+  test('sanitizes both headers and URL', () => {
+    const entry = createSafeLogEntry(
+      {
+        method: 'GET',
+        url: 'http://example.com/api?api_key=secret',
+        headers: {
+          Authorization: 'Bearer token',
+          'Content-Type': 'application/json',
+        },
+      },
+      ['Authorization', 'api_key'],
+    );
+    expect(entry.method).toBe('GET');
+    expect(entry.url).not.toContain('secret');
+    expect(entry.headers.Authorization).toBe('[REDACTED]');
+    expect(entry.headers['Content-Type']).toBe('application/json');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripQueryString
+// ---------------------------------------------------------------------------
+
+describe('stripQueryString', () => {
+  test('strips query string from path', () => {
+    expect(stripQueryString('/v1/run?api_key=secret')).toBe('/v1/run');
+  });
+
+  test('returns path unchanged when no query string', () => {
+    expect(stripQueryString('/v1/models')).toBe('/v1/models');
+  });
+
+  test('handles empty query string', () => {
+    expect(stripQueryString('/api?')).toBe('/api');
+  });
+
+  test('handles multiple question marks', () => {
+    expect(stripQueryString('/api?a=1?b=2')).toBe('/api');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildDecisionTrace
+// ---------------------------------------------------------------------------
+
+describe('buildDecisionTrace', () => {
+  test('matched decision includes selected pattern and credential', () => {
+    const decision: PolicyDecision = {
+      kind: 'matched',
+      credentialId: 'cred-fal',
+      template: {
+        hostPattern: '*.fal.ai',
+        injectionType: 'header',
+        headerName: 'Authorization',
+        valuePrefix: 'Key ',
+      },
+    };
+    const trace = buildDecisionTrace(
+      'api.fal.ai',
+      443,
+      '/v1/run',
+      'https',
+      decision,
+    );
+    expect(trace).toEqual<ProxyDecisionTrace>({
+      host: 'api.fal.ai',
+      port: 443,
+      path: '/v1/run',
+      scheme: 'https',
+      decisionKind: 'matched',
+      candidateCount: 1,
+      selectedPattern: '*.fal.ai',
+      selectedCredentialId: 'cred-fal',
+    });
+  });
+
+  test('ambiguous decision includes candidate count but no selection', () => {
+    const decision: PolicyDecision = {
+      kind: 'ambiguous',
+      candidates: [
+        {
+          credentialId: 'cred-a',
+          template: {
+            hostPattern: '*.fal.ai',
+            injectionType: 'header',
+            headerName: 'Authorization',
+          },
+        },
+        {
+          credentialId: 'cred-b',
+          template: {
+            hostPattern: '*.fal.ai',
+            injectionType: 'header',
+            headerName: 'X-Key',
+          },
+        },
+      ],
+    };
+    const trace = buildDecisionTrace(
+      'api.fal.ai',
+      null,
+      '/',
+      'https',
+      decision,
+    );
+    expect(trace.decisionKind).toBe('ambiguous');
+    expect(trace.candidateCount).toBe(2);
+    expect(trace.selectedPattern).toBeNull();
+    expect(trace.selectedCredentialId).toBeNull();
+  });
+
+  test('missing decision has zero candidates', () => {
+    const decision: PolicyDecision = { kind: 'missing' };
+    const trace = buildDecisionTrace(
+      'unknown.com',
+      443,
+      '/',
+      'https',
+      decision,
+    );
+    expect(trace.decisionKind).toBe('missing');
+    expect(trace.candidateCount).toBe(0);
+    expect(trace.selectedPattern).toBeNull();
+  });
+
+  test('unauthenticated decision has zero candidates', () => {
+    const decision: PolicyDecision = { kind: 'unauthenticated' };
+    const trace = buildDecisionTrace(
+      'example.com',
+      null,
+      '/',
+      'http',
+      decision,
+    );
+    expect(trace.decisionKind).toBe('unauthenticated');
+    expect(trace.candidateCount).toBe(0);
+  });
+
+  test('ask_missing_credential includes matching pattern count', () => {
+    const decision: PolicyDecision = {
+      kind: 'ask_missing_credential',
+      target: {
+        hostname: 'api.fal.ai',
+        port: 443,
+        path: '/v1',
+        scheme: 'https',
+      },
+      matchingPatterns: ['*.fal.ai', 'api.fal.ai'],
+    };
+    const trace = buildDecisionTrace(
+      'api.fal.ai',
+      443,
+      '/v1',
+      'https',
+      decision,
+    );
+    expect(trace.decisionKind).toBe('ask_missing_credential');
+    expect(trace.candidateCount).toBe(2);
+  });
+
+  test('ask_unauthenticated has zero candidates', () => {
+    const decision: PolicyDecision = {
+      kind: 'ask_unauthenticated',
+      target: {
+        hostname: 'example.com',
+        port: null,
+        path: '/',
+        scheme: 'https',
+      },
+    };
+    const trace = buildDecisionTrace(
+      'example.com',
+      null,
+      '/',
+      'https',
+      decision,
+    );
+    expect(trace.decisionKind).toBe('ask_unauthenticated');
+    expect(trace.candidateCount).toBe(0);
+  });
+
+  test('strips query parameters from path to prevent secret leakage', () => {
+    const decision: PolicyDecision = {
+      kind: 'matched',
+      credentialId: 'cred-fal',
+      template: {
+        hostPattern: '*.fal.ai',
+        injectionType: 'header',
+        headerName: 'Authorization',
+        valuePrefix: 'Key ',
+      },
+    };
+    const trace = buildDecisionTrace(
+      'api.fal.ai',
+      443,
+      '/v1/run?api_key=sk-secret-123&token=abc',
+      'https',
+      decision,
+    );
+    expect(trace.path).toBe('/v1/run');
+    expect(JSON.stringify(trace)).not.toContain('sk-secret-123');
+    expect(JSON.stringify(trace)).not.toContain('abc');
+  });
+
+  test('path without query string is unchanged', () => {
+    const decision: PolicyDecision = { kind: 'missing' };
+    const trace = buildDecisionTrace(
+      'example.com',
+      443,
+      '/v1/models',
+      'https',
+      decision,
+    );
+    expect(trace.path).toBe('/v1/models');
+  });
+
+  test('trace never contains secret values', () => {
+    const decision: PolicyDecision = {
+      kind: 'matched',
+      credentialId: 'cred-fal',
+      template: {
+        hostPattern: '*.fal.ai',
+        injectionType: 'header',
+        headerName: 'Authorization',
+        valuePrefix: 'Key ',
+      },
+    };
+    const trace = buildDecisionTrace('api.fal.ai', 443, '/', 'https', decision);
+    const serialized = JSON.stringify(trace);
+    // Should not contain any typical secret patterns
+    expect(serialized).not.toContain('Bearer ');
+    expect(serialized).not.toContain('Key ');
+    expect(serialized).not.toContain('secret');
+    expect(serialized).not.toContain('token');
+    // Should only contain expected fields
+    const keys = Object.keys(trace);
+    expect(keys).toEqual([
+      'host',
+      'port',
+      'path',
+      'scheme',
+      'decisionKind',
+      'candidateCount',
+      'selectedPattern',
+      'selectedCredentialId',
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCredentialRefTrace
+// ---------------------------------------------------------------------------
+
+describe('buildCredentialRefTrace', () => {
+  test('builds trace with all fields', () => {
+    const trace = buildCredentialRefTrace(
+      ['fal/api_key', 'unknown/ref'],
+      ['uuid-123'],
+      ['unknown/ref'],
+    );
+    expect(trace).toEqual<CredentialRefTrace>({
+      rawRefs: ['fal/api_key', 'unknown/ref'],
+      resolvedIds: ['uuid-123'],
+      unresolvedRefs: ['unknown/ref'],
+    });
+  });
+
+  test('empty arrays for clean resolution', () => {
+    const trace = buildCredentialRefTrace(['uuid-abc'], ['uuid-abc'], []);
+    expect(trace.unresolvedRefs).toEqual([]);
+    expect(trace.resolvedIds).toEqual(['uuid-abc']);
+  });
+
+  test('handles completely empty inputs', () => {
+    const trace = buildCredentialRefTrace([], [], []);
+    expect(trace).toEqual<CredentialRefTrace>({
+      rawRefs: [],
+      resolvedIds: [],
+      unresolvedRefs: [],
+    });
+  });
+});

--- a/proxy-sidecar/src/__tests__/mitm-handler.test.ts
+++ b/proxy-sidecar/src/__tests__/mitm-handler.test.ts
@@ -1,0 +1,536 @@
+import { mkdtemp, readFile } from 'node:fs/promises';
+import type { Server } from 'node:http';
+import { createServer as createHttpsServer } from 'node:https';
+import { connect } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { connect as tlsConnect } from 'node:tls';
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'bun:test';
+
+import {
+  ensureLocalCA,
+  getCAPath,
+  issueLeafCert,
+} from '../certs.js';
+import type { RewriteCallback } from '../mitm-handler.js';
+import type { RouteDecision } from '../router.js';
+import { createProxyServer } from '../server.js';
+
+let dataDir: string;
+let caDir: string;
+let caCert: string;
+
+beforeAll(async () => {
+  dataDir = await mkdtemp(join(tmpdir(), 'proxy-sidecar-mitm-test-'));
+  await ensureLocalCA(dataDir);
+  caDir = join(dataDir, 'proxy-ca');
+  caCert = await readFile(getCAPath(dataDir), 'utf-8');
+});
+
+/**
+ * Create a local HTTPS server using a leaf cert issued by our test CA.
+ * Echoes request info as JSON.
+ */
+async function createUpstreamHttpsServer(): Promise<{
+  port: number;
+  close: () => void;
+  lastRequest: () => {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+  } | null;
+}> {
+  const { cert, key } = await issueLeafCert(caDir, 'localhost');
+  let lastReq: {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+  } | null = null;
+
+  const server = createHttpsServer({ cert, key }, (req, res) => {
+    const headers: Record<string, string> = {};
+    for (const [k, v] of Object.entries(req.headers)) {
+      if (v !== undefined) {
+        headers[k] = Array.isArray(v) ? v.join(', ') : v;
+      }
+    }
+    lastReq = { method: req.method ?? 'GET', url: req.url ?? '/', headers };
+    const body = JSON.stringify(lastReq);
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+      'Content-Length': String(Buffer.byteLength(body)),
+    });
+    res.end(body);
+  });
+
+  return new Promise((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('no addr'));
+        return;
+      }
+      resolve({
+        port: addr.port,
+        close: () => server.close(),
+        lastRequest: () => lastReq,
+      });
+    });
+    server.on('error', reject);
+  });
+}
+
+function listenEphemeral(
+  server: Server,
+): Promise<{ port: number; close: () => void }> {
+  return new Promise((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('no addr'));
+        return;
+      }
+      resolve({ port: addr.port, close: () => server.close() });
+    });
+    server.on('error', reject);
+  });
+}
+
+/**
+ * Send CONNECT -> TLS handshake -> HTTP request through the proxy.
+ * Returns the response. Destroys all sockets when done.
+ */
+function connectAndRequest(
+  proxyPort: number,
+  targetHost: string,
+  targetPort: number,
+  method: string,
+  path: string,
+  extraHeaders: Record<string, string> = {},
+): Promise<{
+  statusCode: number;
+  body: string;
+  headers: Record<string, string>;
+}> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('connectAndRequest timed out'));
+    }, 8000);
+
+    const socket = connect(proxyPort, '127.0.0.1', () => {
+      socket.write(
+        `CONNECT ${targetHost}:${targetPort} HTTP/1.1\r\nHost: ${targetHost}:${targetPort}\r\n\r\n`,
+      );
+    });
+
+    let headerBuf = '';
+    const onData = (chunk: Buffer) => {
+      headerBuf += chunk.toString();
+      const endIdx = headerBuf.indexOf('\r\n\r\n');
+      if (endIdx === -1) return;
+
+      socket.removeListener('data', onData);
+      const statusLine = headerBuf.slice(0, headerBuf.indexOf('\r\n'));
+      const connectStatus = Number(statusLine.split(' ')[1]);
+
+      if (connectStatus !== 200) {
+        clearTimeout(timeout);
+        socket.destroy();
+        reject(new Error(`CONNECT failed with ${connectStatus}`));
+        return;
+      }
+
+      const tlsSocket = tlsConnect(
+        { socket, servername: targetHost, ca: caCert },
+        () => {
+          const headerLines = [
+            `${method} ${path} HTTP/1.1`,
+            `Host: ${targetHost}:${targetPort}`,
+            'Connection: close',
+          ];
+          for (const [k, v] of Object.entries(extraHeaders)) {
+            headerLines.push(`${k}: ${v}`);
+          }
+          tlsSocket.write(headerLines.join('\r\n') + '\r\n\r\n');
+        },
+      );
+
+      let responseBuf = '';
+      let resolved = false;
+
+      const tryResolve = () => {
+        if (resolved) return;
+        const headerEndIdx = responseBuf.indexOf('\r\n\r\n');
+        if (headerEndIdx === -1) return;
+
+        const responseHeaderBlock = responseBuf.slice(0, headerEndIdx);
+        const bodyPart = responseBuf.slice(headerEndIdx + 4);
+        const responseLines = responseHeaderBlock.split('\r\n');
+        const statusCode = Number(responseLines[0].split(' ')[1]);
+        const responseHeaders: Record<string, string> = {};
+        for (let i = 1; i < responseLines.length; i++) {
+          const ci = responseLines[i].indexOf(':');
+          if (ci > 0) {
+            responseHeaders[
+              responseLines[i].slice(0, ci).trim().toLowerCase()
+            ] = responseLines[i].slice(ci + 1).trim();
+          }
+        }
+
+        const cl = responseHeaders['content-length'];
+        if (cl !== undefined && bodyPart.length >= Number(cl)) {
+          resolved = true;
+          clearTimeout(timeout);
+          tlsSocket.destroy();
+          resolve({
+            statusCode,
+            body: bodyPart.slice(0, Number(cl)),
+            headers: responseHeaders,
+          });
+        }
+      };
+
+      tlsSocket.on('data', (chunk: Buffer) => {
+        responseBuf += chunk.toString('utf-8');
+        tryResolve();
+      });
+
+      tlsSocket.on('end', () => {
+        if (!resolved) {
+          clearTimeout(timeout);
+          const headerEndIdx = responseBuf.indexOf('\r\n\r\n');
+          if (headerEndIdx === -1) {
+            reject(new Error('No complete HTTP response'));
+            return;
+          }
+          const responseHeaderBlock = responseBuf.slice(0, headerEndIdx);
+          const body = responseBuf.slice(headerEndIdx + 4);
+          const responseLines = responseHeaderBlock.split('\r\n');
+          const statusCode = Number(responseLines[0].split(' ')[1]);
+          const responseHeaders: Record<string, string> = {};
+          for (let i = 1; i < responseLines.length; i++) {
+            const ci = responseLines[i].indexOf(':');
+            if (ci > 0) {
+              responseHeaders[
+                responseLines[i].slice(0, ci).trim().toLowerCase()
+              ] = responseLines[i].slice(ci + 1).trim();
+            }
+          }
+          resolve({ statusCode, body, headers: responseHeaders });
+        }
+      });
+
+      tlsSocket.on('error', (e) => {
+        if (!resolved) {
+          clearTimeout(timeout);
+          reject(e);
+        }
+      });
+    };
+
+    socket.on('data', onData);
+    socket.on('error', (e) => {
+      clearTimeout(timeout);
+      reject(e);
+    });
+  });
+}
+
+describe('MITM handler', () => {
+  const cleanups: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const fn of cleanups) {
+      try {
+        fn();
+      } catch {}
+    }
+    cleanups.length = 0;
+  });
+
+  test('MITM intercepts and can read/rewrite headers', async () => {
+    const upstream = await createUpstreamHttpsServer();
+    cleanups.push(upstream.close);
+
+    const rewriteCallback: RewriteCallback = async (req) => {
+      return {
+        'x-injected-token': 'secret-123',
+        'x-original-host': req.hostname,
+      };
+    };
+
+    const proxy = createProxyServer({
+      mitmHandler: {
+        caDir,
+        shouldIntercept: (): RouteDecision => ({
+          action: 'mitm',
+          reason: 'mitm:credential_injection',
+        }),
+        rewriteCallback,
+        upstreamTlsOptions: { ca: caCert },
+      },
+    });
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px.close);
+
+    const { statusCode, body } = await connectAndRequest(
+      px.port,
+      'localhost',
+      upstream.port,
+      'GET',
+      '/test',
+    );
+
+    expect(statusCode).toBe(200);
+    const parsed = JSON.parse(body);
+    expect(parsed.headers['x-injected-token']).toBe('secret-123');
+    expect(parsed.headers['x-original-host']).toBe('localhost');
+    expect(parsed.url).toBe('/test');
+  });
+
+  test('response streaming works through MITM', async () => {
+    const upstream = await createUpstreamHttpsServer();
+    cleanups.push(upstream.close);
+
+    const proxy = createProxyServer({
+      mitmHandler: {
+        caDir,
+        shouldIntercept: (): RouteDecision => ({
+          action: 'mitm',
+          reason: 'mitm:credential_injection',
+        }),
+        rewriteCallback: async () => ({}),
+        upstreamTlsOptions: { ca: caCert },
+      },
+    });
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px.close);
+
+    const { statusCode, body, headers } = await connectAndRequest(
+      px.port,
+      'localhost',
+      upstream.port,
+      'GET',
+      '/stream-test',
+      { accept: 'application/json' },
+    );
+
+    expect(statusCode).toBe(200);
+    expect(headers['content-type']).toBe('application/json');
+    const parsed = JSON.parse(body);
+    expect(parsed.url).toBe('/stream-test');
+    expect(parsed.method).toBe('GET');
+  });
+
+  test('original request reaches upstream with modifications', async () => {
+    const upstream = await createUpstreamHttpsServer();
+    cleanups.push(upstream.close);
+
+    const rewriteCallback: RewriteCallback = async () => {
+      return { authorization: 'Bearer my-secret-token' };
+    };
+
+    const proxy = createProxyServer({
+      mitmHandler: {
+        caDir,
+        shouldIntercept: (): RouteDecision => ({
+          action: 'mitm',
+          reason: 'mitm:credential_injection',
+        }),
+        rewriteCallback,
+        upstreamTlsOptions: { ca: caCert },
+      },
+    });
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px.close);
+
+    const { statusCode, body } = await connectAndRequest(
+      px.port,
+      'localhost',
+      upstream.port,
+      'GET',
+      '/api/data',
+      { 'x-custom': 'original-value' },
+    );
+
+    expect(statusCode).toBe(200);
+    const parsed = JSON.parse(body);
+    expect(parsed.headers['authorization']).toBe('Bearer my-secret-token');
+    expect(parsed.headers['x-custom']).toBe('original-value');
+
+    const last = upstream.lastRequest();
+    expect(last).not.toBeNull();
+    expect(last!.headers['authorization']).toBe('Bearer my-secret-token');
+    expect(last!.headers['x-custom']).toBe('original-value');
+  });
+
+  test('non-intercepted requests pass through unchanged via tunnel', async () => {
+    const upstream = await createUpstreamHttpsServer();
+    cleanups.push(upstream.close);
+
+    const interceptedHosts: string[] = [];
+    const proxy = createProxyServer({
+      mitmHandler: {
+        caDir,
+        shouldIntercept: (hostname): RouteDecision => {
+          interceptedHosts.push(hostname);
+          return { action: 'tunnel', reason: 'tunnel:no_rewrite' };
+        },
+        rewriteCallback: async () => ({ 'x-should-not-appear': 'true' }),
+      },
+    });
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px.close);
+
+    const result = await new Promise<{ statusCode: number; body: string }>(
+      (resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error('tunnel test timed out')),
+          8000,
+        );
+
+        const socket = connect(px.port, '127.0.0.1', () => {
+          socket.write(
+            `CONNECT localhost:${upstream.port} HTTP/1.1\r\nHost: localhost:${upstream.port}\r\n\r\n`,
+          );
+        });
+
+        let headerBuf = '';
+        const onData = (chunk: Buffer) => {
+          headerBuf += chunk.toString();
+          const endIdx = headerBuf.indexOf('\r\n\r\n');
+          if (endIdx === -1) return;
+          socket.removeListener('data', onData);
+          const connectStatus = Number(
+            headerBuf.slice(0, headerBuf.indexOf('\r\n')).split(' ')[1],
+          );
+
+          if (connectStatus !== 200) {
+            clearTimeout(timeout);
+            socket.destroy();
+            reject(new Error(`CONNECT failed: ${connectStatus}`));
+            return;
+          }
+
+          const tlsSocket = tlsConnect(
+            { socket, servername: 'localhost', ca: caCert },
+            () => {
+              tlsSocket.write(
+                `GET /tunnel-check HTTP/1.1\r\nHost: localhost:${upstream.port}\r\nConnection: close\r\n\r\n`,
+              );
+            },
+          );
+
+          const chunks: Buffer[] = [];
+          tlsSocket.on('data', (c: Buffer) => chunks.push(c));
+          tlsSocket.on('end', () => {
+            clearTimeout(timeout);
+            const raw = Buffer.concat(chunks).toString('utf-8');
+            const hEnd = raw.indexOf('\r\n\r\n');
+            if (hEnd === -1) {
+              reject(new Error('Incomplete response'));
+              return;
+            }
+            resolve({
+              statusCode: Number(
+                raw.slice(0, hEnd).split('\r\n')[0].split(' ')[1],
+              ),
+              body: raw.slice(hEnd + 4),
+            });
+          });
+          tlsSocket.on('error', (e) => {
+            clearTimeout(timeout);
+            reject(e);
+          });
+        };
+
+        socket.on('data', onData);
+        socket.on('error', (e) => {
+          clearTimeout(timeout);
+          reject(e);
+        });
+      },
+    );
+
+    expect(result.statusCode).toBe(200);
+    const parsed = JSON.parse(result.body);
+    expect(parsed.headers['x-should-not-appear']).toBeUndefined();
+    expect(parsed.url).toBe('/tunnel-check');
+    expect(interceptedHosts).toContain('localhost');
+  });
+
+  test('rewriteCallback returning null rejects with 403', async () => {
+    const upstream = await createUpstreamHttpsServer();
+    cleanups.push(upstream.close);
+
+    const proxy = createProxyServer({
+      mitmHandler: {
+        caDir,
+        shouldIntercept: (): RouteDecision => ({
+          action: 'mitm',
+          reason: 'mitm:credential_injection',
+        }),
+        rewriteCallback: async () => null,
+        upstreamTlsOptions: { ca: caCert },
+      },
+    });
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px.close);
+
+    const { statusCode, body } = await connectAndRequest(
+      px.port,
+      'localhost',
+      upstream.port,
+      'GET',
+      '/forbidden',
+    );
+
+    expect(statusCode).toBe(403);
+    expect(body).toContain('Forbidden');
+  });
+
+  test('rewriteCallback receives correct hostname and port', async () => {
+    const upstream = await createUpstreamHttpsServer();
+    cleanups.push(upstream.close);
+
+    let capturedHostname: string | undefined;
+    let capturedPort: number | undefined;
+    let capturedPath: string | undefined;
+    let capturedMethod: string | undefined;
+
+    const rewriteCallback: RewriteCallback = async (req) => {
+      capturedHostname = req.hostname;
+      capturedPort = req.port;
+      capturedPath = req.path;
+      capturedMethod = req.method;
+      return {};
+    };
+
+    const proxy = createProxyServer({
+      mitmHandler: {
+        caDir,
+        shouldIntercept: (): RouteDecision => ({
+          action: 'mitm',
+          reason: 'mitm:credential_injection',
+        }),
+        rewriteCallback,
+        upstreamTlsOptions: { ca: caCert },
+      },
+    });
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px.close);
+
+    await connectAndRequest(
+      px.port,
+      'localhost',
+      upstream.port,
+      'POST',
+      '/api/v1/data',
+    );
+
+    expect(capturedHostname).toBe('localhost');
+    expect(capturedPort).toBe(upstream.port);
+    expect(capturedPath).toBe('/api/v1/data');
+    expect(capturedMethod).toBe('POST');
+  });
+});

--- a/proxy-sidecar/src/__tests__/policy.test.ts
+++ b/proxy-sidecar/src/__tests__/policy.test.ts
@@ -1,0 +1,507 @@
+import { describe, expect, test } from 'bun:test';
+
+import { evaluateRequest, evaluateRequestWithApproval } from '../policy.js';
+import type { CredentialInjectionTemplate } from '../types.js';
+
+function headerTemplate(
+  hostPattern: string,
+  headerName = 'Authorization',
+  valuePrefix = 'Key ',
+): CredentialInjectionTemplate {
+  return { hostPattern, injectionType: 'header', headerName, valuePrefix };
+}
+
+function queryTemplate(
+  hostPattern: string,
+  queryParamName: string,
+): CredentialInjectionTemplate {
+  return { hostPattern, injectionType: 'query', queryParamName };
+}
+
+describe('evaluateRequest', () => {
+  test('returns unauthenticated when no credential_ids are provided', () => {
+    const result = evaluateRequest('api.fal.ai', '/v1/run', [], new Map());
+    expect(result).toEqual({ kind: 'unauthenticated' });
+  });
+
+  test('returns missing when credential_ids exist but no templates match', () => {
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-1', [headerTemplate('*.openai.com')]],
+    ]);
+    const result = evaluateRequest('api.fal.ai', '/', ['cred-1'], templates);
+    expect(result).toEqual({ kind: 'missing' });
+  });
+
+  test('returns missing when credential_id has no templates at all', () => {
+    const result = evaluateRequest(
+      'api.fal.ai',
+      '/',
+      ['cred-unknown'],
+      new Map(),
+    );
+    expect(result).toEqual({ kind: 'missing' });
+  });
+
+  test('returns matched for a single matching credential', () => {
+    const tpl = headerTemplate('*.fal.ai');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-fal', [tpl]],
+    ]);
+    const result = evaluateRequest(
+      'api.fal.ai',
+      '/v1/run',
+      ['cred-fal'],
+      templates,
+    );
+    expect(result).toEqual({
+      kind: 'matched',
+      credentialId: 'cred-fal',
+      template: tpl,
+    });
+  });
+
+  test('returns matched with exact hostname pattern', () => {
+    const tpl = headerTemplate('api.replicate.com', 'Authorization', 'Token ');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-rep', [tpl]],
+    ]);
+    const result = evaluateRequest(
+      'api.replicate.com',
+      '/v1/predictions',
+      ['cred-rep'],
+      templates,
+    );
+    expect(result).toEqual({
+      kind: 'matched',
+      credentialId: 'cred-rep',
+      template: tpl,
+    });
+  });
+
+  test('returns ambiguous when multiple credentials match', () => {
+    const tpl1 = headerTemplate('*.fal.ai', 'Authorization', 'Key ');
+    const tpl2 = headerTemplate('*.fal.ai', 'X-Api-Key');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-a', [tpl1]],
+      ['cred-b', [tpl2]],
+    ]);
+    const result = evaluateRequest(
+      'api.fal.ai',
+      '/',
+      ['cred-a', 'cred-b'],
+      templates,
+    );
+    expect(result.kind).toBe('ambiguous');
+    if (result.kind === 'ambiguous') {
+      expect(result.candidates).toHaveLength(2);
+      expect(result.candidates[0]).toEqual({
+        credentialId: 'cred-a',
+        template: tpl1,
+      });
+      expect(result.candidates[1]).toEqual({
+        credentialId: 'cred-b',
+        template: tpl2,
+      });
+    }
+  });
+
+  test('only considers credentials in the credentialIds list', () => {
+    const tpl = headerTemplate('*.fal.ai');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-a', [tpl]],
+      ['cred-b', [headerTemplate('*.fal.ai', 'X-Key')]],
+    ]);
+    const result = evaluateRequest('api.fal.ai', '/', ['cred-a'], templates);
+    expect(result).toEqual({
+      kind: 'matched',
+      credentialId: 'cred-a',
+      template: tpl,
+    });
+  });
+
+  test('handles multiple templates per credential -- returns first match', () => {
+    const tpl1 = headerTemplate('*.openai.com');
+    const tpl2 = headerTemplate('*.fal.ai');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-multi', [tpl1, tpl2]],
+    ]);
+    const result = evaluateRequest(
+      'api.fal.ai',
+      '/',
+      ['cred-multi'],
+      templates,
+    );
+    expect(result).toEqual({
+      kind: 'matched',
+      credentialId: 'cred-multi',
+      template: tpl2,
+    });
+  });
+
+  test('single credential with exact + wildcard templates picks exact', () => {
+    const tpl1 = headerTemplate('*.fal.ai', 'Authorization', 'Key ');
+    const tpl2 = headerTemplate('api.fal.ai', 'Authorization', 'Bearer ');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-dual', [tpl1, tpl2]],
+    ]);
+    const result = evaluateRequest('api.fal.ai', '/', ['cred-dual'], templates);
+    expect(result).toEqual({
+      kind: 'matched',
+      credentialId: 'cred-dual',
+      template: tpl2,
+    });
+  });
+
+  test('excludes query templates from candidate matching', () => {
+    const tpl = queryTemplate('maps.googleapis.com', 'key');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-gcp', [tpl]],
+    ]);
+    const result = evaluateRequest(
+      'maps.googleapis.com',
+      '/api/geocode',
+      ['cred-gcp'],
+      templates,
+    );
+    expect(result).toEqual({ kind: 'missing' });
+  });
+
+  test('query template alongside header template does not cause ambiguity', () => {
+    const headerTpl = headerTemplate('maps.googleapis.com');
+    const qTpl = queryTemplate('maps.googleapis.com', 'key');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-gcp', [headerTpl, qTpl]],
+    ]);
+    const result = evaluateRequest(
+      'maps.googleapis.com',
+      '/api/geocode',
+      ['cred-gcp'],
+      templates,
+    );
+    expect(result).toEqual({
+      kind: 'matched',
+      credentialId: 'cred-gcp',
+      template: headerTpl,
+    });
+  });
+
+  test('matches hostnames case-insensitively', () => {
+    const tpl = headerTemplate('*.fal.ai');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-fal', [tpl]],
+    ]);
+    const result = evaluateRequest(
+      'API.FAL.AI',
+      '/v1/run',
+      ['cred-fal'],
+      templates,
+    );
+    expect(result).toEqual({
+      kind: 'matched',
+      credentialId: 'cred-fal',
+      template: tpl,
+    });
+  });
+
+  test('bare domain matches wildcard with apex-inclusive matching', () => {
+    const tpl = headerTemplate('*.fal.ai');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-1', [tpl]],
+    ]);
+    const result = evaluateRequest('fal.ai', '/', ['cred-1'], templates);
+    expect(result).toEqual({
+      kind: 'matched',
+      credentialId: 'cred-1',
+      template: tpl,
+    });
+  });
+
+  test('same-credential equal-specificity ties remain ambiguous', () => {
+    const tpl1 = headerTemplate('api.fal.ai', 'Authorization', 'Key ');
+    const tpl2 = headerTemplate('api.fal.ai', 'X-Api-Key', 'Bearer ');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-dual', [tpl1, tpl2]],
+    ]);
+    const result = evaluateRequest('api.fal.ai', '/', ['cred-dual'], templates);
+    expect(result.kind).toBe('ambiguous');
+    if (result.kind === 'ambiguous') {
+      expect(result.candidates).toHaveLength(2);
+    }
+  });
+
+  test('evaluateRequest with apex-inclusive fal.run matches *.fal.run', () => {
+    const tpl = headerTemplate('*.fal.run');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-fal', [tpl]],
+    ]);
+    const result = evaluateRequest('fal.run', '/', ['cred-fal'], templates);
+    expect(result).toEqual({
+      kind: 'matched',
+      credentialId: 'cred-fal',
+      template: tpl,
+    });
+  });
+
+  test('credential with no templates in map is skipped gracefully', () => {
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-a', []],
+    ]);
+    const result = evaluateRequest('api.fal.ai', '/', ['cred-a'], templates);
+    expect(result).toEqual({ kind: 'missing' });
+  });
+
+  test('multiple credential IDs where only one has templates', () => {
+    const tpl = headerTemplate('*.fal.ai');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-fal', [tpl]],
+    ]);
+    const result = evaluateRequest(
+      'api.fal.ai',
+      '/',
+      ['cred-missing', 'cred-fal'],
+      templates,
+    );
+    expect(result).toEqual({
+      kind: 'matched',
+      credentialId: 'cred-fal',
+      template: tpl,
+    });
+  });
+});
+
+describe('evaluateRequestWithApproval', () => {
+  test('passes through matched decisions unchanged', () => {
+    const tpl = headerTemplate('*.fal.ai');
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-fal', [tpl]],
+    ]);
+    const result = evaluateRequestWithApproval(
+      'api.fal.ai',
+      443,
+      '/v1/run',
+      ['cred-fal'],
+      sessionTemplates,
+      [tpl],
+    );
+    expect(result).toEqual({
+      kind: 'matched',
+      credentialId: 'cred-fal',
+      template: tpl,
+    });
+  });
+
+  test('passes through ambiguous decisions unchanged', () => {
+    const tpl1 = headerTemplate('*.fal.ai', 'Authorization', 'Key ');
+    const tpl2 = headerTemplate('*.fal.ai', 'X-Api-Key');
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-a', [tpl1]],
+      ['cred-b', [tpl2]],
+    ]);
+    const result = evaluateRequestWithApproval(
+      'api.fal.ai',
+      null,
+      '/',
+      ['cred-a', 'cred-b'],
+      sessionTemplates,
+      [tpl1, tpl2],
+    );
+    expect(result.kind).toBe('ambiguous');
+  });
+
+  test('returns ask_missing_credential when host matches a known template but session has no matching credential', () => {
+    const sessionTpl = headerTemplate('*.openai.com');
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-openai', [sessionTpl]],
+    ]);
+    const knownFalTpl = headerTemplate('*.fal.ai');
+    const allKnown = [sessionTpl, knownFalTpl];
+
+    const result = evaluateRequestWithApproval(
+      'api.fal.ai',
+      443,
+      '/v1/run',
+      ['cred-openai'],
+      sessionTemplates,
+      allKnown,
+    );
+    expect(result).toEqual({
+      kind: 'ask_missing_credential',
+      target: {
+        hostname: 'api.fal.ai',
+        port: 443,
+        path: '/v1/run',
+        scheme: 'https',
+      },
+      matchingPatterns: ['*.fal.ai'],
+    });
+  });
+
+  test('returns ask_missing_credential with deduplicated patterns', () => {
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-openai', [headerTemplate('*.openai.com')]],
+    ]);
+    const allKnown = [
+      headerTemplate('*.fal.ai', 'Authorization', 'Key '),
+      headerTemplate('*.fal.ai', 'X-Api-Key'),
+    ];
+
+    const result = evaluateRequestWithApproval(
+      'api.fal.ai',
+      null,
+      '/',
+      ['cred-openai'],
+      sessionTemplates,
+      allKnown,
+    );
+    expect(result.kind).toBe('ask_missing_credential');
+    if (result.kind === 'ask_missing_credential') {
+      expect(result.matchingPatterns).toEqual(['*.fal.ai']);
+    }
+  });
+
+  test('returns ask_missing_credential when session has credentials but none have templates', () => {
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>();
+    const allKnown = [headerTemplate('*.fal.ai')];
+
+    const result = evaluateRequestWithApproval(
+      'api.fal.ai',
+      8080,
+      '/generate',
+      ['cred-unknown'],
+      sessionTemplates,
+      allKnown,
+    );
+    expect(result).toEqual({
+      kind: 'ask_missing_credential',
+      target: {
+        hostname: 'api.fal.ai',
+        port: 8080,
+        path: '/generate',
+        scheme: 'https',
+      },
+      matchingPatterns: ['*.fal.ai'],
+    });
+  });
+
+  test('returns ask_unauthenticated when no credentials and host is unknown', () => {
+    const result = evaluateRequestWithApproval(
+      'example.com',
+      null,
+      '/data',
+      [],
+      new Map(),
+      [],
+    );
+    expect(result).toEqual({
+      kind: 'ask_unauthenticated',
+      target: {
+        hostname: 'example.com',
+        port: null,
+        path: '/data',
+        scheme: 'https',
+      },
+    });
+  });
+
+  test('returns ask_unauthenticated when no credentials and registry has templates for other hosts', () => {
+    const allKnown = [headerTemplate('*.fal.ai')];
+
+    const result = evaluateRequestWithApproval(
+      'example.com',
+      443,
+      '/',
+      [],
+      new Map(),
+      allKnown,
+    );
+    expect(result).toEqual({
+      kind: 'ask_unauthenticated',
+      target: {
+        hostname: 'example.com',
+        port: 443,
+        path: '/',
+        scheme: 'https',
+      },
+    });
+  });
+
+  test('returns ask_unauthenticated when session has credentials but host is completely unknown', () => {
+    const sessionTpl = headerTemplate('*.openai.com');
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-openai', [sessionTpl]],
+    ]);
+
+    const result = evaluateRequestWithApproval(
+      'unknown-service.internal',
+      null,
+      '/api',
+      ['cred-openai'],
+      sessionTemplates,
+      [sessionTpl],
+    );
+    expect(result).toEqual({
+      kind: 'ask_unauthenticated',
+      target: {
+        hostname: 'unknown-service.internal',
+        port: null,
+        path: '/api',
+        scheme: 'https',
+      },
+    });
+  });
+
+  test('includes port in target context', () => {
+    const result = evaluateRequestWithApproval(
+      'localhost',
+      3000,
+      '/webhook',
+      [],
+      new Map(),
+      [],
+    );
+    expect(result.kind).toBe('ask_unauthenticated');
+    if (result.kind === 'ask_unauthenticated') {
+      expect(result.target).toEqual({
+        hostname: 'localhost',
+        port: 3000,
+        path: '/webhook',
+        scheme: 'https',
+      });
+    }
+  });
+
+  test('respects scheme parameter', () => {
+    const result = evaluateRequestWithApproval(
+      'example.com',
+      null,
+      '/data',
+      [],
+      new Map(),
+      [],
+      'http',
+    );
+    expect(result.kind).toBe('ask_unauthenticated');
+    if (result.kind === 'ask_unauthenticated') {
+      expect(result.target.scheme).toBe('http');
+    }
+  });
+
+  test('excludes query templates from allKnown matching', () => {
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-a', [headerTemplate('*.openai.com')]],
+    ]);
+    // Only query templates match the host in allKnown
+    const allKnown = [queryTemplate('api.fal.ai', 'key')];
+
+    const result = evaluateRequestWithApproval(
+      'api.fal.ai',
+      null,
+      '/',
+      ['cred-a'],
+      sessionTemplates,
+      allKnown,
+    );
+    // Should be ask_unauthenticated since query templates are excluded
+    expect(result.kind).toBe('ask_unauthenticated');
+  });
+});

--- a/proxy-sidecar/src/__tests__/rewrite-specificity.test.ts
+++ b/proxy-sidecar/src/__tests__/rewrite-specificity.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  compareMatchSpecificity,
+  type HostMatchKind,
+  matchHostPattern,
+} from '../host-pattern-match.js';
+import type { CredentialInjectionTemplate } from '../types.js';
+
+/**
+ * Extracted rewrite candidate selection logic -- mirrors what a
+ * session-manager's rewriteCallback does internally. This allows
+ * testing the selection algorithm without standing up a full MITM
+ * proxy server.
+ */
+function selectRewriteCandidate(
+  hostname: string,
+  templates: Map<string, CredentialInjectionTemplate[]>,
+): { credId: string; tpl: CredentialInjectionTemplate } | 'ambiguous' | 'none' {
+  const perCredentialBest: {
+    credId: string;
+    tpl: CredentialInjectionTemplate;
+  }[] = [];
+
+  for (const [credId, tpls] of templates) {
+    let bestMatch: HostMatchKind = 'none';
+    let bestCandidates: CredentialInjectionTemplate[] = [];
+
+    for (const tpl of tpls) {
+      if (tpl.injectionType === 'query') continue;
+      const match = matchHostPattern(hostname, tpl.hostPattern, {
+        includeApexForWildcard: true,
+      });
+      if (match === 'none') continue;
+
+      const cmp = compareMatchSpecificity(match, bestMatch);
+      if (cmp < 0) {
+        bestMatch = match;
+        bestCandidates = [tpl];
+      } else if (cmp === 0) {
+        bestCandidates.push(tpl);
+      }
+    }
+
+    if (bestCandidates.length === 1) {
+      perCredentialBest.push({ credId, tpl: bestCandidates[0] });
+    } else if (bestCandidates.length > 1) {
+      return 'ambiguous';
+    }
+  }
+
+  if (perCredentialBest.length === 0) return 'none';
+  if (perCredentialBest.length > 1) return 'ambiguous';
+  return perCredentialBest[0];
+}
+
+function headerTemplate(
+  hostPattern: string,
+  headerName = 'Authorization',
+  valuePrefix = 'Key ',
+): CredentialInjectionTemplate {
+  return { hostPattern, injectionType: 'header', headerName, valuePrefix };
+}
+
+function queryTemplate(
+  hostPattern: string,
+  queryParamName: string,
+): CredentialInjectionTemplate {
+  return { hostPattern, injectionType: 'query', queryParamName };
+}
+
+describe('MITM rewrite candidate selection (specificity-aligned)', () => {
+  test('one credential with fal.run + *.fal.run injects exact once', () => {
+    const templates = new Map([
+      [
+        'cred-fal',
+        [
+          headerTemplate('fal.run', 'Authorization', 'Key '),
+          headerTemplate('*.fal.run', 'Authorization', 'Key '),
+        ],
+      ],
+    ]);
+    const result = selectRewriteCandidate('fal.run', templates);
+    expect(result).not.toBe('ambiguous');
+    expect(result).not.toBe('none');
+    if (typeof result === 'object') {
+      expect(result.credId).toBe('cred-fal');
+      expect(result.tpl.hostPattern).toBe('fal.run');
+    }
+  });
+
+  test('one credential with only wildcard matches bare domain via apex inclusion', () => {
+    const templates = new Map([['cred-fal', [headerTemplate('*.fal.run')]]]);
+    const result = selectRewriteCandidate('fal.run', templates);
+    expect(result).not.toBe('ambiguous');
+    expect(result).not.toBe('none');
+    if (typeof result === 'object') {
+      expect(result.credId).toBe('cred-fal');
+    }
+  });
+
+  test('two credentials matching same host still blocks (ambiguous)', () => {
+    const templates = new Map([
+      ['cred-a', [headerTemplate('*.fal.run', 'Authorization')]],
+      ['cred-b', [headerTemplate('*.fal.run', 'X-Api-Key')]],
+    ]);
+    const result = selectRewriteCandidate('api.fal.run', templates);
+    expect(result).toBe('ambiguous');
+  });
+
+  test('no match returns none', () => {
+    const templates = new Map([
+      ['cred-openai', [headerTemplate('*.openai.com')]],
+    ]);
+    const result = selectRewriteCandidate('api.fal.run', templates);
+    expect(result).toBe('none');
+  });
+
+  test('query templates are excluded from candidate selection', () => {
+    const templates = new Map([
+      [
+        'cred-gcp',
+        [
+          queryTemplate('maps.googleapis.com', 'key'),
+          headerTemplate('maps.googleapis.com'),
+        ],
+      ],
+    ]);
+    const result = selectRewriteCandidate('maps.googleapis.com', templates);
+    expect(result).not.toBe('ambiguous');
+    if (typeof result === 'object') {
+      expect(result.tpl.injectionType).toBe('header');
+    }
+  });
+
+  test('same credential equal-specificity tie returns ambiguous', () => {
+    const templates = new Map([
+      [
+        'cred-dual',
+        [
+          headerTemplate('api.fal.run', 'Authorization', 'Key '),
+          headerTemplate('api.fal.run', 'X-Api-Key', 'Bearer '),
+        ],
+      ],
+    ]);
+    const result = selectRewriteCandidate('api.fal.run', templates);
+    expect(result).toBe('ambiguous');
+  });
+
+  test('exact match beats wildcard even when wildcard is listed first', () => {
+    const templates = new Map([
+      [
+        'cred-fal',
+        [
+          headerTemplate('*.fal.ai', 'Authorization', 'Key '),
+          headerTemplate('api.fal.ai', 'Authorization', 'Bearer '),
+        ],
+      ],
+    ]);
+    const result = selectRewriteCandidate('api.fal.ai', templates);
+    expect(result).not.toBe('ambiguous');
+    expect(result).not.toBe('none');
+    if (typeof result === 'object') {
+      expect(result.tpl.hostPattern).toBe('api.fal.ai');
+      expect(result.tpl.valuePrefix).toBe('Bearer ');
+    }
+  });
+
+  test('only query templates for a credential results in no match', () => {
+    const templates = new Map([
+      ['cred-gcp', [queryTemplate('maps.googleapis.com', 'key')]],
+    ]);
+    const result = selectRewriteCandidate('maps.googleapis.com', templates);
+    expect(result).toBe('none');
+  });
+
+  test('empty templates map returns none', () => {
+    const result = selectRewriteCandidate('api.fal.ai', new Map());
+    expect(result).toBe('none');
+  });
+
+  test('credential with empty templates array returns none', () => {
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-empty', []],
+    ]);
+    const result = selectRewriteCandidate('api.fal.ai', templates);
+    expect(result).toBe('none');
+  });
+});

--- a/proxy-sidecar/src/__tests__/router.test.ts
+++ b/proxy-sidecar/src/__tests__/router.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, test } from 'bun:test';
+
+import { routeConnection, type RouteDecision } from '../router.js';
+import type { CredentialInjectionTemplate } from '../types.js';
+
+function headerTemplate(
+  hostPattern: string,
+  headerName = 'Authorization',
+  valuePrefix = 'Key ',
+): CredentialInjectionTemplate {
+  return { hostPattern, injectionType: 'header', headerName, valuePrefix };
+}
+
+function queryTemplate(
+  hostPattern: string,
+  queryParamName: string,
+): CredentialInjectionTemplate {
+  return { hostPattern, injectionType: 'query', queryParamName };
+}
+
+describe('routeConnection', () => {
+  // -- tunnel:no_credentials -------------------------------------------------
+
+  test('returns tunnel:no_credentials when credentialIds is empty', () => {
+    const result = routeConnection('api.fal.ai', 443, [], new Map());
+    expect(result).toEqual<RouteDecision>({
+      action: 'tunnel',
+      reason: 'tunnel:no_credentials',
+    });
+  });
+
+  test('returns tunnel:no_credentials even when templates exist but no ids provided', () => {
+    const templates = new Map<string, readonly CredentialInjectionTemplate[]>([
+      ['cred-1', [headerTemplate('*.fal.ai')]],
+    ]);
+    const result = routeConnection('api.fal.ai', 443, [], templates);
+    expect(result).toEqual<RouteDecision>({
+      action: 'tunnel',
+      reason: 'tunnel:no_credentials',
+    });
+  });
+
+  // -- tunnel:no_rewrite -----------------------------------------------------
+
+  test('returns tunnel:no_rewrite when no template matches the hostname', () => {
+    const templates = new Map<string, readonly CredentialInjectionTemplate[]>([
+      ['cred-1', [headerTemplate('*.openai.com')]],
+    ]);
+    const result = routeConnection('api.fal.ai', 443, ['cred-1'], templates);
+    expect(result).toEqual<RouteDecision>({
+      action: 'tunnel',
+      reason: 'tunnel:no_rewrite',
+    });
+  });
+
+  test('returns tunnel:no_rewrite when credential id has no templates', () => {
+    const result = routeConnection(
+      'api.fal.ai',
+      443,
+      ['cred-unknown'],
+      new Map(),
+    );
+    expect(result).toEqual<RouteDecision>({
+      action: 'tunnel',
+      reason: 'tunnel:no_rewrite',
+    });
+  });
+
+  // -- mitm:credential_injection ---------------------------------------------
+
+  test('returns mitm:credential_injection when a header template matches', () => {
+    const templates = new Map<string, readonly CredentialInjectionTemplate[]>([
+      ['cred-fal', [headerTemplate('*.fal.ai')]],
+    ]);
+    const result = routeConnection('api.fal.ai', 443, ['cred-fal'], templates);
+    expect(result).toEqual<RouteDecision>({
+      action: 'mitm',
+      reason: 'mitm:credential_injection',
+    });
+  });
+
+  test('returns mitm:credential_injection when a query template matches', () => {
+    const templates = new Map<string, readonly CredentialInjectionTemplate[]>([
+      ['cred-gcp', [queryTemplate('maps.googleapis.com', 'key')]],
+    ]);
+    const result = routeConnection(
+      'maps.googleapis.com',
+      443,
+      ['cred-gcp'],
+      templates,
+    );
+    expect(result).toEqual<RouteDecision>({
+      action: 'mitm',
+      reason: 'mitm:credential_injection',
+    });
+  });
+
+  test('returns mitm:credential_injection with exact hostname match', () => {
+    const templates = new Map<string, readonly CredentialInjectionTemplate[]>([
+      [
+        'cred-rep',
+        [headerTemplate('api.replicate.com', 'Authorization', 'Token ')],
+      ],
+    ]);
+    const result = routeConnection(
+      'api.replicate.com',
+      443,
+      ['cred-rep'],
+      templates,
+    );
+    expect(result).toEqual<RouteDecision>({
+      action: 'mitm',
+      reason: 'mitm:credential_injection',
+    });
+  });
+
+  test('returns mitm when any credential matches, even if others do not', () => {
+    const templates = new Map<string, readonly CredentialInjectionTemplate[]>([
+      ['cred-openai', [headerTemplate('*.openai.com')]],
+      ['cred-fal', [headerTemplate('*.fal.ai')]],
+    ]);
+    const result = routeConnection(
+      'api.fal.ai',
+      443,
+      ['cred-openai', 'cred-fal'],
+      templates,
+    );
+    expect(result).toEqual<RouteDecision>({
+      action: 'mitm',
+      reason: 'mitm:credential_injection',
+    });
+  });
+
+  test('matches hostnames case-insensitively', () => {
+    const templates = new Map<string, readonly CredentialInjectionTemplate[]>([
+      ['cred-fal', [headerTemplate('*.fal.ai')]],
+    ]);
+    const result = routeConnection('API.FAL.AI', 443, ['cred-fal'], templates);
+    expect(result).toEqual<RouteDecision>({
+      action: 'mitm',
+      reason: 'mitm:credential_injection',
+    });
+  });
+
+  test('returns mitm when one credential has multiple templates and one matches', () => {
+    const templates = new Map<string, readonly CredentialInjectionTemplate[]>([
+      [
+        'cred-multi',
+        [headerTemplate('*.openai.com'), headerTemplate('*.fal.ai')],
+      ],
+    ]);
+    const result = routeConnection(
+      'api.fal.ai',
+      443,
+      ['cred-multi'],
+      templates,
+    );
+    expect(result).toEqual<RouteDecision>({
+      action: 'mitm',
+      reason: 'mitm:credential_injection',
+    });
+  });
+
+  test('returns mitm for bare domain when wildcard pattern exists (apex-inclusive)', () => {
+    const templates = new Map<string, readonly CredentialInjectionTemplate[]>([
+      ['cred-1', [headerTemplate('*.fal.ai')]],
+    ]);
+    const result = routeConnection('fal.ai', 443, ['cred-1'], templates);
+    expect(result).toEqual<RouteDecision>({
+      action: 'mitm',
+      reason: 'mitm:credential_injection',
+    });
+  });
+
+  // -- port does not affect decision -----------------------------------------
+
+  test('port does not affect routing decision', () => {
+    const templates = new Map<string, readonly CredentialInjectionTemplate[]>([
+      ['cred-fal', [headerTemplate('*.fal.ai')]],
+    ]);
+    const on443 = routeConnection('api.fal.ai', 443, ['cred-fal'], templates);
+    const on8443 = routeConnection('api.fal.ai', 8443, ['cred-fal'], templates);
+    expect(on443).toEqual(on8443);
+  });
+
+  // -- only authorized credential ids are considered -------------------------
+
+  test('ignores credentials not in the credentialIds list', () => {
+    const templates = new Map<string, readonly CredentialInjectionTemplate[]>([
+      ['cred-a', [headerTemplate('*.fal.ai')]],
+      ['cred-b', [headerTemplate('*.openai.com')]],
+    ]);
+    const result = routeConnection('api.fal.ai', 443, ['cred-b'], templates);
+    expect(result).toEqual<RouteDecision>({
+      action: 'tunnel',
+      reason: 'tunnel:no_rewrite',
+    });
+  });
+
+  test('regression: routeConnection fal.run with *.fal.run template => mitm', () => {
+    const templates = new Map<string, readonly CredentialInjectionTemplate[]>([
+      ['cred-fal', [headerTemplate('*.fal.run')]],
+    ]);
+    const result = routeConnection('fal.run', 443, ['cred-fal'], templates);
+    expect(result).toEqual<RouteDecision>({
+      action: 'mitm',
+      reason: 'mitm:credential_injection',
+    });
+  });
+
+  // -- edge cases -----------------------------------------------------------
+
+  test('empty templates map with credential IDs returns tunnel:no_rewrite', () => {
+    const result = routeConnection(
+      'api.fal.ai',
+      443,
+      ['cred-a', 'cred-b'],
+      new Map(),
+    );
+    expect(result).toEqual<RouteDecision>({
+      action: 'tunnel',
+      reason: 'tunnel:no_rewrite',
+    });
+  });
+
+  test('credential ID present in list but absent from map returns tunnel:no_rewrite', () => {
+    const templates = new Map<string, readonly CredentialInjectionTemplate[]>([
+      ['cred-other', [headerTemplate('*.fal.ai')]],
+    ]);
+    const result = routeConnection(
+      'api.fal.ai',
+      443,
+      ['cred-missing'],
+      templates,
+    );
+    expect(result).toEqual<RouteDecision>({
+      action: 'tunnel',
+      reason: 'tunnel:no_rewrite',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds comprehensive unit tests for the proxy-sidecar package
- Tests cover host pattern matching, certificate management, policy engine, router decisions, connect tunnel, HTTP forwarding, MITM handler, rewrite specificity, and logging/diagnostics
- All tests run independently within proxy-sidecar/ without runtime dependencies
- 147 tests across 9 test files covering positive paths and edge cases (malformed inputs, timeouts, partial failures, case-insensitivity, ambiguity detection)

## Test plan
- [x] `cd proxy-sidecar && bun test` -- 147 tests pass
- [x] `cd proxy-sidecar && bunx tsc --noEmit` -- type-check passes

Part of plan: P15-mitm-package-split.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
