### PR TITLE
Add migration wizard state machine (shared module)

### DIFF
--- a/assistant/src/__tests__/migration-wizard.test.ts
+++ b/assistant/src/__tests__/migration-wizard.test.ts
@@ -1,0 +1,1318 @@
+/**
+ * Tests for the migration wizard state machine.
+ *
+ * Covers:
+ * - State creation and initial values
+ * - Direction selection (both directions)
+ * - Step transitions: forward, backward, skip prevention
+ * - Step status tracking: idle, loading, success, error
+ * - Validate step execution: success, validation failure, transport error
+ * - Preflight step execution: success, validation failure, transport error
+ * - Transfer step execution: runtime export+import, managed export+poll+import
+ * - Rebind-secrets completion
+ * - Error handling: retryable vs non-retryable, retry reset
+ * - Persistence: serialize, deserialize, resume, corrupted data
+ * - Query helpers: step order, accessibility, completion
+ * - Full wizard flow end-to-end
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  ImportCommitResponse,
+  ImportPreflightResponse,
+  TransportConfig,
+  ValidateResponse,
+} from "../runtime/migrations/migration-transport.js";
+import type {
+  MigrationWizardState,
+  StepExecutorOptions,
+  WizardStep,
+} from "../runtime/migrations/migration-wizard.js";
+import {
+  canRetryCurrentStep,
+  completeRebindSecrets,
+  createWizardState,
+  deserializeWizardState,
+  executePreflightStep,
+  executeTransferStep,
+  executeValidateStep,
+  getCurrentStepIndex,
+  getStepOrder,
+  getTotalSteps,
+  goBackTo,
+  isResumable,
+  isStepAccessible,
+  isWizardComplete,
+  prepareForResume,
+  resetStepForRetry,
+  selectDirection,
+  serializeWizardState,
+  setBundleUploaded,
+  validateWizardTransition,
+} from "../runtime/migrations/migration-wizard.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function mockFetch(
+  status: number,
+  body: unknown,
+  headers?: Record<string, string>,
+): typeof fetch {
+  return (async () => {
+    const responseHeaders = new Headers(headers);
+    if (
+      typeof body === "object" &&
+      body !== undefined &&
+      !(body instanceof ArrayBuffer)
+    ) {
+      responseHeaders.set("Content-Type", "application/json");
+      return new Response(JSON.stringify(body), {
+        status,
+        headers: responseHeaders,
+      });
+    }
+    if (body instanceof ArrayBuffer) {
+      return new Response(body, { status, headers: responseHeaders });
+    }
+    return new Response(String(body), { status, headers: responseHeaders });
+  }) as typeof fetch;
+}
+
+function runtimeConfig(overrides?: Partial<TransportConfig>): TransportConfig {
+  return {
+    baseURL: "http://localhost:7821",
+    target: "runtime",
+    authHeader: "Bearer test-jwt",
+    fetchFn: mockFetch(200, {}),
+    ...overrides,
+  };
+}
+
+function managedConfig(overrides?: Partial<TransportConfig>): TransportConfig {
+  return {
+    baseURL: "https://platform.vellum.ai",
+    target: "managed",
+    authHeader: "test-session-token",
+    fetchFn: mockFetch(200, {}),
+    ...overrides,
+  };
+}
+
+function makeExecutorOptions(
+  overrides?: Partial<StepExecutorOptions>,
+): StepExecutorOptions {
+  return {
+    sourceConfig: runtimeConfig(),
+    destConfig: runtimeConfig(),
+    bundleData: new ArrayBuffer(16),
+    ...overrides,
+  };
+}
+
+/** Advance state to a specific step for testing. */
+function advanceTo(step: WizardStep): MigrationWizardState {
+  let state = createWizardState();
+  const stepOrder: WizardStep[] = [
+    "select-direction",
+    "upload-bundle",
+    "validate",
+    "preflight-review",
+    "transfer",
+    "rebind-secrets",
+    "complete",
+  ];
+  const targetIdx = stepOrder.indexOf(step);
+
+  if (targetIdx >= 1) {
+    state = selectDirection(state, "managed-to-self-hosted");
+  }
+  if (targetIdx >= 2) {
+    state = setBundleUploaded(state);
+  }
+  if (targetIdx >= 3) {
+    state = {
+      ...state,
+      steps: { ...state.steps, validate: { status: "success" } },
+      currentStep: "preflight-review",
+    };
+  }
+  if (targetIdx >= 4) {
+    state = {
+      ...state,
+      steps: { ...state.steps, "preflight-review": { status: "success" } },
+      currentStep: "transfer",
+    };
+  }
+  if (targetIdx >= 5) {
+    state = {
+      ...state,
+      steps: { ...state.steps, transfer: { status: "success" } },
+      currentStep: "rebind-secrets",
+    };
+  }
+  if (targetIdx >= 6) {
+    state = completeRebindSecrets(state);
+  }
+
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// State creation
+// ---------------------------------------------------------------------------
+
+describe("createWizardState", () => {
+  test("creates initial state with select-direction as first step", () => {
+    const state = createWizardState();
+    expect(state.currentStep).toBe("select-direction");
+    expect(state.direction).toBeUndefined();
+    expect(state.hasBundleData).toBe(false);
+  });
+
+  test("all steps start as idle", () => {
+    const state = createWizardState();
+    const allSteps: WizardStep[] = [
+      "select-direction",
+      "upload-bundle",
+      "validate",
+      "preflight-review",
+      "transfer",
+      "rebind-secrets",
+      "complete",
+    ];
+    for (const step of allSteps) {
+      expect(state.steps[step].status).toBe("idle");
+      expect(state.steps[step].error).toBeUndefined();
+    }
+  });
+
+  test("sets timestamps", () => {
+    const before = new Date().toISOString();
+    const state = createWizardState();
+    const after = new Date().toISOString();
+    expect(state.createdAt >= before).toBe(true);
+    expect(state.createdAt <= after).toBe(true);
+    expect(state.updatedAt).toBe(state.createdAt);
+  });
+
+  test("no results are set initially", () => {
+    const state = createWizardState();
+    expect(state.validateResult).toBeUndefined();
+    expect(state.preflightResult).toBeUndefined();
+    expect(state.exportResult).toBeUndefined();
+    expect(state.importResult).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Direction selection
+// ---------------------------------------------------------------------------
+
+describe("selectDirection", () => {
+  test("managed-to-self-hosted direction advances to upload-bundle", () => {
+    const state = createWizardState();
+    const next = selectDirection(state, "managed-to-self-hosted");
+    expect(next.direction).toBe("managed-to-self-hosted");
+    expect(next.currentStep).toBe("upload-bundle");
+    expect(next.steps["select-direction"].status).toBe("success");
+  });
+
+  test("self-hosted-to-managed direction advances to upload-bundle", () => {
+    const state = createWizardState();
+    const next = selectDirection(state, "self-hosted-to-managed");
+    expect(next.direction).toBe("self-hosted-to-managed");
+    expect(next.currentStep).toBe("upload-bundle");
+    expect(next.steps["select-direction"].status).toBe("success");
+  });
+
+  test("throws when called from wrong step", () => {
+    const state = advanceTo("validate");
+    expect(() => selectDirection(state, "managed-to-self-hosted")).toThrow(
+      "wrong step",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bundle upload
+// ---------------------------------------------------------------------------
+
+describe("setBundleUploaded", () => {
+  test("advances to validate step", () => {
+    const state = advanceTo("upload-bundle");
+    const next = setBundleUploaded(state);
+    expect(next.currentStep).toBe("validate");
+    expect(next.hasBundleData).toBe(true);
+    expect(next.steps["upload-bundle"].status).toBe("success");
+  });
+
+  test("throws when called from wrong step", () => {
+    const state = advanceTo("validate");
+    expect(() => setBundleUploaded(state)).toThrow("wrong step");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transition validation
+// ---------------------------------------------------------------------------
+
+describe("validateWizardTransition", () => {
+  test("same-step transition is always valid", () => {
+    const state = advanceTo("validate");
+    expect(validateWizardTransition(state, "validate").valid).toBe(true);
+  });
+
+  test("forward transition requires current step to be in success", () => {
+    let state = advanceTo("validate");
+    // validate is currently idle
+    const result = validateWizardTransition(state, "preflight-review");
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain("idle");
+
+    // Set validate to success
+    state = {
+      ...state,
+      steps: { ...state.steps, validate: { status: "success" } },
+    };
+    expect(validateWizardTransition(state, "preflight-review").valid).toBe(
+      true,
+    );
+  });
+
+  test("cannot skip steps forward", () => {
+    const state = advanceTo("validate");
+    const result = validateWizardTransition(state, "transfer");
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain("skip");
+  });
+
+  test("backward transition is always allowed", () => {
+    const state = advanceTo("transfer");
+    expect(validateWizardTransition(state, "select-direction").valid).toBe(
+      true,
+    );
+    expect(validateWizardTransition(state, "upload-bundle").valid).toBe(true);
+    expect(validateWizardTransition(state, "validate").valid).toBe(true);
+  });
+
+  test("cannot transition from complete", () => {
+    const state = advanceTo("complete");
+    const result = validateWizardTransition(state, "select-direction");
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain("terminal");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// goBackTo
+// ---------------------------------------------------------------------------
+
+describe("goBackTo", () => {
+  test("going back resets target and subsequent steps to idle", () => {
+    const state = advanceTo("transfer");
+    const backed = goBackTo(state, "upload-bundle");
+    expect(backed.currentStep).toBe("upload-bundle");
+    // Target step is reset
+    expect(backed.steps["upload-bundle"].status).toBe("idle");
+    // Steps after target are reset
+    expect(backed.steps["validate"].status).toBe("idle");
+    expect(backed.steps["preflight-review"].status).toBe("idle");
+    expect(backed.steps["transfer"].status).toBe("idle");
+    // Earlier steps retain their status
+    expect(backed.steps["select-direction"].status).toBe("success");
+  });
+
+  test("going back clears results for reset steps", () => {
+    let state = advanceTo("transfer");
+    state = {
+      ...state,
+      validateResult: { is_valid: true, errors: [], manifest: {} as never },
+    };
+    state = { ...state, preflightResult: { can_import: true } as never };
+    const backed = goBackTo(state, "upload-bundle");
+    expect(backed.validateResult).toBeUndefined();
+    expect(backed.preflightResult).toBeUndefined();
+  });
+
+  test("throws for invalid back-navigation", () => {
+    const state = advanceTo("complete");
+    expect(() => goBackTo(state, "select-direction")).toThrow(
+      "Invalid back-navigation",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executeValidateStep
+// ---------------------------------------------------------------------------
+
+describe("executeValidateStep", () => {
+  test("success — sets status to success and advances to preflight-review", async () => {
+    const validateResponse: ValidateResponse = {
+      is_valid: true,
+      errors: [],
+      manifest: {
+        schema_version: "1.0",
+        created_at: "2026-03-01T00:00:00Z",
+        files: [{ path: "data/db/assistant.db", sha256: "abc", size: 100 }],
+        manifest_sha256: "def",
+      },
+    };
+
+    const state = advanceTo("validate");
+    const options = makeExecutorOptions({
+      destConfig: runtimeConfig({ fetchFn: mockFetch(200, validateResponse) }),
+    });
+
+    const result = await executeValidateStep(state, options);
+    expect(result.steps.validate.status).toBe("success");
+    expect(result.currentStep).toBe("preflight-review");
+    expect(result.validateResult).toBeDefined();
+    if (result.validateResult && result.validateResult.is_valid) {
+      expect(result.validateResult.manifest.schema_version).toBe("1.0");
+    }
+  });
+
+  test("validation failure — sets status to error with retryable flag", async () => {
+    const validateResponse: ValidateResponse = {
+      is_valid: false,
+      errors: [{ code: "INVALID_GZIP", message: "Not a valid gzip file" }],
+    };
+
+    const state = advanceTo("validate");
+    const options = makeExecutorOptions({
+      destConfig: runtimeConfig({ fetchFn: mockFetch(200, validateResponse) }),
+    });
+
+    const result = await executeValidateStep(state, options);
+    expect(result.steps.validate.status).toBe("error");
+    expect(result.steps.validate.error?.retryable).toBe(true);
+    expect(result.steps.validate.error?.message).toContain(
+      "Not a valid gzip file",
+    );
+    expect(result.currentStep).toBe("validate"); // Does not advance
+  });
+
+  test("transport error — maps HTTP error to step error", async () => {
+    const state = advanceTo("validate");
+    const options = makeExecutorOptions({
+      destConfig: runtimeConfig({
+        fetchFn: mockFetch(500, "Internal Server Error"),
+      }),
+    });
+
+    const result = await executeValidateStep(state, options);
+    expect(result.steps.validate.status).toBe("error");
+    expect(result.steps.validate.error?.code).toBe("HTTP_500");
+    expect(result.steps.validate.error?.retryable).toBe(true);
+  });
+
+  test("non-retryable error — 400 is not retryable", async () => {
+    const state = advanceTo("validate");
+    const options = makeExecutorOptions({
+      destConfig: runtimeConfig({ fetchFn: mockFetch(400, "Bad Request") }),
+    });
+
+    const result = await executeValidateStep(state, options);
+    expect(result.steps.validate.status).toBe("error");
+    expect(result.steps.validate.error?.retryable).toBe(false);
+  });
+
+  test("429 rate limit error is retryable", async () => {
+    const state = advanceTo("validate");
+    const options = makeExecutorOptions({
+      destConfig: runtimeConfig({ fetchFn: mockFetch(429, "Rate Limited") }),
+    });
+
+    const result = await executeValidateStep(state, options);
+    expect(result.steps.validate.status).toBe("error");
+    expect(result.steps.validate.error?.retryable).toBe(true);
+    expect(result.steps.validate.error?.code).toBe("HTTP_429");
+  });
+
+  test("loading state is set before async operation", async () => {
+    const stateChanges: MigrationWizardState[] = [];
+    const state = advanceTo("validate");
+    const options = makeExecutorOptions({
+      destConfig: runtimeConfig({
+        fetchFn: mockFetch(200, { is_valid: true, errors: [], manifest: {} }),
+      }),
+      onStateChange: (s) => stateChanges.push(s),
+    });
+
+    await executeValidateStep(state, options);
+    expect(stateChanges.length).toBeGreaterThanOrEqual(2);
+    expect(stateChanges[0].steps.validate.status).toBe("loading");
+  });
+
+  test("throws when called from wrong step", async () => {
+    const state = advanceTo("upload-bundle");
+    const options = makeExecutorOptions();
+    try {
+      await executeValidateStep(state, options);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("wrong step");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executePreflightStep
+// ---------------------------------------------------------------------------
+
+describe("executePreflightStep", () => {
+  test("success — sets status to success and advances to transfer", async () => {
+    const preflightResponse: ImportPreflightResponse = {
+      can_import: true,
+      summary: {
+        total_files: 2,
+        files_to_create: 1,
+        files_to_overwrite: 1,
+        files_unchanged: 0,
+      },
+      files: [
+        {
+          path: "data/db/assistant.db",
+          action: "overwrite",
+          bundle_size: 1024,
+          current_size: 512,
+          bundle_sha256: "abc",
+          current_sha256: "def",
+        },
+      ],
+      conflicts: [],
+      manifest: {
+        schema_version: "1.0",
+        created_at: "2026-03-01T00:00:00Z",
+        files: [],
+        manifest_sha256: "ghi",
+      },
+    };
+
+    const state = advanceTo("preflight-review");
+    const options = makeExecutorOptions({
+      destConfig: runtimeConfig({ fetchFn: mockFetch(200, preflightResponse) }),
+    });
+
+    const result = await executePreflightStep(state, options);
+    expect(result.steps["preflight-review"].status).toBe("success");
+    expect(result.currentStep).toBe("transfer");
+    expect(result.preflightResult).toBeDefined();
+  });
+
+  test("validation failure — sets error state", async () => {
+    const preflightResponse: ImportPreflightResponse = {
+      can_import: false,
+      validation: {
+        is_valid: false,
+        errors: [{ code: "SCHEMA_MISMATCH", message: "Incompatible schema" }],
+      },
+    };
+
+    const state = advanceTo("preflight-review");
+    const options = makeExecutorOptions({
+      destConfig: runtimeConfig({ fetchFn: mockFetch(200, preflightResponse) }),
+    });
+
+    const result = await executePreflightStep(state, options);
+    expect(result.steps["preflight-review"].status).toBe("error");
+    expect(result.steps["preflight-review"].error?.retryable).toBe(true);
+    expect(result.currentStep).toBe("preflight-review");
+  });
+
+  test("transport error is handled", async () => {
+    const state = advanceTo("preflight-review");
+    const options = makeExecutorOptions({
+      destConfig: runtimeConfig({
+        fetchFn: mockFetch(503, "Service Unavailable"),
+      }),
+    });
+
+    const result = await executePreflightStep(state, options);
+    expect(result.steps["preflight-review"].status).toBe("error");
+    expect(result.steps["preflight-review"].error?.retryable).toBe(true);
+  });
+
+  test("throws when called from wrong step", async () => {
+    const state = advanceTo("validate");
+    const options = makeExecutorOptions();
+    try {
+      await executePreflightStep(state, options);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("wrong step");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executeTransferStep
+// ---------------------------------------------------------------------------
+
+describe("executeTransferStep", () => {
+  test("runtime export + import — success", async () => {
+    const archiveBytes = new ArrayBuffer(64);
+    const importResponse: ImportCommitResponse = {
+      success: true,
+      summary: {
+        total_files: 1,
+        files_created: 1,
+        files_overwritten: 0,
+        files_skipped: 0,
+        backups_created: 0,
+      },
+      files: [
+        {
+          path: "data/db/assistant.db",
+          disk_path: "/home/.vellum/data/db/assistant.db",
+          action: "created",
+          size: 64,
+          sha256: "xyz",
+          backup_path: null,
+        },
+      ],
+      manifest: {
+        schema_version: "1.0",
+        created_at: "2026-03-01T00:00:00Z",
+        files: [],
+        manifest_sha256: "abc",
+      },
+      warnings: [],
+    };
+
+    let exportCalled = false;
+    let importCalled = false;
+
+    const sourceFetch = (async (_url: string | URL | Request) => {
+      exportCalled = true;
+      const responseHeaders = new Headers({
+        "Content-Disposition": 'attachment; filename="export.vbundle"',
+        "X-Vbundle-Schema-Version": "1.0",
+        "X-Vbundle-Manifest-Sha256": "abc123",
+      });
+      return new Response(archiveBytes, {
+        status: 200,
+        headers: responseHeaders,
+      });
+    }) as typeof fetch;
+
+    const destFetch = (async () => {
+      importCalled = true;
+      return new Response(JSON.stringify(importResponse), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const state = advanceTo("transfer");
+    const options = makeExecutorOptions({
+      sourceConfig: runtimeConfig({ fetchFn: sourceFetch }),
+      destConfig: runtimeConfig({ fetchFn: destFetch }),
+    });
+
+    const result = await executeTransferStep(state, options);
+    expect(exportCalled).toBe(true);
+    expect(importCalled).toBe(true);
+    expect(result.steps.transfer.status).toBe("success");
+    expect(result.currentStep).toBe("rebind-secrets");
+    expect(result.importResult).toBeDefined();
+    if (result.importResult && result.importResult.success) {
+      expect(result.importResult.summary.files_created).toBe(1);
+    }
+  });
+
+  test("managed export + poll + import — success", async () => {
+    let fetchCallCount = 0;
+    const importResponse: ImportCommitResponse = {
+      success: true,
+      summary: {
+        total_files: 1,
+        files_created: 1,
+        files_overwritten: 0,
+        files_skipped: 0,
+        backups_created: 0,
+      },
+      files: [],
+      manifest: {
+        schema_version: "1.0",
+        created_at: "2026-03-01T00:00:00Z",
+        files: [],
+        manifest_sha256: "abc",
+      },
+      warnings: [],
+    };
+
+    const sourceFetch = (async (url: string | URL | Request) => {
+      fetchCallCount++;
+      const urlStr = String(url);
+      if (urlStr.endsWith("/export/")) {
+        return new Response(
+          JSON.stringify({ job_id: "exp-1", status: "pending" }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+      if (urlStr.includes("/export/") && urlStr.includes("/status/")) {
+        if (fetchCallCount <= 3) {
+          return new Response(
+            JSON.stringify({ status: "processing", job_id: "exp-1" }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            status: "complete",
+            job_id: "exp-1",
+            download_url: "https://cdn.example.com/export.vbundle",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+      if (urlStr === "https://cdn.example.com/export.vbundle") {
+        return new Response(new ArrayBuffer(32), { status: 200 });
+      }
+      return new Response("Not found", { status: 404 });
+    }) as typeof fetch;
+
+    const destFetch = (async () => {
+      return new Response(JSON.stringify(importResponse), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const state = advanceTo("transfer");
+    const options = makeExecutorOptions({
+      sourceConfig: managedConfig({ fetchFn: sourceFetch }),
+      destConfig: runtimeConfig({ fetchFn: destFetch }),
+    });
+
+    const result = await executeTransferStep(state, options);
+    expect(result.steps.transfer.status).toBe("success");
+    expect(result.currentStep).toBe("rebind-secrets");
+  });
+
+  test("export failure — sets error", async () => {
+    const state = advanceTo("transfer");
+    const options = makeExecutorOptions({
+      sourceConfig: runtimeConfig({ fetchFn: mockFetch(500, "Server Error") }),
+    });
+
+    const result = await executeTransferStep(state, options);
+    expect(result.steps.transfer.status).toBe("error");
+    expect(result.steps.transfer.error?.retryable).toBe(true);
+  });
+
+  test("import failure — sets error with reason", async () => {
+    const archiveBytes = new ArrayBuffer(32);
+    const importResponse: ImportCommitResponse = {
+      success: false,
+      reason: "write_failed",
+      message: "Disk full",
+    };
+
+    const sourceFetch = (async () => {
+      return new Response(archiveBytes, {
+        status: 200,
+        headers: {
+          "Content-Disposition": 'attachment; filename="export.vbundle"',
+          "X-Vbundle-Schema-Version": "1.0",
+          "X-Vbundle-Manifest-Sha256": "abc",
+        },
+      });
+    }) as typeof fetch;
+
+    const destFetch = (async () => {
+      return new Response(JSON.stringify(importResponse), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const state = advanceTo("transfer");
+    const options = makeExecutorOptions({
+      sourceConfig: runtimeConfig({ fetchFn: sourceFetch }),
+      destConfig: runtimeConfig({ fetchFn: destFetch }),
+    });
+
+    const result = await executeTransferStep(state, options);
+    expect(result.steps.transfer.status).toBe("error");
+    expect(result.steps.transfer.error?.message).toContain("Disk full");
+    expect(result.steps.transfer.error?.retryable).toBe(true);
+  });
+
+  test("managed export job failure — sets error", async () => {
+    const sourceFetch = (async (url: string | URL | Request) => {
+      const urlStr = String(url);
+      if (urlStr.endsWith("/export/")) {
+        return new Response(
+          JSON.stringify({ job_id: "exp-fail", status: "pending" }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+      if (urlStr.includes("/status/")) {
+        return new Response(
+          JSON.stringify({
+            status: "failed",
+            job_id: "exp-fail",
+            error: "Timeout",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+      return new Response("Not found", { status: 404 });
+    }) as typeof fetch;
+
+    const state = advanceTo("transfer");
+    const options = makeExecutorOptions({
+      sourceConfig: managedConfig({ fetchFn: sourceFetch }),
+    });
+
+    const result = await executeTransferStep(state, options);
+    expect(result.steps.transfer.status).toBe("error");
+    expect(result.steps.transfer.error?.code).toBe("EXPORT_JOB_FAILED");
+    expect(result.steps.transfer.error?.retryable).toBe(true);
+  });
+
+  test("throws when called from wrong step", async () => {
+    const state = advanceTo("validate");
+    const options = makeExecutorOptions();
+    try {
+      await executeTransferStep(state, options);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("wrong step");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// completeRebindSecrets
+// ---------------------------------------------------------------------------
+
+describe("completeRebindSecrets", () => {
+  test("advances to complete", () => {
+    const state = advanceTo("rebind-secrets");
+    const result = completeRebindSecrets(state);
+    expect(result.currentStep).toBe("complete");
+    expect(result.steps["rebind-secrets"].status).toBe("success");
+    expect(result.steps.complete.status).toBe("success");
+  });
+
+  test("throws when called from wrong step", () => {
+    const state = advanceTo("transfer");
+    expect(() => completeRebindSecrets(state)).toThrow("wrong step");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Retry
+// ---------------------------------------------------------------------------
+
+describe("retry", () => {
+  test("canRetryCurrentStep returns true for retryable errors", () => {
+    let state = advanceTo("validate");
+    state = {
+      ...state,
+      steps: {
+        ...state.steps,
+        validate: {
+          status: "error",
+          error: { message: "Server error", code: "HTTP_500", retryable: true },
+        },
+      },
+    };
+    expect(canRetryCurrentStep(state)).toBe(true);
+  });
+
+  test("canRetryCurrentStep returns false for non-retryable errors", () => {
+    let state = advanceTo("validate");
+    state = {
+      ...state,
+      steps: {
+        ...state.steps,
+        validate: {
+          status: "error",
+          error: { message: "Bad request", code: "HTTP_400", retryable: false },
+        },
+      },
+    };
+    expect(canRetryCurrentStep(state)).toBe(false);
+  });
+
+  test("canRetryCurrentStep returns false for non-error states", () => {
+    const state = advanceTo("validate");
+    expect(canRetryCurrentStep(state)).toBe(false);
+  });
+
+  test("resetStepForRetry sets step back to idle", () => {
+    let state = advanceTo("validate");
+    state = {
+      ...state,
+      steps: {
+        ...state.steps,
+        validate: {
+          status: "error",
+          error: { message: "Server error", retryable: true },
+        },
+      },
+    };
+    const reset = resetStepForRetry(state);
+    expect(reset.steps.validate.status).toBe("idle");
+    expect(reset.steps.validate.error).toBeUndefined();
+  });
+
+  test("resetStepForRetry throws for non-retryable step", () => {
+    const state = advanceTo("validate");
+    expect(() => resetStepForRetry(state)).toThrow(
+      "not in a retryable error state",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+describe("persistence", () => {
+  describe("serializeWizardState", () => {
+    test("produces valid JSON", () => {
+      const state = advanceTo("validate");
+      const json = serializeWizardState(state);
+      const parsed = JSON.parse(json);
+      expect(parsed.currentStep).toBe("validate");
+      expect(parsed.direction).toBe("managed-to-self-hosted");
+    });
+
+    test("round-trips through serialize/deserialize", () => {
+      const state = advanceTo("transfer");
+      const json = serializeWizardState(state);
+      const restored = deserializeWizardState(json);
+      expect(restored).toBeDefined();
+      expect(restored!.currentStep).toBe("transfer");
+      expect(restored!.direction).toBe("managed-to-self-hosted");
+      expect(restored!.steps["select-direction"].status).toBe("success");
+    });
+  });
+
+  describe("deserializeWizardState", () => {
+    test("returns undefined for invalid JSON", () => {
+      expect(deserializeWizardState("not json")).toBeUndefined();
+    });
+
+    test("returns undefined for missing required fields", () => {
+      expect(deserializeWizardState("{}")).toBeUndefined();
+      expect(
+        deserializeWizardState('{"currentStep":"validate"}'),
+      ).toBeUndefined();
+    });
+
+    test("returns undefined for unknown step", () => {
+      const state = createWizardState();
+      const json = serializeWizardState(state);
+      const modified = JSON.parse(json);
+      modified.currentStep = "unknown-step";
+      expect(deserializeWizardState(JSON.stringify(modified))).toBeUndefined();
+    });
+
+    test("returns undefined when a step is missing from steps record", () => {
+      const state = createWizardState();
+      const json = serializeWizardState(state);
+      const modified = JSON.parse(json);
+      delete modified.steps["validate"];
+      expect(deserializeWizardState(JSON.stringify(modified))).toBeUndefined();
+    });
+
+    test("clears hasBundleData on deserialization", () => {
+      let state = advanceTo("validate");
+      state = { ...state, hasBundleData: true };
+      const json = serializeWizardState(state);
+      const restored = deserializeWizardState(json);
+      expect(restored!.hasBundleData).toBe(false);
+    });
+  });
+
+  describe("isResumable", () => {
+    test("not resumable on first step", () => {
+      const state = createWizardState();
+      expect(isResumable(state)).toBe(false);
+    });
+
+    test("not resumable without direction", () => {
+      const state = createWizardState();
+      expect(isResumable(state)).toBe(false);
+    });
+
+    test("not resumable when complete", () => {
+      const state = advanceTo("complete");
+      expect(isResumable(state)).toBe(false);
+    });
+
+    test("resumable at validate step with direction set", () => {
+      const state = advanceTo("validate");
+      expect(isResumable(state)).toBe(true);
+    });
+
+    test("resumable at transfer step", () => {
+      const state = advanceTo("transfer");
+      expect(isResumable(state)).toBe(true);
+    });
+  });
+
+  describe("prepareForResume", () => {
+    test("resets loading step to idle", () => {
+      let state = advanceTo("validate");
+      state = {
+        ...state,
+        steps: { ...state.steps, validate: { status: "loading" } },
+      };
+      const prepared = prepareForResume(state);
+      expect(prepared.steps.validate.status).toBe("idle");
+    });
+
+    test("goes back to upload-bundle when bundle data is missing", () => {
+      let state = advanceTo("validate");
+      state = { ...state, hasBundleData: false };
+      const prepared = prepareForResume(state);
+      expect(prepared.currentStep).toBe("upload-bundle");
+      expect(prepared.steps["upload-bundle"].status).toBe("idle");
+    });
+
+    test("preserves step when bundle data is available", () => {
+      let state = advanceTo("validate");
+      state = { ...state, hasBundleData: true };
+      const prepared = prepareForResume(state);
+      expect(prepared.currentStep).toBe("validate");
+    });
+
+    test("does not change error steps", () => {
+      let state = advanceTo("validate");
+      state = {
+        ...state,
+        hasBundleData: true,
+        steps: {
+          ...state.steps,
+          validate: {
+            status: "error",
+            error: { message: "Failed", retryable: true },
+          },
+        },
+      };
+      const prepared = prepareForResume(state);
+      expect(prepared.steps.validate.status).toBe("error");
+      expect(prepared.currentStep).toBe("validate");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Query helpers
+// ---------------------------------------------------------------------------
+
+describe("query helpers", () => {
+  test("getStepOrder returns all steps", () => {
+    const state = advanceTo("validate");
+    const order = getStepOrder(state);
+    expect(order).toHaveLength(7);
+    expect(order[0]).toBe("select-direction");
+    expect(order[6]).toBe("complete");
+  });
+
+  test("getCurrentStepIndex returns correct index", () => {
+    expect(getCurrentStepIndex(createWizardState())).toBe(0);
+    expect(getCurrentStepIndex(advanceTo("validate"))).toBe(2);
+    expect(getCurrentStepIndex(advanceTo("transfer"))).toBe(4);
+    expect(getCurrentStepIndex(advanceTo("complete"))).toBe(6);
+  });
+
+  test("getTotalSteps returns 7", () => {
+    expect(getTotalSteps()).toBe(7);
+  });
+
+  test("isStepAccessible checks transition validity", () => {
+    const state = advanceTo("validate");
+    expect(isStepAccessible(state, "select-direction")).toBe(true);
+    expect(isStepAccessible(state, "upload-bundle")).toBe(true);
+    expect(isStepAccessible(state, "validate")).toBe(true);
+    // Cannot advance because validate is not success
+    expect(isStepAccessible(state, "preflight-review")).toBe(false);
+    expect(isStepAccessible(state, "transfer")).toBe(false);
+  });
+
+  test("isWizardComplete returns true only when complete", () => {
+    expect(isWizardComplete(createWizardState())).toBe(false);
+    expect(isWizardComplete(advanceTo("validate"))).toBe(false);
+    expect(isWizardComplete(advanceTo("complete"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full flow end-to-end
+// ---------------------------------------------------------------------------
+
+describe("full wizard flow", () => {
+  test("managed-to-self-hosted: select → upload → validate → preflight → transfer → rebind → complete", async () => {
+    // Step 1: Select direction
+    let state = createWizardState();
+    state = selectDirection(state, "managed-to-self-hosted");
+    expect(state.currentStep).toBe("upload-bundle");
+
+    // Step 2: Upload bundle
+    state = setBundleUploaded(state);
+    expect(state.currentStep).toBe("validate");
+
+    // Step 3: Validate
+    const validateResponse: ValidateResponse = {
+      is_valid: true,
+      errors: [],
+      manifest: {
+        schema_version: "1.0",
+        created_at: "2026-03-01T00:00:00Z",
+        files: [],
+        manifest_sha256: "abc",
+      },
+    };
+    state = await executeValidateStep(
+      state,
+      makeExecutorOptions({
+        destConfig: runtimeConfig({
+          fetchFn: mockFetch(200, validateResponse),
+        }),
+      }),
+    );
+    expect(state.currentStep).toBe("preflight-review");
+
+    // Step 4: Preflight review
+    const preflightResponse: ImportPreflightResponse = {
+      can_import: true,
+      summary: {
+        total_files: 1,
+        files_to_create: 1,
+        files_to_overwrite: 0,
+        files_unchanged: 0,
+      },
+      files: [],
+      conflicts: [],
+      manifest: {
+        schema_version: "1.0",
+        created_at: "2026-03-01T00:00:00Z",
+        files: [],
+        manifest_sha256: "abc",
+      },
+    };
+    state = await executePreflightStep(
+      state,
+      makeExecutorOptions({
+        destConfig: runtimeConfig({
+          fetchFn: mockFetch(200, preflightResponse),
+        }),
+      }),
+    );
+    expect(state.currentStep).toBe("transfer");
+
+    // Step 5: Transfer (runtime export + import)
+    const importResponse: ImportCommitResponse = {
+      success: true,
+      summary: {
+        total_files: 1,
+        files_created: 1,
+        files_overwritten: 0,
+        files_skipped: 0,
+        backups_created: 0,
+      },
+      files: [],
+      manifest: {
+        schema_version: "1.0",
+        created_at: "2026-03-01T00:00:00Z",
+        files: [],
+        manifest_sha256: "abc",
+      },
+      warnings: [],
+    };
+
+    const sourceFetch = (async () => {
+      return new Response(new ArrayBuffer(32), {
+        status: 200,
+        headers: {
+          "Content-Disposition": 'attachment; filename="export.vbundle"',
+          "X-Vbundle-Schema-Version": "1.0",
+          "X-Vbundle-Manifest-Sha256": "abc",
+        },
+      });
+    }) as typeof fetch;
+
+    const destFetch = (async () => {
+      return new Response(JSON.stringify(importResponse), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    state = await executeTransferStep(
+      state,
+      makeExecutorOptions({
+        sourceConfig: runtimeConfig({ fetchFn: sourceFetch }),
+        destConfig: runtimeConfig({ fetchFn: destFetch }),
+      }),
+    );
+    expect(state.currentStep).toBe("rebind-secrets");
+
+    // Step 6: Rebind secrets
+    state = completeRebindSecrets(state);
+    expect(state.currentStep).toBe("complete");
+    expect(isWizardComplete(state)).toBe(true);
+
+    // Verify all steps are in success state
+    for (const step of getStepOrder(state)) {
+      expect(state.steps[step].status).toBe("success");
+    }
+  });
+
+  test("error → retry → success flow", async () => {
+    let state = advanceTo("validate");
+
+    // First attempt fails
+    state = await executeValidateStep(
+      state,
+      makeExecutorOptions({
+        destConfig: runtimeConfig({
+          fetchFn: mockFetch(503, "Service Unavailable"),
+        }),
+      }),
+    );
+    expect(state.steps.validate.status).toBe("error");
+    expect(canRetryCurrentStep(state)).toBe(true);
+
+    // Reset for retry
+    state = resetStepForRetry(state);
+    expect(state.steps.validate.status).toBe("idle");
+
+    // Second attempt succeeds
+    const validateResponse: ValidateResponse = {
+      is_valid: true,
+      errors: [],
+      manifest: {
+        schema_version: "1.0",
+        created_at: "2026-03-01T00:00:00Z",
+        files: [],
+        manifest_sha256: "abc",
+      },
+    };
+    state = await executeValidateStep(
+      state,
+      makeExecutorOptions({
+        destConfig: runtimeConfig({
+          fetchFn: mockFetch(200, validateResponse),
+        }),
+      }),
+    );
+    expect(state.steps.validate.status).toBe("success");
+    expect(state.currentStep).toBe("preflight-review");
+  });
+
+  test("persistence/resume round-trip", () => {
+    // Build up state to transfer step
+    let state = advanceTo("transfer");
+
+    // Simulate interrupted loading state
+    state = {
+      ...state,
+      steps: { ...state.steps, transfer: { status: "loading" } },
+      hasBundleData: true,
+    };
+
+    // Persist
+    const json = serializeWizardState(state);
+
+    // Restore
+    const restored = deserializeWizardState(json);
+    expect(restored).toBeDefined();
+    expect(restored!.currentStep).toBe("transfer");
+    // Bundle data cleared on deserialization
+    expect(restored!.hasBundleData).toBe(false);
+
+    // Prepare for resume — loading resets to idle, and since no bundle data,
+    // goes back to upload-bundle
+    const prepared = prepareForResume(restored!);
+    expect(prepared.currentStep).toBe("upload-bundle");
+    expect(prepared.steps.transfer.status).toBe("idle");
+    expect(prepared.steps["upload-bundle"].status).toBe("idle");
+
+    // Earlier completed steps remain
+    expect(prepared.steps["select-direction"].status).toBe("success");
+  });
+
+  test("go back and redo flow", () => {
+    let state = advanceTo("transfer");
+
+    // Go back to validate
+    state = goBackTo(state, "validate");
+    expect(state.currentStep).toBe("validate");
+    expect(state.steps.validate.status).toBe("idle");
+    expect(state.steps["preflight-review"].status).toBe("idle");
+    expect(state.steps.transfer.status).toBe("idle");
+
+    // Earlier steps remain successful
+    expect(state.steps["select-direction"].status).toBe("success");
+    expect(state.steps["upload-bundle"].status).toBe("success");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isResumable — corrected test for complete state
+// ---------------------------------------------------------------------------
+
+describe("isResumable edge cases", () => {
+  test("complete state is not resumable", () => {
+    const state = advanceTo("complete");
+    expect(isResumable(state)).toBe(false);
+  });
+
+  test("upload-bundle with direction is resumable", () => {
+    const state = advanceTo("upload-bundle");
+    expect(isResumable(state)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Disabled state (step not yet accessible)
+// ---------------------------------------------------------------------------
+
+describe("disabled states", () => {
+  test("steps beyond current are not accessible and effectively disabled", () => {
+    const state = createWizardState();
+    expect(isStepAccessible(state, "upload-bundle")).toBe(false);
+    expect(isStepAccessible(state, "validate")).toBe(false);
+    expect(isStepAccessible(state, "preflight-review")).toBe(false);
+    expect(isStepAccessible(state, "transfer")).toBe(false);
+    expect(isStepAccessible(state, "rebind-secrets")).toBe(false);
+    expect(isStepAccessible(state, "complete")).toBe(false);
+  });
+
+  test("current step and earlier steps are accessible", () => {
+    const state = advanceTo("transfer");
+    expect(isStepAccessible(state, "select-direction")).toBe(true);
+    expect(isStepAccessible(state, "upload-bundle")).toBe(true);
+    expect(isStepAccessible(state, "validate")).toBe(true);
+    expect(isStepAccessible(state, "preflight-review")).toBe(true);
+    expect(isStepAccessible(state, "transfer")).toBe(true);
+  });
+});

--- a/assistant/src/runtime/migrations/migration-wizard.ts
+++ b/assistant/src/runtime/migrations/migration-wizard.ts
@@ -1,0 +1,765 @@
+/**
+ * Migration wizard state machine — shared module for guided migration UX.
+ *
+ * Drives the multi-step wizard for managed <-> self-hosted assistant
+ * migrations. Usable from both macOS and iOS web views via WKWebView.
+ *
+ * Steps:
+ *   select-direction → upload-bundle → validate → preflight-review →
+ *   transfer → rebind-secrets → complete
+ *
+ * Each step has a status (idle / loading / success / error) with error
+ * details and retry capability. The entire wizard state is serializable
+ * for persistence/resume across app restarts.
+ */
+
+import type {
+  ExportManagedResult,
+  ExportRuntimeResult,
+  ImportCommitResponse,
+  ImportPreflightResponse,
+  TransportConfig,
+  ValidateResponse,
+} from "./migration-transport.js";
+import {
+  exportBundle,
+  importCommit,
+  importPreflight,
+  MigrationTransportError,
+  pollUntilComplete,
+  validateBundle,
+} from "./migration-transport.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type MigrationDirection =
+  | "managed-to-self-hosted"
+  | "self-hosted-to-managed";
+
+export type WizardStep =
+  | "select-direction"
+  | "upload-bundle"
+  | "validate"
+  | "preflight-review"
+  | "transfer"
+  | "rebind-secrets"
+  | "complete";
+
+export type StepStatus = "idle" | "loading" | "success" | "error";
+
+export interface StepError {
+  message: string;
+  code?: string;
+  retryable: boolean;
+}
+
+export interface StepState {
+  status: StepStatus;
+  error?: StepError;
+}
+
+/**
+ * Full wizard state — serializable to JSON for persistence.
+ *
+ * All fields are plain data (no functions, no class instances).
+ * Transport results that contain ArrayBuffer (non-serializable) are
+ * intentionally excluded; the wizard tracks only the structured
+ * metadata from each step.
+ */
+export interface MigrationWizardState {
+  currentStep: WizardStep;
+  direction?: MigrationDirection;
+  steps: Record<WizardStep, StepState>;
+
+  /** Bundle file data is not persisted — must be re-provided on resume. */
+  hasBundleData: boolean;
+
+  /** Validation result from the validate step. */
+  validateResult?: ValidateResponse;
+
+  /** Preflight result from the preflight-review step. */
+  preflightResult?: ImportPreflightResponse;
+
+  /** Export result metadata (no binary data). */
+  exportResult?:
+    | ExportManagedResult
+    | {
+        ok: true;
+        filename: string;
+        schemaVersion: string;
+        manifestSha256: string;
+      };
+
+  /** Import commit result. */
+  importResult?: ImportCommitResponse;
+
+  /** Timestamp of last state change (ISO 8601). */
+  updatedAt: string;
+
+  /** Timestamp of wizard creation (ISO 8601). */
+  createdAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Step ordering and transitions
+// ---------------------------------------------------------------------------
+
+const STEP_ORDER: readonly WizardStep[] = [
+  "select-direction",
+  "upload-bundle",
+  "validate",
+  "preflight-review",
+  "transfer",
+  "rebind-secrets",
+  "complete",
+] as const;
+
+const STEP_INDEX = new Map<WizardStep, number>(
+  STEP_ORDER.map((step, i) => [step, i]),
+);
+
+/**
+ * Steps that are available for a given migration direction.
+ * Both directions use the same steps, but the semantics differ:
+ *
+ * - managed-to-self-hosted: export from managed, import to local runtime
+ * - self-hosted-to-managed: export from local runtime, import to managed
+ */
+function stepsForDirection(
+  _direction: MigrationDirection,
+): readonly WizardStep[] {
+  return STEP_ORDER;
+}
+
+// ---------------------------------------------------------------------------
+// Transition validation
+// ---------------------------------------------------------------------------
+
+export interface TransitionResult {
+  valid: boolean;
+  reason?: string;
+}
+
+/**
+ * Check whether advancing from `current` to `next` is a valid transition.
+ *
+ * Rules:
+ * - Can advance to the immediately next step if the current step is in 'success' status.
+ * - Can go back to any earlier step (allows re-doing steps).
+ * - Cannot skip steps forward.
+ * - 'complete' is a terminal step — no further transitions.
+ */
+export function validateWizardTransition(
+  state: MigrationWizardState,
+  next: WizardStep,
+): TransitionResult {
+  const current = state.currentStep;
+  if (current === next) {
+    return { valid: true };
+  }
+
+  if (current === "complete") {
+    return {
+      valid: false,
+      reason: 'Cannot transition from terminal step "complete"',
+    };
+  }
+
+  const currentIdx = STEP_INDEX.get(current)!;
+  const nextIdx = STEP_INDEX.get(next)!;
+
+  // Going backward is always allowed
+  if (nextIdx < currentIdx) {
+    return { valid: true };
+  }
+
+  // Going forward: can only advance one step at a time, and current must be 'success'
+  if (nextIdx > currentIdx + 1) {
+    return {
+      valid: false,
+      reason: `Cannot skip from "${current}" to "${next}"`,
+    };
+  }
+
+  // nextIdx === currentIdx + 1
+  if (state.steps[current].status !== "success") {
+    return {
+      valid: false,
+      reason: `Cannot advance from "${current}" — step status is "${state.steps[current].status}", expected "success"`,
+    };
+  }
+
+  return { valid: true };
+}
+
+// ---------------------------------------------------------------------------
+// State factory
+// ---------------------------------------------------------------------------
+
+function makeStepStates(): Record<WizardStep, StepState> {
+  const steps = {} as Record<WizardStep, StepState>;
+  for (const step of STEP_ORDER) {
+    steps[step] = { status: "idle" };
+  }
+  return steps;
+}
+
+/**
+ * Create a fresh wizard state.
+ */
+export function createWizardState(): MigrationWizardState {
+  const now = new Date().toISOString();
+  return {
+    currentStep: "select-direction",
+    steps: makeStepStates(),
+    hasBundleData: false,
+    updatedAt: now,
+    createdAt: now,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State transitions — pure functions that return a new state
+// ---------------------------------------------------------------------------
+
+function touch(state: MigrationWizardState): MigrationWizardState {
+  return { ...state, updatedAt: new Date().toISOString() };
+}
+
+function setStepStatus(
+  state: MigrationWizardState,
+  step: WizardStep,
+  status: StepStatus,
+  error?: StepError,
+): MigrationWizardState {
+  return touch({
+    ...state,
+    steps: {
+      ...state.steps,
+      [step]: { status, ...(error ? { error } : {}) },
+    },
+  });
+}
+
+/**
+ * Set the migration direction and advance to the next step.
+ */
+export function selectDirection(
+  state: MigrationWizardState,
+  direction: MigrationDirection,
+): MigrationWizardState {
+  if (state.currentStep !== "select-direction") {
+    throw new Error(
+      `selectDirection called in wrong step: "${state.currentStep}"`,
+    );
+  }
+
+  const updated = setStepStatus(state, "select-direction", "success");
+  return touch({
+    ...updated,
+    direction,
+    currentStep: "upload-bundle",
+  });
+}
+
+/**
+ * Record that bundle data has been provided and advance to validate.
+ */
+export function setBundleUploaded(
+  state: MigrationWizardState,
+): MigrationWizardState {
+  if (state.currentStep !== "upload-bundle") {
+    throw new Error(
+      `setBundleUploaded called in wrong step: "${state.currentStep}"`,
+    );
+  }
+
+  const updated = setStepStatus(state, "upload-bundle", "success");
+  return touch({
+    ...updated,
+    hasBundleData: true,
+    currentStep: "validate",
+  });
+}
+
+/**
+ * Go back to a previous step. Resets all steps after the target step
+ * to 'idle' so they can be re-executed.
+ */
+export function goBackTo(
+  state: MigrationWizardState,
+  targetStep: WizardStep,
+): MigrationWizardState {
+  const result = validateWizardTransition(state, targetStep);
+  if (!result.valid) {
+    throw new Error(`Invalid back-navigation: ${result.reason}`);
+  }
+
+  const targetIdx = STEP_INDEX.get(targetStep)!;
+  const newSteps = { ...state.steps };
+
+  // Reset the target step and all steps after it to idle
+  for (const step of STEP_ORDER) {
+    const idx = STEP_INDEX.get(step)!;
+    if (idx >= targetIdx) {
+      newSteps[step] = { status: "idle" };
+    }
+  }
+
+  return touch({
+    ...state,
+    currentStep: targetStep,
+    steps: newSteps,
+    // Clear results for steps that were reset
+    ...(targetIdx <= STEP_INDEX.get("validate")!
+      ? { validateResult: undefined }
+      : {}),
+    ...(targetIdx <= STEP_INDEX.get("preflight-review")!
+      ? { preflightResult: undefined }
+      : {}),
+    ...(targetIdx <= STEP_INDEX.get("transfer")!
+      ? { exportResult: undefined, importResult: undefined }
+      : {}),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Async step executors — coordinate transport calls with state updates
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for executing a wizard step, including transport config
+ * and an optional state update callback for UI reactivity.
+ */
+export interface StepExecutorOptions {
+  sourceConfig: TransportConfig;
+  destConfig: TransportConfig;
+  bundleData: ArrayBuffer;
+  onStateChange?: (state: MigrationWizardState) => void;
+}
+
+/**
+ * Build a StepError from a caught exception.
+ */
+function toStepError(err: unknown): StepError {
+  if (err instanceof MigrationTransportError) {
+    const retryable =
+      err.statusCode === 429 ||
+      (err.statusCode >= 500 && err.statusCode <= 504);
+    return {
+      message: err.message,
+      code: `HTTP_${err.statusCode}`,
+      retryable,
+    };
+  }
+  if (err instanceof Error) {
+    return { message: err.message, retryable: false };
+  }
+  return { message: String(err), retryable: false };
+}
+
+/**
+ * Execute the validate step: call validateBundle and update state.
+ */
+export async function executeValidateStep(
+  state: MigrationWizardState,
+  options: StepExecutorOptions,
+): Promise<MigrationWizardState> {
+  if (state.currentStep !== "validate") {
+    throw new Error(
+      `executeValidateStep called in wrong step: "${state.currentStep}"`,
+    );
+  }
+
+  let current = setStepStatus(state, "validate", "loading");
+  options.onStateChange?.(current);
+
+  try {
+    const result = await validateBundle(options.destConfig, options.bundleData);
+    if (result.is_valid) {
+      current = setStepStatus(current, "validate", "success");
+      current = {
+        ...current,
+        validateResult: result,
+        currentStep: "preflight-review",
+      };
+    } else {
+      current = setStepStatus(current, "validate", "error", {
+        message:
+          result.errors.map((e) => e.message).join("; ") ||
+          "Bundle validation failed",
+        code: result.errors[0]?.code,
+        retryable: true,
+      });
+      current = { ...current, validateResult: result };
+    }
+  } catch (err) {
+    current = setStepStatus(current, "validate", "error", toStepError(err));
+  }
+
+  current = touch(current);
+  options.onStateChange?.(current);
+  return current;
+}
+
+/**
+ * Execute the preflight-review step: call importPreflight and update state.
+ */
+export async function executePreflightStep(
+  state: MigrationWizardState,
+  options: StepExecutorOptions,
+): Promise<MigrationWizardState> {
+  if (state.currentStep !== "preflight-review") {
+    throw new Error(
+      `executePreflightStep called in wrong step: "${state.currentStep}"`,
+    );
+  }
+
+  let current = setStepStatus(state, "preflight-review", "loading");
+  options.onStateChange?.(current);
+
+  try {
+    const result = await importPreflight(
+      options.destConfig,
+      options.bundleData,
+    );
+    if (result.can_import) {
+      current = setStepStatus(current, "preflight-review", "success");
+      current = {
+        ...current,
+        preflightResult: result,
+        currentStep: "transfer",
+      };
+    } else {
+      current = setStepStatus(current, "preflight-review", "error", {
+        message:
+          result.validation.errors.map((e) => e.message).join("; ") ||
+          "Import preflight validation failed",
+        code: result.validation.errors[0]?.code,
+        retryable: true,
+      });
+      current = { ...current, preflightResult: result };
+    }
+  } catch (err) {
+    current = setStepStatus(
+      current,
+      "preflight-review",
+      "error",
+      toStepError(err),
+    );
+  }
+
+  current = touch(current);
+  options.onStateChange?.(current);
+  return current;
+}
+
+/**
+ * Execute the transfer step: export from source and import to destination.
+ *
+ * For managed sources, this includes async export polling.
+ * For runtime sources, the export returns binary data directly.
+ */
+export async function executeTransferStep(
+  state: MigrationWizardState,
+  options: StepExecutorOptions,
+): Promise<MigrationWizardState> {
+  if (state.currentStep !== "transfer") {
+    throw new Error(
+      `executeTransferStep called in wrong step: "${state.currentStep}"`,
+    );
+  }
+
+  let current = setStepStatus(state, "transfer", "loading");
+  options.onStateChange?.(current);
+
+  try {
+    // Phase 1: Export from source
+    const exportResult = await exportBundle(options.sourceConfig);
+
+    let bundleToImport: ArrayBuffer;
+
+    if ("archive" in exportResult) {
+      // Runtime export — binary archive available immediately
+      const runtimeExport = exportResult as ExportRuntimeResult;
+      bundleToImport = runtimeExport.archive;
+      current = {
+        ...current,
+        exportResult: {
+          ok: true,
+          filename: runtimeExport.filename,
+          schemaVersion: runtimeExport.schemaVersion,
+          manifestSha256: runtimeExport.manifestSha256,
+        },
+      };
+    } else {
+      // Managed export — poll until complete, then fetch archive
+      const managedExport = exportResult as ExportManagedResult;
+      current = { ...current, exportResult: managedExport };
+      options.onStateChange?.(touch(current));
+
+      const finalStatus = await pollUntilComplete(
+        options.sourceConfig,
+        "export",
+        managedExport.jobId,
+        { intervalMs: 2000, maxAttempts: 60 },
+      );
+
+      if (finalStatus.status === "failed") {
+        current = setStepStatus(current, "transfer", "error", {
+          message: `Export job failed: ${finalStatus.error}`,
+          code: "EXPORT_JOB_FAILED",
+          retryable: true,
+        });
+        current = touch(current);
+        options.onStateChange?.(current);
+        return current;
+      }
+
+      // Download the export archive
+      if (!finalStatus.downloadUrl) {
+        current = setStepStatus(current, "transfer", "error", {
+          message: "Export completed but no download URL was provided",
+          code: "NO_DOWNLOAD_URL",
+          retryable: true,
+        });
+        current = touch(current);
+        options.onStateChange?.(current);
+        return current;
+      }
+
+      const fetchFn = options.sourceConfig.fetchFn ?? globalThis.fetch;
+      const downloadResponse = await fetchFn(finalStatus.downloadUrl);
+      if (!downloadResponse.ok) {
+        throw new MigrationTransportError(
+          `Failed to download export: HTTP ${downloadResponse.status}`,
+          downloadResponse.status,
+          await downloadResponse.text().catch(() => "<unreadable>"),
+        );
+      }
+      bundleToImport = await downloadResponse.arrayBuffer();
+    }
+
+    // Phase 2: Import to destination
+    const importResult = await importCommit(options.destConfig, bundleToImport);
+    current = { ...current, importResult };
+
+    if (importResult.success) {
+      current = setStepStatus(current, "transfer", "success");
+      current = { ...current, currentStep: "rebind-secrets" };
+    } else {
+      current = setStepStatus(current, "transfer", "error", {
+        message:
+          importResult.message || `Import failed: ${importResult.reason}`,
+        code: importResult.reason,
+        retryable: true,
+      });
+    }
+  } catch (err) {
+    current = setStepStatus(current, "transfer", "error", toStepError(err));
+  }
+
+  current = touch(current);
+  options.onStateChange?.(current);
+  return current;
+}
+
+/**
+ * Mark the rebind-secrets step as complete.
+ *
+ * This step is UI-driven (the user confirms they've rebound secrets
+ * and channels). The wizard just tracks its completion.
+ */
+export function completeRebindSecrets(
+  state: MigrationWizardState,
+): MigrationWizardState {
+  if (state.currentStep !== "rebind-secrets") {
+    throw new Error(
+      `completeRebindSecrets called in wrong step: "${state.currentStep}"`,
+    );
+  }
+
+  let current = setStepStatus(state, "rebind-secrets", "success");
+  current = { ...current, currentStep: "complete" };
+  current = setStepStatus(current, "complete", "success");
+  return touch(current);
+}
+
+// ---------------------------------------------------------------------------
+// Persistence helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize wizard state to a JSON string for persistence.
+ *
+ * The state is already plain data — this is a convenience wrapper
+ * that validates the shape and strips any undefined values.
+ */
+export function serializeWizardState(state: MigrationWizardState): string {
+  return JSON.stringify(state);
+}
+
+/**
+ * Deserialize a persisted wizard state from JSON.
+ *
+ * Returns undefined if the input is invalid or corrupted.
+ * On successful deserialization, `hasBundleData` is set to false
+ * because binary ArrayBuffer data cannot be persisted — the user
+ * must re-provide the bundle file after resuming.
+ */
+export function deserializeWizardState(
+  json: string,
+): MigrationWizardState | undefined {
+  try {
+    const parsed = JSON.parse(json) as MigrationWizardState;
+
+    // Validate required fields
+    if (
+      !parsed.currentStep ||
+      !parsed.steps ||
+      !parsed.createdAt ||
+      !parsed.updatedAt
+    ) {
+      return undefined;
+    }
+
+    // Validate that currentStep is a known step
+    if (!STEP_INDEX.has(parsed.currentStep)) {
+      return undefined;
+    }
+
+    // Validate that all steps exist
+    for (const step of STEP_ORDER) {
+      if (!parsed.steps[step] || !parsed.steps[step].status) {
+        return undefined;
+      }
+    }
+
+    // Bundle data is never persisted — must be re-provided
+    return { ...parsed, hasBundleData: false };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Check if a persisted wizard state can be meaningfully resumed.
+ *
+ * A wizard is resumable if:
+ * - It has a direction selected
+ * - It is not already complete
+ * - It is not on the first step (nothing to resume)
+ */
+export function isResumable(state: MigrationWizardState): boolean {
+  if (!state.direction) return false;
+  if (state.currentStep === "complete") return false;
+  if (state.currentStep === "select-direction") return false;
+  return true;
+}
+
+/**
+ * Prepare a deserialized state for resumption.
+ *
+ * If the current step was in 'loading' status when the app closed,
+ * resets it to 'idle' so the user can retry. Steps that require
+ * bundle data (validate, preflight-review, transfer) will need the
+ * bundle re-uploaded if it was not persisted.
+ */
+export function prepareForResume(
+  state: MigrationWizardState,
+): MigrationWizardState {
+  let current = { ...state };
+
+  // Reset loading steps to idle (they were interrupted)
+  const step = current.currentStep;
+  if (current.steps[step].status === "loading") {
+    current = setStepStatus(current, step, "idle");
+  }
+
+  // If we need bundle data but don't have it, go back to upload-bundle
+  const needsBundleData =
+    step === "validate" || step === "preflight-review" || step === "transfer";
+  if (needsBundleData && !current.hasBundleData) {
+    current = {
+      ...current,
+      currentStep: "upload-bundle",
+      steps: {
+        ...current.steps,
+        "upload-bundle": { status: "idle" },
+      },
+    };
+  }
+
+  return touch(current);
+}
+
+// ---------------------------------------------------------------------------
+// Query helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the ordered list of steps for the current wizard configuration.
+ */
+export function getStepOrder(
+  state: MigrationWizardState,
+): readonly WizardStep[] {
+  return state.direction ? stepsForDirection(state.direction) : STEP_ORDER;
+}
+
+/**
+ * Get the index of the current step (0-based).
+ */
+export function getCurrentStepIndex(state: MigrationWizardState): number {
+  return STEP_INDEX.get(state.currentStep)!;
+}
+
+/**
+ * Get the total number of steps.
+ */
+export function getTotalSteps(): number {
+  return STEP_ORDER.length;
+}
+
+/**
+ * Check if a step is accessible (can be navigated to) from the current state.
+ */
+export function isStepAccessible(
+  state: MigrationWizardState,
+  step: WizardStep,
+): boolean {
+  return validateWizardTransition(state, step).valid;
+}
+
+/**
+ * Check if the wizard is in a terminal (completed) state.
+ */
+export function isWizardComplete(state: MigrationWizardState): boolean {
+  return (
+    state.currentStep === "complete" &&
+    state.steps["complete"].status === "success"
+  );
+}
+
+/**
+ * Check if the current step has an error that can be retried.
+ */
+export function canRetryCurrentStep(state: MigrationWizardState): boolean {
+  const stepState = state.steps[state.currentStep];
+  return stepState.status === "error" && (stepState.error?.retryable ?? false);
+}
+
+/**
+ * Reset the current step's error state to idle for retry.
+ */
+export function resetStepForRetry(
+  state: MigrationWizardState,
+): MigrationWizardState {
+  if (!canRetryCurrentStep(state)) {
+    throw new Error(
+      `Cannot retry step "${state.currentStep}" — not in a retryable error state`,
+    );
+  }
+  return setStepStatus(state, state.currentStep, "idle");
+}


### PR DESCRIPTION
## Summary
- Add shared migration wizard state machine with step tracking and transitions
- Support both managed->self-hosted and self-hosted->managed directions
- Include loading/error/retry states for each step
- Add persistence/resume support for multi-step flows
- Add comprehensive tests for state transitions and error handling

Part of plan: P29-migration-wizard-ui.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
