### PR TITLE
fix: scope sidebar contrast changes to light mode and restore token distinction

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/SidebarSearchButton.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/SidebarSearchButton.swift
@@ -9,6 +9,7 @@ struct SidebarSearchButton: View {
     let action: () -> Void
 
     @State private var isHovered = false
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         Button(action: action) {
@@ -44,13 +45,15 @@ struct SidebarSearchButton: View {
                 .foregroundColor(VColor.textMuted)
                 .padding(.horizontal, VSpacing.xs)
                 .padding(.vertical, VSpacing.xxs)
-                .background(VColor.surfaceBorder.opacity(0.7))
+                .background(VColor.surfaceBorder.opacity(colorScheme == .dark ? 0.5 : 0.7))
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.xs))
         }
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.sm)
         .background(
-            (isHovered ? VColor.surfaceBorder.opacity(0.7) : VColor.surfaceBorder.opacity(0.4))
+            (isHovered
+                ? VColor.surfaceBorder.opacity(colorScheme == .dark ? 0.5 : 0.7)
+                : VColor.surfaceBorder.opacity(colorScheme == .dark ? 0.25 : 0.4))
                 .animation(VAnimation.fast, value: isHovered)
         )
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -174,7 +174,7 @@ public enum VColor {
 
     // Text
     public static let textPrimary = adaptiveColor(light: Stone._900, dark: Moss._50)
-    public static let textSecondary = adaptiveColor(light: Stone._600, dark: Moss._400)
+    public static let textSecondary = adaptiveColor(light: Stone._700, dark: Moss._400)
     public static let textMuted = adaptiveColor(light: Stone._600, dark: Moss._500)
 
     // Accent


### PR DESCRIPTION
Addresses reviewer feedback on #11831:

1. Gate search badge and row opacity increases to light mode only, preserving original dark-mode values
2. Shift textSecondary to Stone._700 in light mode so it remains distinct from textMuted (Stone._600)

Fixes: Codex and Devin feedback on #11831