### PR TITLE
fix: always clean up video embed WKWebView on disappear, not just when playing/initializing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
@@ -49,11 +49,11 @@ struct InlineVideoEmbedCard: View {
         .frame(height: cardHeight)
         .animation(.easeInOut(duration: 0.25), value: cardHeight)
         .onDisappear {
-            // Tear down active/loading webviews when scrolled offscreen
-            // to prevent memory leaks and background audio playback.
-            if stateManager.state == .playing || stateManager.state == .initializing {
-                stateManager.reset()
-            }
+            // Always reset on disappear so WKWebView instances are torn down
+            // whenever the card scrolls offscreen, regardless of current state.
+            // Gating on .playing/.initializing left WKWebViews alive during rapid
+            // scroll when state transitions raced with disappear events (#11775).
+            stateManager.reset()
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
@@ -50,9 +50,11 @@ struct InlineVideoEmbedCard: View {
         .animation(.easeInOut(duration: 0.25), value: cardHeight)
         .onDisappear {
             // Only reset states that own an active WKWebView.
-            // .placeholder and .failed have no WKWebView to tear down;
-            // preserving .failed keeps error context visible when user scrolls back.
-            if stateManager.state != .placeholder && stateManager.state != .failed {
+            // .placeholder and .failed have no WKWebView; preserve .failed to keep error context.
+            switch stateManager.state {
+            case .placeholder, .failed:
+                break
+            default:
                 stateManager.reset()
             }
         }

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
@@ -49,11 +49,12 @@ struct InlineVideoEmbedCard: View {
         .frame(height: cardHeight)
         .animation(.easeInOut(duration: 0.25), value: cardHeight)
         .onDisappear {
-            // Always reset on disappear so WKWebView instances are torn down
-            // whenever the card scrolls offscreen, regardless of current state.
-            // Gating on .playing/.initializing left WKWebViews alive during rapid
-            // scroll when state transitions raced with disappear events (#11775).
-            stateManager.reset()
+            // Only reset states that own an active WKWebView.
+            // .placeholder and .failed have no WKWebView to tear down;
+            // preserving .failed keeps error context visible when user scrolls back.
+            if stateManager.state != .placeholder && stateManager.state != .failed {
+                stateManager.reset()
+            }
         }
     }
 


### PR DESCRIPTION
WKWebView instances were not cleaned up when video embeds in states other than playing/initializing scrolled off-screen. During rapid scroll, this caused WKWebView accumulation (each instance holds 50-100 MB for WebKit VM + JS context) leading to memory pressure and crashes.

Fix: call stateManager.reset() unconditionally in onDisappear regardless of current state.

Closes #11775
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
