### PR TITLE
fix: restore Twitter/X tab original titles

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -596,7 +596,7 @@ struct SettingsPanel: View {
                 Spacer()
                 VSegmentedControl(
                     items: [
-                        (label: "Set Up", tag: "local_byo"),
+                        (label: "Local (BYO App)", tag: "local_byo"),
                         (label: "Managed", tag: "managed"),
                     ],
                     selection: $store.twitterMode,
@@ -613,7 +613,7 @@ struct SettingsPanel: View {
                 HStack(spacing: VSpacing.sm) {
                     Image(systemName: "info.circle")
                         .foregroundStyle(VColor.textSecondary)
-                    Text("Managed mode is coming soon. Switch to Set Up to connect now.")
+                    Text("Managed mode is coming soon. Switch to Local (BYO App) to connect now.")
                         .font(VFont.caption)
                         .foregroundStyle(VColor.textSecondary)
                 }


### PR DESCRIPTION
Restore original tab labels: 'Set Up' → 'Local (BYO App)'. Update coming-soon message to reference correct tab name.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
