### PR TITLE
Add CI job for MITM package build/test only

### DIFF
--- a/.github/workflows/ci-main-proxy-sidecar.yaml
+++ b/.github/workflows/ci-main-proxy-sidecar.yaml
@@ -1,0 +1,134 @@
+name: CI Main Proxy Sidecar Checks
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'proxy-sidecar/**'
+      - '.github/workflows/ci-main-proxy-sidecar.yaml'
+
+jobs:
+  checks:
+    name: Type Check & Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: proxy-sidecar
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.9'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Test with coverage
+        run: bun test --coverage
+
+      - name: Track consecutive failures
+        if: always()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # github.workflow returns the display name, not the filename.
+          # Extract the filename from github.workflow_ref instead.
+          WORKFLOW_REF="${{ github.workflow_ref }}"
+          WORKFLOW_NAME="${WORKFLOW_REF%%@*}"
+          WORKFLOW_NAME="${WORKFLOW_NAME##*/}"
+
+          # Get the last 100 completed runs of this workflow on main (excluding current)
+          RUNS=$(gh api "/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_NAME}/runs?branch=main&status=completed&per_page=100" \
+            --jq '[.workflow_runs[] | select(.id != '${{ github.run_id }}') | .conclusion]')
+
+          # Count consecutive failures from most recent
+          CONSECUTIVE=0
+          for conclusion in $(echo "$RUNS" | jq -r '.[]'); do
+            if [ "$conclusion" = "failure" ]; then
+              CONSECUTIVE=$((CONSECUTIVE + 1))
+            else
+              break
+            fi
+          done
+
+          # Add current run result
+          if [ "${{ job.status }}" = "failure" ]; then
+            CONSECUTIVE=$((CONSECUTIVE + 1))
+          else
+            CONSECUTIVE=0
+          fi
+
+          echo "Consecutive failures on main: $CONSECUTIVE"
+
+  notify:
+    name: Slack Notification
+    needs: [checks]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get Slack ID
+        id: slack-id
+        run: |
+          GITHUB_USER="${{ github.actor }}"
+
+          if [[ "${{ needs.checks.result }}" == "failure" ]]; then
+            STATUS="failure"
+          elif [[ "${{ needs.checks.result }}" == "cancelled" ]]; then
+            STATUS="cancelled"
+          elif [[ "${{ needs.checks.result }}" == "skipped" ]]; then
+            STATUS="skipped"
+          else
+            STATUS="success"
+          fi
+
+          SLACK_ID=$(yq ".github_to_slack_all_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+
+          if [ "$SLACK_ID" = "null" ]; then
+            case $STATUS in
+              failure)
+                SLACK_ID=$(yq ".github_to_slack_failure_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+                ;;
+              success)
+                SLACK_ID=$(yq ".github_to_slack_success_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+                ;;
+              cancelled)
+                SLACK_ID=$(yq ".github_to_slack_cancelled_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+                ;;
+            esac
+          fi
+
+          if [ "$SLACK_ID" = "null" ]; then
+            SLACK_ID="$GITHUB_USER"
+          fi
+
+          if [ "$SLACK_ID" = "$GITHUB_USER" ]; then
+            echo "should_tag=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_tag=true" >> $GITHUB_OUTPUT
+          fi
+          echo "id=$SLACK_ID" >> $GITHUB_OUTPUT
+          echo "status=$STATUS" >> $GITHUB_OUTPUT
+
+      - uses: act10ns/slack@v2
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_USER_ID: ${{ steps.slack-id.outputs.id }}
+          SHOULD_TAG: ${{ steps.slack-id.outputs.should_tag }}
+        with:
+          status: ${{ steps.slack-id.outputs.status }}
+          channel: "#build-alerts"
+          config: .github/config/slack.yaml

--- a/.github/workflows/pr-proxy-sidecar.yaml
+++ b/.github/workflows/pr-proxy-sidecar.yaml
@@ -1,0 +1,63 @@
+name: PR Proxy Sidecar Checks
+
+on:
+  pull_request:
+    types: [labeled, synchronize, opened, reopened]
+    paths:
+      - 'proxy-sidecar/**'
+      - '.github/workflows/pr-proxy-sidecar.yaml'
+
+concurrency:
+  group: pr-proxy-sidecar-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
+    name: Type Check & Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: proxy-sidecar
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.9'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Test
+        run: bun run test
+
+  docker:
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
+    name: Docker Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: proxy-sidecar
+          push: false
+          load: true
+          tags: proxy-sidecar:ci-${{ github.event.pull_request.number }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Adds GitHub Actions CI workflow for the proxy-sidecar package
- Runs type-checking, tests, and Docker build on PRs touching proxy-sidecar/
- Adds main-branch CI with coverage, consecutive failure tracking, and Slack notifications
- Follows existing CI patterns from assistant/gateway/cli workflows

Part of plan: P15-mitm-package-split.md (PR 6 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
