### PR TITLE
fix: show cancel label instead of hardcoded "Dismissed" in confirmation feedback

### DIFF
--- a/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
@@ -122,7 +122,7 @@ public struct ConfirmationSurfaceView: View {
                 Image(systemName: "xmark.circle.fill")
                     .font(VFont.caption)
                     .foregroundColor(VColor.textMuted)
-                Text("Dismissed")
+                Text(data.cancelLabel ?? "Dismissed")
                     .font(VFont.captionMedium)
                     .foregroundColor(VColor.textSecondary)
             }


### PR DESCRIPTION
## Summary
- When a confirmation surface has a custom `cancelLabel` (e.g., "Let me pick"), the post-action feedback UI now shows that label instead of always displaying "Dismissed"
- Falls back to "Dismissed" when no custom label is set
- Complements the server-side fix in #11822 which already propagates the cancel label to the LLM message

## Test plan
- [ ] Show a confirmation surface with a custom `cancelLabel` (e.g., `cancelLabel: "Let me pick"`)
- [ ] Click the cancel button and verify the feedback chip shows "Let me pick" instead of "Dismissed"
- [ ] Show a confirmation surface without a custom `cancelLabel` and verify the feedback still shows "Dismissed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
