### PR TITLE
fix: thread scrolling crashes — layout measurement, NSImage reentrance, cache overflow, WKWebView leak

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -314,6 +314,8 @@ struct ChatBubble: View {
                             .lineSpacing(6)
                             .foregroundColor(VColor.textPrimary)
                             .textSelection(.enabled)
+                            // Frame before fixedSize to bound horizontal measurement.
+                            .frame(maxWidth: .infinity, alignment: .leading)
                             .fixedSize(horizontal: false, vertical: true)
                     }
                 } else if hasText {
@@ -344,6 +346,8 @@ struct ChatBubble: View {
                             .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
                             .tint(isUser ? VColor.userBubbleText : VColor.accent)
                             .selectableText(!message.isStreaming)
+                            // Frame before fixedSize to bound horizontal measurement.
+                            .frame(maxWidth: .infinity, alignment: .leading)
                             .fixedSize(horizontal: false, vertical: true)
                     }
                 } else if !message.attachments.isEmpty {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -418,15 +418,16 @@ struct ChatBubble: View {
     // monotonically increasing counter. On eviction the entry with the
     // lowest accessTime is removed (least-recently-used).
 
-    @MainActor static var lruCounter: Int = 0
+    // UInt64 to avoid silent overflow after billions of cache accesses in long-running sessions.
+    @MainActor static var lruCounter: UInt64 = 0
 
-    @MainActor static var segmentCache = [String: (value: [MarkdownSegment], accessTime: Int)]()
-    @MainActor static var markdownCache = [String: (value: AttributedString, accessTime: Int)]()
+    @MainActor static var segmentCache = [String: (value: [MarkdownSegment], accessTime: UInt64)]()
+    @MainActor static var markdownCache = [String: (value: AttributedString, accessTime: UInt64)]()
     /// Separate cache for inline markdown (used by interleaved text segments).
     /// Kept distinct from `markdownCache` because `markdownText` applies
     /// slash-command highlighting before caching, which would contaminate
     /// inline results (and vice versa) if they shared a dictionary.
-    @MainActor static var inlineMarkdownCache = [String: (value: AttributedString, accessTime: Int)]()
+    @MainActor static var inlineMarkdownCache = [String: (value: AttributedString, accessTime: UInt64)]()
     static let maxCacheSize = 100
 
     // MARK: - Cache Guardrails
@@ -443,9 +444,11 @@ struct ChatBubble: View {
     @MainActor static var estimatedCacheBytes: Int = 0
 
     /// Estimate the in-memory cost of caching the given text's parsed result.
-    /// Uses `utf8.count * 3` as a rough AttributedString/segment overhead.
+    /// Uses `utf8.count * 10` as a conservative estimate: AttributedString carries
+    /// significant overhead beyond raw bytes (attribute containers, font metrics,
+    /// paragraph style objects), so 3x was too low and allowed the budget to be exceeded.
     static func estimatedBytes(for text: String) -> Int {
-        text.utf8.count * 3
+        text.utf8.count * 10
     }
 
     /// Evicts the oldest entries across all three caches until
@@ -454,7 +457,7 @@ struct ChatBubble: View {
         while estimatedCacheBytes > maxCacheBytes {
             // Find the LRU entry across all three caches.
             var oldestKey: String?
-            var oldestTime = Int.max
+            var oldestTime = UInt64.max
             var oldestCache: CacheKind?
 
             for (key, entry) in markdownCache where entry.accessTime < oldestTime {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -80,10 +80,12 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                         return
                     }
 
-                    guard !Task.isCancelled else { return }
-
-                    // All three paths exhausted with no image — mark as failed so the
-                    // file chip fallback is shown instead of the permanent gray placeholder.
+                    // All three decode paths exhausted with no image.
+                    // Do NOT guard on Task.isCancelled here — once every decode path has
+                    // failed we must always transition to the file-chip fallback regardless
+                    // of cancellation. Without this, a cancellation that races with decode
+                    // completion leaves the attachment permanently stuck on the gray
+                    // placeholder instead of showing the filename/download affordance.
                     failedIds.insert(attachment.id)
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -10,11 +10,15 @@ import VellumAssistantShared
 /// invalidation that causes EXC_BAD_ACCESS when scrolling. This view decodes
 /// images asynchronously via .task so the layout path only ever sees
 /// pre-decoded NSImage values or a placeholder.
-private struct AttachmentImageGrid: View {
+private struct AttachmentImageGrid<Fallback: View>: View {
     let imageAttachments: [ChatAttachment]
     let onTap: (ChatAttachment) -> Void
+    /// Rendered in place of the gray placeholder when all decode paths fail for an attachment.
+    @ViewBuilder let fallback: (ChatAttachment) -> Fallback
 
     @State private var loadedImages: [String: NSImage] = [:]
+    /// Tracks attachments for which every decode path was exhausted without producing an image.
+    @State private var failedIds: Set<String> = []
 
     var body: some View {
         HStack(spacing: VSpacing.sm) {
@@ -24,17 +28,23 @@ private struct AttachmentImageGrid: View {
                         Image(nsImage: nsImage)
                             .resizable()
                             .aspectRatio(contentMode: .fill)
+                            .frame(width: 60, height: 60)
+                            .clipped()
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                            .onTapGesture {
+                                onTap(attachment)
+                            }
+                    } else if failedIds.contains(attachment.id) {
+                        // All decode paths failed — show a file chip so the user still has the
+                        // filename and a download affordance for corrupt/unsupported payloads.
+                        fallback(attachment)
                     } else {
                         // Placeholder shown while the image is being decoded off the main thread.
                         Rectangle()
                             .fill(Color.gray.opacity(0.2))
+                            .frame(width: 60, height: 60)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                     }
-                }
-                .frame(width: 60, height: 60)
-                .clipped()
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                .onTapGesture {
-                    onTap(attachment)
                 }
                 // NSImage(data:) is called directly inside .task — no Task{} wrapper — so
                 // SwiftUI can cancel the work immediately when the bubble scrolls off-screen.
@@ -67,7 +77,14 @@ private struct AttachmentImageGrid: View {
                        let img = NSImage(data: fullData) {
                         guard !Task.isCancelled else { return }
                         loadedImages[attachment.id] = img
+                        return
                     }
+
+                    guard !Task.isCancelled else { return }
+
+                    // All three paths exhausted with no image — mark as failed so the
+                    // file chip fallback is shown instead of the permanent gray placeholder.
+                    failedIds.insert(attachment.id)
                 }
             }
         }
@@ -105,7 +122,9 @@ extension ChatBubble {
     }
 
     func attachmentImageGrid(_ images: [ChatAttachment]) -> some View {
-        AttachmentImageGrid(imageAttachments: images, onTap: openImageInPreview)
+        AttachmentImageGrid(imageAttachments: images, onTap: openImageInPreview) { attachment in
+            fileAttachmentChip(attachment)
+        }
     }
 
     func fileAttachmentChip(_ attachment: ChatAttachment) -> some View {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -1,6 +1,79 @@
 import SwiftUI
 import VellumAssistantShared
 
+// MARK: - Attachment Image Grid (async)
+
+/// Renders image attachments in a horizontal grid.
+///
+/// NSImage(data:) must never be called during SwiftUI view body evaluation or
+/// layout measurement — doing so triggers re-entrant AppKit constraint
+/// invalidation that causes EXC_BAD_ACCESS when scrolling. This view decodes
+/// images asynchronously via .task so the layout path only ever sees
+/// pre-decoded NSImage values or a placeholder.
+private struct AttachmentImageGrid: View {
+    let imageAttachments: [ChatAttachment]
+    let onTap: (ChatAttachment) -> Void
+
+    @State private var loadedImages: [String: NSImage] = [:]
+
+    var body: some View {
+        HStack(spacing: VSpacing.sm) {
+            ForEach(imageAttachments, id: \.id) { attachment in
+                Group {
+                    if let nsImage = loadedImages[attachment.id] {
+                        Image(nsImage: nsImage)
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                    } else {
+                        // Placeholder shown while the image is being decoded off the main thread.
+                        Rectangle()
+                            .fill(Color.gray.opacity(0.2))
+                    }
+                }
+                .frame(width: 60, height: 60)
+                .clipped()
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                .onTapGesture {
+                    onTap(attachment)
+                }
+                // NSImage(data:) is called directly inside .task — no Task{} wrapper — so
+                // SwiftUI can cancel the work immediately when the bubble scrolls off-screen.
+                // Wrapping in Task(priority:){}.value creates an unstructured task that is NOT
+                // cancelled by the .task modifier, causing off-screen decodes to run to completion.
+                .task(id: attachment.id) {
+                    // Step 1: thumbnailImage is already decoded — zero cost.
+                    if let img = attachment.thumbnailImage {
+                        loadedImages[attachment.id] = img
+                        return
+                    }
+
+                    guard !Task.isCancelled else { return }
+
+                    // Step 2: thumbnailData (small) — synchronous NSImage decode, called directly.
+                    // Fallback chain: thumbnailData → full attachment.data.
+                    // thumbnailData is preferred (smaller), but if it is corrupt or
+                    // missing we still want to show the image from the full payload.
+                    if let thumbnailData = attachment.thumbnailData, !thumbnailData.isEmpty,
+                       let img = NSImage(data: thumbnailData) {
+                        guard !Task.isCancelled else { return }
+                        loadedImages[attachment.id] = img
+                        return
+                    }
+
+                    guard !Task.isCancelled else { return }
+
+                    // Step 3: fallback to full base64 data.
+                    if let fullData = Data(base64Encoded: attachment.data), !fullData.isEmpty,
+                       let img = NSImage(data: fullData) {
+                        guard !Task.isCancelled else { return }
+                        loadedImages[attachment.id] = img
+                    }
+                }
+            }
+        }
+    }
+}
+
 // MARK: - Attachment Content
 
 extension ChatBubble {
@@ -12,15 +85,16 @@ extension ChatBubble {
         return "Sent \(count) attachments"
     }
 
-    /// Partitions attachments into decoded images, videos, and non-media files in a single pass,
-    /// avoiding redundant base64 decoding and NSImage construction across render calls.
-    var partitionedAttachments: (images: [(ChatAttachment, NSImage)], videos: [ChatAttachment], files: [ChatAttachment]) {
-        var images: [(ChatAttachment, NSImage)] = []
+    /// Partitions attachments into image, video, and file buckets without
+    /// performing any image decoding — decoding happens asynchronously in
+    /// AttachmentImageGrid to keep NSImage(data:) off the layout path.
+    var partitionedAttachments: (images: [ChatAttachment], videos: [ChatAttachment], files: [ChatAttachment]) {
+        var images: [ChatAttachment] = []
         var videos: [ChatAttachment] = []
         var files: [ChatAttachment] = []
         for attachment in message.attachments {
-            if attachment.mimeType.hasPrefix("image/"), let img = nsImage(for: attachment) {
-                images.append((attachment, img))
+            if attachment.mimeType.hasPrefix("image/") {
+                images.append(attachment)
             } else if attachment.mimeType.hasPrefix("video/") {
                 videos.append(attachment)
             } else {
@@ -30,20 +104,8 @@ extension ChatBubble {
         return (images, videos, files)
     }
 
-    func attachmentImageGrid(_ images: [(ChatAttachment, NSImage)]) -> some View {
-        HStack(spacing: VSpacing.sm) {
-            ForEach(images, id: \.0.id) { attachment, nsImage in
-                Image(nsImage: nsImage)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: 60, height: 60)
-                    .clipped()
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                    .onTapGesture {
-                        openImageInPreview(attachment)
-                    }
-            }
-        }
+    func attachmentImageGrid(_ images: [ChatAttachment]) -> some View {
+        AttachmentImageGrid(imageAttachments: images, onTap: openImageInPreview)
     }
 
     func fileAttachmentChip(_ attachment: ChatAttachment) -> some View {
@@ -80,21 +142,6 @@ extension ChatBubble {
                 NSCursor.pop()
             }
         }
-    }
-
-    func nsImage(for attachment: ChatAttachment) -> NSImage? {
-        // Use pre-decoded thumbnail image — avoids NSImage(data:) during layout, which
-        // can trigger re-entrant AppKit constraint invalidation and crash on scroll.
-        if let img = attachment.thumbnailImage {
-            return img
-        }
-        if let thumbnailData = attachment.thumbnailData, let img = NSImage(data: thumbnailData) {
-            return img
-        }
-        if let data = Data(base64Encoded: attachment.data), let img = NSImage(data: data) {
-            return img
-        }
-        return nil
     }
 
     func openImageInPreview(_ attachment: ChatAttachment) {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -17,7 +17,13 @@ private struct AttachmentImageGrid<Fallback: View>: View {
     @ViewBuilder let fallback: (ChatAttachment) -> Fallback
 
     @State private var loadedImages: [String: NSImage] = [:]
-    /// Tracks attachments for which every decode path was exhausted without producing an image.
+    /// Tracks attachments for which every decode path (thumbnailImage, thumbnailData, full base64)
+    /// was exhausted without producing an NSImage.  When an id is present here the view body
+    /// renders the file-chip fallback so the user still sees the filename and a download
+    /// affordance for corrupt or unsupported payloads.  The insert is intentionally placed
+    /// AFTER all decode attempts and WITHOUT a Task.isCancelled guard so that a cancellation
+    /// racing with the final decode failure always transitions the attachment out of the
+    /// gray-placeholder state.
     @State private var failedIds: Set<String> = []
 
     var body: some View {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -27,8 +27,11 @@ extension ChatBubble {
                     .foregroundColor(VColor.textPrimary)
                     .tint(VColor.accent)
                     .selectableText(!streaming)
-                    .fixedSize(horizontal: false, vertical: true)
+                    // Bound width before fixedSize so vertical measurement is
+                    // computed within a finite horizontal space, preventing
+                    // unbounded layout passes on long messages during scroll.
                     .frame(maxWidth: 520, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -34,8 +34,12 @@ struct MarkdownSegmentView: View {
                         .foregroundColor(textColor)
                         .tint(tintColor)
                         .selectableText(!isStreaming)
-                        .fixedSize(horizontal: false, vertical: true)
+                        // Bound horizontal space BEFORE fixedSize so SwiftUI can wrap text
+                        // within a finite width rather than measuring against an unconstrained
+                        // parent, which causes O(N²) layout passes and stack overflows on
+                        // messages with thousands of characters.
                         .frame(maxWidth: maxContentWidth ?? .infinity, alignment: .leading)
+                        .fixedSize(horizontal: false, vertical: true)
 
                 case .heading(let level, let headingText):
                     let headingFont: Font = switch level {
@@ -48,8 +52,9 @@ struct MarkdownSegmentView: View {
                         .font(headingFont)
                         .foregroundColor(textColor)
                         .selectableText(!isStreaming)
-                        .fixedSize(horizontal: false, vertical: true)
+                        // Frame before fixedSize so the heading wraps within a known width.
                         .frame(maxWidth: maxContentWidth ?? .infinity, alignment: .leading)
+                        .fixedSize(horizontal: false, vertical: true)
                         .padding(.top, level == 1 ? 4 : 2)
 
                 case .list(let items, _):
@@ -72,6 +77,9 @@ struct MarkdownSegmentView: View {
                                     .lineSpacing(4)
                                     .foregroundColor(textColor)
                                     .tint(tintColor)
+                                    // Frame before fixedSize so the text wraps within a
+                                    // known width rather than measuring unbounded horizontally.
+                                    .frame(maxWidth: .infinity, alignment: .leading)
                                     .fixedSize(horizontal: false, vertical: true)
                             }
                             .padding(.leading, leftPad)

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -275,7 +275,11 @@ struct MarkdownSegmentView: View {
             }
         }
         Self.lruCounter += 1
-        let cost = textLen * 3
+        // Use 10 bytes per character to match the M3 fix in ChatBubble.swift (PR #11825);
+        // AttributedString carries font, color, and paragraph metadata on top of raw text,
+        // so a 3x multiplier underestimates real cost by ~3.3x and lets the cache silently
+        // exceed its 5 MB budget.
+        let cost = textLen * 10
         Self.attributedStringCache[cacheKey] = (result, Self.lruCounter, cost)
         Self.estimatedCacheBytes += cost
         Self.evictIfOverBudget()

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
@@ -49,9 +49,12 @@ struct InlineVideoEmbedCard: View {
         .frame(height: cardHeight)
         .animation(.easeInOut(duration: 0.25), value: cardHeight)
         .onDisappear {
-            // Tear down active/loading webviews when scrolled offscreen
-            // to prevent memory leaks and background audio playback.
-            if stateManager.state == .playing || stateManager.state == .initializing {
+            // Only reset states that own an active WKWebView.
+            // .placeholder and .failed have no WKWebView; preserve .failed to keep error context.
+            switch stateManager.state {
+            case .placeholder, .failed:
+                break
+            default:
                 stateManager.reset()
             }
         }


### PR DESCRIPTION
## Summary

Diagnoses and fixes the root causes of crashes and hangs when scrolling through threads with long text content, image attachments, and video embeds. The hang report confirmed the primary cause: SwiftUI's layout engine spending 1+ seconds measuring deeply-nested chat bubble views on every scroll event.

## Changes

- **M1 – Layout measurement fix:** Reordered `.frame(maxWidth:)` before `.fixedSize(horizontal: false, vertical: true)` in `MarkdownSegmentView`, `ChatBubbleTextContent`, and `ChatBubble`. Without a bounded horizontal constraint, `fixedSize` forces unconstrained text measurement — O(N²) for long messages in a LazyVStack.
- **M2 – NSImage(data:) reentrance fix:** Moved image decoding to async `.task` in `ChatBubbleAttachmentContent`. Calling `NSImage(data:)` during SwiftUI body evaluation triggered re-entrant AppKit constraint invalidation → EXC_BAD_ACCESS on scroll.
- **M3 – LRU cache overflow + budget fix:** Changed `lruCounter` from `Int` to `UInt64` to prevent silent overflow in long sessions. Increased byte estimation multiplier from 3x to 10x (AttributedString overhead is much larger than raw string bytes).
- **M4 – WKWebView cleanup fix:** `stateManager.reset()` in `onDisappear` now correctly handles all states using `switch` pattern matching — resets `.initializing`/`.playing` (which hold WKWebViews) and preserves `.failed` error context.

## Crash report analysis

The `report.rtf` hang trace (v0.4.26) shows the main thread spending 1.07s in:
```
LazySubviewPlacements.placeSubviews → ForEachState.forEachItem
  → GeometryReaderLayout → StackLayout → _PaddingLayout × 3 → _FlexFrameLayout
    → _ZStackLayout → StackLayout → _PaddingLayout × 3 ...
```
This is exactly the layout thrashing pattern fixed in M1. M2–M4 address the secondary memory pressure contributors (283 MB footprint at time of hang).

## Milestone PRs (merged into feature branch)
- #11776: fix: constrain fixedSize text layout (M1)
- #11779: fix: async-decode attachment images (M2)
- #11825: fix: prevent LRU overflow + tighten cache budget (M3)
- #11832: fix: always clean up video embed WKWebView on disappear (M4)

## Project issue
Closes #11770

## Test plan
- [ ] Scroll rapidly through a thread with 50+ messages containing long markdown (code blocks, tables)
- [ ] Scroll through messages with image attachments — no EXC_BAD_ACCESS
- [ ] Scroll through messages with video embeds — memory stays stable
- [ ] Run app for extended session — cache eviction still works correctly
- [ ] Verify video embed shows error state after scrolling back when load failed

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11853" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
