### PR TITLE
fix: remove SMS from guardian verification prompt and intent routing

### DIFF
--- a/assistant/src/__tests__/guardian-verification-intent-routing.test.ts
+++ b/assistant/src/__tests__/guardian-verification-intent-routing.test.ts
@@ -13,7 +13,6 @@ describe("direct guardian setup phrases trigger forced routing", () => {
     "verify me as your guardian",
     "confirm me as guardian",
     "confirm me as your guardian",
-    "set me as guardian for SMS",
     "set me as guardian for voice",
     "set me as guardian for telegram",
     "set me up as guardian",
@@ -25,10 +24,8 @@ describe("direct guardian setup phrases trigger forced routing", () => {
     "can you verify me as guardian",
     "I want to become your guardian",
     "register me as your guardian",
-    "help me set myself up as your guardian via sms",
     "I need to set myself as guardian",
     "guardian verify",
-    "set me up as guardian for text message",
   ];
 
   for (const phrase of directSetupPhrases) {
@@ -142,14 +139,15 @@ describe("slash commands are never intercepted", () => {
 // =====================================================================
 
 describe("channel hint extraction", () => {
-  test("detects SMS channel hint", () => {
+  test("SMS phrases still trigger setup but without SMS channel hint", () => {
     const result = resolveGuardianVerificationIntent(
       "set me as guardian for SMS",
     );
     expect(result.kind).toBe("direct_setup");
     if (result.kind === "direct_setup") {
-      expect(result.channelHint).toBe("sms");
-      expect(result.rewrittenContent).toContain("sms channel");
+      // SMS is no longer a supported channel; the intent still matches on
+      // the guardian setup pattern but no channel hint is extracted.
+      expect(result.channelHint).toBeUndefined();
     }
   });
 

--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -279,9 +279,9 @@ describe("Guardian verification routing section in system prompt", () => {
     expect(prompt).toContain("verify guardian");
   });
 
-  test('routing section includes trigger phrase "set guardian for SMS"', () => {
+  test('routing section does not include SMS trigger phrase', () => {
     const prompt = buildSystemPrompt();
-    expect(prompt).toContain("set guardian for SMS");
+    expect(prompt).not.toContain("set guardian for SMS");
   });
 
   test('routing section includes trigger phrase "verify my Telegram account"', () => {
@@ -309,14 +309,13 @@ describe("Guardian verification routing section in system prompt", () => {
     expect(prompt).toContain("guardian-verify-setup");
   });
 
-  test("routing section mentions all three channels", () => {
+  test("routing section mentions voice and telegram channels but not sms", () => {
     const prompt = buildSystemPrompt();
-    // The section should mention sms, voice, and telegram as supported channels
     const routingStart = prompt.indexOf("## Routing: Guardian Verification");
     const routingSection = prompt.substring(routingStart, routingStart + 1000);
-    expect(routingSection).toContain("sms");
     expect(routingSection).toContain("voice");
     expect(routingSection).toContain("telegram");
+    expect(routingSection).not.toContain("sms");
   });
 
   test("routing section contains exclusivity wording", () => {

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -226,15 +226,14 @@ export function buildGuardianVerificationRoutingSection(): string {
     "",
     "### Trigger phrases",
     '- "verify guardian"',
-    '- "set guardian for SMS"',
     '- "verify my Telegram account"',
     '- "verify voice channel"',
     '- "verify my phone number"',
     '- "set up guardian verification"',
     "",
     "### What it does",
-    "The skill walks through outbound guardian verification for SMS, voice, or Telegram:",
-    "1. Confirm channel (sms, voice, telegram)",
+    "The skill walks through outbound guardian verification for voice or Telegram:",
+    "1. Confirm channel (voice, telegram)",
     "2. Collect destination (phone number or Telegram handle/chat ID)",
     "3. Start outbound verification via runtime HTTP API",
     "4. Guide the user through code entry, resend, or cancel",
@@ -245,7 +244,7 @@ export function buildGuardianVerificationRoutingSection(): string {
     "- Guardian verification intents must only be handled by `guardian-verify-setup` — load it exclusively.",
     "- Do NOT load `phone-calls` for guardian verification intent routing. The phone-calls skill does not orchestrate verification flows.",
     '- If the user asks to "load phone-calls and guardian verification", prioritize `guardian-verify-setup` and continue the verification flow. Only load `phone-calls` if the user also asks to configure or place regular calls.',
-    '- If the user has already explicitly specified a channel (e.g., "verify my phone for SMS", "verify my Telegram"), do not re-ask which channel unless the input is contradictory. Note: "verify my phone number" alone is ambiguous (phone numbers apply to both sms and voice) — ask which channel.',
+    '- If the user has already explicitly specified a channel (e.g., "verify my phone for voice", "verify my Telegram"), do not re-ask which channel unless the input is contradictory.',
   ].join("\n");
 }
 

--- a/assistant/src/daemon/guardian-verification-intent.ts
+++ b/assistant/src/daemon/guardian-verification-intent.ts
@@ -7,7 +7,7 @@
 
 export type GuardianVerificationIntentResult =
   | { kind: 'none' }
-  | { kind: 'direct_setup'; rewrittenContent: string; channelHint?: 'sms' | 'voice' | 'telegram' };
+  | { kind: 'direct_setup'; rewrittenContent: string; channelHint?: 'voice' | 'telegram' };
 
 // ── Direct setup patterns ────────────────────────────────────────────────
 // These capture imperative requests to start guardian verification.
@@ -42,8 +42,7 @@ const CONCEPTUAL_PATTERNS: RegExp[] = [
 
 // ── Channel hint extraction ──────────────────────────────────────────────
 
-const CHANNEL_HINT_PATTERNS: Array<{ pattern: RegExp; channel: 'sms' | 'voice' | 'telegram' }> = [
-  { pattern: /\b(?:sms|text\s*(?:message)?)\b/i, channel: 'sms' },
+const CHANNEL_HINT_PATTERNS: Array<{ pattern: RegExp; channel: 'voice' | 'telegram' }> = [
   { pattern: /\b(?:voice|call|phone\s*call|by\s+phone)\b/i, channel: 'voice' },
   { pattern: /\btelegram\b/i, channel: 'telegram' },
 ];
@@ -63,7 +62,7 @@ function isDirectSetupIntent(text: string): boolean {
   return DIRECT_SETUP_PATTERNS.some((p) => p.test(text));
 }
 
-function extractChannelHint(text: string): 'sms' | 'voice' | 'telegram' | undefined {
+function extractChannelHint(text: string): 'voice' | 'telegram' | undefined {
   for (const { pattern, channel } of CHANNEL_HINT_PATTERNS) {
     if (pattern.test(text)) return channel;
   }


### PR DESCRIPTION
## Summary
- Update system-prompt.ts to remove SMS from guardian verification channel list and trigger phrases
- Update guardian-verification-intent.ts to stop routing SMS channel hints
- Update tests to match new voice+Telegram-only behavior
- Addresses reviewer feedback from PR #11697

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
