### PR TITLE
ci: parallelize lint, typecheck, and tests

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -38,14 +38,25 @@ jobs:
       - name: Verify Swift decoder is in sync with contract
         run: bun run ipc:check-swift-drift
 
-      - name: Type check
-        run: bunx tsc --noEmit
+      - name: Lint, Type check & Test
+        run: |
+          set +e
+          bunx tsc --noEmit &
+          TSC_PID=$!
+          bun run lint &
+          LINT_PID=$!
+          bun run test:stable &
+          TEST_PID=$!
 
-      - name: Lint
-        run: bun run lint
+          TSC_RC=0;  wait $TSC_PID  || TSC_RC=$?
+          LINT_RC=0; wait $LINT_PID || LINT_RC=$?
+          TEST_RC=0; wait $TEST_PID || TEST_RC=$?
 
-      - name: Test
-        run: bun run test:stable
+          if [ $TSC_RC -ne 0 ];  then echo "::error::Type check failed (exit $TSC_RC)"; fi
+          if [ $LINT_RC -ne 0 ]; then echo "::error::Lint failed (exit $LINT_RC)"; fi
+          if [ $TEST_RC -ne 0 ]; then echo "::error::Tests failed (exit $TEST_RC)"; fi
+
+          [ $TSC_RC -eq 0 ] && [ $LINT_RC -eq 0 ] && [ $TEST_RC -eq 0 ]
         env:
           TEST_WORKERS: '4'
 


### PR DESCRIPTION
## Summary
- Combine the separate Type check, Lint, and Test steps into a single parallel step in `ci-main-assistant.yaml`
- All three run concurrently with proper exit code collection and error reporting via `::error::` annotations
- Saves ~30-50s by overlapping lint (~25s) and tsc (~32s) with the test warmup phase

## Original prompt
Parallelize lint + typecheck + tests in CI to save ~30-50s off total job time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
