### PR TITLE
feat: add sidebar search bar that launches command palette

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -136,6 +136,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     private var quickInputWindow: QuickInputWindow?
     private var quickInputHotKeyRef: EventHotKeyRef?
     private var quickInputEventHandlerRef: EventHandlerRef?
+    private var commandPaletteWindow: CommandPaletteWindow?
+    private var cmdKLocalMonitor: Any?
     public let services = AppServices()
     private let assistantCli = AssistantCli()
     public let updateManager = UpdateManager()
@@ -1876,6 +1878,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         registerGlobalHotkeyMonitor()
         registerQuickInputMonitor()
         registerFnVMonitor()
+        registerCmdKMonitor()
 
         globalHotkeyObserver = NotificationCenter.default
             .publisher(for: UserDefaults.didChangeNotification)
@@ -1976,6 +1979,36 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             _ = handler(event)
         }
         fnVLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+    }
+
+    /// Registers Cmd+K as a local shortcut to open the command palette.
+    /// Only active when the app is focused (local monitor, not global).
+    private func registerCmdKMonitor() {
+        let handler: (NSEvent) -> NSEvent? = { [weak self] event in
+            // Cmd+K: keyCode 40 is kVK_ANSI_K
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            guard event.keyCode == 40,
+                  mods == [.command] else {
+                return event
+            }
+            Task { @MainActor in
+                guard self?.isBootstrapping != true else { return }
+                self?.toggleCommandPalette()
+            }
+            return nil // consume the event
+        }
+        cmdKLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+    }
+
+    func toggleCommandPalette() {
+        if let window = commandPaletteWindow, window.isVisible {
+            window.dismiss()
+            return
+        }
+
+        let window = CommandPaletteWindow()
+        window.show()
+        commandPaletteWindow = window
     }
 
     func toggleQuickInput(aboveDock: Bool = false, requestScreenPermission: Bool? = nil) {

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteView.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// SwiftUI view for the command palette search overlay.
+struct CommandPaletteView: View {
+    @Bindable var viewModel: CommandPaletteViewModel
+    var onDismiss: () -> Void
+
+    @FocusState private var isSearchFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Search input
+            HStack(spacing: VSpacing.md) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundColor(VColor.textMuted)
+                    .font(.system(size: 16, weight: .medium))
+
+                TextField("Search conversations, memories, schedules...", text: $viewModel.query)
+                    .textFieldStyle(.plain)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .focused($isSearchFocused)
+
+                if !viewModel.query.isEmpty {
+                    Button {
+                        viewModel.query = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(VColor.textMuted)
+                            .font(.system(size: 14))
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                // Shortcut hint
+                Text("\u{2318}K")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .padding(.horizontal, VSpacing.xs)
+                    .padding(.vertical, VSpacing.xxs)
+                    .background(VColor.surfaceBorder.opacity(0.5))
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.xs))
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.md)
+
+            // Divider
+            VColor.divider
+                .frame(height: 1)
+
+            // Empty state when no query
+            if viewModel.query.isEmpty {
+                emptyState
+            }
+        }
+        .background(VColor.surface)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.3), radius: 20, y: 10)
+        .frame(width: 600)
+        .onAppear {
+            isSearchFocused = true
+        }
+        .onKeyPress(.escape) {
+            onDismiss()
+            return .handled
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: VSpacing.sm) {
+            Text("Type to search across your conversations, memories, schedules, and contacts.")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .multilineTextAlignment(.center)
+        }
+        .padding(VSpacing.xl)
+        .frame(maxWidth: .infinity)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteViewModel.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// State management for the command palette (CMD+K).
+@MainActor
+@Observable
+final class CommandPaletteViewModel {
+    var query = ""
+    var selectedIndex = 0
+
+    /// Resets state for a fresh palette opening.
+    func reset() {
+        query = ""
+        selectedIndex = 0
+    }
+
+    func moveSelectionUp() {
+        if selectedIndex > 0 {
+            selectedIndex -= 1
+        }
+    }
+
+    func moveSelectionDown(maxIndex: Int) {
+        if selectedIndex < maxIndex {
+            selectedIndex += 1
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteWindow.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteWindow.swift
@@ -1,0 +1,151 @@
+import AppKit
+import SwiftUI
+import VellumAssistantShared
+
+/// Borderless NSPanel subclass that can become key window.
+/// Without this override, borderless windows refuse key status
+/// and SwiftUI TextField won't accept keyboard input.
+private class CommandPalettePanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+}
+
+/// A borderless, floating NSPanel that hosts the command palette (CMD+K).
+/// Appears centered on the active screen, slightly above center (Spotlight-style).
+/// Dismisses itself when it resigns key window status.
+@MainActor
+final class CommandPaletteWindow {
+    private var panel: NSPanel?
+    private var resignObserver: Any?
+    private var isDismissing = false
+    private let viewModel = CommandPaletteViewModel()
+
+    /// Callback invoked when the user selects a result that navigates to a conversation.
+    var onSelectConversation: ((String) -> Void)?
+
+    func show() {
+        let panel = makePanel()
+        centerOnScreen(panel)
+        presentPanel(panel)
+    }
+
+    // MARK: - Panel Creation & Presentation
+
+    private func makePanel() -> NSPanel {
+        if let existing = panel {
+            existing.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return existing
+        }
+
+        viewModel.reset()
+
+        let view = CommandPaletteView(
+            viewModel: viewModel,
+            onDismiss: { [weak self] in
+                self?.dismiss()
+            }
+        )
+
+        let hostingController = NSHostingController(rootView: view)
+        hostingController.sizingOptions = [.intrinsicContentSize]
+
+        let newPanel = CommandPalettePanel(
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 120),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        newPanel.contentViewController = hostingController
+        newPanel.level = .floating
+        newPanel.isMovableByWindowBackground = true
+        newPanel.titleVisibility = .hidden
+        newPanel.titlebarAppearsTransparent = true
+        newPanel.isReleasedWhenClosed = false
+        newPanel.backgroundColor = .clear
+        newPanel.isOpaque = false
+        newPanel.hasShadow = true
+        newPanel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+        return newPanel
+    }
+
+    private func presentPanel(_ panel: NSPanel) {
+        panel.alphaValue = 0
+        panel.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = VAnimation.durationFast
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            panel.animator().alphaValue = 1
+        }
+
+        resignObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResignKeyNotification,
+            object: panel,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.dismiss()
+            }
+        }
+
+        self.panel = panel
+    }
+
+    func dismiss() {
+        guard !isDismissing else { return }
+        isDismissing = true
+
+        if let resignObserver {
+            NotificationCenter.default.removeObserver(resignObserver)
+        }
+        resignObserver = nil
+
+        guard let panel else {
+            isDismissing = false
+            return
+        }
+
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = VAnimation.durationFast
+            context.timingFunction = CAMediaTimingFunction(name: .easeIn)
+            panel.animator().alphaValue = 0
+        }, completionHandler: { [weak self] in
+            MainActor.assumeIsolated {
+                panel.close()
+                self?.panel = nil
+                self?.isDismissing = false
+            }
+        })
+    }
+
+    var isVisible: Bool {
+        panel?.isVisible ?? false
+    }
+
+    // MARK: - Positioning
+
+    private func centerOnScreen(_ panel: NSPanel) {
+        let mouseLocation = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first(where: { $0.frame.contains(mouseLocation) })
+            ?? NSScreen.main
+            ?? NSScreen.screens.first
+        guard let screenFrame = screen?.visibleFrame else { return }
+
+        if let fittingSize = panel.contentView?.fittingSize {
+            let width = max(fittingSize.width, 600)
+            let height = fittingSize.height
+            let x = screenFrame.midX - width / 2
+            // Position ~1/3 from top (Spotlight-style)
+            let y = screenFrame.midY + screenFrame.height * 0.15
+            panel.setFrame(
+                NSRect(x: x, y: y, width: width, height: height),
+                display: true
+            )
+        } else {
+            panel.center()
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1164,6 +1164,11 @@ struct MainWindowView: View {
                     .padding(.vertical, VSpacing.sm)
             }
 
+            // MARK: Search Bar
+            SidebarSearchButton(isExpanded: true) {
+                AppDelegate.shared?.toggleCommandPalette()
+            }
+
             // MARK: Nav Items (fixed)
             SidebarNavRow(icon: "brain.head.profile", label: "Intelligence", isActive: windowState.activePanel == .intelligence) {
                 windowState.togglePanel(.intelligence)
@@ -1362,6 +1367,10 @@ struct MainWindowView: View {
                 VColor.divider
                     .frame(height: 1)
                     .padding(.horizontal, VSpacing.xs)
+            }
+
+            SidebarSearchButton(isExpanded: false) {
+                AppDelegate.shared?.toggleCommandPalette()
             }
 
             SidebarNavRow(icon: "brain.head.profile", label: "Intelligence", isActive: windowState.activePanel == .intelligence, isExpanded: false) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/SidebarSearchButton.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/SidebarSearchButton.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// A search bar button in the sidebar that opens the command palette.
+/// In expanded mode, it looks like a search input field with a shortcut hint.
+/// In collapsed mode, it shows only a magnifying glass icon.
+struct SidebarSearchButton: View {
+    var isExpanded: Bool = true
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            if isExpanded {
+                expandedContent
+            } else {
+                collapsedContent
+            }
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, isExpanded ? VSpacing.sm : VSpacing.xs)
+        .onHover { hovering in
+            isHovered = hovering
+            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+    }
+
+    private var expandedContent: some View {
+        HStack(spacing: VSpacing.sm) {
+            Image(systemName: "magnifyingglass")
+                .foregroundColor(VColor.textMuted)
+                .font(.system(size: 12, weight: .medium))
+
+            Text("Search...")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .lineLimit(1)
+
+            Spacer()
+
+            Text("\u{2318}K")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .padding(.horizontal, VSpacing.xs)
+                .padding(.vertical, VSpacing.xxs)
+                .background(VColor.surfaceBorder.opacity(0.5))
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.xs))
+        }
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.sm)
+        .background(
+            (isHovered ? VColor.surfaceBorder.opacity(0.5) : VColor.surfaceBorder.opacity(0.25))
+                .animation(VAnimation.fast, value: isHovered)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+    }
+
+    private var collapsedContent: some View {
+        Image(systemName: "magnifyingglass")
+            .foregroundColor(VColor.textMuted)
+            .font(.system(size: 13, weight: .medium))
+            .frame(width: 20)
+            .padding(.vertical, VSpacing.sm)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .background(
+                (isHovered ? VColor.surfaceBorder.opacity(0.5) : .clear)
+                    .animation(VAnimation.fast, value: isHovered)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .help("Search (\u{2318}K)")
+    }
+}


### PR DESCRIPTION
## Summary
- Create `SidebarSearchButton` component for expanded (search field style) and collapsed (icon) sidebar modes
- Insert search button above Intelligence nav row in both expanded and collapsed sidebar layouts
- Clicking the button calls `AppDelegate.toggleCommandPalette()` to open the CMD+K palette
- Part of the CMD+K command palette feature (PR 4 of 7)

## Test plan
- [ ] `cd clients/macos && swift build` compiles cleanly
- [ ] Expanded sidebar shows search bar with magnifying glass and CMD+K hint above Intelligence
- [ ] Collapsed sidebar shows magnifying glass icon with tooltip
- [ ] Clicking either opens the command palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
