### PR TITLE
fix: align RunningIndicator with assistant text by making horizontal padding conditional

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatWidgetViews.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatWidgetViews.swift
@@ -86,7 +86,7 @@ struct RunningIndicator: View {
 
                 Spacer()
             }
-            .padding(.horizontal, VSpacing.sm)
+            .padding(.horizontal, onTap != nil ? VSpacing.sm : 0)
             .padding(.vertical, VSpacing.xs)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)


### PR DESCRIPTION
Make RunningIndicator's .padding(.horizontal, VSpacing.sm) conditional on onTap \!= nil. Non-tappable indicators (all current call sites) get zero horizontal padding, aligning them flush with assistant message text. Tappable indicators retain the 8pt padding for hit target and hover background.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
