### PR TITLE
Things page redesign: layout, hover menu, and nav flicker fix

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1156,6 +1156,7 @@ struct MainWindowView: View {
                         sidebarPinnedAppRow(app)
                     }
                 }
+                .drawingGroup() // Isolate into Metal layer to prevent re-renders from sibling hover
 
                 VColor.divider
                     .frame(height: 1)
@@ -1356,6 +1357,7 @@ struct MainWindowView: View {
                         sidebarPinnedAppRow(app, isExpanded: false)
                     }
                 }
+                .drawingGroup() // Isolate into Metal layer to prevent re-renders from sibling hover
 
                 VColor.divider
                     .frame(height: 1)
@@ -1610,10 +1612,12 @@ private struct SidebarPrimaryRow: View {
             .padding(.trailing, isExpanded ? VSpacing.sm : 0)
             .padding(.vertical, VSpacing.sm)
             .frame(maxWidth: .infinity, alignment: isExpanded ? .leading : .center)
-            .background(isActive ? adaptiveColor(light: Moss._100, dark: Moss._700) : isHovered ? adaptiveColor(light: Moss._100, dark: Moss._700).opacity(0.5) : .clear)
+            .background(
+                (isActive ? adaptiveColor(light: Moss._100, dark: Moss._700) : isHovered ? adaptiveColor(light: Moss._100, dark: Moss._700).opacity(0.5) : .clear)
+                    .animation(VAnimation.fast, value: isHovered)
+            )
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())
-            .animation(VAnimation.fast, value: isHovered)
         }
         .buttonStyle(.plain)
         .padding(.horizontal, isExpanded ? VSpacing.sm : VSpacing.xs)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Full-screen apps grid view showing all apps as a card grid with search and pinned/recent sections.
+/// Full-screen apps grid view showing all apps as a flat card grid with search.
 struct AppsGridView: View {
     @ObservedObject var appListManager: AppListManager
     let daemonClient: DaemonClient
@@ -9,7 +9,6 @@ struct AppsGridView: View {
 
     @State private var searchText = ""
     @State private var hoveredAppId: String?
-    @State private var recentVisibleCount = 10
     @State private var editingApp: AppListManager.AppItem?
 
     /// Cache of lazily-loaded preview screenshots keyed by app ID.
@@ -18,7 +17,7 @@ struct AppsGridView: View {
     /// In-flight preview fetch tasks, keyed by app ID, so they can be cancelled.
     @State private var previewTasks: [String: Task<Void, Never>] = [:]
 
-    private let columns = Array(repeating: GridItem(.flexible(), spacing: VSpacing.xl), count: 4)
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: VSpacing.xl), count: 5)
 
     /// Maximum width of the centered content area.
     private let maxContentWidth: CGFloat = 1400
@@ -28,34 +27,48 @@ struct AppsGridView: View {
             if appListManager.apps.isEmpty {
                 noAppsEmptyState
             } else {
-                ScrollView {
-                    VStack(spacing: VSpacing.xxl) {
-                        searchBar
-                            .padding(.top, VSpacing.xxl)
-
-                        if !filteredPinnedApps.isEmpty {
-                            pinnedSectionView
-                        }
-
-                        if !filteredRecentApps.isEmpty {
-                            recentSectionView
-                        }
-
-                        if filteredPinnedApps.isEmpty && filteredRecentApps.isEmpty && !searchText.isEmpty {
-                            VEmptyState(
-                                title: "No apps matched",
-                                subtitle: "No apps matched \"\(searchText)\"",
-                                icon: "magnifyingglass"
-                            )
-                            .frame(maxWidth: .infinity)
-                            .padding(.top, VSpacing.xxxl)
-                        }
+                VStack(alignment: .leading, spacing: 0) {
+                    // Header
+                    HStack(alignment: .center) {
+                        Text("Things")
+                            .font(VFont.panelTitle)
+                            .foregroundColor(VColor.textPrimary)
+                        Spacer()
                     }
-                    .frame(maxWidth: maxContentWidth)
-                    .frame(maxWidth: .infinity)
-                    .padding(.horizontal, VSpacing.xxxl)
-                    .padding(.bottom, VSpacing.xxl)
+                    .padding(.bottom, VSpacing.md)
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    ScrollView {
+                        VStack(spacing: VSpacing.xxl) {
+                            searchBar
+
+                            let allApps = filteredApps
+                            if !allApps.isEmpty {
+                                LazyVGrid(columns: columns, spacing: VSpacing.xxl) {
+                                    ForEach(allApps) { app in
+                                        appCard(app)
+                                            .onAppear { fetchPreviewIfNeeded(app) }
+                                    }
+                                }
+                            }
+
+                            if allApps.isEmpty && !searchText.isEmpty {
+                                VEmptyState(
+                                    title: "No apps matched",
+                                    subtitle: "No apps matched \"\(searchText)\"",
+                                    icon: "magnifyingglass"
+                                )
+                                .frame(maxWidth: .infinity)
+                                .padding(.top, VSpacing.xxxl)
+                            }
+                        }
+                        .frame(maxWidth: maxContentWidth)
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, VSpacing.lg)
+                    }
                 }
+                .padding(VSpacing.lg)
             }
         }
         .background(VColor.backgroundSubtle)
@@ -100,60 +113,7 @@ struct AppsGridView: View {
     // MARK: - Search Bar
 
     private var searchBar: some View {
-        VSearchBar(placeholder: "Search apps...", text: $searchText)
-    }
-
-    // MARK: - Sections
-
-    private var pinnedSectionView: some View {
-        VStack(alignment: .leading, spacing: VSpacing.lg) {
-            Text("Pinned")
-                .font(VFont.headline)
-                .foregroundColor(VColor.textSecondary)
-
-            LazyVGrid(columns: columns, spacing: VSpacing.xxl) {
-                ForEach(filteredPinnedApps) { app in
-                    appCard(app)
-                        .onAppear { fetchPreviewIfNeeded(app) }
-                }
-            }
-        }
-    }
-
-    private var recentSectionView: some View {
-        VStack(alignment: .leading, spacing: VSpacing.lg) {
-            Text("Recent")
-                .font(VFont.headline)
-                .foregroundColor(VColor.textSecondary)
-
-            let visibleRecent = Array(filteredRecentApps.prefix(recentVisibleCount))
-
-            LazyVGrid(columns: columns, spacing: VSpacing.xxl) {
-                ForEach(visibleRecent) { app in
-                    appCard(app)
-                        .onAppear { fetchPreviewIfNeeded(app) }
-                }
-            }
-
-            if filteredRecentApps.count > recentVisibleCount {
-                HStack {
-                    Spacer()
-                    Button {
-                        withAnimation(VAnimation.standard) {
-                            recentVisibleCount += 10
-                        }
-                    } label: {
-                        Text("Show more")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.accent)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Show more recent apps")
-                    Spacer()
-                }
-                .padding(.top, VSpacing.sm)
-            }
-        }
+        VSearchBar(placeholder: "Find your things", text: $searchText)
     }
 
     // MARK: - App Card
@@ -206,19 +166,17 @@ struct AppsGridView: View {
                 )
                 .shadow(color: .black.opacity(0.06), radius: 4, y: 2)
 
-                // Name + description below the image
+                // Name + date below the image
                 VStack(alignment: .leading, spacing: 2) {
                     Text(app.name)
                         .font(VFont.bodyBold)
                         .foregroundColor(VColor.textPrimary)
                         .lineLimit(1)
 
-                    if let description = app.description, !description.isEmpty {
-                        Text(description)
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-                            .lineLimit(1)
-                    }
+                    Text(Self.formatDate(app.lastOpenedAt))
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                        .lineLimit(1)
                 }
                 .padding(.horizontal, VSpacing.xs)
             }
@@ -301,22 +259,28 @@ struct AppsGridView: View {
         return VAppIconGenerator.generate(from: app.name, type: app.appType)
     }
 
-    private var filteredPinnedApps: [AppListManager.AppItem] {
-        let pinned = appListManager.displayApps.filter { $0.isPinned }
-        guard !searchText.isEmpty else { return pinned }
-        return pinned.filter { matchesSearch($0) }
-    }
-
-    private var filteredRecentApps: [AppListManager.AppItem] {
-        let unpinned = appListManager.displayApps.filter { !$0.isPinned }
-            .sorted { ($0.lastOpenedAt) > ($1.lastOpenedAt) }
-        guard !searchText.isEmpty else { return unpinned }
-        return unpinned.filter { matchesSearch($0) }
+    /// All apps sorted with pinned first (by pinnedOrder), then unpinned (by lastOpenedAt desc), filtered by search.
+    private var filteredApps: [AppListManager.AppItem] {
+        let sorted = appListManager.displayApps
+        guard !searchText.isEmpty else { return sorted }
+        return sorted.filter { matchesSearch($0) }
     }
 
     private func matchesSearch(_ app: AppListManager.AppItem) -> Bool {
         app.name.localizedCaseInsensitiveContains(searchText) ||
         (app.description?.localizedCaseInsensitiveContains(searchText) ?? false)
+    }
+
+    /// Formats a date in a locale-aware medium style (e.g. "Jan 12, 2026" in en_US).
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }()
+
+    private static func formatDate(_ date: Date) -> String {
+        dateFormatter.string(from: date)
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -176,8 +176,14 @@ struct AppsGridView: View {
                             Label(app.isPinned ? "Unpin" : "Pin", systemImage: app.isPinned ? "pin.slash" : "pin")
                         }
                         Button(role: .destructive) {
-                            hoveredAppId = nil
-                            NSCursor.pop()
+                            // Only pop the cursor if onHover exit hasn't already done so.
+                            // When the menu popover opens the cursor leaves the card, firing
+                            // the onHover exit which pops the cursor and nils hoveredAppId.
+                            // Popping again here would unbalance the cursor stack.
+                            if hoveredAppId != nil {
+                                hoveredAppId = nil
+                                NSCursor.pop()
+                            }
                             appListManager.removeApp(id: app.id)
                         } label: {
                             Label("Delete", systemImage: "trash")

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -43,17 +43,18 @@ struct AppsGridView: View {
                         VStack(spacing: VSpacing.xxl) {
                             searchBar
 
-                            let allApps = filteredApps
-                            if !allApps.isEmpty {
-                                LazyVGrid(columns: columns, spacing: VSpacing.xxl) {
-                                    ForEach(allApps) { app in
-                                        appCard(app)
-                                            .onAppear { fetchPreviewIfNeeded(app) }
-                                    }
-                                }
+                            let pinned = filteredPinnedApps
+                            let recents = filteredRecentApps
+
+                            if !pinned.isEmpty {
+                                appSection(title: "Pinned", apps: pinned)
                             }
 
-                            if allApps.isEmpty && !searchText.isEmpty {
+                            if !recents.isEmpty {
+                                appSection(title: "Recents", apps: recents)
+                            }
+
+                            if pinned.isEmpty && recents.isEmpty && !searchText.isEmpty {
                                 VEmptyState(
                                     title: "No apps matched",
                                     subtitle: "No apps matched \"\(searchText)\"",
@@ -165,44 +166,38 @@ struct AppsGridView: View {
                         .stroke(VColor.surfaceBorder, lineWidth: 1)
                 )
                 .overlay(alignment: .topTrailing) {
-                    Menu {
-                        Button {
-                            if app.isPinned {
-                                appListManager.unpinApp(id: app.id)
-                            } else {
-                                appListManager.pinApp(id: app.id)
+                    VIconButton(label: "App actions", icon: "ellipsis", iconOnly: true, variant: .filled(VColor.buttonPrimary), size: 24) {}
+                        .overlay {
+                            Menu {
+                                Button {
+                                    if app.isPinned {
+                                        appListManager.unpinApp(id: app.id)
+                                    } else {
+                                        appListManager.pinApp(id: app.id)
+                                    }
+                                } label: {
+                                    Label(app.isPinned ? "Unpin" : "Pin", systemImage: app.isPinned ? "pin.slash" : "pin")
+                                }
+                                Button(role: .destructive) {
+                                    if hoveredAppId != nil {
+                                        hoveredAppId = nil
+                                        NSCursor.pop()
+                                    }
+                                    appListManager.removeApp(id: app.id)
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            } label: {
+                                Color.clear
                             }
-                        } label: {
-                            Label(app.isPinned ? "Unpin" : "Pin", systemImage: app.isPinned ? "pin.slash" : "pin")
+                            .menuStyle(.borderlessButton)
+                            .menuIndicator(.hidden)
                         }
-                        Button(role: .destructive) {
-                            // Only pop the cursor if onHover exit hasn't already done so.
-                            // When the menu popover opens the cursor leaves the card, firing
-                            // the onHover exit which pops the cursor and nils hoveredAppId.
-                            // Popping again here would unbalance the cursor stack.
-                            if hoveredAppId != nil {
-                                hoveredAppId = nil
-                                NSCursor.pop()
-                            }
-                            appListManager.removeApp(id: app.id)
-                        } label: {
-                            Label("Delete", systemImage: "trash")
-                        }
-                    } label: {
-                        Image(systemName: "ellipsis")
-                            .font(.system(size: 14, weight: .bold))
-                            .foregroundColor(.white)
-                            .frame(width: 28, height: 28)
-                            .background(Circle().fill(Color(hex: 0x4B6845)))
-                    }
-                    .menuStyle(.borderlessButton)
-                    .menuIndicator(.hidden)
-                    .accessibilityLabel("App actions")
-                    .fixedSize()
-                    .padding(VSpacing.sm)
-                    .opacity(isHovered ? 1 : 0)
-                    .allowsHitTesting(isHovered)
-                    .animation(VAnimation.fast, value: isHovered)
+                        .accessibilityLabel("App actions")
+                        .padding(VSpacing.sm)
+                        .opacity(isHovered ? 1 : 0)
+                        .allowsHitTesting(isHovered)
+                        .animation(VAnimation.fast, value: isHovered)
                 }
                 .shadow(color: .black.opacity(0.06), radius: 4, y: 2)
 
@@ -223,8 +218,6 @@ struct AppsGridView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .opacity(isHovered ? 0.85 : 1.0)
-        .animation(VAnimation.fast, value: isHovered)
         .onHover { hovering in
             hoveredAppId = hovering ? app.id : nil
             if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
@@ -290,6 +283,23 @@ struct AppsGridView: View {
         previewTasks[appId] = task
     }
 
+    // MARK: - Sections
+
+    private func appSection(title: String, apps: [AppListManager.AppItem]) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text(title)
+                .font(VFont.headline)
+                .foregroundColor(VColor.textSecondary)
+
+            LazyVGrid(columns: columns, spacing: VSpacing.xxl) {
+                ForEach(apps) { app in
+                    appCard(app)
+                        .onAppear { fetchPreviewIfNeeded(app) }
+                }
+            }
+        }
+    }
+
     // MARK: - Helpers
 
     private func resolvedIcon(for app: AppListManager.AppItem) -> (sfSymbol: String, colors: [String]) {
@@ -299,11 +309,18 @@ struct AppsGridView: View {
         return VAppIconGenerator.generate(from: app.name, type: app.appType)
     }
 
-    /// All apps sorted with pinned first (by pinnedOrder), then unpinned (by lastOpenedAt desc), filtered by search.
-    private var filteredApps: [AppListManager.AppItem] {
-        let sorted = appListManager.displayApps
-        guard !searchText.isEmpty else { return sorted }
-        return sorted.filter { matchesSearch($0) }
+    /// Pinned apps filtered by search text.
+    private var filteredPinnedApps: [AppListManager.AppItem] {
+        let pinned = appListManager.pinnedApps
+        guard !searchText.isEmpty else { return pinned }
+        return pinned.filter { matchesSearch($0) }
+    }
+
+    /// Unpinned apps sorted by lastOpenedAt descending, filtered by search text.
+    private var filteredRecentApps: [AppListManager.AppItem] {
+        let unpinned = appListManager.displayApps.filter { !$0.isPinned }
+        guard !searchText.isEmpty else { return unpinned }
+        return unpinned.filter { matchesSearch($0) }
     }
 
     private func matchesSearch(_ app: AppListManager.AppItem) -> Bool {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -164,6 +164,40 @@ struct AppsGridView: View {
                     RoundedRectangle(cornerRadius: VRadius.lg)
                         .stroke(VColor.surfaceBorder, lineWidth: 1)
                 )
+                .overlay(alignment: .topTrailing) {
+                    Menu {
+                        Button {
+                            if app.isPinned {
+                                appListManager.unpinApp(id: app.id)
+                            } else {
+                                appListManager.pinApp(id: app.id)
+                            }
+                        } label: {
+                            Label(app.isPinned ? "Unpin" : "Pin", systemImage: app.isPinned ? "pin.slash" : "pin")
+                        }
+                        Button(role: .destructive) {
+                            hoveredAppId = nil
+                            NSCursor.pop()
+                            appListManager.removeApp(id: app.id)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis")
+                            .font(.system(size: 14, weight: .bold))
+                            .foregroundColor(.white)
+                            .frame(width: 28, height: 28)
+                            .background(Circle().fill(Color(hex: 0x4B6845)))
+                    }
+                    .menuStyle(.borderlessButton)
+                    .menuIndicator(.hidden)
+                    .accessibilityLabel("App actions")
+                    .fixedSize()
+                    .padding(VSpacing.sm)
+                    .opacity(isHovered ? 1 : 0)
+                    .allowsHitTesting(isHovered)
+                    .animation(VAnimation.fast, value: isHovered)
+                }
                 .shadow(color: .black.opacity(0.06), radius: 4, y: 2)
 
                 // Name + date below the image

--- a/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
@@ -3,24 +3,33 @@ import SwiftUI
 import AppKit
 #endif
 
+public enum VIconButtonVariant {
+    case standard
+    case filled(Color)
+}
+
 public struct VIconButton: View {
     public let label: String
     public var icon: String = ""
     public var customIcon: Image? = nil
     public var isActive: Bool = false
     public var iconOnly: Bool = false
+    public var variant: VIconButtonVariant = .standard
+    public var size: CGFloat? = nil
     public var tooltip: String? = nil
     public let action: () -> Void
 
     @State private var isHovered = false
     @FocusState private var isFocused: Bool
 
-    public init(label: String, icon: String = "", customIcon: Image? = nil, isActive: Bool = false, iconOnly: Bool = false, tooltip: String? = nil, action: @escaping () -> Void) {
+    public init(label: String, icon: String = "", customIcon: Image? = nil, isActive: Bool = false, iconOnly: Bool = false, variant: VIconButtonVariant = .standard, size: CGFloat? = nil, tooltip: String? = nil, action: @escaping () -> Void) {
         self.label = label
         self.icon = icon
         self.customIcon = customIcon
         self.isActive = isActive
         self.iconOnly = iconOnly
+        self.variant = variant
+        self.size = size
         self.tooltip = tooltip
         self.action = action
     }
@@ -40,21 +49,30 @@ public struct VIconButton: View {
                         .font(VFont.caption)
                 }
             }
-            .foregroundColor(iconForegroundColor)
+            .foregroundColor(iconForegroundForVariant)
         }
         .focused($isFocused)
-        .buttonStyle(VIconButtonStyle(isActive: isActive, isHovered: isHovered, isFocused: isFocused))
+        .buttonStyle(VIconButtonStyle(isActive: isActive, isHovered: isHovered, isFocused: isFocused, size: size, variant: variant))
         #if os(macOS)
         .onHover { hovering in
             isHovered = hovering
-            if hovering { NSCursor.pointingHand.set() }
-            else { NSCursor.arrow.set() }
+            if case .filled = variant {} else {
+                if hovering { NSCursor.pointingHand.set() }
+                else { NSCursor.arrow.set() }
+            }
         }
         #else
         .onHover { isHovered = $0 }
         #endif
         .accessibilityLabel(label)
         .modifier(OptionalHelpModifier(tooltip: tooltip))
+    }
+
+    private var iconForegroundForVariant: Color {
+        if case .filled = variant {
+            return .white
+        }
+        return iconForegroundColor
     }
 
     private var iconForegroundColor: Color {
@@ -85,18 +103,24 @@ public struct VIconButtonStyle: ButtonStyle {
     public var isHovered: Bool
     public var isFocused: Bool
     public var size: CGFloat?
+    public var variant: VIconButtonVariant
 
     @Environment(\.isEnabled) private var isEnabled
 
-    public init(isActive: Bool = false, isHovered: Bool, isFocused: Bool = false, size: CGFloat? = nil) {
+    public init(isActive: Bool = false, isHovered: Bool, isFocused: Bool = false, size: CGFloat? = nil, variant: VIconButtonVariant = .standard) {
         self.isActive = isActive
         self.isHovered = isHovered
         self.isFocused = isFocused
         self.size = size
+        self.variant = variant
     }
 
     public func makeBody(configuration: Configuration) -> some View {
-        let shape = RoundedRectangle(cornerRadius: VRadius.md)
+        let cornerRadius: CGFloat = {
+            if case .filled = variant { return VRadius.md }
+            return VRadius.md
+        }()
+        let shape = RoundedRectangle(cornerRadius: cornerRadius)
 
         configuration.label
             .frame(width: size, height: size)
@@ -118,6 +142,12 @@ public struct VIconButtonStyle: ButtonStyle {
     }
 
     private func backgroundColor(isPressed: Bool) -> Color {
+        if case .filled(let color) = variant {
+            guard isEnabled else { return color.opacity(0.5) }
+            if isPressed { return color.opacity(0.7) }
+            if isHovered { return color.opacity(0.85) }
+            return color
+        }
         guard isEnabled else {
             return isActive ? adaptiveColor(light: Moss._100, dark: Moss._700).opacity(0.5) : .clear
         }
@@ -133,6 +163,7 @@ public struct VIconButtonStyle: ButtonStyle {
     }
 
     private var borderColor: Color {
+        if case .filled = variant { return .clear }
         guard isEnabled, isFocused else { return .clear }
         return VColor.accent.opacity(0.72)
     }
@@ -146,8 +177,9 @@ public struct VIconButtonStyle: ButtonStyle {
             VIconButton(label: "Active", icon: "star.fill", isActive: true) {}
             VIconButton(label: "Icon Only", icon: "plus", iconOnly: true) {}
             VIconButton(label: "Active Icon", icon: "pencil", isActive: true, iconOnly: true) {}
+            VIconButton(label: "Filled", icon: "ellipsis", iconOnly: true, variant: .filled(VColor.buttonPrimary)) {}
         }
         .padding()
     }
-    .frame(width: 400, height: 80)
+    .frame(width: 500, height: 80)
 }

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -141,6 +141,31 @@ struct ButtonsGallerySection: View {
 
             Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
 
+            // MARK: - VIconButton (Filled)
+            GallerySectionHeader(
+                title: "VIconButton (Filled)",
+                description: "Filled icon buttons with a solid background color and white icon."
+            )
+
+            VCard {
+                HStack(spacing: VSpacing.xl) {
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Primary").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VIconButton(label: "More", icon: "ellipsis", iconOnly: true, variant: .filled(VColor.buttonPrimary)) {}
+                    }
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Accent").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VIconButton(label: "Add", icon: "plus", iconOnly: true, variant: .filled(VColor.accent)) {}
+                    }
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Error").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VIconButton(label: "Delete", icon: "trash", iconOnly: true, variant: .filled(VColor.error)) {}
+                    }
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
             // MARK: - VIconButton (Icon Only)
             GallerySectionHeader(
                 title: "VIconButton (Icon Only)",


### PR DESCRIPTION
## Summary
Redesigns the Things page to match the Intelligence page styling, adds a 3-dot context menu on app card hover, and fixes sidebar navigation hover flicker.

## Changes
- **Layout update**: Replaced sectioned grid (Pinned/Recent) with a flat 5-column grid. Added "Things" header with `VFont.panelTitle`, 16px container padding, divider below header. Removed the X close button. Added locale-aware date subtitles. Updated search placeholder to "Find your things".
- **Hover menu**: Added a 3-dot ellipsis menu overlay on app card hover with Pin/Unpin and Delete actions. Includes proper hit-testing (`allowsHitTesting`), accessibility labels, and cursor stack management on delete.
- **Nav flicker fix**: Scoped `.animation()` in `SidebarPrimaryRow` to only the background modifier, and added `.drawingGroup()` to pinned apps VStack to prevent base64 image re-decode on hover.

## Milestone PRs (merged into feature branch)
- #11711: M1: Update Things page layout to match Intelligence page styling
- #11719: M2: Add 3-dot hover menu overlay on app cards
- #11732: M3: Fix sidebar nav hover preview flicker

## Project issue
Closes #11700

## Test plan
- [ ] Verify Things page layout matches Intelligence page (header, padding, divider)
- [ ] Verify search bar remains full-width
- [ ] Verify no X close button on Things page
- [ ] Verify 3-dot menu appears on app card hover with Pin/Unpin and Delete options
- [ ] Verify hovering sidebar nav items doesn't cause preview card flicker
- [ ] Verify cursor resets properly after deleting an app via the 3-dot menu

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
