### PR TITLE
fix: increase sidebar contrast in light mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/SidebarSearchButton.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/SidebarSearchButton.swift
@@ -44,13 +44,13 @@ struct SidebarSearchButton: View {
                 .foregroundColor(VColor.textMuted)
                 .padding(.horizontal, VSpacing.xs)
                 .padding(.vertical, VSpacing.xxs)
-                .background(VColor.surfaceBorder.opacity(0.5))
+                .background(VColor.surfaceBorder.opacity(0.7))
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.xs))
         }
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.sm)
         .background(
-            (isHovered ? VColor.surfaceBorder.opacity(0.5) : VColor.surfaceBorder.opacity(0.25))
+            (isHovered ? VColor.surfaceBorder.opacity(0.7) : VColor.surfaceBorder.opacity(0.4))
                 .animation(VAnimation.fast, value: isHovered)
         )
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -175,7 +175,7 @@ public enum VColor {
     // Text
     public static let textPrimary = adaptiveColor(light: Stone._900, dark: Moss._50)
     public static let textSecondary = adaptiveColor(light: Stone._600, dark: Moss._400)
-    public static let textMuted = adaptiveColor(light: Stone._500, dark: Moss._500)
+    public static let textMuted = adaptiveColor(light: Stone._600, dark: Moss._500)
 
     // Accent
     public static let accent = adaptiveColor(light: Color(hex: 0x262624), dark: Forest._600)
@@ -207,7 +207,7 @@ public enum VColor {
     // Interactive states
     public static let ghostHover = adaptiveColor(light: Stone._100, dark: Moss._700)
     public static let ghostPressed = adaptiveColor(light: Stone._200, dark: Moss._600)
-    public static let divider = adaptiveColor(light: Stone._200, dark: Moss._700)
+    public static let divider = adaptiveColor(light: Stone._300, dark: Moss._700)
     public static let hoverOverlay = adaptiveColor(light: Color(hex: 0x000000), dark: Moss._200)
     public static let toggleOff = adaptiveColor(light: Stone._200, dark: Moss._600)
     public static let toggleBorder = adaptiveColor(light: Stone._400, dark: Moss._600)


### PR DESCRIPTION
## Summary

- Darken `textMuted` light-mode value from `Stone._500` to `Stone._600` for better contrast on warm backgrounds (~2.6:1 → ~3.9:1)
- Strengthen `divider` light-mode value from `Stone._200` to `Stone._300` so section dividers are actually visible
- Boost sidebar search bar background opacities (0.25→0.4 default, 0.5→0.7 hover) and ⌘K badge opacity (0.5→0.7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
