### PR TITLE
Unify voice trusted-contact in-call continuation

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -171,6 +171,7 @@ import {
 import {
   createBinding,
   createChallenge,
+  createVerificationSession,
 } from "../memory/channel-guardian-store.js";
 import { addMessage, getMessages } from "../memory/conversation-store.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
@@ -3847,6 +3848,227 @@ describe("relay-server", () => {
     expect(text).not.toBeNull();
     expect(text!).toContain("+15559876543");
     expect(text!).toContain("failed");
+
+    relay.destroy();
+  });
+
+  // ── Trusted-contact in-call continuation ─────────────────────────────
+
+  test("inbound trusted-contact verification: DTMF code entry continues same call with handoff copy", async () => {
+    ensureConversation("conv-tc-verify-continue");
+    const session = createCallSession({
+      conversationId: "conv-tc-verify-continue",
+      provider: "twilio",
+      fromNumber: "+15553334444",
+      toNumber: "+15551111111",
+      assistantId: "self",
+    });
+
+    // Create a trusted-contact verification challenge with status 'pending'
+    // so getPendingChallenge finds it during inbound setup, and
+    // verificationPurpose 'trusted_contact' so validateAndConsumeChallenge
+    // returns the correct verificationType.
+    const tcSecret = "654321";
+    createVerificationSession({
+      id: randomUUID(),
+      assistantId: "self",
+      channel: "voice",
+      challengeHash: createHash("sha256").update(tcSecret).digest("hex"),
+      expiresAt: Date.now() + 10 * 60 * 1000,
+      status: "pending",
+      verificationPurpose: "trusted_contact",
+    });
+    const secret = tcSecret;
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Sure, I can help with that."]),
+    );
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_tc_verify_continue",
+        from: "+15553334444",
+        to: "+15551111111",
+      }),
+    );
+
+    // Should be in verification-pending state
+    expect(relay.isGuardianVerificationActive()).toBe(true);
+    expect(relay.getConnectionState()).toBe("verification_pending");
+
+    // Enter the correct code via DTMF
+    for (const digit of secret) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Verification should have succeeded — call remains connected
+    expect(relay.isGuardianVerificationActive()).toBe(false);
+    expect(relay.getConnectionState()).toBe("connected");
+
+    // Deterministic handoff copy should have been sent (not a fresh greeting)
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === "text");
+    expect(
+      textMessages.some((m) => (m.token ?? "").includes("said I can speak with you")),
+    ).toBe(true);
+
+    // No end message should have been sent — call stays alive
+    const endMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string })
+      .filter((m) => m.type === "end");
+    expect(endMessages.length).toBe(0);
+
+    // assistant_spoke event should have been recorded for the handoff
+    const events = getCallEvents(session.id);
+    expect(
+      events.some((e) => e.eventType === "assistant_spoke"),
+    ).toBe(true);
+
+    // Session should be in_progress (not completed/failed)
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe("in_progress");
+
+    relay.destroy();
+  });
+
+  test("inbound guardian verification (non-trusted-contact): still starts normal call flow", async () => {
+    ensureConversation("conv-guardian-verify-normal");
+    const session = createCallSession({
+      conversationId: "conv-guardian-verify-normal",
+      provider: "twilio",
+      fromNumber: "+15552223333",
+      toNumber: "+15551111111",
+      assistantId: "self",
+    });
+
+    // Create a guardian challenge (default verificationPurpose = 'guardian')
+    const secret = createPendingVoiceGuardianChallenge("self");
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Hello, how can I help you?"]),
+    );
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_guardian_verify_normal",
+        from: "+15552223333",
+        to: "+15551111111",
+      }),
+    );
+
+    expect(relay.isGuardianVerificationActive()).toBe(true);
+
+    // Enter the correct code
+    for (const digit of secret) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Should have transitioned to connected with normal greeting (not handoff copy)
+    expect(relay.isGuardianVerificationActive()).toBe(false);
+    expect(relay.getConnectionState()).toBe("connected");
+
+    // Guardian binding should have been created
+    const binding = getGuardianBinding("self", "voice");
+    expect(binding).not.toBeNull();
+
+    // Normal greeting should fire (from mockSendMessage), not the handoff copy
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === "text");
+    expect(
+      textMessages.some((m) => (m.token ?? "").includes("how can I help")),
+    ).toBe(true);
+
+    relay.destroy();
+  });
+
+  test("invite redemption success: continues call with handoff copy instead of ending", async () => {
+    ensureConversation("conv-invite-continue");
+    const session = createCallSession({
+      conversationId: "conv-invite-continue",
+      provider: "twilio",
+      fromNumber: "+15557776666",
+      toNumber: "+15551111111",
+      assistantId: "self",
+    });
+
+    const code = generateVoiceCode(6);
+    const codeHash = hashVoiceCode(code);
+    createInvite({
+      assistantId: "self",
+      sourceChannel: "voice",
+      maxUses: 1,
+      expectedExternalUserId: "+15557776666",
+      voiceCodeHash: codeHash,
+      voiceCodeDigits: 6,
+      friendName: "Eve",
+      guardianName: "Frank",
+    });
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["I'd be happy to help."]),
+    );
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_invite_continue",
+        from: "+15557776666",
+        to: "+15551111111",
+      }),
+    );
+
+    // Should be in verification-pending for invite redemption
+    expect(relay.getConnectionState()).toBe("verification_pending");
+
+    // Enter the correct code via DTMF
+    for (const digit of code) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Call should remain connected
+    expect(relay.getConnectionState()).toBe("connected");
+
+    // Handoff copy should have been sent
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === "text");
+    expect(
+      textMessages.some((m) => (m.token ?? "").includes("said I can speak with you")),
+    ).toBe(true);
+
+    // No end message — call stays alive
+    const endMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string })
+      .filter((m) => m.type === "end");
+    expect(endMessages.length).toBe(0);
+
+    // Session should be in_progress
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe("in_progress");
+
+    // invite_redemption_succeeded event should exist
+    const events = getCallEvents(session.id);
+    expect(
+      events.some((e) => e.eventType === "invite_redemption_succeeded"),
+    ).toBe(true);
 
     relay.destroy();
   });

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -791,6 +791,65 @@ export class RelayConnection {
   }
 
   /**
+   * Shared post-activation handoff for all trusted-contact success paths
+   * (access-request approval, invite redemption, verification code).
+   * Activates the caller, updates guardian context, delivers deterministic
+   * transition copy, and marks the next utterance as opening-ack so the
+   * LLM continues naturally.
+   */
+  private continueCallAfterTrustedContactActivation(params: {
+    assistantId: string;
+    fromNumber: string;
+    callerName?: string;
+  }): void {
+    const { assistantId, fromNumber, callerName } = params;
+
+    try {
+      upsertMember({
+        assistantId,
+        sourceChannel: 'voice',
+        externalUserId: fromNumber,
+        externalChatId: fromNumber,
+        displayName: callerName,
+        status: 'active',
+        policy: 'allow',
+      });
+    } catch (err) {
+      log.error({ err, callSessionId: this.callSessionId }, 'Failed to activate voice caller as trusted contact');
+    }
+
+    const updatedTrust = resolveActorTrust({
+      assistantId,
+      sourceChannel: 'voice',
+      conversationExternalId: fromNumber,
+      actorExternalId: fromNumber,
+    });
+
+    if (this.controller) {
+      this.controller.setGuardianContext(
+        toGuardianRuntimeContextFromTrust(updatedTrust, fromNumber),
+      );
+    }
+
+    this.connectionState = 'connected';
+    updateCallSession(this.callSessionId, { status: 'in_progress' });
+
+    const guardianLabel = this.resolveGuardianLabel();
+    const handoffText = `Great! ${guardianLabel} said I can speak with you. How can I help?`;
+    this.sendTextToken(handoffText, true);
+
+    recordCallEvent(this.callSessionId, 'assistant_spoke', { text: handoffText });
+    const session = getCallSession(this.callSessionId);
+    if (session) {
+      fireCallTranscriptNotifier(session.conversationId, this.callSessionId, 'assistant', handoffText);
+    }
+
+    if (this.controller) {
+      this.controller.markNextCallerTurnAsOpeningAck();
+    }
+  }
+
+  /**
    * Enter verification-pending state for an inbound call with a pending
    * voice guardian challenge. Prompts the caller to enter their six-digit
    * verification code via DTMF or by speaking it.
@@ -975,8 +1034,15 @@ export class RelayConnection {
         setTimeout(() => {
           this.endSession('Guardian verification succeeded');
         }, getTtsPlaybackDelayMs());
+      } else if (result.verificationType === 'trusted_contact') {
+        // Inbound trusted-contact verification: activate and continue
+        // the live call with the shared handoff primitive.
+        this.continueCallAfterTrustedContactActivation({
+          assistantId: this.guardianChallengeAssistantId,
+          fromNumber: this.guardianVerificationFromNumber,
+        });
       } else {
-        // Inbound: proceed to normal call flow
+        // Inbound guardian verification: proceed to normal call flow
         if (this.controller) {
           const verifiedActorTrust = resolveActorTrust({
             assistantId: this.guardianChallengeAssistantId,
@@ -1287,7 +1353,6 @@ export class RelayConnection {
    */
   private handleAccessRequestApproved(): void {
     this.clearAccessRequestWait();
-    this.connectionState = 'connected';
 
     const assistantId = this.accessRequestAssistantId!;
     const fromNumber = this.accessRequestFromNumber!;
@@ -1299,68 +1364,20 @@ export class RelayConnection {
       requestId: this.accessRequestId,
     });
 
-    // Activate the caller as a trusted contact via the existing upsert path
-    try {
-      upsertMember({
-        assistantId,
-        sourceChannel: 'voice',
-        externalUserId: fromNumber,
-        externalChatId: fromNumber,
-        displayName: callerName ?? undefined,
-        status: 'active',
-        policy: 'allow',
-      });
-    } catch (err) {
-      log.error({ err, callSessionId: this.callSessionId }, 'Failed to activate voice caller as trusted contact');
-    }
-
-    // Re-resolve actor trust now that the member is active
-    const updatedTrust = resolveActorTrust({
-      assistantId,
-      sourceChannel: 'voice',
-      conversationExternalId: fromNumber,
-      actorExternalId: fromNumber,
-    });
-
-    if (this.controller) {
-      this.controller.setGuardianContext(
-        toGuardianRuntimeContextFromTrust(updatedTrust, fromNumber),
-      );
-    }
-
-    updateCallSession(this.callSessionId, { status: 'in_progress' });
-
     log.info(
       { callSessionId: this.callSessionId, from: fromNumber },
       'Access request approved — caller activated and continuing call',
     );
 
-    // Deliver deterministic transition copy directly via TTS instead of
-    // routing through handleUserInstruction, which would start a fresh
-    // model turn and risk reintroduction/disclosure reset.
-    const guardianLabel = this.resolveGuardianLabel();
-    const handoffText = `Great! ${guardianLabel} said I can speak with you. How can I help?`;
-    this.sendTextToken(handoffText, true);
-
-    // Record the deterministic handoff as an assistant_spoke event and
-    // fire the transcript notifier so it appears in conversation history
-    // and real-time transcript subscribers — matching the parity of text
-    // spoken through the normal runTurn() pipeline.
-    recordCallEvent(this.callSessionId, 'assistant_spoke', { text: handoffText });
-    const session = getCallSession(this.callSessionId);
-    if (session) {
-      fireCallTranscriptNotifier(session.conversationId, this.callSessionId, 'assistant', handoffText);
-    }
+    this.continueCallAfterTrustedContactActivation({
+      assistantId,
+      fromNumber,
+      callerName: callerName ?? undefined,
+    });
 
     recordCallEvent(this.callSessionId, 'inbound_acl_post_approval_handoff_spoken', {
       from: fromNumber,
     });
-
-    // Mark the next caller utterance as an opening acknowledgment so the
-    // LLM continues naturally without emitting a fresh introduction.
-    if (this.controller) {
-      this.controller.markNextCallerTurnAsOpeningAck();
-    }
   }
 
   /**
@@ -1591,7 +1608,6 @@ export class RelayConnection {
     });
 
     if (result.ok) {
-      this.connectionState = 'connected';
       this.inviteRedemptionActive = false;
       this.verificationAttempts = 0;
       this.dtmfBuffer = '';
@@ -1605,18 +1621,11 @@ export class RelayConnection {
         'Voice invite redemption succeeded',
       );
 
-      if (this.controller) {
-        const redeemedActorTrust = resolveActorTrust({
-          assistantId: this.inviteRedemptionAssistantId,
-          sourceChannel: 'voice',
-          conversationExternalId: this.inviteRedemptionFromNumber,
-          actorExternalId: this.inviteRedemptionFromNumber,
-        });
-        this.controller.setGuardianContext(
-          toGuardianRuntimeContextFromTrust(redeemedActorTrust, this.inviteRedemptionFromNumber),
-        );
-        this.startNormalCallFlow(this.controller, true);
-      }
+      this.continueCallAfterTrustedContactActivation({
+        assistantId: this.inviteRedemptionAssistantId,
+        fromNumber: this.inviteRedemptionFromNumber,
+        callerName: this.inviteRedemptionFriendName ?? undefined,
+      });
     } else {
       // On any invalid/expired code, emit exact deterministic failure copy and end call immediately.
       this.inviteRedemptionActive = false;

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -801,21 +801,24 @@ export class RelayConnection {
     assistantId: string;
     fromNumber: string;
     callerName?: string;
+    skipMemberActivation?: boolean;
   }): void {
     const { assistantId, fromNumber, callerName } = params;
 
-    try {
-      upsertMember({
-        assistantId,
-        sourceChannel: 'voice',
-        externalUserId: fromNumber,
-        externalChatId: fromNumber,
-        displayName: callerName,
-        status: 'active',
-        policy: 'allow',
-      });
-    } catch (err) {
-      log.error({ err, callSessionId: this.callSessionId }, 'Failed to activate voice caller as trusted contact');
+    if (!params.skipMemberActivation) {
+      try {
+        upsertMember({
+          assistantId,
+          sourceChannel: 'voice',
+          externalUserId: fromNumber,
+          externalChatId: fromNumber,
+          displayName: callerName,
+          status: 'active',
+          policy: 'allow',
+        });
+      } catch (err) {
+        log.error({ err, callSessionId: this.callSessionId }, 'Failed to activate voice caller as trusted contact');
+      }
     }
 
     const updatedTrust = resolveActorTrust({
@@ -1625,6 +1628,7 @@ export class RelayConnection {
         assistantId: this.inviteRedemptionAssistantId,
         fromNumber: this.inviteRedemptionFromNumber,
         callerName: this.inviteRedemptionFriendName ?? undefined,
+        skipMemberActivation: true,
       });
     } else {
       // On any invalid/expired code, emit exact deterministic failure copy and end call immediately.


### PR DESCRIPTION
## Summary
- Adds a shared `continueCallAfterTrustedContactActivation()` helper that activates the caller as a trusted contact, updates guardian context, delivers deterministic handoff copy, and marks the next utterance as opening-ack
- Routes all three trusted-contact success paths through this helper: access-request approval, invite code redemption, and verification code entry
- Branches `attemptGuardianCodeVerification()` inbound success by `verificationType` so trusted-contact verification continues the live call instead of starting a fresh greeting
- Adds 3 regression tests: trusted-contact verification continuation, guardian verification non-regression, and invite redemption continuation

## Original prompt
/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/.private/plans/voice-trusted-contact-invite-in-call-continuation-plan-2026-03-03.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
