### PR TITLE
Add runtime migration-validate endpoint

### DIFF
--- a/assistant/src/__tests__/migration-validate-http.test.ts
+++ b/assistant/src/__tests__/migration-validate-http.test.ts
@@ -1,0 +1,698 @@
+/**
+ * HTTP-layer integration tests for POST /v1/migrations/validate.
+ *
+ * Tests cover:
+ * - Success: valid .vbundle archive returns is_valid: true with manifest
+ * - Validation failures: invalid gzip, missing entries, bad manifest, checksum mismatches
+ * - Request errors: empty body, invalid multipart
+ * - Auth: route policy enforcement (settings.write scope required)
+ * - Integration: existing routes are unaffected by the new endpoint
+ */
+import { createHash } from "node:crypto";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gzipSync } from "node:zlib";
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+/** Convert a Uint8Array to an ArrayBuffer for BodyInit compatibility. */
+function toArrayBuffer(data: Uint8Array): ArrayBuffer {
+  // Slice to get an owned ArrayBuffer (not a view into a SharedArrayBuffer)
+  return data.buffer.slice(
+    data.byteOffset,
+    data.byteOffset + data.byteLength,
+  ) as ArrayBuffer;
+}
+
+const testDir = realpathSync(
+  mkdtempSync(join(tmpdir(), "migration-validate-http-test-")),
+);
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getSocketPath: () => join(testDir, "test.sock"),
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    secretDetection: { enabled: false },
+    sandbox: { enabled: false },
+  }),
+}));
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  hasUngatedHttpAuthDisabled: () => false,
+  getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
+  getGatewayPort: () => 7830,
+  getRuntimeHttpPort: () => 7821,
+  getRuntimeHttpHost: () => "127.0.0.1",
+  getRuntimeProxyBearerToken: () => undefined,
+  getRuntimeGatewayOriginSecret: () => undefined,
+  getIngressPublicBaseUrl: () => undefined,
+  setIngressPublicBaseUrl: () => {},
+}));
+
+import { validateVBundle } from "../runtime/migrations/vbundle-validator.js";
+import { handleMigrationValidate } from "../runtime/routes/migration-routes.js";
+
+afterAll(() => {
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tar archive builder helpers
+// ---------------------------------------------------------------------------
+
+const BLOCK_SIZE = 512;
+
+function padToBlock(data: Uint8Array): Uint8Array {
+  const remainder = data.length % BLOCK_SIZE;
+  if (remainder === 0) return data;
+  const padded = new Uint8Array(data.length + (BLOCK_SIZE - remainder));
+  padded.set(data);
+  return padded;
+}
+
+function writeOctal(
+  buf: Uint8Array,
+  offset: number,
+  length: number,
+  value: number,
+): void {
+  const str = value.toString(8).padStart(length - 1, "0");
+  for (let i = 0; i < str.length; i++) {
+    buf[offset + i] = str.charCodeAt(i);
+  }
+  buf[offset + length - 1] = 0;
+}
+
+function computeHeaderChecksum(header: Uint8Array): number {
+  // Per tar spec, checksum uses spaces (0x20) in the checksum field
+  let sum = 0;
+  for (let i = 0; i < 512; i++) {
+    if (i >= 148 && i < 156) {
+      sum += 0x20; // space
+    } else {
+      sum += header[i];
+    }
+  }
+  return sum;
+}
+
+function createTarEntry(name: string, data: Uint8Array): Uint8Array {
+  const header = new Uint8Array(BLOCK_SIZE);
+  const encoder = new TextEncoder();
+
+  // File name (0-99)
+  const nameBytes = encoder.encode(name);
+  header.set(nameBytes.subarray(0, 100), 0);
+
+  // File mode (100-107): 0644
+  writeOctal(header, 100, 8, 0o644);
+
+  // Owner ID (108-115)
+  writeOctal(header, 108, 8, 0);
+
+  // Group ID (116-123)
+  writeOctal(header, 116, 8, 0);
+
+  // File size (124-135)
+  writeOctal(header, 124, 12, data.length);
+
+  // Modification time (136-147)
+  writeOctal(header, 136, 12, Math.floor(Date.now() / 1000));
+
+  // Type flag (156): regular file
+  header[156] = "0".charCodeAt(0);
+
+  // USTAR magic (257-262)
+  const magic = encoder.encode("ustar\0");
+  header.set(magic, 257);
+
+  // USTAR version (263-264)
+  header[263] = "0".charCodeAt(0);
+  header[264] = "0".charCodeAt(0);
+
+  // Compute and write checksum (148-155)
+  const checksum = computeHeaderChecksum(header);
+  writeOctal(header, 148, 7, checksum);
+  header[155] = 0x20; // trailing space
+
+  // Combine header + data (padded to block boundary) + end-of-archive
+  const paddedData = padToBlock(data);
+  const result = new Uint8Array(header.length + paddedData.length);
+  result.set(header, 0);
+  result.set(paddedData, header.length);
+  return result;
+}
+
+function createTarArchive(
+  entries: Array<{ name: string; data: Uint8Array }>,
+): Uint8Array {
+  const parts: Uint8Array[] = [];
+  for (const entry of entries) {
+    parts.push(createTarEntry(entry.name, entry.data));
+  }
+  // End-of-archive: two zero blocks
+  parts.push(new Uint8Array(BLOCK_SIZE * 2));
+
+  const totalLength = parts.reduce((sum, p) => sum + p.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.length;
+  }
+  return result;
+}
+
+function sha256Hex(data: Uint8Array | string): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+function canonicalizeJson(obj: unknown): string {
+  return JSON.stringify(obj, (_key, value) => {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      const sorted: Record<string, unknown> = {};
+      for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+        sorted[k] = (value as Record<string, unknown>)[k];
+      }
+      return sorted;
+    }
+    return value;
+  });
+}
+
+interface VBundleFile {
+  path: string;
+  data: Uint8Array;
+}
+
+function createValidVBundle(
+  files?: VBundleFile[],
+  overrides?: Partial<{
+    schema_version: string;
+    source: string;
+    description: string;
+  }>,
+): Uint8Array {
+  const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]); // "SQLite"
+  const bundleFiles = files ?? [{ path: "data/db/assistant.db", data: dbData }];
+
+  const fileEntries = bundleFiles.map((f) => ({
+    path: f.path,
+    sha256: sha256Hex(f.data),
+    size: f.data.length,
+  }));
+
+  const manifestWithoutChecksum = {
+    schema_version: overrides?.schema_version ?? "1.0",
+    created_at: new Date().toISOString(),
+    source: overrides?.source ?? "test",
+    description: overrides?.description ?? "Test bundle",
+    files: fileEntries,
+  };
+
+  const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
+  const manifest = {
+    ...manifestWithoutChecksum,
+    manifest_sha256: manifestSha256,
+  };
+  const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
+
+  const tarEntries = [
+    { name: "manifest.json", data: manifestData },
+    ...bundleFiles.map((f) => ({ name: f.path, data: f.data })),
+  ];
+
+  const tar = createTarArchive(tarEntries);
+  return gzipSync(tar);
+}
+
+// ---------------------------------------------------------------------------
+// Validator unit tests
+// ---------------------------------------------------------------------------
+
+describe("validateVBundle", () => {
+  test("valid bundle returns is_valid: true with manifest", () => {
+    const vbundle = createValidVBundle();
+    const result = validateVBundle(vbundle);
+
+    expect(result.is_valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.manifest).toBeDefined();
+    expect(result.manifest?.schema_version).toBe("1.0");
+    expect(result.manifest?.files).toHaveLength(1);
+    expect(result.manifest?.files[0].path).toBe("data/db/assistant.db");
+  });
+
+  test("valid bundle with multiple files", () => {
+    const configData = new TextEncoder().encode('{"key": "value"}');
+    const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
+    const files: VBundleFile[] = [
+      { path: "data/db/assistant.db", data: dbData },
+      { path: "config/settings.json", data: configData },
+    ];
+    const vbundle = createValidVBundle(files);
+    const result = validateVBundle(vbundle);
+
+    expect(result.is_valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.manifest?.files).toHaveLength(2);
+  });
+
+  test("invalid gzip returns INVALID_GZIP error", () => {
+    const result = validateVBundle(new Uint8Array([0x00, 0x01, 0x02]));
+
+    expect(result.is_valid).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].code).toBe("INVALID_GZIP");
+  });
+
+  test("missing manifest.json returns MISSING_ENTRY error", () => {
+    const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
+    const tar = createTarArchive([
+      { name: "data/db/assistant.db", data: dbData },
+    ]);
+    const vbundle = gzipSync(tar);
+    const result = validateVBundle(vbundle);
+
+    expect(result.is_valid).toBe(false);
+    const manifestError = result.errors.find(
+      (e) => e.code === "MISSING_ENTRY" && e.path === "manifest.json",
+    );
+    expect(manifestError).toBeDefined();
+  });
+
+  test("missing data/db/assistant.db returns MISSING_ENTRY error", () => {
+    const manifestData = new TextEncoder().encode(
+      JSON.stringify({
+        schema_version: "1.0",
+        created_at: new Date().toISOString(),
+        files: [],
+        manifest_sha256: "placeholder",
+      }),
+    );
+    const tar = createTarArchive([
+      { name: "manifest.json", data: manifestData },
+    ]);
+    const vbundle = gzipSync(tar);
+    const result = validateVBundle(vbundle);
+
+    expect(result.is_valid).toBe(false);
+    const dbError = result.errors.find(
+      (e) => e.code === "MISSING_ENTRY" && e.path === "data/db/assistant.db",
+    );
+    expect(dbError).toBeDefined();
+  });
+
+  test("invalid manifest JSON returns INVALID_MANIFEST_JSON error", () => {
+    const badJson = new TextEncoder().encode("not valid json{{{");
+    const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
+    const tar = createTarArchive([
+      { name: "manifest.json", data: badJson },
+      { name: "data/db/assistant.db", data: dbData },
+    ]);
+    const vbundle = gzipSync(tar);
+    const result = validateVBundle(vbundle);
+
+    expect(result.is_valid).toBe(false);
+    expect(result.errors.some((e) => e.code === "INVALID_MANIFEST_JSON")).toBe(
+      true,
+    );
+  });
+
+  test("manifest with missing required fields returns MANIFEST_SCHEMA_ERROR", () => {
+    // Missing schema_version, created_at, files, manifest_sha256
+    const manifestData = new TextEncoder().encode(
+      JSON.stringify({ extra: "field" }),
+    );
+    const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
+    const tar = createTarArchive([
+      { name: "manifest.json", data: manifestData },
+      { name: "data/db/assistant.db", data: dbData },
+    ]);
+    const vbundle = gzipSync(tar);
+    const result = validateVBundle(vbundle);
+
+    expect(result.is_valid).toBe(false);
+    expect(result.errors.some((e) => e.code === "MANIFEST_SCHEMA_ERROR")).toBe(
+      true,
+    );
+  });
+
+  test("manifest checksum mismatch returns MANIFEST_CHECKSUM_MISMATCH", () => {
+    const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
+    const manifest = {
+      schema_version: "1.0",
+      created_at: new Date().toISOString(),
+      files: [
+        {
+          path: "data/db/assistant.db",
+          sha256: sha256Hex(dbData),
+          size: dbData.length,
+        },
+      ],
+      manifest_sha256:
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    };
+    const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
+    const tar = createTarArchive([
+      { name: "manifest.json", data: manifestData },
+      { name: "data/db/assistant.db", data: dbData },
+    ]);
+    const vbundle = gzipSync(tar);
+    const result = validateVBundle(vbundle);
+
+    expect(result.is_valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.code === "MANIFEST_CHECKSUM_MISMATCH"),
+    ).toBe(true);
+  });
+
+  test("file checksum mismatch returns FILE_CHECKSUM_MISMATCH", () => {
+    const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
+    const wrongChecksum =
+      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    const manifestWithoutChecksum = {
+      schema_version: "1.0",
+      created_at: new Date().toISOString(),
+      files: [
+        {
+          path: "data/db/assistant.db",
+          sha256: wrongChecksum,
+          size: dbData.length,
+        },
+      ],
+    };
+    const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
+    const manifest = {
+      ...manifestWithoutChecksum,
+      manifest_sha256: manifestSha256,
+    };
+    const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
+
+    const tar = createTarArchive([
+      { name: "manifest.json", data: manifestData },
+      { name: "data/db/assistant.db", data: dbData },
+    ]);
+    const vbundle = gzipSync(tar);
+    const result = validateVBundle(vbundle);
+
+    expect(result.is_valid).toBe(false);
+    expect(result.errors.some((e) => e.code === "FILE_CHECKSUM_MISMATCH")).toBe(
+      true,
+    );
+  });
+
+  test("file size mismatch returns FILE_SIZE_MISMATCH", () => {
+    const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
+
+    const manifestWithoutChecksum = {
+      schema_version: "1.0",
+      created_at: new Date().toISOString(),
+      files: [
+        { path: "data/db/assistant.db", sha256: sha256Hex(dbData), size: 999 },
+      ],
+    };
+    const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
+    const manifest = {
+      ...manifestWithoutChecksum,
+      manifest_sha256: manifestSha256,
+    };
+    const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
+
+    const tar = createTarArchive([
+      { name: "manifest.json", data: manifestData },
+      { name: "data/db/assistant.db", data: dbData },
+    ]);
+    const vbundle = gzipSync(tar);
+    const result = validateVBundle(vbundle);
+
+    expect(result.is_valid).toBe(false);
+    expect(result.errors.some((e) => e.code === "FILE_SIZE_MISMATCH")).toBe(
+      true,
+    );
+  });
+
+  test("missing declared file returns MISSING_DECLARED_FILE", () => {
+    const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
+    const missingFileHash = sha256Hex(new TextEncoder().encode("missing"));
+
+    const manifestWithoutChecksum = {
+      schema_version: "1.0",
+      created_at: new Date().toISOString(),
+      files: [
+        {
+          path: "data/db/assistant.db",
+          sha256: sha256Hex(dbData),
+          size: dbData.length,
+        },
+        { path: "config/missing.json", sha256: missingFileHash, size: 7 },
+      ],
+    };
+    const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
+    const manifest = {
+      ...manifestWithoutChecksum,
+      manifest_sha256: manifestSha256,
+    };
+    const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
+
+    const tar = createTarArchive([
+      { name: "manifest.json", data: manifestData },
+      { name: "data/db/assistant.db", data: dbData },
+    ]);
+    const vbundle = gzipSync(tar);
+    const result = validateVBundle(vbundle);
+
+    expect(result.is_valid).toBe(false);
+    expect(
+      result.errors.some(
+        (e) =>
+          e.code === "MISSING_DECLARED_FILE" &&
+          e.path === "config/missing.json",
+      ),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP route handler tests
+// ---------------------------------------------------------------------------
+
+describe("handleMigrationValidate", () => {
+  test("POST with valid vbundle returns 200 with is_valid: true", async () => {
+    const vbundle = createValidVBundle();
+    const req = new Request("http://localhost/v1/migrations/validate", {
+      method: "POST",
+      headers: { "Content-Type": "application/octet-stream" },
+      body: toArrayBuffer(vbundle),
+    });
+
+    const res = await handleMigrationValidate(req);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.is_valid).toBe(true);
+    expect(body.errors).toEqual([]);
+    expect(body.manifest).toBeDefined();
+  });
+
+  test("POST with invalid gzip returns 200 with is_valid: false", async () => {
+    const req = new Request("http://localhost/v1/migrations/validate", {
+      method: "POST",
+      headers: { "Content-Type": "application/octet-stream" },
+      body: toArrayBuffer(new Uint8Array([0xde, 0xad, 0xbe, 0xef])),
+    });
+
+    const res = await handleMigrationValidate(req);
+    const body = (await res.json()) as {
+      is_valid: boolean;
+      errors: Array<{ code: string }>;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.is_valid).toBe(false);
+    expect(body.errors.length).toBeGreaterThan(0);
+    expect(body.errors[0].code).toBe("INVALID_GZIP");
+  });
+
+  test("POST with empty body returns 400", async () => {
+    const req = new Request("http://localhost/v1/migrations/validate", {
+      method: "POST",
+      headers: { "Content-Type": "application/octet-stream" },
+      body: toArrayBuffer(new Uint8Array(0)),
+    });
+
+    const res = await handleMigrationValidate(req);
+    const body = (await res.json()) as {
+      error: { code: string; message: string };
+    };
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  test("POST with multipart form data containing valid vbundle", async () => {
+    const vbundle = createValidVBundle();
+    const formData = new FormData();
+    formData.append("file", new Blob([toArrayBuffer(vbundle)]), "test.vbundle");
+
+    const req = new Request("http://localhost/v1/migrations/validate", {
+      method: "POST",
+      body: formData,
+    });
+
+    const res = await handleMigrationValidate(req);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.is_valid).toBe(true);
+  });
+
+  test("POST multipart without file field returns 400", async () => {
+    const formData = new FormData();
+    formData.append("notfile", "some text");
+
+    const req = new Request("http://localhost/v1/migrations/validate", {
+      method: "POST",
+      body: formData,
+    });
+
+    const res = await handleMigrationValidate(req);
+    const body = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  test("POST with missing manifest returns validation errors", async () => {
+    const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
+    const tar = createTarArchive([
+      { name: "data/db/assistant.db", data: dbData },
+    ]);
+    const vbundle = gzipSync(tar);
+
+    const req = new Request("http://localhost/v1/migrations/validate", {
+      method: "POST",
+      headers: { "Content-Type": "application/octet-stream" },
+      body: toArrayBuffer(vbundle),
+    });
+
+    const res = await handleMigrationValidate(req);
+    const body = (await res.json()) as {
+      is_valid: boolean;
+      errors: Array<{ code: string; path?: string }>;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.is_valid).toBe(false);
+    expect(
+      body.errors.some(
+        (e) => e.code === "MISSING_ENTRY" && e.path === "manifest.json",
+      ),
+    ).toBe(true);
+  });
+
+  test("POST with checksum mismatch returns validation errors", async () => {
+    const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
+    const manifest = {
+      schema_version: "1.0",
+      created_at: new Date().toISOString(),
+      files: [
+        {
+          path: "data/db/assistant.db",
+          sha256: sha256Hex(dbData),
+          size: dbData.length,
+        },
+      ],
+      manifest_sha256:
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    };
+    const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
+    const tar = createTarArchive([
+      { name: "manifest.json", data: manifestData },
+      { name: "data/db/assistant.db", data: dbData },
+    ]);
+    const vbundle = gzipSync(tar);
+
+    const req = new Request("http://localhost/v1/migrations/validate", {
+      method: "POST",
+      headers: { "Content-Type": "application/octet-stream" },
+      body: toArrayBuffer(vbundle),
+    });
+
+    const res = await handleMigrationValidate(req);
+    const body = (await res.json()) as {
+      is_valid: boolean;
+      errors: Array<{ code: string }>;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.is_valid).toBe(false);
+    expect(
+      body.errors.some((e) => e.code === "MANIFEST_CHECKSUM_MISMATCH"),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth policy registration test
+// ---------------------------------------------------------------------------
+
+describe("route policy registration", () => {
+  test("migrations/validate policy requires settings.write scope", async () => {
+    // Import route-policy to verify the registration exists
+    const { getPolicy } = await import("../runtime/auth/route-policy.js");
+    const policy = getPolicy("migrations/validate");
+
+    expect(policy).toBeDefined();
+    expect(policy?.requiredScopes).toContain("settings.write");
+    expect(policy?.allowedPrincipalTypes).toContain("actor");
+    expect(policy?.allowedPrincipalTypes).toContain("svc_gateway");
+    expect(policy?.allowedPrincipalTypes).toContain("ipc");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: existing routes unaffected
+// ---------------------------------------------------------------------------
+
+describe("integration: existing routes unaffected", () => {
+  test("GET /v1/health still works (not intercepted by migration routes)", async () => {
+    const { handleHealth } =
+      await import("../runtime/routes/identity-routes.js");
+    const res = handleHealth();
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("healthy");
+  });
+});

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -9,11 +9,11 @@
  * type safety but always allow the request through.
  */
 
-import { isHttpAuthDisabled } from '../../config/env.js';
-import { getLogger } from '../../util/logger.js';
-import type { AuthContext, PrincipalType, Scope } from './types.js';
+import { isHttpAuthDisabled } from "../../config/env.js";
+import { getLogger } from "../../util/logger.js";
+import type { AuthContext, PrincipalType, Scope } from "./types.js";
 
-const log = getLogger('route-policy');
+const log = getLogger("route-policy");
 
 // ---------------------------------------------------------------------------
 // Policy definition
@@ -77,11 +77,20 @@ export function enforcePolicy(
   // Check principal type
   if (!policy.allowedPrincipalTypes.includes(authCtx.principalType)) {
     log.warn(
-      { endpoint, principalType: authCtx.principalType, allowed: policy.allowedPrincipalTypes },
-      'Route policy denied: principal type not allowed',
+      {
+        endpoint,
+        principalType: authCtx.principalType,
+        allowed: policy.allowedPrincipalTypes,
+      },
+      "Route policy denied: principal type not allowed",
     );
     return Response.json(
-      { error: { code: 'FORBIDDEN', message: 'Principal type not permitted for this endpoint' } },
+      {
+        error: {
+          code: "FORBIDDEN",
+          message: "Principal type not permitted for this endpoint",
+        },
+      },
       { status: 403 },
     );
   }
@@ -91,10 +100,15 @@ export function enforcePolicy(
     if (!authCtx.scopes.has(scope)) {
       log.warn(
         { endpoint, missingScope: scope, principalType: authCtx.principalType },
-        'Route policy denied: missing required scope',
+        "Route policy denied: missing required scope",
       );
       return Response.json(
-        { error: { code: 'FORBIDDEN', message: `Missing required scope: ${scope}` } },
+        {
+          error: {
+            code: "FORBIDDEN",
+            message: `Missing required scope: ${scope}`,
+          },
+        },
         { status: 403 },
       );
     }
@@ -110,152 +124,197 @@ export function enforcePolicy(
 // Standard actor endpoints — chat, approvals, settings, etc.
 const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   // Conversation / messaging
-  { endpoint: 'messages:GET', scopes: ['chat.read'] },
-  { endpoint: 'messages:POST', scopes: ['chat.write'] },
-  { endpoint: 'conversations', scopes: ['chat.read'] },
-  { endpoint: 'conversations/attention', scopes: ['chat.read'] },
-  { endpoint: 'conversations/seen', scopes: ['chat.write'] },
-  { endpoint: 'search', scopes: ['chat.read'] },
-  { endpoint: 'suggestion', scopes: ['chat.read'] },
+  { endpoint: "messages:GET", scopes: ["chat.read"] },
+  { endpoint: "messages:POST", scopes: ["chat.write"] },
+  { endpoint: "conversations", scopes: ["chat.read"] },
+  { endpoint: "conversations/attention", scopes: ["chat.read"] },
+  { endpoint: "conversations/seen", scopes: ["chat.write"] },
+  { endpoint: "search", scopes: ["chat.read"] },
+  { endpoint: "suggestion", scopes: ["chat.read"] },
 
   // Approvals
-  { endpoint: 'confirm', scopes: ['approval.write'] },
-  { endpoint: 'secret', scopes: ['approval.write'] },
-  { endpoint: 'trust-rules', scopes: ['approval.write'] },
-  { endpoint: 'pending-interactions', scopes: ['approval.read'] },
+  { endpoint: "confirm", scopes: ["approval.write"] },
+  { endpoint: "secret", scopes: ["approval.write"] },
+  { endpoint: "trust-rules", scopes: ["approval.write"] },
+  { endpoint: "pending-interactions", scopes: ["approval.read"] },
 
   // Guardian actions
-  { endpoint: 'guardian-actions/pending', scopes: ['approval.read'] },
-  { endpoint: 'guardian-actions/decision', scopes: ['approval.write'] },
+  { endpoint: "guardian-actions/pending", scopes: ["approval.read"] },
+  { endpoint: "guardian-actions/decision", scopes: ["approval.write"] },
 
   // Events (SSE)
-  { endpoint: 'events', scopes: ['chat.read'] },
+  { endpoint: "events", scopes: ["chat.read"] },
 
   // Attachments
-  { endpoint: 'attachments:POST', scopes: ['attachments.write'] },
-  { endpoint: 'attachments:DELETE', scopes: ['attachments.write'] },
-  { endpoint: 'attachments:GET', scopes: ['attachments.read'] },
-  { endpoint: 'attachments/content:GET', scopes: ['attachments.read'] },
+  { endpoint: "attachments:POST", scopes: ["attachments.write"] },
+  { endpoint: "attachments:DELETE", scopes: ["attachments.write"] },
+  { endpoint: "attachments:GET", scopes: ["attachments.read"] },
+  { endpoint: "attachments/content:GET", scopes: ["attachments.read"] },
 
   // Calls
-  { endpoint: 'calls/start', scopes: ['calls.write'] },
-  { endpoint: 'calls:GET', scopes: ['calls.read'] },
-  { endpoint: 'calls/cancel', scopes: ['calls.write'] },
-  { endpoint: 'calls/answer', scopes: ['calls.write'] },
-  { endpoint: 'calls/instruction', scopes: ['calls.write'] },
+  { endpoint: "calls/start", scopes: ["calls.write"] },
+  { endpoint: "calls:GET", scopes: ["calls.read"] },
+  { endpoint: "calls/cancel", scopes: ["calls.write"] },
+  { endpoint: "calls/answer", scopes: ["calls.write"] },
+  { endpoint: "calls/instruction", scopes: ["calls.write"] },
 
   // Settings / integrations / identity
-  { endpoint: 'identity', scopes: ['settings.read'] },
-  { endpoint: 'brain-graph', scopes: ['settings.read'] },
-  { endpoint: 'brain-graph-ui', scopes: ['settings.read'] },
-  { endpoint: 'home-base-ui', scopes: ['settings.read'] },
-  { endpoint: 'contacts', scopes: ['settings.read'] },
-  { endpoint: 'contacts/merge', scopes: ['settings.write'] },
-  { endpoint: 'contacts:GET', scopes: ['settings.read'] },
-  { endpoint: 'ingress/members', scopes: ['settings.read'] },
-  { endpoint: 'ingress/members:POST', scopes: ['settings.write'] },
-  { endpoint: 'ingress/members/block', scopes: ['settings.write'] },
-  { endpoint: 'ingress/members:DELETE', scopes: ['settings.write'] },
-  { endpoint: 'ingress/invites', scopes: ['settings.read'] },
-  { endpoint: 'ingress/invites:POST', scopes: ['settings.write'] },
-  { endpoint: 'ingress/invites/redeem', scopes: ['settings.write'] },
-  { endpoint: 'ingress/invites:DELETE', scopes: ['settings.write'] },
-  { endpoint: 'integrations/telegram/config', scopes: ['settings.read'] },
-  { endpoint: 'integrations/telegram/config:POST', scopes: ['settings.write'] },
-  { endpoint: 'integrations/telegram/config:DELETE', scopes: ['settings.write'] },
-  { endpoint: 'integrations/telegram/commands', scopes: ['settings.write'] },
-  { endpoint: 'integrations/telegram/setup', scopes: ['settings.write'] },
-  { endpoint: 'integrations/slack/channel/config', scopes: ['settings.read'] },
-  { endpoint: 'integrations/slack/channel/config:POST', scopes: ['settings.write'] },
-  { endpoint: 'integrations/slack/channel/config:DELETE', scopes: ['settings.write'] },
-  { endpoint: 'integrations/guardian/challenge', scopes: ['settings.write'] },
-  { endpoint: 'integrations/guardian/status', scopes: ['settings.read'] },
-  { endpoint: 'integrations/guardian/outbound/start', scopes: ['settings.write'] },
-  { endpoint: 'integrations/guardian/outbound/resend', scopes: ['settings.write'] },
-  { endpoint: 'integrations/guardian/outbound/cancel', scopes: ['settings.write'] },
-  { endpoint: 'integrations/twilio/config', scopes: ['settings.read'] },
-  { endpoint: 'integrations/twilio/credentials:POST', scopes: ['settings.write'] },
-  { endpoint: 'integrations/twilio/credentials:DELETE', scopes: ['settings.write'] },
-  { endpoint: 'integrations/twilio/numbers', scopes: ['settings.read'] },
-  { endpoint: 'integrations/twilio/numbers/provision', scopes: ['settings.write'] },
-  { endpoint: 'integrations/twilio/numbers/assign', scopes: ['settings.write'] },
-  { endpoint: 'integrations/twilio/numbers/release', scopes: ['settings.write'] },
-  { endpoint: 'integrations/twilio/sms/compliance', scopes: ['settings.read'] },
-  { endpoint: 'integrations/twilio/sms/compliance/tollfree', scopes: ['settings.write'] },
-  { endpoint: 'integrations/twilio/sms/compliance/tollfree:PATCH', scopes: ['settings.write'] },
-  { endpoint: 'integrations/twilio/sms/compliance/tollfree:DELETE', scopes: ['settings.write'] },
-  { endpoint: 'integrations/twilio/sms/test', scopes: ['settings.write'] },
-  { endpoint: 'integrations/twilio/sms/doctor', scopes: ['settings.write'] },
+  { endpoint: "identity", scopes: ["settings.read"] },
+  { endpoint: "brain-graph", scopes: ["settings.read"] },
+  { endpoint: "brain-graph-ui", scopes: ["settings.read"] },
+  { endpoint: "home-base-ui", scopes: ["settings.read"] },
+  { endpoint: "contacts", scopes: ["settings.read"] },
+  { endpoint: "contacts/merge", scopes: ["settings.write"] },
+  { endpoint: "contacts:GET", scopes: ["settings.read"] },
+  { endpoint: "ingress/members", scopes: ["settings.read"] },
+  { endpoint: "ingress/members:POST", scopes: ["settings.write"] },
+  { endpoint: "ingress/members/block", scopes: ["settings.write"] },
+  { endpoint: "ingress/members:DELETE", scopes: ["settings.write"] },
+  { endpoint: "ingress/invites", scopes: ["settings.read"] },
+  { endpoint: "ingress/invites:POST", scopes: ["settings.write"] },
+  { endpoint: "ingress/invites/redeem", scopes: ["settings.write"] },
+  { endpoint: "ingress/invites:DELETE", scopes: ["settings.write"] },
+  { endpoint: "integrations/telegram/config", scopes: ["settings.read"] },
+  { endpoint: "integrations/telegram/config:POST", scopes: ["settings.write"] },
+  {
+    endpoint: "integrations/telegram/config:DELETE",
+    scopes: ["settings.write"],
+  },
+  { endpoint: "integrations/telegram/commands", scopes: ["settings.write"] },
+  { endpoint: "integrations/telegram/setup", scopes: ["settings.write"] },
+  { endpoint: "integrations/slack/channel/config", scopes: ["settings.read"] },
+  {
+    endpoint: "integrations/slack/channel/config:POST",
+    scopes: ["settings.write"],
+  },
+  {
+    endpoint: "integrations/slack/channel/config:DELETE",
+    scopes: ["settings.write"],
+  },
+  { endpoint: "integrations/guardian/challenge", scopes: ["settings.write"] },
+  { endpoint: "integrations/guardian/status", scopes: ["settings.read"] },
+  {
+    endpoint: "integrations/guardian/outbound/start",
+    scopes: ["settings.write"],
+  },
+  {
+    endpoint: "integrations/guardian/outbound/resend",
+    scopes: ["settings.write"],
+  },
+  {
+    endpoint: "integrations/guardian/outbound/cancel",
+    scopes: ["settings.write"],
+  },
+  { endpoint: "integrations/twilio/config", scopes: ["settings.read"] },
+  {
+    endpoint: "integrations/twilio/credentials:POST",
+    scopes: ["settings.write"],
+  },
+  {
+    endpoint: "integrations/twilio/credentials:DELETE",
+    scopes: ["settings.write"],
+  },
+  { endpoint: "integrations/twilio/numbers", scopes: ["settings.read"] },
+  {
+    endpoint: "integrations/twilio/numbers/provision",
+    scopes: ["settings.write"],
+  },
+  {
+    endpoint: "integrations/twilio/numbers/assign",
+    scopes: ["settings.write"],
+  },
+  {
+    endpoint: "integrations/twilio/numbers/release",
+    scopes: ["settings.write"],
+  },
+  { endpoint: "integrations/twilio/sms/compliance", scopes: ["settings.read"] },
+  {
+    endpoint: "integrations/twilio/sms/compliance/tollfree",
+    scopes: ["settings.write"],
+  },
+  {
+    endpoint: "integrations/twilio/sms/compliance/tollfree:PATCH",
+    scopes: ["settings.write"],
+  },
+  {
+    endpoint: "integrations/twilio/sms/compliance/tollfree:DELETE",
+    scopes: ["settings.write"],
+  },
+  { endpoint: "integrations/twilio/sms/test", scopes: ["settings.write"] },
+  { endpoint: "integrations/twilio/sms/doctor", scopes: ["settings.write"] },
 
   // Channel readiness
-  { endpoint: 'channels/readiness', scopes: ['settings.read'] },
-  { endpoint: 'channels/readiness/refresh', scopes: ['settings.write'] },
+  { endpoint: "channels/readiness", scopes: ["settings.read"] },
+  { endpoint: "channels/readiness/refresh", scopes: ["settings.write"] },
 
   // Dead letters
-  { endpoint: 'channels/dead-letters', scopes: ['settings.read'] },
-  { endpoint: 'channels/replay', scopes: ['settings.write'] },
+  { endpoint: "channels/dead-letters", scopes: ["settings.read"] },
+  { endpoint: "channels/replay", scopes: ["settings.write"] },
 
   // Secrets
-  { endpoint: 'secrets', scopes: ['settings.write'] },
+  { endpoint: "secrets", scopes: ["settings.write"] },
 
   // Pairing (authenticated)
-  { endpoint: 'pairing/register', scopes: ['settings.write'] },
+  { endpoint: "pairing/register", scopes: ["settings.write"] },
 
   // Apps
-  { endpoint: 'apps/share', scopes: ['settings.write'] },
-  { endpoint: 'apps/shared:GET', scopes: ['settings.read'] },
-  { endpoint: 'apps/shared:DELETE', scopes: ['settings.write'] },
-  { endpoint: 'apps/shared/metadata', scopes: ['settings.read'] },
+  { endpoint: "apps/share", scopes: ["settings.write"] },
+  { endpoint: "apps/shared:GET", scopes: ["settings.read"] },
+  { endpoint: "apps/shared:DELETE", scopes: ["settings.write"] },
+  { endpoint: "apps/shared/metadata", scopes: ["settings.read"] },
 
   // Debug
-  { endpoint: 'debug', scopes: ['settings.read'] },
+  { endpoint: "debug", scopes: ["settings.read"] },
 
   // Browser relay
-  { endpoint: 'browser-relay/status', scopes: ['settings.read'] },
-  { endpoint: 'browser-relay/command', scopes: ['settings.write'] },
+  { endpoint: "browser-relay/status", scopes: ["settings.read"] },
+  { endpoint: "browser-relay/command", scopes: ["settings.write"] },
 
   // Interfaces
-  { endpoint: 'interfaces', scopes: ['settings.read'] },
+  { endpoint: "interfaces", scopes: ["settings.read"] },
 
   // Trust rule CRUD management
-  { endpoint: 'trust-rules/manage:GET', scopes: ['settings.read'] },
-  { endpoint: 'trust-rules/manage:POST', scopes: ['settings.write'] },
-  { endpoint: 'trust-rules/manage:DELETE', scopes: ['settings.write'] },
-  { endpoint: 'trust-rules/manage:PATCH', scopes: ['settings.write'] },
+  { endpoint: "trust-rules/manage:GET", scopes: ["settings.read"] },
+  { endpoint: "trust-rules/manage:POST", scopes: ["settings.write"] },
+  { endpoint: "trust-rules/manage:DELETE", scopes: ["settings.write"] },
+  { endpoint: "trust-rules/manage:PATCH", scopes: ["settings.write"] },
 
   // Surface actions
-  { endpoint: 'surface-actions', scopes: ['chat.write'] },
+  { endpoint: "surface-actions", scopes: ["chat.write"] },
 
   // Conversation deletion (channel-facing)
-  { endpoint: 'channels/conversation:DELETE', scopes: ['chat.write'] },
+  { endpoint: "channels/conversation:DELETE", scopes: ["chat.write"] },
 
   // Delivery ack
-  { endpoint: 'channels/delivery-ack', scopes: ['internal.write'] },
+  { endpoint: "channels/delivery-ack", scopes: ["internal.write"] },
+
+  // Migrations
+  { endpoint: "migrations/validate", scopes: ["settings.write"] },
 ];
 
 for (const { endpoint, scopes } of ACTOR_ENDPOINTS) {
   registerPolicy(endpoint, {
     requiredScopes: scopes,
-    allowedPrincipalTypes: ['actor', 'svc_gateway', 'ipc'],
+    allowedPrincipalTypes: ["actor", "svc_gateway", "ipc"],
   });
 }
 
 // Channel inbound: gateway-only
-registerPolicy('channels/inbound', {
-  requiredScopes: ['ingress.write'],
-  allowedPrincipalTypes: ['svc_gateway'],
+registerPolicy("channels/inbound", {
+  requiredScopes: ["ingress.write"],
+  allowedPrincipalTypes: ["svc_gateway"],
 });
 
 // Internal forwarding endpoints: gateway-only
 const INTERNAL_ENDPOINTS = [
-  'internal/twilio/voice-webhook',
-  'internal/twilio/status',
-  'internal/twilio/connect-action',
-  'internal/oauth/callback',
+  "internal/twilio/voice-webhook",
+  "internal/twilio/status",
+  "internal/twilio/connect-action",
+  "internal/oauth/callback",
 ];
 for (const endpoint of INTERNAL_ENDPOINTS) {
   registerPolicy(endpoint, {
-    requiredScopes: ['internal.write'],
-    allowedPrincipalTypes: ['svc_gateway'],
+    requiredScopes: ["internal.write"],
+    allowedPrincipalTypes: ["svc_gateway"],
   });
 }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -32,32 +32,44 @@ import {
   getGatewayInternalBaseUrl,
   hasUngatedHttpAuthDisabled,
   isHttpAuthDisabled,
-} from '../config/env.js';
-import type { ServerMessage } from '../daemon/ipc-contract.js';
-import { PairingStore } from '../daemon/pairing-store.js';
-import { type Confidence, getAttentionStateByConversationIds, recordConversationSeenSignal, type SignalType } from '../memory/conversation-attention-store.js';
-import * as conversationStore from '../memory/conversation-store.js';
-import * as externalConversationStore from '../memory/external-conversation-store.js';
-import { consumeCallback, consumeCallbackError } from '../security/oauth-callback-registry.js';
-import { getLogger } from '../util/logger.js';
-import { buildAssistantEvent } from './assistant-event.js';
-import { assistantEventHub } from './assistant-event-hub.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
+} from "../config/env.js";
+import type { ServerMessage } from "../daemon/ipc-contract.js";
+import { PairingStore } from "../daemon/pairing-store.js";
+import {
+  type Confidence,
+  getAttentionStateByConversationIds,
+  recordConversationSeenSignal,
+  type SignalType,
+} from "../memory/conversation-attention-store.js";
+import * as conversationStore from "../memory/conversation-store.js";
+import * as externalConversationStore from "../memory/external-conversation-store.js";
+import {
+  consumeCallback,
+  consumeCallbackError,
+} from "../security/oauth-callback-registry.js";
+import { getLogger } from "../util/logger.js";
+import { buildAssistantEvent } from "./assistant-event.js";
+import { assistantEventHub } from "./assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
 // Auth
-import { authenticateRequest } from './auth/middleware.js';
-import { enforcePolicy, getPolicy } from './auth/route-policy.js';
-import { mintDaemonDeliveryToken, mintUiPageToken, verifyToken } from './auth/token-service.js';
-import type { AuthContext } from './auth/types.js';
-import { sweepFailedEvents } from './channel-retry-sweep.js';
-import { httpError } from './http-errors.js';
+import { authenticateRequest } from "./auth/middleware.js";
+import { enforcePolicy, getPolicy } from "./auth/route-policy.js";
+import {
+  mintDaemonDeliveryToken,
+  mintUiPageToken,
+  verifyToken,
+} from "./auth/token-service.js";
+import type { AuthContext } from "./auth/types.js";
+import { sweepFailedEvents } from "./channel-retry-sweep.js";
+import { httpError } from "./http-errors.js";
 // Middleware
 import {
   extractBearerToken,
   isLoopbackHost,
   isPrivateNetworkOrigin,
   isPrivateNetworkPeer,
-} from './middleware/auth.js';
-import { withErrorHandling } from './middleware/error-handler.js';
+} from "./middleware/auth.js";
+import { withErrorHandling } from "./middleware/error-handler.js";
 import {
   apiRateLimiter,
   extractClientIp,
@@ -169,6 +181,7 @@ import {
   handleSetupTelegram,
   handleStartOutbound,
 } from "./routes/integration-routes.js";
+import { handleMigrationValidate } from "./routes/migration-routes.js";
 import type { PairingHandlerContext } from "./routes/pairing-routes.js";
 // Extracted route handlers
 import {
@@ -245,30 +258,40 @@ const MAX_REQUEST_BODY_BYTES = 50 * 1024 * 1024;
  * Order matters: more specific patterns must come before general ones so
  * that e.g. `attachments/{id}/content` matches before `attachments/{id}`.
  */
-const PARAMETERIZED_ROUTE_PATTERNS: Array<{ re: RegExp; policyBase: string }> = [
-  // calls/{id}/cancel, calls/{id}/answer, calls/{id}/instruction
-  { re: /^calls\/[^/]+\/(cancel|answer|instruction)$/, policyBase: 'calls/$1' },
-  // calls/{id} (GET status)
-  { re: /^calls\/[^/]+$/, policyBase: 'calls' },
-  // contacts/{id}
-  { re: /^contacts\/[^/]+$/, policyBase: 'contacts' },
-  // ingress/members/{id}/block
-  { re: /^ingress\/members\/[^/]+\/block$/, policyBase: 'ingress/members/block' },
-  // ingress/members/{id}
-  { re: /^ingress\/members\/[^/]+$/, policyBase: 'ingress/members' },
-  // ingress/invites/{id}
-  { re: /^ingress\/invites\/[^/]+$/, policyBase: 'ingress/invites' },
-  // integrations/twilio/sms/compliance/tollfree/{sid}
-  { re: /^integrations\/twilio\/sms\/compliance\/tollfree\/[^/]+$/, policyBase: 'integrations/twilio/sms/compliance/tollfree' },
-  // attachments/{id}/content
-  { re: /^attachments\/[^/]+\/content$/, policyBase: 'attachments/content' },
-  // attachments/{id}
-  { re: /^attachments\/[^/]+$/, policyBase: 'attachments' },
-  // trust-rules/manage/{id}
-  { re: /^trust-rules\/manage\/[^/]+$/, policyBase: 'trust-rules/manage' },
-  // interfaces/{path}
-  { re: /^interfaces\/.+$/, policyBase: 'interfaces' },
-];
+const PARAMETERIZED_ROUTE_PATTERNS: Array<{ re: RegExp; policyBase: string }> =
+  [
+    // calls/{id}/cancel, calls/{id}/answer, calls/{id}/instruction
+    {
+      re: /^calls\/[^/]+\/(cancel|answer|instruction)$/,
+      policyBase: "calls/$1",
+    },
+    // calls/{id} (GET status)
+    { re: /^calls\/[^/]+$/, policyBase: "calls" },
+    // contacts/{id}
+    { re: /^contacts\/[^/]+$/, policyBase: "contacts" },
+    // ingress/members/{id}/block
+    {
+      re: /^ingress\/members\/[^/]+\/block$/,
+      policyBase: "ingress/members/block",
+    },
+    // ingress/members/{id}
+    { re: /^ingress\/members\/[^/]+$/, policyBase: "ingress/members" },
+    // ingress/invites/{id}
+    { re: /^ingress\/invites\/[^/]+$/, policyBase: "ingress/invites" },
+    // integrations/twilio/sms/compliance/tollfree/{sid}
+    {
+      re: /^integrations\/twilio\/sms\/compliance\/tollfree\/[^/]+$/,
+      policyBase: "integrations/twilio/sms/compliance/tollfree",
+    },
+    // attachments/{id}/content
+    { re: /^attachments\/[^/]+\/content$/, policyBase: "attachments/content" },
+    // attachments/{id}
+    { re: /^attachments\/[^/]+$/, policyBase: "attachments" },
+    // trust-rules/manage/{id}
+    { re: /^trust-rules\/manage\/[^/]+$/, policyBase: "trust-rules/manage" },
+    // interfaces/{path}
+    { re: /^interfaces\/.+$/, policyBase: "interfaces" },
+  ];
 
 /**
  * Strip parameterized segments from an endpoint string so it matches
@@ -292,7 +315,10 @@ function normalizeEndpointForPolicy(endpoint: string, method: string): string {
     const match = endpoint.match(re);
     if (match) {
       // Support capture-group substitution (e.g. calls/$1 -> calls/cancel)
-      return policyBase.replace(/\$(\d+)/g, (_, idx) => match[Number(idx)] ?? '');
+      return policyBase.replace(
+        /\$(\d+)/g,
+        (_, idx) => match[Number(idx)] ?? "",
+      );
     }
   }
   return endpoint;
@@ -597,10 +623,16 @@ export class RuntimeHttpServer {
     // needs to work when the access token is expired. Bootstrap has its
     // own loopback IP validation; refresh is secured by the refresh token
     // in the request body (32 random bytes, hash-only storage).
-    if (path === '/v1/integrations/guardian/vellum/bootstrap' && req.method === 'POST') {
+    if (
+      path === "/v1/integrations/guardian/vellum/bootstrap" &&
+      req.method === "POST"
+    ) {
       return await handleGuardianBootstrap(req, server);
     }
-    if (path === '/v1/integrations/guardian/vellum/refresh' && req.method === 'POST') {
+    if (
+      path === "/v1/integrations/guardian/vellum/refresh" &&
+      req.method === "POST"
+    ) {
       return await handleGuardianRefresh(req);
     }
 
@@ -628,7 +660,13 @@ export class RuntimeHttpServer {
         return rateLimitResponse(result);
       }
       // Attach rate limit headers to the eventual response
-      const originalResponse = await this.handleAuthenticatedRequest(req, url, path, server, authContext);
+      const originalResponse = await this.handleAuthenticatedRequest(
+        req,
+        url,
+        path,
+        server,
+        authContext,
+      );
       const headers = new Headers(originalResponse.headers);
       for (const [k, v] of Object.entries(rateLimitHeaders(result))) {
         headers.set(k, v);
@@ -646,10 +684,16 @@ export class RuntimeHttpServer {
   /**
    * Handle requests that have already passed auth and rate limiting.
    */
-  private async handleAuthenticatedRequest(req: Request, url: URL, path: string, server: ReturnType<typeof Bun.serve>, authContext: AuthContext): Promise<Response> {
+  private async handleAuthenticatedRequest(
+    req: Request,
+    url: URL,
+    path: string,
+    server: ReturnType<typeof Bun.serve>,
+    authContext: AuthContext,
+  ): Promise<Response> {
     // Pairing registration (bearer-authenticated)
-    if (path === '/v1/pairing/register' && req.method === 'POST') {
-      const policyDenied = enforcePolicy('pairing/register', authContext);
+    if (path === "/v1/pairing/register" && req.method === "POST") {
+      const policyDenied = enforcePolicy("pairing/register", authContext);
       if (policyDenied) return policyDenied;
       return await handlePairingRegister(req, this.pairingContext);
     }
@@ -669,68 +713,97 @@ export class RuntimeHttpServer {
     }
 
     // Cloud sharing endpoints
-    if (path === '/v1/apps/share' && req.method === 'POST') {
-      const policyDenied = enforcePolicy('apps/share', authContext);
+    if (path === "/v1/apps/share" && req.method === "POST") {
+      const policyDenied = enforcePolicy("apps/share", authContext);
       if (policyDenied) return policyDenied;
-      try { return await handleShareApp(req); } catch (err) {
-        log.error({ err }, 'Runtime HTTP handler error sharing app');
-        return httpError('INTERNAL_ERROR', 'Internal server error', 500);
+      try {
+        return await handleShareApp(req);
+      } catch (err) {
+        log.error({ err }, "Runtime HTTP handler error sharing app");
+        return httpError("INTERNAL_ERROR", "Internal server error", 500);
       }
     }
 
     const sharedTokenMatch = path.match(/^\/v1\/apps\/shared\/([^/]+)$/);
     if (sharedTokenMatch) {
       const shareToken = sharedTokenMatch[1];
-      if (req.method === 'GET') {
-        const policyDenied = enforcePolicy('apps/shared:GET', authContext);
+      if (req.method === "GET") {
+        const policyDenied = enforcePolicy("apps/shared:GET", authContext);
         if (policyDenied) return policyDenied;
-        try { return handleDownloadSharedApp(shareToken); } catch (err) {
-          log.error({ err, shareToken }, 'Runtime HTTP handler error downloading shared app');
-          return httpError('INTERNAL_ERROR', 'Internal server error', 500);
+        try {
+          return handleDownloadSharedApp(shareToken);
+        } catch (err) {
+          log.error(
+            { err, shareToken },
+            "Runtime HTTP handler error downloading shared app",
+          );
+          return httpError("INTERNAL_ERROR", "Internal server error", 500);
         }
       }
-      if (req.method === 'DELETE') {
-        const policyDenied = enforcePolicy('apps/shared:DELETE', authContext);
+      if (req.method === "DELETE") {
+        const policyDenied = enforcePolicy("apps/shared:DELETE", authContext);
         if (policyDenied) return policyDenied;
-        try { return handleDeleteSharedApp(shareToken); } catch (err) {
-          log.error({ err, shareToken }, 'Runtime HTTP handler error deleting shared app');
-          return httpError('INTERNAL_ERROR', 'Internal server error', 500);
+        try {
+          return handleDeleteSharedApp(shareToken);
+        } catch (err) {
+          log.error(
+            { err, shareToken },
+            "Runtime HTTP handler error deleting shared app",
+          );
+          return httpError("INTERNAL_ERROR", "Internal server error", 500);
         }
       }
     }
 
-    const sharedMetadataMatch = path.match(/^\/v1\/apps\/shared\/([^/]+)\/metadata$/);
-    if (sharedMetadataMatch && req.method === 'GET') {
-      const policyDenied = enforcePolicy('apps/shared/metadata', authContext);
+    const sharedMetadataMatch = path.match(
+      /^\/v1\/apps\/shared\/([^/]+)\/metadata$/,
+    );
+    if (sharedMetadataMatch && req.method === "GET") {
+      const policyDenied = enforcePolicy("apps/shared/metadata", authContext);
       if (policyDenied) return policyDenied;
-      try { return handleGetSharedAppMetadata(sharedMetadataMatch[1]); } catch (err) {
-        log.error({ err, shareToken: sharedMetadataMatch[1] }, 'Runtime HTTP handler error getting shared app metadata');
-        return httpError('INTERNAL_ERROR', 'Internal server error', 500);
+      try {
+        return handleGetSharedAppMetadata(sharedMetadataMatch[1]);
+      } catch (err) {
+        log.error(
+          { err, shareToken: sharedMetadataMatch[1] },
+          "Runtime HTTP handler error getting shared app metadata",
+        );
+        return httpError("INTERNAL_ERROR", "Internal server error", 500);
       }
     }
 
     // Secret management endpoint
-    if (path === '/v1/secrets' && req.method === 'POST') {
-      const policyDenied = enforcePolicy('secrets', authContext);
+    if (path === "/v1/secrets" && req.method === "POST") {
+      const policyDenied = enforcePolicy("secrets", authContext);
       if (policyDenied) return policyDenied;
-      try { return await handleAddSecret(req); } catch (err) {
-        log.error({ err }, 'Runtime HTTP handler error adding secret');
-        return httpError('INTERNAL_ERROR', 'Internal server error', 500);
+      try {
+        return await handleAddSecret(req);
+      } catch (err) {
+        log.error({ err }, "Runtime HTTP handler error adding secret");
+        return httpError("INTERNAL_ERROR", "Internal server error", 500);
       }
     }
-    if (path === '/v1/secrets' && req.method === 'DELETE') {
-      const policyDenied = enforcePolicy('secrets', authContext);
+    if (path === "/v1/secrets" && req.method === "DELETE") {
+      const policyDenied = enforcePolicy("secrets", authContext);
       if (policyDenied) return policyDenied;
-      try { return await handleDeleteSecret(req); } catch (err) {
-        log.error({ err }, 'Runtime HTTP handler error deleting secret');
-        return httpError('INTERNAL_ERROR', 'Internal server error', 500);
+      try {
+        return await handleDeleteSecret(req);
+      } catch (err) {
+        log.error({ err }, "Runtime HTTP handler error deleting secret");
+        return httpError("INTERNAL_ERROR", "Internal server error", 500);
       }
     }
 
     // Runtime routes: /v1/<endpoint>
     const routeMatch = path.match(/^\/v1\/(.+)$/);
     if (routeMatch) {
-      return this.dispatchEndpoint(routeMatch[1], req, url, server, authContext);
+      return this.dispatchEndpoint(
+        routeMatch[1],
+        req,
+        url,
+        server,
+        authContext,
+      );
     }
 
     return httpError("NOT_FOUND", "Not found", 404);
@@ -753,13 +826,13 @@ export class RuntimeHttpServer {
 
     if (!isHttpAuthDisabled()) {
       const wsUrl = new URL(req.url);
-      const token = wsUrl.searchParams.get('token');
+      const token = wsUrl.searchParams.get("token");
       if (!token) {
-        return httpError('UNAUTHORIZED', 'Unauthorized', 401);
+        return httpError("UNAUTHORIZED", "Unauthorized", 401);
       }
-      const jwtResult = verifyToken(token, 'vellum-daemon');
+      const jwtResult = verifyToken(token, "vellum-daemon");
       if (!jwtResult.ok) {
-        return httpError('UNAUTHORIZED', 'Unauthorized', 401);
+        return httpError("UNAUTHORIZED", "Unauthorized", 401);
       }
     }
 
@@ -1010,20 +1083,28 @@ export class RuntimeHttpServer {
       if (endpoint === "search" && req.method === "GET")
         return handleSearchConversations(url);
 
-      if (endpoint === 'messages' && req.method === 'POST') {
-        return await handleSendMessage(req, {
-          processMessage: this.processMessage,
-          persistAndProcessMessage: this.persistAndProcessMessage,
-          sendMessageDeps: this.sendMessageDeps,
-          approvalConversationGenerator: this.approvalConversationGenerator,
-        }, authContext);
+      if (endpoint === "messages" && req.method === "POST") {
+        return await handleSendMessage(
+          req,
+          {
+            processMessage: this.processMessage,
+            persistAndProcessMessage: this.persistAndProcessMessage,
+            sendMessageDeps: this.sendMessageDeps,
+            approvalConversationGenerator: this.approvalConversationGenerator,
+          },
+          authContext,
+        );
       }
 
       // Standalone approval endpoints — keyed by requestId, orthogonal to message sending
-      if (endpoint === 'confirm' && req.method === 'POST') return await handleConfirm(req, authContext);
-      if (endpoint === 'secret' && req.method === 'POST') return await handleSecret(req, authContext);
-      if (endpoint === 'trust-rules' && req.method === 'POST') return await handleTrustRule(req, authContext);
-      if (endpoint === 'pending-interactions' && req.method === 'GET') return handleListPendingInteractions(url, authContext);
+      if (endpoint === "confirm" && req.method === "POST")
+        return await handleConfirm(req, authContext);
+      if (endpoint === "secret" && req.method === "POST")
+        return await handleSecret(req, authContext);
+      if (endpoint === "trust-rules" && req.method === "POST")
+        return await handleTrustRule(req, authContext);
+      if (endpoint === "pending-interactions" && req.method === "GET")
+        return handleListPendingInteractions(url, authContext);
 
       // Trust rule CRUD — standalone management (not approval-flow)
       if (endpoint === "trust-rules/manage" && req.method === "GET")
@@ -1051,8 +1132,10 @@ export class RuntimeHttpServer {
       }
 
       // Guardian action endpoints — deterministic button-based decisions
-      if (endpoint === 'guardian-actions/pending' && req.method === 'GET') return handleGuardianActionsPending(url, authContext);
-      if (endpoint === 'guardian-actions/decision' && req.method === 'POST') return await handleGuardianActionDecision(req, authContext);
+      if (endpoint === "guardian-actions/pending" && req.method === "GET")
+        return handleGuardianActionsPending(url, authContext);
+      if (endpoint === "guardian-actions/decision" && req.method === "POST")
+        return await handleGuardianActionDecision(req, authContext);
 
       // Contacts
       if (endpoint === "contacts" && req.method === "GET")
@@ -1245,9 +1328,17 @@ export class RuntimeHttpServer {
       if (endpoint === "channels/conversation" && req.method === "DELETE")
         return await handleDeleteConversation(req, assistantId);
 
-      if (endpoint === 'channels/inbound' && req.method === 'POST') {
+      if (endpoint === "channels/inbound" && req.method === "POST") {
         // Route policy enforces svc_gateway principal type.
-        return await handleChannelInbound(req, this.processMessage, assistantId, this.approvalCopyGenerator, this.approvalConversationGenerator, this.guardianActionCopyGenerator, this.guardianFollowUpConversationGenerator);
+        return await handleChannelInbound(
+          req,
+          this.processMessage,
+          assistantId,
+          this.approvalCopyGenerator,
+          this.approvalConversationGenerator,
+          this.guardianActionCopyGenerator,
+          this.guardianFollowUpConversationGenerator,
+        );
       }
 
       if (endpoint === "channels/delivery-ack" && req.method === "POST")
@@ -1283,8 +1374,14 @@ export class RuntimeHttpServer {
 
       // Internal Twilio forwarding endpoints (gateway -> runtime).
       // Route policy enforces svc_gateway principal type.
-      if (endpoint === 'internal/twilio/voice-webhook' && req.method === 'POST') {
-        const json = await req.json() as { params: Record<string, string>; originalUrl?: string };
+      if (
+        endpoint === "internal/twilio/voice-webhook" &&
+        req.method === "POST"
+      ) {
+        const json = (await req.json()) as {
+          params: Record<string, string>;
+          originalUrl?: string;
+        };
         const formBody = new URLSearchParams(json.params).toString();
         const reconstructedUrl = json.originalUrl ?? req.url;
         const fakeReq = new Request(reconstructedUrl, {
@@ -1295,8 +1392,8 @@ export class RuntimeHttpServer {
         return await handleVoiceWebhook(fakeReq);
       }
 
-      if (endpoint === 'internal/twilio/status' && req.method === 'POST') {
-        const json = await req.json() as { params: Record<string, string> };
+      if (endpoint === "internal/twilio/status" && req.method === "POST") {
+        const json = (await req.json()) as { params: Record<string, string> };
         const formBody = new URLSearchParams(json.params).toString();
         const fakeReq = new Request(req.url, {
           method: "POST",
@@ -1306,8 +1403,11 @@ export class RuntimeHttpServer {
         return await handleStatusCallback(fakeReq);
       }
 
-      if (endpoint === 'internal/twilio/connect-action' && req.method === 'POST') {
-        const json = await req.json() as { params: Record<string, string> };
+      if (
+        endpoint === "internal/twilio/connect-action" &&
+        req.method === "POST"
+      ) {
+        const json = (await req.json()) as { params: Record<string, string> };
         const formBody = new URLSearchParams(json.params).toString();
         const fakeReq = new Request(req.url, {
           method: "POST",
@@ -1317,16 +1417,30 @@ export class RuntimeHttpServer {
         return await handleConnectAction(fakeReq);
       }
 
-      if (endpoint === 'identity' && req.method === 'GET') return handleGetIdentity();
-      if (endpoint === 'brain-graph' && req.method === 'GET') return handleGetBrainGraph();
-      if (endpoint === 'brain-graph-ui' && req.method === 'GET') return handleServeBrainGraphUI(mintUiPageToken());
-      if (endpoint === 'home-base-ui' && req.method === 'GET') return handleServeHomeBaseUI(mintUiPageToken());
-      if (endpoint === 'events' && req.method === 'GET') return handleSubscribeAssistantEvents(req, url, { authContext });
+      if (endpoint === "identity" && req.method === "GET")
+        return handleGetIdentity();
+      if (endpoint === "brain-graph" && req.method === "GET")
+        return handleGetBrainGraph();
+      if (endpoint === "brain-graph-ui" && req.method === "GET")
+        return handleServeBrainGraphUI(mintUiPageToken());
+      if (endpoint === "home-base-ui" && req.method === "GET")
+        return handleServeHomeBaseUI(mintUiPageToken());
+      if (endpoint === "events" && req.method === "GET")
+        return handleSubscribeAssistantEvents(req, url, { authContext });
+
+      // Migration endpoints
+      if (endpoint === "migrations/validate" && req.method === "POST")
+        return await handleMigrationValidate(req);
 
       // Internal OAuth callback endpoint (gateway -> runtime)
-      if (endpoint === 'internal/oauth/callback' && req.method === 'POST') {
-        const json = await req.json() as { state: string; code?: string; error?: string };
-        if (!json.state) return httpError('BAD_REQUEST', 'Missing state parameter', 400);
+      if (endpoint === "internal/oauth/callback" && req.method === "POST") {
+        const json = (await req.json()) as {
+          state: string;
+          code?: string;
+          error?: string;
+        };
+        if (!json.state)
+          return httpError("BAD_REQUEST", "Missing state parameter", 400);
         if (json.error) {
           const consumed = consumeCallbackError(json.state, json.error);
           return consumed

--- a/assistant/src/runtime/migrations/vbundle-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-validator.ts
@@ -1,0 +1,316 @@
+/**
+ * Validates .vbundle archive files for migration import/export.
+ *
+ * A .vbundle is a gzip-compressed tar archive containing:
+ * - manifest.json: metadata with schema_version, checksums, and bundle info
+ * - data/db/assistant.db: the SQLite database
+ * - Additional config files as declared in the manifest
+ *
+ * Validation steps:
+ * 1. Archive structure: valid gzip tar with required entries
+ * 2. Manifest schema: required fields and correct types
+ * 3. Manifest checksum: SHA-256 of canonicalized JSON matches declared digest
+ * 4. Per-file content integrity: SHA-256 of each file matches manifest checksums
+ */
+
+import { createHash } from "node:crypto";
+import { gunzipSync } from "node:zlib";
+
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Manifest schema
+// ---------------------------------------------------------------------------
+
+const ManifestFileEntry = z.object({
+  path: z.string(),
+  sha256: z.string(),
+  size: z.number().int().nonnegative(),
+});
+
+const ManifestSchema = z.object({
+  schema_version: z.string(),
+  created_at: z.string(),
+  source: z.string().optional(),
+  description: z.string().optional(),
+  files: z.array(ManifestFileEntry),
+  manifest_sha256: z.string(),
+});
+
+export type ManifestFileEntryType = z.infer<typeof ManifestFileEntry>;
+export type ManifestType = z.infer<typeof ManifestSchema>;
+
+// ---------------------------------------------------------------------------
+// Validation result types
+// ---------------------------------------------------------------------------
+
+export interface ValidationError {
+  code: string;
+  message: string;
+  path?: string;
+}
+
+export interface VBundleValidationResult {
+  is_valid: boolean;
+  errors: ValidationError[];
+  manifest?: ManifestType;
+}
+
+// ---------------------------------------------------------------------------
+// Tar parsing (minimal, spec-compliant for ustar/GNU tar)
+// ---------------------------------------------------------------------------
+
+interface TarEntry {
+  name: string;
+  data: Uint8Array;
+  size: number;
+}
+
+/**
+ * Parse a raw tar archive (uncompressed) into its entries.
+ * Handles ustar and GNU tar long name extensions.
+ */
+function parseTar(buffer: Uint8Array): TarEntry[] {
+  const entries: TarEntry[] = [];
+  let offset = 0;
+  const BLOCK_SIZE = 512;
+  let longName: string | null = null;
+
+  while (offset + BLOCK_SIZE <= buffer.length) {
+    const header = buffer.subarray(offset, offset + BLOCK_SIZE);
+
+    // Check for end-of-archive (two consecutive zero blocks)
+    if (header.every((b) => b === 0)) {
+      break;
+    }
+
+    // Extract file name
+    let name: string;
+    if (longName) {
+      name = longName;
+      longName = null;
+    } else {
+      // POSIX ustar: prefix (345 bytes at 345) + name (100 bytes at 0)
+      const rawName = decodeNullTerminated(header, 0, 100);
+      const prefix = decodeNullTerminated(header, 345, 155);
+      name = prefix ? `${prefix}/${rawName}` : rawName;
+    }
+
+    // File type (byte 156)
+    const typeFlag = String.fromCharCode(header[156]);
+
+    // File size in octal (bytes 124-135)
+    const sizeStr = decodeNullTerminated(header, 124, 12);
+    const size = parseInt(sizeStr, 8) || 0;
+
+    // Calculate data blocks
+    const dataBlocks = Math.ceil(size / BLOCK_SIZE);
+    const dataStart = offset + BLOCK_SIZE;
+    const data = buffer.subarray(dataStart, dataStart + size);
+
+    // GNU tar long name extension (type 'L')
+    if (typeFlag === "L") {
+      longName = new TextDecoder().decode(data).replace(/\0+$/, "");
+      offset = dataStart + dataBlocks * BLOCK_SIZE;
+      continue;
+    }
+
+    // Regular file or hard link
+    if (typeFlag === "0" || typeFlag === "\0" || typeFlag === "") {
+      entries.push({ name: normalizePath(name), data, size });
+    }
+
+    offset = dataStart + dataBlocks * BLOCK_SIZE;
+  }
+
+  return entries;
+}
+
+function decodeNullTerminated(
+  buf: Uint8Array,
+  start: number,
+  maxLen: number,
+): string {
+  let end = start;
+  while (end < start + maxLen && buf[end] !== 0) {
+    end++;
+  }
+  return new TextDecoder().decode(buf.subarray(start, end));
+}
+
+function normalizePath(p: string): string {
+  // Remove leading ./ and trailing /
+  return p.replace(/^\.\//, "").replace(/\/+$/, "");
+}
+
+// ---------------------------------------------------------------------------
+// Hash helpers
+// ---------------------------------------------------------------------------
+
+function sha256Hex(data: Uint8Array | string): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+/**
+ * Canonicalize a JSON object by sorting keys recursively, then SHA-256 hash it.
+ * This matches the platform's canonicalization approach.
+ */
+function canonicalizeJson(obj: unknown): string {
+  return JSON.stringify(obj, (_key, value) => {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      const sorted: Record<string, unknown> = {};
+      for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+        sorted[k] = (value as Record<string, unknown>)[k];
+      }
+      return sorted;
+    }
+    return value;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Core validation
+// ---------------------------------------------------------------------------
+
+const REQUIRED_ENTRIES = ["manifest.json", "data/db/assistant.db"];
+
+/**
+ * Validate a .vbundle archive from raw bytes.
+ *
+ * Performs four validation passes:
+ * 1. Archive structure (gzip decompression, tar parsing, required entries)
+ * 2. Manifest schema (Zod validation of manifest.json)
+ * 3. Manifest checksum (SHA-256 of canonicalized JSON without manifest_sha256)
+ * 4. Per-file content integrity (SHA-256 of each file vs manifest declaration)
+ */
+export function validateVBundle(data: Uint8Array): VBundleValidationResult {
+  const errors: ValidationError[] = [];
+
+  // Step 1: Decompress gzip
+  let tarData: Uint8Array;
+  try {
+    tarData = gunzipSync(data);
+  } catch (err) {
+    errors.push({
+      code: "INVALID_GZIP",
+      message: `Archive is not a valid gzip file: ${err instanceof Error ? err.message : String(err)}`,
+    });
+    return { is_valid: false, errors };
+  }
+
+  // Step 2: Parse tar
+  let entries: TarEntry[];
+  try {
+    entries = parseTar(tarData);
+  } catch (err) {
+    errors.push({
+      code: "INVALID_TAR",
+      message: `Archive is not a valid tar file: ${err instanceof Error ? err.message : String(err)}`,
+    });
+    return { is_valid: false, errors };
+  }
+
+  // Build a lookup map for entries
+  const entryMap = new Map<string, TarEntry>();
+  for (const entry of entries) {
+    entryMap.set(entry.name, entry);
+  }
+
+  // Step 3: Check required entries
+  for (const required of REQUIRED_ENTRIES) {
+    if (!entryMap.has(required)) {
+      errors.push({
+        code: "MISSING_ENTRY",
+        message: `Required archive entry not found: ${required}`,
+        path: required,
+      });
+    }
+  }
+
+  // If manifest.json is missing, we cannot proceed with further validation
+  const manifestEntry = entryMap.get("manifest.json");
+  if (!manifestEntry) {
+    return { is_valid: false, errors };
+  }
+
+  // Step 4: Parse and validate manifest schema
+  let manifestRaw: unknown;
+  try {
+    manifestRaw = JSON.parse(new TextDecoder().decode(manifestEntry.data));
+  } catch (err) {
+    errors.push({
+      code: "INVALID_MANIFEST_JSON",
+      message: `manifest.json is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      path: "manifest.json",
+    });
+    return { is_valid: false, errors };
+  }
+
+  const parseResult = ManifestSchema.safeParse(manifestRaw);
+  if (!parseResult.success) {
+    for (const issue of parseResult.error.issues) {
+      errors.push({
+        code: "MANIFEST_SCHEMA_ERROR",
+        message: `Manifest validation error at ${issue.path.join(".")}: ${issue.message}`,
+        path: `manifest.json/${issue.path.join(".")}`,
+      });
+    }
+    return { is_valid: false, errors };
+  }
+
+  const manifest = parseResult.data;
+
+  // Step 5: Verify manifest checksum
+  // The manifest_sha256 field is the SHA-256 of the canonicalized JSON
+  // with the manifest_sha256 field itself excluded.
+  const manifestForChecksum = { ...(manifestRaw as Record<string, unknown>) };
+  delete manifestForChecksum.manifest_sha256;
+  const canonicalized = canonicalizeJson(manifestForChecksum);
+  const computedManifestSha256 = sha256Hex(canonicalized);
+
+  if (computedManifestSha256 !== manifest.manifest_sha256) {
+    errors.push({
+      code: "MANIFEST_CHECKSUM_MISMATCH",
+      message: `Manifest checksum mismatch: expected ${manifest.manifest_sha256}, computed ${computedManifestSha256}`,
+      path: "manifest.json",
+    });
+  }
+
+  // Step 6: Verify per-file content integrity
+  for (const fileEntry of manifest.files) {
+    const archiveEntry = entryMap.get(fileEntry.path);
+    if (!archiveEntry) {
+      errors.push({
+        code: "MISSING_DECLARED_FILE",
+        message: `File declared in manifest not found in archive: ${fileEntry.path}`,
+        path: fileEntry.path,
+      });
+      continue;
+    }
+
+    // Verify size
+    if (archiveEntry.size !== fileEntry.size) {
+      errors.push({
+        code: "FILE_SIZE_MISMATCH",
+        message: `Size mismatch for ${fileEntry.path}: manifest declares ${fileEntry.size} bytes, archive has ${archiveEntry.size} bytes`,
+        path: fileEntry.path,
+      });
+    }
+
+    // Verify SHA-256
+    const computedSha256 = sha256Hex(archiveEntry.data);
+    if (computedSha256 !== fileEntry.sha256) {
+      errors.push({
+        code: "FILE_CHECKSUM_MISMATCH",
+        message: `Checksum mismatch for ${fileEntry.path}: expected ${fileEntry.sha256}, computed ${computedSha256}`,
+        path: fileEntry.path,
+      });
+    }
+  }
+
+  return {
+    is_valid: errors.length === 0,
+    errors,
+    manifest: errors.length === 0 ? manifest : undefined,
+  };
+}

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -1,0 +1,86 @@
+/**
+ * Route handlers for migration endpoints.
+ *
+ * POST /v1/migrations/validate — validate a .vbundle archive upload.
+ *
+ * Accepts raw binary body (Content-Type: application/octet-stream) or
+ * multipart form data with a "file" field. Returns structured validation
+ * results with is_valid flag and detailed error descriptions.
+ */
+
+import { getLogger } from "../../util/logger.js";
+import { httpError } from "../http-errors.js";
+import { validateVBundle } from "../migrations/vbundle-validator.js";
+
+const log = getLogger("migration-routes");
+
+/**
+ * POST /v1/migrations/validate
+ *
+ * Validates a .vbundle archive. The file can be sent as:
+ * - Raw binary body with Content-Type: application/octet-stream
+ * - Multipart form data with a "file" field
+ *
+ * Returns:
+ *   200: { is_valid: true, manifest: { ... } }
+ *   200: { is_valid: false, errors: [{ code, message, path? }] }
+ *   400: Standard error envelope for missing/empty body
+ *   422: Standard error envelope for completely unparseable input
+ */
+export async function handleMigrationValidate(req: Request): Promise<Response> {
+  let fileData: Uint8Array | null = null;
+
+  const contentType = req.headers.get("content-type") ?? "";
+
+  if (contentType.includes("multipart/form-data")) {
+    try {
+      const formData = await req.formData();
+      const file = formData.get("file");
+      if (!file || !(file instanceof Blob)) {
+        return httpError(
+          "BAD_REQUEST",
+          'Multipart upload requires a "file" field',
+          400,
+        );
+      }
+      fileData = new Uint8Array(await file.arrayBuffer());
+    } catch (err) {
+      log.error({ err }, "Failed to parse multipart form data");
+      return httpError("BAD_REQUEST", "Invalid multipart form data", 400);
+    }
+  } else {
+    // Treat as raw binary body
+    try {
+      const arrayBuffer = await req.arrayBuffer();
+      fileData = new Uint8Array(arrayBuffer);
+    } catch (err) {
+      log.error({ err }, "Failed to read request body");
+      return httpError("BAD_REQUEST", "Failed to read request body", 400);
+    }
+  }
+
+  if (!fileData || fileData.length === 0) {
+    return httpError(
+      "BAD_REQUEST",
+      "Request body is empty — a .vbundle file is required",
+      400,
+    );
+  }
+
+  try {
+    const result = validateVBundle(fileData);
+
+    return Response.json({
+      is_valid: result.is_valid,
+      errors: result.errors,
+      ...(result.manifest ? { manifest: result.manifest } : {}),
+    });
+  } catch (err) {
+    log.error({ err }, "Unexpected error during vbundle validation");
+    return httpError(
+      "INTERNAL_ERROR",
+      err instanceof Error ? err.message : "Unexpected validation error",
+      500,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add POST /v1/migrations/validate endpoint to the runtime HTTP server
- Implement TypeScript vbundle validation (archive structure, manifest schema, checksums, content digests)
- Add API contract tests for success, validation failure, and error scenarios

Part of plan: P28-self-host-export-import-validate.md (PR 1 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
