### PR TITLE
fix: cast mock fetch through unknown in migration-wizard tests

### DIFF
--- a/assistant/src/__tests__/migration-wizard.test.ts
+++ b/assistant/src/__tests__/migration-wizard.test.ts
@@ -78,7 +78,7 @@ function mockFetch(
       return new Response(body, { status, headers: responseHeaders });
     }
     return new Response(String(body), { status, headers: responseHeaders });
-  }) as typeof fetch;
+  }) as unknown as typeof fetch;
 }
 
 function runtimeConfig(overrides?: Partial<TransportConfig>): TransportConfig {
@@ -598,7 +598,7 @@ describe("executeTransferStep", () => {
         status: 200,
         headers: responseHeaders,
       });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const destFetch = (async () => {
       importCalled = true;
@@ -606,7 +606,7 @@ describe("executeTransferStep", () => {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const state = advanceTo("transfer");
     const options = makeExecutorOptions({
@@ -684,14 +684,14 @@ describe("executeTransferStep", () => {
         return new Response(new ArrayBuffer(32), { status: 200 });
       }
       return new Response("Not found", { status: 404 });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const destFetch = (async () => {
       return new Response(JSON.stringify(importResponse), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const state = advanceTo("transfer");
     const options = makeExecutorOptions({
@@ -732,14 +732,14 @@ describe("executeTransferStep", () => {
           "X-Vbundle-Manifest-Sha256": "abc",
         },
       });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const destFetch = (async () => {
       return new Response(JSON.stringify(importResponse), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const state = advanceTo("transfer");
     const options = makeExecutorOptions({
@@ -779,7 +779,7 @@ describe("executeTransferStep", () => {
         );
       }
       return new Response("Not found", { status: 404 });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const state = advanceTo("transfer");
     const options = makeExecutorOptions({
@@ -1157,14 +1157,14 @@ describe("full wizard flow", () => {
           "X-Vbundle-Manifest-Sha256": "abc",
         },
       });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const destFetch = (async () => {
       return new Response(JSON.stringify(importResponse), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     state = await executeTransferStep(
       state,


### PR DESCRIPTION
## Summary
- Fix TS2352 errors in `migration-wizard.test.ts` — same `as typeof fetch` issue as #11830 but in a different test file
- Cast all mock fetch functions through `unknown` first (`as unknown as typeof fetch`)

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22643942862/job/65626968906

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
