### PR TITLE
feat: add deep semantic search and command palette polish

### DIFF
--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -72,6 +72,14 @@
       "label": "Local HTTP Enabled",
       "description": "Enable local HTTP transport mode in macOS app",
       "defaultEnabled": false
+    },
+    {
+      "id": "command-palette",
+      "scope": "assistant",
+      "key": "feature_flags.command-palette.enabled",
+      "label": "Command Palette",
+      "description": "Enable the CMD+K command palette for unified search across conversations, memories, schedules, and contacts",
+      "defaultEnabled": true
     }
   ]
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -2010,11 +2010,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
         // Static actions
         window.actions = [
-            CommandPaletteAction(id: "new-conversation", icon: "square.and.pencil", label: "New Conversation", shortcutHint: nil) { [weak self] in
+            CommandPaletteAction(id: "new-conversation", icon: "square.and.pencil", label: "New Conversation", shortcutHint: "\u{2318}N") { [weak self] in
                 self?.mainWindow?.threadManager.enterDraftMode()
                 self?.mainWindow?.windowState.selection = nil
             },
-            CommandPaletteAction(id: "settings", icon: "gear", label: "Settings", shortcutHint: nil) { [weak self] in
+            CommandPaletteAction(id: "settings", icon: "gear", label: "Settings", shortcutHint: "\u{2318},") { [weak self] in
                 self?.mainWindow?.windowState.togglePanel(.settings)
             },
             CommandPaletteAction(id: "app-directory", icon: "square.grid.2x2", label: "App Directory", shortcutHint: nil) { [weak self] in

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteView.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteView.swift
@@ -98,8 +98,22 @@ struct CommandPaletteView: View {
                         // Server results sections
                         let serverOffset = actions.count + recents.count
                         serverResultsSections(startIndex: serverOffset)
+
+                        // Deep search indicator
+                        if viewModel.isDeepSearching {
+                            HStack(spacing: VSpacing.sm) {
+                                ProgressView()
+                                    .controlSize(.mini)
+                                Text("Searching deeper...")
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.textMuted)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .padding(.vertical, VSpacing.sm)
+                        }
                     }
                     .padding(.vertical, VSpacing.xs)
+                    .animation(.easeInOut(duration: VAnimation.durationFast), value: viewModel.serverResults.memories.count)
                 }
                 .frame(maxHeight: 400)
             }
@@ -388,12 +402,21 @@ struct CommandPaletteView: View {
     }
 
     private var emptyState: some View {
-        VStack(spacing: VSpacing.sm) {
-            Text(viewModel.query.isEmpty ? "Type to search..." : "No results found.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
-                .multilineTextAlignment(.center)
+        VStack(spacing: VSpacing.xs) {
+            if viewModel.query.isEmpty {
+                Text("Type to search...")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            } else {
+                Text("No results found.")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                Text("Try rephrasing your search.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            }
         }
+        .multilineTextAlignment(.center)
         .padding(VSpacing.xl)
         .frame(maxWidth: .infinity)
     }

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteViewModel.swift
@@ -7,6 +7,7 @@ final class CommandPaletteViewModel {
     var query = ""
     var selectedIndex = 0
     var isSearching = false
+    var isDeepSearching = false
 
     /// Static actions (set once at palette creation).
     var actions: [CommandPaletteAction] = []
@@ -19,6 +20,9 @@ final class CommandPaletteViewModel {
 
     /// Debounce task for search queries.
     private var searchTask: Task<Void, Never>?
+
+    /// Deep search task that runs after fast results arrive.
+    private var deepSearchTask: Task<Void, Never>?
 
     /// Base URL and token resolver for runtime HTTP calls.
     var runtimeHTTPResolver: (() -> (baseURL: String, token: String)?)?
@@ -67,9 +71,12 @@ final class CommandPaletteViewModel {
         query = ""
         selectedIndex = 0
         isSearching = false
+        isDeepSearching = false
         serverResults = .empty
         searchTask?.cancel()
         searchTask = nil
+        deepSearchTask?.cancel()
+        deepSearchTask = nil
     }
 
     func moveSelectionUp() {
@@ -97,11 +104,13 @@ final class CommandPaletteViewModel {
     /// Triggers a debounced server search. Call this when the query changes.
     func triggerSearch() {
         searchTask?.cancel()
+        deepSearchTask?.cancel()
 
         let trimmed = query.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else {
             serverResults = .empty
             isSearching = false
+            isDeepSearching = false
             return
         }
 
@@ -113,30 +122,66 @@ final class CommandPaletteViewModel {
             guard !Task.isCancelled else { return }
 
             guard let self else { return }
-            let results = await self.performSearch(query: trimmed)
+            let results = await self.performSearch(query: trimmed, deep: false)
 
             guard !Task.isCancelled else { return }
             self.serverResults = results
             self.isSearching = false
             self.clampSelection()
+
+            // Auto-fire deep search after fast results arrive
+            self.triggerDeepSearch(query: trimmed)
         }
     }
 
-    private func performSearch(query: String) async -> GlobalSearchResults {
+    /// Fires a deep semantic search after the fast phase completes.
+    private func triggerDeepSearch(query: String) {
+        deepSearchTask?.cancel()
+        isDeepSearching = true
+
+        deepSearchTask = Task { [weak self] in
+            guard let self else { return }
+            let deepResults = await self.performSearch(query: query, deep: true)
+
+            guard !Task.isCancelled else { return }
+
+            // Merge deep memory results with existing, deduplicating by ID
+            let existingMemoryIds = Set(self.serverResults.memories.map(\.id))
+            let newMemories = deepResults.memories.filter { !existingMemoryIds.contains($0.id) }
+            if !newMemories.isEmpty {
+                var updated = self.serverResults
+                updated = GlobalSearchResults(
+                    conversations: updated.conversations,
+                    memories: updated.memories + newMemories,
+                    schedules: updated.schedules,
+                    contacts: updated.contacts
+                )
+                self.serverResults = updated
+                self.clampSelection()
+            }
+            self.isDeepSearching = false
+        }
+    }
+
+    private func performSearch(query: String, deep: Bool) async -> GlobalSearchResults {
         guard let resolver = runtimeHTTPResolver,
               let http = resolver() else {
             return .empty
         }
 
         let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
-        guard let url = URL(string: "\(http.baseURL)/v1/search/global?q=\(encoded)&limit=10") else {
+        var urlString = "\(http.baseURL)/v1/search/global?q=\(encoded)&limit=10"
+        if deep {
+            urlString += "&deep=true&categories=memories"
+        }
+        guard let url = URL(string: urlString) else {
             return .empty
         }
 
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
-        request.timeoutInterval = 5
+        request.timeoutInterval = deep ? 10 : 5
 
         do {
             let (data, response) = try await URLSession.shared.data(for: request)

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -72,6 +72,14 @@
       "label": "Local HTTP Enabled",
       "description": "Enable local HTTP transport mode in macOS app",
       "defaultEnabled": false
+    },
+    {
+      "id": "command-palette",
+      "scope": "assistant",
+      "key": "feature_flags.command-palette.enabled",
+      "label": "Command Palette",
+      "description": "Enable the CMD+K command palette for unified search across conversations, memories, schedules, and contacts",
+      "defaultEnabled": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Auto-fire deep semantic search (Qdrant) after fast results arrive, merging semantic memories with deduplication
- Show "Searching deeper..." indicator while semantic search runs
- Improve empty state with "Try rephrasing your search" guidance
- Add keyboard shortcut hints (⌘N, ⌘,) to New Conversation and Settings actions
- Register `command_palette` feature flag in the unified registry (default enabled)
- Animate height transitions as deep results arrive

## Test plan
- [ ] Type a query — verify fast results appear, then "Searching deeper..." briefly shows
- [ ] Verify additional semantic memory results merge in after deep search completes
- [ ] Verify no duplicate memories appear (deduplication by ID)
- [ ] Check empty state shows "No results found. Try rephrasing your search."
- [ ] Verify ⌘N and ⌘, hints appear on New Conversation and Settings actions
- [ ] Verify `command_palette` flag appears in feature flag registry and guard tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
