### PR TITLE
feat: add effort field to provider config types and user-facing config schema

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -22,6 +22,7 @@ export interface AgentLoopConfig {
   maxTokens: number;
   maxInputTokens?: number; // context window size for tool result truncation
   thinking?: { enabled: boolean; budgetTokens: number };
+  effort: "low" | "medium" | "high";
   toolChoice?:
     | { type: "auto" }
     | { type: "any" }
@@ -80,6 +81,7 @@ export type AgentEvent =
 
 const DEFAULT_CONFIG: AgentLoopConfig = {
   maxTokens: 16000,
+  effort: "high",
   maxToolUseTurns: 40,
   minTurnIntervalMs: 150,
 };
@@ -223,6 +225,8 @@ export class AgentLoop {
             budget_tokens: budgetTokens,
           };
         }
+
+        providerConfig.effort = this.config.effort;
 
         if (this.config.toolChoice) {
           providerConfig.tool_choice = this.config.toolChoice;
@@ -647,7 +651,10 @@ export class AgentLoop {
         if (softLimit > 0 && toolUseTurns === softLimit) {
           resultBlocks.push({
             type: "text",
-            text: `<system_notice>${APPROACHING_LIMIT_WARNING.replace("{remaining}", String(APPROACHING_LIMIT_OFFSET))}</system_notice>`,
+            text: `<system_notice>${APPROACHING_LIMIT_WARNING.replace(
+              "{remaining}",
+              String(APPROACHING_LIMIT_OFFSET),
+            )}</system_notice>`,
           });
         } else if (toolUseTurns % PROGRESS_CHECK_INTERVAL === 0) {
           resultBlocks.push({

--- a/assistant/src/config/core-schema.ts
+++ b/assistant/src/config/core-schema.ts
@@ -1,301 +1,330 @@
-import { z } from 'zod';
+import { z } from "zod";
 
-const VALID_SECRET_ACTIONS = ['redact', 'warn', 'block', 'prompt'] as const;
-const VALID_PERMISSIONS_MODES = ['legacy', 'strict', 'workspace'] as const;
-const VALID_SMS_PROVIDERS = ['twilio'] as const;
+const VALID_SECRET_ACTIONS = ["redact", "warn", "block", "prompt"] as const;
+const VALID_PERMISSIONS_MODES = ["legacy", "strict", "workspace"] as const;
+const VALID_SMS_PROVIDERS = ["twilio"] as const;
 
 export const TimeoutConfigSchema = z.object({
   shellMaxTimeoutSec: z
-    .number({ error: 'timeouts.shellMaxTimeoutSec must be a number' })
-    .finite('timeouts.shellMaxTimeoutSec must be finite')
-    .positive('timeouts.shellMaxTimeoutSec must be a positive number')
+    .number({ error: "timeouts.shellMaxTimeoutSec must be a number" })
+    .finite("timeouts.shellMaxTimeoutSec must be finite")
+    .positive("timeouts.shellMaxTimeoutSec must be a positive number")
     .default(600),
   shellDefaultTimeoutSec: z
-    .number({ error: 'timeouts.shellDefaultTimeoutSec must be a number' })
-    .finite('timeouts.shellDefaultTimeoutSec must be finite')
-    .positive('timeouts.shellDefaultTimeoutSec must be a positive number')
+    .number({ error: "timeouts.shellDefaultTimeoutSec must be a number" })
+    .finite("timeouts.shellDefaultTimeoutSec must be finite")
+    .positive("timeouts.shellDefaultTimeoutSec must be a positive number")
     .default(120),
   permissionTimeoutSec: z
-    .number({ error: 'timeouts.permissionTimeoutSec must be a number' })
-    .finite('timeouts.permissionTimeoutSec must be finite')
-    .positive('timeouts.permissionTimeoutSec must be a positive number')
+    .number({ error: "timeouts.permissionTimeoutSec must be a number" })
+    .finite("timeouts.permissionTimeoutSec must be finite")
+    .positive("timeouts.permissionTimeoutSec must be a positive number")
     .default(300),
   toolExecutionTimeoutSec: z
-    .number({ error: 'timeouts.toolExecutionTimeoutSec must be a number' })
-    .finite('timeouts.toolExecutionTimeoutSec must be finite')
-    .positive('timeouts.toolExecutionTimeoutSec must be a positive number')
+    .number({ error: "timeouts.toolExecutionTimeoutSec must be a number" })
+    .finite("timeouts.toolExecutionTimeoutSec must be finite")
+    .positive("timeouts.toolExecutionTimeoutSec must be a positive number")
     .default(120),
   providerStreamTimeoutSec: z
-    .number({ error: 'timeouts.providerStreamTimeoutSec must be a number' })
-    .finite('timeouts.providerStreamTimeoutSec must be finite')
-    .positive('timeouts.providerStreamTimeoutSec must be a positive number')
+    .number({ error: "timeouts.providerStreamTimeoutSec must be a number" })
+    .finite("timeouts.providerStreamTimeoutSec must be finite")
+    .positive("timeouts.providerStreamTimeoutSec must be a positive number")
     .default(300),
 });
 
 export const RateLimitConfigSchema = z.object({
   maxRequestsPerMinute: z
-    .number({ error: 'rateLimit.maxRequestsPerMinute must be a number' })
-    .int('rateLimit.maxRequestsPerMinute must be an integer')
-    .nonnegative('rateLimit.maxRequestsPerMinute must be a non-negative integer')
+    .number({ error: "rateLimit.maxRequestsPerMinute must be a number" })
+    .int("rateLimit.maxRequestsPerMinute must be an integer")
+    .nonnegative(
+      "rateLimit.maxRequestsPerMinute must be a non-negative integer",
+    )
     .default(0),
   maxTokensPerSession: z
-    .number({ error: 'rateLimit.maxTokensPerSession must be a number' })
-    .int('rateLimit.maxTokensPerSession must be an integer')
-    .nonnegative('rateLimit.maxTokensPerSession must be a non-negative integer')
+    .number({ error: "rateLimit.maxTokensPerSession must be a number" })
+    .int("rateLimit.maxTokensPerSession must be an integer")
+    .nonnegative("rateLimit.maxTokensPerSession must be a non-negative integer")
     .default(0),
 });
 
 export const CustomSecretPatternSchema = z.object({
-  label: z.string({ error: 'secretDetection.customPatterns[].label must be a string' }),
-  pattern: z.string({ error: 'secretDetection.customPatterns[].pattern must be a string' }),
+  label: z.string({
+    error: "secretDetection.customPatterns[].label must be a string",
+  }),
+  pattern: z.string({
+    error: "secretDetection.customPatterns[].pattern must be a string",
+  }),
 });
 
 export const SecretDetectionConfigSchema = z.object({
   enabled: z
-    .boolean({ error: 'secretDetection.enabled must be a boolean' })
+    .boolean({ error: "secretDetection.enabled must be a boolean" })
     .default(true),
   action: z
     .enum(VALID_SECRET_ACTIONS, {
-      error: `secretDetection.action must be one of: ${VALID_SECRET_ACTIONS.join(', ')}`,
+      error: `secretDetection.action must be one of: ${VALID_SECRET_ACTIONS.join(
+        ", ",
+      )}`,
     })
-    .default('redact'),
+    .default("redact"),
   entropyThreshold: z
-    .number({ error: 'secretDetection.entropyThreshold must be a number' })
-    .finite('secretDetection.entropyThreshold must be finite')
-    .positive('secretDetection.entropyThreshold must be a positive number')
+    .number({ error: "secretDetection.entropyThreshold must be a number" })
+    .finite("secretDetection.entropyThreshold must be finite")
+    .positive("secretDetection.entropyThreshold must be a positive number")
     .default(4.0),
   allowOneTimeSend: z
-    .boolean({ error: 'secretDetection.allowOneTimeSend must be a boolean' })
+    .boolean({ error: "secretDetection.allowOneTimeSend must be a boolean" })
     .default(false),
   blockIngress: z
-    .boolean({ error: 'secretDetection.blockIngress must be a boolean' })
+    .boolean({ error: "secretDetection.blockIngress must be a boolean" })
     .default(true),
-  customPatterns: z
-    .array(CustomSecretPatternSchema)
-    .optional(),
+  customPatterns: z.array(CustomSecretPatternSchema).optional(),
 });
 
 export const PermissionsConfigSchema = z.object({
   mode: z
     .enum(VALID_PERMISSIONS_MODES, {
-      error: `permissions.mode must be one of: ${VALID_PERMISSIONS_MODES.join(', ')}`,
+      error: `permissions.mode must be one of: ${VALID_PERMISSIONS_MODES.join(
+        ", ",
+      )}`,
     })
-    .default('workspace'),
+    .default("workspace"),
 });
 
 export const AuditLogConfigSchema = z.object({
   retentionDays: z
-    .number({ error: 'auditLog.retentionDays must be a number' })
-    .int('auditLog.retentionDays must be an integer')
-    .nonnegative('auditLog.retentionDays must be a non-negative integer')
+    .number({ error: "auditLog.retentionDays must be a number" })
+    .int("auditLog.retentionDays must be an integer")
+    .nonnegative("auditLog.retentionDays must be a non-negative integer")
     .default(0),
 });
 
 export const LogFileConfigSchema = z.object({
-  dir: z
-    .string({ error: 'logFile.dir must be a string' })
-    .optional(),
+  dir: z.string({ error: "logFile.dir must be a string" }).optional(),
   retentionDays: z
-    .number({ error: 'logFile.retentionDays must be a number' })
-    .int('logFile.retentionDays must be an integer')
-    .positive('logFile.retentionDays must be a positive integer')
+    .number({ error: "logFile.retentionDays must be a number" })
+    .int("logFile.retentionDays must be an integer")
+    .positive("logFile.retentionDays must be a positive integer")
     .default(30),
 });
 
 export const ThinkingConfigSchema = z.object({
   enabled: z
-    .boolean({ error: 'thinking.enabled must be a boolean' })
+    .boolean({ error: "thinking.enabled must be a boolean" })
     .default(false),
   budgetTokens: z
-    .number({ error: 'thinking.budgetTokens must be a number' })
-    .int('thinking.budgetTokens must be an integer')
-    .positive('thinking.budgetTokens must be a positive integer')
+    .number({ error: "thinking.budgetTokens must be a number" })
+    .int("thinking.budgetTokens must be an integer")
+    .positive("thinking.budgetTokens must be a positive integer")
     .default(10000),
   streamThinking: z
-    .boolean({ error: 'thinking.streamThinking must be a boolean' })
+    .boolean({ error: "thinking.streamThinking must be a boolean" })
     .default(false),
 });
 
+export const EffortSchema = z
+  .enum(["low", "medium", "high"], {
+    error: 'effort must be "low", "medium", or "high"',
+  })
+  .default("high");
+
+export type Effort = z.infer<typeof EffortSchema>;
+
 export const ContextWindowConfigSchema = z.object({
   enabled: z
-    .boolean({ error: 'contextWindow.enabled must be a boolean' })
+    .boolean({ error: "contextWindow.enabled must be a boolean" })
     .default(true),
   maxInputTokens: z
-    .number({ error: 'contextWindow.maxInputTokens must be a number' })
-    .int('contextWindow.maxInputTokens must be an integer')
-    .positive('contextWindow.maxInputTokens must be a positive integer')
+    .number({ error: "contextWindow.maxInputTokens must be a number" })
+    .int("contextWindow.maxInputTokens must be an integer")
+    .positive("contextWindow.maxInputTokens must be a positive integer")
     .default(200000),
   targetInputTokens: z
-    .number({ error: 'contextWindow.targetInputTokens must be a number' })
-    .int('contextWindow.targetInputTokens must be an integer')
-    .positive('contextWindow.targetInputTokens must be a positive integer')
+    .number({ error: "contextWindow.targetInputTokens must be a number" })
+    .int("contextWindow.targetInputTokens must be an integer")
+    .positive("contextWindow.targetInputTokens must be a positive integer")
     .default(110000),
   compactThreshold: z
-    .number({ error: 'contextWindow.compactThreshold must be a number' })
-    .finite('contextWindow.compactThreshold must be finite')
-    .gt(0, 'contextWindow.compactThreshold must be greater than 0')
-    .lte(1, 'contextWindow.compactThreshold must be less than or equal to 1')
+    .number({ error: "contextWindow.compactThreshold must be a number" })
+    .finite("contextWindow.compactThreshold must be finite")
+    .gt(0, "contextWindow.compactThreshold must be greater than 0")
+    .lte(1, "contextWindow.compactThreshold must be less than or equal to 1")
     .default(0.8),
   preserveRecentUserTurns: z
-    .number({ error: 'contextWindow.preserveRecentUserTurns must be a number' })
-    .int('contextWindow.preserveRecentUserTurns must be an integer')
-    .positive('contextWindow.preserveRecentUserTurns must be a positive integer')
+    .number({ error: "contextWindow.preserveRecentUserTurns must be a number" })
+    .int("contextWindow.preserveRecentUserTurns must be an integer")
+    .positive(
+      "contextWindow.preserveRecentUserTurns must be a positive integer",
+    )
     .default(8),
   summaryMaxTokens: z
-    .number({ error: 'contextWindow.summaryMaxTokens must be a number' })
-    .int('contextWindow.summaryMaxTokens must be an integer')
-    .positive('contextWindow.summaryMaxTokens must be a positive integer')
+    .number({ error: "contextWindow.summaryMaxTokens must be a number" })
+    .int("contextWindow.summaryMaxTokens must be an integer")
+    .positive("contextWindow.summaryMaxTokens must be a positive integer")
     .default(1200),
   chunkTokens: z
-    .number({ error: 'contextWindow.chunkTokens must be a number' })
-    .int('contextWindow.chunkTokens must be an integer')
-    .positive('contextWindow.chunkTokens must be a positive integer')
+    .number({ error: "contextWindow.chunkTokens must be a number" })
+    .int("contextWindow.chunkTokens must be an integer")
+    .positive("contextWindow.chunkTokens must be a positive integer")
     .default(12000),
 });
 
 export const ModelPricingOverrideSchema = z.object({
-  provider: z.string({ error: 'pricingOverrides[].provider must be a string' }),
-  modelPattern: z.string({ error: 'pricingOverrides[].modelPattern must be a string' }),
+  provider: z.string({ error: "pricingOverrides[].provider must be a string" }),
+  modelPattern: z.string({
+    error: "pricingOverrides[].modelPattern must be a string",
+  }),
   inputPer1M: z
-    .number({ error: 'pricingOverrides[].inputPer1M must be a number' })
-    .nonnegative('pricingOverrides[].inputPer1M must be a non-negative number'),
+    .number({ error: "pricingOverrides[].inputPer1M must be a number" })
+    .nonnegative("pricingOverrides[].inputPer1M must be a non-negative number"),
   outputPer1M: z
-    .number({ error: 'pricingOverrides[].outputPer1M must be a number' })
-    .nonnegative('pricingOverrides[].outputPer1M must be a non-negative number'),
+    .number({ error: "pricingOverrides[].outputPer1M must be a number" })
+    .nonnegative(
+      "pricingOverrides[].outputPer1M must be a non-negative number",
+    ),
 });
 
 export const SmsConfigSchema = z.object({
-  enabled: z
-    .boolean({ error: 'sms.enabled must be a boolean' })
-    .default(false),
+  enabled: z.boolean({ error: "sms.enabled must be a boolean" }).default(false),
   provider: z
     .enum(VALID_SMS_PROVIDERS, {
-      error: `sms.provider must be one of: ${VALID_SMS_PROVIDERS.join(', ')}`,
+      error: `sms.provider must be one of: ${VALID_SMS_PROVIDERS.join(", ")}`,
     })
-    .default('twilio'),
+    .default("twilio"),
   phoneNumber: z
-    .string({ error: 'sms.phoneNumber must be a string' })
-    .default(''),
+    .string({ error: "sms.phoneNumber must be a string" })
+    .default(""),
   assistantPhoneNumbers: z
-    .record(z.string(), z.string({ error: 'sms.assistantPhoneNumbers values must be strings' }))
+    .record(
+      z.string(),
+      z.string({ error: "sms.assistantPhoneNumbers values must be strings" }),
+    )
     .optional(),
 });
 
 export const IngressWebhookConfigSchema = z.object({
   secret: z
-    .string({ error: 'ingress.webhook.secret must be a string' })
-    .default(''),
+    .string({ error: "ingress.webhook.secret must be a string" })
+    .default(""),
   timeoutMs: z
-    .number({ error: 'ingress.webhook.timeoutMs must be a number' })
-    .int('ingress.webhook.timeoutMs must be an integer')
-    .positive('ingress.webhook.timeoutMs must be a positive integer')
+    .number({ error: "ingress.webhook.timeoutMs must be a number" })
+    .int("ingress.webhook.timeoutMs must be an integer")
+    .positive("ingress.webhook.timeoutMs must be a positive integer")
     .default(30_000),
   maxRetries: z
-    .number({ error: 'ingress.webhook.maxRetries must be a number' })
-    .int('ingress.webhook.maxRetries must be an integer')
-    .nonnegative('ingress.webhook.maxRetries must be a non-negative integer')
+    .number({ error: "ingress.webhook.maxRetries must be a number" })
+    .int("ingress.webhook.maxRetries must be an integer")
+    .nonnegative("ingress.webhook.maxRetries must be a non-negative integer")
     .default(2),
   initialBackoffMs: z
-    .number({ error: 'ingress.webhook.initialBackoffMs must be a number' })
-    .int('ingress.webhook.initialBackoffMs must be an integer')
-    .positive('ingress.webhook.initialBackoffMs must be a positive integer')
+    .number({ error: "ingress.webhook.initialBackoffMs must be a number" })
+    .int("ingress.webhook.initialBackoffMs must be an integer")
+    .positive("ingress.webhook.initialBackoffMs must be a positive integer")
     .default(500),
   maxPayloadBytes: z
-    .number({ error: 'ingress.webhook.maxPayloadBytes must be a number' })
-    .int('ingress.webhook.maxPayloadBytes must be an integer')
-    .positive('ingress.webhook.maxPayloadBytes must be a positive integer')
+    .number({ error: "ingress.webhook.maxPayloadBytes must be a number" })
+    .int("ingress.webhook.maxPayloadBytes must be an integer")
+    .positive("ingress.webhook.maxPayloadBytes must be a positive integer")
     .default(1_048_576),
 });
 
 export const IngressRateLimitConfigSchema = z.object({
   maxRequestsPerMinute: z
-    .number({ error: 'ingress.rateLimit.maxRequestsPerMinute must be a number' })
-    .int('ingress.rateLimit.maxRequestsPerMinute must be an integer')
-    .nonnegative('ingress.rateLimit.maxRequestsPerMinute must be a non-negative integer')
+    .number({
+      error: "ingress.rateLimit.maxRequestsPerMinute must be a number",
+    })
+    .int("ingress.rateLimit.maxRequestsPerMinute must be an integer")
+    .nonnegative(
+      "ingress.rateLimit.maxRequestsPerMinute must be a non-negative integer",
+    )
     .default(0),
   maxRequestsPerHour: z
-    .number({ error: 'ingress.rateLimit.maxRequestsPerHour must be a number' })
-    .int('ingress.rateLimit.maxRequestsPerHour must be an integer')
-    .nonnegative('ingress.rateLimit.maxRequestsPerHour must be a non-negative integer')
+    .number({ error: "ingress.rateLimit.maxRequestsPerHour must be a number" })
+    .int("ingress.rateLimit.maxRequestsPerHour must be an integer")
+    .nonnegative(
+      "ingress.rateLimit.maxRequestsPerHour must be a non-negative integer",
+    )
     .default(0),
 });
 
 const IngressBaseSchema = z.object({
-  enabled: z
-    .boolean({ error: 'ingress.enabled must be a boolean' })
-    .optional(),
+  enabled: z.boolean({ error: "ingress.enabled must be a boolean" }).optional(),
   publicBaseUrl: z
-    .string({ error: 'ingress.publicBaseUrl must be a string' })
+    .string({ error: "ingress.publicBaseUrl must be a string" })
     .refine(
-      (val) => val === '' || /^https?:\/\//i.test(val),
-      'ingress.publicBaseUrl must be an absolute URL starting with http:// or https://',
+      (val) => val === "" || /^https?:\/\//i.test(val),
+      "ingress.publicBaseUrl must be an absolute URL starting with http:// or https://",
     )
-    .default(''),
-  webhook: IngressWebhookConfigSchema.default(IngressWebhookConfigSchema.parse({})),
-  rateLimit: IngressRateLimitConfigSchema.default(IngressRateLimitConfigSchema.parse({})),
+    .default(""),
+  webhook: IngressWebhookConfigSchema.default(
+    IngressWebhookConfigSchema.parse({}),
+  ),
+  rateLimit: IngressRateLimitConfigSchema.default(
+    IngressRateLimitConfigSchema.parse({}),
+  ),
   shutdownDrainMs: z
-    .number({ error: 'ingress.shutdownDrainMs must be a number' })
-    .int('ingress.shutdownDrainMs must be an integer')
-    .nonnegative('ingress.shutdownDrainMs must be a non-negative integer')
+    .number({ error: "ingress.shutdownDrainMs must be a number" })
+    .int("ingress.shutdownDrainMs must be an integer")
+    .nonnegative("ingress.shutdownDrainMs must be a non-negative integer")
     .default(5_000),
 });
 
-export const IngressConfigSchema = IngressBaseSchema
-  .default(IngressBaseSchema.parse({}))
-  .transform((val) => ({
-    ...val,
-    // Backward compatibility: if `enabled` was never explicitly set (undefined),
-    // infer it from whether a publicBaseUrl is configured. Existing users who
-    // have a URL but predate the `enabled` field should not have their webhooks
-    // silently disabled on upgrade.
-    //
-    // When publicBaseUrl is empty and enabled is unset, leave enabled as
-    // undefined so getPublicBaseUrl() can still fall through to the
-    // INGRESS_PUBLIC_BASE_URL env-var fallback (env-only setups).
-    enabled: val.enabled ?? (val.publicBaseUrl ? true : undefined),
-  }));
+export const IngressConfigSchema = IngressBaseSchema.default(
+  IngressBaseSchema.parse({}),
+).transform((val) => ({
+  ...val,
+  // Backward compatibility: if `enabled` was never explicitly set (undefined),
+  // infer it from whether a publicBaseUrl is configured. Existing users who
+  // have a URL but predate the `enabled` field should not have their webhooks
+  // silently disabled on upgrade.
+  //
+  // When publicBaseUrl is empty and enabled is unset, leave enabled as
+  // undefined so getPublicBaseUrl() can still fall through to the
+  // INGRESS_PUBLIC_BASE_URL env-var fallback (env-only setups).
+  enabled: val.enabled ?? (val.publicBaseUrl ? true : undefined),
+}));
 
 export const PlatformConfigSchema = z.object({
   baseUrl: z
-    .string({ error: 'platform.baseUrl must be a string' })
+    .string({ error: "platform.baseUrl must be a string" })
     .refine(
-      (val) => val === '' || /^https?:\/\//i.test(val),
-      'platform.baseUrl must be an absolute URL starting with http:// or https://',
+      (val) => val === "" || /^https?:\/\//i.test(val),
+      "platform.baseUrl must be an absolute URL starting with http:// or https://",
     )
-    .default(''),
+    .default(""),
 });
 
 export type PlatformConfig = z.infer<typeof PlatformConfigSchema>;
 
 export const DaemonConfigSchema = z.object({
   startupSocketWaitMs: z
-    .number({ error: 'daemon.startupSocketWaitMs must be a number' })
-    .int('daemon.startupSocketWaitMs must be an integer')
-    .positive('daemon.startupSocketWaitMs must be a positive integer')
+    .number({ error: "daemon.startupSocketWaitMs must be a number" })
+    .int("daemon.startupSocketWaitMs must be an integer")
+    .positive("daemon.startupSocketWaitMs must be a positive integer")
     .default(5000),
   stopTimeoutMs: z
-    .number({ error: 'daemon.stopTimeoutMs must be a number' })
-    .int('daemon.stopTimeoutMs must be an integer')
-    .positive('daemon.stopTimeoutMs must be a positive integer')
+    .number({ error: "daemon.stopTimeoutMs must be a number" })
+    .int("daemon.stopTimeoutMs must be an integer")
+    .positive("daemon.stopTimeoutMs must be a positive integer")
     .default(5000),
   sigkillGracePeriodMs: z
-    .number({ error: 'daemon.sigkillGracePeriodMs must be a number' })
-    .int('daemon.sigkillGracePeriodMs must be an integer')
-    .positive('daemon.sigkillGracePeriodMs must be a positive integer')
+    .number({ error: "daemon.sigkillGracePeriodMs must be a number" })
+    .int("daemon.sigkillGracePeriodMs must be an integer")
+    .positive("daemon.sigkillGracePeriodMs must be a positive integer")
     .default(2000),
   titleGenerationMaxTokens: z
-    .number({ error: 'daemon.titleGenerationMaxTokens must be a number' })
-    .int('daemon.titleGenerationMaxTokens must be an integer')
-    .positive('daemon.titleGenerationMaxTokens must be a positive integer')
+    .number({ error: "daemon.titleGenerationMaxTokens must be a number" })
+    .int("daemon.titleGenerationMaxTokens must be an integer")
+    .positive("daemon.titleGenerationMaxTokens must be a positive integer")
     .default(30),
   standaloneRecording: z
-    .boolean({ error: 'daemon.standaloneRecording must be a boolean' })
+    .boolean({ error: "daemon.standaloneRecording must be a boolean" })
     .default(true),
 });
 
 export const UiConfigSchema = z.object({
   userTimezone: z
-    .string({ error: 'ui.userTimezone must be a string' })
+    .string({ error: "ui.userTimezone must be a string" })
     .optional(),
 });
 
@@ -311,7 +340,9 @@ export type ContextWindowConfig = z.infer<typeof ContextWindowConfigSchema>;
 export type ModelPricingOverride = z.infer<typeof ModelPricingOverrideSchema>;
 export type SmsConfig = z.infer<typeof SmsConfigSchema>;
 export type IngressWebhookConfig = z.infer<typeof IngressWebhookConfigSchema>;
-export type IngressRateLimitConfig = z.infer<typeof IngressRateLimitConfigSchema>;
+export type IngressRateLimitConfig = z.infer<
+  typeof IngressRateLimitConfigSchema
+>;
 export type DaemonConfig = z.infer<typeof DaemonConfigSchema>;
 export type IngressConfig = z.infer<typeof IngressConfigSchema>;
 export type UiConfig = z.infer<typeof UiConfigSchema>;

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -34,6 +34,7 @@ export type {
   AuditLogConfig,
   ContextWindowConfig,
   DaemonConfig,
+  Effort,
   IngressConfig,
   IngressRateLimitConfig,
   IngressWebhookConfig,
@@ -52,6 +53,7 @@ export {
   AuditLogConfigSchema,
   ContextWindowConfigSchema,
   DaemonConfigSchema,
+  EffortSchema,
   IngressConfigSchema,
   IngressRateLimitConfigSchema,
   IngressWebhookConfigSchema,
@@ -145,6 +147,7 @@ import {
   AuditLogConfigSchema,
   ContextWindowConfigSchema,
   DaemonConfigSchema,
+  EffortSchema,
   IngressConfigSchema,
   LogFileConfigSchema,
   ModelPricingOverrideSchema,
@@ -199,13 +202,17 @@ export const AssistantConfigSchema = z
       .default({} as any),
     webSearchProvider: z
       .enum(VALID_WEB_SEARCH_PROVIDERS, {
-        error: `webSearchProvider must be one of: ${VALID_WEB_SEARCH_PROVIDERS.join(", ")}`,
+        error: `webSearchProvider must be one of: ${VALID_WEB_SEARCH_PROVIDERS.join(
+          ", ",
+        )}`,
       })
       .default("anthropic-native"),
     providerOrder: z
       .array(
         z.enum(VALID_PROVIDERS, {
-          error: `Each providerOrder entry must be one of: ${VALID_PROVIDERS.join(", ")}`,
+          error: `Each providerOrder entry must be one of: ${VALID_PROVIDERS.join(
+            ", ",
+          )}`,
         }),
       )
       .default([]),
@@ -219,6 +226,7 @@ export const AssistantConfigSchema = z
       .int("maxToolUseTurns must be an integer")
       .nonnegative("maxToolUseTurns must be a non-negative integer")
       .default(40),
+    effort: EffortSchema,
     thinking: ThinkingConfigSchema.default(ThinkingConfigSchema.parse({})),
     contextWindow: ContextWindowConfigSchema.default(
       ContextWindowConfigSchema.parse({}),

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -15,7 +15,8 @@
  * - session-usage.ts        — recordUsage
  */
 
-import { AgentLoop, type ResolvedSystemPrompt } from "../agent/loop.js";
+import type { ResolvedSystemPrompt } from "../agent/loop.js";
+import { AgentLoop } from "../agent/loop.js";
 import type {
   TurnChannelContext,
   TurnInterfaceContext,
@@ -57,8 +58,8 @@ import type {
 } from "./ipc-protocol.js";
 import { runAgentLoopImpl } from "./session-agent-loop.js";
 import { ConflictGate } from "./session-conflict-gate.js";
+import type { HistorySessionContext } from "./session-history.js";
 import {
-  type HistorySessionContext,
   regenerate as regenerateImpl,
   undo as undoImpl,
 } from "./session-history.js";
@@ -67,18 +68,18 @@ import {
   disposeSession,
   loadFromDb as loadFromDbImpl,
 } from "./session-lifecycle.js";
+import type { RedirectToSecurePromptOptions } from "./session-messaging.js";
 import {
   enqueueMessage as enqueueMessageImpl,
   persistUserMessage as persistUserMessageImpl,
   redirectToSecurePrompt as redirectToSecurePromptImpl,
-  type RedirectToSecurePromptOptions,
 } from "./session-messaging.js";
 // Extracted modules
 import { registerSessionNotifiers } from "./session-notifiers.js";
+import type { ProcessSessionContext } from "./session-process.js";
 import {
   drainQueue as drainQueueImpl,
   processMessage as processMessageImpl,
-  type ProcessSessionContext,
 } from "./session-process.js";
 import type {
   QueueDrainReason,
@@ -95,11 +96,11 @@ import {
   handleSurfaceAction as handleSurfaceActionImpl,
   handleSurfaceUndo as handleSurfaceUndoImpl,
 } from "./session-surfaces.js";
+import type { ToolSetupContext } from "./session-tool-setup.js";
 import {
   buildToolDefinitions,
   createResolveToolsCallback,
   createToolExecutor,
-  type ToolSetupContext,
 } from "./session-tool-setup.js";
 import { refreshWorkspaceTopLevelContextIfNeeded as refreshWorkspaceImpl } from "./session-workspace.js";
 import { TraceEmitter } from "./trace-emitter.js";
@@ -118,11 +119,8 @@ export const DEFAULT_MEMORY_POLICY: Readonly<SessionMemoryPolicy> =
   });
 
 export { findLastUndoableUserMessageIndex } from "./session-history.js";
-export {
-  MAX_QUEUE_DEPTH,
-  type QueueDrainReason,
-  type QueuePolicy,
-} from "./session-queue-manager.js";
+export type { QueueDrainReason, QueuePolicy } from "./session-queue-manager.js";
+export { MAX_QUEUE_DEPTH } from "./session-queue-manager.js";
 
 export class Session {
   public readonly conversationId: string;
@@ -334,6 +332,7 @@ export class Session {
         maxTokens,
         maxInputTokens: config.contextWindow.maxInputTokens,
         thinking: config.thinking,
+        effort: config.effort,
         maxToolUseTurns: config.maxToolUseTurns,
       },
       toolDefs.length > 0 ? toolDefs : undefined,

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -71,9 +71,9 @@ export interface ToolDefinition {
 }
 
 export type ModelIntent =
-  | 'latency-optimized'
-  | 'quality-optimized'
-  | 'vision-optimized';
+  | "latency-optimized"
+  | "quality-optimized"
+  | "vision-optimized";
 
 export interface ProviderResponse {
   content: ContentBlock[];
@@ -93,13 +93,14 @@ export interface ProviderResponse {
 }
 
 export type ProviderEvent =
-  | { type: 'text_delta'; text: string }
-  | { type: 'thinking_delta'; thinking: string }
-  | { type: 'input_json_delta'; toolName: string; accumulatedJson: string };
+  | { type: "text_delta"; text: string }
+  | { type: "thinking_delta"; thinking: string }
+  | { type: "input_json_delta"; toolName: string; accumulatedJson: string };
 
 export interface SendMessageConfig {
   model?: string;
   modelIntent?: ModelIntent;
+  effort?: "low" | "medium" | "high";
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
- Add `effort` (`'low' | 'medium' | 'high'`) as a named field on `SendMessageConfig` in the provider types
- Add `EffortSchema` to config with default `'high'` (equivalent to current behavior)
- Wire effort through session → AgentLoop → providerConfig
- Fix pre-existing prettier parsing errors in session.ts (inline type imports incompatible with local prettier version)

Part of plan: effort-parameter.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
