### PR TITLE
Add POST /v1/integrations/guardian/revoke gateway API

### DIFF
--- a/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
@@ -154,6 +154,29 @@ If the response shows the guardian is bound, confirm success: "Guardian verified
 
 If not yet bound, offer to resend (Step 4) or generate a new session (Step 3).
 
+## Step 7: Revoke Guardian Binding
+
+If the user wants to remove themselves (or the current guardian) from a channel, use the revoke endpoint:
+
+```bash
+curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/revoke" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" \
+  -d '{"channel": "<channel>"}'
+```
+
+Replace `<channel>` with the channel to unbind from (e.g. `voice`, `telegram`).
+
+### On success (`success: true`)
+
+Confirm to the user: "Guardian binding revoked for [channel]. The previous guardian no longer has access to this channel."
+
+### On error (`success: false`)
+
+| Error code | Action |
+|---|---|
+| `not_bound` | Tell the user there is no active guardian binding for this channel — nothing to revoke. |
+
 ## Important Notes
 
 - Verification codes expire after 10 minutes. If the session expires, start a new one.
@@ -161,3 +184,4 @@ If not yet bound, offer to resend (Step 4) or generate a new session (Step 3).
 - Per-destination rate limiting allows up to 10 sends within a 1-hour rolling window.
 - Guardian verification is identity-bound: the code can only be consumed by the identity matching the destination provided at start time.
 - **Missing `secret` guardrail**: For voice and Telegram chat-ID flows, the API response MUST include a `secret` field. If `secret` is unexpectedly absent from a start or resend response that otherwise indicates success, treat this as a control-plane error. Do NOT fabricate a code or tell the user to proceed without one. Instead, tell the user something went wrong and ask them to retry the start (Step 3) or resend (Step 4).
+- **Revoking a guardian**: To remove the current guardian from a channel, use the revoke API (Step 7). This revokes the binding AND revokes the guardian's ingress member record, so they lose access to the channel. A new guardian can then be verified for that channel.

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -150,6 +150,49 @@ export function getGuardianStatus(
 }
 
 // ---------------------------------------------------------------------------
+// Revoke guardian binding
+// ---------------------------------------------------------------------------
+
+export function revokeGuardianForChannel(
+  channel?: ChannelId,
+): GuardianVerificationResult {
+  const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
+  const resolvedChannel = channel ?? 'telegram';
+
+  // Capture binding before revoking so we can revoke the guardian's
+  // ingress member record — without this, the guardian would still pass
+  // the ACL check after unbinding.
+  const bindingBeforeRevoke = getGuardianBinding(assistantId, resolvedChannel);
+  if (!bindingBeforeRevoke) {
+    return {
+      success: false,
+      error: 'not_bound',
+      message: 'No active guardian binding exists for this channel.',
+      channel: resolvedChannel,
+    };
+  }
+
+  revokeGuardianBinding(assistantId, resolvedChannel);
+  revokePendingChallenges(assistantId, resolvedChannel);
+
+  const member = findMember({
+    assistantId,
+    sourceChannel: resolvedChannel,
+    externalUserId: bindingBeforeRevoke.guardianExternalUserId,
+    externalChatId: bindingBeforeRevoke.guardianDeliveryChatId,
+  });
+  if (member) {
+    revokeMember(member.id, 'guardian_binding_revoked');
+  }
+
+  return {
+    success: true,
+    bound: false,
+    channel: resolvedChannel,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Guardian verification handler
 // ---------------------------------------------------------------------------
 
@@ -169,31 +212,8 @@ export function handleGuardianVerification(
       const result = getGuardianStatus(channel);
       ctx.send(socket, { type: 'guardian_verification_response', ...result });
     } else if (msg.action === 'revoke') {
-      // Capture binding before revoking so we can revoke the guardian's
-      // ingress member record — without this, the guardian would still pass
-      // the ACL check after unbinding.
-      const bindingBeforeRevoke = getGuardianBinding(assistantId, channel);
-      revokeGuardianBinding(assistantId, channel);
-      revokePendingChallenges(assistantId, channel);
-
-      if (bindingBeforeRevoke) {
-        const member = findMember({
-          assistantId,
-          sourceChannel: channel,
-          externalUserId: bindingBeforeRevoke.guardianExternalUserId,
-          externalChatId: bindingBeforeRevoke.guardianDeliveryChatId,
-        });
-        if (member) {
-          revokeMember(member.id, 'guardian_binding_revoked');
-        }
-      }
-
-      ctx.send(socket, {
-        type: 'guardian_verification_response',
-        success: true,
-        bound: false,
-        channel,
-      });
+      const result = revokeGuardianForChannel(channel);
+      ctx.send(socket, { type: 'guardian_verification_response', ...result });
     } else if (msg.action === 'start_outbound') {
       const result = startOutbound({ channel, destination: msg.destination, rebind: msg.rebind, originConversationId: msg.originConversationId });
       ctx.send(socket, { type: 'guardian_verification_response', ...result });

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -193,6 +193,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   },
   { endpoint: "integrations/guardian/challenge", scopes: ["settings.write"] },
   { endpoint: "integrations/guardian/status", scopes: ["settings.read"] },
+  { endpoint: "integrations/guardian/revoke", scopes: ["settings.write"] },
   {
     endpoint: "integrations/guardian/outbound/start",
     scopes: ["settings.write"],

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -175,6 +175,7 @@ import {
   handleGetSlackChannelConfig,
   handleGetTelegramConfig,
   handleResendOutbound,
+  handleRevokeGuardian,
   handleSetSlackChannelConfig,
   handleSetTelegramCommands,
   handleSetTelegramConfig,
@@ -1217,6 +1218,11 @@ export class RuntimeHttpServer {
         return await handleCreateGuardianChallenge(req);
       if (endpoint === "integrations/guardian/status" && req.method === "GET")
         return handleGetGuardianStatus(url);
+      if (
+        endpoint === "integrations/guardian/revoke" &&
+        req.method === "POST"
+      )
+        return await handleRevokeGuardian(req);
       if (
         endpoint === "integrations/guardian/outbound/start" &&
         req.method === "POST"

--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -16,6 +16,7 @@
  * Guardian verification:
  * POST   /v1/integrations/guardian/challenge        — create a verification challenge
  * GET    /v1/integrations/guardian/status            — check guardian binding status
+ * POST   /v1/integrations/guardian/revoke            — revoke active guardian binding
  * POST   /v1/integrations/guardian/outbound/start    — start outbound verification
  * POST   /v1/integrations/guardian/outbound/resend   — resend outbound verification
  * POST   /v1/integrations/guardian/outbound/cancel   — cancel outbound verification
@@ -25,6 +26,7 @@ import type { ChannelId } from '../../channels/types.js';
 import {
   createGuardianChallenge,
   getGuardianStatus,
+  revokeGuardianForChannel,
 } from '../../daemon/handlers/config-channels.js';
 import {
   clearSlackChannelConfig,
@@ -166,6 +168,20 @@ export function handleGetGuardianStatus(url: URL): Response {
   const channel = (url.searchParams.get('channel') as ChannelId | null) ?? undefined;
   const result = getGuardianStatus(channel);
   return Response.json(result);
+}
+
+/**
+ * POST /v1/integrations/guardian/revoke
+ *
+ * Body: { channel?: ChannelId }
+ */
+export async function handleRevokeGuardian(req: Request): Promise<Response> {
+  const body = (await req.json()) as {
+    channel?: ChannelId;
+  };
+  const result = revokeGuardianForChannel(body.channel);
+  const status = result.success ? 200 : 400;
+  return Response.json(result, { status });
 }
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/http/routes/guardian-control-plane-proxy.ts
+++ b/gateway/src/http/routes/guardian-control-plane-proxy.ts
@@ -90,6 +90,10 @@ export function createGuardianControlPlaneProxyHandler(config: GatewayConfig) {
       return proxyToRuntime(req, "/v1/integrations/guardian/status", url.search);
     },
 
+    async handleRevokeGuardian(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/integrations/guardian/revoke", "");
+    },
+
     async handleStartGuardianOutbound(req: Request): Promise<Response> {
       return proxyToRuntime(req, "/v1/integrations/guardian/outbound/start", "");
     },

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -462,6 +462,7 @@ function main() {
       if (
         (url.pathname === "/v1/integrations/guardian/challenge" && req.method === "POST")
         || (url.pathname === "/v1/integrations/guardian/status" && req.method === "GET")
+        || (url.pathname === "/v1/integrations/guardian/revoke" && req.method === "POST")
         || (url.pathname === "/v1/integrations/guardian/outbound/start" && req.method === "POST")
         || (url.pathname === "/v1/integrations/guardian/outbound/resend" && req.method === "POST")
         || (url.pathname === "/v1/integrations/guardian/outbound/cancel" && req.method === "POST")
@@ -474,6 +475,9 @@ function main() {
         }
         if (url.pathname === "/v1/integrations/guardian/status") {
           return guardianControlPlaneProxy.handleGetGuardianStatus(tracedReq);
+        }
+        if (url.pathname === "/v1/integrations/guardian/revoke") {
+          return guardianControlPlaneProxy.handleRevokeGuardian(tracedReq);
         }
         if (url.pathname === "/v1/integrations/guardian/outbound/start") {
           return guardianControlPlaneProxy.handleStartGuardianOutbound(tracedReq);


### PR DESCRIPTION
## Summary
- Add `POST /v1/integrations/guardian/revoke` endpoint across the full stack: runtime route handler, gateway proxy, and route policy registration
- Extract revoke logic from IPC handler into a reusable `revokeGuardianForChannel()` function that returns a proper error when no binding exists (`not_bound`)
- Update the Guardian Verify Setup skill to document the revoke API and how to use it to remove a guardian from a channel

## Original prompt
If we don't already have one, add a new gateway API for revoking/unbinding a verified guardian from a specific channel. It should be the opposite of verifying a guardian. We should update the verify guardian skill to make known that this API is available and can be used to remove oneself as a guardian of the assistant from a specified channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
