### PR TITLE
Fix TS type narrowing errors in migration cross-version test

### DIFF
--- a/assistant/src/__tests__/migration-cross-version-compatibility.test.ts
+++ b/assistant/src/__tests__/migration-cross-version-compatibility.test.ts
@@ -875,9 +875,7 @@ describe("round-trip: export -> validate -> preflight -> import", () => {
 
     const validationResult = validateVBundle(archiveData);
     expect(validationResult.is_valid).toBe(true);
-    expect(validationResult.manifest?.manifest_sha256).toBe(
-      headerSha ?? undefined,
-    );
+    expect(validationResult.manifest?.manifest_sha256).toBe(headerSha!);
   });
 });
 
@@ -905,9 +903,12 @@ describe("partial failure scenarios", () => {
     });
 
     expect(result.ok).toBe(false);
-    if (!result.ok && result.reason === "write_failed") {
-      expect(result.message).toBeDefined();
-      expect(result.message.length).toBeGreaterThan(0);
+    if (!result.ok) {
+      expect(result.reason).toBe("write_failed");
+      if (result.reason === "write_failed") {
+        expect(result.message).toBeDefined();
+        expect(result.message.length).toBeGreaterThan(0);
+      }
     }
 
     // Clean up
@@ -922,10 +923,13 @@ describe("partial failure scenarios", () => {
     });
 
     expect(result.ok).toBe(false);
-    if (!result.ok && result.reason === "validation_failed") {
-      expect(result.errors).toBeDefined();
-      expect(result.errors.length).toBeGreaterThan(0);
-      expect(result.errors[0].code).toBe("INVALID_GZIP");
+    if (!result.ok) {
+      expect(result.reason).toBe("validation_failed");
+      if (result.reason === "validation_failed") {
+        expect(result.errors).toBeDefined();
+        expect(result.errors.length).toBeGreaterThan(0);
+        expect(result.errors[0].code).toBe("INVALID_GZIP");
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- Use non-null assertion for `headerSha` (already asserted as defined) instead of `?? undefined` which didn't resolve the `string | null` vs `string | undefined` type mismatch
- Fix discriminated union narrowing by using nested if-statements instead of compound conditions (`!result.ok && result.reason === "..."`) which TypeScript can't narrow through

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22643359815

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
