### PR TITLE
Add slack_edit_message tool for editing bot messages

### DIFF
--- a/assistant/src/__tests__/slack-skill.test.ts
+++ b/assistant/src/__tests__/slack-skill.test.ts
@@ -61,12 +61,13 @@ describe("slack skill TOOLS.json", () => {
     expect(names).toContain("slack_channel_details");
     expect(names).toContain("slack_configure_channels");
     expect(names).toContain("slack_add_reaction");
+    expect(names).toContain("slack_edit_message");
     expect(names).toContain("slack_delete_message");
     expect(names).toContain("slack_leave_channel");
   });
 
-  test("has 6 tools total", () => {
-    expect(toolsJson.tools.length).toBe(6);
+  test("has 7 tools total", () => {
+    expect(toolsJson.tools.length).toBe(7);
   });
 
   test("all tools have required fields", () => {

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -162,6 +162,10 @@ SMS is supported as a messaging provider with limited capabilities. The conversa
 
 - **Add Reaction**: Add an emoji reaction to a message
 - **Leave Channel**: Leave a Slack channel
+- **Edit Message**: `slack_edit_message` — edit a message the assistant previously sent. Requires `channel_id` and the message timestamp (`ts`) from the original send response. High risk — requires confidence score.
+- **Delete Message**: `slack_delete_message` — delete a message the assistant previously sent. Requires `channel_id` and the message timestamp (`ts`). High risk — requires confidence score. This is irreversible.
+
+When sending a Slack message, retain the `ts` (message timestamp) from the send response — it is needed to edit or delete that message later. Only messages sent by the assistant's bot can be edited or deleted.
 
 ### Gmail-specific
 

--- a/assistant/src/config/bundled-skills/slack/TOOLS.json
+++ b/assistant/src/config/bundled-skills/slack/TOOLS.json
@@ -98,12 +98,7 @@
             "description": "Confidence score (0-1) for this action"
           }
         },
-        "required": [
-          "channel",
-          "timestamp",
-          "emoji",
-          "confidence"
-        ]
+        "required": ["channel", "timestamp", "emoji", "confidence"]
       },
       "executor": "tools/slack-add-reaction.ts",
       "execution_target": "host"
@@ -129,13 +124,39 @@
             "description": "Confidence score (0-1) for this action"
           }
         },
-        "required": [
-          "channel",
-          "timestamp",
-          "confidence"
-        ]
+        "required": ["channel", "timestamp", "confidence"]
       },
       "executor": "tools/slack-delete-message.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "slack_edit_message",
+      "description": "Edit a Slack message previously posted by the bot. Include a confidence score (0-1).",
+      "category": "slack",
+      "risk": "high",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "channel": {
+            "type": "string",
+            "description": "Slack channel ID"
+          },
+          "timestamp": {
+            "type": "string",
+            "description": "Message timestamp (ts) to edit"
+          },
+          "text": {
+            "type": "string",
+            "description": "New message text"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          }
+        },
+        "required": ["channel", "timestamp", "text", "confidence"]
+      },
+      "executor": "tools/slack-edit-message.ts",
       "execution_target": "host"
     },
     {
@@ -155,10 +176,7 @@
             "description": "Confidence score (0-1) for this action"
           }
         },
-        "required": [
-          "channel",
-          "confidence"
-        ]
+        "required": ["channel", "confidence"]
       },
       "executor": "tools/slack-leave-channel.ts",
       "execution_target": "host"

--- a/assistant/src/config/bundled-skills/slack/tools/slack-edit-message.ts
+++ b/assistant/src/config/bundled-skills/slack/tools/slack-edit-message.ts
@@ -1,0 +1,28 @@
+import { updateMessage } from "../../../../messaging/providers/slack/client.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok, withSlackToken } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const channel = input.channel as string;
+  const timestamp = input.timestamp as string;
+  const text = input.text as string;
+
+  if (!channel || !timestamp || !text) {
+    return err("channel, timestamp, and text are all required.");
+  }
+
+  try {
+    return await withSlackToken(async (token) => {
+      await updateMessage(token, channel, timestamp, text);
+      return ok(`Message updated.`);
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/messaging/providers/slack/client.ts
+++ b/assistant/src/messaging/providers/slack/client.ts
@@ -9,6 +9,7 @@ import type {
   SlackApiResponse,
   SlackAuthTestResponse,
   SlackChatDeleteResponse,
+  SlackChatUpdateResponse,
   SlackConversationHistoryResponse,
   SlackConversationInfoResponse,
   SlackConversationLeaveResponse,
@@ -20,9 +21,9 @@ import type {
   SlackReactionAddResponse,
   SlackSearchMessagesResponse,
   SlackUserInfoResponse,
-} from './types.js';
+} from "./types.js";
 
-const SLACK_API_BASE = 'https://slack.com/api';
+const SLACK_API_BASE = "https://slack.com/api";
 
 export class SlackApiError extends Error {
   constructor(
@@ -31,7 +32,7 @@ export class SlackApiError extends Error {
     message: string,
   ) {
     super(message);
-    this.name = 'SlackApiError';
+    this.name = "SlackApiError";
   }
 }
 
@@ -48,8 +49,8 @@ async function request<T extends SlackApiResponse>(
 
   let init: RequestInit;
   if (body) {
-    headers['Content-Type'] = 'application/json; charset=utf-8';
-    init = { method: 'POST', headers, body: JSON.stringify(body) };
+    headers["Content-Type"] = "application/json; charset=utf-8";
+    init = { method: "POST", headers, body: JSON.stringify(body) };
   } else {
     if (params) {
       const searchParams = new URLSearchParams();
@@ -58,37 +59,52 @@ async function request<T extends SlackApiResponse>(
       }
       url += `?${searchParams}`;
     }
-    init = { method: 'GET', headers };
+    init = { method: "GET", headers };
   }
 
   const resp = await fetch(url, init);
   if (!resp.ok) {
-    throw new SlackApiError(resp.status, `http_${resp.status}`, `Slack API HTTP ${resp.status}`);
+    throw new SlackApiError(
+      resp.status,
+      `http_${resp.status}`,
+      `Slack API HTTP ${resp.status}`,
+    );
   }
 
   const data = (await resp.json()) as T;
   if (!data.ok) {
-    const slackError = data.error ?? 'unknown_error';
+    const slackError = data.error ?? "unknown_error";
     // Map auth errors to 401 for token-manager retry
-    const status = ['invalid_auth', 'token_expired', 'token_revoked', 'not_authed'].includes(slackError) ? 401 : 400;
-    throw new SlackApiError(status, slackError, `Slack API error: ${slackError}`);
+    const status = [
+      "invalid_auth",
+      "token_expired",
+      "token_revoked",
+      "not_authed",
+    ].includes(slackError)
+      ? 401
+      : 400;
+    throw new SlackApiError(
+      status,
+      slackError,
+      `Slack API error: ${slackError}`,
+    );
   }
 
   return data;
 }
 
 export async function authTest(token: string): Promise<SlackAuthTestResponse> {
-  return request<SlackAuthTestResponse>(token, 'auth.test');
+  return request<SlackAuthTestResponse>(token, "auth.test");
 }
 
 export async function listConversations(
   token: string,
-  types = 'public_channel,private_channel,mpim,im',
+  types = "public_channel,private_channel,mpim,im",
   excludeArchived = true,
   limit = 200,
   cursor?: string,
 ): Promise<SlackConversationsListResponse> {
-  return request<SlackConversationsListResponse>(token, 'conversations.list', {
+  return request<SlackConversationsListResponse>(token, "conversations.list", {
     types,
     exclude_archived: String(excludeArchived),
     limit: String(limit),
@@ -100,7 +116,9 @@ export async function conversationInfo(
   token: string,
   channel: string,
 ): Promise<SlackConversationInfoResponse> {
-  return request<SlackConversationInfoResponse>(token, 'conversations.info', { channel });
+  return request<SlackConversationInfoResponse>(token, "conversations.info", {
+    channel,
+  });
 }
 
 export async function conversationHistory(
@@ -111,13 +129,17 @@ export async function conversationHistory(
   oldest?: string,
   cursor?: string,
 ): Promise<SlackConversationHistoryResponse> {
-  return request<SlackConversationHistoryResponse>(token, 'conversations.history', {
-    channel,
-    limit: String(limit),
-    latest,
-    oldest,
-    cursor,
-  });
+  return request<SlackConversationHistoryResponse>(
+    token,
+    "conversations.history",
+    {
+      channel,
+      limit: String(limit),
+      latest,
+      oldest,
+      cursor,
+    },
+  );
 }
 
 export async function conversationReplies(
@@ -126,11 +148,15 @@ export async function conversationReplies(
   ts: string,
   limit = 50,
 ): Promise<SlackConversationRepliesResponse> {
-  return request<SlackConversationRepliesResponse>(token, 'conversations.replies', {
-    channel,
-    ts,
-    limit: String(limit),
-  });
+  return request<SlackConversationRepliesResponse>(
+    token,
+    "conversations.replies",
+    {
+      channel,
+      ts,
+      limit: String(limit),
+    },
+  );
 }
 
 export async function conversationMark(
@@ -138,26 +164,36 @@ export async function conversationMark(
   channel: string,
   ts: string,
 ): Promise<SlackConversationMarkResponse> {
-  return request<SlackConversationMarkResponse>(token, 'conversations.mark', undefined, {
-    channel,
-    ts,
-  });
+  return request<SlackConversationMarkResponse>(
+    token,
+    "conversations.mark",
+    undefined,
+    {
+      channel,
+      ts,
+    },
+  );
 }
 
 export async function conversationsOpen(
   token: string,
   userId: string,
 ): Promise<SlackConversationsOpenResponse> {
-  return request<SlackConversationsOpenResponse>(token, 'conversations.open', undefined, {
-    users: userId,
-  });
+  return request<SlackConversationsOpenResponse>(
+    token,
+    "conversations.open",
+    undefined,
+    {
+      users: userId,
+    },
+  );
 }
 
 export async function userInfo(
   token: string,
   userId: string,
 ): Promise<SlackUserInfoResponse> {
-  return request<SlackUserInfoResponse>(token, 'users.info', { user: userId });
+  return request<SlackUserInfoResponse>(token, "users.info", { user: userId });
 }
 
 export async function postMessage(
@@ -168,7 +204,12 @@ export async function postMessage(
 ): Promise<SlackPostMessageResponse> {
   const body: Record<string, unknown> = { channel, text };
   if (threadTs) body.thread_ts = threadTs;
-  return request<SlackPostMessageResponse>(token, 'chat.postMessage', undefined, body);
+  return request<SlackPostMessageResponse>(
+    token,
+    "chat.postMessage",
+    undefined,
+    body,
+  );
 }
 
 export async function searchMessages(
@@ -177,7 +218,7 @@ export async function searchMessages(
   count = 20,
   page = 1,
 ): Promise<SlackSearchMessagesResponse> {
-  return request<SlackSearchMessagesResponse>(token, 'search.messages', {
+  return request<SlackSearchMessagesResponse>(token, "search.messages", {
     query,
     count: String(count),
     page: String(page),
@@ -190,10 +231,23 @@ export async function addReaction(
   timestamp: string,
   name: string,
 ): Promise<SlackReactionAddResponse> {
-  return request<SlackReactionAddResponse>(token, 'reactions.add', undefined, {
+  return request<SlackReactionAddResponse>(token, "reactions.add", undefined, {
     channel,
     timestamp,
     name,
+  });
+}
+
+export async function updateMessage(
+  token: string,
+  channel: string,
+  ts: string,
+  text: string,
+): Promise<SlackChatUpdateResponse> {
+  return request<SlackChatUpdateResponse>(token, "chat.update", undefined, {
+    channel,
+    ts,
+    text,
   });
 }
 
@@ -202,7 +256,7 @@ export async function deleteMessage(
   channel: string,
   ts: string,
 ): Promise<SlackChatDeleteResponse> {
-  return request<SlackChatDeleteResponse>(token, 'chat.delete', undefined, {
+  return request<SlackChatDeleteResponse>(token, "chat.delete", undefined, {
     channel,
     ts,
   });
@@ -212,7 +266,12 @@ export async function leaveConversation(
   token: string,
   channel: string,
 ): Promise<SlackConversationLeaveResponse> {
-  return request<SlackConversationLeaveResponse>(token, 'conversations.leave', undefined, {
-    channel,
-  });
+  return request<SlackConversationLeaveResponse>(
+    token,
+    "conversations.leave",
+    undefined,
+    {
+      channel,
+    },
+  );
 }

--- a/assistant/src/messaging/providers/slack/types.ts
+++ b/assistant/src/messaging/providers/slack/types.ts
@@ -126,4 +126,10 @@ export interface SlackChatDeleteResponse extends SlackApiResponse {
   ts: string;
 }
 
+export interface SlackChatUpdateResponse extends SlackApiResponse {
+  channel: string;
+  ts: string;
+  text: string;
+}
+
 export type SlackConversationMarkResponse = SlackApiResponse;


### PR DESCRIPTION
## Summary
- Add `chat.update` Slack API support via new `updateMessage` client function and `SlackChatUpdateResponse` type
- Add `slack_edit_message` tool (risk: high, requires confidence score) so the assistant can edit messages it previously sent
- Note: `slack_delete_message` already existed — no changes needed for delete

## Changes
- `assistant/src/messaging/providers/slack/types.ts` — new `SlackChatUpdateResponse` interface
- `assistant/src/messaging/providers/slack/client.ts` — new `updateMessage()` function calling `chat.update`
- `assistant/src/config/bundled-skills/slack/tools/slack-edit-message.ts` — tool executor
- `assistant/src/config/bundled-skills/slack/TOOLS.json` — tool definition with channel, timestamp, text, and confidence params

## Test plan
- [ ] Verify TypeScript compiles cleanly (`tsc --noEmit` passes)
- [ ] Test `slack_edit_message` tool against a real Slack workspace by editing a bot-sent message
- [ ] Confirm error handling for missing params and invalid timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
