### PR TITLE
fix: gateway card Connected + Disconnect buttons when connected

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -27,7 +27,6 @@ struct GatewaySettingsCard: View {
 
             // Gateway running status row
             if store.gatewayReachable == true {
-                VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success, size: .medium) {}
                 tunnelConfigEntry
             } else if tunnelSetupExpanded || !gatewayUrlText.isEmpty {
                 tunnelConfigEntry

--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -132,7 +132,8 @@ struct GatewaySettingsCard: View {
                 .focused($isGatewayUrlFocused)
 
             HStack(spacing: VSpacing.sm) {
-                if store.gatewayReachable == true {
+                let urlChanged = gatewayUrlText != store.ingressPublicBaseUrl
+                if store.gatewayReachable == true && !urlChanged {
                     VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success, size: .medium) {}
                     VButton(label: "Disconnect", style: .danger, size: .medium) {
                         store.saveIngressPublicBaseUrl("")
@@ -145,10 +146,17 @@ struct GatewaySettingsCard: View {
                         tunnelSetupExpanded = false
                     }
                     // No .disabled() — empty URL is valid (clears the tunnel target)
-                    VButton(label: "Cancel", style: .tertiary, size: .medium) {
-                        gatewayUrlText = store.ingressPublicBaseUrl
-                        isGatewayUrlFocused = false
-                        tunnelSetupExpanded = false
+                    if store.gatewayReachable == true {
+                        VButton(label: "Disconnect", style: .danger, size: .medium) {
+                            store.saveIngressPublicBaseUrl("")
+                            tunnelSetupExpanded = false
+                        }
+                    } else {
+                        VButton(label: "Cancel", style: .tertiary, size: .medium) {
+                            gatewayUrlText = store.ingressPublicBaseUrl
+                            isGatewayUrlFocused = false
+                            tunnelSetupExpanded = false
+                        }
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -133,16 +133,24 @@ struct GatewaySettingsCard: View {
                 .focused($isGatewayUrlFocused)
 
             HStack(spacing: VSpacing.sm) {
-                VButton(label: "Save", style: .secondary, size: .medium) {
-                    store.saveIngressPublicBaseUrl(gatewayUrlText)
-                    isGatewayUrlFocused = false
-                    tunnelSetupExpanded = false
-                }
-                // No .disabled() — empty URL is valid (clears the tunnel target)
-                VButton(label: "Cancel", style: .tertiary, size: .medium) {
-                    gatewayUrlText = store.ingressPublicBaseUrl
-                    isGatewayUrlFocused = false
-                    tunnelSetupExpanded = false
+                if store.gatewayReachable == true {
+                    VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success, size: .medium) {}
+                    VButton(label: "Disconnect", style: .danger, size: .medium) {
+                        store.saveIngressPublicBaseUrl("")
+                        tunnelSetupExpanded = false
+                    }
+                } else {
+                    VButton(label: "Save", style: .secondary, size: .medium) {
+                        store.saveIngressPublicBaseUrl(gatewayUrlText)
+                        isGatewayUrlFocused = false
+                        tunnelSetupExpanded = false
+                    }
+                    // No .disabled() — empty URL is valid (clears the tunnel target)
+                    VButton(label: "Cancel", style: .tertiary, size: .medium) {
+                        gatewayUrlText = store.ingressPublicBaseUrl
+                        isGatewayUrlFocused = false
+                        tunnelSetupExpanded = false
+                    }
                 }
             }
         }


### PR DESCRIPTION
When gateway is reachable, replace Save + Cancel with Connected (success) + Disconnect (danger) buttons in GatewaySettingsCard
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
