### PR TITLE
feat: eliminate plaintext credential readback from skill flows

### DIFF
--- a/assistant/src/__tests__/bundled-skills-credential-readback-guard.test.ts
+++ b/assistant/src/__tests__/bundled-skills-credential-readback-guard.test.ts
@@ -1,0 +1,100 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, test } from 'bun:test';
+
+/**
+ * Guard test: bundled skills must not contain patterns that require
+ * reading plaintext secrets back from secure storage or credential vault.
+ *
+ * These anti-patterns leak secrets into conversation context:
+ * - `credential_store action=get` — unsupported action that reads plaintext
+ * - `<value from credential_store ...>` or `<api_key_from_credential_store>` — plaintext placeholders
+ * - Direct keychain retrieval commands targeting credential keys
+ *
+ * Instead, skills should:
+ * - Use `credential_store action=prompt` to collect credentials securely
+ * - Call server-side endpoints that resolve credentials from secure storage
+ */
+
+const BUNDLED_SKILLS_DIR = join(import.meta.dir, '..', 'config', 'bundled-skills');
+
+/** Recursively collect all .md files under a directory. */
+function collectMarkdownFiles(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      results.push(...collectMarkdownFiles(full));
+    } else if (entry.endsWith('.md')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+const skillFiles = collectMarkdownFiles(BUNDLED_SKILLS_DIR);
+
+describe('bundled skills credential readback guard', () => {
+  test('no bundled skills use credential_store action=get', () => {
+    const violations: string[] = [];
+    for (const file of skillFiles) {
+      const content = readFileSync(file, 'utf-8');
+      // Match credential_store with action=get (with or without quotes, flexible whitespace)
+      if (/credential_store\s+[^]*?action\s*=\s*"?get"?/i.test(content)) {
+        const rel = file.replace(BUNDLED_SKILLS_DIR + '/', '');
+        violations.push(rel);
+      }
+    }
+    expect(
+      violations,
+      `Bundled skills must not use \`credential_store action=get\` — ` +
+      `this reads plaintext secrets into conversation context. ` +
+      `Use server-side endpoints that resolve credentials from secure storage instead.\n` +
+      `Violations:\n${violations.map((v) => `  - ${v}`).join('\n')}`,
+    ).toEqual([]);
+  });
+
+  test('no bundled skills use plaintext credential placeholders', () => {
+    const violations: string[] = [];
+    // Match patterns like <value from credential_store ...> or <api_key_from_credential_store>
+    const placeholderPattern = /<[^>]*(?:from\s+credential_store|credential_store)[^>]*>/i;
+    for (const file of skillFiles) {
+      const content = readFileSync(file, 'utf-8');
+      if (placeholderPattern.test(content)) {
+        const rel = file.replace(BUNDLED_SKILLS_DIR + '/', '');
+        violations.push(rel);
+      }
+    }
+    expect(
+      violations,
+      `Bundled skills must not use plaintext credential placeholders ` +
+      `like \`<value from credential_store ...>\` — these require reading secrets into conversation context. ` +
+      `Use server-side endpoints that resolve credentials from secure storage instead.\n` +
+      `Violations:\n${violations.map((v) => `  - ${v}`).join('\n')}`,
+    ).toEqual([]);
+  });
+
+  test('no bundled skills use direct keychain retrieval for credential keys', () => {
+    const violations: string[] = [];
+    // Match security find-generic-password or secret-tool lookup targeting credential: keys
+    const keychainPatterns = [
+      /security\s+find-generic-password\s+[^]*?credential:/,
+      /secret-tool\s+lookup\s+[^]*?credential:/,
+    ];
+    for (const file of skillFiles) {
+      const content = readFileSync(file, 'utf-8');
+      for (const pattern of keychainPatterns) {
+        if (pattern.test(content)) {
+          const rel = file.replace(BUNDLED_SKILLS_DIR + '/', '');
+          if (!violations.includes(rel)) violations.push(rel);
+        }
+      }
+    }
+    expect(
+      violations,
+      `Bundled skills must not use direct keychain/secret-tool commands to read credential keys. ` +
+      `Use server-side endpoints that resolve credentials from secure storage instead.\n` +
+      `Violations:\n${violations.map((v) => `  - ${v}`).join('\n')}`,
+    ).toEqual([]);
+  });
+});

--- a/assistant/src/__tests__/ngrok-auth-endpoint.test.ts
+++ b/assistant/src/__tests__/ngrok-auth-endpoint.test.ts
@@ -38,9 +38,14 @@ mock.module('../util/logger.js', () => ({
 
 // Mock secure keys storage
 const secureStore = new Map<string, string>();
+let setSecureKeyShouldFail = false;
 mock.module('../security/secure-keys.js', () => ({
   getSecureKey: (key: string) => secureStore.get(key),
-  setSecureKey: (key: string, value: string) => { secureStore.set(key, value); return true; },
+  setSecureKey: (key: string, value: string) => {
+    if (setSecureKeyShouldFail) return false;
+    secureStore.set(key, value);
+    return true;
+  },
   deleteSecureKey: (key: string) => secureStore.delete(key),
 }));
 
@@ -94,6 +99,7 @@ beforeEach(() => {
   metadataUpserts.length = 0;
   spawnExitCode = 0;
   spawnArgs = [];
+  setSecureKeyShouldFail = false;
 });
 
 describe('ngrok auth endpoint', () => {
@@ -163,6 +169,29 @@ describe('ngrok auth endpoint', () => {
 
     expect(data.success).toBe(false);
     expect(data.error).toContain('ngrok config add-authtoken failed');
+  });
+
+  test('setSecureKey failure returns success with warning', async () => {
+    setSecureKeyShouldFail = true;
+
+    const req = new Request('http://localhost/v1/integrations/public-ingress/ngrok/auth', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ authToken: 'ngrok_token_456' }),
+    });
+
+    const res = await handleNgrokAuth(req);
+    const data = await res.json() as { success: boolean; hasToken: boolean; source: string; warning?: string };
+
+    expect(data.success).toBe(true);
+    expect(data.hasToken).toBe(true);
+    expect(data.source).toBe('body');
+    expect(data.warning).toBeDefined();
+    expect(data.warning).toContain('could not be persisted');
+    // Token should not be in the store since setSecureKey failed
+    expect(secureStore.has('credential:ngrok:authtoken')).toBe(false);
+    // Metadata should not be upserted since storage failed
+    expect(metadataUpserts).not.toContainEqual({ service: 'ngrok', field: 'authtoken' });
   });
 
   test('body-provided token is not persisted when ngrok command fails', async () => {

--- a/assistant/src/__tests__/ngrok-auth-endpoint.test.ts
+++ b/assistant/src/__tests__/ngrok-auth-endpoint.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for the public-ingress ngrok auth endpoint.
+ *
+ * Verifies that POST /v1/integrations/public-ingress/ngrok/auth resolves
+ * the auth token from secure storage, runs ngrok config server-side,
+ * and persists body-provided tokens.
+ */
+
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = realpathSync(mkdtempSync(join(tmpdir(), 'ngrok-auth-test-')));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  getWorkspaceConfigPath: () => join(testDir, 'config.json'),
+  getWorkspaceDir: () => testDir,
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+  isDebug: () => false,
+  truncateForLog: (v: string) => v,
+}));
+
+// Mock secure keys storage
+const secureStore = new Map<string, string>();
+mock.module('../security/secure-keys.js', () => ({
+  getSecureKey: (key: string) => secureStore.get(key),
+  setSecureKey: (key: string, value: string) => { secureStore.set(key, value); return true; },
+  deleteSecureKey: (key: string) => secureStore.delete(key),
+}));
+
+// Track metadata upserts
+const metadataUpserts: Array<{ service: string; field: string }> = [];
+mock.module('../tools/credentials/metadata-store.js', () => ({
+  upsertCredentialMetadata: (service: string, field: string) => {
+    metadataUpserts.push({ service, field });
+  },
+  deleteCredentialMetadata: () => {},
+}));
+
+// Mock Bun.spawn to simulate ngrok command execution
+let spawnExitCode = 0;
+let spawnArgs: string[] = [];
+const originalBunSpawn = Bun.spawn;
+// @ts-expect-error - overriding Bun.spawn for test
+Bun.spawn = (cmd: string[], opts?: Record<string, unknown>) => {
+  spawnArgs = cmd;
+  const exitPromise = Promise.resolve(spawnExitCode);
+  return {
+    exited: exitPromise,
+    stdout: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
+    stderr: spawnExitCode === 0
+      ? new ReadableStream({ start(ctrl) { ctrl.close(); } })
+      : new ReadableStream({
+          start(ctrl) {
+            ctrl.enqueue(new TextEncoder().encode('ngrok error'));
+            ctrl.close();
+          },
+        }),
+    pid: 12345,
+    kill: () => {},
+  };
+};
+
+const { handleNgrokAuth } = await import('../runtime/routes/ngrok-routes.js');
+
+// Ensure metadata directory exists
+mkdirSync(join(testDir, 'credentials'), { recursive: true });
+writeFileSync(join(testDir, 'credentials', 'metadata.json'), JSON.stringify({ version: 2, credentials: {} }));
+
+afterAll(() => {
+  // @ts-expect-error - restoring Bun.spawn
+  Bun.spawn = originalBunSpawn;
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  secureStore.clear();
+  metadataUpserts.length = 0;
+  spawnExitCode = 0;
+  spawnArgs = [];
+});
+
+describe('ngrok auth endpoint', () => {
+  test('body token path: configures ngrok and persists to secure storage', async () => {
+    const req = new Request('http://localhost/v1/integrations/public-ingress/ngrok/auth', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ authToken: 'ngrok_token_123' }),
+    });
+
+    const res = await handleNgrokAuth(req);
+    const data = await res.json() as { success: boolean; hasToken: boolean; source: string };
+
+    expect(data.success).toBe(true);
+    expect(data.hasToken).toBe(true);
+    expect(data.source).toBe('body');
+    expect(spawnArgs).toEqual(['ngrok', 'config', 'add-authtoken', 'ngrok_token_123']);
+    expect(secureStore.get('credential:ngrok:authtoken')).toBe('ngrok_token_123');
+    expect(metadataUpserts).toContainEqual({ service: 'ngrok', field: 'authtoken' });
+  });
+
+  test('stored-token path: resolves from secure storage', async () => {
+    secureStore.set('credential:ngrok:authtoken', 'stored_ngrok_token');
+
+    const req = new Request('http://localhost/v1/integrations/public-ingress/ngrok/auth', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    const res = await handleNgrokAuth(req);
+    const data = await res.json() as { success: boolean; hasToken: boolean; source: string };
+
+    expect(data.success).toBe(true);
+    expect(data.hasToken).toBe(true);
+    expect(data.source).toBe('secure_storage');
+    expect(spawnArgs).toEqual(['ngrok', 'config', 'add-authtoken', 'stored_ngrok_token']);
+  });
+
+  test('missing token failure: returns 400 with clear guidance', async () => {
+    const req = new Request('http://localhost/v1/integrations/public-ingress/ngrok/auth', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    const res = await handleNgrokAuth(req);
+    const data = await res.json() as { success: boolean; error: string; hasToken: boolean };
+
+    expect(res.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.hasToken).toBe(false);
+    expect(data.error).toContain('credential_store');
+  });
+
+  test('ngrok command failure is surfaced', async () => {
+    spawnExitCode = 1;
+
+    const req = new Request('http://localhost/v1/integrations/public-ingress/ngrok/auth', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ authToken: 'bad_token' }),
+    });
+
+    const res = await handleNgrokAuth(req);
+    const data = await res.json() as { success: boolean; error: string };
+
+    expect(data.success).toBe(false);
+    expect(data.error).toContain('ngrok config add-authtoken failed');
+  });
+
+  test('body-provided token is not persisted when ngrok command fails', async () => {
+    spawnExitCode = 1;
+
+    const req = new Request('http://localhost/v1/integrations/public-ingress/ngrok/auth', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ authToken: 'fail_token' }),
+    });
+
+    await handleNgrokAuth(req);
+
+    // Token should not be persisted since the command failed
+    expect(secureStore.has('credential:ngrok:authtoken')).toBe(false);
+  });
+});

--- a/assistant/src/__tests__/twilio-credential-resolution.test.ts
+++ b/assistant/src/__tests__/twilio-credential-resolution.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for Twilio credentials endpoint server-side credential resolution.
+ *
+ * Verifies that POST /v1/integrations/twilio/credentials can resolve
+ * credentials from secure storage when body omits them, and that explicit
+ * body values take precedence.
+ */
+
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = realpathSync(mkdtempSync(join(tmpdir(), 'twilio-cred-test-')));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  getWorkspaceConfigPath: () => join(testDir, 'config.json'),
+  getWorkspaceDir: () => testDir,
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+  isDebug: () => false,
+  truncateForLog: (v: string) => v,
+}));
+
+mock.module('../config/env.js', () => ({
+  isHttpAuthDisabled: () => true,
+  hasUngatedHttpAuthDisabled: () => false,
+  getGatewayInternalBaseUrl: () => 'http://localhost:8080',
+}));
+
+// Mock secure keys storage
+const secureStore = new Map<string, string>();
+mock.module('../security/secure-keys.js', () => ({
+  getSecureKey: (key: string) => secureStore.get(key),
+  setSecureKey: (key: string, value: string) => { secureStore.set(key, value); return true; },
+  deleteSecureKey: (key: string) => secureStore.delete(key),
+}));
+
+// Track metadata upserts
+const metadataUpserts: Array<{ service: string; field: string }> = [];
+mock.module('../tools/credentials/metadata-store.js', () => ({
+  upsertCredentialMetadata: (service: string, field: string) => {
+    metadataUpserts.push({ service, field });
+  },
+  deleteCredentialMetadata: () => {},
+}));
+
+// Mock the Twilio REST helpers
+mock.module('../calls/twilio-rest.js', () => ({
+  hasTwilioCredentials: () => secureStore.has('credential:twilio:account_sid') && secureStore.has('credential:twilio:auth_token'),
+  listIncomingPhoneNumbers: async () => [],
+}));
+
+mock.module('../config/loader.js', () => ({
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getConfig: () => ({ memory: { enabled: false } }),
+}));
+
+mock.module('../daemon/handlers/config-channels.js', () => ({
+  getReadinessService: () => ({ getReadiness: async () => [] }),
+}));
+
+mock.module('../daemon/handlers/config-ingress.js', () => ({
+  syncTwilioWebhooks: async () => ({ warning: undefined }),
+}));
+
+// Track fetch calls to Twilio API
+let lastFetchUrl = '';
+let fetchShouldSucceed = true;
+const originalFetch = globalThis.fetch;
+globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+  const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+  if (url.includes('api.twilio.com')) {
+    lastFetchUrl = url;
+    if (fetchShouldSucceed) {
+      return new Response(JSON.stringify({ sid: 'ACtest', status: 'active' }), { status: 200 });
+    }
+    return new Response('Unauthorized', { status: 401 });
+  }
+  return originalFetch(input, init);
+};
+
+const { handleSetTwilioCredentials } = await import('../runtime/routes/twilio-routes.js');
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  secureStore.clear();
+  metadataUpserts.length = 0;
+  lastFetchUrl = '';
+  fetchShouldSucceed = true;
+});
+
+// Ensure metadata directory exists
+mkdirSync(join(testDir, 'credentials'), { recursive: true });
+writeFileSync(join(testDir, 'credentials', 'metadata.json'), JSON.stringify({ version: 2, credentials: {} }));
+
+describe('Twilio credentials endpoint server-side resolution', () => {
+  test('explicit body credentials are accepted and validated', async () => {
+    const req = new Request('http://localhost/v1/integrations/twilio/credentials', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ accountSid: 'ACexplicit', authToken: 'token123' }),
+    });
+
+    const res = await handleSetTwilioCredentials(req);
+    const data = await res.json() as { success: boolean; hasCredentials: boolean };
+
+    expect(data.success).toBe(true);
+    expect(data.hasCredentials).toBe(true);
+    expect(lastFetchUrl).toContain('ACexplicit');
+    expect(secureStore.get('credential:twilio:account_sid')).toBe('ACexplicit');
+    expect(secureStore.get('credential:twilio:auth_token')).toBe('token123');
+  });
+
+  test('empty body resolves credentials from secure storage', async () => {
+    secureStore.set('credential:twilio:account_sid', 'ACstored');
+    secureStore.set('credential:twilio:auth_token', 'storedToken');
+
+    const req = new Request('http://localhost/v1/integrations/twilio/credentials', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    const res = await handleSetTwilioCredentials(req);
+    const data = await res.json() as { success: boolean; hasCredentials: boolean };
+
+    expect(data.success).toBe(true);
+    expect(data.hasCredentials).toBe(true);
+    expect(lastFetchUrl).toContain('ACstored');
+  });
+
+  test('empty body with missing stored credentials fails with clear error', async () => {
+    const req = new Request('http://localhost/v1/integrations/twilio/credentials', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    const res = await handleSetTwilioCredentials(req);
+    const data = await res.json() as { success: boolean; error: string };
+
+    expect(res.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toContain('accountSid');
+    expect(data.error).toContain('authToken');
+    expect(data.error).toContain('credential_store');
+  });
+
+  test('partial stored credentials (only account_sid) fails cleanly', async () => {
+    secureStore.set('credential:twilio:account_sid', 'ACpartial');
+
+    const req = new Request('http://localhost/v1/integrations/twilio/credentials', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    const res = await handleSetTwilioCredentials(req);
+    const data = await res.json() as { success: boolean; error: string };
+
+    expect(res.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toContain('authToken');
+    expect(data.error).not.toContain('accountSid');
+  });
+
+  test('explicit body values take precedence over stored values', async () => {
+    secureStore.set('credential:twilio:account_sid', 'ACstored');
+    secureStore.set('credential:twilio:auth_token', 'storedToken');
+
+    const req = new Request('http://localhost/v1/integrations/twilio/credentials', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ accountSid: 'ACoverride', authToken: 'overrideToken' }),
+    });
+
+    const res = await handleSetTwilioCredentials(req);
+    const data = await res.json() as { success: boolean };
+
+    expect(data.success).toBe(true);
+    expect(lastFetchUrl).toContain('ACoverride');
+    expect(secureStore.get('credential:twilio:account_sid')).toBe('ACoverride');
+  });
+
+  test('invalid credentials from Twilio API return error', async () => {
+    fetchShouldSucceed = false;
+
+    const req = new Request('http://localhost/v1/integrations/twilio/credentials', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ accountSid: 'ACbad', authToken: 'badToken' }),
+    });
+
+    const res = await handleSetTwilioCredentials(req);
+    const data = await res.json() as { success: boolean; error: string };
+
+    expect(data.success).toBe(false);
+    expect(data.error).toContain('validation failed');
+  });
+});

--- a/assistant/src/__tests__/twilio-credential-resolution.test.ts
+++ b/assistant/src/__tests__/twilio-credential-resolution.test.ts
@@ -45,14 +45,21 @@ mock.module('../config/env.js', () => ({
 // Mock secure keys storage
 const secureStore = new Map<string, string>();
 const setSecureKeyCalls: Array<{ key: string; value: string }> = [];
+const deleteSecureKeyCalls: Array<{ key: string }> = [];
+/** Keys for which setSecureKey should return false (simulate storage failure). */
+const setSecureKeyFailures = new Set<string>();
 mock.module('../security/secure-keys.js', () => ({
   getSecureKey: (key: string) => secureStore.get(key),
   setSecureKey: (key: string, value: string) => {
     setSecureKeyCalls.push({ key, value });
+    if (setSecureKeyFailures.has(key)) return false;
     secureStore.set(key, value);
     return true;
   },
-  deleteSecureKey: (key: string) => secureStore.delete(key),
+  deleteSecureKey: (key: string) => {
+    deleteSecureKeyCalls.push({ key });
+    secureStore.delete(key);
+  },
 }));
 
 // Track metadata upserts
@@ -110,6 +117,8 @@ afterAll(() => {
 beforeEach(() => {
   secureStore.clear();
   setSecureKeyCalls.length = 0;
+  deleteSecureKeyCalls.length = 0;
+  setSecureKeyFailures.clear();
   metadataUpserts.length = 0;
   lastFetchUrl = '';
   fetchShouldSucceed = true;
@@ -230,6 +239,62 @@ describe('Twilio credentials endpoint server-side resolution', () => {
     expect(setSecureKeyCalls).toEqual([]);
     // No metadata upserts should have been made either
     expect(metadataUpserts).toEqual([]);
+  });
+
+  test('partial body (authToken only) rollback does not delete stored account_sid', async () => {
+    // Pre-seed account_sid in storage (simulating a previously stored credential)
+    secureStore.set('credential:twilio:account_sid', 'ACprevious');
+    secureStore.set('credential:twilio:auth_token', 'oldToken');
+    // Clear tracking arrays after seeding
+    setSecureKeyCalls.length = 0;
+    deleteSecureKeyCalls.length = 0;
+    metadataUpserts.length = 0;
+
+    // Make setSecureKey fail for auth_token to trigger rollback
+    setSecureKeyFailures.add('credential:twilio:auth_token');
+
+    const req = new Request('http://localhost/v1/integrations/twilio/credentials', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ authToken: 'newRotatedToken' }),
+    });
+
+    const res = await handleSetTwilioCredentials(req);
+    const data = await res.json() as { success: boolean; error: string };
+
+    expect(data.success).toBe(false);
+    expect(data.error).toContain('Auth Token');
+
+    // The stored account_sid should NOT have been deleted because it was not provided in the body
+    expect(secureStore.get('credential:twilio:account_sid')).toBe('ACprevious');
+    expect(deleteSecureKeyCalls.filter((c) => c.key === 'credential:twilio:account_sid')).toEqual([]);
+  });
+
+  test('partial body (accountSid only) persists only account_sid', async () => {
+    // Pre-seed auth_token in storage
+    secureStore.set('credential:twilio:auth_token', 'existingToken');
+    setSecureKeyCalls.length = 0;
+    metadataUpserts.length = 0;
+
+    const req = new Request('http://localhost/v1/integrations/twilio/credentials', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ accountSid: 'ACnew' }),
+    });
+
+    const res = await handleSetTwilioCredentials(req);
+    const data = await res.json() as { success: boolean; hasCredentials: boolean };
+
+    expect(data.success).toBe(true);
+    expect(data.hasCredentials).toBe(true);
+
+    // Only account_sid should have been written, not auth_token
+    expect(setSecureKeyCalls).toEqual([
+      { key: 'credential:twilio:account_sid', value: 'ACnew' },
+    ]);
+    expect(metadataUpserts).toEqual([
+      { service: 'twilio', field: 'account_sid' },
+    ]);
   });
 
   test('invalid credentials from Twilio API return error', async () => {

--- a/assistant/src/__tests__/twilio-credential-resolution.test.ts
+++ b/assistant/src/__tests__/twilio-credential-resolution.test.ts
@@ -44,9 +44,14 @@ mock.module('../config/env.js', () => ({
 
 // Mock secure keys storage
 const secureStore = new Map<string, string>();
+const setSecureKeyCalls: Array<{ key: string; value: string }> = [];
 mock.module('../security/secure-keys.js', () => ({
   getSecureKey: (key: string) => secureStore.get(key),
-  setSecureKey: (key: string, value: string) => { secureStore.set(key, value); return true; },
+  setSecureKey: (key: string, value: string) => {
+    setSecureKeyCalls.push({ key, value });
+    secureStore.set(key, value);
+    return true;
+  },
   deleteSecureKey: (key: string) => secureStore.delete(key),
 }));
 
@@ -104,6 +109,7 @@ afterAll(() => {
 
 beforeEach(() => {
   secureStore.clear();
+  setSecureKeyCalls.length = 0;
   metadataUpserts.length = 0;
   lastFetchUrl = '';
   fetchShouldSucceed = true;
@@ -200,6 +206,30 @@ describe('Twilio credentials endpoint server-side resolution', () => {
     expect(data.success).toBe(true);
     expect(lastFetchUrl).toContain('ACoverride');
     expect(secureStore.get('credential:twilio:account_sid')).toBe('ACoverride');
+  });
+
+  test('empty body does not rewrite credentials to secure storage', async () => {
+    secureStore.set('credential:twilio:account_sid', 'ACstored');
+    secureStore.set('credential:twilio:auth_token', 'storedToken');
+    // Clear the tracking arrays after seeding the store so we only see calls from the handler
+    setSecureKeyCalls.length = 0;
+    metadataUpserts.length = 0;
+
+    const req = new Request('http://localhost/v1/integrations/twilio/credentials', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    const res = await handleSetTwilioCredentials(req);
+    const data = await res.json() as { success: boolean; hasCredentials: boolean };
+
+    expect(data.success).toBe(true);
+    expect(data.hasCredentials).toBe(true);
+    // The handler should NOT have called setSecureKey when credentials came from storage
+    expect(setSecureKeyCalls).toEqual([]);
+    // No metadata upserts should have been made either
+    expect(metadataUpserts).toEqual([]);
   });
 
   test('invalid credentials from Twilio API return error', async () => {

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -132,8 +132,6 @@ After the user picks a voice, use `voice_config_update` to set the shared voice 
 voice_config_update setting="tts_voice_id" value="<selected-voice-id>"
 ```
 
-**If the user wants a voice not on this list**, they can browse more voices at https://elevenlabs.io/voice-library and provide the voice ID manually.
-
 ## Step 4: Verify Setup (Test Call)
 
 Before making real calls, offer a quick verification:
@@ -234,25 +232,7 @@ Users who have an ElevenLabs account and API key (e.g., from the **voice-setup**
 - **Use custom or cloned voices** — if the user has created a custom voice or voice clone in their ElevenLabs account, they can use its voice ID here. These voices are available in Twilio ConversationRelay just like pre-made voices.
 - **Preview voices before choosing** — each voice in the API response includes a `preview_url` with an audio sample.
 
-To check if the user has an API key stored:
-
-```bash
-credential_store action=get service=elevenlabs field=api_key
-```
-
-If they have a key and want to browse voices, fetch the voice list:
-
-```bash
-curl -s "https://api.elevenlabs.io/v2/voices?category=premade&page_size=50" \
-  -H "xi-api-key: <api_key_from_credential_store>" | python3 -m json.tool
-```
-
-To search for a specific voice style:
-
-```bash
-curl -s "https://api.elevenlabs.io/v2/voices?search=warm+female&page_size=10" \
-  -H "xi-api-key: <api_key_from_credential_store>" | python3 -m json.tool
-```
+**If the user wants a voice not on the curated list above**, they can browse more voices at https://elevenlabs.io/voice-library and provide the voice ID manually.
 
 After the user picks a voice, set the shared voice ID:
 

--- a/assistant/src/config/bundled-skills/public-ingress/SKILL.md
+++ b/assistant/src/config/bundled-skills/public-ingress/SKILL.md
@@ -78,19 +78,16 @@ If not authenticated:
    - description: `Get your auth token from https://dashboard.ngrok.com/get-started/your-authtoken`
    - usage_description: `ngrok authentication token for creating public tunnels`
 
-3. Once the credential is stored, configure ngrok by reading the token directly from the OS keychain and piping it to ngrok so the plaintext never enters the conversation:
+3. Once the credential is stored, configure ngrok server-side. The endpoint resolves the token from secure storage automatically:
 
-   **macOS:**
    ```bash
-   ngrok config add-authtoken "$(security find-generic-password -s vellum-assistant -a credential:ngrok:authtoken -w)"
+   curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/public-ingress/ngrok/auth" \
+     -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{}'
    ```
 
-   **Linux:**
-   ```bash
-   ngrok config add-authtoken "$(secret-tool lookup service vellum-assistant account credential:ngrok:authtoken)"
-   ```
-
-   If the keychain command fails (e.g., headless environment without a keyring), fall back to asking the user to re-enter the token via `credential_store prompt` and then paste it into `ngrok config add-authtoken` manually as a last resort.
+   The endpoint runs `ngrok config add-authtoken` server-side so the plaintext token never enters the conversation. If it fails, check the error message and ask the user to re-enter the token via `credential_store prompt`.
 
 Verify authentication succeeded by checking `ngrok config check` again.
 

--- a/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
@@ -14,10 +14,10 @@ You are helping your user configure Twilio for voice calls and SMS messaging. Tw
 # 1. Check current status
 curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/config" \
   -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
-# 2. Store credentials (after collecting via credential_store prompt)
+# 2. Validate and store credentials (after collecting via credential_store prompt)
 curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/credentials" \
   -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" -H "Content-Type: application/json" \
-  -d '{"accountSid":"ACxxx","authToken":"xxx"}'
+  -d '{}'
 # 3. Provision or assign a number
 curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/numbers/provision" \
   -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" -H "Content-Type: application/json" \
@@ -91,16 +91,16 @@ If credentials are not yet stored, guide the user through Twilio account setup:
 - Call `credential_store` with `action: "prompt"`, `service: "twilio"`, `field: "account_sid"`, `label: "Twilio Account SID"`, `description: "Enter your Account SID from the Twilio Console dashboard"`, and `placeholder: "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"`.
 - Call `credential_store` with `action: "prompt"`, `service: "twilio"`, `field: "auth_token"`, `label: "Twilio Auth Token"`, `description: "Enter your Auth Token from the Twilio Console dashboard"`, and `placeholder: "your_auth_token"`.
 
-After both credentials are collected, retrieve them from secure storage and send them to the gateway:
+After both credentials are collected, tell the gateway to validate and store them. The endpoint automatically resolves credentials from secure storage — no need to read them back:
 
 ```bash
 curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/credentials" \
   -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"accountSid":"<value from credential_store for twilio/account_sid>","authToken":"<value from credential_store for twilio/auth_token>"}'
+  -d '{}'
 ```
 
-Both `accountSid` and `authToken` are required — the endpoint validates the credentials against the Twilio API before storing them. If credentials are invalid, the response returns an error. Tell the user and ask them to re-enter via the secure prompt.
+The endpoint resolves `accountSid` and `authToken` from secure storage (`credential:twilio:account_sid`, `credential:twilio:auth_token`), validates them against the Twilio API, and stores them. If credentials are invalid, the response returns an error. Tell the user and ask them to re-enter via the secure prompt.
 
 **Note:** Setting credentials is a global operation — credentials are stored once and shared across all assistants. The `assistantId` parameter is accepted but ignored.
 

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -173,6 +173,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: 'integrations/guardian/outbound/start', scopes: ['settings.write'] },
   { endpoint: 'integrations/guardian/outbound/resend', scopes: ['settings.write'] },
   { endpoint: 'integrations/guardian/outbound/cancel', scopes: ['settings.write'] },
+  { endpoint: 'integrations/public-ingress/ngrok/auth', scopes: ['settings.write'] },
   { endpoint: 'integrations/twilio/config', scopes: ['settings.read'] },
   { endpoint: 'integrations/twilio/credentials:POST', scopes: ['settings.write'] },
   { endpoint: 'integrations/twilio/credentials:DELETE', scopes: ['settings.write'] },

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -169,6 +169,7 @@ import {
   handleSetupTelegram,
   handleStartOutbound,
 } from "./routes/integration-routes.js";
+import { handleNgrokAuth } from "./routes/ngrok-routes.js";
 import type { PairingHandlerContext } from "./routes/pairing-routes.js";
 // Extracted route handlers
 import {
@@ -1149,6 +1150,10 @@ export class RuntimeHttpServer {
 
       // Guardian vellum channel bootstrap and refresh are handled before
       // JWT auth in routeRequest() — they are not dispatched here.
+
+      // Integrations — Public ingress (ngrok)
+      if (endpoint === 'integrations/public-ingress/ngrok/auth' && req.method === 'POST')
+        return await handleNgrokAuth(req);
 
       // Integrations — Twilio config
       if (endpoint === "integrations/twilio/config" && req.method === "GET")

--- a/assistant/src/runtime/routes/ngrok-routes.ts
+++ b/assistant/src/runtime/routes/ngrok-routes.ts
@@ -67,10 +67,14 @@ export async function handleNgrokAuth(req: Request): Promise<Response> {
   }
 
   // If the token was provided in the body, persist it to secure storage
+  let warning: string | undefined;
   if (body.authToken) {
     const stored = setSecureKey('credential:ngrok:authtoken', body.authToken);
     if (stored) {
       upsertCredentialMetadata('ngrok', 'authtoken', {});
+    } else {
+      log.warn('Failed to persist ngrok auth token to secure storage');
+      warning = 'ngrok was configured successfully, but the token could not be persisted to secure storage. It may need to be provided again next time.';
     }
   }
 
@@ -78,5 +82,6 @@ export async function handleNgrokAuth(req: Request): Promise<Response> {
     success: true,
     hasToken: true,
     source,
+    ...(warning ? { warning } : {}),
   });
 }

--- a/assistant/src/runtime/routes/ngrok-routes.ts
+++ b/assistant/src/runtime/routes/ngrok-routes.ts
@@ -1,0 +1,82 @@
+/**
+ * Route handlers for public-ingress ngrok integration.
+ *
+ * POST /v1/integrations/public-ingress/ngrok/auth — configure ngrok auth token server-side
+ */
+
+import { getSecureKey, setSecureKey } from '../../security/secure-keys.js';
+import { upsertCredentialMetadata } from '../../tools/credentials/metadata-store.js';
+import { getLogger } from '../../util/logger.js';
+
+const log = getLogger('ngrok-routes');
+
+/**
+ * POST /v1/integrations/public-ingress/ngrok/auth
+ *
+ * Body: { authToken?: string }
+ *
+ * Accepts an explicit auth token in the body or an empty body `{}`.
+ * When the body omits the token, it is resolved from secure storage
+ * (`credential:ngrok:authtoken`). Runs `ngrok config add-authtoken`
+ * server-side so the token never appears in conversation context.
+ */
+export async function handleNgrokAuth(req: Request): Promise<Response> {
+  const body = (await req.json().catch(() => ({}))) as { authToken?: string };
+
+  // Resolve token: prefer explicit body value, fall back to secure storage
+  const authToken = body.authToken || getSecureKey('credential:ngrok:authtoken');
+
+  if (!authToken) {
+    return Response.json({
+      success: false,
+      hasToken: false,
+      source: 'none',
+      error: 'Missing ngrok auth token. Provide it in the request body or store it via credential_store first.',
+    }, { status: 400 });
+  }
+
+  const source = body.authToken ? 'body' : 'secure_storage';
+
+  // Run ngrok config add-authtoken server-side
+  try {
+    const proc = Bun.spawn(['ngrok', 'config', 'add-authtoken', authToken], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      log.warn({ exitCode, stderr: stderr.slice(0, 500) }, 'ngrok config add-authtoken failed');
+      return Response.json({
+        success: false,
+        hasToken: true,
+        source,
+        error: `ngrok config add-authtoken failed (exit ${exitCode}): ${stderr.trim().slice(0, 200)}`,
+      });
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Failed to run ngrok config add-authtoken');
+    return Response.json({
+      success: false,
+      hasToken: true,
+      source,
+      error: `Failed to run ngrok command: ${message}`,
+    });
+  }
+
+  // If the token was provided in the body, persist it to secure storage
+  if (body.authToken) {
+    const stored = setSecureKey('credential:ngrok:authtoken', body.authToken);
+    if (stored) {
+      upsertCredentialMetadata('ngrok', 'authtoken', {});
+    }
+  }
+
+  return Response.json({
+    success: true,
+    hasToken: true,
+    source,
+  });
+}

--- a/assistant/src/runtime/routes/twilio-routes.ts
+++ b/assistant/src/runtime/routes/twilio-routes.ts
@@ -153,10 +153,12 @@ export async function handleSetTwilioCredentials(req: Request): Promise<Response
   const body = (await req.json().catch(() => ({}))) as { accountSid?: string; authToken?: string };
 
   // Resolve credentials: prefer explicit body values, fall back to secure storage.
-  // Track provenance so we only persist when credentials were provided in the body.
+  // Track per-field provenance so we only persist/rollback fields actually provided
+  // in the body — not ones merely re-read from storage.
+  const accountSidFromBody = !!body.accountSid;
+  const authTokenFromBody = !!body.authToken;
   const accountSid = body.accountSid || getSecureKey('credential:twilio:account_sid');
   const authToken = body.authToken || getSecureKey('credential:twilio:auth_token');
-  const credentialsFromBody = !!(body.accountSid || body.authToken);
 
   if (!accountSid || !authToken) {
     const missing: string[] = [];
@@ -193,10 +195,10 @@ export async function handleSetTwilioCredentials(req: Request): Promise<Response
     });
   }
 
-  // Only persist credentials when they were provided in the request body.
+  // Only persist each credential when it was provided in the request body.
   // When resolved from secure storage, skip the write path to avoid turning
   // a read/validate call into a mutating one.
-  if (credentialsFromBody) {
+  if (accountSidFromBody) {
     const sidStored = setSecureKey('credential:twilio:account_sid', accountSid);
     if (!sidStored) {
       return Response.json({
@@ -205,18 +207,22 @@ export async function handleSetTwilioCredentials(req: Request): Promise<Response
         error: 'Failed to store Account SID in secure storage',
       });
     }
+    upsertCredentialMetadata('twilio', 'account_sid', {});
+  }
 
+  if (authTokenFromBody) {
     const tokenStored = setSecureKey('credential:twilio:auth_token', authToken);
     if (!tokenStored) {
-      deleteSecureKey('credential:twilio:account_sid');
+      // Only roll back account_sid if it was actually written by this request
+      if (accountSidFromBody) {
+        deleteSecureKey('credential:twilio:account_sid');
+      }
       return Response.json({
         success: false,
         hasCredentials: false,
         error: 'Failed to store Auth Token in secure storage',
       });
     }
-
-    upsertCredentialMetadata('twilio', 'account_sid', {});
     upsertCredentialMetadata('twilio', 'auth_token', {});
   }
 

--- a/assistant/src/runtime/routes/twilio-routes.ts
+++ b/assistant/src/runtime/routes/twilio-routes.ts
@@ -203,11 +203,10 @@ export async function handleSetTwilioCredentials(req: Request): Promise<Response
     if (!sidStored) {
       return Response.json({
         success: false,
-        hasCredentials: false,
+        hasCredentials: hasTwilioCredentials(),
         error: 'Failed to store Account SID in secure storage',
       });
     }
-    upsertCredentialMetadata('twilio', 'account_sid', {});
   }
 
   if (authTokenFromBody) {
@@ -219,12 +218,15 @@ export async function handleSetTwilioCredentials(req: Request): Promise<Response
       }
       return Response.json({
         success: false,
-        hasCredentials: false,
+        hasCredentials: hasTwilioCredentials(),
         error: 'Failed to store Auth Token in secure storage',
       });
     }
-    upsertCredentialMetadata('twilio', 'auth_token', {});
   }
+
+  // Only upsert metadata after both credential writes have completed successfully.
+  if (accountSidFromBody) upsertCredentialMetadata('twilio', 'account_sid', {});
+  if (authTokenFromBody) upsertCredentialMetadata('twilio', 'auth_token', {});
 
   return Response.json({ success: true, hasCredentials: true });
 }

--- a/assistant/src/runtime/routes/twilio-routes.ts
+++ b/assistant/src/runtime/routes/twilio-routes.ts
@@ -152,9 +152,11 @@ export function handleGetTwilioConfig(): Response {
 export async function handleSetTwilioCredentials(req: Request): Promise<Response> {
   const body = (await req.json().catch(() => ({}))) as { accountSid?: string; authToken?: string };
 
-  // Resolve credentials: prefer explicit body values, fall back to secure storage
+  // Resolve credentials: prefer explicit body values, fall back to secure storage.
+  // Track provenance so we only persist when credentials were provided in the body.
   const accountSid = body.accountSid || getSecureKey('credential:twilio:account_sid');
   const authToken = body.authToken || getSecureKey('credential:twilio:auth_token');
+  const credentialsFromBody = !!(body.accountSid || body.authToken);
 
   if (!accountSid || !authToken) {
     const missing: string[] = [];
@@ -191,28 +193,32 @@ export async function handleSetTwilioCredentials(req: Request): Promise<Response
     });
   }
 
-  // Store credentials securely
-  const sidStored = setSecureKey('credential:twilio:account_sid', accountSid);
-  if (!sidStored) {
-    return Response.json({
-      success: false,
-      hasCredentials: false,
-      error: 'Failed to store Account SID in secure storage',
-    });
-  }
+  // Only persist credentials when they were provided in the request body.
+  // When resolved from secure storage, skip the write path to avoid turning
+  // a read/validate call into a mutating one.
+  if (credentialsFromBody) {
+    const sidStored = setSecureKey('credential:twilio:account_sid', accountSid);
+    if (!sidStored) {
+      return Response.json({
+        success: false,
+        hasCredentials: false,
+        error: 'Failed to store Account SID in secure storage',
+      });
+    }
 
-  const tokenStored = setSecureKey('credential:twilio:auth_token', authToken);
-  if (!tokenStored) {
-    deleteSecureKey('credential:twilio:account_sid');
-    return Response.json({
-      success: false,
-      hasCredentials: false,
-      error: 'Failed to store Auth Token in secure storage',
-    });
-  }
+    const tokenStored = setSecureKey('credential:twilio:auth_token', authToken);
+    if (!tokenStored) {
+      deleteSecureKey('credential:twilio:account_sid');
+      return Response.json({
+        success: false,
+        hasCredentials: false,
+        error: 'Failed to store Auth Token in secure storage',
+      });
+    }
 
-  upsertCredentialMetadata('twilio', 'account_sid', {});
-  upsertCredentialMetadata('twilio', 'auth_token', {});
+    upsertCredentialMetadata('twilio', 'account_sid', {});
+    upsertCredentialMetadata('twilio', 'auth_token', {});
+  }
 
   return Response.json({ success: true, hasCredentials: true });
 }

--- a/assistant/src/runtime/routes/twilio-routes.ts
+++ b/assistant/src/runtime/routes/twilio-routes.ts
@@ -141,24 +141,37 @@ export function handleGetTwilioConfig(): Response {
 /**
  * POST /v1/integrations/twilio/credentials
  *
- * Body: { accountSid: string, authToken: string }
+ * Body: { accountSid?: string, authToken?: string }
+ *
+ * Accepts either explicit credentials in the body or an empty body `{}`.
+ * When the body omits credentials, they are resolved from secure storage
+ * (`credential:twilio:account_sid` and `credential:twilio:auth_token`).
+ * This enables skill flows that collect credentials via `credential_store`
+ * prompts without ever reading the plaintext back into conversation context.
  */
 export async function handleSetTwilioCredentials(req: Request): Promise<Response> {
   const body = (await req.json().catch(() => ({}))) as { accountSid?: string; authToken?: string };
 
-  if (!body.accountSid || !body.authToken) {
+  // Resolve credentials: prefer explicit body values, fall back to secure storage
+  const accountSid = body.accountSid || getSecureKey('credential:twilio:account_sid');
+  const authToken = body.authToken || getSecureKey('credential:twilio:auth_token');
+
+  if (!accountSid || !authToken) {
+    const missing: string[] = [];
+    if (!accountSid) missing.push('accountSid');
+    if (!authToken) missing.push('authToken');
     return Response.json({
       success: false,
       hasCredentials: hasTwilioCredentials(),
-      error: 'accountSid and authToken are required',
+      error: `Missing ${missing.join(' and ')}. Provide them in the request body or store them via credential_store first.`,
     }, { status: 400 });
   }
 
   // Validate credentials against Twilio API
-  const authHeader = 'Basic ' + Buffer.from(`${body.accountSid}:${body.authToken}`).toString('base64');
+  const authHeader = 'Basic ' + Buffer.from(`${accountSid}:${authToken}`).toString('base64');
   try {
     const res = await fetch(
-      `https://api.twilio.com/2010-04-01/Accounts/${body.accountSid}.json`,
+      `https://api.twilio.com/2010-04-01/Accounts/${accountSid}.json`,
       { method: 'GET', headers: { Authorization: authHeader } },
     );
     if (!res.ok) {
@@ -179,7 +192,7 @@ export async function handleSetTwilioCredentials(req: Request): Promise<Response
   }
 
   // Store credentials securely
-  const sidStored = setSecureKey('credential:twilio:account_sid', body.accountSid);
+  const sidStored = setSecureKey('credential:twilio:account_sid', accountSid);
   if (!sidStored) {
     return Response.json({
       success: false,
@@ -188,7 +201,7 @@ export async function handleSetTwilioCredentials(req: Request): Promise<Response
     });
   }
 
-  const tokenStored = setSecureKey('credential:twilio:auth_token', body.authToken);
+  const tokenStored = setSecureKey('credential:twilio:auth_token', authToken);
   if (!tokenStored) {
     deleteSecureKey('credential:twilio:account_sid');
     return Response.json({

--- a/gateway/src/http/routes/twilio-control-plane-proxy.ts
+++ b/gateway/src/http/routes/twilio-control-plane-proxy.ts
@@ -130,5 +130,9 @@ export function createTwilioControlPlaneProxyHandler(config: GatewayConfig) {
     async handleSmsDoctor(req: Request): Promise<Response> {
       return proxyToRuntime(req, "/v1/integrations/twilio/sms/doctor", "");
     },
+
+    async handleNgrokAuth(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/integrations/public-ingress/ngrok/auth", "");
+    },
   };
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -555,6 +555,13 @@ function main() {
         return twilioControlPlaneProxy.handleSmsDoctor(tracedReq);
       }
 
+      // ── Public ingress (ngrok) control-plane proxy ──
+      if (url.pathname === "/v1/integrations/public-ingress/ngrok/auth" && req.method === "POST") {
+        const authError = requireEdgeAuth();
+        if (authError) return authError;
+        return twilioControlPlaneProxy.handleNgrokAuth(tracedReq);
+      }
+
       // ── Twilio tollfree verification dynamic path routes ──
       const tollfreeVerificationMatch = url.pathname.match(
         /^\/v1\/integrations\/twilio\/sms\/compliance\/tollfree\/([^/]+)$/,

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1189,6 +1189,31 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/integrations/public-ingress/ngrok/auth": {
+        post: {
+          summary: "Configure ngrok auth token",
+          description:
+            "Authenticated gateway endpoint that configures the ngrok auth token server-side. Accepts an explicit token in the body or resolves from secure storage.",
+          operationId: "ngrokAuthPost",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: false,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "ngrok auth token configured" },
+            "400": { description: "Missing auth token" },
+            "401": { description: "Unauthorized — missing or invalid bearer token" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
       "/v1/integrations/twilio/config": {
         get: {
           summary: "Get Twilio integration config",
@@ -1209,11 +1234,11 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Set Twilio credentials",
           description:
-            "Authenticated gateway endpoint that stores Twilio account credentials via the assistant runtime.",
+            "Authenticated gateway endpoint that stores Twilio account credentials via the assistant runtime. Accepts explicit credentials in the body or an empty body to resolve from secure storage.",
           operationId: "twilioCredentialsPost",
           security: [{ BearerAuth: [] }],
           requestBody: {
-            required: true,
+            required: false,
             content: {
               "application/json": {
                 schema: { type: "object", additionalProperties: true },


### PR DESCRIPTION
## Summary
- **Twilio credentials endpoint** (`POST /v1/integrations/twilio/credentials`) now accepts empty body `{}` and resolves `accountSid`/`authToken` from secure storage, matching the Telegram-style server-side credential pattern
- **New ngrok auth endpoint** (`POST /v1/integrations/public-ingress/ngrok/auth`) runs `ngrok config add-authtoken` server-side so the token never enters conversation context
- **Skill cleanup**: removed `credential_store action=get`, `<value from credential_store>` placeholders, and direct keychain retrieval commands from twilio-setup, public-ingress, and phone-calls skills
- **Regression guard tests**: new guard test scans all bundled skills to prevent reintroduction of credential readback anti-patterns; route-level tests for Twilio credential resolution and ngrok auth endpoint

## Original prompt
/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/twilio-credential-reliability-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
