### PR TITLE
fix: align progress indicator with assistant message text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatWidgetViews.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatWidgetViews.swift
@@ -86,7 +86,7 @@ struct RunningIndicator: View {
 
                 Spacer()
             }
-            .padding(.horizontal, VSpacing.sm)
+            .padding(.horizontal, onTap != nil ? VSpacing.sm : 0)
             .padding(.vertical, VSpacing.xs)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)


### PR DESCRIPTION
## Summary
- Make RunningIndicator's horizontal padding conditional on `onTap` — non-tappable indicators get zero padding, aligning them flush with assistant message text
- Single-line change in `ChatWidgetViews.swift`: `.padding(.horizontal, VSpacing.sm)` → `.padding(.horizontal, onTap != nil ? VSpacing.sm : 0)`

## Changes
- `clients/macos/vellum-assistant/Features/Chat/ChatWidgetViews.swift` (line 89)

## Milestone PRs (merged into feature branch)
- #11746: M1 — Make RunningIndicator horizontal padding conditional on onTap

## Project issue
Closes #11744

## Test plan
- [ ] Open a conversation and trigger the "Processing results..." indicator — verify it aligns with assistant text above
- [ ] Verify the standalone "Thinking..." indicator in MessageListView also aligns
- [ ] Verify streaming code indicators still display correctly

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
