### PR TITLE
fix: cast mock fetch through unknown for Bun type compat

### DIFF
--- a/assistant/src/__tests__/transfer-progress-screen.test.ts
+++ b/assistant/src/__tests__/transfer-progress-screen.test.ts
@@ -74,7 +74,7 @@ function mockFetch(
       return new Response(body, { status, headers: responseHeaders });
     }
     return new Response(String(body), { status, headers: responseHeaders });
-  }) as typeof fetch;
+  }) as unknown as typeof fetch;
 }
 
 function runtimeConfig(overrides?: Partial<TransportConfig>): TransportConfig {


### PR DESCRIPTION
## Summary
- Cast mock fetch return through `unknown` before `typeof fetch` in `transfer-progress-screen.test.ts` to fix TS2352 error caused by Bun's `fetch` having a `preconnect` property that the mock doesn't implement.

## Original prompt
fix this Ci issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22644278389/job/65628122294

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
