### PR TITLE
Fix type error in migration export route

### DIFF
--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -132,7 +132,7 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
     const timestamp = manifest.created_at.replace(/[:.]/g, "-");
     const filename = `export-${timestamp}.vbundle`;
 
-    return new Response(archive, {
+    return new Response(new Blob([archive]), {
       status: 200,
       headers: {
         "Content-Type": "application/octet-stream",


### PR DESCRIPTION
## Summary
- Wrap `archive` (Uint8Array) in `new Blob([...])` to satisfy the `BodyInit` type constraint in the `Response` constructor at `migration-routes.ts:135`.

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22642613734/job/65622330537

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
