### PR TITLE
feat: add app_delete IPC and fix Things page menu click zone

### DIFF
--- a/assistant/src/daemon/handlers/apps.ts
+++ b/assistant/src/daemon/handlers/apps.ts
@@ -10,11 +10,12 @@ import { defaultGallery } from '../../gallery/default-gallery.js';
 import { resolveHomeBaseAppId } from '../../home-base/bootstrap.js';
 import { isPrebuiltHomeBaseApp } from '../../home-base/prebuilt-home-base-updater.js';
 import { getAppDiff, getAppFileAtVersion, getAppHistory, restoreAppVersion } from '../../memory/app-git-service.js';
-import { createApp, createAppRecord, deleteAppRecord, getApp, getAppPreview, listApps, queryAppRecords, updateApp,updateAppRecord } from '../../memory/app-store.js';
+import { createApp, createAppRecord, deleteApp, deleteAppRecord, getApp, getAppPreview, listApps, queryAppRecords, updateApp,updateAppRecord } from '../../memory/app-store.js';
 import { createSharedAppLink } from '../../memory/shared-app-links-store.js';
 import { computeContentId } from '../../util/content-id.js';
 import type {
   AppDataRequest,
+  AppDeleteRequest,
   AppDiffRequest,
   AppFileAtVersionRequest,
   AppHistoryRequest,
@@ -211,6 +212,20 @@ export function handleAppPreview(
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, appId: msg.appId }, 'Failed to get app preview');
     ctx.send(socket, { type: 'error', message: `Failed to get app preview: ${message}` });
+  }
+}
+
+export function handleAppDelete(
+  msg: AppDeleteRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  try {
+    deleteApp(msg.appId);
+    ctx.send(socket, { type: 'app_delete_response', success: true });
+  } catch (err) {
+    log.error({ err, appId: msg.appId }, 'Failed to delete app');
+    ctx.send(socket, { type: 'app_delete_response', success: false });
   }
 }
 
@@ -572,6 +587,7 @@ export const appHandlers = defineHandlers({
   app_preview_request: handleAppPreview,
   apps_list: (_msg, socket, ctx) => handleAppsList(socket, ctx),
   shared_apps_list: (_msg, socket, ctx) => handleSharedAppsList(socket, ctx),
+  app_delete: handleAppDelete,
   shared_app_delete: handleSharedAppDelete,
   fork_shared_app: handleForkSharedApp,
   share_app_cloud: handleShareAppCloud,

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -49,6 +49,7 @@
     "accept_starter_bundle",
     "add_trust_rule",
     "app_data_request",
+    "app_delete",
     "app_diff_request",
     "app_file_at_version_request",
     "app_history_request",
@@ -189,6 +190,7 @@
   "serverWireTypes": [
     "accept_starter_bundle_response",
     "app_data_response",
+    "app_delete_response",
     "app_diff_response",
     "app_file_at_version_response",
     "app_files_changed",

--- a/assistant/src/daemon/ipc-contract/apps.ts
+++ b/assistant/src/daemon/ipc-contract/apps.ts
@@ -33,6 +33,11 @@ export interface SharedAppsListRequest {
   type: 'shared_apps_list';
 }
 
+export interface AppDeleteRequest {
+  type: 'app_delete';
+  appId: string;
+}
+
 export interface SharedAppDeleteRequest {
   type: 'shared_app_delete';
   uuid: string;
@@ -213,6 +218,11 @@ export interface SharedAppsListResponse {
   }>;
 }
 
+export interface AppDeleteResponse {
+  type: 'app_delete_response';
+  success: boolean;
+}
+
 export interface SharedAppDeleteResponse {
   type: 'shared_app_delete_response';
   success: boolean;
@@ -364,6 +374,7 @@ export type _AppsClientMessages =
   | HomeBaseGetRequest
   | AppOpenRequest
   | SharedAppsListRequest
+  | AppDeleteRequest
   | SharedAppDeleteRequest
   | ForkSharedAppRequest
   | BundleAppRequest
@@ -388,6 +399,7 @@ export type _AppsServerMessages =
   | AppsListResponse
   | HomeBaseGetResponse
   | SharedAppsListResponse
+  | AppDeleteResponse
   | SharedAppDeleteResponse
   | ForkSharedAppResponse
   | BundleAppResponse

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -166,38 +166,41 @@ struct AppsGridView: View {
                         .stroke(VColor.surfaceBorder, lineWidth: 1)
                 )
                 .overlay(alignment: .topTrailing) {
-                    VIconButton(label: "App actions", icon: "ellipsis", iconOnly: true, variant: .filled(VColor.buttonPrimary), size: 24) {}
-                        .overlay {
-                            Menu {
-                                Button {
-                                    if app.isPinned {
-                                        appListManager.unpinApp(id: app.id)
-                                    } else {
-                                        appListManager.pinApp(id: app.id)
-                                    }
-                                } label: {
-                                    Label(app.isPinned ? "Unpin" : "Pin", systemImage: app.isPinned ? "pin.slash" : "pin")
-                                }
-                                Button(role: .destructive) {
-                                    if hoveredAppId != nil {
-                                        hoveredAppId = nil
-                                        NSCursor.pop()
-                                    }
-                                    appListManager.removeApp(id: app.id)
-                                } label: {
-                                    Label("Delete", systemImage: "trash")
+                    ZStack {
+                        VIconButton(label: "App actions", icon: "ellipsis", iconOnly: true, variant: .filled(VColor.buttonPrimary), size: 24) {}
+                            .allowsHitTesting(false)
+                        Menu {
+                            Button {
+                                if app.isPinned {
+                                    appListManager.unpinApp(id: app.id)
+                                } else {
+                                    appListManager.pinApp(id: app.id)
                                 }
                             } label: {
-                                Color.clear
+                                Label(app.isPinned ? "Unpin" : "Pin", systemImage: app.isPinned ? "pin.slash" : "pin")
                             }
-                            .menuStyle(.borderlessButton)
-                            .menuIndicator(.hidden)
+                            Button(role: .destructive) {
+                                if hoveredAppId != nil {
+                                    hoveredAppId = nil
+                                    NSCursor.pop()
+                                }
+                                try? daemonClient.sendAppDelete(appId: app.id)
+                                appListManager.removeApp(id: app.id)
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        } label: {
+                            Color.clear.contentShape(Rectangle())
                         }
-                        .accessibilityLabel("App actions")
-                        .padding(VSpacing.sm)
-                        .opacity(isHovered ? 1 : 0)
-                        .allowsHitTesting(isHovered)
-                        .animation(VAnimation.fast, value: isHovered)
+                        .menuStyle(.borderlessButton)
+                        .menuIndicator(.hidden)
+                        .fixedSize()
+                    }
+                    .accessibilityLabel("App actions")
+                    .padding(VSpacing.sm)
+                    .opacity(isHovered ? 1 : 0)
+                    .allowsHitTesting(isHovered)
+                    .animation(VAnimation.fast, value: isHovered)
                 }
                 .shadow(color: .black.opacity(0.06), radius: 4, y: 2)
 

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -311,6 +311,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `shared_apps_list_response` message.
     public var onSharedAppsListResponse: ((SharedAppsListResponseMessage) -> Void)?
 
+    /// Called when the daemon sends an `app_delete_response` message.
+    public var onAppDeleteResponse: ((AppDeleteResponseMessage) -> Void)?
+
     /// Called when the daemon sends a `shared_app_delete_response` message.
     public var onSharedAppDeleteResponse: ((SharedAppDeleteResponseMessage) -> Void)?
 
@@ -1121,6 +1124,11 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Request the list of shared/received apps.
     public func sendSharedAppsList() throws {
         try send(SharedAppsListRequestMessage())
+    }
+
+    /// Delete a persistent user-created app by ID.
+    public func sendAppDelete(appId: String) throws {
+        try send(AppDeleteRequestMessage(appId: appId))
     }
 
     /// Delete a shared app by UUID.

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -121,6 +121,8 @@ extension DaemonClient {
             onAppRestoreResponse?(msg)
         case .sharedAppsListResponse(let msg):
             onSharedAppsListResponse?(msg)
+        case .appDeleteResponse(let msg):
+            onAppDeleteResponse?(msg)
         case .sharedAppDeleteResponse(let msg):
             onSharedAppDeleteResponse?(msg)
         case .forkSharedAppResponse(let msg):

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -92,6 +92,26 @@ public struct IPCAppDataResponse: Codable, Sendable {
     }
 }
 
+public struct IPCAppDeleteRequest: Codable, Sendable {
+    public let type: String
+    public let appId: String
+
+    public init(type: String, appId: String) {
+        self.type = type
+        self.appId = appId
+    }
+}
+
+public struct IPCAppDeleteResponse: Codable, Sendable {
+    public let type: String
+    public let success: Bool
+
+    public init(type: String, success: Bool) {
+        self.type = type
+        self.success = success
+    }
+}
+
 public struct IPCAppDiffRequest: Codable, Sendable {
     public let type: String
     public let appId: String

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -485,6 +485,16 @@ extension IPCSharedAppsListRequest {
     }
 }
 
+/// Sent to delete a persistent user-created app by ID.
+/// Backed by generated `IPCAppDeleteRequest`.
+public typealias AppDeleteRequestMessage = IPCAppDeleteRequest
+
+extension IPCAppDeleteRequest {
+    public init(appId: String) {
+        self.init(type: "app_delete", appId: appId)
+    }
+}
+
 /// Sent to delete a shared app by UUID.
 /// Backed by generated `IPCSharedAppDeleteRequest`.
 public typealias SharedAppDeleteRequestMessage = IPCSharedAppDeleteRequest
@@ -1404,6 +1414,10 @@ extension IPCSharedAppsListResponseApp: Identifiable {
 /// Backed by generated `IPCSharedAppsListResponse`.
 public typealias SharedAppsListResponseMessage = IPCSharedAppsListResponse
 
+/// Response from deleting a persistent user-created app.
+/// Backed by generated `IPCAppDeleteResponse`.
+public typealias AppDeleteResponseMessage = IPCAppDeleteResponse
+
 /// Response from deleting a shared app.
 /// Backed by generated `IPCSharedAppDeleteResponse`.
 public typealias SharedAppDeleteResponseMessage = IPCSharedAppDeleteResponse
@@ -2191,6 +2205,7 @@ public enum ServerMessage: Decodable, Sendable {
     case appHistoryResponse(IPCAppHistoryResponse)
     case appRestoreResponse(IPCAppRestoreResponse)
     case sharedAppsListResponse(SharedAppsListResponseMessage)
+    case appDeleteResponse(AppDeleteResponseMessage)
     case sharedAppDeleteResponse(SharedAppDeleteResponseMessage)
     case forkSharedAppResponse(ForkSharedAppResponseMessage)
     case bundleAppResponse(BundleAppResponseMessage)
@@ -2490,6 +2505,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "shared_apps_list_response":
             let message = try SharedAppsListResponseMessage(from: decoder)
             self = .sharedAppsListResponse(message)
+        case "app_delete_response":
+            let message = try AppDeleteResponseMessage(from: decoder)
+            self = .appDeleteResponse(message)
         case "shared_app_delete_response":
             let message = try SharedAppDeleteResponseMessage(from: decoder)
             self = .sharedAppDeleteResponse(message)


### PR DESCRIPTION
## Summary
- Add `app_delete` IPC message type so deleting an app from the Things page also removes it from daemon persistent storage (not just the local list)
- Fix the 3-dot menu click zone on app cards by restructuring the overlay as a `ZStack` so the `Menu` hit area reliably matches the button frame
- Wire `sendAppDelete` through DaemonClient, IPCMessages, and DaemonMessageRouter

## Test plan
- [ ] Click the 3-dot button on an app card — menu opens reliably on first click
- [ ] Delete an app — it's removed from both the Things page and daemon storage (doesn't reappear on reload)
- [ ] Pin/unpin still works from the menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
