### PR TITLE
fix: section typography, spacing, and appearance tab inline layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -250,19 +250,19 @@ struct SettingsPanel: View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             // ANTHROPIC section
             VStack(alignment: .leading, spacing: VSpacing.md) {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("Anthropic")
                         .font(VFont.sectionTitle)
                         .foregroundColor(VColor.textPrimary)
                     Text("Required for AI responses")
-                        .font(VFont.caption)
+                        .font(VFont.sectionDescription)
                         .foregroundColor(VColor.textMuted)
                 }
 
                 if store.hasKey {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
                         Text("Active Model")
-                            .font(VFont.body)
+                            .font(VFont.inputLabel)
                             .foregroundColor(VColor.textSecondary)
                         VDropdown(
                             placeholder: "Select a model…",
@@ -291,7 +291,7 @@ struct SettingsPanel: View {
                 } else if anthropicSetupExpanded {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
                         Text("API Key")
-                            .font(VFont.caption)
+                            .font(VFont.inputLabel)
                             .foregroundColor(VColor.textSecondary)
 
                         SecureField("This is your private generated key", text: $apiKeyText)
@@ -336,12 +336,12 @@ struct SettingsPanel: View {
 
             // PERPLEXITY SEARCH section
             VStack(alignment: .leading, spacing: VSpacing.md) {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("Perplexity Search")
                         .font(VFont.sectionTitle)
                         .foregroundColor(VColor.textPrimary)
                     Text("Enables real-time web search in responses")
-                        .font(VFont.caption)
+                        .font(VFont.sectionDescription)
                         .foregroundColor(VColor.textMuted)
                 }
 
@@ -357,7 +357,7 @@ struct SettingsPanel: View {
                 } else if perplexitySetupExpanded {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
                         Text("API Key")
-                            .font(VFont.caption)
+                            .font(VFont.inputLabel)
                             .foregroundColor(VColor.textSecondary)
 
                         SecureField("Your Perplexity API key", text: $perplexityKeyText)
@@ -402,12 +402,12 @@ struct SettingsPanel: View {
 
             // BRAVE SEARCH section
             VStack(alignment: .leading, spacing: VSpacing.md) {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("Brave Search")
                         .font(VFont.sectionTitle)
                         .foregroundColor(VColor.textPrimary)
                     Text("Enables private web search in responses")
-                        .font(VFont.caption)
+                        .font(VFont.sectionDescription)
                         .foregroundColor(VColor.textMuted)
                 }
 
@@ -423,7 +423,7 @@ struct SettingsPanel: View {
                 } else if braveSetupExpanded {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
                         Text("API Key")
-                            .font(VFont.caption)
+                            .font(VFont.inputLabel)
                             .foregroundColor(VColor.textSecondary)
 
                         SecureField("Your Brave Search API key", text: $braveKeyText)
@@ -468,12 +468,12 @@ struct SettingsPanel: View {
 
             // IMAGE GENERATION section
             VStack(alignment: .leading, spacing: VSpacing.md) {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("Image Generation")
                         .font(VFont.sectionTitle)
                         .foregroundColor(VColor.textPrimary)
                     Text("Enables AI image generation via Gemini")
-                        .font(VFont.caption)
+                        .font(VFont.sectionDescription)
                         .foregroundColor(VColor.textMuted)
                 }
 
@@ -492,7 +492,7 @@ struct SettingsPanel: View {
 
                     HStack {
                         Text("Model")
-                            .font(VFont.body)
+                            .font(VFont.inputLabel)
                             .foregroundColor(VColor.textSecondary)
                         Spacer()
                         Picker("", selection: Binding(
@@ -510,7 +510,7 @@ struct SettingsPanel: View {
                 } else if imageGenSetupExpanded {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
                         Text("API Key")
-                            .font(VFont.caption)
+                            .font(VFont.inputLabel)
                             .foregroundColor(VColor.textSecondary)
 
                         SecureField("Your Gemini API key", text: $imageGenKeyText)
@@ -579,12 +579,12 @@ struct SettingsPanel: View {
 
     private var twitterSection: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
                 Text("Twitter / X")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
                 Text("Post and read tweets as your assistant")
-                    .font(VFont.caption)
+                    .font(VFont.sectionDescription)
                     .foregroundColor(VColor.textMuted)
             }
 
@@ -641,7 +641,7 @@ struct SettingsPanel: View {
                 // OAuth client credentials entry
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("OAuth Client ID")
-                        .font(VFont.caption)
+                        .font(VFont.inputLabel)
                         .foregroundColor(VColor.textSecondary)
 
                     TextField("OAuth Client ID", text: $twitterClientId)
@@ -650,7 +650,7 @@ struct SettingsPanel: View {
                         .foregroundColor(VColor.textPrimary)
 
                     Text("OAuth Client Secret (optional)")
-                        .font(VFont.caption)
+                        .font(VFont.inputLabel)
                         .foregroundColor(VColor.textSecondary)
 
                     SecureField("OAuth Client Secret (optional)", text: $twitterClientSecret)

--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -16,12 +16,12 @@ struct GatewaySettingsCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
                 Text("Gateway")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
                 Text("Local gateway that forwards requests to this assistant")
-                    .font(VFont.caption)
+                    .font(VFont.sectionDescription)
                     .foregroundColor(VColor.textMuted)
             }
 
@@ -80,9 +80,9 @@ struct GatewaySettingsCard: View {
 
     private var tunnelConfigEntry: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
                 Text("Local Gateway Target")
-                    .font(VFont.caption)
+                    .font(VFont.inputLabel)
                     .foregroundColor(VColor.textSecondary)
                 HStack(spacing: VSpacing.sm) {
                     Text(store.localGatewayTarget)
@@ -123,7 +123,7 @@ struct GatewaySettingsCard: View {
             }
 
             Text("Gateway URL")
-                .font(VFont.caption)
+                .font(VFont.inputLabel)
                 .foregroundColor(VColor.textSecondary)
 
             TextField("https://your-tunnel.example.com", text: $gatewayUrlText)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -114,7 +114,7 @@ struct SettingsAccountTab: View {
 
             if store.isDevMode {
                 Text("Platform URL")
-                    .font(VFont.caption)
+                    .font(VFont.inputLabel)
                     .foregroundColor(VColor.textSecondary)
 
                 // When platform is reachable, show a Connected badge and keep the input field
@@ -350,9 +350,9 @@ struct SettingsAccountTab: View {
                 .foregroundColor(VColor.textPrimary)
 
             VStack(alignment: .leading, spacing: VSpacing.lg) {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("Retire this assistant")
-                        .font(VFont.body)
+                        .font(VFont.inputLabel)
                         .foregroundColor(VColor.textSecondary)
                     if lockfileAssistants.count > 1 {
                         Text("Stops the current assistant and switches to another.")
@@ -439,9 +439,9 @@ struct SettingsAccountTab: View {
                     .foregroundColor(VColor.textPrimary)
 
                 VStack(alignment: .leading, spacing: VSpacing.lg) {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
                         Text("Hatch a new assistant")
-                            .font(VFont.body)
+                            .font(VFont.inputLabel)
                             .foregroundColor(VColor.textSecondary)
                         Text("Starts the initial setup flow to create a new assistant.")
                             .font(VFont.caption)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
@@ -77,7 +77,7 @@ struct SettingsAdvancedDevTab: View {
             }
 
             Text("Sourced from the gateway API. Changes are synced remotely.")
-                .font(VFont.caption)
+                .font(VFont.sectionDescription)
                 .foregroundColor(VColor.textMuted)
 
             if let error = assistantFlagsError {
@@ -195,7 +195,7 @@ struct SettingsAdvancedDevTab: View {
                 .foregroundColor(VColor.textPrimary)
 
             Text("Local-only flags stored in UserDefaults on this Mac.")
-                .font(VFont.caption)
+                .font(VFont.sectionDescription)
                 .foregroundColor(VColor.textMuted)
 
             if macOSFlagStates.isEmpty {
@@ -225,9 +225,9 @@ struct SettingsAdvancedDevTab: View {
                     .foregroundColor(VColor.textPrimary)
 
                 VStack(alignment: .leading, spacing: VSpacing.md) {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
                         Text("Environment Variables")
-                            .font(VFont.body)
+                            .font(VFont.inputLabel)
                             .foregroundColor(VColor.textSecondary)
                         Text("View env vars for both the app and daemon processes")
                             .font(VFont.caption)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -56,6 +56,7 @@ struct SettingsAppearanceTab: View {
                             .font(VFont.caption)
                             .foregroundColor(VColor.textMuted)
                     }
+                    Spacer()
                     VDropdown(
                         placeholder: "Not Set",
                         selection: $selectedTimezone,

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -24,10 +24,11 @@ struct SettingsAppearanceTab: View {
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
 
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                HStack(alignment: .center, spacing: VSpacing.lg) {
                     Text("Theme")
-                        .font(VFont.body)
+                        .font(VFont.inputLabel)
                         .foregroundColor(VColor.textSecondary)
+                    Spacer()
                     VSegmentedControl(
                         items: [
                             (label: "System", tag: "system"),
@@ -46,20 +47,22 @@ struct SettingsAppearanceTab: View {
                     .fixedSize()
                 }
 
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("User timezone")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textSecondary)
-                    Text("Timezone used for time-aware responses.")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
+                HStack(alignment: .top, spacing: VSpacing.lg) {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("User timezone")
+                            .font(VFont.inputLabel)
+                            .foregroundColor(VColor.textSecondary)
+                        Text("Timezone used for time-aware responses.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
                     VDropdown(
                         placeholder: "Not Set",
                         selection: $selectedTimezone,
                         options: [(label: "Not Set", value: "")] + Self.knownTimezones.map { (label: $0, value: $0) },
                         emptyValue: ""
                     )
-                    .frame(width: 360)
+                    .frame(width: 200)
                 }
                 .onChange(of: selectedTimezone) { _, newValue in
                     if newValue.isEmpty {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAutomationTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAutomationTab.swift
@@ -20,9 +20,9 @@ struct SettingsAutomationTab: View {
                         .foregroundColor(VColor.textPrimary)
 
                     VStack(alignment: .leading, spacing: VSpacing.lg) {
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        VStack(alignment: .leading, spacing: VSpacing.sm) {
                             Text("Manage Reminders")
-                                .font(VFont.body)
+                                .font(VFont.inputLabel)
                                 .foregroundColor(VColor.textSecondary)
                             Text("View and manage one-shot reminders created by the assistant")
                                 .font(VFont.caption)
@@ -44,9 +44,9 @@ struct SettingsAutomationTab: View {
                         .foregroundColor(VColor.textPrimary)
 
                     VStack(alignment: .leading, spacing: VSpacing.lg) {
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        VStack(alignment: .leading, spacing: VSpacing.sm) {
                             Text("Manage Scheduled Tasks")
-                                .font(VFont.body)
+                                .font(VFont.inputLabel)
                                 .foregroundColor(VColor.textSecondary)
                             Text("View and manage recurring tasks (cron and RRULE schedules)")
                                 .font(VFont.caption)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -112,7 +112,7 @@ struct SettingsChannelsTab: View {
     private var bearerTokenContent: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             Text("Bearer Token")
-                .font(VFont.bodyMedium)
+                .font(VFont.inputLabel)
                 .foregroundColor(VColor.textSecondary)
 
             if bearerToken.isEmpty {
@@ -204,12 +204,12 @@ struct SettingsChannelsTab: View {
 
     private var emailCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
                 Text("Email")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
                 Text("Send and receive emails as your assistant")
-                    .font(VFont.caption)
+                    .font(VFont.sectionDescription)
                     .foregroundColor(VColor.textMuted)
             }
 
@@ -263,12 +263,12 @@ struct SettingsChannelsTab: View {
 
     private var telegramCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
                 Text("Telegram")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
                 Text("Message your assistant from Telegram")
-                    .font(VFont.caption)
+                    .font(VFont.sectionDescription)
                     .foregroundColor(VColor.textMuted)
             }
 
@@ -374,7 +374,7 @@ struct SettingsChannelsTab: View {
     private var telegramCredentialEntry: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             Text("Bot Token")
-                .font(VFont.caption)
+                .font(VFont.inputLabel)
                 .foregroundColor(VColor.textSecondary)
 
             SecureField("Telegram bot token", text: $telegramBotTokenText)
@@ -415,12 +415,12 @@ struct SettingsChannelsTab: View {
 
     private var slackChannelCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
                 Text("Slack")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
                 Text("Message your assistant from Slack")
-                    .font(VFont.caption)
+                    .font(VFont.sectionDescription)
                     .foregroundColor(VColor.textMuted)
             }
 
@@ -465,7 +465,7 @@ struct SettingsChannelsTab: View {
     private var slackChannelCredentialEntry: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             Text("Slack Credentials")
-                .font(VFont.caption)
+                .font(VFont.inputLabel)
                 .foregroundColor(VColor.textSecondary)
 
             SecureField("Bot Token (xoxb-...)", text: $slackChannelBotTokenInput)
@@ -519,12 +519,12 @@ struct SettingsChannelsTab: View {
 
     private var twilioCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
                 Text("SMS")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
                 Text("Text your assistant using Twilio as the SMS provider")
-                    .font(VFont.caption)
+                    .font(VFont.sectionDescription)
                     .foregroundColor(VColor.textMuted)
             }
 
@@ -547,9 +547,9 @@ struct SettingsChannelsTab: View {
             // Phone number row (only when credentials exist)
             if store.twilioHasCredentials {
                 Divider().background(VColor.surfaceBorder)
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("Phone Number")
-                        .font(VFont.caption)
+                        .font(VFont.inputLabel)
                         .foregroundColor(VColor.textSecondary)
                     VDropdown(
                         placeholder: "Not Set",
@@ -594,12 +594,12 @@ struct SettingsChannelsTab: View {
 
     private var voiceCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
                 Text("Phone Calling")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
                 Text("Receive and make phone calls via Twilio")
-                    .font(VFont.caption)
+                    .font(VFont.sectionDescription)
                     .foregroundColor(VColor.textMuted)
             }
 
@@ -622,9 +622,9 @@ struct SettingsChannelsTab: View {
             // Phone number row (only when credentials exist)
             if store.twilioHasCredentials {
                 Divider().background(VColor.surfaceBorder)
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("Phone Number")
-                        .font(VFont.caption)
+                        .font(VFont.inputLabel)
                         .foregroundColor(VColor.textSecondary)
                     VDropdown(
                         placeholder: "Not Set",
@@ -671,7 +671,7 @@ struct SettingsChannelsTab: View {
     private var twilioCredentialEntry: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             Text("Account SID and Auth Token")
-                .font(VFont.caption)
+                .font(VFont.inputLabel)
                 .foregroundColor(VColor.textSecondary)
 
             TextField("Account SID", text: $twilioAccountSidText)
@@ -722,7 +722,7 @@ struct SettingsChannelsTab: View {
     private var voiceCredentialEntry: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             Text("Account SID and Auth Token")
-                .font(VFont.caption)
+                .font(VFont.inputLabel)
                 .foregroundColor(VColor.textSecondary)
 
             TextField("Account SID", text: $voiceAccountSidText)
@@ -1444,12 +1444,12 @@ struct SettingsChannelsTab: View {
 
     private var mobileCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
                 Text("Mobile (iOS)")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
                 Text("Connect your phone to your assistant through the iOS app")
-                    .font(VFont.caption)
+                    .font(VFont.sectionDescription)
                     .foregroundColor(VColor.textMuted)
             }
 
@@ -1457,7 +1457,7 @@ struct SettingsChannelsTab: View {
             if !store.approvedDevices.isEmpty {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text("Devices")
-                        .font(VFont.caption)
+                        .font(VFont.inputLabel)
                         .foregroundColor(VColor.textSecondary)
 
                     ForEach(store.approvedDevices, id: \.hashedDeviceId) { device in

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -7,13 +7,13 @@ struct ToolPermissionTesterView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
                 Text("Permission Simulator")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
 
                 Text("Test how a tool invocation would be evaluated by the permission system.")
-                    .font(VFont.caption)
+                    .font(VFont.sectionDescription)
                     .foregroundColor(VColor.textMuted)
             }
 
@@ -319,7 +319,7 @@ struct ToolPermissionTesterView: View {
 
     private func fieldLabel(_ text: String) -> some View {
         Text(text)
-            .font(VFont.captionMedium)
+            .font(VFont.inputLabel)
             .foregroundColor(VColor.textSecondary)
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -54,12 +54,12 @@ struct VoiceSettingsView: View {
 
     private var pttCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
                 Text("Push to Talk")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
                 Text("Hold the activation key to dictate text or start a voice conversation. Uses on-device speech recognition.")
-                    .font(VFont.caption)
+                    .font(VFont.sectionDescription)
                     .foregroundColor(VColor.textMuted)
             }
 
@@ -88,8 +88,8 @@ struct VoiceSettingsView: View {
             if pttEnabled {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("Activation key")
-                        .font(VFont.bodyMedium)
-                        .foregroundColor(VColor.textPrimary)
+                        .font(VFont.inputLabel)
+                        .foregroundColor(VColor.textSecondary)
 
                     HStack(spacing: VSpacing.sm) {
                         // Preset buttons
@@ -278,12 +278,12 @@ struct VoiceSettingsView: View {
 
     private var wakeWordCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
                 Text("Talk to Vellum, hands free")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
                 Text("Wake word lets you start a conversation by speaking a keyword aloud \u{2014} no need to click or press anything. It uses on-device speech recognition, so nothing you say ever leaves your Mac.")
-                    .font(VFont.caption)
+                    .font(VFont.sectionDescription)
                     .foregroundColor(VColor.textMuted)
                     .lineSpacing(2)
             }
@@ -313,8 +313,8 @@ struct VoiceSettingsView: View {
                 // Keyword
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("Keyword")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
+                        .font(VFont.inputLabel)
+                        .foregroundColor(VColor.textSecondary)
 
                     TextField("Enter wake word or phrase", text: $wakeWordKeyword)
                         .vInputStyle()
@@ -338,10 +338,10 @@ struct VoiceSettingsView: View {
 
                 // Conversation timeout
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
                         Text("Conversation timeout")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textPrimary)
+                            .font(VFont.inputLabel)
+                            .foregroundColor(VColor.textSecondary)
                         Text("How long to wait for follow-up speech before ending the conversation.")
                             .font(VFont.caption)
                             .foregroundColor(VColor.textMuted)
@@ -408,12 +408,12 @@ struct VoiceSettingsView: View {
 
     private var ttsCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
                 Text("Text-to-Speech")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
                 Text("ElevenLabs provides high-quality voice responses during voice conversations. An API key is required.")
-                    .font(VFont.caption)
+                    .font(VFont.sectionDescription)
                     .foregroundColor(VColor.textMuted)
             }
 
@@ -429,7 +429,7 @@ struct VoiceSettingsView: View {
             } else if ttsSetupExpanded {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("ElevenLabs API Key")
-                        .font(VFont.caption)
+                        .font(VFont.inputLabel)
                         .foregroundColor(VColor.textSecondary)
 
                     SecureField("Your ElevenLabs API key", text: $elevenLabsKeyText)

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -92,7 +92,9 @@ public enum VFont {
     /// Display font (used for panel headers like "AGENT", "GENERATED CONTENT")
     public static let display    = Font.custom("Inter-SemiBold", size: adaptiveSize(18))
     public static let panelTitle   = Font.custom("Inter-Medium", size: adaptiveSize(24))
-    public static let sectionTitle   = Font.custom("Inter-Medium", size: adaptiveSize(18))
+    public static let sectionTitle   = Font.custom("Inter-SemiBold", size: adaptiveSize(18))
+    public static let sectionDescription = Font.custom("Inter-Medium", size: 14)
+    public static let inputLabel         = Font.custom("Inter-Medium", size: 12)
 
     /// Small label (used for thread tab names)
     public static let tabLabel   = Font.custom("Inter", size: 11)


### PR DESCRIPTION
## Summary

- Update `VFont.sectionTitle` from Inter-Medium to Inter-SemiBold (18px) to match design spec "18px semi bold (600)"
- Add two new typography tokens: `sectionDescription` (Inter-Medium 14px) and `inputLabel` (Inter-Medium 12px)
- Apply `sectionDescription` to section-level helper text (e.g. "Required for AI responses", "Enables real-time web search") replacing `VFont.caption` throughout all settings views
- Apply `inputLabel` to field labels directly above input widgets (TextField, SecureField, VDropdown) replacing `VFont.body`/`VFont.caption` throughout all settings views
- Update inner VStack spacing from `VSpacing.xs` to `VSpacing.sm` for (sectionTitle + sectionDescription) and (label + input) pairs
- Refactor Appearance tab Display section: Theme row becomes an inline `HStack` with label on left and segmented control on right; Timezone row becomes an inline `HStack` with label+description on left and a 200px dropdown on right

## Test plan

- [ ] Open Settings → Models & Services: verify "Anthropic", "Perplexity Search", "Brave Search", "Image Generation", "Twitter / X" section headers appear bolder (SemiBold), descriptions appear at 14px medium, input labels ("API Key", "Active Model") appear at 12px medium
- [ ] Open Settings → Appearance: verify Theme row is inline (label left, segmented control right), Timezone row is inline (label+description left, 200px dropdown right)
- [ ] Open Settings → Channels: verify all channel cards (Mobile, Telegram, Slack, SMS, Phone Calling, Email) have 14px medium descriptions and 12px medium credential input labels
- [ ] Open Settings → Voice: verify PTT, Wake Word, and TTS section descriptions appear at 14px medium; "Activation key", "Keyword", "Conversation timeout", "ElevenLabs API Key" appear at 12px medium
- [ ] Open Settings → Account: verify Gateway card description and "Local Gateway Target"/"Gateway URL" labels appear at correct sizes
- [ ] Open Settings → Advanced (dev mode): verify "Assistant Feature Flags" and "macOS Feature Flags" section descriptions appear at 14px medium; "Environment Variables" label at 12px medium

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
