### PR TITLE
Add runtime export endpoint skeleton and file layout generation

### DIFF
--- a/assistant/src/__tests__/migration-export-http.test.ts
+++ b/assistant/src/__tests__/migration-export-http.test.ts
@@ -1,0 +1,299 @@
+/**
+ * HTTP-layer integration tests for POST /v1/migrations/export.
+ *
+ * Tests cover:
+ * - Success: valid .vbundle archive returned with correct headers
+ * - Archive structure: returned archive passes vbundle validation
+ * - Manifest correctness: schema_version, file entries, checksums
+ * - Custom description: optional JSON body sets manifest description
+ * - Auth: route policy enforcement (settings.write scope required)
+ * - Integration: existing routes are unaffected by the new endpoint
+ */
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+const testDir = realpathSync(
+  mkdtempSync(join(tmpdir(), "migration-export-http-test-")),
+);
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getSocketPath: () => join(testDir, "test.sock"),
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    secretDetection: { enabled: false },
+    sandbox: { enabled: false },
+  }),
+}));
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  hasUngatedHttpAuthDisabled: () => false,
+  getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
+  getGatewayPort: () => 7830,
+  getRuntimeHttpPort: () => 7821,
+  getRuntimeHttpHost: () => "127.0.0.1",
+  getRuntimeProxyBearerToken: () => undefined,
+  getRuntimeGatewayOriginSecret: () => undefined,
+  getIngressPublicBaseUrl: () => undefined,
+  setIngressPublicBaseUrl: () => {},
+}));
+
+import { validateVBundle } from "../runtime/migrations/vbundle-validator.js";
+import {
+  handleMigrationExport,
+  handleMigrationValidate,
+} from "../runtime/routes/migration-routes.js";
+
+afterAll(() => {
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Success tests
+// ---------------------------------------------------------------------------
+
+describe("handleMigrationExport", () => {
+  test("POST returns 200 with binary vbundle archive", async () => {
+    const req = new Request("http://localhost/v1/migrations/export", {
+      method: "POST",
+    });
+
+    const res = await handleMigrationExport(req);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/octet-stream");
+    expect(res.headers.get("Content-Disposition")).toMatch(
+      /^attachment; filename="export-.*\.vbundle"$/,
+    );
+    expect(res.headers.get("Content-Length")).toBeDefined();
+    expect(Number(res.headers.get("Content-Length"))).toBeGreaterThan(0);
+    expect(res.headers.get("X-Vbundle-Schema-Version")).toBe("1.0");
+    expect(res.headers.get("X-Vbundle-Manifest-Sha256")).toBeDefined();
+    expect(res.headers.get("X-Vbundle-Manifest-Sha256")!.length).toBe(64);
+  });
+
+  test("returned archive passes vbundle validation", async () => {
+    const req = new Request("http://localhost/v1/migrations/export", {
+      method: "POST",
+    });
+
+    const res = await handleMigrationExport(req);
+    const arrayBuffer = await res.arrayBuffer();
+    const archiveData = new Uint8Array(arrayBuffer);
+
+    const validationResult = validateVBundle(archiveData);
+
+    expect(validationResult.is_valid).toBe(true);
+    expect(validationResult.errors).toHaveLength(0);
+    expect(validationResult.manifest).toBeDefined();
+  });
+
+  test("manifest has correct structure and metadata", async () => {
+    const req = new Request("http://localhost/v1/migrations/export", {
+      method: "POST",
+    });
+
+    const res = await handleMigrationExport(req);
+    const arrayBuffer = await res.arrayBuffer();
+    const archiveData = new Uint8Array(arrayBuffer);
+
+    const validationResult = validateVBundle(archiveData);
+    const manifest = validationResult.manifest!;
+
+    expect(manifest.schema_version).toBe("1.0");
+    expect(manifest.source).toBe("runtime-export");
+    expect(manifest.created_at).toBeDefined();
+    expect(manifest.manifest_sha256).toBeDefined();
+
+    // Verify file entries
+    const filePaths = manifest.files.map((f) => f.path);
+    expect(filePaths).toContain("data/db/assistant.db");
+    expect(filePaths).toContain("config/settings.json");
+
+    // Verify each file entry has proper sha256 and size
+    for (const file of manifest.files) {
+      expect(file.sha256).toBeDefined();
+      expect(file.sha256.length).toBe(64);
+      expect(file.size).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  test("custom description from JSON body is used in manifest", async () => {
+    const req = new Request("http://localhost/v1/migrations/export", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ description: "My custom export description" }),
+    });
+
+    const res = await handleMigrationExport(req);
+    const arrayBuffer = await res.arrayBuffer();
+    const archiveData = new Uint8Array(arrayBuffer);
+
+    const validationResult = validateVBundle(archiveData);
+    const manifest = validationResult.manifest!;
+
+    expect(manifest.description).toBe("My custom export description");
+  });
+
+  test("invalid JSON body is gracefully handled with defaults", async () => {
+    const req = new Request("http://localhost/v1/migrations/export", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not valid json{{{",
+    });
+
+    const res = await handleMigrationExport(req);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/octet-stream");
+
+    const arrayBuffer = await res.arrayBuffer();
+    const archiveData = new Uint8Array(arrayBuffer);
+    const validationResult = validateVBundle(archiveData);
+
+    expect(validationResult.is_valid).toBe(true);
+  });
+
+  test("POST without Content-Type returns valid archive", async () => {
+    const req = new Request("http://localhost/v1/migrations/export", {
+      method: "POST",
+    });
+
+    const res = await handleMigrationExport(req);
+
+    expect(res.status).toBe(200);
+
+    const arrayBuffer = await res.arrayBuffer();
+    const archiveData = new Uint8Array(arrayBuffer);
+    const validationResult = validateVBundle(archiveData);
+
+    expect(validationResult.is_valid).toBe(true);
+  });
+
+  test("Content-Length header matches actual body length", async () => {
+    const req = new Request("http://localhost/v1/migrations/export", {
+      method: "POST",
+    });
+
+    const res = await handleMigrationExport(req);
+    const arrayBuffer = await res.arrayBuffer();
+
+    expect(Number(res.headers.get("Content-Length"))).toBe(
+      arrayBuffer.byteLength,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth policy registration tests
+// ---------------------------------------------------------------------------
+
+describe("route policy registration", () => {
+  test("migrations/export policy requires settings.write scope", async () => {
+    const { getPolicy } = await import("../runtime/auth/route-policy.js");
+    const policy = getPolicy("migrations/export");
+
+    expect(policy).toBeDefined();
+    expect(policy?.requiredScopes).toContain("settings.write");
+    expect(policy?.allowedPrincipalTypes).toContain("actor");
+    expect(policy?.allowedPrincipalTypes).toContain("svc_gateway");
+    expect(policy?.allowedPrincipalTypes).toContain("ipc");
+  });
+
+  test("migrations/validate policy is still registered", async () => {
+    const { getPolicy } = await import("../runtime/auth/route-policy.js");
+    const policy = getPolicy("migrations/validate");
+
+    expect(policy).toBeDefined();
+    expect(policy?.requiredScopes).toContain("settings.write");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth policy shape tests
+// ---------------------------------------------------------------------------
+
+describe("auth policy shape", () => {
+  test("export policy requires settings.write and would deny without it", async () => {
+    const { getPolicy } = await import("../runtime/auth/route-policy.js");
+    const policy = getPolicy("migrations/export");
+
+    expect(policy).toBeDefined();
+    // Verify the policy shape means a caller without settings.write would be denied
+    expect(policy!.requiredScopes).toEqual(["settings.write"]);
+    // Verify only the expected principal types are allowed
+    expect(policy!.allowedPrincipalTypes).toEqual(
+      expect.arrayContaining(["actor", "svc_gateway", "ipc"]),
+    );
+    expect(policy!.allowedPrincipalTypes).toHaveLength(3);
+  });
+
+  test("export policy matches validate policy shape", async () => {
+    const { getPolicy } = await import("../runtime/auth/route-policy.js");
+    const exportPolicy = getPolicy("migrations/export");
+    const validatePolicy = getPolicy("migrations/validate");
+
+    // Both migration endpoints should have the same auth requirements
+    expect(exportPolicy!.requiredScopes).toEqual(
+      validatePolicy!.requiredScopes,
+    );
+    expect(exportPolicy!.allowedPrincipalTypes).toEqual(
+      validatePolicy!.allowedPrincipalTypes,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: existing routes unaffected
+// ---------------------------------------------------------------------------
+
+describe("integration: existing routes unaffected", () => {
+  test("validate endpoint still works correctly", async () => {
+    // Just confirm that importing both handlers works without conflicts
+    const validateHandler = handleMigrationValidate;
+    const exportHandler = handleMigrationExport;
+
+    expect(typeof validateHandler).toBe("function");
+    expect(typeof exportHandler).toBe("function");
+  });
+
+  test("GET /v1/health still works (not intercepted by migration routes)", async () => {
+    const { handleHealth } =
+      await import("../runtime/routes/identity-routes.js");
+    const res = handleHealth();
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("healthy");
+  });
+});

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -290,6 +290,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
 
   // Migrations
   { endpoint: "migrations/validate", scopes: ["settings.write"] },
+  { endpoint: "migrations/export", scopes: ["settings.write"] },
 ];
 
 for (const { endpoint, scopes } of ACTOR_ENDPOINTS) {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -181,7 +181,10 @@ import {
   handleSetupTelegram,
   handleStartOutbound,
 } from "./routes/integration-routes.js";
-import { handleMigrationValidate } from "./routes/migration-routes.js";
+import {
+  handleMigrationExport,
+  handleMigrationValidate,
+} from "./routes/migration-routes.js";
 import type { PairingHandlerContext } from "./routes/pairing-routes.js";
 // Extracted route handlers
 import {
@@ -1431,6 +1434,8 @@ export class RuntimeHttpServer {
       // Migration endpoints
       if (endpoint === "migrations/validate" && req.method === "POST")
         return await handleMigrationValidate(req);
+      if (endpoint === "migrations/export" && req.method === "POST")
+        return await handleMigrationExport(req);
 
       // Internal OAuth callback endpoint (gateway -> runtime)
       if (endpoint === "internal/oauth/callback" && req.method === "POST") {

--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -1,0 +1,267 @@
+/**
+ * Builds .vbundle archive files for migration export.
+ *
+ * A .vbundle is a gzip-compressed tar archive containing:
+ * - manifest.json: metadata with schema_version, checksums, and bundle info
+ * - data/db/assistant.db: the SQLite database (placeholder in skeleton mode)
+ * - Additional config files as declared in the manifest
+ *
+ * This module produces the archive skeleton with correct file layout and
+ * checksums. PR-3 will populate the actual conversation/memory data.
+ */
+
+import { createHash } from "node:crypto";
+import { gzipSync } from "node:zlib";
+
+import type {
+  ManifestFileEntryType,
+  ManifestType,
+} from "./vbundle-validator.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface VBundleFileEntry {
+  path: string;
+  data: Uint8Array;
+}
+
+export interface BuildVBundleOptions {
+  /** Files to include in the archive. Must include data/db/assistant.db. */
+  files: VBundleFileEntry[];
+  /** Schema version for the manifest. Defaults to "1.0". */
+  schemaVersion?: string;
+  /** Source identifier (e.g. "runtime-export"). */
+  source?: string;
+  /** Human-readable description. */
+  description?: string;
+}
+
+export interface BuildVBundleResult {
+  /** The complete .vbundle archive as gzipped tar bytes. */
+  archive: Uint8Array;
+  /** The manifest that was embedded in the archive. */
+  manifest: ManifestType;
+}
+
+// ---------------------------------------------------------------------------
+// Hash helpers
+// ---------------------------------------------------------------------------
+
+function sha256Hex(data: Uint8Array | string): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+/**
+ * Canonicalize a JSON object by sorting keys recursively, then stringify.
+ * Matches the canonicalization used by vbundle-validator.
+ */
+function canonicalizeJson(obj: unknown): string {
+  return JSON.stringify(obj, (_key, value) => {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      const sorted: Record<string, unknown> = {};
+      for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+        sorted[k] = (value as Record<string, unknown>)[k];
+      }
+      return sorted;
+    }
+    return value;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tar archive builder (minimal, ustar-compatible)
+// ---------------------------------------------------------------------------
+
+const BLOCK_SIZE = 512;
+
+function padToBlock(data: Uint8Array): Uint8Array {
+  const remainder = data.length % BLOCK_SIZE;
+  if (remainder === 0) return data;
+  const padded = new Uint8Array(data.length + (BLOCK_SIZE - remainder));
+  padded.set(data);
+  return padded;
+}
+
+function writeOctal(
+  buf: Uint8Array,
+  offset: number,
+  length: number,
+  value: number,
+): void {
+  const str = value.toString(8).padStart(length - 1, "0");
+  for (let i = 0; i < str.length; i++) {
+    buf[offset + i] = str.charCodeAt(i);
+  }
+  buf[offset + length - 1] = 0;
+}
+
+function computeHeaderChecksum(header: Uint8Array): number {
+  let sum = 0;
+  for (let i = 0; i < 512; i++) {
+    if (i >= 148 && i < 156) {
+      sum += 0x20; // space placeholder per tar spec
+    } else {
+      sum += header[i];
+    }
+  }
+  return sum;
+}
+
+function createTarEntry(name: string, data: Uint8Array): Uint8Array {
+  const header = new Uint8Array(BLOCK_SIZE);
+  const encoder = new TextEncoder();
+
+  // File name (0-99)
+  const nameBytes = encoder.encode(name);
+  header.set(nameBytes.subarray(0, 100), 0);
+
+  // File mode (100-107): 0644
+  writeOctal(header, 100, 8, 0o644);
+
+  // Owner ID (108-115)
+  writeOctal(header, 108, 8, 0);
+
+  // Group ID (116-123)
+  writeOctal(header, 116, 8, 0);
+
+  // File size (124-135)
+  writeOctal(header, 124, 12, data.length);
+
+  // Modification time (136-147)
+  writeOctal(header, 136, 12, Math.floor(Date.now() / 1000));
+
+  // Type flag (156): regular file
+  header[156] = "0".charCodeAt(0);
+
+  // USTAR magic (257-262)
+  const magic = encoder.encode("ustar\0");
+  header.set(magic, 257);
+
+  // USTAR version (263-264)
+  header[263] = "0".charCodeAt(0);
+  header[264] = "0".charCodeAt(0);
+
+  // Compute and write checksum (148-155)
+  const checksum = computeHeaderChecksum(header);
+  writeOctal(header, 148, 7, checksum);
+  header[155] = 0x20; // trailing space
+
+  // Combine header + padded data
+  const paddedData = padToBlock(data);
+  const result = new Uint8Array(header.length + paddedData.length);
+  result.set(header, 0);
+  result.set(paddedData, header.length);
+  return result;
+}
+
+function createTarArchive(
+  entries: Array<{ name: string; data: Uint8Array }>,
+): Uint8Array {
+  const parts: Uint8Array[] = [];
+  for (const entry of entries) {
+    parts.push(createTarEntry(entry.name, entry.data));
+  }
+  // End-of-archive: two zero blocks
+  parts.push(new Uint8Array(BLOCK_SIZE * 2));
+
+  const totalLength = parts.reduce((sum, p) => sum + p.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.length;
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Core builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a .vbundle archive from the given files and metadata.
+ *
+ * Generates a valid manifest with SHA-256 checksums for all files and
+ * a self-referencing manifest_sha256 checksum. The archive is returned
+ * as gzip-compressed tar bytes.
+ */
+export function buildVBundle(options: BuildVBundleOptions): BuildVBundleResult {
+  const {
+    files,
+    schemaVersion = "1.0",
+    source = "runtime-export",
+    description = "Runtime export bundle",
+  } = options;
+
+  // Build file entries for the manifest
+  const fileEntries: ManifestFileEntryType[] = files.map((f) => ({
+    path: f.path,
+    sha256: sha256Hex(f.data),
+    size: f.data.length,
+  }));
+
+  // Build manifest without the self-checksum
+  const manifestWithoutChecksum = {
+    schema_version: schemaVersion,
+    created_at: new Date().toISOString(),
+    source,
+    description,
+    files: fileEntries,
+  };
+
+  // Compute the manifest self-checksum
+  const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
+  const manifest: ManifestType = {
+    ...manifestWithoutChecksum,
+    manifest_sha256: manifestSha256,
+  };
+
+  const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
+
+  // Build tar entries: manifest first, then all files
+  const tarEntries = [
+    { name: "manifest.json", data: manifestData },
+    ...files.map((f) => ({ name: f.path, data: f.data })),
+  ];
+
+  const tar = createTarArchive(tarEntries);
+  const archive = gzipSync(tar);
+
+  return { archive, manifest };
+}
+
+// ---------------------------------------------------------------------------
+// Skeleton builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a skeleton .vbundle with placeholder content.
+ *
+ * The skeleton includes:
+ * - manifest.json with proper metadata and checksums
+ * - data/db/assistant.db as an empty placeholder
+ * - config/settings.json as an empty JSON object placeholder
+ *
+ * PR-3 will replace the placeholder data with actual exported content.
+ */
+export function buildSkeletonVBundle(options?: {
+  source?: string;
+  description?: string;
+}): BuildVBundleResult {
+  // Placeholder SQLite database (empty file)
+  const dbPlaceholder = new Uint8Array(0);
+
+  // Placeholder config
+  const configPlaceholder = new TextEncoder().encode("{}");
+
+  return buildVBundle({
+    files: [
+      { path: "data/db/assistant.db", data: dbPlaceholder },
+      { path: "config/settings.json", data: configPlaceholder },
+    ],
+    source: options?.source ?? "runtime-export",
+    description: options?.description ?? "Runtime export bundle (skeleton)",
+  });
+}

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -2,6 +2,7 @@
  * Route handlers for migration endpoints.
  *
  * POST /v1/migrations/validate — validate a .vbundle archive upload.
+ * POST /v1/migrations/export  — generate and download a .vbundle archive.
  *
  * Accepts raw binary body (Content-Type: application/octet-stream) or
  * multipart form data with a "file" field. Returns structured validation
@@ -10,6 +11,7 @@
 
 import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
+import { buildSkeletonVBundle } from "../migrations/vbundle-builder.js";
 import { validateVBundle } from "../migrations/vbundle-validator.js";
 
 const log = getLogger("migration-routes");
@@ -80,6 +82,69 @@ export async function handleMigrationValidate(req: Request): Promise<Response> {
     return httpError(
       "INTERNAL_ERROR",
       err instanceof Error ? err.message : "Unexpected validation error",
+      500,
+    );
+  }
+}
+
+/**
+ * POST /v1/migrations/export
+ *
+ * Generates a .vbundle archive skeleton and returns it as a binary download.
+ * The archive contains the correct file layout structure (manifest, db
+ * placeholder, config directory) but does not populate actual conversation
+ * or memory data — that is reserved for PR-3.
+ *
+ * Accepts an optional JSON body:
+ *   { "description": "Human-readable export description" }
+ *
+ * Returns:
+ *   200: Binary .vbundle archive (Content-Type: application/octet-stream)
+ *        with Content-Disposition header for download.
+ *   500: Standard error envelope for unexpected failures.
+ *
+ * Auth: Requires settings.write scope. Allowed for actor, svc_gateway, ipc.
+ */
+export async function handleMigrationExport(req: Request): Promise<Response> {
+  let description: string | undefined;
+
+  // Parse optional JSON body for export metadata
+  const contentType = req.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    try {
+      const body = (await req.json()) as Record<string, unknown>;
+      if (typeof body.description === "string") {
+        description = body.description;
+      }
+    } catch (err) {
+      log.warn({ err }, "Failed to parse export request body — using defaults");
+    }
+  }
+
+  try {
+    const { archive, manifest } = buildSkeletonVBundle({
+      source: "runtime-export",
+      description,
+    });
+
+    const timestamp = manifest.created_at.replace(/[:.]/g, "-");
+    const filename = `export-${timestamp}.vbundle`;
+
+    return new Response(archive, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/octet-stream",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+        "Content-Length": String(archive.length),
+        "X-Vbundle-Schema-Version": manifest.schema_version,
+        "X-Vbundle-Manifest-Sha256": manifest.manifest_sha256,
+      },
+    });
+  } catch (err) {
+    log.error({ err }, "Failed to build export bundle");
+    return httpError(
+      "INTERNAL_ERROR",
+      err instanceof Error ? err.message : "Unexpected export error",
       500,
     );
   }


### PR DESCRIPTION
## Summary
- Add POST /migrations/export endpoint to the runtime HTTP server
- Generate .vbundle archive skeleton with correct file layout (manifest, db, config)
- Return archive as binary download response
- Add API contract tests for export endpoint

Part of plan: P28-self-host-export-import-validate.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
