### PR TITLE
fix: add separator between Theme and Timezone in Appearance tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -47,6 +47,8 @@ struct SettingsAppearanceTab: View {
                     .fixedSize()
                 }
 
+                Divider().background(VColor.surfaceBorder)
+
                 HStack(alignment: .top, spacing: VSpacing.lg) {
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         Text("User timezone")


### PR DESCRIPTION
Add Divider between Theme and User Timezone sections in the Display card of SettingsAppearanceTab
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
