### PR TITLE
fix: section description font size 12px

### DIFF
--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -93,7 +93,7 @@ public enum VFont {
     public static let display    = Font.custom("Inter-SemiBold", size: adaptiveSize(18))
     public static let panelTitle   = Font.custom("Inter-Medium", size: adaptiveSize(24))
     public static let sectionTitle   = Font.custom("Inter-SemiBold", size: adaptiveSize(18))
-    public static let sectionDescription = Font.custom("Inter", size: 13)
+    public static let sectionDescription = Font.custom("Inter", size: 12)
     public static let inputLabel         = Font.custom("Inter-Medium", size: 12)
 
     /// Small label (used for thread tab names)


### PR DESCRIPTION
## Summary
Reduce section description font size from 13px to 12px, giving more visual separation from body text and tightening the settings card hierarchy.

## Changes
- `TypographyTokens.swift`: `sectionDescription` size 13 → 12

## Test plan
- [ ] Section descriptions in Settings (Appearance, Account, Channels, etc.) render at 12px

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
