### PR TITLE
fix: remove hardcoded port 7821 from migration-transport JSDoc comment

### DIFF
--- a/assistant/src/runtime/migrations/migration-transport.ts
+++ b/assistant/src/runtime/migrations/migration-transport.ts
@@ -32,7 +32,7 @@
 export type MigrationTarget = "runtime" | "managed";
 
 export interface TransportConfig {
-  /** Base URL of the target API (e.g. "http://localhost:7821" or "https://platform.vellum.ai"). */
+  /** Base URL of the target API (e.g. "https://platform.vellum.ai"). */
   baseURL: string;
   /** Which API surface to target. Managed endpoints use trailing slashes. */
   target: MigrationTarget;


### PR DESCRIPTION
## Summary
- Remove `localhost:7821` example from `TransportConfig.baseURL` JSDoc comment in `migration-transport.ts`
- This was tripping the `gateway-only-guard.test.ts` which scans for hardcoded runtime port references

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22643817139

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
