### PR TITLE
fix: gateway connected state — hide URL input, Connected+Disconnect buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -27,7 +27,7 @@ struct GatewaySettingsCard: View {
 
             // Gateway running status row
             if store.gatewayReachable == true {
-                VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success, size: .medium) {}
+                // Connected: show local target address + Connected/Disconnect, no URL input
                 tunnelConfigEntry
             } else if tunnelSetupExpanded || !gatewayUrlText.isEmpty {
                 tunnelConfigEntry
@@ -122,27 +122,40 @@ struct GatewaySettingsCard: View {
                     .foregroundColor(VColor.textSecondary)
             }
 
-            Text("Gateway URL")
-                .font(VFont.inputLabel)
-                .foregroundColor(VColor.textSecondary)
+            // Gateway URL input — hidden when connected
+            if store.gatewayReachable != true {
+                Text("Gateway URL")
+                    .font(VFont.inputLabel)
+                    .foregroundColor(VColor.textSecondary)
 
-            TextField("https://your-tunnel.example.com", text: $gatewayUrlText)
-                .vInputStyle()
-                .font(VFont.body)
-                .foregroundColor(VColor.textPrimary)
-                .focused($isGatewayUrlFocused)
+                TextField("https://your-tunnel.example.com", text: $gatewayUrlText)
+                    .vInputStyle()
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .focused($isGatewayUrlFocused)
+            }
 
             HStack(spacing: VSpacing.sm) {
-                VButton(label: "Save", style: .secondary, size: .medium) {
-                    store.saveIngressPublicBaseUrl(gatewayUrlText)
-                    isGatewayUrlFocused = false
-                    tunnelSetupExpanded = false
-                }
-                // No .disabled() — empty URL is valid (clears the tunnel target)
-                VButton(label: "Cancel", style: .tertiary, size: .medium) {
-                    gatewayUrlText = store.ingressPublicBaseUrl
-                    isGatewayUrlFocused = false
-                    tunnelSetupExpanded = false
+                if store.gatewayReachable == true {
+                    // Connected: status indicator + disconnect
+                    VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success, size: .medium) {}
+                    VButton(label: "Disconnect", style: .danger, size: .medium) {
+                        store.saveIngressPublicBaseUrl("")
+                        tunnelSetupExpanded = false
+                    }
+                } else {
+                    // Not connected: save/cancel
+                    VButton(label: "Save", style: .secondary, size: .medium) {
+                        store.saveIngressPublicBaseUrl(gatewayUrlText)
+                        isGatewayUrlFocused = false
+                        tunnelSetupExpanded = false
+                    }
+                    // No .disabled() — empty URL is valid (clears the tunnel target)
+                    VButton(label: "Cancel", style: .tertiary, size: .medium) {
+                        gatewayUrlText = store.ingressPublicBaseUrl
+                        isGatewayUrlFocused = false
+                        tunnelSetupExpanded = false
+                    }
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -14,6 +14,14 @@ struct GatewaySettingsCard: View {
     @State private var gatewayTargetCopied: Bool = false
     @State private var tunnelSetupExpanded: Bool = false
 
+    /// True only when the local gateway is running AND a tunnel URL has been configured.
+    /// Gating on both conditions ensures Disconnect (which clears the URL) transitions
+    /// back to the setup form even though the local gateway process keeps running.
+    private var isGatewayConnected: Bool {
+        store.gatewayReachable == true &&
+        !store.ingressPublicBaseUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
@@ -26,7 +34,7 @@ struct GatewaySettingsCard: View {
             }
 
             // Gateway running status row
-            if store.gatewayReachable == true {
+            if isGatewayConnected {
                 // Connected: show local target address + Connected/Disconnect, no URL input
                 tunnelConfigEntry
             } else if tunnelSetupExpanded || !gatewayUrlText.isEmpty {
@@ -122,8 +130,8 @@ struct GatewaySettingsCard: View {
                     .foregroundColor(VColor.textSecondary)
             }
 
-            // Gateway URL input — hidden when connected
-            if store.gatewayReachable != true {
+            // Gateway URL input — hidden when connected (tunnel URL set + gateway running)
+            if !isGatewayConnected {
                 Text("Gateway URL")
                     .font(VFont.inputLabel)
                     .foregroundColor(VColor.textSecondary)
@@ -136,12 +144,13 @@ struct GatewaySettingsCard: View {
             }
 
             HStack(spacing: VSpacing.sm) {
-                if store.gatewayReachable == true {
+                if isGatewayConnected {
                     // Connected: status indicator + disconnect
                     VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success, size: .medium) {}
                     VButton(label: "Disconnect", style: .danger, size: .medium) {
                         store.saveIngressPublicBaseUrl("")
-                        tunnelSetupExpanded = false
+                        // Show setup form immediately so user can re-enter a URL
+                        tunnelSetupExpanded = true
                     }
                 } else {
                     // Not connected: save/cancel


### PR DESCRIPTION
## Summary
When the local gateway is connected, the UI now shows only the Local Gateway Target address (read-only, copyable) and **Connected** (success) + **Disconnect** (danger) buttons. The Gateway URL input field is hidden.

When disconnected (including after clicking Disconnect), the full form is shown: Local Gateway Target + Gateway URL input + Save + Cancel.

## Changes
- `GatewaySettingsCard.swift`: wrap Gateway URL label + TextField in `if store.gatewayReachable != true` guard; swap Save/Cancel for Connected/Disconnect in buttons HStack when connected; remove the duplicate top-level Connected button from `body`

## Test plan
- [ ] Gateway connected: see Connected + Disconnect buttons, no URL input
- [ ] Click Disconnect: URL input appears, Save + Cancel shown
- [ ] Gateway not connected: URL input visible, Save + Cancel shown

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
