### PR TITLE
Add health/readiness endpoints in sidecar server

### DIFF
--- a/proxy-sidecar/src/__tests__/config.test.ts
+++ b/proxy-sidecar/src/__tests__/config.test.ts
@@ -8,6 +8,7 @@ describe('loadConfig', () => {
     expect(config).toEqual({
       port: 8080,
       host: '0.0.0.0',
+      healthPort: 8081,
       caDir: null,
       logLevel: 'info',
     });
@@ -79,5 +80,29 @@ describe('loadConfig', () => {
   it('accepts port 65535 (maximum)', () => {
     const config = loadConfig({ PROXY_PORT: '65535' });
     expect(config.port).toBe(65535);
+  });
+
+  it('reads PROXY_HEALTH_PORT from the environment', () => {
+    const config = loadConfig({ PROXY_HEALTH_PORT: '9091' });
+    expect(config.healthPort).toBe(9091);
+  });
+
+  it('defaults PROXY_HEALTH_PORT to 8081', () => {
+    const config = loadConfig({});
+    expect(config.healthPort).toBe(8081);
+  });
+
+  it('throws ConfigError for invalid PROXY_HEALTH_PORT', () => {
+    expect(() => loadConfig({ PROXY_HEALTH_PORT: 'bad' })).toThrow(ConfigError);
+  });
+
+  it('throws ConfigError for out-of-range PROXY_HEALTH_PORT', () => {
+    expect(() => loadConfig({ PROXY_HEALTH_PORT: '0' })).toThrow(ConfigError);
+    expect(() => loadConfig({ PROXY_HEALTH_PORT: '70000' })).toThrow(ConfigError);
+  });
+
+  it('treats empty PROXY_HEALTH_PORT the same as missing', () => {
+    const config = loadConfig({ PROXY_HEALTH_PORT: '' });
+    expect(config.healthPort).toBe(8081);
   });
 });

--- a/proxy-sidecar/src/__tests__/health.test.ts
+++ b/proxy-sidecar/src/__tests__/health.test.ts
@@ -1,0 +1,162 @@
+import http from 'node:http';
+
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+
+import { createHealthServer } from '../health.js';
+
+/**
+ * Helper: make an HTTP request to the health server and return the response.
+ */
+function request(
+  port: number,
+  path: string,
+  method: string = 'GET',
+): Promise<{ status: number; body: string; headers: http.IncomingHttpHeaders }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: '127.0.0.1', port, path, method },
+      (res) => {
+        let body = '';
+        res.on('data', (chunk: Buffer) => {
+          body += chunk.toString();
+        });
+        res.on('end', () => {
+          resolve({ status: res.statusCode!, body, headers: res.headers });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests with proxy "ready"
+// ---------------------------------------------------------------------------
+
+describe('health server (proxy ready)', () => {
+  let server: http.Server;
+  let port: number;
+
+  beforeAll(async () => {
+    server = createHealthServer({ isReady: () => true });
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+    const addr = server.address();
+    port = typeof addr === 'object' && addr ? addr.port : 0;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  it('GET /healthz returns 200 with status ok', async () => {
+    const res = await request(port, '/healthz');
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ status: 'ok' });
+    expect(res.headers['content-type']).toBe('application/json');
+  });
+
+  it('GET /readyz returns 200 when proxy is ready', async () => {
+    const res = await request(port, '/readyz');
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ status: 'ready' });
+    expect(res.headers['content-type']).toBe('application/json');
+  });
+
+  it('returns 404 for unknown paths', async () => {
+    const res = await request(port, '/unknown');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 405 for non-GET methods', async () => {
+    const res = await request(port, '/healthz', 'POST');
+    expect(res.status).toBe(405);
+    expect(res.headers['allow']).toBe('GET');
+  });
+
+  it('returns 404 for root path', async () => {
+    const res = await request(port, '/');
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests with proxy "not ready"
+// ---------------------------------------------------------------------------
+
+describe('health server (proxy not ready)', () => {
+  let server: http.Server;
+  let port: number;
+
+  beforeAll(async () => {
+    server = createHealthServer({ isReady: () => false });
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+    const addr = server.address();
+    port = typeof addr === 'object' && addr ? addr.port : 0;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  it('GET /healthz still returns 200 (process is alive)', async () => {
+    const res = await request(port, '/healthz');
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ status: 'ok' });
+  });
+
+  it('GET /readyz returns 503 when proxy is not ready', async () => {
+    const res = await request(port, '/readyz');
+    expect(res.status).toBe(503);
+    expect(JSON.parse(res.body)).toEqual({ status: 'not_ready' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dynamic readiness transition
+// ---------------------------------------------------------------------------
+
+describe('health server (dynamic readiness)', () => {
+  let server: http.Server;
+  let port: number;
+  let ready = false;
+
+  beforeAll(async () => {
+    server = createHealthServer({ isReady: () => ready });
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+    const addr = server.address();
+    port = typeof addr === 'object' && addr ? addr.port : 0;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  it('reflects readiness changes dynamically', async () => {
+    // Initially not ready
+    let res = await request(port, '/readyz');
+    expect(res.status).toBe(503);
+
+    // Transition to ready
+    ready = true;
+    res = await request(port, '/readyz');
+    expect(res.status).toBe(200);
+
+    // Transition back to not ready (e.g., during shutdown)
+    ready = false;
+    res = await request(port, '/readyz');
+    expect(res.status).toBe(503);
+  });
+});

--- a/proxy-sidecar/src/config.ts
+++ b/proxy-sidecar/src/config.ts
@@ -11,6 +11,8 @@ export interface SidecarConfig {
   port: number;
   /** Host address to bind to. */
   host: string;
+  /** Port for the health/readiness HTTP server. */
+  healthPort: number;
   /** Optional CA directory for MITM interception (contains ca.pem / ca-key.pem). */
   caDir: string | null;
   /** Log level for the sidecar process. */
@@ -23,25 +25,27 @@ export interface SidecarConfig {
  * Environment variables:
  *   PROXY_PORT            - Port to listen on (default: 8080)
  *   PROXY_HOST            - Host to bind to (default: "0.0.0.0")
+ *   PROXY_HEALTH_PORT     - Port for health/readiness endpoints (default: 8081)
  *   PROXY_CA_DIR          - Path to CA directory for MITM (optional)
  *   PROXY_LOG_LEVEL       - Log level: debug | info | warn | error (default: "info")
  */
 export function loadConfig(env: Record<string, string | undefined> = process.env): SidecarConfig {
-  const port = parsePort(env.PROXY_PORT);
+  const port = parsePort(env.PROXY_PORT, 'PROXY_PORT');
+  const healthPort = parsePort(env.PROXY_HEALTH_PORT, 'PROXY_HEALTH_PORT', 8081);
   const host = env.PROXY_HOST ?? '0.0.0.0';
   const caDir = env.PROXY_CA_DIR ?? null;
   const logLevel = parseLogLevel(env.PROXY_LOG_LEVEL);
 
-  return { port, host, caDir, logLevel };
+  return { port, host, healthPort, caDir, logLevel };
 }
 
-function parsePort(raw: string | undefined): number {
-  if (raw === undefined || raw === '') return 8080;
+function parsePort(raw: string | undefined, envName: string = 'PROXY_PORT', defaultPort: number = 8080): number {
+  if (raw === undefined || raw === '') return defaultPort;
 
   const port = Number(raw);
   if (!Number.isInteger(port) || port < 1 || port > 65535) {
     throw new ConfigError(
-      `PROXY_PORT must be an integer between 1 and 65535, got "${raw}"`,
+      `${envName} must be an integer between 1 and 65535, got "${raw}"`,
     );
   }
   return port;

--- a/proxy-sidecar/src/health.ts
+++ b/proxy-sidecar/src/health.ts
@@ -1,0 +1,62 @@
+/**
+ * Health / readiness HTTP server for the proxy sidecar.
+ *
+ * Exposes two endpoints on a separate control port:
+ *   GET /healthz  - Liveness probe. Returns 200 whenever the process is alive.
+ *   GET /readyz   - Readiness probe. Returns 200 only when the proxy server
+ *                   is listening and ready to accept connections.
+ *
+ * All other paths return 404. Non-GET methods return 405.
+ */
+
+import { createServer, type Server } from 'node:http';
+
+export interface HealthServerOptions {
+  /**
+   * Callback that returns `true` when the proxy server is ready to accept
+   * connections. The readiness probe delegates to this function.
+   */
+  isReady: () => boolean;
+}
+
+/**
+ * Create an HTTP server that serves health and readiness endpoints.
+ *
+ * The returned server is not yet listening -- the caller is responsible for
+ * calling `.listen()`.
+ */
+export function createHealthServer(options: HealthServerOptions): Server {
+  const { isReady } = options;
+
+  const server = createServer((req, res) => {
+    // Only support GET requests
+    if (req.method !== 'GET') {
+      res.writeHead(405, { 'Content-Type': 'text/plain', Allow: 'GET' });
+      res.end('Method Not Allowed\n');
+      return;
+    }
+
+    switch (req.url) {
+      case '/healthz': {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'ok' }));
+        return;
+      }
+
+      case '/readyz': {
+        const ready = isReady();
+        const statusCode = ready ? 200 : 503;
+        res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: ready ? 'ready' : 'not_ready' }));
+        return;
+      }
+
+      default: {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Not Found\n');
+      }
+    }
+  });
+
+  return server;
+}

--- a/proxy-sidecar/src/index.ts
+++ b/proxy-sidecar/src/index.ts
@@ -64,6 +64,10 @@ export type { MitmHandlerConfig, ProxyServerConfig } from './server.js';
 export { ConfigError, loadConfig } from './config.js';
 export type { SidecarConfig } from './config.js';
 
+// Health / readiness server
+export { createHealthServer } from './health.js';
+export type { HealthServerOptions } from './health.js';
+
 // Logging/diagnostics
 export {
   buildCredentialRefTrace,

--- a/proxy-sidecar/src/main.ts
+++ b/proxy-sidecar/src/main.ts
@@ -18,6 +18,7 @@
 import type { Server } from 'node:http';
 
 import { ConfigError, loadConfig } from './config.js';
+import { createHealthServer } from './health.js';
 import { createProxyServer } from './server.js';
 import type { ProxyServerConfig } from './server.js';
 
@@ -37,6 +38,8 @@ function log(level: string, msg: string, extra?: Record<string, unknown>): void 
 // ---------------------------------------------------------------------------
 
 let server: Server | null = null;
+let healthServer: Server | null = null;
+let proxyListening = false;
 
 function main(): void {
   let config;
@@ -53,6 +56,7 @@ function main(): void {
   log('info', 'proxy-sidecar starting', {
     port: config.port,
     host: config.host,
+    healthPort: config.healthPort,
     caDir: config.caDir,
     logLevel: config.logLevel,
   });
@@ -69,6 +73,7 @@ function main(): void {
   server = createProxyServer(serverConfig);
 
   server.listen(config.port, config.host, () => {
+    proxyListening = true;
     const addr = server!.address();
     const boundPort = typeof addr === 'object' && addr ? addr.port : config.port;
     log('info', 'proxy-sidecar listening', {
@@ -81,6 +86,23 @@ function main(): void {
     log('error', 'server error', { error: String(err) });
     process.exit(1);
   });
+
+  // Start health/readiness server on separate control port
+  healthServer = createHealthServer({
+    isReady: () => proxyListening,
+  });
+
+  healthServer.listen(config.healthPort, config.host, () => {
+    log('info', 'health server listening', {
+      port: config.healthPort,
+      host: config.host,
+    });
+  });
+
+  healthServer.on('error', (err) => {
+    log('error', 'health server error', { error: String(err) });
+    process.exit(1);
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -89,21 +111,39 @@ function main(): void {
 
 function shutdown(signal: string): void {
   log('info', 'shutting down', { signal });
+  proxyListening = false;
 
-  if (!server) {
+  if (!server && !healthServer) {
     process.exit(0);
     return;
   }
 
-  // Stop accepting new connections and wait for in-flight requests.
-  server.close((err) => {
+  let pending = 0;
+  let hasError = false;
+
+  const onClosed = (name: string) => (err?: Error) => {
     if (err) {
-      log('error', 'error during shutdown', { error: String(err) });
-      process.exit(1);
+      log('error', `error during ${name} shutdown`, { error: String(err) });
+      hasError = true;
     }
-    log('info', 'proxy-sidecar stopped');
-    process.exit(0);
-  });
+    pending--;
+    if (pending === 0) {
+      log('info', 'proxy-sidecar stopped');
+      process.exit(hasError ? 1 : 0);
+    }
+  };
+
+  // Close health server first so probes report not-ready during drain
+  if (healthServer) {
+    pending++;
+    healthServer.close(onClosed('health'));
+  }
+
+  // Stop accepting new proxy connections and wait for in-flight requests.
+  if (server) {
+    pending++;
+    server.close(onClosed('proxy'));
+  }
 
   // Force-exit after 10 seconds if graceful shutdown stalls.
   setTimeout(() => {


### PR DESCRIPTION
## Summary
- Adds /healthz and /readyz HTTP endpoints for Kubernetes liveness and readiness probes
- Health check runs on a separate control port (configurable via PROXY_HEALTH_PORT, default 8081)
- Includes focused unit tests for health/readiness behavior

Part of plan: P15-mitm-package-split.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11737" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
