### PR TITLE
feat: wire command palette to global search API with live results

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -2038,6 +2038,17 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             self?.mainWindow?.threadManager.selectThread(id: threadId)
         }
 
+        // Wire runtime HTTP resolver for server search
+        window.runtimeHTTPResolver = {
+            let port = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"]
+                .flatMap(Int.init) ?? 7821
+            if let jwt = ActorTokenManager.getToken(), !jwt.isEmpty {
+                return ("http://localhost:\(port)", jwt)
+            }
+            guard let token = readHttpToken() else { return nil }
+            return ("http://localhost:\(port)", token)
+        }
+
         window.show()
         commandPaletteWindow = window
     }

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteActions.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteActions.swift
@@ -16,15 +16,82 @@ struct CommandPaletteRecentItem: Identifiable {
     let lastInteracted: Date
 }
 
+// MARK: - Server Search Results
+
+/// A conversation result from the global search API.
+struct SearchResultConversation: Identifiable, Decodable {
+    let id: String
+    let title: String?
+    let updatedAt: Double
+    let excerpt: String
+    let matchCount: Int
+}
+
+/// A memory result from the global search API.
+struct SearchResultMemory: Identifiable, Decodable {
+    let id: String
+    let kind: String
+    let text: String
+    let subject: String?
+    let confidence: Double
+    let updatedAt: Double
+    let source: String?
+}
+
+/// A schedule result from the global search API.
+struct SearchResultSchedule: Identifiable, Decodable {
+    let id: String
+    let name: String
+    let expression: String
+    let message: String
+    let enabled: Bool
+    let nextRunAt: Double?
+}
+
+/// A contact result from the global search API.
+struct SearchResultContact: Identifiable, Decodable {
+    let id: String
+    let displayName: String
+    let relationship: String?
+    let lastInteraction: Double?
+}
+
+/// The grouped results from the global search API.
+struct GlobalSearchResults: Decodable {
+    let conversations: [SearchResultConversation]
+    let memories: [SearchResultMemory]
+    let schedules: [SearchResultSchedule]
+    let contacts: [SearchResultContact]
+
+    static let empty = GlobalSearchResults(
+        conversations: [], memories: [], schedules: [], contacts: []
+    )
+}
+
+struct GlobalSearchResponse: Decodable {
+    let query: String
+    let results: GlobalSearchResults
+}
+
+// MARK: - Unified Item Enum
+
 /// A search result item shown in the command palette.
 enum CommandPaletteItem: Identifiable {
     case action(CommandPaletteAction)
     case recent(CommandPaletteRecentItem)
+    case conversation(SearchResultConversation)
+    case memory(SearchResultMemory)
+    case schedule(SearchResultSchedule)
+    case contact(SearchResultContact)
 
     var id: String {
         switch self {
         case .action(let a): return "action:\(a.id)"
         case .recent(let r): return "recent:\(r.id.uuidString)"
+        case .conversation(let c): return "conv:\(c.id)"
+        case .memory(let m): return "mem:\(m.id)"
+        case .schedule(let s): return "sched:\(s.id)"
+        case .contact(let c): return "contact:\(c.id)"
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteView.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteView.swift
@@ -6,6 +6,7 @@ struct CommandPaletteView: View {
     @Bindable var viewModel: CommandPaletteViewModel
     var onDismiss: () -> Void
     var onSelectRecent: ((UUID) -> Void)?
+    var onSelectConversation: ((String) -> Void)?
 
     @FocusState private var isSearchFocused: Bool
 
@@ -13,9 +14,15 @@ struct CommandPaletteView: View {
         VStack(spacing: 0) {
             // Search input
             HStack(spacing: VSpacing.md) {
-                Image(systemName: "magnifyingglass")
-                    .foregroundColor(VColor.textMuted)
-                    .font(.system(size: 16, weight: .medium))
+                if viewModel.isSearching {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(width: 16, height: 16)
+                } else {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundColor(VColor.textMuted)
+                        .font(.system(size: 16, weight: .medium))
+                }
 
                 TextField("Search conversations, memories, schedules...", text: $viewModel.query)
                     .textFieldStyle(.plain)
@@ -29,6 +36,7 @@ struct CommandPaletteView: View {
                 if !viewModel.query.isEmpty {
                     Button {
                         viewModel.query = ""
+                        viewModel.serverResults = .empty
                     } label: {
                         Image(systemName: "xmark.circle.fill")
                             .foregroundColor(VColor.textMuted)
@@ -55,7 +63,7 @@ struct CommandPaletteView: View {
 
             // Results list
             let items = viewModel.allItems
-            if items.isEmpty {
+            if items.isEmpty && !viewModel.isSearching {
                 emptyState
             } else {
                 ScrollView {
@@ -76,16 +84,20 @@ struct CommandPaletteView: View {
                         // Recent items section
                         let recents = viewModel.filteredRecents
                         if !recents.isEmpty {
+                            let recentsOffset = actions.count
                             sectionHeader("Recent")
-                            let actionsCount = actions.count
                             ForEach(Array(recents.enumerated()), id: \.element.id) { index, recent in
-                                recentRow(recent, isSelected: viewModel.selectedIndex == actionsCount + index)
+                                recentRow(recent, isSelected: viewModel.selectedIndex == recentsOffset + index)
                                     .onTapGesture {
                                         onSelectRecent?(recent.id)
                                         onDismiss()
                                     }
                             }
                         }
+
+                        // Server results sections
+                        let serverOffset = actions.count + recents.count
+                        serverResultsSections(startIndex: serverOffset)
                     }
                     .padding(.vertical, VSpacing.xs)
                 }
@@ -117,6 +129,7 @@ struct CommandPaletteView: View {
         }
         .onChange(of: viewModel.query) {
             viewModel.clampSelection()
+            viewModel.triggerSearch()
         }
     }
 
@@ -130,6 +143,57 @@ struct CommandPaletteView: View {
             .padding(.horizontal, VSpacing.lg)
             .padding(.top, VSpacing.sm)
             .padding(.bottom, VSpacing.xs)
+    }
+
+    // MARK: - Server Results Sections
+
+    @ViewBuilder
+    private func serverResultsSections(startIndex: Int) -> some View {
+        let conversations = viewModel.serverResults.conversations
+        let memories = viewModel.serverResults.memories
+        let schedules = viewModel.serverResults.schedules
+        let contacts = viewModel.serverResults.contacts
+
+        var offset = startIndex
+
+        if !conversations.isEmpty {
+            let convOffset = offset
+            sectionHeader("Conversations")
+            ForEach(Array(conversations.enumerated()), id: \.element.id) { index, conv in
+                conversationRow(conv, isSelected: viewModel.selectedIndex == convOffset + index)
+                    .onTapGesture {
+                        onSelectConversation?(conv.id)
+                        onDismiss()
+                    }
+            }
+            let _ = (offset += conversations.count)
+        }
+
+        if !memories.isEmpty {
+            let memOffset = offset
+            sectionHeader("Memories")
+            ForEach(Array(memories.enumerated()), id: \.element.id) { index, memory in
+                memoryRow(memory, isSelected: viewModel.selectedIndex == memOffset + index)
+            }
+            let _ = (offset += memories.count)
+        }
+
+        if !schedules.isEmpty {
+            let schedOffset = offset
+            sectionHeader("Schedules")
+            ForEach(Array(schedules.enumerated()), id: \.element.id) { index, schedule in
+                scheduleRow(schedule, isSelected: viewModel.selectedIndex == schedOffset + index)
+            }
+            let _ = (offset += schedules.count)
+        }
+
+        if !contacts.isEmpty {
+            let contactOffset = offset
+            sectionHeader("Contacts")
+            ForEach(Array(contacts.enumerated()), id: \.element.id) { index, contact in
+                contactRow(contact, isSelected: viewModel.selectedIndex == contactOffset + index)
+            }
+        }
     }
 
     // MARK: - Row Views
@@ -192,9 +256,140 @@ struct CommandPaletteView: View {
         .contentShape(Rectangle())
     }
 
+    private func conversationRow(_ conv: SearchResultConversation, isSelected: Bool) -> some View {
+        HStack(spacing: VSpacing.md) {
+            Image(systemName: "bubble.left.and.bubble.right")
+                .foregroundColor(VColor.textSecondary)
+                .font(.system(size: 13))
+                .frame(width: 20, alignment: .center)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(conv.title ?? "Untitled")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(1)
+
+                if !conv.excerpt.isEmpty {
+                    Text(conv.excerpt)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer()
+
+            Text(relativeTimestamp(conv.updatedAt))
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+        .background(isSelected ? VColor.surfaceBorder.opacity(0.5) : .clear)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        .padding(.horizontal, VSpacing.xs)
+        .contentShape(Rectangle())
+    }
+
+    private func memoryRow(_ memory: SearchResultMemory, isSelected: Bool) -> some View {
+        HStack(spacing: VSpacing.md) {
+            Image(systemName: "brain")
+                .foregroundColor(VColor.textSecondary)
+                .font(.system(size: 13))
+                .frame(width: 20, alignment: .center)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(memory.text)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(2)
+
+                Text(memory.kind)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .padding(.horizontal, VSpacing.xs)
+                    .padding(.vertical, 1)
+                    .background(VColor.surfaceBorder.opacity(0.5))
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.xs))
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+        .background(isSelected ? VColor.surfaceBorder.opacity(0.5) : .clear)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        .padding(.horizontal, VSpacing.xs)
+        .contentShape(Rectangle())
+    }
+
+    private func scheduleRow(_ schedule: SearchResultSchedule, isSelected: Bool) -> some View {
+        HStack(spacing: VSpacing.md) {
+            Image(systemName: "clock")
+                .foregroundColor(VColor.textSecondary)
+                .font(.system(size: 13))
+                .frame(width: 20, alignment: .center)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(schedule.name)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(1)
+
+                Text(schedule.message)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Text(schedule.enabled ? "Active" : "Paused")
+                .font(VFont.caption)
+                .foregroundColor(schedule.enabled ? VColor.success : VColor.textMuted)
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+        .background(isSelected ? VColor.surfaceBorder.opacity(0.5) : .clear)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        .padding(.horizontal, VSpacing.xs)
+        .contentShape(Rectangle())
+    }
+
+    private func contactRow(_ contact: SearchResultContact, isSelected: Bool) -> some View {
+        HStack(spacing: VSpacing.md) {
+            Image(systemName: "person.2")
+                .foregroundColor(VColor.textSecondary)
+                .font(.system(size: 13))
+                .frame(width: 20, alignment: .center)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(contact.displayName)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(1)
+
+                if let relationship = contact.relationship, !relationship.isEmpty {
+                    Text(relationship)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+        .background(isSelected ? VColor.surfaceBorder.opacity(0.5) : .clear)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        .padding(.horizontal, VSpacing.xs)
+        .contentShape(Rectangle())
+    }
+
     private var emptyState: some View {
         VStack(spacing: VSpacing.sm) {
-            Text("No results found.")
+            Text(viewModel.query.isEmpty ? "Type to search..." : "No results found.")
                 .font(VFont.caption)
                 .foregroundColor(VColor.textMuted)
                 .multilineTextAlignment(.center)
@@ -215,6 +410,12 @@ struct CommandPaletteView: View {
         case .recent(let recent):
             onSelectRecent?(recent.id)
             onDismiss()
+        case .conversation(let conv):
+            onSelectConversation?(conv.id)
+            onDismiss()
+        case .memory, .schedule, .contact:
+            // Non-navigable results — no action on Enter
+            break
         }
     }
 
@@ -224,5 +425,10 @@ struct CommandPaletteView: View {
         if interval < 3600 { return "\(Int(interval / 60))m ago" }
         if interval < 86400 { return "\(Int(interval / 3600))h ago" }
         return "\(Int(interval / 86400))d ago"
+    }
+
+    private func relativeTimestamp(_ epochMs: Double) -> String {
+        let date = Date(timeIntervalSince1970: epochMs / 1000)
+        return relativeTime(date)
     }
 }

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteViewModel.swift
@@ -6,12 +6,22 @@ import Foundation
 final class CommandPaletteViewModel {
     var query = ""
     var selectedIndex = 0
+    var isSearching = false
 
     /// Static actions (set once at palette creation).
     var actions: [CommandPaletteAction] = []
 
     /// Recent conversations (set once at palette creation from ThreadManager).
     var recentItems: [CommandPaletteRecentItem] = []
+
+    /// Server search results populated from the global search API.
+    var serverResults = GlobalSearchResults.empty
+
+    /// Debounce task for search queries.
+    private var searchTask: Task<Void, Never>?
+
+    /// Base URL and token resolver for runtime HTTP calls.
+    var runtimeHTTPResolver: (() -> (baseURL: String, token: String)?)?
 
     /// Filtered actions based on the current query.
     var filteredActions: [CommandPaletteAction] {
@@ -27,9 +37,16 @@ final class CommandPaletteViewModel {
         return recentItems.filter { $0.title.lowercased().contains(q) }
     }
 
-    /// All visible items in display order (actions first, then recents).
+    /// All visible items in display order (actions, recents, then server results by category).
     var allItems: [CommandPaletteItem] {
-        filteredActions.map { .action($0) } + filteredRecents.map { .recent($0) }
+        var items: [CommandPaletteItem] = []
+        items += filteredActions.map { .action($0) }
+        items += filteredRecents.map { .recent($0) }
+        items += serverResults.conversations.map { .conversation($0) }
+        items += serverResults.memories.map { .memory($0) }
+        items += serverResults.schedules.map { .schedule($0) }
+        items += serverResults.contacts.map { .contact($0) }
+        return items
     }
 
     /// Total count of visible items.
@@ -37,10 +54,22 @@ final class CommandPaletteViewModel {
         allItems.count
     }
 
+    /// Whether there are any server results to display.
+    var hasServerResults: Bool {
+        !serverResults.conversations.isEmpty ||
+        !serverResults.memories.isEmpty ||
+        !serverResults.schedules.isEmpty ||
+        !serverResults.contacts.isEmpty
+    }
+
     /// Resets state for a fresh palette opening.
     func reset() {
         query = ""
         selectedIndex = 0
+        isSearching = false
+        serverResults = .empty
+        searchTask?.cancel()
+        searchTask = nil
     }
 
     func moveSelectionUp() {
@@ -60,6 +89,65 @@ final class CommandPaletteViewModel {
         let maxIndex = max(0, totalItemCount - 1)
         if selectedIndex > maxIndex {
             selectedIndex = maxIndex
+        }
+    }
+
+    // MARK: - Server Search
+
+    /// Triggers a debounced server search. Call this when the query changes.
+    func triggerSearch() {
+        searchTask?.cancel()
+
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else {
+            serverResults = .empty
+            isSearching = false
+            return
+        }
+
+        isSearching = true
+
+        searchTask = Task { [weak self] in
+            // 150ms debounce
+            try? await Task.sleep(nanoseconds: 150_000_000)
+            guard !Task.isCancelled else { return }
+
+            guard let self else { return }
+            let results = await self.performSearch(query: trimmed)
+
+            guard !Task.isCancelled else { return }
+            self.serverResults = results
+            self.isSearching = false
+            self.clampSelection()
+        }
+    }
+
+    private func performSearch(query: String) async -> GlobalSearchResults {
+        guard let resolver = runtimeHTTPResolver,
+              let http = resolver() else {
+            return .empty
+        }
+
+        let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
+        guard let url = URL(string: "\(http.baseURL)/v1/search/global?q=\(encoded)&limit=10") else {
+            return .empty
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 5
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                return .empty
+            }
+            let decoded = try JSONDecoder().decode(GlobalSearchResponse.self, from: data)
+            return decoded.results
+        } catch {
+            return .empty
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteWindow.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteWindow.swift
@@ -28,6 +28,9 @@ final class CommandPaletteWindow {
     /// Recent conversations to show in the palette.
     var recentItems: [CommandPaletteRecentItem] = []
 
+    /// Resolver for runtime HTTP base URL and bearer token.
+    var runtimeHTTPResolver: (() -> (baseURL: String, token: String)?)?
+
     func show() {
         let panel = makePanel()
         centerOnScreen(panel)
@@ -46,6 +49,7 @@ final class CommandPaletteWindow {
         viewModel.reset()
         viewModel.actions = actions
         viewModel.recentItems = recentItems
+        viewModel.runtimeHTTPResolver = runtimeHTTPResolver
 
         let view = CommandPaletteView(
             viewModel: viewModel,
@@ -54,6 +58,10 @@ final class CommandPaletteWindow {
             },
             onSelectRecent: { [weak self] threadId in
                 self?.onSelectConversation?(threadId)
+            },
+            onSelectConversation: { [weak self] convId in
+                guard let uuid = UUID(uuidString: convId) else { return }
+                self?.onSelectConversation?(uuid)
             }
         )
 


### PR DESCRIPTION
## Summary
- Wire the CMD+K command palette to the `GET /v1/search/global` endpoint with 150ms debounced search
- Add categorized server results (Conversations, Memories, Schedules, Contacts) below static actions and recent items
- Show a loading spinner during search, with category headers and distinct row layouts per result type
- Conversation results are clickable and navigate to the thread; memories show kind badges, schedules show active/paused status

## Test plan
- [ ] Open CMD+K and type a query — verify loading spinner appears briefly
- [ ] Verify server results appear grouped by category with headers
- [ ] Click a conversation result — verify it navigates to that thread
- [ ] Clear the search — verify server results disappear
- [ ] Verify arrow key navigation works across all result types
- [ ] Verify Enter on a conversation result navigates to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
