### PR TITLE
fix: update secondary button background to match logo green tint

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -158,9 +158,9 @@ private struct VButtonStyle: ButtonStyle {
             if isHovered { return VColor.buttonPrimaryHover }
             return VColor.buttonPrimary
         case .secondary:
-            if isPressed { return adaptiveColor(light: Color(hex: 0xC0CEBC), dark: Color(hex: 0x4A4A46)) }
-            if isHovered { return adaptiveColor(light: Color(hex: 0xCAD7C6), dark: Color(hex: 0x424240)) }
-            return adaptiveColor(light: Forest._200, dark: Color(hex: 0x3A3A37))
+            if isPressed { return adaptiveColor(light: Color(hex: 0xC3D2C3), dark: Color(hex: 0x4A4A46)) }
+            if isHovered { return adaptiveColor(light: Color(hex: 0xCBD8CB), dark: Color(hex: 0x424240)) }
+            return adaptiveColor(light: Color(hex: 0xD4DFD4), dark: Color(hex: 0x3A3A37))
         case .danger:
             if isPressed { return Color(hex: 0xE0745A) }
             if isHovered { return Color(hex: 0xD4582F) }


### PR DESCRIPTION
## Summary
- Changed secondary button background from `Forest._200` (warm sage `#D4DFD0`) to a true-green tint (`#D4DFD4`) derived from the logo green
- Updated hover (`#CBD8CB`) and pressed (`#C3D2C3`) states to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
