### PR TITLE
fix: section description font → regular weight + reduce title/description spacing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -16,7 +16,7 @@ struct GatewaySettingsCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
                 Text("Gateway")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
@@ -190,13 +190,15 @@ struct SettingsAdvancedDevTab: View {
 
     private var macOSFeatureFlagSection: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("macOS Feature Flags")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.textPrimary)
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("macOS Feature Flags")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
 
-            Text("Local-only flags stored in UserDefaults on this Mac.")
-                .font(VFont.sectionDescription)
-                .foregroundColor(VColor.textMuted)
+                Text("Local-only flags stored in UserDefaults on this Mac.")
+                    .font(VFont.sectionDescription)
+                    .foregroundColor(VColor.textMuted)
+            }
 
             if macOSFlagStates.isEmpty {
                 Text("No macOS feature flags available.")

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -204,7 +204,7 @@ struct SettingsChannelsTab: View {
 
     private var emailCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
                 Text("Email")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
@@ -263,7 +263,7 @@ struct SettingsChannelsTab: View {
 
     private var telegramCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
                 Text("Telegram")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
@@ -415,7 +415,7 @@ struct SettingsChannelsTab: View {
 
     private var slackChannelCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
                 Text("Slack")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
@@ -519,7 +519,7 @@ struct SettingsChannelsTab: View {
 
     private var twilioCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
                 Text("SMS")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
@@ -594,7 +594,7 @@ struct SettingsChannelsTab: View {
 
     private var voiceCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
                 Text("Phone Calling")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
@@ -1444,7 +1444,7 @@ struct SettingsChannelsTab: View {
 
     private var mobileCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
                 Text("Mobile (iOS)")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -7,7 +7,7 @@ struct ToolPermissionTesterView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
                 Text("Permission Simulator")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -54,7 +54,7 @@ struct VoiceSettingsView: View {
 
     private var pttCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
                 Text("Push to Talk")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
@@ -278,7 +278,7 @@ struct VoiceSettingsView: View {
 
     private var wakeWordCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
                 Text("Talk to Vellum, hands free")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
@@ -408,7 +408,7 @@ struct VoiceSettingsView: View {
 
     private var ttsCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
                 Text("Text-to-Speech")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -93,7 +93,7 @@ public enum VFont {
     public static let display    = Font.custom("Inter-SemiBold", size: adaptiveSize(18))
     public static let panelTitle   = Font.custom("Inter-Medium", size: adaptiveSize(24))
     public static let sectionTitle   = Font.custom("Inter-SemiBold", size: adaptiveSize(18))
-    public static let sectionDescription = Font.custom("Inter", size: 14)
+    public static let sectionDescription = Font.custom("Inter", size: 13)
     public static let inputLabel         = Font.custom("Inter-Medium", size: 12)
 
     /// Small label (used for thread tab names)

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -93,7 +93,7 @@ public enum VFont {
     public static let display    = Font.custom("Inter-SemiBold", size: adaptiveSize(18))
     public static let panelTitle   = Font.custom("Inter-Medium", size: adaptiveSize(24))
     public static let sectionTitle   = Font.custom("Inter-SemiBold", size: adaptiveSize(18))
-    public static let sectionDescription = Font.custom("Inter-Medium", size: 14)
+    public static let sectionDescription = Font.custom("Inter", size: 14)
     public static let inputLabel         = Font.custom("Inter-Medium", size: 12)
 
     /// Small label (used for thread tab names)


### PR DESCRIPTION
- VFont.sectionDescription: Inter-Medium → Inter (regular weight)\n- Reduce spacing between section title and description from VSpacing.sm (8px) to VSpacing.xs (4px) across all settings sections
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
