### PR TITLE
fix: revoke pending challenges even when no guardian binding exists

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -159,21 +159,24 @@ export function revokeGuardianForChannel(
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const resolvedChannel = channel ?? 'telegram';
 
+  // Always revoke pending challenges first — the macOS app uses
+  // action: "revoke" to cancel an in-flight challenge even before
+  // a binding exists (e.g. during verification setup).
+  revokePendingChallenges(assistantId, resolvedChannel);
+
   // Capture binding before revoking so we can revoke the guardian's
   // ingress member record — without this, the guardian would still pass
   // the ACL check after unbinding.
   const bindingBeforeRevoke = getGuardianBinding(assistantId, resolvedChannel);
   if (!bindingBeforeRevoke) {
     return {
-      success: false,
-      error: 'not_bound',
-      message: 'No active guardian binding exists for this channel.',
+      success: true,
+      bound: false,
       channel: resolvedChannel,
     };
   }
 
   revokeGuardianBinding(assistantId, resolvedChannel);
-  revokePendingChallenges(assistantId, resolvedChannel);
 
   const member = findMember({
     assistantId,


### PR DESCRIPTION
## Summary
- Move `revokePendingChallenges()` call before the binding existence check so it always runs
- Ensures canceling verification during setup (before binding is complete) still invalidates pending challenges
- Addresses reviewer feedback from PR #11782

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
