### PR TITLE
fix: silence nudge test race condition (reduce post-answer wait)

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -2138,13 +2138,15 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
-  test('silence timeout suppressed during in-call guardian consultation (pendingGuardianInput)', async () => {
+  test("silence timeout suppressed during in-call guardian consultation (pendingGuardianInput)", async () => {
     mockSilenceTimeoutMs = 50; // Short timeout for testing
     mockConsultationTimeoutMs = 10_000; // Long enough to not interfere
 
     // LLM emits an ASK_GUARDIAN marker so the controller creates a pendingGuardianInput
     mockStartVoiceTurn.mockImplementation(
-      createMockVoiceTurn(["Let me check with your guardian. [ASK_GUARDIAN: Can this caller access the account?]"]),
+      createMockVoiceTurn([
+        "Let me check with your guardian. [ASK_GUARDIAN: Can this caller access the account?]",
+      ]),
     );
     const { relay, controller } = setupController();
 
@@ -2174,7 +2176,7 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
-  test('silence nudge resumes after guardian consultation resolves', async () => {
+  test("silence nudge resumes after guardian consultation resolves", async () => {
     mockSilenceTimeoutMs = 50; // Short timeout for testing
     mockConsultationTimeoutMs = 10_000; // Long enough to not interfere
 
@@ -2197,8 +2199,10 @@ describe("call-controller", () => {
       createMockVoiceTurn(["Great news, your guardian approved the request."]),
     );
     await controller.handleUserAnswer("Yes, approved");
-    // Allow the answer-driven turn to complete
-    await new Promise((r) => setTimeout(r, 100));
+    // Allow the fire-and-forget answer turn to complete (mock is sync,
+    // only needs microtask ticks). Must be shorter than the silence
+    // timeout (50ms) so the nudge timer hasn't fired when we clear tokens.
+    await new Promise((r) => setTimeout(r, 20));
 
     // Guardian input request should now be cleared
     expect(controller.getPendingConsultationQuestionId()).toBeNull();


### PR DESCRIPTION
## Summary
- The `silence nudge resumes after guardian consultation resolves` test had a timer race: it waited 100ms for the answer turn but the silence timeout was 50ms, so the nudge fired and was cleared before assertion
- Reduced the post-answer wait from 100ms to 20ms (mock voice turn is synchronous, only needs microtask ticks)

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22641744762/job/65619323579

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
