### PR TITLE
fix: prevent LRU overflow (Int→UInt64) and tighten cache byte estimation (3x→10x)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -418,15 +418,16 @@ struct ChatBubble: View {
     // monotonically increasing counter. On eviction the entry with the
     // lowest accessTime is removed (least-recently-used).
 
-    @MainActor static var lruCounter: Int = 0
+    // UInt64 to avoid silent overflow after billions of cache accesses in long-running sessions.
+    @MainActor static var lruCounter: UInt64 = 0
 
-    @MainActor static var segmentCache = [String: (value: [MarkdownSegment], accessTime: Int)]()
-    @MainActor static var markdownCache = [String: (value: AttributedString, accessTime: Int)]()
+    @MainActor static var segmentCache = [String: (value: [MarkdownSegment], accessTime: UInt64)]()
+    @MainActor static var markdownCache = [String: (value: AttributedString, accessTime: UInt64)]()
     /// Separate cache for inline markdown (used by interleaved text segments).
     /// Kept distinct from `markdownCache` because `markdownText` applies
     /// slash-command highlighting before caching, which would contaminate
     /// inline results (and vice versa) if they shared a dictionary.
-    @MainActor static var inlineMarkdownCache = [String: (value: AttributedString, accessTime: Int)]()
+    @MainActor static var inlineMarkdownCache = [String: (value: AttributedString, accessTime: UInt64)]()
     static let maxCacheSize = 100
 
     // MARK: - Cache Guardrails
@@ -443,9 +444,11 @@ struct ChatBubble: View {
     @MainActor static var estimatedCacheBytes: Int = 0
 
     /// Estimate the in-memory cost of caching the given text's parsed result.
-    /// Uses `utf8.count * 3` as a rough AttributedString/segment overhead.
+    /// Uses `utf8.count * 10` as a conservative estimate: AttributedString carries
+    /// significant overhead beyond raw bytes (attribute containers, font metrics,
+    /// paragraph style objects), so 3x was too low and allowed the budget to be exceeded.
     static func estimatedBytes(for text: String) -> Int {
-        text.utf8.count * 3
+        text.utf8.count * 10
     }
 
     /// Evicts the oldest entries across all three caches until
@@ -454,7 +457,7 @@ struct ChatBubble: View {
         while estimatedCacheBytes > maxCacheBytes {
             // Find the LRU entry across all three caches.
             var oldestKey: String?
-            var oldestTime = Int.max
+            var oldestTime = UInt64.max
             var oldestCache: CacheKind?
 
             for (key, entry) in markdownCache where entry.accessTime < oldestTime {


### PR DESCRIPTION
Two cache reliability fixes in ChatBubble:

1. lruCounter Int→UInt64: avoids silent overflow breaking LRU eviction after billions of cache accesses in long sessions
2. estimatedBytes multiplier 3x→10x: AttributedString has significant overhead beyond raw string bytes (attribute containers, font metrics, paragraph styles), so the previous 3x estimate allowed real memory use to far exceed the 5MB budget

Closes #11774
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
