### PR TITLE
Fix Uint8Array<ArrayBufferLike> not assignable to BlobPart in export route

### DIFF
--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -137,7 +137,12 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
     const timestamp = manifest.created_at.replace(/[:.]/g, "-");
     const filename = `export-${timestamp}.vbundle`;
 
-    return new Response(new Blob([archive]), {
+    const body = archive.buffer.slice(
+      archive.byteOffset,
+      archive.byteOffset + archive.byteLength,
+    ) as ArrayBuffer;
+
+    return new Response(body, {
       status: 200,
       headers: {
         "Content-Type": "application/octet-stream",


### PR DESCRIPTION
## Summary
- Fix TypeScript error where `Uint8Array<ArrayBufferLike>` is not assignable to `BlobPart` in the migration export route
- Extract `ArrayBuffer` via `archive.buffer.slice()` with type assertion instead of wrapping `Uint8Array` in `Blob`

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22642922679/job/65623440618

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
