### PR TITLE
fix: cast all remaining mock fetch through unknown for Bun type compat

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -110,7 +110,7 @@ globalThis.fetch = (async (
     return new Response(JSON.stringify({ ok: true }), { status: 200 });
   }
   return originalFetch(input, init as never);
-}) as typeof fetch;
+}) as unknown as typeof fetch;
 import { eq } from "drizzle-orm";
 
 import {

--- a/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
+++ b/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
@@ -282,7 +282,7 @@ describe("Verification control messages are deterministic (guard)", () => {
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }
       return originalFetch(input, init as never);
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     try {
       const req = new Request("http://localhost/channels/inbound", {
@@ -369,7 +369,7 @@ describe("Verification control messages are deterministic (guard)", () => {
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }
       return originalFetch(input, init as never);
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     try {
       const req = new Request("http://localhost/channels/inbound", {

--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -123,7 +123,7 @@ globalThis.fetch = (async (
     return new Response(JSON.stringify({ ok: true }), { status: 200 });
   }
   return originalFetch(input, init as never);
-}) as typeof fetch;
+}) as unknown as typeof fetch;
 
 // ---------------------------------------------------------------------------
 // Now import modules under test (after mocks are in place)

--- a/assistant/src/__tests__/handlers-telegram-config.test.ts
+++ b/assistant/src/__tests__/handlers-telegram-config.test.ts
@@ -279,7 +279,7 @@ describe("Telegram config handler", () => {
         );
       }
       return originalFetch(url);
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const msg: TelegramConfigRequest = {
       type: "telegram_config",
@@ -340,7 +340,7 @@ describe("Telegram config handler", () => {
         );
       }
       return originalFetch(url);
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const msg: TelegramConfigRequest = {
       type: "telegram_config",
@@ -404,7 +404,7 @@ describe("Telegram config handler", () => {
         );
       }
       return originalFetch(url);
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const msg: TelegramConfigRequest = {
       type: "telegram_config",
@@ -529,7 +529,7 @@ describe("Telegram config handler", () => {
         );
       }
       return originalFetch(url);
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const msg: TelegramConfigRequest = {
       type: "telegram_config",
@@ -581,7 +581,7 @@ describe("Telegram config handler", () => {
         );
       }
       return originalFetch(url);
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const msg: TelegramConfigRequest = {
       type: "telegram_config",
@@ -629,7 +629,7 @@ describe("Telegram config handler", () => {
         );
       }
       return originalFetch(url);
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const msg: TelegramConfigRequest = {
       type: "telegram_config",
@@ -707,7 +707,7 @@ describe("Telegram config handler", () => {
         );
       }
       return originalFetch(url);
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const msg: TelegramConfigRequest = {
       type: "telegram_config",
@@ -813,7 +813,7 @@ describe("Telegram config handler", () => {
         );
       }
       return originalFetch(url);
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const msg: TelegramConfigRequest = {
       type: "telegram_config",
@@ -882,7 +882,7 @@ describe("Telegram config handler", () => {
         );
       }
       return originalFetch(url);
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const msg: TelegramConfigRequest = {
       type: "telegram_config",
@@ -946,7 +946,7 @@ describe("Telegram config handler", () => {
         });
       }
       return originalFetch(url);
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const { ctx, sent } = createTestContext();
     await handleTelegramConfig(
@@ -1040,7 +1040,7 @@ describe("Telegram config handler", () => {
         });
       }
       return originalFetch(url);
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const msg: TelegramConfigRequest = {
       type: "telegram_config",
@@ -1096,7 +1096,7 @@ describe("Telegram config handler", () => {
         });
       }
       return originalFetch(url);
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const msg: TelegramConfigRequest = {
       type: "telegram_config",
@@ -1159,7 +1159,7 @@ describe("Telegram config handler", () => {
         );
       }
       return originalFetch(url);
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const msg: TelegramConfigRequest = {
       type: "telegram_config",
@@ -1198,7 +1198,7 @@ describe("Telegram config handler", () => {
         });
       }
       return originalFetch(url);
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     // Call set_commands WITHOUT explicit commands to use defaults
     const msg: TelegramConfigRequest = {

--- a/assistant/src/__tests__/ingress-reconcile.test.ts
+++ b/assistant/src/__tests__/ingress-reconcile.test.ts
@@ -170,7 +170,7 @@ describe("Ingress reconcile trigger in handleIngressConfig", () => {
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }
       return originalFetch(url, init);
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
   });
 
   afterEach(() => {
@@ -432,7 +432,7 @@ describe("Ingress reconcile trigger in handleIngressConfig", () => {
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }
       return originalFetch(url, init);
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const msg: IngressConfigRequest = {
       type: "ingress_config",

--- a/assistant/src/__tests__/oauth2-gateway-transport.test.ts
+++ b/assistant/src/__tests__/oauth2-gateway-transport.test.ts
@@ -129,7 +129,7 @@ globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     });
   }
   return originalFetch(input, init);
-}) as typeof fetch;
+}) as unknown as typeof fetch;
 
 // ---------------------------------------------------------------------------
 // Import module under test AFTER mocks are in place

--- a/assistant/src/__tests__/twilio-provider.test.ts
+++ b/assistant/src/__tests__/twilio-provider.test.ts
@@ -163,7 +163,7 @@ describe("TwilioConversationRelayProvider", () => {
         return new Response(JSON.stringify({ sid: "CA_test_123" }), {
           status: 200,
         });
-      }) as typeof fetch;
+      }) as unknown as typeof fetch;
 
       try {
         const result = await provider.initiateCall({
@@ -218,7 +218,7 @@ describe("TwilioConversationRelayProvider", () => {
         return new Response(JSON.stringify({ outgoing_caller_ids: [] }), {
           status: 200,
         });
-      }) as typeof fetch;
+      }) as unknown as typeof fetch;
 
       const result = await provider.checkCallerIdEligibility("+15550001111");
       expect(result.eligible).toBe(true);
@@ -246,7 +246,7 @@ describe("TwilioConversationRelayProvider", () => {
           );
         }
         return new Response("Not found", { status: 404 });
-      }) as typeof fetch;
+      }) as unknown as typeof fetch;
 
       const result = await provider.checkCallerIdEligibility("+15550001111");
       expect(result.eligible).toBe(true);
@@ -269,7 +269,7 @@ describe("TwilioConversationRelayProvider", () => {
           });
         }
         return new Response("Not found", { status: 404 });
-      }) as typeof fetch;
+      }) as unknown as typeof fetch;
 
       const result = await provider.checkCallerIdEligibility("+15559999999");
       expect(result.eligible).toBe(false);
@@ -289,7 +289,7 @@ describe("TwilioConversationRelayProvider", () => {
           return new Response("Internal Server Error", { status: 500 });
         }
         return new Response("Not found", { status: 404 });
-      }) as typeof fetch;
+      }) as unknown as typeof fetch;
 
       await expect(
         provider.checkCallerIdEligibility("+15550001111"),
@@ -310,7 +310,7 @@ describe("TwilioConversationRelayProvider", () => {
           });
         }
         return new Response("Not found", { status: 404 });
-      }) as typeof fetch;
+      }) as unknown as typeof fetch;
 
       await expect(
         provider.checkCallerIdEligibility("+15550001111"),
@@ -333,7 +333,7 @@ describe("TwilioConversationRelayProvider", () => {
         return new Response(JSON.stringify({ outgoing_caller_ids: [] }), {
           status: 200,
         });
-      }) as typeof fetch;
+      }) as unknown as typeof fetch;
 
       await provider.checkCallerIdEligibility("+15550001111");
 

--- a/assistant/src/__tests__/validation-results-screen.test.ts
+++ b/assistant/src/__tests__/validation-results-screen.test.ts
@@ -77,7 +77,7 @@ function mockFetch(
       return new Response(body, { status, headers: responseHeaders });
     }
     return new Response(String(body), { status, headers: responseHeaders });
-  }) as typeof fetch;
+  }) as unknown as typeof fetch;
 }
 
 function runtimeConfig(overrides?: Partial<TransportConfig>): TransportConfig {
@@ -633,7 +633,7 @@ describe("retryValidationFlow", () => {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const options = makeExecutorOptions({
       destConfig: runtimeConfig({ fetchFn: sequentialFetch }),
@@ -720,7 +720,7 @@ describe("executeValidationFlow", () => {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const stateChanges: MigrationWizardState[] = [];
     const options = makeExecutorOptions({
@@ -1015,7 +1015,7 @@ describe("executeValidationFlow — onStateChange callbacks", () => {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const stateChanges: ValidationScreenState[] = [];
     const options = makeExecutorOptions({


### PR DESCRIPTION
## Summary
- Fix TS2352 errors across all remaining test files with `as typeof fetch` casts
- Updated 8 test files: validation-results-screen, twilio-provider, oauth2-gateway-transport, ingress-reconcile, handlers-telegram-config, guardian-outbound-http, deterministic-verification-control-plane, channel-guardian
- All casts now go through `unknown` first (`as unknown as typeof fetch`) to satisfy Bun's `fetch` type which includes `preconnect`

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22644114430/job/65627554299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
