### PR TITLE
Add Dockerfile/image build for MITM package

### DIFF
--- a/proxy-sidecar/.dockerignore
+++ b/proxy-sidecar/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.env
+.env.*
+!.env.example
+*.log
+.DS_Store

--- a/proxy-sidecar/Dockerfile
+++ b/proxy-sidecar/Dockerfile
@@ -1,0 +1,48 @@
+# Build stage
+FROM debian:trixie@sha256:3615a749858a1cba49b408fb49c37093db813321355a9ab7c1f9f4836341e9db AS builder
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --production
+
+COPY . .
+
+# Runtime stage
+FROM debian:trixie-slim@sha256:1d3c811171a08a5adaa4a163fbafd96b61b87aa871bbc7aa15431ac275d3d430 AS runner
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy bun binary from builder instead of re-installing
+COPY --from=builder /root/.bun/bin/bun /usr/local/bin/bun
+
+RUN groupadd --system --gid 1001 proxysidecar && \
+    useradd --system --uid 1001 --gid proxysidecar --create-home proxysidecar
+
+COPY --from=builder --chown=proxysidecar:proxysidecar /app /app
+
+USER proxysidecar
+
+# Proxy port
+EXPOSE 8080
+# Health/readiness port
+EXPOSE 8081
+
+ENV PROXY_PORT=8080
+ENV PROXY_HEALTH_PORT=8081
+ENV PROXY_HOST=0.0.0.0
+
+CMD ["bun", "run", "src/main.ts"]


### PR DESCRIPTION
## Summary
- Adds Dockerfile for building the proxy-sidecar as an independent container image
- Multi-stage build (debian:trixie builder + debian:trixie-slim runner) for minimal image size
- Runs as non-root `proxysidecar` user following existing gateway/assistant patterns
- Exposes proxy port (8080) and health port (8081)
- Includes .dockerignore for clean builds

## Validation
- Docker image builds successfully (`docker build -t proxy-sidecar:test .`)
- Container starts and health endpoints respond:
  - `GET /healthz` returns `{"status":"ok"}`
  - `GET /readyz` returns `{"status":"ready"}`
- TypeScript type-checking passes (`bunx tsc --noEmit`)

Part of plan: P15-mitm-package-split (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
