### PR TITLE
Fix import sort order in http-server.ts

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -139,7 +139,6 @@ import {
   handleListContacts,
   handleMergeContacts,
 } from "./routes/contact-routes.js";
-import { handleGlobalSearch } from "./routes/global-search-routes.js";
 import { handleListConversationAttention } from "./routes/conversation-attention-routes.js";
 // Route handlers — grouped by domain
 import {
@@ -150,6 +149,7 @@ import {
 } from "./routes/conversation-routes.js";
 import { handleDebug } from "./routes/debug-routes.js";
 import { handleSubscribeAssistantEvents } from "./routes/events-routes.js";
+import { handleGlobalSearch } from "./routes/global-search-routes.js";
 import {
   handleGuardianActionDecision,
   handleGuardianActionsPending,


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error by moving `global-search-routes.js` import to alphabetical position

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22643387993/job/65625046626

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
