### PR TITLE
Add runtime export payload population for conversations + memory

### DIFF
--- a/assistant/src/__tests__/migration-export-http.test.ts
+++ b/assistant/src/__tests__/migration-export-http.test.ts
@@ -6,27 +6,41 @@
  * - Archive structure: returned archive passes vbundle validation
  * - Manifest correctness: schema_version, file entries, checksums
  * - Custom description: optional JSON body sets manifest description
+ * - Real data: exported archive contains actual file contents from disk
+ * - Graceful fallback: missing db/config produces valid archive with defaults
  * - Auth: route policy enforcement (settings.write scope required)
  * - Integration: existing routes are unaffected by the new endpoint
  */
-import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { createHash } from "node:crypto";
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterAll, describe, expect, mock, test } from "bun:test";
+import { gunzipSync } from "node:zlib";
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
 
 const testDir = realpathSync(
   mkdtempSync(join(tmpdir(), "migration-export-http-test-")),
 );
+const testDbDir = join(testDir, "db");
+const testDbPath = join(testDbDir, "assistant.db");
+const testConfigPath = join(testDir, "config.json");
 
 mock.module("../util/platform.js", () => ({
   getRootDir: () => testDir,
   getDataDir: () => testDir,
+  getWorkspaceConfigPath: () => testConfigPath,
   isMacOS: () => process.platform === "darwin",
   isLinux: () => process.platform === "linux",
   isWindows: () => process.platform === "win32",
   getSocketPath: () => join(testDir, "test.sock"),
   getPidPath: () => join(testDir, "test.pid"),
-  getDbPath: () => join(testDir, "test.db"),
+  getDbPath: () => testDbPath,
   getLogPath: () => join(testDir, "test.log"),
   ensureDataDir: () => {},
 }));
@@ -70,6 +84,20 @@ import {
   handleMigrationValidate,
 } from "../runtime/routes/migration-routes.js";
 
+// Test fixture data: a minimal SQLite header to simulate a real database file
+const SQLITE_HEADER = new Uint8Array([
+  0x53, 0x51, 0x4c, 0x69, 0x74, 0x65, 0x20, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74,
+  0x20, 0x33, 0x00,
+]);
+const TEST_CONFIG = { provider: "anthropic", model: "test-model" };
+
+beforeAll(() => {
+  // Write test fixture files so the export reads real data
+  mkdirSync(testDbDir, { recursive: true });
+  writeFileSync(testDbPath, SQLITE_HEADER);
+  writeFileSync(testConfigPath, JSON.stringify(TEST_CONFIG, null, 2));
+});
+
 afterAll(() => {
   try {
     rmSync(testDir, { recursive: true });
@@ -77,6 +105,52 @@ afterAll(() => {
     /* best effort */
   }
 });
+
+// ---------------------------------------------------------------------------
+// Tar parsing helper (mirrors vbundle-validator's internal parser)
+// ---------------------------------------------------------------------------
+
+interface TarEntry {
+  name: string;
+  data: Uint8Array;
+}
+
+function parseTarEntries(gzippedData: Uint8Array): TarEntry[] {
+  const tarData = gunzipSync(gzippedData);
+  const entries: TarEntry[] = [];
+  let offset = 0;
+  const BLOCK_SIZE = 512;
+
+  while (offset + BLOCK_SIZE <= tarData.length) {
+    const header = tarData.subarray(offset, offset + BLOCK_SIZE);
+    if (header.every((b) => b === 0)) break;
+
+    let end = 0;
+    while (end < 100 && header[end] !== 0) end++;
+    const name = new TextDecoder().decode(header.subarray(0, end));
+
+    let sizeEnd = 124;
+    while (sizeEnd < 136 && header[sizeEnd] !== 0) sizeEnd++;
+    const sizeStr = new TextDecoder().decode(header.subarray(124, sizeEnd));
+    const size = parseInt(sizeStr, 8) || 0;
+
+    const dataStart = offset + BLOCK_SIZE;
+    const data = tarData.subarray(dataStart, dataStart + size);
+    const dataBlocks = Math.ceil(size / BLOCK_SIZE);
+
+    if (header[156] === "0".charCodeAt(0) || header[156] === 0) {
+      entries.push({ name, data: new Uint8Array(data) });
+    }
+
+    offset = dataStart + dataBlocks * BLOCK_SIZE;
+  }
+
+  return entries;
+}
+
+function sha256Hex(data: Uint8Array): string {
+  return createHash("sha256").update(data).digest("hex");
+}
 
 // ---------------------------------------------------------------------------
 // Success tests
@@ -211,6 +285,173 @@ describe("handleMigrationExport", () => {
     expect(Number(res.headers.get("Content-Length"))).toBe(
       arrayBuffer.byteLength,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real data population tests
+// ---------------------------------------------------------------------------
+
+describe("export data population", () => {
+  test("archive contains actual database file content from disk", async () => {
+    const req = new Request("http://localhost/v1/migrations/export", {
+      method: "POST",
+    });
+
+    const res = await handleMigrationExport(req);
+    const archiveData = new Uint8Array(await res.arrayBuffer());
+    const entries = parseTarEntries(archiveData);
+
+    const dbEntry = entries.find((e) => e.name === "data/db/assistant.db");
+    expect(dbEntry).toBeDefined();
+    expect(dbEntry!.data.length).toBe(SQLITE_HEADER.length);
+    // Verify the exported data matches the test fixture exactly
+    expect(sha256Hex(dbEntry!.data)).toBe(sha256Hex(SQLITE_HEADER));
+  });
+
+  test("archive contains actual config file content from disk", async () => {
+    const req = new Request("http://localhost/v1/migrations/export", {
+      method: "POST",
+    });
+
+    const res = await handleMigrationExport(req);
+    const archiveData = new Uint8Array(await res.arrayBuffer());
+    const entries = parseTarEntries(archiveData);
+
+    const configEntry = entries.find((e) => e.name === "config/settings.json");
+    expect(configEntry).toBeDefined();
+
+    const configContent = new TextDecoder().decode(configEntry!.data);
+    const parsedConfig = JSON.parse(configContent);
+    expect(parsedConfig.provider).toBe("anthropic");
+    expect(parsedConfig.model).toBe("test-model");
+  });
+
+  test("manifest file sizes match actual file sizes on disk", async () => {
+    const req = new Request("http://localhost/v1/migrations/export", {
+      method: "POST",
+    });
+
+    const res = await handleMigrationExport(req);
+    const archiveData = new Uint8Array(await res.arrayBuffer());
+
+    const validationResult = validateVBundle(archiveData);
+    const manifest = validationResult.manifest!;
+
+    const dbFile = manifest.files.find(
+      (f) => f.path === "data/db/assistant.db",
+    );
+    expect(dbFile).toBeDefined();
+    expect(dbFile!.size).toBe(SQLITE_HEADER.length);
+
+    const configFile = manifest.files.find(
+      (f) => f.path === "config/settings.json",
+    );
+    expect(configFile).toBeDefined();
+    const expectedConfigSize = Buffer.byteLength(
+      JSON.stringify(TEST_CONFIG, null, 2),
+    );
+    expect(configFile!.size).toBe(expectedConfigSize);
+  });
+
+  test("manifest checksums match actual file content", async () => {
+    const req = new Request("http://localhost/v1/migrations/export", {
+      method: "POST",
+    });
+
+    const res = await handleMigrationExport(req);
+    const archiveData = new Uint8Array(await res.arrayBuffer());
+    const entries = parseTarEntries(archiveData);
+
+    const validationResult = validateVBundle(archiveData);
+    const manifest = validationResult.manifest!;
+
+    for (const fileEntry of manifest.files) {
+      const tarEntry = entries.find((e) => e.name === fileEntry.path);
+      expect(tarEntry).toBeDefined();
+      expect(sha256Hex(tarEntry!.data)).toBe(fileEntry.sha256);
+    }
+  });
+
+  test("database content is non-empty (real data, not skeleton)", async () => {
+    const req = new Request("http://localhost/v1/migrations/export", {
+      method: "POST",
+    });
+
+    const res = await handleMigrationExport(req);
+    const archiveData = new Uint8Array(await res.arrayBuffer());
+
+    const validationResult = validateVBundle(archiveData);
+    const manifest = validationResult.manifest!;
+
+    const dbFile = manifest.files.find(
+      (f) => f.path === "data/db/assistant.db",
+    );
+    expect(dbFile).toBeDefined();
+    // The skeleton used size 0 — real export should have actual content
+    expect(dbFile!.size).toBeGreaterThan(0);
+  });
+
+  test("config content is real JSON (not empty object placeholder)", async () => {
+    const req = new Request("http://localhost/v1/migrations/export", {
+      method: "POST",
+    });
+
+    const res = await handleMigrationExport(req);
+    const archiveData = new Uint8Array(await res.arrayBuffer());
+    const entries = parseTarEntries(archiveData);
+
+    const configEntry = entries.find((e) => e.name === "config/settings.json");
+    expect(configEntry).toBeDefined();
+
+    const configContent = new TextDecoder().decode(configEntry!.data);
+    // The skeleton used "{}" — real export should have actual config
+    expect(configContent).not.toBe("{}");
+    expect(JSON.parse(configContent)).toHaveProperty("provider");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Graceful fallback tests
+// ---------------------------------------------------------------------------
+
+describe("export graceful fallback", () => {
+  test("missing database produces valid archive with empty db entry", async () => {
+    const { buildExportVBundle } =
+      await import("../runtime/migrations/vbundle-builder.js");
+
+    const result = buildExportVBundle({
+      dbPath: join(testDir, "nonexistent.db"),
+      configPath: testConfigPath,
+    });
+
+    const validationResult = validateVBundle(result.archive);
+    expect(validationResult.is_valid).toBe(true);
+
+    const dbFile = result.manifest.files.find(
+      (f) => f.path === "data/db/assistant.db",
+    );
+    expect(dbFile).toBeDefined();
+    expect(dbFile!.size).toBe(0);
+  });
+
+  test("missing config produces valid archive with empty JSON config", async () => {
+    const { buildExportVBundle } =
+      await import("../runtime/migrations/vbundle-builder.js");
+
+    const result = buildExportVBundle({
+      dbPath: testDbPath,
+      configPath: join(testDir, "nonexistent-config.json"),
+    });
+
+    const validationResult = validateVBundle(result.archive);
+    expect(validationResult.is_valid).toBe(true);
+
+    const configFile = result.manifest.files.find(
+      (f) => f.path === "config/settings.json",
+    );
+    expect(configFile).toBeDefined();
+    expect(configFile!.size).toBe(2); // "{}" is 2 bytes
   });
 });
 

--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -3,14 +3,12 @@
  *
  * A .vbundle is a gzip-compressed tar archive containing:
  * - manifest.json: metadata with schema_version, checksums, and bundle info
- * - data/db/assistant.db: the SQLite database (placeholder in skeleton mode)
- * - Additional config files as declared in the manifest
- *
- * This module produces the archive skeleton with correct file layout and
- * checksums. PR-3 will populate the actual conversation/memory data.
+ * - data/db/assistant.db: the SQLite database with conversations and memory
+ * - config/settings.json: the assistant configuration
  */
 
 import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
 import { gzipSync } from "node:zlib";
 
 import type {
@@ -233,35 +231,54 @@ export function buildVBundle(options: BuildVBundleOptions): BuildVBundleResult {
 }
 
 // ---------------------------------------------------------------------------
-// Skeleton builder
+// Export builder — reads real data from disk
 // ---------------------------------------------------------------------------
 
-/**
- * Build a skeleton .vbundle with placeholder content.
- *
- * The skeleton includes:
- * - manifest.json with proper metadata and checksums
- * - data/db/assistant.db as an empty placeholder
- * - config/settings.json as an empty JSON object placeholder
- *
- * PR-3 will replace the placeholder data with actual exported content.
- */
-export function buildSkeletonVBundle(options?: {
+export interface BuildExportVBundleOptions {
+  /** Path to the SQLite database file (e.g. ~/.vellum/workspace/data/db/assistant.db). */
+  dbPath: string;
+  /** Path to the config file (e.g. ~/.vellum/workspace/config.json). */
+  configPath: string;
+  /** Source identifier. Defaults to "runtime-export". */
   source?: string;
+  /** Human-readable description. */
   description?: string;
-}): BuildVBundleResult {
-  // Placeholder SQLite database (empty file)
-  const dbPlaceholder = new Uint8Array(0);
+}
 
-  // Placeholder config
-  const configPlaceholder = new TextEncoder().encode("{}");
+/**
+ * Build a .vbundle archive populated with real assistant data.
+ *
+ * Reads the actual SQLite database (which contains all conversations,
+ * messages, memory segments, embeddings, and other assistant state) and
+ * the config file from disk. Returns a complete, self-validating archive
+ * ready for migration import.
+ *
+ * Falls back gracefully: if the database does not exist, an empty file is
+ * included. If the config does not exist, an empty JSON object is used.
+ */
+export function buildExportVBundle(
+  options: BuildExportVBundleOptions,
+): BuildVBundleResult {
+  const { dbPath, configPath, source, description } = options;
+
+  // Read the actual SQLite database file. The database contains all
+  // conversation history, messages, memory segments, embeddings, and
+  // other persistent assistant state in a single file.
+  const dbData = existsSync(dbPath)
+    ? new Uint8Array(readFileSync(dbPath))
+    : new Uint8Array(0);
+
+  // Read the config file (settings, provider config, feature flags, etc.).
+  const configData = existsSync(configPath)
+    ? new Uint8Array(readFileSync(configPath))
+    : new TextEncoder().encode("{}");
 
   return buildVBundle({
     files: [
-      { path: "data/db/assistant.db", data: dbPlaceholder },
-      { path: "config/settings.json", data: configPlaceholder },
+      { path: "data/db/assistant.db", data: dbData },
+      { path: "config/settings.json", data: configData },
     ],
-    source: options?.source ?? "runtime-export",
-    description: options?.description ?? "Runtime export bundle (skeleton)",
+    source: source ?? "runtime-export",
+    description: description ?? "Runtime export bundle",
   });
 }

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -10,8 +10,9 @@
  */
 
 import { getLogger } from "../../util/logger.js";
+import { getDbPath, getWorkspaceConfigPath } from "../../util/platform.js";
 import { httpError } from "../http-errors.js";
-import { buildSkeletonVBundle } from "../migrations/vbundle-builder.js";
+import { buildExportVBundle } from "../migrations/vbundle-builder.js";
 import { validateVBundle } from "../migrations/vbundle-validator.js";
 
 const log = getLogger("migration-routes");
@@ -90,10 +91,9 @@ export async function handleMigrationValidate(req: Request): Promise<Response> {
 /**
  * POST /v1/migrations/export
  *
- * Generates a .vbundle archive skeleton and returns it as a binary download.
- * The archive contains the correct file layout structure (manifest, db
- * placeholder, config directory) but does not populate actual conversation
- * or memory data — that is reserved for PR-3.
+ * Exports the assistant's real data as a .vbundle archive. The archive
+ * contains the SQLite database (all conversations, messages, memory
+ * segments, embeddings) and the config file.
  *
  * Accepts an optional JSON body:
  *   { "description": "Human-readable export description" }
@@ -122,7 +122,9 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
   }
 
   try {
-    const { archive, manifest } = buildSkeletonVBundle({
+    const { archive, manifest } = buildExportVBundle({
+      dbPath: getDbPath(),
+      configPath: getWorkspaceConfigPath(),
       source: "runtime-export",
       description,
     });


### PR DESCRIPTION
## Summary
- Populate export bundles with real assistant data (database, config, conversations, memory)
- Replace skeleton placeholders with actual file contents from the assistant workspace
- Add focused tests for data export functionality

Part of plan: P28-self-host-export-import-validate.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
