### PR TITLE
Fix TS2352 fetch cast errors in migration-transport tests

### DIFF
--- a/assistant/src/__tests__/migration-transport.test.ts
+++ b/assistant/src/__tests__/migration-transport.test.ts
@@ -63,7 +63,7 @@ function mockFetch(
       return new Response(body, { status, headers: responseHeaders });
     }
     return new Response(String(body), { status, headers: responseHeaders });
-  }) as typeof fetch;
+  }) as unknown as typeof fetch;
 }
 
 /** Create a mock fetch that captures the request for inspection. */
@@ -76,7 +76,7 @@ function capturingFetch(
   const fetchFn = (async (url: string | URL | Request, init?: RequestInit) => {
     captured.push({ url: String(url), init: init ?? {} });
     return mockFetch(status, body, headers)(url, init);
-  }) as typeof fetch;
+  }) as unknown as typeof fetch;
   return { fetchFn, captured };
 }
 
@@ -630,7 +630,7 @@ describe("pollUntilComplete", () => {
         }),
         { status: 200 },
       );
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const progressCalls: JobStatusResponse[] = [];
     const result = await pollUntilComplete(
@@ -664,7 +664,7 @@ describe("pollUntilComplete", () => {
         }),
         { status: 200 },
       );
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const result = await pollUntilComplete(
       managedConfig({ fetchFn }),
@@ -685,7 +685,7 @@ describe("pollUntilComplete", () => {
         JSON.stringify({ status: "pending", job_id: "job-slow" }),
         { status: 200 },
       );
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     try {
       await pollUntilComplete(
@@ -819,7 +819,7 @@ describe("Multi-step flow behavior", () => {
         );
       }
       return new Response("Not found", { status: 404 });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const config = runtimeConfig({ fetchFn });
     const fileData = new ArrayBuffer(8);
@@ -874,7 +874,7 @@ describe("Multi-step flow behavior", () => {
         );
       }
       return new Response("Not found", { status: 404 });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const config = managedConfig({ fetchFn });
 


### PR DESCRIPTION
## Summary
- Cast mock fetch functions through `unknown` before `as typeof fetch` to fix TS2352 errors caused by Bun's `fetch` type including a `preconnect` property that arrow functions don't have.

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22643442112

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
