### PR TITLE
feat: guardian call thread affinity and message-level deep-link anchoring

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -1987,7 +1987,7 @@ The pairing function (`pairDeliveryWithConversation`) is resilient — errors ar
 
 The notification pipeline uses a single conversation materialization path across producers:
 
-1. **Canonical pipeline** (`emitNotificationSignal` → decision engine → broadcaster → conversation pairing → adapters): The broadcaster pairs each delivery with a conversation, then dispatches a `notification_intent` IPC event via the Vellum adapter. The IPC payload includes `deepLinkMetadata` (e.g. `{ conversationId }`) so the macOS/iOS client can deep-link to the relevant context when the user taps the notification.
+1. **Canonical pipeline** (`emitNotificationSignal` → decision engine → broadcaster → conversation pairing → adapters): The broadcaster pairs each delivery with a conversation, then dispatches a `notification_intent` IPC event via the Vellum adapter. The IPC payload includes `deepLinkMetadata` (e.g. `{ conversationId, messageId }`) so the macOS/iOS client can deep-link to the relevant context when the user taps the notification. When `messageId` is present, the client scrolls to that specific message within the thread (message-level anchoring).
 2. **Guardian bookkeeping** (`dispatchGuardianQuestion`): Guardian dispatch creates `guardian_action_request` / `guardian_action_delivery` audit rows derived from pipeline delivery results and the per-dispatch `onThreadCreated` callback — there is no separate thread-creation path.
 
 ### Thread Surfacing via `notification_thread_created` IPC (Creation-Only)
@@ -2016,6 +2016,15 @@ The decision engine produces per-channel thread actions using a candidate-driven
 5. **IPC gating**: `notification_thread_created` fires only on actual creation, not on reuse.
 6. **Audit trail**: Thread actions are persisted in both `notification_decisions.validation_results` and `notification_deliveries` columns (`thread_action`, `thread_target_conversation_id`, `thread_decision_fallback_used`).
 
+### Guardian Call Thread Affinity
+
+When a guardian question originates from an active phone call (`callSessionId` present on the signal), the decision engine enforces thread affinity so all questions within the same call land in one vellum thread:
+
+- **First question in a call** (no `conversationAffinityHint`): `enforceGuardianCallThreadAffinity` forces `start_new` for the vellum channel, creating a dedicated thread for the call.
+- **Subsequent questions in the same call** (affinity hint already set by `dispatchGuardianQuestion`): The guard is a no-op, and `enforceConversationAffinity` routes to `reuse_existing` using the hint's `conversationId`.
+
+This guard runs **before** `enforceConversationAffinity` in the post-decision chain so the two cooperate: the first dispatch creates the thread, and subsequent dispatches reuse it via the affinity hint that `dispatchGuardianQuestion` sets after observing the first delivery's `conversationId`.
+
 ### Guardian Multi-Request Disambiguation in Reused Threads
 
 When the decision engine routes multiple guardian questions to the same conversation (via `reuse_existing`), those questions share a single thread. The guardian disambiguates which question they are answering using **request-code prefixes**:
@@ -2034,7 +2043,7 @@ Reminders carry optional `routingIntent` (`single_channel` | `multi_channel` | `
 
 Notifications are delivered to three channel types:
 
-- **Vellum (always connected)**: Local IPC via the daemon's broadcast mechanism. The `VellumAdapter` emits a `notification_intent` message with rendered copy and optional `deepLinkMetadata`.
+- **Vellum (always connected)**: Local IPC via the daemon's broadcast mechanism. The `VellumAdapter` emits a `notification_intent` message with rendered copy and optional `deepLinkMetadata` (includes `conversationId` for thread navigation and `messageId` for message-level scroll anchoring).
 - **Telegram (when guardian binding exists)**: HTTP POST to the gateway's `/deliver/telegram` endpoint. Requires an active guardian binding for the assistant.
 - **SMS (when guardian binding exists)**: HTTP POST to the gateway's `/deliver/sms` endpoint. Follows the same pattern as Telegram; the `SmsAdapter` sends text-only messages via the Twilio Messages API. The `assistantId` is threaded through the delivery payload for multi-assistant phone number resolution.
 

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -696,6 +696,85 @@ describe("guardian-dispatch", () => {
     });
   });
 
+  test("ASK_GUARDIAN_APPROVAL path (toolName present) uses same-thread affinity on second dispatch", async () => {
+    const convId = "conv-dispatch-affinity-tool";
+    ensureConversation(convId);
+
+    const sharedConversationId = "conv-affinity-tool-guardian";
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: "twilio",
+      fromNumber: "+15550001111",
+      toNumber: "+15550002222",
+    });
+
+    // First dispatch — tool-approval style pending_question (toolName set)
+    const pq1 = createPendingQuestion(
+      session.id,
+      "Allow send_email to bob@example.com?",
+    );
+    mockEmitResult = {
+      signalId: "sig-tool-affinity-1",
+      deduplicated: false,
+      dispatched: true,
+      reason: "ok",
+      deliveryResults: [
+        {
+          channel: "vellum",
+          destination: "vellum",
+          status: "sent",
+          conversationId: sharedConversationId,
+        },
+      ],
+    };
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: "self",
+      pendingQuestion: pq1,
+      toolName: "send_email",
+    });
+
+    const firstParams = emitCalls[0] as Record<string, unknown>;
+    expect(firstParams.conversationAffinityHint).toBeUndefined();
+
+    // Second dispatch — also with toolName
+    emitCalls.length = 0;
+    const pq2 = createPendingQuestion(
+      session.id,
+      "Allow run_script with sudo?",
+    );
+    mockEmitResult = {
+      signalId: "sig-tool-affinity-2",
+      deduplicated: false,
+      dispatched: true,
+      reason: "ok",
+      deliveryResults: [
+        {
+          channel: "vellum",
+          destination: "vellum",
+          status: "sent",
+          conversationId: sharedConversationId,
+        },
+      ],
+    };
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: "self",
+      pendingQuestion: pq2,
+      toolName: "run_script",
+    });
+
+    const secondParams = emitCalls[0] as Record<string, unknown>;
+    expect(secondParams.conversationAffinityHint).toEqual({
+      vellum: sharedConversationId,
+    });
+  });
+
   test("third guardian question in same call session also carries affinity hint", async () => {
     const convId = "conv-dispatch-affinity-2";
     ensureConversation(convId);

--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -18,10 +18,16 @@ import {
   normalizeForDirectiveMatching,
   sanitizeIdentityField,
 } from "../notifications/copy-composer.js";
-import { validateThreadActions } from "../notifications/decision-engine.js";
+import {
+  enforceGuardianCallThreadAffinity,
+  validateThreadActions,
+} from "../notifications/decision-engine.js";
 import type { NotificationSignal } from "../notifications/signal.js";
 import type { ThreadCandidateSet } from "../notifications/thread-candidates.js";
-import type { NotificationChannel } from "../notifications/types.js";
+import type {
+  NotificationChannel,
+  NotificationDecision,
+} from "../notifications/types.js";
 
 // -- Helpers -----------------------------------------------------------------
 
@@ -821,6 +827,108 @@ describe("notification decision strategy", () => {
       expect(text).not.toContain("\x00");
       expect(text).toContain("A1B2C3 approve");
       expect(text).toContain("open invite flow");
+    });
+  });
+
+  // -- Guardian call thread affinity enforcement --------------------------------
+
+  describe("guardian call thread affinity enforcement", () => {
+    function makeDecision(
+      overrides?: Partial<NotificationDecision>,
+    ): NotificationDecision {
+      return {
+        shouldNotify: true,
+        selectedChannels: ["vellum"],
+        reasoningSummary: "test",
+        renderedCopy: {
+          vellum: { title: "Test", body: "Body" },
+        },
+        dedupeKey: "test-key",
+        confidence: 0.8,
+        fallbackUsed: false,
+        ...overrides,
+      };
+    }
+
+    test("guardian.question with callSessionId and no affinity hint forces start_new for vellum", () => {
+      const decision = makeDecision();
+      const signal = makeSignal({
+        sourceEventName: "guardian.question",
+        contextPayload: {
+          requestId: "req-1",
+          requestCode: "A1B2C3",
+          questionText: "What is the gate code?",
+          requestKind: "pending_question",
+          callSessionId: "call-session-1",
+          activeGuardianRequestCount: 1,
+        },
+      });
+
+      const result = enforceGuardianCallThreadAffinity(decision, signal);
+      expect(result.threadActions?.vellum).toEqual({ action: "start_new" });
+    });
+
+    test("guardian.question with callSessionId and existing affinity hint does not override", () => {
+      const decision = makeDecision({
+        threadActions: {
+          vellum: { action: "reuse_existing", conversationId: "conv-123" },
+        },
+      });
+      const signal = makeSignal({
+        sourceEventName: "guardian.question",
+        contextPayload: {
+          requestId: "req-2",
+          requestCode: "D4E5F6",
+          questionText: "Should I let them in?",
+          requestKind: "pending_question",
+          callSessionId: "call-session-2",
+          activeGuardianRequestCount: 2,
+        },
+        conversationAffinityHint: { vellum: "conv-123" },
+      });
+
+      const result = enforceGuardianCallThreadAffinity(decision, signal);
+      // Should remain unchanged — the affinity hint takes precedence
+      expect(result.threadActions?.vellum).toEqual({
+        action: "reuse_existing",
+        conversationId: "conv-123",
+      });
+    });
+
+    test("non-guardian event is not affected by guardian call thread affinity", () => {
+      const decision = makeDecision({
+        threadActions: {
+          vellum: { action: "reuse_existing", conversationId: "conv-456" },
+        },
+      });
+      const signal = makeSignal({
+        sourceEventName: "reminder.fired",
+        contextPayload: { message: "Take out the trash" },
+      });
+
+      const result = enforceGuardianCallThreadAffinity(decision, signal);
+      expect(result.threadActions?.vellum).toEqual({
+        action: "reuse_existing",
+        conversationId: "conv-456",
+      });
+    });
+
+    test("guardian.question without callSessionId is not affected", () => {
+      const decision = makeDecision();
+      const signal = makeSignal({
+        sourceEventName: "guardian.question",
+        contextPayload: {
+          requestId: "req-3",
+          requestCode: "G7H8I9",
+          questionText: "Allow this?",
+          requestKind: "tool_grant_request",
+          toolName: "host_bash",
+        },
+      });
+
+      const result = enforceGuardianCallThreadAffinity(decision, signal);
+      // No callSessionId → no enforcement
+      expect(result.threadActions).toBeUndefined();
     });
   });
 });

--- a/assistant/src/__tests__/notification-deep-link.test.ts
+++ b/assistant/src/__tests__/notification-deep-link.test.ts
@@ -159,6 +159,24 @@ describe("notification deep-link metadata", () => {
       expect(metadata.workItemId).toBe("work-item-7");
     });
 
+    test("deep-link payload includes messageId when present", async () => {
+      const messages: ServerMessage[] = [];
+      const adapter = new VellumAdapter((msg) => messages.push(msg));
+
+      await adapter.send(
+        {
+          sourceEventName: "guardian.question",
+          copy: { title: "Question", body: "Body" },
+          deepLinkTarget: { conversationId: "conv-1", messageId: "msg-1" },
+        },
+        { channel: "vellum" },
+      );
+
+      const msg = messages[0] as unknown as Record<string, unknown>;
+      const metadata = msg.deepLinkMetadata as Record<string, unknown>;
+      expect(metadata.messageId).toBe("msg-1");
+    });
+
     // ── Deep-link conversationId present regardless of reuse/new ──────
 
     test("deep-link payload includes conversationId for a newly created conversation", async () => {

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -165,6 +165,9 @@ export class NotificationBroadcaster {
       let deepLinkTarget = decision.deepLinkTarget;
       if (channel === 'vellum' && pairing.conversationId) {
         deepLinkTarget = { ...deepLinkTarget, conversationId: pairing.conversationId };
+        if (pairing.messageId) {
+          deepLinkTarget = { ...deepLinkTarget, messageId: pairing.messageId };
+        }
 
         // Resolve guardian scoping for thread-created events so clients
         // can filter guardian-sensitive threads the same way they filter

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -609,6 +609,7 @@ export async function evaluateSignal(
     let decision = buildFallbackDecision(signal, availableChannels);
     decision = enforceGuardianRequestCode(decision, signal);
     decision = enforceAccessRequestInstructions(decision, signal);
+    decision = enforceGuardianCallThreadAffinity(decision, signal);
     decision = enforceConversationAffinity(decision, signal.conversationAffinityHint);
     decision.persistedDecisionId = persistDecision(signal, decision);
     return decision;
@@ -625,6 +626,7 @@ export async function evaluateSignal(
 
   decision = enforceGuardianRequestCode(decision, signal);
   decision = enforceAccessRequestInstructions(decision, signal);
+  decision = enforceGuardianCallThreadAffinity(decision, signal);
   decision = enforceConversationAffinity(decision, signal.conversationAffinityHint);
   decision.persistedDecisionId = persistDecision(signal, decision);
 
@@ -758,6 +760,46 @@ export function enforceRoutingIntent(
   }
 
   return decision;
+}
+
+// ── Guardian call thread affinity ────────────────────────────────────────
+
+/**
+ * Force a new vellum thread for the first guardian question in a phone call.
+ *
+ * When a guardian.question signal carries a callSessionId but has no
+ * conversationAffinityHint, this is the first dispatch in a new call and
+ * should get its own thread. Without this guard the LLM might reuse a
+ * thread from a previous call. For subsequent dispatches within the same
+ * call, the affinity hint already exists and enforceConversationAffinity
+ * handles routing — so this guard is a no-op.
+ */
+export function enforceGuardianCallThreadAffinity(
+  decision: NotificationDecision,
+  signal: NotificationSignal,
+): NotificationDecision {
+  if (signal.sourceEventName !== 'guardian.question') return decision;
+
+  const callSessionId = signal.contextPayload?.callSessionId;
+  if (typeof callSessionId !== 'string' || callSessionId.trim().length === 0) return decision;
+
+  // If an affinity hint already exists for vellum, the second+ dispatch
+  // will be handled by enforceConversationAffinity — nothing to do here.
+  if (signal.conversationAffinityHint?.vellum) return decision;
+
+  const enforced = { ...decision };
+  const threadActions: Partial<Record<NotificationChannel, ThreadAction>> = {
+    ...(decision.threadActions ?? {}),
+  };
+  threadActions.vellum = { action: 'start_new' };
+  enforced.threadActions = threadActions;
+
+  log.info(
+    { callSessionId },
+    'Guardian call thread affinity: first question in call — forcing start_new for vellum',
+  );
+
+  return enforced;
 }
 
 // ── Conversation affinity enforcement ───────────────────────────────────

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -200,6 +200,16 @@ extension AppDelegate {
         return nil
     }
 
+    private func messageId(from userInfo: [AnyHashable: Any]) -> String? {
+        if let direct = userInfo["messageId"] as? String {
+            return direct
+        }
+        if let snake = userInfo["message_id"] as? String {
+            return snake
+        }
+        return nil
+    }
+
     private func pruneFallbackMarkers(nowMs: Double) {
         fallbackDeliveredAtMs = fallbackDeliveredAtMs.filter { _, deliveredAt in
             nowMs - deliveredAt <= fallbackDedupWindowMs
@@ -505,10 +515,11 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             let conversationId =
                 response.notification.request.content.userInfo["conversationId"] as? String ??
                 response.notification.request.content.userInfo["conversation_id"] as? String
+            let messageId = self.messageId(from: response.notification.request.content.userInfo)
             await MainActor.run {
                 guard !self.isBootstrapping else { return }
                 if let conversationId {
-                    self.openConversationThread(conversationId: conversationId)
+                    self.openConversationThread(conversationId: conversationId, anchorMessageId: messageId)
                     self.sendConversationSeenSignal(
                         conversationId: conversationId,
                         signalType: "macos_notification_view",

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -332,7 +332,10 @@ extension AppDelegate {
     /// Opens the main window and navigates to the thread for the given conversation ID.
     /// Retries if the thread isn't populated yet (e.g., ThreadManager hasn't loaded it).
     /// Used by Quick Chat and notification deep links.
-    func openConversationThread(conversationId: String?) {
+    /// - Parameters:
+    ///   - conversationId: The conversation to navigate to.
+    ///   - anchorMessageId: Optional message ID to scroll to after the thread is selected.
+    func openConversationThread(conversationId: String?, anchorMessageId: String? = nil) {
         showMainWindow()
         guard let conversationId else { return }
 
@@ -351,6 +354,11 @@ extension AppDelegate {
             // already set above, so we call markConversationSeen explicitly to
             // keep both the local flag and the daemon's server-side state in sync.
             threadManager.markConversationSeen(threadId: thread.id)
+            // Set pending anchor message so the message list scrolls to the
+            // relevant notification message when the view appears.
+            if let anchorMessageId, let anchorUUID = UUID(uuidString: anchorMessageId) {
+                threadManager.setPendingAnchorMessage(threadId: thread.id, messageId: anchorUUID)
+            }
             return true
         }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -74,6 +74,8 @@ struct ChatView: View {
     var voiceService: OpenAIVoiceService? = nil
     var onEndVoiceMode: (() -> Void)? = nil
     var threadId: UUID?
+    /// When set, scroll to this message ID and clear the binding.
+    @Binding var anchorMessageId: UUID?
 
     // MARK: - Pagination
 
@@ -212,6 +214,7 @@ struct ChatView: View {
                             isLoadingMoreMessages: isLoadingMoreMessages,
                             loadPreviousMessagePage: loadPreviousMessagePage,
                             threadId: threadId,
+                            anchorMessageId: $anchorMessageId,
                             isNearBottom: $isNearBottom
                         )
                         .safeAreaInset(edge: .bottom) {
@@ -592,6 +595,7 @@ struct ChatView_Preview: PreviewProvider {
 
 private struct ChatViewPreviewWrapper: View {
     @State private var text = ""
+    @State private var anchorMessageId: UUID?
 
     private let sampleMessages: [ChatMessage] = [
         ChatMessage(role: .assistant, text: "Hello! How can I help you today?"),
@@ -647,7 +651,8 @@ private struct ChatViewPreviewWrapper: View {
                 onCopyDebugInfo: {},
                 watchSession: nil,
                 onStopWatch: {},
-                subagentDetailStore: SubagentDetailStore()
+                subagentDetailStore: SubagentDetailStore(),
+                anchorMessageId: $anchorMessageId
             )
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -586,7 +586,12 @@ struct MessageListView: View {
                 }
                 isThreadContentHovered = false
                 DispatchQueue.main.async {
-                    proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                    // Skip scroll-to-bottom when an anchor message is pending —
+                    // the anchorMessageId onChange handler will scroll to the
+                    // specific message instead.
+                    if anchorMessageId == nil {
+                        proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                    }
                 }
             }
             .onChange(of: anchorMessageId) {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -588,13 +588,10 @@ struct MessageListView: View {
                 DispatchQueue.main.async {
                     // Skip scroll-to-bottom when an anchor message is pending —
                     // the anchorMessageId onChange handler will scroll to the
-                    // specific message instead.
+                    // specific message instead. Stale anchors from other threads
+                    // are cleared by ThreadManager.activeThreadId.didSet, so
+                    // anchorMessageId here always belongs to the current thread.
                     if anchorMessageId == nil {
-                        proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
-                    } else if !messages.contains(where: { $0.id == anchorMessageId }) {
-                        // Anchor is stale (belongs to a different thread) — clear
-                        // it and scroll to bottom normally.
-                        anchorMessageId = nil
                         proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                     }
                 }
@@ -611,9 +608,11 @@ struct MessageListView: View {
                     anchorMessageId = nil
                 }
             }
-            .onChange(of: messages) {
-                // Retry anchor scroll when messages update (e.g., history loads
-                // after a thread switch triggered by a notification deep-link).
+            .onChange(of: messages.count) {
+                // Retry anchor scroll when new messages arrive (e.g., history
+                // loads after a thread switch triggered by a notification
+                // deep-link). Uses messages.count instead of messages to avoid
+                // O(n) array equality checks on every streaming token.
                 guard let id = anchorMessageId else { return }
                 if messages.contains(where: { $0.id == id }) {
                     withAnimation {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -591,6 +591,11 @@ struct MessageListView: View {
                     // specific message instead.
                     if anchorMessageId == nil {
                         proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                    } else if !messages.contains(where: { $0.id == anchorMessageId }) {
+                        // Anchor is stale (belongs to a different thread) — clear
+                        // it and scroll to bottom normally.
+                        anchorMessageId = nil
+                        proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -497,7 +497,17 @@ struct MessageListView: View {
             }
             .onAppear {
                 isAppActive = NSApp.isActive
-                proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                if let id = anchorMessageId, messages.contains(where: { $0.id == id }) {
+                    // Anchor is already set and the target message is loaded —
+                    // scroll to it immediately instead of falling through to bottom.
+                    proxy.scrollTo(id, anchor: .center)
+                    anchorMessageId = nil
+                } else if anchorMessageId == nil {
+                    proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                }
+                // When anchorMessageId is set but the target message isn't loaded
+                // yet, skip scrolling entirely — onChange(of: messages.count) will
+                // retry once history finishes loading.
             }
             .onDisappear {
                 hoverExitDebounceTask?.cancel()

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -595,7 +595,22 @@ struct MessageListView: View {
                 }
             }
             .onChange(of: anchorMessageId) {
-                if let id = anchorMessageId {
+                guard let id = anchorMessageId else { return }
+                // Only scroll and clear if the target message is already loaded;
+                // otherwise leave the anchor set so the messages-change handler
+                // can retry once history finishes loading.
+                if messages.contains(where: { $0.id == id }) {
+                    withAnimation {
+                        proxy.scrollTo(id, anchor: .center)
+                    }
+                    anchorMessageId = nil
+                }
+            }
+            .onChange(of: messages) {
+                // Retry anchor scroll when messages update (e.g., history loads
+                // after a thread switch triggered by a notification deep-link).
+                guard let id = anchorMessageId else { return }
+                if messages.contains(where: { $0.id == id }) {
                     withAnimation {
                         proxy.scrollTo(id, anchor: .center)
                     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -51,6 +51,9 @@ struct MessageListView: View {
     var loadPreviousMessagePage: (() async -> Bool)?
 
     var threadId: UUID?
+    /// When set, scroll to this message ID and clear the binding.
+    /// Used by notification deep links to anchor the view to a specific message.
+    @Binding var anchorMessageId: UUID?
     @Binding var isNearBottom: Bool
     @Environment(\.conversationZoomScale) private var conversationZoomScale
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
@@ -584,6 +587,14 @@ struct MessageListView: View {
                 isThreadContentHovered = false
                 DispatchQueue.main.async {
                     proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                }
+            }
+            .onChange(of: anchorMessageId) {
+                if let id = anchorMessageId {
+                    withAnimation {
+                        proxy.scrollTo(id, anchor: .center)
+                    }
+                    anchorMessageId = nil
                 }
             }
             .onChange(of: currentPendingRequestId) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -418,7 +418,8 @@ extension MainWindowView {
                     onEndVoiceMode: {
                         voiceModeManager.deactivate()
                     },
-                    threadId: threadManager.activeThreadId
+                    threadId: threadManager.activeThreadId,
+                    anchorMessageId: $threadManager.pendingAnchorMessageId
                 )
                 .environment(\.conversationZoomScale, conversationZoomManager.zoomLevel)
                 .overlay(alignment: .top) {
@@ -605,6 +606,7 @@ struct ActiveChatViewWrapper: View {
     var voiceService: OpenAIVoiceService? = nil
     var onEndVoiceMode: (() -> Void)? = nil
     var threadId: UUID?
+    @Binding var anchorMessageId: UUID?
 
     /// Reads the persisted bootstrap state so the chat view can suppress
     /// the empty state during first-launch bootstrap.
@@ -723,6 +725,7 @@ struct ActiveChatViewWrapper: View {
             voiceService: voiceService,
             onEndVoiceMode: onEndVoiceMode,
             threadId: threadId,
+            anchorMessageId: $anchorMessageId,
             displayedMessageCount: viewModel.displayedMessageCount,
             hasMoreMessages: viewModel.hasMoreMessages,
             isLoadingMoreMessages: viewModel.isLoadingMoreMessages,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -60,6 +60,13 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                     lastActiveThreadIdString = nil
                 }
             }
+            // Clear stale anchor when switching away from the thread that
+            // owns it — prevents the anchor from suppressing scroll-to-bottom
+            // on unrelated thread switches.
+            if let anchorThread = pendingAnchorThreadId, anchorThread != activeThreadId {
+                pendingAnchorMessageId = nil
+                pendingAnchorThreadId = nil
+            }
             // Subscribe to the new active view model's changes
             subscribeToActiveViewModel()
         }
@@ -103,6 +110,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     private var interactionStateCancellables: [UUID: Set<AnyCancellable>] = [:]
     /// Pending anchor message ID for scroll-to behavior on notification deep links.
     @Published var pendingAnchorMessageId: UUID?
+    /// Tracks which thread the pending anchor belongs to so stale anchors are
+    /// cleared automatically when the user switches to a different thread.
+    private var pendingAnchorThreadId: UUID?
     /// Session IDs whose seen signals are deferred pending undo expiration.
     private var pendingSeenSessionIds: [String] = []
     /// Task that auto-commits deferred seen signals after the undo window.
@@ -1031,6 +1041,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     func setPendingAnchorMessage(threadId: UUID, messageId: UUID) {
         guard activeThreadId == threadId else { return }
         pendingAnchorMessageId = messageId
+        pendingAnchorThreadId = threadId
     }
 
     /// Consume the pending anchor message, returning it if present. Resets to nil.

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -101,6 +101,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     @Published private(set) var threadInteractionStates: [UUID: ThreadInteractionState] = [:]
     /// Subscriptions to per-thread interaction-state changes.
     private var interactionStateCancellables: [UUID: Set<AnyCancellable>] = [:]
+    /// Pending anchor message ID for scroll-to behavior on notification deep links.
+    @Published var pendingAnchorMessageId: UUID?
     /// Session IDs whose seen signals are deferred pending undo expiration.
     private var pendingSeenSessionIds: [String] = []
     /// Task that auto-commits deferred seen signals after the undo window.
@@ -1022,6 +1024,20 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         if let sessionId = threads[idx].sessionId {
             emitConversationSeenSignal(conversationId: sessionId)
         }
+    }
+
+    /// Set a pending anchor message for scroll-to behavior on notification deep links.
+    /// Only takes effect when the specified thread is currently active.
+    func setPendingAnchorMessage(threadId: UUID, messageId: UUID) {
+        guard activeThreadId == threadId else { return }
+        pendingAnchorMessageId = messageId
+    }
+
+    /// Consume the pending anchor message, returning it if present. Resets to nil.
+    func consumePendingAnchorMessage() -> UUID? {
+        let id = pendingAnchorMessageId
+        pendingAnchorMessageId = nil
+        return id
     }
 
     /// Mark all visible (non-archived, non-private) threads as seen locally.

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -1044,13 +1044,6 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         pendingAnchorThreadId = threadId
     }
 
-    /// Consume the pending anchor message, returning it if present. Resets to nil.
-    func consumePendingAnchorMessage() -> UUID? {
-        let id = pendingAnchorMessageId
-        pendingAnchorMessageId = nil
-        return id
-    }
-
     /// Mark all visible (non-archived, non-private) threads as seen locally.
     /// IPC signals are NOT sent immediately — call `commitPendingSeenSignals()`
     /// after the undo window expires, or `cancelPendingSeenSignals()` if the


### PR DESCRIPTION
## Summary
- Add `enforceGuardianCallThreadAffinity` post-decision guard in the notification decision engine that forces `start_new` for vellum on the first guardian question in a phone call (no affinity hint), ensuring all subsequent questions within the same call land in the same thread via `enforceConversationAffinity`
- Include `messageId` in deep-link metadata (`broadcaster.ts`) so notification taps can scroll to a specific message within a thread
- Thread `anchorMessageId` through the macOS Swift view hierarchy (`ThreadManager` → `PanelCoordinator` → `ChatView` → `MessageListView`) for message-level scroll anchoring on notification tap
- Add tests for thread affinity enforcement, deep-link messageId passthrough, and guardian dispatch with toolName

## Original prompt
/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/.private/plans/guardian-call-thread-affinity-and-message-anchor.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
