### PR TITLE
feat: surface deselection context to LLM and increase scan limits

### DIFF
--- a/assistant/src/__tests__/session-surfaces-deselection.test.ts
+++ b/assistant/src/__tests__/session-surfaces-deselection.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { ListSurfaceData, TableColumn, TableRow, TableSurfaceData } from '../daemon/ipc-contract/surfaces.js';
+import type { SurfaceData, SurfaceType } from '../daemon/ipc-protocol.js';
+import {
+  buildDeselectionDescription,
+  describeTableRow,
+  formatDeselectionList,
+} from '../daemon/session-surfaces.js';
+
+const cols: TableColumn[] = [
+  { id: 'sender', label: 'Sender' },
+  { id: 'count', label: 'Emails Found' },
+];
+
+function makeTableState(rows: TableRow[]): { surfaceType: SurfaceType; data: SurfaceData } {
+  const data: TableSurfaceData = { columns: cols, rows, selectionMode: 'multiple' };
+  return { surfaceType: 'table', data };
+}
+
+function makeListState(items: ListSurfaceData['items']): { surfaceType: SurfaceType; data: SurfaceData } {
+  const data: ListSurfaceData = { items, selectionMode: 'multiple' };
+  return { surfaceType: 'list', data };
+}
+
+describe('describeTableRow', () => {
+  test('extracts plain string cell value', () => {
+    const row: TableRow = { id: 'r1', cells: { sender: 'Acme Corp', count: '5' } };
+    expect(describeTableRow(row, cols)).toBe('Acme Corp');
+  });
+
+  test('extracts text from rich cell value object', () => {
+    const row: TableRow = {
+      id: 'r2',
+      cells: { sender: { text: 'Newsletter Inc', icon: 'envelope', iconColor: 'muted' }, count: '12' },
+    };
+    expect(describeTableRow(row, cols)).toBe('Newsletter Inc');
+  });
+
+  test('falls back to row id when columns are empty', () => {
+    const row: TableRow = { id: 'r3', cells: { sender: 'X' } };
+    expect(describeTableRow(row, [])).toBe('r3');
+  });
+
+  test('falls back to row id when first column cell is missing', () => {
+    const row: TableRow = { id: 'r4', cells: { count: '3' } };
+    expect(describeTableRow(row, cols)).toBe('r4');
+  });
+});
+
+describe('formatDeselectionList', () => {
+  test('formats labels as bullet list', () => {
+    const result = formatDeselectionList(['Alpha', 'Beta']);
+    expect(result).toBe('- Alpha\n- Beta');
+  });
+
+  test('returns empty string for empty list', () => {
+    expect(formatDeselectionList([])).toBe('');
+  });
+
+  test('truncates at 20 items with suffix', () => {
+    const labels = Array.from({ length: 25 }, (_, i) => `Item ${i + 1}`);
+    const result = formatDeselectionList(labels);
+    const lines = result.split('\n');
+    expect(lines).toHaveLength(21); // 20 items + 1 "(and 5 more)"
+    expect(lines[20]).toBe('(and 5 more)');
+    expect(lines[0]).toBe('- Item 1');
+    expect(lines[19]).toBe('- Item 20');
+  });
+});
+
+describe('buildDeselectionDescription', () => {
+  test('table with deselections includes deselected labels', () => {
+    const state = makeTableState([
+      { id: 'r1', cells: { sender: 'Keep Me', count: '2' } },
+      { id: 'r2', cells: { sender: 'Archive Me', count: '10' } },
+      { id: 'r3', cells: { sender: 'Also Keep', count: '1' } },
+    ]);
+    const result = buildDeselectionDescription('table', state, ['r2']);
+    expect(result).toContain('Deselected items (user chose NOT to include):');
+    expect(result).toContain('- Keep Me');
+    expect(result).toContain('- Also Keep');
+    expect(result).not.toContain('Archive Me');
+  });
+
+  test('list with deselections includes deselected titles', () => {
+    const state = makeListState([
+      { id: 'i1', title: 'Important' },
+      { id: 'i2', title: 'Spam Newsletter' },
+      { id: 'i3', title: 'Another Important' },
+    ]);
+    const result = buildDeselectionDescription('list', state, ['i2']);
+    expect(result).toContain('Deselected items (user chose NOT to include):');
+    expect(result).toContain('- Important');
+    expect(result).toContain('- Another Important');
+    expect(result).not.toContain('Spam Newsletter');
+  });
+
+  test('all selected — no deselection text', () => {
+    const state = makeTableState([
+      { id: 'r1', cells: { sender: 'A', count: '1' } },
+      { id: 'r2', cells: { sender: 'B', count: '2' } },
+    ]);
+    const result = buildDeselectionDescription('table', state, ['r1', 'r2']);
+    expect(result).toBe('');
+  });
+
+  test('non-selectable rows excluded from deselection list', () => {
+    const state = makeTableState([
+      { id: 'r1', cells: { sender: 'Selectable', count: '3' }, selectable: true },
+      { id: 'r2', cells: { sender: 'Not Selectable', count: '5' }, selectable: false },
+      { id: 'r3', cells: { sender: 'Also Selectable', count: '1' } },
+    ]);
+    // Only r1 is selected — r2 is non-selectable so should not appear as deselected, r3 should
+    const result = buildDeselectionDescription('table', state, ['r1']);
+    expect(result).toContain('- Also Selectable');
+    expect(result).not.toContain('Not Selectable');
+  });
+
+  test('rich cell values (objects with text field) handled correctly', () => {
+    const state = makeTableState([
+      { id: 'r1', cells: { sender: { text: 'Elevate (invoices)', icon: 'doc', iconColor: 'muted' }, count: '7' } },
+      { id: 'r2', cells: { sender: { text: 'Promo Blast', icon: 'megaphone', iconColor: 'warning' }, count: '20' } },
+    ]);
+    const result = buildDeselectionDescription('table', state, ['r2']);
+    expect(result).toContain('- Elevate (invoices)');
+    expect(result).not.toContain('Promo Blast');
+  });
+
+  test('truncation at 20 items with "(and N more)" suffix', () => {
+    const rows: TableRow[] = Array.from({ length: 25 }, (_, i) => ({
+      id: `r${i}`,
+      cells: { sender: `Sender ${i}`, count: '1' },
+    }));
+    const state = makeTableState(rows);
+    // Select none — all 25 are deselected
+    const result = buildDeselectionDescription('table', state, []);
+    expect(result).toContain('(and 5 more)');
+    // Should have exactly 20 bullet items
+    const bullets = result.match(/^- /gm);
+    expect(bullets).toHaveLength(20);
+  });
+
+  test('returns empty for undefined surface state', () => {
+    expect(buildDeselectionDescription('table', undefined, ['r1'])).toBe('');
+  });
+
+  test('returns empty for mismatched surface type', () => {
+    const state = makeTableState([{ id: 'r1', cells: { sender: 'A', count: '1' } }]);
+    // Pass 'list' type but table state
+    expect(buildDeselectionDescription('list', state, [])).toBe('');
+  });
+});

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -291,7 +291,7 @@ Use `messaging_analyze_activity` to classify channels or conversations by activi
 
 When a user asks to declutter, clean up, or organize their email — start scanning immediately. Don't ask what kind of cleanup they want or request permission to read their inbox. Go straight to scanning — but once results are ready, always show them via `ui_show` and let the user choose actions before archiving or unsubscribing.
 
-**CRITICAL**: Never call `gmail_batch_archive`, `gmail_archive_by_query`, `gmail_unsubscribe`, or `messaging_archive_by_sender` unless the user has clicked an action button on the table for that specific batch. Each batch of results requires its own explicit user confirmation via the table UI. If the user says "keep going" or "keep decluttering," that means scan and present a new table — NOT auto-archive. Previous batch approvals do not carry forward.
+**CRITICAL**: Never call `gmail_batch_archive`, `gmail_archive_by_query`, `gmail_unsubscribe`, or `messaging_archive_by_sender` unless the user has clicked an action button on the table for that specific batch. Each batch of results requires its own explicit user confirmation via the table UI. If the user says "keep going" or "keep decluttering," that means scan and present a new table — NOT auto-archive. Previous batch approvals do not carry forward, but **deselections DO carry forward**: when the user deselects senders from a cleanup table, the system records those deselections as user preferences. Before building the next cleanup table, check `<dynamic-user-profile>` for previously deselected senders and exclude them from future cleanup tables — the user already indicated they want to keep those.
 
 ### Provider Selection
 
@@ -327,9 +327,7 @@ When a user asks to declutter, clean up, or organize their email — start scann
 
 - **Zero results**: Tell the user "No newsletter emails found" and suggest broadening the query (e.g. removing the category filter or extending the date range)
 - **Unsubscribe failures**: Report per-sender success/failure; the existing `gmail_unsubscribe` tool handles edge cases
-- **Truncation handling**: The scan covers up to 2000 messages per call (cap 5000). The default 2000 captures the vast majority of newsletter senders. If `truncated` is true:
-  - Tell the user: "Scanned [N] messages — here are your top senders." The top senders are almost always captured in the first pass.
-  - If the user explicitly asks to scan more, make ONE additional call with the `page_token`. Never chain more than 2 calls total.
+- **Truncation handling**: The scan covers up to 5,000 messages by default (cap 10,000). If `truncated` is true, the top senders are still captured — don't offer to scan more. Tell the user: "Scanned [N] messages — here are your top senders."
 - **Time budget exceeded**: If the scan returns `time_budget_exceeded: true`, present whatever results were collected. Do not retry or continue — the partial results are useful as-is.
 
 ### Scan ID

--- a/assistant/src/config/bundled-skills/messaging/TOOLS.json
+++ b/assistant/src/config/bundled-skills/messaging/TOOLS.json
@@ -959,15 +959,15 @@
           },
           "max_messages": {
             "type": "number",
-            "description": "Maximum messages to scan (default 2000, cap 5000)"
+            "description": "Maximum messages to scan (default 5000, cap 10000)"
           },
           "max_senders": {
             "type": "number",
-            "description": "Maximum senders to return (default 30)"
+            "description": "Maximum senders to return (default 50)"
           },
           "page_token": {
             "type": "string",
-            "description": "Resume token from a previous scan's next_page_token to continue scanning beyond the cap"
+            "description": "Resume token from a previous scan (rarely needed — scans now cover up to 10,000 messages in a single call)"
           }
         }
       },
@@ -992,7 +992,7 @@
           },
           "max_messages": {
             "type": "number",
-            "description": "Maximum messages to scan (default 2000, cap 2000)"
+            "description": "Maximum messages to scan (default 5000, cap 5000)"
           },
           "max_senders": {
             "type": "number",
@@ -1000,7 +1000,7 @@
           },
           "page_token": {
             "type": "string",
-            "description": "Resume token from a previous scan's next_page_token to continue scanning beyond the cap"
+            "description": "Resume token from a previous scan (rarely needed — scans now cover up to 5,000 messages in a single call)"
           }
         }
       },
@@ -1046,7 +1046,7 @@
         "properties": {
           "max_messages": {
             "type": "number",
-            "description": "Maximum messages to scan (default 500, cap 2000)"
+            "description": "Maximum messages to scan (default 2000, cap 5000)"
           },
           "max_senders": {
             "type": "number",
@@ -1062,7 +1062,7 @@
           },
           "page_token": {
             "type": "string",
-            "description": "Resume token from a previous scan's next_page_token to continue scanning beyond the cap"
+            "description": "Resume token from a previous scan (rarely needed — scans now cover up to 5,000 messages in a single call)"
           }
         }
       },

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-outreach-scan.ts
@@ -8,8 +8,8 @@ import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.j
 import { storeScanResult } from './scan-result-store.js';
 import { err,ok } from './shared.js';
 
-const MAX_MESSAGES_CAP = 2000;
-const MAX_IDS_PER_SENDER = 1000;
+const MAX_MESSAGES_CAP = 5000;
+const MAX_IDS_PER_SENDER = 5000;
 const MAX_SAMPLE_SUBJECTS = 3;
 
 interface OutreachSenderAggregation {
@@ -68,7 +68,7 @@ function mostCommon(items: string[]): string {
 }
 
 export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-  const maxMessages = Math.min((input.max_messages as number) ?? 500, MAX_MESSAGES_CAP);
+  const maxMessages = Math.min((input.max_messages as number) ?? 2000, MAX_MESSAGES_CAP);
   const maxSenders = (input.max_senders as number) ?? 30;
   const timeRange = (input.time_range as string) ?? '90d';
   const minConfidence = (input.min_confidence as number) ?? 0.5;
@@ -238,7 +238,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         senders,
         total_scanned: allMessageIds.length,
         outreach_detected: totalOutreachDetected,
-        ...(truncated ? { truncated: true, next_page_token: pageToken } : {}),
+        ...(truncated ? { truncated: true } : {}),
         ...(timeBudgetExceeded ? { time_budget_exceeded: true } : {}),
       }));
     });

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
@@ -6,7 +6,7 @@ import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.j
 import { storeScanResult } from './scan-result-store.js';
 import { err,ok } from './shared.js';
 
-const MAX_MESSAGES_CAP = 5000;
+const MAX_MESSAGES_CAP = 10000;
 const MAX_IDS_PER_SENDER = 5000;
 const MAX_SAMPLE_SUBJECTS = 3;
 
@@ -38,8 +38,8 @@ function parseFrom(from: string): { displayName: string; email: string } {
 
 export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
   const query = (input.query as string) ?? 'category:promotions newer_than:90d';
-  const maxMessages = Math.min((input.max_messages as number) ?? 2000, MAX_MESSAGES_CAP);
-  const maxSenders = (input.max_senders as number) ?? 30;
+  const maxMessages = Math.min((input.max_messages as number) ?? 5000, MAX_MESSAGES_CAP);
+  const maxSenders = (input.max_senders as number) ?? 50;
   const inputPageToken = input.page_token as string | undefined;
 
   try {
@@ -190,7 +190,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         senders: resultSenders,
         total_scanned: allMessageIds.length,
         query_used: query,
-        ...(truncated ? { truncated: true, next_page_token: pageToken } : {}),
+        ...(truncated ? { truncated: true } : {}),
         ...(timeBudgetExceeded ? { time_budget_exceeded: true } : {}),
         note: `message_count reflects emails found per sender within the ${allMessageIds.length} messages scanned. Use scan_id with gmail_batch_archive to archive messages (pass scan_id + sender_ids instead of message_ids).`,
       }));

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-sender-digest.ts
@@ -24,7 +24,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
           senders: [],
           total_scanned: result.totalScanned,
           query_used: result.queryUsed,
-          ...(result.truncated ? { truncated: true, next_page_token: result.nextPageToken } : {}),
+          ...(result.truncated ? { truncated: true } : {}),
           message: 'No emails found matching the query. Try broadening the search (e.g. remove category filter or extend date range).',
         }));
       }
@@ -53,7 +53,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         senders,
         total_scanned: result.totalScanned,
         query_used: result.queryUsed,
-        ...(result.truncated ? { truncated: true, next_page_token: result.nextPageToken } : {}),
+        ...(result.truncated ? { truncated: true } : {}),
         note: `message_count reflects emails found per sender within the ${result.totalScanned} messages scanned. Use scan_id with the archive tool to archive messages (pass scan_id + sender_ids instead of message_ids).`,
       }));
     });

--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -12,9 +12,13 @@ import type {
   CardSurfaceData,
   DynamicPageSurfaceData,
   FileUploadSurfaceData,
+  ListSurfaceData,
   ServerMessage,
   SurfaceData,
   SurfaceType,
+  TableColumn,
+  TableRow,
+  TableSurfaceData,
   UiSurfaceShow,
 } from './ipc-protocol.js';
 import { INTERACTIVE_SURFACE_TYPES } from './ipc-protocol.js';
@@ -377,6 +381,69 @@ export function handleSurfaceUndo(ctx: SurfaceSessionContext, surfaceId: string)
   log.info({ conversationId: ctx.conversationId, surfaceId, remaining: stack.length }, 'Surface undo applied');
 }
 
+/** Extract a human-readable label from a table row using the first column value. */
+export function describeTableRow(row: TableRow, columns: TableColumn[]): string {
+  if (columns.length === 0) return row.id;
+  const firstColId = columns[0].id;
+  const cell = row.cells[firstColId];
+  if (cell == null) return row.id;
+  if (typeof cell === 'string') return cell;
+  return cell.text;
+}
+
+const MAX_DESELECTION_ITEMS = 20;
+
+/** Format a list of deselected item labels as a bullet list, capped at MAX_DESELECTION_ITEMS. */
+export function formatDeselectionList(labels: string[]): string {
+  if (labels.length === 0) return '';
+  const shown = labels.slice(0, MAX_DESELECTION_ITEMS);
+  const lines = shown.map(l => `- ${l}`);
+  if (labels.length > MAX_DESELECTION_ITEMS) {
+    lines.push(`(and ${labels.length - MAX_DESELECTION_ITEMS} more)`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Compute a deselection description by diffing selectedIds against the stored
+ * surface state rows/items. Returns empty string when nothing was deselected.
+ */
+export function buildDeselectionDescription(
+  surfaceType: SurfaceType,
+  surfaceState: { surfaceType: SurfaceType; data: SurfaceData } | undefined,
+  selectedIds: string[],
+): string {
+  if (!surfaceState) return '';
+  const selectedSet = new Set(selectedIds);
+
+  if (surfaceType === 'table' && surfaceState.surfaceType === 'table') {
+    const tableData = surfaceState.data as TableSurfaceData;
+    const deselectedLabels: string[] = [];
+    for (const row of tableData.rows) {
+      if (row.selectable === false) continue;
+      if (!selectedSet.has(row.id)) {
+        deselectedLabels.push(describeTableRow(row, tableData.columns));
+      }
+    }
+    if (deselectedLabels.length === 0) return '';
+    return `\n\nDeselected items (user chose NOT to include):\n${formatDeselectionList(deselectedLabels)}`;
+  }
+
+  if (surfaceType === 'list' && surfaceState.surfaceType === 'list') {
+    const listData = surfaceState.data as ListSurfaceData;
+    const deselectedLabels: string[] = [];
+    for (const item of listData.items) {
+      if (!selectedSet.has(item.id)) {
+        deselectedLabels.push(item.title);
+      }
+    }
+    if (deselectedLabels.length === 0) return '';
+    return `\n\nDeselected items (user chose NOT to include):\n${formatDeselectionList(deselectedLabels)}`;
+  }
+
+  return '';
+}
+
 export function handleSurfaceAction(ctx: SurfaceSessionContext, surfaceId: string, actionId: string, data?: Record<string, unknown>): void {
   const pending = ctx.pendingSurfaceActions.get(surfaceId);
   if (!pending) {
@@ -406,16 +473,23 @@ export function handleSurfaceAction(ctx: SurfaceSessionContext, surfaceId: strin
 
   // Build a human-readable summary so the LLM clearly understands the
   // user's decision instead of parsing raw JSON.
-  const summary = buildCompletionSummary(pending.surfaceType, actionId, data);
+  const stored = ctx.surfaceState.get(surfaceId);
+  const surfaceData = stored?.data as Record<string, unknown> | undefined;
+  const summary = buildCompletionSummary(pending.surfaceType, actionId, data, surfaceData);
   let fallbackContent = `[User action on ${pending.surfaceType} surface: ${summary}]`;
   // Append structured data so the LLM has access to IDs/values it needs
   // to act on (e.g. selectedIds for archiving).
   if (data && Object.keys(data).length > 0) {
     fallbackContent += `\n\nAction data: ${JSON.stringify(data)}`;
   }
+  // Append deselection context for table/list surfaces so the LLM knows what the user chose to keep.
+  const selectedIds = data?.selectedIds as string[] | undefined;
+  if (selectedIds && (pending.surfaceType === 'table' || pending.surfaceType === 'list')) {
+    fallbackContent += buildDeselectionDescription(pending.surfaceType, stored, selectedIds);
+  }
   const content = prompt || fallbackContent;
   // Show the user plain-text instead of raw JSON action data.
-  const displayContent = prompt ? undefined : buildUserFacingLabel(pending.surfaceType, actionId, data);
+  const displayContent = prompt ? undefined : buildUserFacingLabel(pending.surfaceType, actionId, data, surfaceData);
 
   const requestId = uuid();
   ctx.surfaceActionRequestIds.add(requestId);
@@ -529,9 +603,12 @@ export function refreshSurfacesForApp(ctx: SurfaceSessionContext, appId: string,
   return refreshed;
 }
 
-export function buildCompletionSummary(surfaceType: string | undefined, actionId: string, data?: Record<string, unknown>): string {
+export function buildCompletionSummary(surfaceType: string | undefined, actionId: string, data?: Record<string, unknown>, surfaceData?: Record<string, unknown>): string {
   if (surfaceType === 'confirmation') {
-    if (actionId === 'cancel') return 'Cancelled';
+    if (actionId === 'cancel') {
+      const cancelLabel = typeof surfaceData?.cancelLabel === 'string' ? surfaceData.cancelLabel : undefined;
+      return cancelLabel ? `User chose: "${cancelLabel}"` : 'Cancelled';
+    }
     if (actionId === 'confirm') return 'Confirmed';
     // Preserve the actual action ID so the LLM knows the user's exact choice
     // (e.g. "deny", "no", "reject") rather than misreporting it as confirmed.
@@ -560,11 +637,14 @@ export function buildCompletionSummary(surfaceType: string | undefined, actionId
  * surface action. Unlike `buildCompletionSummary` (which is for the LLM),
  * this produces natural language the user can glance at.
  */
-export function buildUserFacingLabel(surfaceType: string | undefined, actionId: string, data?: Record<string, unknown>): string {
+export function buildUserFacingLabel(surfaceType: string | undefined, actionId: string, data?: Record<string, unknown>, surfaceData?: Record<string, unknown>): string {
   const count = (data?.selectedIds as string[] | undefined)?.length;
 
   if (surfaceType === 'confirmation') {
-    if (actionId === 'cancel') return 'Cancelled';
+    if (actionId === 'cancel') {
+      const cancelLabel = typeof surfaceData?.cancelLabel === 'string' ? surfaceData.cancelLabel : undefined;
+      return cancelLabel ?? 'Cancelled';
+    }
     if (actionId === 'confirm') return 'Confirmed';
     return `Selected: ${actionId}`;
   }
@@ -775,7 +855,7 @@ export async function surfaceProxyResolver(
     const lastAction = ctx.lastSurfaceAction.get(surfaceId);
     const stored = ctx.surfaceState.get(surfaceId);
     if (lastAction) {
-      const summary = buildCompletionSummary(stored?.surfaceType, lastAction.actionId, lastAction.data);
+      const summary = buildCompletionSummary(stored?.surfaceType, lastAction.actionId, lastAction.data, stored?.data as Record<string, unknown> | undefined);
       ctx.sendToClient({
         type: 'ui_surface_complete',
         sessionId: ctx.conversationId,

--- a/assistant/src/messaging/provider-types.ts
+++ b/assistant/src/messaging/provider-types.ts
@@ -102,8 +102,6 @@ export interface SenderDigestResult {
   queryUsed: string;
   /** True when pagination was stopped because the scan cap was reached but more messages exist. */
   truncated?: boolean;
-  /** Resume token for sequential scanning — present when truncated is true. */
-  nextPageToken?: string;
 }
 
 export interface ArchiveResult {

--- a/assistant/src/messaging/providers/gmail/adapter.ts
+++ b/assistant/src/messaging/providers/gmail/adapter.ts
@@ -196,9 +196,9 @@ export const gmailMessagingProvider: MessagingProvider = {
   },
 
   async senderDigest(token: string, query: string, options?: { maxMessages?: number; maxSenders?: number; pageToken?: string }): Promise<SenderDigestResult> {
-    const maxMessages = Math.min(options?.maxMessages ?? 2000, 2000);
+    const maxMessages = Math.min(options?.maxMessages ?? 5000, 5000);
     const maxSenders = options?.maxSenders ?? 30;
-    const maxIdsPerSender = 2000;
+    const maxIdsPerSender = 5000;
 
     const allMessageIds: string[] = [];
     const fetchPromises: Promise<GmailMessage[]>[] = [];
@@ -296,7 +296,7 @@ export const gmailMessagingProvider: MessagingProvider = {
       hasMore: s.hasMore,
     }));
 
-    return { senders, totalScanned: allMessageIds.length, queryUsed: query, ...(truncated ? { truncated, nextPageToken: pageToken } : {}) };
+    return { senders, totalScanned: allMessageIds.length, queryUsed: query, ...(truncated ? { truncated } : {}) };
   },
 
   async archiveByQuery(token: string, query: string): Promise<ArchiveResult> {


### PR DESCRIPTION
## Summary
- **Deselection context**: When users deselect items from a table/list surface (e.g. email cleanup), the LLM now receives a "Deselected items" section listing what the user chose to keep. This enables the memory system to record deselection preferences and exclude those senders from future cleanup tables.
- **Scan limit increases**: Bumped `gmail_sender_digest` default from 2k→5k messages (cap 10k), `gmail_outreach_scan` from 500→2k (cap 5k), and `messaging_sender_digest` cap to 5k. Removed `next_page_token` from truncated responses since single-call scans now cover enough messages.
- **Cancel label forwarding**: Confirmation surface cancel actions now show the actual `cancelLabel` text (e.g. "Not Now") instead of generic "Cancelled".

## Test plan
- [x] `bun test session-surfaces-deselection` — 15 new tests covering table/list deselection, non-selectable row exclusion, rich cell values, truncation at 20 items, edge cases
- [x] `bun test starter-task-flow` — existing surface action tests pass
- [x] `bunx tsc --noEmit` — type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
