### PR TITLE
fix: gate benchmark baseline upload on successful benchmark execution

### DIFF
--- a/.github/workflows/ci-benchmarks.yaml
+++ b/.github/workflows/ci-benchmarks.yaml
@@ -44,6 +44,7 @@ jobs:
         continue-on-error: true
 
       - name: Run benchmarks
+        id: run-benchmarks
         run: bash scripts/run-benchmarks.sh
 
       - name: Compare against baseline
@@ -51,7 +52,7 @@ jobs:
         run: bash scripts/compare-benchmarks.sh baseline/benchmark-results.json benchmark-results.json
 
       - name: Upload results as new baseline
-        if: ${{ !cancelled() }}
+        if: steps.run-benchmarks.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-baseline


### PR DESCRIPTION
Follow-up to #11823. The `\!cancelled()` condition was too broad — it uploaded baseline even when the benchmark run itself failed, potentially poisoning the baseline with bad data. This change adds a step ID to the benchmark run step and conditions the upload on that step's success, while still allowing uploads when the compare step fails (which was the original intent of #11823).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
