### PR TITLE
assistant: resolve guardian prompts/decisions by conversation scope (source + destination)

### DIFF
--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -57,6 +57,19 @@ mock.module("../memory/canonical-guardian-store.js", () => ({
   ) => listPendingByDestinationMock(conversationId, sourceChannel),
   listCanonicalGuardianRequests: (filters?: Record<string, unknown>) =>
     listCanonicalMock(filters),
+  listPendingRequestsByConversationScope: (conversationId: string) => {
+    const byDest = listPendingByDestinationMock(conversationId);
+    const bySrc = listCanonicalMock({ status: "pending", conversationId });
+    const seen = new Set<string>();
+    const result: Array<{ id: string; kind?: string }> = [];
+    for (const r of [...bySrc, ...byDest]) {
+      if (!seen.has(r.id)) {
+        seen.add(r.id);
+        result.push(r);
+      }
+    }
+    return result;
+  },
 }));
 
 mock.module("../runtime/confirmation-request-guardian-bridge.js", () => ({

--- a/assistant/src/__tests__/guardian-actions-endpoint.test.ts
+++ b/assistant/src/__tests__/guardian-actions-endpoint.test.ts
@@ -58,6 +58,7 @@ mock.module("../approvals/guardian-decision-primitive.js", () => ({
 
 import { guardianActionsHandlers } from "../daemon/handlers/guardian-actions.js";
 import {
+  createCanonicalGuardianDelivery,
   createCanonicalGuardianRequest,
   generateCanonicalRequestCode,
 } from "../memory/canonical-guardian-store.js";
@@ -99,6 +100,7 @@ function ensureConversation(id: string): void {
 
 function resetTables(): void {
   const db = getDb();
+  db.run("DELETE FROM canonical_guardian_deliveries");
   db.run("DELETE FROM canonical_guardian_requests");
   db.run("DELETE FROM channel_guardian_approval_requests");
   db.run("DELETE FROM conversations");
@@ -277,6 +279,37 @@ describe("HTTP handleGuardianActionDecision", () => {
         requestId: "req-scope-2",
         action: "reject",
         conversationId: "conv-match",
+      }),
+    });
+    const res = await handleGuardianActionDecision(req, mockAuthContext);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.applied).toBe(true);
+  });
+
+  test("allows decision when conversationId matches a delivery destination", async () => {
+    createTestCanonicalRequest({
+      conversationId: "conv-source-http",
+      requestId: "req-dest-scope-http",
+      kind: "pending_question",
+    });
+    createCanonicalGuardianDelivery({
+      requestId: "req-dest-scope-http",
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-guardian-thread",
+    });
+    mockApplyCanonicalGuardianDecision.mockResolvedValueOnce({
+      applied: true,
+      requestId: "req-dest-scope-http",
+      grantMinted: false,
+    });
+
+    const req = new Request("http://localhost/v1/guardian-actions/decision", {
+      method: "POST",
+      body: JSON.stringify({
+        requestId: "req-dest-scope-http",
+        action: "approve_once",
+        conversationId: "conv-guardian-thread",
       }),
     });
     const res = await handleGuardianActionDecision(req, mockAuthContext);
@@ -588,6 +621,67 @@ describe("listGuardianDecisionPrompts", () => {
     expect(promptsB).toHaveLength(1);
     expect(promptsB[0].requestId).toBe("req-b");
   });
+
+  test("includes requests delivered to the queried destination conversation", () => {
+    createTestCanonicalRequest({
+      conversationId: "conv-source",
+      requestId: "req-dest-1",
+      kind: "pending_question",
+      questionText: "What should I do?",
+    });
+    createCanonicalGuardianDelivery({
+      requestId: "req-dest-1",
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-guardian-dest",
+    });
+
+    const prompts = listGuardianDecisionPrompts({
+      conversationId: "conv-guardian-dest",
+    });
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0].requestId).toBe("req-dest-1");
+    expect(prompts[0].questionText).toBe("What should I do?");
+  });
+
+  test("normalizes prompt conversationId to the queried thread ID", () => {
+    createTestCanonicalRequest({
+      conversationId: "conv-source-norm",
+      requestId: "req-norm-1",
+      kind: "access_request",
+      questionText: "Grant access?",
+    });
+    createCanonicalGuardianDelivery({
+      requestId: "req-norm-1",
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-dest-norm",
+    });
+
+    const prompts = listGuardianDecisionPrompts({
+      conversationId: "conv-dest-norm",
+    });
+    expect(prompts).toHaveLength(1);
+    // conversationId should be normalized to the queried thread, not the source
+    expect(prompts[0].conversationId).toBe("conv-dest-norm");
+  });
+
+  test("deduplicates requests found by both source and destination", () => {
+    createTestCanonicalRequest({
+      conversationId: "conv-same",
+      requestId: "req-dedup-1",
+    });
+    // Deliver to the same conversation (source == destination)
+    createCanonicalGuardianDelivery({
+      requestId: "req-dedup-1",
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-same",
+    });
+
+    const prompts = listGuardianDecisionPrompts({
+      conversationId: "conv-same",
+    });
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0].requestId).toBe("req-dedup-1");
+  });
 });
 
 // =========================================================================
@@ -705,6 +799,38 @@ describe("IPC guardian_action_decision", () => {
         requestId: "req-ipc-match",
         action: "reject",
         conversationId: "conv-ipc-match",
+      } as any,
+      socket as any,
+      ctx as any,
+    );
+    expect(sent).toHaveLength(1);
+    expect(sent[0].applied).toBe(true);
+  });
+
+  test("allows decision when conversationId matches a delivery destination", async () => {
+    createTestCanonicalRequest({
+      conversationId: "conv-ipc-source",
+      requestId: "req-ipc-dest-scope",
+      kind: "pending_question",
+    });
+    createCanonicalGuardianDelivery({
+      requestId: "req-ipc-dest-scope",
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-ipc-guardian-thread",
+    });
+    mockApplyCanonicalGuardianDecision.mockResolvedValueOnce({
+      applied: true,
+      requestId: "req-ipc-dest-scope",
+      grantMinted: false,
+    });
+
+    const { socket, ctx, sent } = createIpcStub();
+    await handler(
+      {
+        type: "guardian_action_decision",
+        requestId: "req-ipc-dest-scope",
+        action: "approve_once",
+        conversationId: "conv-ipc-guardian-thread",
       } as any,
       socket as any,
       ctx as any,
@@ -848,5 +974,39 @@ describe("IPC guardian_actions_pending_request", () => {
     expect(sent).toHaveLength(1);
     const prompts = sent[0].prompts as unknown[];
     expect(prompts).toHaveLength(0);
+  });
+
+  test("returns prompts delivered to the queried destination conversation", () => {
+    createTestCanonicalRequest({
+      conversationId: "conv-ipc-source-list",
+      requestId: "req-ipc-dest-list",
+      kind: "pending_question",
+      questionText: "Voice question?",
+    });
+    createCanonicalGuardianDelivery({
+      requestId: "req-ipc-dest-list",
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-ipc-dest-list",
+    });
+
+    const { socket, ctx, sent } = createIpcStub();
+    handler(
+      {
+        type: "guardian_actions_pending_request",
+        conversationId: "conv-ipc-dest-list",
+      } as any,
+      socket as any,
+      ctx as any,
+    );
+    expect(sent).toHaveLength(1);
+    const prompts = sent[0].prompts as Array<{
+      requestId: string;
+      questionText: string;
+      conversationId: string;
+    }>;
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0].requestId).toBe("req-ipc-dest-list");
+    expect(prompts[0].questionText).toBe("Voice question?");
+    expect(prompts[0].conversationId).toBe("conv-ipc-dest-list");
   });
 });

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -211,13 +211,10 @@ describe("routing invariant: all decision paths reference applyCanonicalGuardian
     expect(source).not.toContain("getPendingDeliveriesByConversation");
   });
 
-  test("daemon/session-process.ts seeds router hints from delivery and conversation scopes", () => {
+  test("daemon/session-process.ts seeds router hints via listPendingRequestsByConversationScope", () => {
     const fullPath = join(srcRoot, "daemon/session-process.ts");
     const source = readFileSync(fullPath, "utf-8");
-    expect(source).toContain(
-      "listPendingCanonicalGuardianRequestsByDestinationConversation",
-    );
-    expect(source).toContain("listCanonicalGuardianRequests");
+    expect(source).toContain("listPendingRequestsByConversationScope");
   });
 
   test("guardian-reply-router routes all decisions through applyCanonicalGuardianDecision", () => {

--- a/assistant/src/__tests__/session-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/session-abort-tool-results.test.ts
@@ -198,6 +198,7 @@ mock.module("../agent/loop.js", () => ({
 mock.module("../memory/canonical-guardian-store.js", () => ({
   listPendingCanonicalGuardianRequestsByDestinationConversation: () => [],
   listCanonicalGuardianRequests: () => [],
+  listPendingRequestsByConversationScope: () => [],
   createCanonicalGuardianRequest: () => ({
     id: "mock-cg-id",
     code: "MOCK",

--- a/assistant/src/__tests__/session-confirmation-signals.test.ts
+++ b/assistant/src/__tests__/session-confirmation-signals.test.ts
@@ -219,6 +219,7 @@ mock.module("../agent/loop.js", () => ({
 mock.module("../memory/canonical-guardian-store.js", () => ({
   listPendingCanonicalGuardianRequestsByDestinationConversation: () => [],
   listCanonicalGuardianRequests: () => [],
+  listPendingRequestsByConversationScope: () => [],
   createCanonicalGuardianRequest: () => ({
     id: "mock-cg-id",
     code: "MOCK",

--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -324,6 +324,7 @@ mock.module("../agent/loop.js", () => ({
 mock.module("../memory/canonical-guardian-store.js", () => ({
   listPendingCanonicalGuardianRequestsByDestinationConversation: () => [],
   listCanonicalGuardianRequests: () => [],
+  listPendingRequestsByConversationScope: () => [],
   createCanonicalGuardianRequest: () => ({
     id: "mock-cg-id",
     code: "MOCK",

--- a/assistant/src/__tests__/session-pre-run-repair.test.ts
+++ b/assistant/src/__tests__/session-pre-run-repair.test.ts
@@ -155,6 +155,7 @@ mock.module("../context/window-manager.js", () => ({
 mock.module("../memory/canonical-guardian-store.js", () => ({
   listPendingCanonicalGuardianRequestsByDestinationConversation: () => [],
   listCanonicalGuardianRequests: () => [],
+  listPendingRequestsByConversationScope: () => [],
   createCanonicalGuardianRequest: () => ({
     id: "mock-cg-id",
     code: "MOCK",

--- a/assistant/src/__tests__/session-profile-injection.test.ts
+++ b/assistant/src/__tests__/session-profile-injection.test.ts
@@ -284,6 +284,7 @@ mock.module("../agent/loop.js", () => ({
 mock.module("../memory/canonical-guardian-store.js", () => ({
   listPendingCanonicalGuardianRequestsByDestinationConversation: () => [],
   listCanonicalGuardianRequests: () => [],
+  listPendingRequestsByConversationScope: () => [],
   createCanonicalGuardianRequest: () => ({
     id: "mock-cg-id",
     code: "MOCK",

--- a/assistant/src/__tests__/session-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/session-provider-retry-repair.test.ts
@@ -280,6 +280,7 @@ mock.module("../agent/loop.js", () => ({
 mock.module("../memory/canonical-guardian-store.js", () => ({
   listPendingCanonicalGuardianRequestsByDestinationConversation: () => [],
   listCanonicalGuardianRequests: () => [],
+  listPendingRequestsByConversationScope: () => [],
   createCanonicalGuardianRequest: () => ({
     id: "mock-cg-id",
     code: "MOCK",

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -259,6 +259,7 @@ mock.module("../agent/loop.js", () => ({
 mock.module("../memory/canonical-guardian-store.js", () => ({
   listPendingCanonicalGuardianRequestsByDestinationConversation: () => [],
   listCanonicalGuardianRequests: () => [],
+  listPendingRequestsByConversationScope: () => [],
   createCanonicalGuardianRequest: () => ({
     id: "mock-cg-id",
     code: "MOCK",

--- a/assistant/src/__tests__/session-slash-known.test.ts
+++ b/assistant/src/__tests__/session-slash-known.test.ts
@@ -196,6 +196,7 @@ mock.module("../agent/loop.js", () => ({
 mock.module("../memory/canonical-guardian-store.js", () => ({
   listPendingCanonicalGuardianRequestsByDestinationConversation: () => [],
   listCanonicalGuardianRequests: () => [],
+  listPendingRequestsByConversationScope: () => [],
   createCanonicalGuardianRequest: () => ({
     id: "mock-cg-id",
     code: "MOCK",

--- a/assistant/src/__tests__/session-slash-queue.test.ts
+++ b/assistant/src/__tests__/session-slash-queue.test.ts
@@ -196,6 +196,7 @@ mock.module("../agent/loop.js", () => ({
 mock.module("../memory/canonical-guardian-store.js", () => ({
   listPendingCanonicalGuardianRequestsByDestinationConversation: () => [],
   listCanonicalGuardianRequests: () => [],
+  listPendingRequestsByConversationScope: () => [],
   createCanonicalGuardianRequest: () => ({
     id: "mock-cg-id",
     code: "MOCK",

--- a/assistant/src/__tests__/session-slash-unknown.test.ts
+++ b/assistant/src/__tests__/session-slash-unknown.test.ts
@@ -219,6 +219,7 @@ mock.module("../agent/loop.js", () => ({
 mock.module("../memory/canonical-guardian-store.js", () => ({
   listPendingCanonicalGuardianRequestsByDestinationConversation: () => [],
   listCanonicalGuardianRequests: () => [],
+  listPendingRequestsByConversationScope: () => [],
   createCanonicalGuardianRequest: () => ({
     id: "mock-cg-id",
     code: "MOCK",

--- a/assistant/src/__tests__/session-workspace-injection.test.ts
+++ b/assistant/src/__tests__/session-workspace-injection.test.ts
@@ -241,6 +241,7 @@ mock.module("../agent/loop.js", () => ({
 mock.module("../memory/canonical-guardian-store.js", () => ({
   listPendingCanonicalGuardianRequestsByDestinationConversation: () => [],
   listCanonicalGuardianRequests: () => [],
+  listPendingRequestsByConversationScope: () => [],
   createCanonicalGuardianRequest: () => ({
     id: "mock-cg-id",
     code: "MOCK",

--- a/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
@@ -225,6 +225,7 @@ mock.module("../agent/loop.js", () => ({
 mock.module("../memory/canonical-guardian-store.js", () => ({
   listPendingCanonicalGuardianRequestsByDestinationConversation: () => [],
   listCanonicalGuardianRequests: () => [],
+  listPendingRequestsByConversationScope: () => [],
   createCanonicalGuardianRequest: () => ({
     id: "mock-cg-id",
     code: "MOCK",

--- a/assistant/src/daemon/handlers/guardian-actions.ts
+++ b/assistant/src/daemon/handlers/guardian-actions.ts
@@ -1,7 +1,7 @@
 import {
   applyCanonicalGuardianDecision,
 } from '../../approvals/guardian-decision-primitive.js';
-import { getCanonicalGuardianRequest } from '../../memory/canonical-guardian-store.js';
+import { getCanonicalGuardianRequest, isRequestInConversationScope } from '../../memory/canonical-guardian-store.js';
 import type { ApprovalAction } from '../../runtime/channel-approval-types.js';
 import { resolveLocalIpcGuardianContext } from '../../runtime/local-actor-identity.js';
 import { listGuardianDecisionPrompts } from '../../runtime/routes/guardian-action-routes.js';
@@ -31,11 +31,12 @@ export const guardianActionsHandlers = defineHandlers({
     }
 
     // Verify conversationId scoping before applying the canonical decision.
-    // A caller must not be able to cross-resolve requests from a different conversation.
+    // The decision is allowed when the conversationId matches the request's
+    // source conversation OR a recorded delivery destination conversation.
     if (msg.conversationId) {
       const canonicalRequest = getCanonicalGuardianRequest(msg.requestId);
-      if (canonicalRequest && canonicalRequest.conversationId && canonicalRequest.conversationId !== msg.conversationId) {
-        log.warn({ requestId: msg.requestId, expected: canonicalRequest.conversationId, got: msg.conversationId }, 'conversationId mismatch');
+      if (canonicalRequest && canonicalRequest.conversationId && !isRequestInConversationScope(msg.requestId, msg.conversationId)) {
+        log.warn({ requestId: msg.requestId, expected: canonicalRequest.conversationId, got: msg.conversationId }, 'conversationId not in scope');
         ctx.send(socket, {
           type: 'guardian_action_decision_response',
           applied: false,

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -11,8 +11,7 @@ import type { TurnChannelContext, TurnInterfaceContext } from '../channels/types
 import { parseChannelId, parseInterfaceId } from '../channels/types.js';
 import { getConfig } from '../config/loader.js';
 import {
-  listCanonicalGuardianRequests,
-  listPendingCanonicalGuardianRequestsByDestinationConversation,
+  listPendingRequestsByConversationScope,
 } from '../memory/canonical-guardian-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
@@ -362,13 +361,7 @@ export async function processMessage(
   session.currentPage = currentPage;
   const trimmedContent = content.trim();
   const canonicalPendingRequestHintIdsForConversation = trimmedContent.length > 0
-    ? Array.from(new Set([
-        ...listPendingCanonicalGuardianRequestsByDestinationConversation(session.conversationId, 'vellum').map((request) => request.id),
-        ...listCanonicalGuardianRequests({
-          status: 'pending',
-          conversationId: session.conversationId,
-        }).map((request) => request.id),
-      ]))
+    ? listPendingRequestsByConversationScope(session.conversationId).map((request) => request.id)
     : [];
   const canonicalPendingRequestIdsForConversation = canonicalPendingRequestHintIdsForConversation.length > 0
     ? canonicalPendingRequestHintIdsForConversation

--- a/assistant/src/memory/canonical-guardian-store.ts
+++ b/assistant/src/memory/canonical-guardian-store.ts
@@ -533,6 +533,71 @@ export function listPendingCanonicalGuardianRequestsByDestinationChat(
   return pendingRequests;
 }
 
+// ---------------------------------------------------------------------------
+// Conversation scope helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * List pending canonical requests in scope for a conversation, unioning:
+ *   1. Requests whose source `conversationId` matches the queried thread.
+ *   2. Requests that have a delivery whose `destinationConversationId` matches.
+ *
+ * Deduplicates by request ID so a request that was both sourced from and
+ * delivered to the same conversation only appears once.
+ */
+export function listPendingRequestsByConversationScope(
+  conversationId: string,
+): CanonicalGuardianRequest[] {
+  const bySource = listCanonicalGuardianRequests({
+    conversationId,
+    status: 'pending',
+  });
+
+  const byDestination = listPendingCanonicalGuardianRequestsByDestinationConversation(conversationId);
+
+  const seen = new Set<string>();
+  const result: CanonicalGuardianRequest[] = [];
+
+  for (const req of bySource) {
+    if (!seen.has(req.id)) {
+      seen.add(req.id);
+      result.push(req);
+    }
+  }
+
+  for (const req of byDestination) {
+    if (!seen.has(req.id)) {
+      seen.add(req.id);
+      result.push(req);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Check whether a guardian decision's `conversationId` is in scope for a
+ * canonical request. A decision is in scope when:
+ *   - The request's source `conversationId` matches, OR
+ *   - Any recorded delivery has `destinationConversationId` matching.
+ *
+ * Returns `true` when the decision is allowed from the given conversation.
+ */
+export function isRequestInConversationScope(
+  requestId: string,
+  conversationId: string,
+): boolean {
+  const request = getCanonicalGuardianRequest(requestId);
+  if (!request) return false;
+
+  // Source conversation match
+  if (request.conversationId === conversationId) return true;
+
+  // Destination delivery match
+  const deliveries = listCanonicalGuardianDeliveries(requestId);
+  return deliveries.some((d) => d.destinationConversationId === conversationId);
+}
+
 export interface UpdateCanonicalGuardianDeliveryParams {
   status?: string;
   destinationMessageId?: string;

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -12,8 +12,7 @@ import * as attachmentsStore from '../../memory/attachments-store.js';
 import {
   createCanonicalGuardianRequest,
   generateCanonicalRequestCode,
-  listCanonicalGuardianRequests,
-  listPendingCanonicalGuardianRequestsByDestinationConversation,
+  listPendingRequestsByConversationScope,
 } from '../../memory/canonical-guardian-store.js';
 import {
   getConversationByKey,
@@ -49,28 +48,14 @@ const SUGGESTION_CACHE_MAX = 100;
 
 function collectCanonicalGuardianRequestHintIds(
   conversationId: string,
-  sourceChannel: string,
+  _sourceChannel: string,
   session: import('../../daemon/session.js').Session,
 ): string[] {
-  const requests = [
-    ...listPendingCanonicalGuardianRequestsByDestinationConversation(conversationId, sourceChannel)
-      .map((request) => ({ id: request.id, kind: request.kind })),
-    ...listCanonicalGuardianRequests({
-      status: 'pending',
-      conversationId,
-    }).map((request) => ({ id: request.id, kind: request.kind })),
-  ];
+  const requests = listPendingRequestsByConversationScope(conversationId);
 
-  const deduped = new Map<string, string>();
-  for (const request of requests) {
-    if (!deduped.has(request.id)) {
-      deduped.set(request.id, request.kind ?? '');
-    }
-  }
-
-  return Array.from(deduped.entries())
-    .filter(([requestId, kind]) => kind !== 'tool_approval' || session.hasPendingConfirmation(requestId))
-    .map(([requestId]) => requestId);
+  return requests
+    .filter((req) => req.kind !== 'tool_approval' || session.hasPendingConfirmation(req.id))
+    .map((req) => req.id);
 }
 
 async function tryConsumeCanonicalGuardianReply(params: {

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -18,7 +18,8 @@ import { isHttpAuthDisabled } from '../../config/env.js';
 import {
   type CanonicalGuardianRequest,
   getCanonicalGuardianRequest,
-  listCanonicalGuardianRequests,
+  isRequestInConversationScope,
+  listPendingRequestsByConversationScope,
 } from '../../memory/canonical-guardian-store.js';
 import { getActiveBinding } from '../../memory/guardian-bindings.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
@@ -113,10 +114,11 @@ export async function handleGuardianActionDecision(req: Request, authContext: Au
   }
 
   // Verify conversationId scoping before applying the canonical decision.
-  // A caller must not be able to cross-resolve requests from a different conversation.
+  // The decision is allowed when the conversationId matches the request's
+  // source conversation OR a recorded delivery destination conversation.
   if (conversationId) {
     const canonicalRequest = getCanonicalGuardianRequest(requestId);
-    if (canonicalRequest && canonicalRequest.conversationId && canonicalRequest.conversationId !== conversationId) {
+    if (canonicalRequest && canonicalRequest.conversationId && !isRequestInConversationScope(requestId, conversationId)) {
       return httpError('NOT_FOUND', 'No pending guardian action found for this requestId', 404);
     }
   }
@@ -172,9 +174,13 @@ export async function handleGuardianActionDecision(req: Request, authContext: Au
 /**
  * Build a list of GuardianDecisionPrompt objects for the given conversation.
  *
- * Reads exclusively from the canonical guardian requests store. All request
- * kinds (tool_approval, pending_question, access_request, etc.) that have
- * been created as canonical requests will appear here.
+ * Uses the conversation scope helper to union requests whose source
+ * `conversationId` matches AND requests delivered to this conversation.
+ * This allows guardian destination threads (including macOS Vellum threads)
+ * to surface prompts for all canonical kinds.
+ *
+ * The returned prompts normalize `conversationId` to the queried thread ID
+ * for client rendering stability.
  */
 export function listGuardianDecisionPrompts(params: {
   conversationId: string;
@@ -182,10 +188,7 @@ export function listGuardianDecisionPrompts(params: {
   const { conversationId } = params;
   const prompts: GuardianDecisionPrompt[] = [];
 
-  const canonicalRequests = listCanonicalGuardianRequests({
-    conversationId,
-    status: 'pending',
-  });
+  const canonicalRequests = listPendingRequestsByConversationScope(conversationId);
 
   for (const req of canonicalRequests) {
     // Skip expired canonical requests
@@ -233,7 +236,10 @@ function mapCanonicalRequestToPrompt(
     toolName: req.toolName ?? null,
     actions,
     expiresAt,
-    conversationId: req.conversationId ?? conversationId,
+    // Normalize to the queried thread ID for client rendering stability.
+    // The canonical request's source conversationId may differ from the
+    // guardian destination thread the client is viewing.
+    conversationId,
     callSessionId: req.callSessionId ?? null,
     kind: req.kind,
   };


### PR DESCRIPTION
## Summary

Make guardian action listing and decision submission work from the guardian destination thread for all canonical kinds.

- Add shared canonical helper for conversation scope lookup (unions source + destination)
- Update listGuardianDecisionPrompts to use shared scope helper
- Normalize prompt conversationId to queried thread ID for client rendering stability
- Add shared decision-is-in-scope check for both HTTP and IPC handlers
- Keep existing identity/principal authorization unchanged

Closes #11837
Part of #11836
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
