### PR TITLE
ci: bump CI test workers from 2 to 4

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Test
         run: bun run test:stable
+        env:
+          TEST_WORKERS: '4'
 
       - name: Track consecutive failures
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1376,6 +1376,7 @@ jobs:
         working-directory: assistant
         env:
           EXCLUDE_EXPERIMENTAL: 'true'
+          TEST_WORKERS: '4'
 
   ci-cli:
     needs: bump-and-tag


### PR DESCRIPTION
## Summary
- Set `TEST_WORKERS: 4` in both `ci-main-assistant.yaml` and `release.yml` test steps
- The default 2-core runner auto-detects 2 workers, but our process-isolated test runner benefits from over-subscribing since tests are I/O-bound (each file runs in its own Bun process)

## Original prompt
Bump CI test workers from auto-detected 2 to 4 while keeping the same runner size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
