### PR TITLE
Suppress silence nudge during in-call guardian consultation wait

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -2138,6 +2138,86 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
+  test('silence timeout suppressed during in-call guardian consultation (pendingConsultation)', async () => {
+    mockSilenceTimeoutMs = 50; // Short timeout for testing
+    mockConsultationTimeoutMs = 10_000; // Long enough to not interfere
+
+    // LLM emits an ASK_GUARDIAN marker so the controller creates a pendingConsultation
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Let me check with your guardian. [ASK_GUARDIAN: Can this caller access the account?]"]),
+    );
+    const { relay, controller } = setupController();
+
+    // Trigger a turn that creates a pending consultation
+    await controller.handleCallerUtterance("I need to access the account");
+    // Allow turn to complete
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Verify a consultation is now pending
+    expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
+    // Relay state is still 'connected' (not 'awaiting_guardian_decision')
+    expect(relay.mockConnectionState).toBe("connected");
+
+    // Clear any tokens from the turn itself
+    relay.sentTokens.length = 0;
+
+    // Wait for the silence timeout to fire
+    await new Promise((r) => setTimeout(r, 200));
+
+    // "Are you still there?" should NOT have been sent because
+    // pendingConsultation is active
+    const silenceTokens = relay.sentTokens.filter((t) =>
+      t.token.includes("Are you still there?"),
+    );
+    expect(silenceTokens.length).toBe(0);
+
+    controller.destroy();
+  });
+
+  test('silence nudge resumes after guardian consultation resolves', async () => {
+    mockSilenceTimeoutMs = 50; // Short timeout for testing
+    mockConsultationTimeoutMs = 10_000; // Long enough to not interfere
+
+    // LLM emits an ASK_GUARDIAN marker so the controller creates a pendingConsultation
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Let me check. [ASK_GUARDIAN: Is this approved?]"]),
+    );
+    const { relay, controller } = setupController();
+
+    // Trigger a turn that creates a pending consultation
+    await controller.handleCallerUtterance("Can I do this?");
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Verify consultation is pending
+    expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
+
+    // Now resolve the consultation by providing an answer
+    // Mock the next LLM turn for the answer-driven follow-up
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Great news, your guardian approved the request."]),
+    );
+    await controller.handleUserAnswer("Yes, approved");
+    // Allow the answer-driven turn to complete
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Consultation should now be cleared
+    expect(controller.getPendingConsultationQuestionId()).toBeNull();
+
+    // Clear tokens from the answer turn
+    relay.sentTokens.length = 0;
+
+    // Wait for the silence timeout to fire again
+    await new Promise((r) => setTimeout(r, 200));
+
+    // "Are you still there?" SHOULD fire now that consultation is resolved
+    const silenceTokens = relay.sentTokens.filter((t) =>
+      t.token.includes("Are you still there?"),
+    );
+    expect(silenceTokens.length).toBe(1);
+
+    controller.destroy();
+  });
+
   // ── Pointer message regression tests ─────────────────────────────
 
   test("END_CALL marker writes completed pointer to origin conversation", async () => {

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -2138,22 +2138,22 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
-  test('silence timeout suppressed during in-call guardian consultation (pendingConsultation)', async () => {
+  test('silence timeout suppressed during in-call guardian consultation (pendingGuardianInput)', async () => {
     mockSilenceTimeoutMs = 50; // Short timeout for testing
     mockConsultationTimeoutMs = 10_000; // Long enough to not interfere
 
-    // LLM emits an ASK_GUARDIAN marker so the controller creates a pendingConsultation
+    // LLM emits an ASK_GUARDIAN marker so the controller creates a pendingGuardianInput
     mockStartVoiceTurn.mockImplementation(
       createMockVoiceTurn(["Let me check with your guardian. [ASK_GUARDIAN: Can this caller access the account?]"]),
     );
     const { relay, controller } = setupController();
 
-    // Trigger a turn that creates a pending consultation
+    // Trigger a turn that creates a pending guardian input request
     await controller.handleCallerUtterance("I need to access the account");
     // Allow turn to complete
     await new Promise((r) => setTimeout(r, 50));
 
-    // Verify a consultation is now pending
+    // Verify a guardian input request is now pending
     expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
     // Relay state is still 'connected' (not 'awaiting_guardian_decision')
     expect(relay.mockConnectionState).toBe("connected");
@@ -2165,7 +2165,7 @@ describe("call-controller", () => {
     await new Promise((r) => setTimeout(r, 200));
 
     // "Are you still there?" should NOT have been sent because
-    // pendingConsultation is active
+    // pendingGuardianInput is active
     const silenceTokens = relay.sentTokens.filter((t) =>
       t.token.includes("Are you still there?"),
     );
@@ -2178,17 +2178,17 @@ describe("call-controller", () => {
     mockSilenceTimeoutMs = 50; // Short timeout for testing
     mockConsultationTimeoutMs = 10_000; // Long enough to not interfere
 
-    // LLM emits an ASK_GUARDIAN marker so the controller creates a pendingConsultation
+    // LLM emits an ASK_GUARDIAN marker so the controller creates a pendingGuardianInput
     mockStartVoiceTurn.mockImplementation(
       createMockVoiceTurn(["Let me check. [ASK_GUARDIAN: Is this approved?]"]),
     );
     const { relay, controller } = setupController();
 
-    // Trigger a turn that creates a pending consultation
+    // Trigger a turn that creates a pending guardian input request
     await controller.handleCallerUtterance("Can I do this?");
     await new Promise((r) => setTimeout(r, 50));
 
-    // Verify consultation is pending
+    // Verify guardian input request is pending
     expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
 
     // Now resolve the consultation by providing an answer
@@ -2200,7 +2200,7 @@ describe("call-controller", () => {
     // Allow the answer-driven turn to complete
     await new Promise((r) => setTimeout(r, 100));
 
-    // Consultation should now be cleared
+    // Guardian input request should now be cleared
     expect(controller.getPendingConsultationQuestionId()).toBeNull();
 
     // Clear tokens from the answer turn
@@ -2209,7 +2209,7 @@ describe("call-controller", () => {
     // Wait for the silence timeout to fire again
     await new Promise((r) => setTimeout(r, 200));
 
-    // "Are you still there?" SHOULD fire now that consultation is resolved
+    // "Are you still there?" SHOULD fire now that guardian wait is resolved
     const silenceTokens = relay.sentTokens.filter((t) =>
       t.token.includes("Are you still there?"),
     );

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -1061,13 +1061,26 @@ export class CallController {
     }, maxDurationMs);
   }
 
+  /**
+   * Returns true when the caller is waiting on guardian input — either
+   * an inbound access-request wait (relay state) or an in-call
+   * consultation wait (controller state). Used to suppress the generic
+   * "Are you still there?" silence nudge.
+   */
+  private isAwaitingGuardianInput(): boolean {
+    return (
+      this.pendingConsultation !== null ||
+      this.relay.getConnectionState() === 'awaiting_guardian_decision'
+    );
+  }
+
   private resetSilenceTimer(): void {
     if (this.silenceTimer) clearTimeout(this.silenceTimer);
     this.silenceTimer = setTimeout(() => {
       // During guardian wait states, the relay heartbeat timer handles
       // periodic updates — suppress the generic "Are you still there?"
       // which is confusing when the caller is waiting on a decision.
-      if (this.relay.getConnectionState() === 'awaiting_guardian_decision') {
+      if (this.isAwaitingGuardianInput()) {
         log.debug({ callSessionId: this.callSessionId }, 'Silence timeout suppressed during guardian wait');
         return;
       }

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -44,11 +44,13 @@ const log = getLogger('call-controller');
 type ControllerState = 'idle' | 'processing' | 'speaking';
 
 /**
- * Tracks a pending guardian consultation independently of the controller's
+ * Tracks a pending guardian input request independently of the controller's
  * turn state. This allows the call to continue normal turn processing
- * (idle -> processing -> speaking) while a consultation is outstanding.
+ * (idle -> processing -> speaking) while a guardian consultation is outstanding.
+ * Also used to suppress the silence nudge ("Are you still there?") while
+ * the caller is waiting on a guardian decision.
  */
-interface PendingConsultation {
+interface PendingGuardianInput {
   questionText: string;
   questionId: string;
   toolApprovalMeta: { toolName: string; inputDigest: string } | null;
@@ -191,16 +193,17 @@ export class CallController {
   private durationTimer: ReturnType<typeof setTimeout> | null = null;
   private durationWarningTimer: ReturnType<typeof setTimeout> | null = null;
   /**
-   * Tracks the currently pending guardian consultation, if any. Decoupled
+   * Tracks the currently pending guardian input request, if any. Decoupled
    * from the controller's turn state so callers can continue to trigger
-   * normal turns while consultation is outstanding.
+   * normal turns while a guardian consultation is outstanding. Also
+   * suppresses the silence nudge while non-null.
    */
-  private pendingConsultation: PendingConsultation | null = null;
+  private pendingGuardianInput: PendingGuardianInput | null = null;
   private durationEndTimer: ReturnType<typeof setTimeout> | null = null;
   private task: string | null;
   /** True when the call session was created via the inbound path (no outbound task). */
   private isInbound: boolean;
-  /** Instructions queued while an LLM turn is in-flight or during pending consultation */
+  /** Instructions queued while an LLM turn is in-flight or during pending guardian input */
   private pendingInstructions: string[] = [];
   /** Ensures the call opener is triggered at most once per call. */
   private initialGreetingStarted = false;
@@ -271,7 +274,7 @@ export class CallController {
    * incoming answers to the correct consultation record.
    */
   getPendingConsultationQuestionId(): string | null {
-    return this.pendingConsultation?.questionId ?? null;
+    return this.pendingGuardianInput?.questionId ?? null;
   }
 
   /**
@@ -357,7 +360,7 @@ export class CallController {
    * speaking.
    */
   async handleUserAnswer(answerText: string): Promise<boolean> {
-    if (!this.pendingConsultation) {
+    if (!this.pendingGuardianInput) {
       log.warn(
         { callSessionId: this.callSessionId, state: this.state },
         'handleUserAnswer called but no pending consultation exists',
@@ -366,8 +369,8 @@ export class CallController {
     }
 
     // Clear the consultation timeout and record
-    clearTimeout(this.pendingConsultation.timer);
-    this.pendingConsultation = null;
+    clearTimeout(this.pendingGuardianInput.timer);
+    this.pendingGuardianInput = null;
 
     updateCallSession(this.callSessionId, { status: 'in_progress' });
 
@@ -436,7 +439,7 @@ export class CallController {
     if (this.silenceTimer) clearTimeout(this.silenceTimer);
     if (this.durationTimer) clearTimeout(this.durationTimer);
     if (this.durationWarningTimer) clearTimeout(this.durationWarningTimer);
-    if (this.pendingConsultation) { clearTimeout(this.pendingConsultation.timer); this.pendingConsultation = null; }
+    if (this.pendingGuardianInput) { clearTimeout(this.pendingGuardianInput.timer); this.pendingGuardianInput = null; }
     if (this.durationEndTimer) { clearTimeout(this.durationEndTimer); this.durationEndTimer = null; }
     this.llmRunVersion++;
     this.abortCurrentTurn();
@@ -713,30 +716,30 @@ export class CallController {
           // the prior pending consultation (preserves tool scope on re-asks).
           const effectiveToolMeta = toolApprovalMeta
             ? { toolName: toolApprovalMeta.toolName, inputDigest: toolApprovalMeta.inputDigest }
-            : this.pendingConsultation?.toolApprovalMeta ?? null;
+            : this.pendingGuardianInput?.toolApprovalMeta ?? null;
 
           // Coalesce repeated identical asks: if a consultation is already
           // pending for the same tool/action (or same informational question),
           // avoid churning requests and just keep the existing one.
-          if (this.pendingConsultation) {
+          if (this.pendingGuardianInput) {
             const isSameToolAction =
-              effectiveToolMeta && this.pendingConsultation.toolApprovalMeta
-                ? effectiveToolMeta.toolName === this.pendingConsultation.toolApprovalMeta.toolName
-                  && effectiveToolMeta.inputDigest === this.pendingConsultation.toolApprovalMeta.inputDigest
-                : !effectiveToolMeta && !this.pendingConsultation.toolApprovalMeta;
+              effectiveToolMeta && this.pendingGuardianInput.toolApprovalMeta
+                ? effectiveToolMeta.toolName === this.pendingGuardianInput.toolApprovalMeta.toolName
+                  && effectiveToolMeta.inputDigest === this.pendingGuardianInput.toolApprovalMeta.inputDigest
+                : !effectiveToolMeta && !this.pendingGuardianInput.toolApprovalMeta;
 
             if (isSameToolAction) {
               // Same tool/action — coalesce. Keep the existing consultation
               // alive and skip creating a new request.
               log.info(
-                { callSessionId: this.callSessionId, questionId: this.pendingConsultation.questionId },
+                { callSessionId: this.callSessionId, questionId: this.pendingGuardianInput.questionId },
                 'Coalescing repeated ASK_GUARDIAN — same tool/action already pending',
               );
               recordCallEvent(this.callSessionId, 'guardian_consult_coalesced', { question: questionText });
               // Fall through to normal turn completion (idle + flushPendingInstructions)
             } else {
               // Materially different intent — supersede the old consultation.
-              clearTimeout(this.pendingConsultation.timer);
+              clearTimeout(this.pendingGuardianInput.timer);
 
               // Expire the previous consultation's storage records so stale
               // guardian answers cannot match the old request.
@@ -752,7 +755,7 @@ export class CallController {
                 );
               }
 
-              this.pendingConsultation = null;
+              this.pendingGuardianInput = null;
 
               // Dispatch the new consultation with effective tool metadata.
               // The previous request ID is passed through so the dispatch
@@ -773,10 +776,10 @@ export class CallController {
         // Without this, the consultation timeout can fire on an already-ended
         // call, overwriting 'completed' status back to 'in_progress' and
         // starting a new LLM turn on a dead session. Similarly, a late
-        // handleUserAnswer could be accepted since pendingConsultation is
+        // handleUserAnswer could be accepted since pendingGuardianInput is
         // still non-null.
-        if (this.pendingConsultation) {
-          clearTimeout(this.pendingConsultation.timer);
+        if (this.pendingGuardianInput) {
+          clearTimeout(this.pendingGuardianInput.timer);
 
           // Expire store-side consultation records so clients don't observe
           // a completed call with a dangling pendingQuestion, and guardian
@@ -787,7 +790,7 @@ export class CallController {
             expireCanonicalGuardianRequest(previousRequest.id);
           }
 
-          this.pendingConsultation = null;
+          this.pendingGuardianInput = null;
         }
 
         const currentSession = getCallSession(this.callSessionId);
@@ -928,7 +931,7 @@ export class CallController {
     // record, not the global controller state.
     const consultationTimer = setTimeout(() => {
       // Only fire if this consultation is still the active one
-      if (!this.pendingConsultation || this.pendingConsultation.questionId !== pendingQuestion.id) return;
+      if (!this.pendingGuardianInput || this.pendingGuardianInput.questionId !== pendingQuestion.id) return;
 
       log.info({ callSessionId: this.callSessionId }, 'Guardian consultation timed out');
 
@@ -960,7 +963,7 @@ export class CallController {
 
       // Expire pending questions and update call state
       expirePendingQuestions(this.callSessionId);
-      this.pendingConsultation = null;
+      this.pendingGuardianInput = null;
       updateCallSession(this.callSessionId, { status: 'in_progress' });
       this.guardianUnavailableForCall = true;
       recordCallEvent(this.callSessionId, 'guardian_consultation_timed_out', { question: questionText });
@@ -982,7 +985,7 @@ export class CallController {
       }
     }, getUserConsultationTimeoutMs());
 
-    this.pendingConsultation = {
+    this.pendingGuardianInput = {
       questionText,
       questionId: pendingQuestion.id,
       toolApprovalMeta: effectiveToolMeta,
@@ -1061,26 +1064,15 @@ export class CallController {
     }, maxDurationMs);
   }
 
-  /**
-   * Returns true when the caller is waiting on guardian input — either
-   * an inbound access-request wait (relay state) or an in-call
-   * consultation wait (controller state). Used to suppress the generic
-   * "Are you still there?" silence nudge.
-   */
-  private isAwaitingGuardianInput(): boolean {
-    return (
-      this.pendingConsultation !== null ||
-      this.relay.getConnectionState() === 'awaiting_guardian_decision'
-    );
-  }
-
   private resetSilenceTimer(): void {
     if (this.silenceTimer) clearTimeout(this.silenceTimer);
     this.silenceTimer = setTimeout(() => {
       // During guardian wait states, the relay heartbeat timer handles
       // periodic updates — suppress the generic "Are you still there?"
       // which is confusing when the caller is waiting on a decision.
-      if (this.isAwaitingGuardianInput()) {
+      // Two paths: in-call consultation (pendingGuardianInput) and
+      // inbound access-request wait (relay state).
+      if (this.pendingGuardianInput !== null || this.relay.getConnectionState() === 'awaiting_guardian_decision') {
         log.debug({ callSessionId: this.callSessionId }, 'Silence timeout suppressed during guardian wait');
         return;
       }

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -629,7 +629,7 @@ Or re-run the public-ingress skill to auto-detect and save the new URL.
 
 ### Call drops after 30 seconds of silence
 
-The system has a 30-second silence timeout. If nobody speaks for 30 seconds, the agent will ask "Are you still there?" This is expected behavior.
+The system has a 30-second silence timeout. If nobody speaks for 30 seconds during normal conversation, the agent will ask "Are you still there?" This is expected behavior. During guardian wait states (inbound access-request wait or in-call guardian consultation wait), this generic silence nudge is suppressed — the guardian-wait heartbeat messaging is used instead.
 
 ### Call quality sounds off
 


### PR DESCRIPTION
## Summary
- Add `isAwaitingGuardianInput()` helper to `CallController` that returns true when either a `pendingConsultation` is active (in-call guardian wait) or the relay is in `awaiting_guardian_decision` state (inbound access-request wait)
- Update `resetSilenceTimer()` to use this helper, preventing "Are you still there?" from firing during any guardian wait state
- Add two regression tests: suppression during pendingConsultation, and resumption after consultation resolves
- Update SKILL.md silence timeout documentation to clarify suppression behavior

## Original prompt
/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/.private/plans/voice-guardian-wait-silence-suppression-handoff-2026-03-03.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
