### PR TITLE
fix: align button green colors with logo green

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -186,11 +186,11 @@ private struct VButtonStyle: ButtonStyle {
         switch style {
         case .primary: return .white
         case .tertiary: return VColor.buttonSecondaryText
-        case .secondary: return adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._400)
+        case .secondary: return adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400)
         case .danger: return .white
-        case .ghost: return Color(hex: 0x516748)
+        case .ghost: return Color(hex: 0x537D53)
         case .outlined: return VColor.buttonSecondaryText
-        case .success: return adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._300)
+        case .success: return adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._300)
         }
     }
 

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -181,7 +181,7 @@ public enum VColor {
     public static let accent = adaptiveColor(light: Color(hex: 0x262624), dark: Forest._600)
 
     // Icon & button accent
-    public static let iconAccent = adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._500)
+    public static let iconAccent = adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._500)
 
     // Send button — always green
     public static let sendButton = Color(hex: 0x216C37)
@@ -216,10 +216,10 @@ public enum VColor {
     public static let slashCommand = adaptiveColor(light: Forest._500, dark: Forest._300)
 
     // Button colors
-    public static let buttonPrimary = adaptiveColor(light: Color(hex: 0x4B6845), dark: Color(hex: 0x4B6845))
-    public static let buttonPrimaryHover = adaptiveColor(light: Color(hex: 0x5A7B54), dark: Color(hex: 0x5A7B54))
-    public static let buttonPrimaryPressed = adaptiveColor(light: Color(hex: 0x3D5739), dark: Color(hex: 0x3D5739))
-    public static let buttonSecondaryBorder = adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._500)
-    public static let buttonSecondaryText = adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._400)
+    public static let buttonPrimary = adaptiveColor(light: Color(hex: 0x537D53), dark: Color(hex: 0x537D53))
+    public static let buttonPrimaryHover = adaptiveColor(light: Color(hex: 0x629062), dark: Color(hex: 0x629062))
+    public static let buttonPrimaryPressed = adaptiveColor(light: Color(hex: 0x456C47), dark: Color(hex: 0x456C47))
+    public static let buttonSecondaryBorder = adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._500)
+    public static let buttonSecondaryText = adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400)
     public static let buttonTertiaryBackground = adaptiveColor(light: Moss._200, dark: Moss._700)
 }


### PR DESCRIPTION
## Summary
- Updated all button accent greens from `#4B6845` (muted sage) to `#537D53` to match the logo's primary green
- Adjusted primary button hover (`#629062`) and pressed (`#456C47`) states proportionally
- Updated secondary, ghost, and success button foreground colors for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
