### PR TITLE
fix: Platform URL Set Up button not working

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -12,6 +12,7 @@ struct SettingsAccountTab: View {
 
     // -- Account / Vellum section state --
     @State private var platformUrlText: String = ""
+    @State private var platformUrlExpanded: Bool = false
     @FocusState private var isPlatformUrlFocused: Bool
 
     // -- Assistant Info state (from SettingsAdvancedTab) --
@@ -132,14 +133,16 @@ struct SettingsAccountTab: View {
                             store.savePlatformBaseUrl(platformUrlText)
                             Task { await store.checkVellumPlatform() }
                             isPlatformUrlFocused = false
+                            platformUrlExpanded = false
                         }
                         .disabled(platformUrlText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                         VButton(label: "Cancel", style: .tertiary, size: .medium) {
                             platformUrlText = store.platformBaseUrl
                             isPlatformUrlFocused = false
+                            platformUrlExpanded = false
                         }
                     }
-                } else if isPlatformUrlFocused || !platformUrlText.isEmpty {
+                } else if isPlatformUrlFocused || platformUrlExpanded || !platformUrlText.isEmpty {
                     TextField("https://platform.vellum.ai", text: $platformUrlText)
                         .vInputStyle()
                         .font(VFont.body)
@@ -150,16 +153,18 @@ struct SettingsAccountTab: View {
                             store.savePlatformBaseUrl(platformUrlText)
                             Task { await store.checkVellumPlatform() }
                             isPlatformUrlFocused = false
+                            platformUrlExpanded = false
                         }
                         .disabled(platformUrlText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                         VButton(label: "Cancel", style: .tertiary, size: .medium) {
                             platformUrlText = store.platformBaseUrl
                             isPlatformUrlFocused = false
+                            platformUrlExpanded = false
                         }
                     }
                 } else {
                     VButton(label: "Set Up", style: .secondary, size: .medium) {
-                        isPlatformUrlFocused = true
+                        platformUrlExpanded = true
                     }
                 }
 


### PR DESCRIPTION
Add @State platformUrlExpanded to control form visibility separately from @FocusState. Setting @FocusState to true before the TextField renders does not expand the form; use a separate bool instead.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
