### PR TITLE
Remove proxied bash per-invocation approval special-casing

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -4292,28 +4292,25 @@ describe("Permission Checker", () => {
   });
 });
 
-describe("bash network_mode=proxied force prompt", () => {
+describe("bash network_mode=proxied — no special-casing", () => {
   beforeEach(() => {
     clearCache();
     testConfig.permissions = { mode: "legacy" };
     testConfig.skills = { load: { extraDirs: [] } };
   });
 
-  test("proxied bash always prompts even when trust rules would allow", async () => {
-    // The global sandbox allow rule would normally auto-allow any bash command,
-    // but proxied mode injects credentials so it must always prompt.
+  test("proxied bash follows normal rules (auto-allowed by default rule)", async () => {
+    // Proxied bash is no longer force-prompted — the default allow-bash rule
+    // auto-allows low/medium risk commands regardless of network_mode.
     const result = await check(
       "bash",
       { command: "curl https://api.example.com", network_mode: "proxied" },
       "/tmp",
     );
-    expect(result.decision).toBe("prompt");
-    expect(result.reason).toContain("Proxied network mode");
+    expect(result.decision).toBe("allow");
   });
 
-  test("host_bash with network_mode=proxied follows normal flow (not force-prompted)", async () => {
-    // host_bash does not support network_mode — proxied-mode force-prompt
-    // applies only to sandboxed bash, not host_bash.
+  test("host_bash with network_mode=proxied follows normal flow", async () => {
     addRule("host_bash", "**", "everywhere");
     const result = await check(
       "host_bash",
@@ -4321,13 +4318,11 @@ describe("bash network_mode=proxied force prompt", () => {
       "/tmp",
     );
     expect(result.decision).toBe("allow");
-    expect(result.reason).not.toContain("Proxied network mode");
   });
 
   test("non-proxied bash follows normal flow (auto-allowed)", async () => {
     const result = await check("bash", { command: "ls" }, "/tmp");
     expect(result.decision).toBe("allow");
-    expect(result.reason).not.toContain("Proxied network mode");
   });
 
   test("non-proxied bash with trust rule follows normal flow", async () => {
@@ -4338,19 +4333,6 @@ describe("bash network_mode=proxied force prompt", () => {
       "/tmp",
     );
     expect(result.decision).toBe("allow");
-    expect(result.reason).not.toContain("Proxied network mode");
-  });
-
-  test("proxied bash prompt reason is descriptive", async () => {
-    const result = await check(
-      "bash",
-      { command: "wget http://example.com", network_mode: "proxied" },
-      "/tmp",
-    );
-    expect(result.decision).toBe("prompt");
-    expect(result.reason).toBe(
-      "Proxied network mode requires explicit approval for each invocation.",
-    );
   });
 
   test("proxied bash with network_mode=off follows normal flow", async () => {
@@ -4362,7 +4344,7 @@ describe("bash network_mode=proxied force prompt", () => {
     expect(result.decision).toBe("allow");
   });
 
-  test("proxied bash prompts even in strict mode with matching rule", async () => {
+  test("proxied bash with matching allow rule in strict mode is allowed", async () => {
     testConfig.permissions = { mode: "strict" };
     addRule("bash", "*", "everywhere");
     const result = await check(
@@ -4370,8 +4352,7 @@ describe("bash network_mode=proxied force prompt", () => {
       { command: "curl https://api.example.com", network_mode: "proxied" },
       "/tmp",
     );
-    expect(result.decision).toBe("prompt");
-    expect(result.reason).toContain("Proxied network mode");
+    expect(result.decision).toBe("allow");
   });
 
   test("deny rule still blocks proxied bash command", async () => {
@@ -4702,16 +4683,16 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
     }
   });
 
-  // ── proxied bash — prompt takes precedence over workspace mode ──
+  // ── proxied bash — follows normal rules (no special-casing) ──
 
-  test("bash with network_mode=proxied → prompt (proxied check before workspace mode)", async () => {
+  test("bash with network_mode=proxied → allow (follows normal rules in workspace mode)", async () => {
     const result = await check(
       "bash",
       { command: "curl https://api.example.com", network_mode: "proxied" },
       workspaceDir,
     );
-    expect(result.decision).toBe("prompt");
-    expect(result.reason).toContain("Proxied");
+    // Default allow-bash rule auto-allows; proxied mode is not special-cased.
+    expect(result.decision).toBe("allow");
   });
 
   // ── host tools — default ask rules prompt ──

--- a/assistant/src/__tests__/ephemeral-permissions.test.ts
+++ b/assistant/src/__tests__/ephemeral-permissions.test.ts
@@ -353,14 +353,14 @@ describe("ephemeral-permissions", () => {
       expect(result.decision).toBe("deny");
     });
 
-    test("proxied bash still prompts in workspace mode", async () => {
+    test("proxied bash follows normal rules in workspace mode (no special-casing)", async () => {
       const result = await check(
         "bash",
         { command: "echo hello", network_mode: "proxied" },
         testDir,
       );
-      expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("Proxied");
+      // Default allow-bash rule auto-allows; proxied mode is not special-cased.
+      expect(result.decision).toBe("allow");
     });
 
     test("ephemeral task rules + workspace mode: deny rule wins", async () => {

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -1894,218 +1894,10 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
 });
 
 // ---------------------------------------------------------------------------
-// persistentDecisionsAllowed contract (PR 15)
+// persistentDecisionsAllowed contract
 // ---------------------------------------------------------------------------
 
 describe("ToolExecutor persistentDecisionsAllowed contract", () => {
-  beforeEach(() => {
-    fakeToolResult = { content: "ok", isError: false };
-    lastCheckArgs = undefined;
-    getToolOverride = undefined;
-    checkResultOverride = {
-      decision: "prompt",
-      reason:
-        "Proxied network mode requires explicit approval for each invocation.",
-    };
-    checkFnOverride = undefined;
-    if (addRuleSpy) {
-      addRuleSpy.mockRestore();
-      addRuleSpy = undefined;
-    }
-  });
-
-  function setupAddRuleSpy() {
-    addRuleSpy = spyOn(trustStore, "addRule").mockImplementation(
-      (
-        tool: string,
-        pattern: string,
-        scope: string,
-        decision = "allow",
-        priority = 100,
-        options?: { allowHighRisk?: boolean; executionTarget?: string },
-      ) => {
-        return {
-          id: "spy-rule-id",
-          tool,
-          pattern,
-          scope,
-          decision,
-          priority,
-          createdAt: Date.now(),
-          ...options,
-        } as TrustRule;
-      },
-    );
-    return addRuleSpy;
-  }
-
-  test("proxied bash always_allow does NOT save a trust rule", async () => {
-    const spy = setupAddRuleSpy();
-
-    const prompter = makePrompterWithDecision(
-      "always_allow",
-      "bash:*",
-      "/tmp/project",
-    );
-    const executor = new ToolExecutor(prompter);
-    const result = await executor.execute(
-      "bash",
-      { command: "curl https://example.com", network_mode: "proxied" },
-      makeContext(),
-    );
-
-    expect(result.isError).toBe(false);
-    expect(spy).not.toHaveBeenCalled();
-  });
-
-  test("non-proxied bash always_allow DOES save a trust rule", async () => {
-    const spy = setupAddRuleSpy();
-
-    const prompter = makePrompterWithDecision(
-      "always_allow",
-      "bash:*",
-      "/tmp/project",
-    );
-    const executor = new ToolExecutor(prompter);
-    const result = await executor.execute(
-      "bash",
-      { command: "git status" },
-      makeContext(),
-    );
-
-    expect(result.isError).toBe(false);
-    expect(spy).toHaveBeenCalledTimes(1);
-  });
-
-  test("proxied bash always_deny does NOT save a trust rule", async () => {
-    const spy = setupAddRuleSpy();
-
-    const prompter = makePrompterWithDecision(
-      "always_deny",
-      "bash:*",
-      "/tmp/project",
-    );
-    const executor = new ToolExecutor(prompter);
-    const result = await executor.execute(
-      "bash",
-      { command: "curl https://evil.com", network_mode: "proxied" },
-      makeContext(),
-    );
-
-    expect(result.isError).toBe(true);
-    expect(spy).not.toHaveBeenCalled();
-  });
-
-  test("persistentDecisionsAllowed: false is emitted in lifecycle event for proxied bash", async () => {
-    let capturedEvent: ToolPermissionPromptEvent | undefined;
-    const prompter = makePrompterWithDecision("allow");
-    const executor = new ToolExecutor(prompter);
-    const result = await executor.execute(
-      "bash",
-      { command: "curl https://example.com", network_mode: "proxied" },
-      makeContext({
-        onToolLifecycleEvent: (event: ToolLifecycleEvent) => {
-          if (event.type === "permission_prompt") {
-            capturedEvent = event;
-          }
-        },
-      }),
-    );
-
-    expect(result.isError).toBe(false);
-    expect(capturedEvent).toBeDefined();
-    expect(capturedEvent!.persistentDecisionsAllowed).toBe(false);
-  });
-
-  test("persistentDecisionsAllowed: true is emitted in lifecycle event for non-proxied bash", async () => {
-    let capturedEvent: ToolPermissionPromptEvent | undefined;
-    const prompter = makePrompterWithDecision("allow");
-    const executor = new ToolExecutor(prompter);
-    const result = await executor.execute(
-      "bash",
-      { command: "echo hello" },
-      makeContext({
-        onToolLifecycleEvent: (event: ToolLifecycleEvent) => {
-          if (event.type === "permission_prompt") {
-            capturedEvent = event;
-          }
-        },
-      }),
-    );
-
-    expect(result.isError).toBe(false);
-    expect(capturedEvent).toBeDefined();
-    expect(capturedEvent!.persistentDecisionsAllowed).toBe(true);
-  });
-
-  test("persistentDecisionsAllowed is passed to prompter confirmation_request for proxied bash", async () => {
-    let capturedPersistent: unknown;
-    const prompter = {
-      prompt: async (
-        _toolName: string,
-        _input: Record<string, unknown>,
-        _riskLevel: string,
-        _allowlistOptions: AllowlistOption[],
-        _scopeOptions: ScopeOption[],
-        _diff: unknown,
-        _sandboxed: unknown,
-        _sessionId: unknown,
-        _executionTarget: unknown,
-        persistentDecisionsAllowed: boolean | undefined,
-      ) => {
-        capturedPersistent = persistentDecisionsAllowed;
-        return { decision: "allow" as const };
-      },
-      resolveConfirmation: () => {},
-      updateSender: () => {},
-      dispose: () => {},
-    } as unknown as PermissionPrompter;
-
-    const executor = new ToolExecutor(prompter);
-    const result = await executor.execute(
-      "bash",
-      { command: "curl https://example.com", network_mode: "proxied" },
-      makeContext(),
-    );
-
-    expect(result.isError).toBe(false);
-    expect(capturedPersistent).toBe(false);
-  });
-
-  test("host_bash with proxied network_mode still allows persistent decisions", async () => {
-    // host_bash does not support network_mode — proxied-mode persistence
-    // blocking applies only to sandboxed bash, not host_bash.
-    const spy = setupAddRuleSpy();
-
-    const prompter = makePrompterWithDecision(
-      "always_allow",
-      "host_bash:*",
-      "/tmp/project",
-    );
-    const executor = new ToolExecutor(prompter);
-    const result = await executor.execute(
-      "host_bash",
-      { command: "curl https://example.com", network_mode: "proxied" },
-      makeContext(),
-    );
-
-    expect(result.isError).toBe(false);
-    expect(spy).toHaveBeenCalledTimes(1);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// E2E: Proxied bash vs. proxy approval persistence invariants (PR 32)
-//
-// Design invariant: the proxied-run activation prompt (when the agent wants
-// to run `bash` with `network_mode=proxied`) must NOT allow saving persistent
-// trust rules — each invocation must be explicitly approved. In contrast,
-// the proxy-request approval path (when the proxy service asks the user
-// about a specific outbound request) CAN save persistent trust rules so the
-// user doesn't get re-prompted for the same host/pattern.
-// ---------------------------------------------------------------------------
-
-describe("E2E: proxied bash activation vs proxy approval persistence", () => {
   beforeEach(() => {
     fakeToolResult = { content: "ok", isError: false };
     lastCheckArgs = undefined;
@@ -2146,10 +1938,143 @@ describe("E2E: proxied bash activation vs proxy approval persistence", () => {
     return addRuleSpy;
   }
 
-  test("proxied bash: always_allow skips rule, always_deny skips rule, non-proxied bash saves both", async () => {
+  test("proxied bash always_allow saves a trust rule (no special-casing)", async () => {
     const spy = setupAddRuleSpy();
 
-    // 1. Proxied bash always_allow -> NO rule saved
+    const prompter = makePrompterWithDecision(
+      "always_allow",
+      "bash:*",
+      "/tmp/project",
+    );
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute(
+      "bash",
+      { command: "curl https://example.com", network_mode: "proxied" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test("non-proxied bash always_allow saves a trust rule", async () => {
+    const spy = setupAddRuleSpy();
+
+    const prompter = makePrompterWithDecision(
+      "always_allow",
+      "bash:*",
+      "/tmp/project",
+    );
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute(
+      "bash",
+      { command: "git status" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test("proxied bash always_deny saves a deny rule (no special-casing)", async () => {
+    const spy = setupAddRuleSpy();
+
+    const prompter = makePrompterWithDecision(
+      "always_deny",
+      "bash:*",
+      "/tmp/project",
+    );
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute(
+      "bash",
+      { command: "curl https://evil.com", network_mode: "proxied" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test("persistentDecisionsAllowed: true is emitted in lifecycle event for proxied bash", async () => {
+    let capturedEvent: ToolPermissionPromptEvent | undefined;
+    const prompter = makePrompterWithDecision("allow");
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute(
+      "bash",
+      { command: "curl https://example.com", network_mode: "proxied" },
+      makeContext({
+        onToolLifecycleEvent: (event: ToolLifecycleEvent) => {
+          if (event.type === "permission_prompt") {
+            capturedEvent = event;
+          }
+        },
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(capturedEvent).toBeDefined();
+    expect(capturedEvent!.persistentDecisionsAllowed).toBe(true);
+  });
+
+  test("persistentDecisionsAllowed: true is emitted in lifecycle event for non-proxied bash", async () => {
+    let capturedEvent: ToolPermissionPromptEvent | undefined;
+    const prompter = makePrompterWithDecision("allow");
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute(
+      "bash",
+      { command: "echo hello" },
+      makeContext({
+        onToolLifecycleEvent: (event: ToolLifecycleEvent) => {
+          if (event.type === "permission_prompt") {
+            capturedEvent = event;
+          }
+        },
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(capturedEvent).toBeDefined();
+    expect(capturedEvent!.persistentDecisionsAllowed).toBe(true);
+  });
+
+  test("persistentDecisionsAllowed is true for proxied bash in prompter confirmation_request", async () => {
+    let capturedPersistent: unknown;
+    const prompter = {
+      prompt: async (
+        _toolName: string,
+        _input: Record<string, unknown>,
+        _riskLevel: string,
+        _allowlistOptions: AllowlistOption[],
+        _scopeOptions: ScopeOption[],
+        _diff: unknown,
+        _sandboxed: unknown,
+        _sessionId: unknown,
+        _executionTarget: unknown,
+        persistentDecisionsAllowed: boolean | undefined,
+      ) => {
+        capturedPersistent = persistentDecisionsAllowed;
+        return { decision: "allow" as const };
+      },
+      resolveConfirmation: () => {},
+      updateSender: () => {},
+      dispose: () => {},
+    } as unknown as PermissionPrompter;
+
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute(
+      "bash",
+      { command: "curl https://example.com", network_mode: "proxied" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(capturedPersistent).toBe(true);
+  });
+
+  test("bash always_allow saves a trust rule regardless of network_mode", async () => {
+    const spy = setupAddRuleSpy();
+
+    // 1. Proxied bash always_allow -> rule IS saved
     const p1 = makePrompterWithDecision(
       "always_allow",
       "bash:curl*",
@@ -2162,61 +2087,22 @@ describe("E2E: proxied bash activation vs proxy approval persistence", () => {
       makeContext(),
     );
     expect(r1.isError).toBe(false);
-    expect(spy).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockClear();
 
-    // 2. Proxied bash always_deny -> NO rule saved
+    // 2. Non-proxied bash always_allow -> rule IS saved
     const p2 = makePrompterWithDecision(
-      "always_deny",
-      "bash:curl*",
-      "/tmp/project",
-    );
-    const e2 = new ToolExecutor(p2);
-    const r2 = await e2.execute(
-      "bash",
-      { command: "curl https://evil.com", network_mode: "proxied" },
-      makeContext(),
-    );
-    expect(r2.isError).toBe(true);
-    expect(spy).not.toHaveBeenCalled();
-
-    // 3. Non-proxied bash always_allow -> rule IS saved
-    const p3 = makePrompterWithDecision(
       "always_allow",
       "bash:git*",
       "/tmp/project",
     );
-    const e3 = new ToolExecutor(p3);
-    const r3 = await e3.execute("bash", { command: "git push" }, makeContext());
-    expect(r3.isError).toBe(false);
+    const e2 = new ToolExecutor(p2);
+    const r2 = await e2.execute("bash", { command: "git push" }, makeContext());
+    expect(r2.isError).toBe(false);
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy.mock.calls[0][0]).toBe("bash");
-    expect(spy.mock.calls[0][1]).toBe("bash:git*");
-    expect(spy.mock.calls[0][3]).toBe("allow");
   });
 
-  test("proxied bash always_allow_high_risk also skips rule saving", async () => {
-    const spy = setupAddRuleSpy();
-
-    const prompter = makePrompterWithDecision(
-      "always_allow_high_risk",
-      "bash:*",
-      "everywhere",
-    );
-    const executor = new ToolExecutor(prompter);
-    const result = await executor.execute(
-      "bash",
-      {
-        command: "curl -X POST https://api.example.com/deploy",
-        network_mode: "proxied",
-      },
-      makeContext(),
-    );
-
-    expect(result.isError).toBe(false);
-    expect(spy).not.toHaveBeenCalled();
-  });
-
-  test("non-proxied bash always_deny DOES save a deny rule", async () => {
+  test("bash always_deny saves a deny rule regardless of network_mode", async () => {
     const spy = setupAddRuleSpy();
 
     const prompter = makePrompterWithDecision(
@@ -2238,51 +2124,7 @@ describe("E2E: proxied bash activation vs proxy approval persistence", () => {
     expect(spy.mock.calls[0][3]).toBe("deny");
   });
 
-  test("file_write with proxied network_mode is NOT affected (persistence still allowed)", async () => {
-    // Only bash with proxied mode disables persistence
-    const spy = setupAddRuleSpy();
-
-    const prompter = makePrompterWithDecision(
-      "always_allow",
-      "file_write:*",
-      "/tmp/project",
-    );
-    const executor = new ToolExecutor(prompter);
-    const result = await executor.execute(
-      "file_write",
-      { path: "/tmp/test.txt", content: "data", network_mode: "proxied" },
-      makeContext(),
-    );
-
-    expect(result.isError).toBe(false);
-    expect(spy).toHaveBeenCalledTimes(1);
-  });
-
-  test("host_bash proxied always_allow_high_risk still saves rule (host_bash ignores network_mode)", async () => {
-    // host_bash does not support network_mode — persistence blocking
-    // applies only to sandboxed bash.
-    const spy = setupAddRuleSpy();
-
-    const prompter = makePrompterWithDecision(
-      "always_allow_high_risk",
-      "host_bash:*",
-      "everywhere",
-    );
-    const executor = new ToolExecutor(prompter);
-    const result = await executor.execute(
-      "host_bash",
-      {
-        command: "wget https://example.com/data.tar.gz",
-        network_mode: "proxied",
-      },
-      makeContext(),
-    );
-
-    expect(result.isError).toBe(false);
-    expect(spy).toHaveBeenCalledTimes(1);
-  });
-
-  test('proxied bash denied result message omits "rule saved" suffix', async () => {
+  test('proxied bash denied result message includes "rule saved" suffix', async () => {
     setupAddRuleSpy();
 
     const prompter = makePrompterWithDecision(
@@ -2298,9 +2140,8 @@ describe("E2E: proxied bash activation vs proxy approval persistence", () => {
     );
 
     expect(result.isError).toBe(true);
-    // Since no rule was saved, the message should NOT include "rule was saved"
     expect(result.content).toContain("Permission denied by user");
-    expect(result.content).not.toContain("rule was saved");
+    expect(result.content).toContain("rule was saved");
   });
 
   test('non-proxied bash denied result message includes "rule saved" suffix', async () => {

--- a/assistant/src/__tests__/tool-permission-simulate-handler.test.ts
+++ b/assistant/src/__tests__/tool-permission-simulate-handler.test.ts
@@ -191,7 +191,7 @@ describe("tool_permission_simulate handler", () => {
     expect(res.promptPayload!.persistentDecisionsAllowed).toBe(true);
   });
 
-  test("proxied bash disables persistent decisions", async () => {
+  test("proxied bash is not special-cased (follows normal rules)", async () => {
     const { ctx, sent } = createTestContext();
     const msg: ToolPermissionSimulateRequest = {
       type: "tool_permission_simulate",
@@ -202,9 +202,9 @@ describe("tool_permission_simulate handler", () => {
 
     const res = getResponse(sent);
     expect(res.success).toBe(true);
-    expect(res.decision).toBe("prompt");
-    expect(res.promptPayload).toBeDefined();
-    expect(res.promptPayload!.persistentDecisionsAllowed).toBe(false);
+    // Proxied bash now follows normal permission rules — the default
+    // allow-bash rule auto-allows low-risk commands just like non-proxied bash.
+    expect(res.decision).toBe("allow");
   });
 
   test("forcePromptSideEffects promotes allow to prompt for side-effect tools", async () => {

--- a/assistant/src/daemon/handlers/config-tools.ts
+++ b/assistant/src/daemon/handlers/config-tools.ts
@@ -105,11 +105,7 @@ export async function handleToolPermissionSimulate(
     if (result.decision === 'prompt') {
       const allowlistOptions = await generateAllowlistOptions(msg.toolName, msg.input);
       const scopeOptions = generateScopeOptions(workingDir, msg.toolName);
-      const persistentDecisionsAllowed = !(
-        msg.toolName === 'bash'
-        && msg.input.network_mode === 'proxied'
-      );
-      promptPayload = { allowlistOptions, scopeOptions, persistentDecisionsAllowed };
+      promptPayload = { allowlistOptions, scopeOptions, persistentDecisionsAllowed: true };
     }
 
     ctx.send(socket, {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -532,9 +532,8 @@ export class Session {
     );
 
     // Mode activation (setTimedMode / setThreadMode) is intentionally NOT
-    // done here. It is handled in permission-checker.ts where
-    // persistentDecisionsAllowed context is available — this prevents
-    // proxied bash commands from escalating into blanket auto-approval.
+    // done here. It is handled in permission-checker.ts where the
+    // guardian trust-class and conversation context are available.
 
     // Emit authoritative confirmation state and activity transition centrally
     // so ALL callers (IPC handlers, /v1/confirm, channel bridges) get

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -511,15 +511,6 @@ export async function check(
     return { decision: 'deny', reason: `Blocked by deny rule: ${matchedRule.pattern}`, matchedRule };
   }
 
-  // Proxied network mode requires explicit user approval for every
-  // invocation because the command routes through an authenticated
-  // proxy with injected credentials. This runs after deny rules but
-  // before allow/ask rules so that trust rules cannot auto-approve
-  // proxied commands.
-  if (toolName === 'bash' && input.network_mode === 'proxied') {
-    return { decision: 'prompt', reason: 'Proxied network mode requires explicit approval for each invocation.' };
-  }
-
   if (matchedRule) {
     if (matchedRule.decision === 'ask') {
       // Ask rules always prompt — never auto-allow or auto-deny

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -162,15 +162,8 @@ export class PermissionChecker {
         // skip the interactive prompt and auto-approve. Only applies to
         // guardian actors — untrusted actors cannot leverage this to bypass
         // guardian-required gates (those are enforced in pre-execution gates).
-        // Proxied bash commands require per-invocation approval and must not
-        // be auto-approved by a temporary override — they are excluded here
-        // by requiring persistent decisions to be allowed.
-        const persistentDecisionsAllowedForOverride = !(
-          name === "bash" && input.network_mode === "proxied"
-        );
         if (
           context.trustClass === "guardian" &&
-          persistentDecisionsAllowedForOverride &&
           getEffectiveMode(context.conversationId) !== undefined
         ) {
           log.info(
@@ -207,18 +200,12 @@ export class PermissionChecker {
           sandboxed = wrapped.sandboxed;
         }
 
-        // Proxied bash prompts are non-persistent — no trust rule saving allowed
-        const persistentDecisionsAllowed = !(
-          name === "bash" && input.network_mode === "proxied"
-        );
+        const persistentDecisionsAllowed = true;
 
-        // Only offer temporary approval options to guardians when persistent
-        // decisions are allowed (proxied bash is excluded since it requires
-        // per-invocation approval).
+        // Offer temporary approval options to guardians.
         const temporaryOptionsAvailable:
           | Array<"allow_10m" | "allow_thread">
           | undefined =
-          persistentDecisionsAllowed &&
           context.trustClass === "guardian"
             ? ["allow_10m", "allow_thread"]
             : undefined;
@@ -399,19 +386,13 @@ export class PermissionChecker {
         // time-limited or thread-scoped override. Subsequent tool
         // invocations in this conversation will auto-approve without
         // prompting (checked above in the temporary override block).
-        // Gated on persistentDecisionsAllowed so that proxied bash
-        // commands (which require per-invocation approval) cannot
-        // escalate into blanket auto-approval.
-        if (persistentDecisionsAllowed && response.decision === "allow_10m") {
+        if (response.decision === "allow_10m") {
           setTimedMode(context.conversationId);
           log.info(
             { toolName: name, conversationId: context.conversationId },
             "Activated timed (10m) temporary approval mode",
           );
-        } else if (
-          persistentDecisionsAllowed &&
-          response.decision === "allow_thread"
-        ) {
+        } else if (response.decision === "allow_thread") {
           setThreadMode(context.conversationId);
           log.info(
             { toolName: name, conversationId: context.conversationId },


### PR DESCRIPTION
## Summary
- Removes the special-casing that forced proxied bash commands (`network_mode: "proxied"`) to require explicit approval on every invocation, bypassing thread-level and timed approval overrides
- Proxied bash is now treated identically to all other tools for permission decisions, trust rule persistence, and temporary approval modes
- Removes the early-return in `checker.ts`, the `persistentDecisionsAllowedForOverride` guard in `permission-checker.ts`, and the proxied bash check in the simulation handler

## Test plan
- [x] All affected test files pass individually (`tool-executor`, `tool-permission-simulate-handler`, `channel-approvals`, `approval-routes-http`, `handlers-user-message-approval-consumption`, `channel-approval-routes`, `daemon-server-session-init`)
- [ ] Manual: use a skill that calls bash with `network_mode: "proxied"`, click "Allow for this thread", verify no re-prompt on next proxied call

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
