### PR TITLE
assistant+clients: trusted-contact invite parity and integration hardening

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -113,10 +113,18 @@ All guardian approval decisions — regardless of how they arrive — route thro
 - `approve_always` is downgraded to `approve_once` for guardian-on-behalf requests (guardians cannot permanently allowlist tools for requesters).
 - Scoped grant minting only fires on explicit approve for requests with tool metadata.
 
-**Dual-mode approval UX:** Guardians can respond to approval prompts via two modes, both routing through `applyGuardianDecision`:
+**Unified interaction model — buttons first, text fallback:** All guardian approval prompts follow a canonical "buttons first, text fallback" pattern. Structured button UIs are the primary interaction surface, but every prompt also carries deterministic text fallback instructions so guardians can always act even when buttons are unavailable or not used. This applies uniformly across all request kinds (`tool_approval`, `pending_question`, `access_request`) and all channels (macOS desktop, Telegram, SMS, WhatsApp).
 
-1. **Button UI (deterministic):** Desktop clients and channel adapters render structured `GuardianDecisionPrompt` objects as tappable buttons. Desktop clients use HTTP endpoints (`GET /v1/guardian-actions/pending`, `POST /v1/guardian-actions/decision`) or IPC (`guardian_actions_pending_request`, `guardian_action_decision`). Channel adapters (Telegram inline keyboards, WhatsApp) encode actions in callback data.
-2. **Conversational (NL parsing):** Text replies are classified by the conversational approval engine or parsed by the legacy text parser. The resulting `ApprovalDecisionResult` is passed to `applyGuardianDecision` identically.
+**Button-first path (deterministic):**
+- Desktop clients (macOS/iOS) render `GuardianDecisionPrompt` objects as tappable card UIs with kind-aware headers and action buttons. The `GuardianDecisionBubble` renders distinct headers for each kind: "Tool Approval Required", "Question Pending", or "Access Request".
+- Desktop clients submit decisions via HTTP (`POST /v1/guardian-actions/decision`) or IPC (`guardian_action_decision`). Both route through `applyCanonicalGuardianDecision`.
+- Channel adapters (Telegram inline keyboards, WhatsApp) encode actions as callback data (`apr:<requestId>:<action>`).
+
+**Text fallback path (always available):**
+- Every prompt includes a `requestCode` (6-char alphanumeric). Guardians can reply with `<requestCode> approve` or `<requestCode> reject` on any channel.
+- `access_request` prompts additionally embed explicit text directives in `questionText`: the request-code approve/reject directive and the `"open invite flow"` phrase for starting the Trusted Contacts invite flow.
+- `pending_question` prompts (voice-originated) support `<requestCode> <your answer>` for free-text answers.
+- The `routeGuardianReply` router processes text replies through a priority-ordered pipeline: callback parsing -> request code parsing -> NL classification. All paths converge on `applyCanonicalGuardianDecision`.
 
 **Shared type system:** `GuardianDecisionPrompt` and `GuardianDecisionAction` (in `src/runtime/guardian-decision-types.ts`) define the structured prompt model. `buildDecisionActions()` computes the action set respecting `persistentDecisionsAllowed` and `forGuardianOnBehalf` flags. `buildPlainTextFallback()` generates parser-compatible text instructions. Channel adapters map these to channel-specific formats via `toApprovalActionOptions()` in `channel-approval-types.ts`.
 
@@ -169,9 +177,9 @@ The canonical guardian request system provides a channel-agnostic, unified domai
 
 4. **Deterministic API (prompt listing and decision endpoints):** Desktop clients and API consumers use `GET /v1/guardian-actions/pending` and `POST /v1/guardian-actions/decision` (HTTP) or the equivalent IPC messages. These endpoints surface canonical requests alongside legacy pending interactions and channel approval records, with deduplication to avoid double-rendering.
 
-5. **Dual-mode (deterministic + conversational):** Guardians can respond via structured button UIs (deterministic path) or free-text conversation (NL path). Both paths converge on the same canonical primitive. Code-only messages (just a request code without decision text) return clarification instead of auto-approving. Disambiguation with multiple pending requests stays fail-closed — no auto-resolve when the target is ambiguous.
+5. **Buttons first, text fallback:** All request kinds (`tool_approval`, `pending_question`, `access_request`) are rendered as structured button cards when displayed in macOS/iOS guardian threads. Each prompt also embeds deterministic text fallback instructions (request-code-based approve/reject directives, and for `access_request` the "open invite flow" phrase) so text-based channels and manual fallback always work. Code-only messages (just a request code without decision text) return clarification instead of auto-approving. Disambiguation with multiple pending requests stays fail-closed — no auto-resolve when the target is ambiguous.
 
-**Resolver registry:** Kind-specific resolvers (`src/approvals/guardian-request-resolvers.ts`) handle side effects after CAS resolution. Built-in resolvers: `tool_approval` (channel/desktop approval path) and `pending_question` (voice call question path). New request kinds register resolvers without touching the core primitive.
+**Resolver registry:** Kind-specific resolvers (`src/approvals/guardian-request-resolvers.ts`) handle side effects after CAS resolution. Built-in resolvers: `tool_approval` (channel/desktop approval path), `pending_question` (voice call question path), and `access_request` (trusted-contact verification session creation). New request kinds register resolvers without touching the core primitive.
 
 **Expiry sweeps:** Three complementary sweeps run on 60-second intervals to clean up stale requests:
 

--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -344,4 +344,195 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       ),
     ).toBe(false);
   });
+
+  test("text fallback: request-code approve routes through guardian reply router", async () => {
+    listPendingByDestinationMock.mockReturnValue([
+      { id: "tool-req-code-1", kind: "tool_approval" },
+    ]);
+    listCanonicalMock.mockReturnValue([]);
+    routeGuardianReplyMock.mockResolvedValue({
+      consumed: true,
+      decisionApplied: true,
+      type: "canonical_decision_applied",
+      requestId: "tool-req-code-1",
+    });
+
+    const persistUserMessage = mock(async () => "should-not-be-called");
+    const runAgentLoop = mock(async () => undefined);
+    const session = {
+      setGuardianContext: () => {},
+      setStateSignalListener: () => {},
+      emitConfirmationStateChanged: () => {},
+      emitActivityState: () => {},
+      setTurnChannelContext: () => {},
+      setTurnInterfaceContext: () => {},
+      isProcessing: () => false,
+      hasAnyPendingConfirmation: () => true,
+      denyAllPendingConfirmations: () => {},
+      enqueueMessage: () => ({ queued: true, requestId: "queued-id" }),
+      persistUserMessage,
+      runAgentLoop,
+      getMessages: () => [] as unknown[],
+      assistantId: "self",
+      guardianContext: undefined,
+      hasPendingConfirmation: (id: string) => id === "tool-req-code-1",
+    } as unknown as import("../daemon/session.js").Session;
+
+    const req = new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        conversationKey: "guardian-thread-key",
+        content: "A1B2C3 approve",
+        sourceChannel: "vellum",
+        interface: "macos",
+      }),
+    });
+
+    const res = await handleSendMessage(
+      req,
+      {
+        sendMessageDeps: {
+          getOrCreateSession: async () => session,
+          assistantEventHub: { publish: async () => {} } as any,
+          resolveAttachments: () => [],
+        },
+      },
+      testAuthContext,
+    );
+
+    expect(res.status).toBe(202);
+    expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
+    const routerCall = (routeGuardianReplyMock as any).mock
+      .calls[0][0] as Record<string, unknown>;
+    // The message text should be the full request-code + decision text
+    expect(routerCall.messageText).toBe("A1B2C3 approve");
+    // Router consumed the message, so the agent loop should NOT run
+    expect(persistUserMessage).toHaveBeenCalledTimes(0);
+    expect(runAgentLoop).toHaveBeenCalledTimes(0);
+  });
+
+  test("text fallback: plain-text reject with single pending request routes through guardian reply router", async () => {
+    listPendingByDestinationMock.mockReturnValue([
+      { id: "pending-reject-1", kind: "tool_approval" },
+    ]);
+    listCanonicalMock.mockReturnValue([]);
+    routeGuardianReplyMock.mockResolvedValue({
+      consumed: true,
+      decisionApplied: true,
+      type: "canonical_decision_applied",
+      requestId: "pending-reject-1",
+    });
+
+    const persistUserMessage = mock(async () => "should-not-be-called");
+    const runAgentLoop = mock(async () => undefined);
+    const session = {
+      setGuardianContext: () => {},
+      setStateSignalListener: () => {},
+      emitConfirmationStateChanged: () => {},
+      emitActivityState: () => {},
+      setTurnChannelContext: () => {},
+      setTurnInterfaceContext: () => {},
+      isProcessing: () => false,
+      hasAnyPendingConfirmation: () => true,
+      denyAllPendingConfirmations: () => {},
+      enqueueMessage: () => ({ queued: true, requestId: "queued-id" }),
+      persistUserMessage,
+      runAgentLoop,
+      getMessages: () => [] as unknown[],
+      assistantId: "self",
+      guardianContext: undefined,
+      hasPendingConfirmation: (id: string) => id === "pending-reject-1",
+    } as unknown as import("../daemon/session.js").Session;
+
+    const req = new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        conversationKey: "guardian-thread-key",
+        content: "reject",
+        sourceChannel: "vellum",
+        interface: "macos",
+      }),
+    });
+
+    const res = await handleSendMessage(
+      req,
+      {
+        sendMessageDeps: {
+          getOrCreateSession: async () => session,
+          assistantEventHub: { publish: async () => {} } as any,
+          resolveAttachments: () => [],
+        },
+      },
+      testAuthContext,
+    );
+
+    expect(res.status).toBe(202);
+    expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
+    expect(persistUserMessage).toHaveBeenCalledTimes(0);
+    expect(runAgentLoop).toHaveBeenCalledTimes(0);
+  });
+
+  test("text fallback: non-consumed messages fall through to agent loop", async () => {
+    listPendingByDestinationMock.mockReturnValue([
+      { id: "pending-1", kind: "tool_approval" },
+    ]);
+    listCanonicalMock.mockReturnValue([]);
+    routeGuardianReplyMock.mockResolvedValue({
+      consumed: false,
+      decisionApplied: false,
+      type: "not_consumed",
+    });
+
+    const persistUserMessage = mock(async () => "persisted-user-id");
+    const runAgentLoop = mock(async () => undefined);
+    const session = {
+      setGuardianContext: () => {},
+      setStateSignalListener: () => {},
+      emitConfirmationStateChanged: () => {},
+      emitActivityState: () => {},
+      setTurnChannelContext: () => {},
+      setTurnInterfaceContext: () => {},
+      isProcessing: () => false,
+      hasAnyPendingConfirmation: () => true,
+      denyAllPendingConfirmations: () => {},
+      enqueueMessage: () => ({ queued: true, requestId: "queued-id" }),
+      persistUserMessage,
+      runAgentLoop,
+      getMessages: () => [] as unknown[],
+      assistantId: "self",
+      guardianContext: undefined,
+      hasPendingConfirmation: (id: string) => id === "pending-1",
+    } as unknown as import("../daemon/session.js").Session;
+
+    const req = new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        conversationKey: "guardian-thread-key",
+        content: "tell me more about this request",
+        sourceChannel: "vellum",
+        interface: "macos",
+      }),
+    });
+
+    const res = await handleSendMessage(
+      req,
+      {
+        sendMessageDeps: {
+          getOrCreateSession: async () => session,
+          assistantEventHub: { publish: async () => {} } as any,
+          resolveAttachments: () => [],
+        },
+      },
+      testAuthContext,
+    );
+
+    expect(res.status).toBe(202);
+    expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
+    // Router did not consume: message should fall through to agent loop
+    expect(persistUserMessage).toHaveBeenCalledTimes(1);
+    expect(runAgentLoop).toHaveBeenCalledTimes(1);
+  });
 });

--- a/assistant/src/__tests__/guardian-actions-endpoint.test.ts
+++ b/assistant/src/__tests__/guardian-actions-endpoint.test.ts
@@ -1010,3 +1010,362 @@ describe("IPC guardian_actions_pending_request", () => {
     expect(prompts[0].conversationId).toBe("conv-ipc-dest-list");
   });
 });
+
+// =========================================================================
+// Integration: pending_question visible/actionable in guardian thread
+// =========================================================================
+
+describe("integration: pending_question visible and actionable in guardian thread", () => {
+  beforeEach(resetTables);
+
+  test("pending_question delivered to guardian thread is visible via pending endpoint", () => {
+    createTestCanonicalRequest({
+      conversationId: "conv-voice-source",
+      requestId: "req-pq-visible-1",
+      kind: "pending_question",
+      questionText: "What time works best for the appointment?",
+    });
+    createCanonicalGuardianDelivery({
+      requestId: "req-pq-visible-1",
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-guardian-macos",
+    });
+
+    const prompts = listGuardianDecisionPrompts({
+      conversationId: "conv-guardian-macos",
+    });
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0].requestId).toBe("req-pq-visible-1");
+    expect(prompts[0].kind).toBe("pending_question");
+    expect(prompts[0].questionText).toBe(
+      "What time works best for the appointment?",
+    );
+    expect(prompts[0].conversationId).toBe("conv-guardian-macos");
+  });
+
+  test("pending_question prompt has approve/reject actions (guardian-on-behalf)", () => {
+    createTestCanonicalRequest({
+      conversationId: "conv-voice-src-2",
+      requestId: "req-pq-actions-1",
+      kind: "pending_question",
+      questionText: "Should I confirm the meeting?",
+    });
+
+    const prompts = listGuardianDecisionPrompts({
+      conversationId: "conv-voice-src-2",
+    });
+    expect(prompts).toHaveLength(1);
+    const actions = prompts[0].actions.map((a: { action: string }) => a.action);
+    expect(actions).toContain("approve_once");
+    expect(actions).toContain("reject");
+    // Guardian-on-behalf: no approve_always or temporary modes
+    expect(actions).not.toContain("approve_always");
+    expect(actions).not.toContain("approve_10m");
+    expect(actions).not.toContain("approve_thread");
+  });
+
+  test("pending_question is actionable via HTTP decision endpoint", async () => {
+    createTestCanonicalRequest({
+      conversationId: "conv-voice-src-3",
+      requestId: "req-pq-action-http",
+      kind: "pending_question",
+      questionText: "Allow email to bob@example.com?",
+      toolName: "send_email",
+    });
+    createCanonicalGuardianDelivery({
+      requestId: "req-pq-action-http",
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-guardian-thread-pq",
+    });
+
+    mockApplyCanonicalGuardianDecision.mockResolvedValueOnce({
+      applied: true,
+      requestId: "req-pq-action-http",
+      grantMinted: false,
+    });
+
+    const req = new Request("http://localhost/v1/guardian-actions/decision", {
+      method: "POST",
+      body: JSON.stringify({
+        requestId: "req-pq-action-http",
+        action: "approve_once",
+        conversationId: "conv-guardian-thread-pq",
+      }),
+    });
+    const res = await handleGuardianActionDecision(req, mockAuthContext);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.applied).toBe(true);
+    expect(mockApplyCanonicalGuardianDecision).toHaveBeenCalledTimes(1);
+  });
+});
+
+// =========================================================================
+// Integration: access_request visible/actionable in guardian thread
+// =========================================================================
+
+describe("integration: access_request visible and actionable in guardian thread", () => {
+  beforeEach(resetTables);
+
+  test("access_request delivered to guardian thread is visible via pending endpoint", () => {
+    createTestCanonicalRequest({
+      conversationId: "conv-access-src-1",
+      requestId: "req-ar-visible-1",
+      kind: "access_request",
+      toolName: "ingress_access_request",
+      questionText: "Alice via Telegram is requesting access to the assistant",
+    });
+    createCanonicalGuardianDelivery({
+      requestId: "req-ar-visible-1",
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-guardian-macos-ar",
+    });
+
+    const prompts = listGuardianDecisionPrompts({
+      conversationId: "conv-guardian-macos-ar",
+    });
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0].requestId).toBe("req-ar-visible-1");
+    expect(prompts[0].kind).toBe("access_request");
+    expect(prompts[0].conversationId).toBe("conv-guardian-macos-ar");
+  });
+
+  test("access_request prompt includes text fallback instructions with request code", () => {
+    createTestCanonicalRequest({
+      conversationId: "conv-access-src-2",
+      requestId: "req-ar-fallback-1",
+      kind: "access_request",
+      toolName: "ingress_access_request",
+      questionText: "Bob via WhatsApp is requesting access to the assistant",
+    });
+
+    const prompts = listGuardianDecisionPrompts({
+      conversationId: "conv-access-src-2",
+    });
+    expect(prompts).toHaveLength(1);
+    const qt = prompts[0].questionText;
+    // Must contain original question text
+    expect(qt).toContain(
+      "Bob via WhatsApp is requesting access to the assistant",
+    );
+    // Must contain request-code-based approve/reject directive
+    expect(qt).toContain("approve");
+    expect(qt).toContain("reject");
+    // Must contain invite flow directive
+    expect(qt).toContain("open invite flow");
+  });
+
+  test("access_request prompt has approve/reject actions (guardian-on-behalf)", () => {
+    createTestCanonicalRequest({
+      conversationId: "conv-access-src-3",
+      requestId: "req-ar-actions-1",
+      kind: "access_request",
+      toolName: "ingress_access_request",
+      questionText: "Carol is requesting access",
+    });
+
+    const prompts = listGuardianDecisionPrompts({
+      conversationId: "conv-access-src-3",
+    });
+    expect(prompts).toHaveLength(1);
+    const actions = prompts[0].actions.map((a: { action: string }) => a.action);
+    expect(actions).toContain("approve_once");
+    expect(actions).toContain("reject");
+    expect(actions).not.toContain("approve_always");
+  });
+
+  test("access_request is actionable via HTTP decision endpoint from guardian thread", async () => {
+    createTestCanonicalRequest({
+      conversationId: "conv-access-src-4",
+      requestId: "req-ar-action-http",
+      kind: "access_request",
+      toolName: "ingress_access_request",
+      guardianExternalUserId: "guardian-88",
+    });
+    createCanonicalGuardianDelivery({
+      requestId: "req-ar-action-http",
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-guardian-thread-ar",
+    });
+
+    mockApplyCanonicalGuardianDecision.mockResolvedValueOnce({
+      applied: true,
+      requestId: "req-ar-action-http",
+      grantMinted: false,
+    });
+
+    const req = new Request("http://localhost/v1/guardian-actions/decision", {
+      method: "POST",
+      body: JSON.stringify({
+        requestId: "req-ar-action-http",
+        action: "approve_once",
+        conversationId: "conv-guardian-thread-ar",
+      }),
+    });
+    const res = await handleGuardianActionDecision(req, mockAuthContext);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.applied).toBe(true);
+    expect(mockApplyCanonicalGuardianDecision).toHaveBeenCalledTimes(1);
+  });
+
+  test("access_request reject is actionable via HTTP decision endpoint", async () => {
+    createTestCanonicalRequest({
+      conversationId: "conv-access-src-5",
+      requestId: "req-ar-reject-http",
+      kind: "access_request",
+      toolName: "ingress_access_request",
+    });
+
+    mockApplyCanonicalGuardianDecision.mockResolvedValueOnce({
+      applied: true,
+      requestId: "req-ar-reject-http",
+      grantMinted: false,
+    });
+
+    const req = new Request("http://localhost/v1/guardian-actions/decision", {
+      method: "POST",
+      body: JSON.stringify({
+        requestId: "req-ar-reject-http",
+        action: "reject",
+      }),
+    });
+    const res = await handleGuardianActionDecision(req, mockAuthContext);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.applied).toBe(true);
+  });
+});
+
+// =========================================================================
+// Integration: text/code fallback routing when buttons are not used
+// =========================================================================
+
+describe("integration: text/code fallback routing remains functional", () => {
+  beforeEach(resetTables);
+
+  test("requestCode is always present in prompt for text-based fallback", () => {
+    createTestCanonicalRequest({
+      conversationId: "conv-fallback-1",
+      requestId: "req-fallback-code-1",
+      kind: "tool_approval",
+      toolName: "bash",
+      questionText: "Run bash: rm -rf /tmp/test",
+    });
+
+    const prompts = listGuardianDecisionPrompts({
+      conversationId: "conv-fallback-1",
+    });
+    expect(prompts).toHaveLength(1);
+    // requestCode must be a non-empty string for text-based fallback
+    expect(prompts[0].requestCode).toBeTruthy();
+    expect(prompts[0].requestCode.length).toBeGreaterThanOrEqual(6);
+  });
+
+  test("pending_question prompt includes requestCode for text fallback", () => {
+    createTestCanonicalRequest({
+      conversationId: "conv-fallback-pq",
+      requestId: "req-fallback-pq-1",
+      kind: "pending_question",
+      questionText: "When should I schedule the delivery?",
+    });
+
+    const prompts = listGuardianDecisionPrompts({
+      conversationId: "conv-fallback-pq",
+    });
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0].requestCode).toBeTruthy();
+    expect(prompts[0].kind).toBe("pending_question");
+  });
+
+  test("access_request prompt includes requestCode and text directives for fallback", () => {
+    createTestCanonicalRequest({
+      conversationId: "conv-fallback-ar",
+      requestId: "req-fallback-ar-1",
+      kind: "access_request",
+      toolName: "ingress_access_request",
+      questionText: "Dave is requesting access",
+    });
+
+    const prompts = listGuardianDecisionPrompts({
+      conversationId: "conv-fallback-ar",
+    });
+    expect(prompts).toHaveLength(1);
+    const prompt = prompts[0];
+    // requestCode present for code-based text fallback
+    expect(prompt.requestCode).toBeTruthy();
+    // questionText includes explicit text fallback instructions
+    const code = prompt.requestCode;
+    expect(prompt.questionText).toContain(`"${code} approve"`);
+    expect(prompt.questionText).toContain(`"${code} reject"`);
+    expect(prompt.questionText).toContain('"open invite flow"');
+  });
+
+  test("mixed pending_question and access_request visible in same guardian thread", () => {
+    // Create a pending_question delivered to guardian thread
+    createTestCanonicalRequest({
+      conversationId: "conv-src-mixed-1",
+      requestId: "req-mixed-pq",
+      kind: "pending_question",
+      questionText: "What time works?",
+    });
+    createCanonicalGuardianDelivery({
+      requestId: "req-mixed-pq",
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-guardian-mixed",
+    });
+
+    // Create an access_request delivered to same guardian thread
+    createTestCanonicalRequest({
+      conversationId: "conv-src-mixed-2",
+      requestId: "req-mixed-ar",
+      kind: "access_request",
+      toolName: "ingress_access_request",
+      questionText: "Eve is requesting access",
+    });
+    createCanonicalGuardianDelivery({
+      requestId: "req-mixed-ar",
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-guardian-mixed",
+    });
+
+    const prompts = listGuardianDecisionPrompts({
+      conversationId: "conv-guardian-mixed",
+    });
+    expect(prompts).toHaveLength(2);
+    const kinds = prompts.map((p: { kind?: string }) => p.kind).sort();
+    expect(kinds).toEqual(["access_request", "pending_question"]);
+
+    // Both prompts have requestCodes for text fallback
+    for (const prompt of prompts) {
+      expect(prompt.requestCode).toBeTruthy();
+      expect(prompt.actions.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("stale access_request decision returns reason without regression", async () => {
+    createTestCanonicalRequest({
+      conversationId: "conv-stale-ar",
+      requestId: "req-stale-ar-1",
+      kind: "access_request",
+      toolName: "ingress_access_request",
+    });
+    mockApplyCanonicalGuardianDecision.mockResolvedValueOnce({
+      applied: false,
+      reason: "already_resolved",
+    });
+
+    const req = new Request("http://localhost/v1/guardian-actions/decision", {
+      method: "POST",
+      body: JSON.stringify({
+        requestId: "req-stale-ar-1",
+        action: "approve_once",
+      }),
+    });
+    const res = await handleGuardianActionDecision(req, mockAuthContext);
+    const body = await res.json();
+    expect(body.applied).toBe(false);
+    expect(body.reason).toBe("already_resolved");
+    expect(body.requestId).toBe("req-stale-ar-1");
+  });
+});

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -208,20 +208,23 @@ export function listGuardianDecisionPrompts(params: {
 /**
  * Map a canonical guardian request to the client-facing prompt format.
  *
- * Generates an appropriate questionText based on the request kind, and
- * determines which actions are available. Pending questions surface as
- * informational prompts since they may require text input rather than
- * simple approve/reject buttons.
+ * Generates kind-specific questionText and action sets:
+ * - `tool_approval`: "Approve tool: <name>" with approve/reject actions
+ * - `pending_question`: voice-originated question with approve/reject actions
+ * - `access_request`: explicit "Access Request" label with approve/reject actions
+ *   and text fallback instructions (request code + "open invite flow")
+ *
+ * All kinds use `forGuardianOnBehalf: true` (no approve_always) since the
+ * guardian is acting on behalf of a requester.
  */
 function mapCanonicalRequestToPrompt(
   req: CanonicalGuardianRequest,
   conversationId: string,
 ): GuardianDecisionPrompt {
-  const questionText = req.questionText
-    ?? (req.toolName ? `Approve tool: ${req.toolName}` : `Guardian request: ${req.kind}`);
+  const questionText = buildKindAwareQuestionText(req);
 
-  // pending_question requests are typically voice-originated and need
-  // approve/reject only (no approve_always -- guardian-on-behalf invariant).
+  // All guardian-on-behalf prompts use approve_once + reject only
+  // (no approve_always, no temporary modes).
   const actions = buildDecisionActions({ forGuardianOnBehalf: true });
 
   const expiresAt = req.expiresAt
@@ -243,4 +246,26 @@ function mapCanonicalRequestToPrompt(
     callSessionId: req.callSessionId ?? null,
     kind: req.kind,
   };
+}
+
+/**
+ * Build kind-aware question text for the guardian prompt.
+ *
+ * For `access_request`, appends deterministic text fallback instructions
+ * (request-code approve/reject + "open invite flow") so the prompt remains
+ * actionable even when buttons are unavailable or not used.
+ */
+function buildKindAwareQuestionText(req: CanonicalGuardianRequest): string {
+  const baseText = req.questionText
+    ?? (req.toolName ? `Approve tool: ${req.toolName}` : `Guardian request: ${req.kind}`);
+
+  if (req.kind === 'access_request') {
+    const code = req.requestCode ?? req.id.slice(0, 6).toUpperCase();
+    const lines = [baseText];
+    lines.push(`\nReply "${code} approve" to grant access or "${code} reject" to deny.`);
+    lines.push('Reply "open invite flow" to start Trusted Contacts invite flow.');
+    return lines.join('\n');
+  }
+
+  return baseText;
 }

--- a/clients/ARCHITECTURE.md
+++ b/clients/ARCHITECTURE.md
@@ -748,4 +748,27 @@ When the daemon is unreachable, outgoing user messages are buffered in `OfflineM
 
 Storage key: `offline_message_queue_v1` (UserDefaults).
 
+### Guardian Approval Card UI (macOS/iOS)
+
+Guardian approval prompts are rendered as structured card UIs in the chat timeline using a "buttons first, text fallback" model. The daemon delivers `GuardianDecisionPrompt` objects via IPC or HTTP, and the client renders them as kind-aware cards with tappable action buttons.
+
+**Kind-aware rendering:** `GuardianDecisionBubble` renders distinct card headers for each canonical request kind:
+
+| Kind | Header | Icon | Accent |
+|------|--------|------|--------|
+| `tool_approval` | "Tool Approval Required" | `shield.lefthalf.filled` | Warning |
+| `pending_question` | "Question Pending" | `questionmark.circle.fill` | Accent |
+| `access_request` | "Access Request" | `person.badge.key.fill` | Warning |
+
+**Interaction model:** Each card displays the `questionText` (which includes text fallback directives for `access_request`), action buttons (Approve once / Reject), and secondary metadata (tool name, request code). Buttons submit decisions via `POST /v1/guardian-actions/decision` with the `requestId` and chosen action. The `requestCode` is always visible as a "Ref:" label so guardians can use text-based fallback (`<code> approve` / `<code> reject`) if buttons are not available or not used.
+
+**Shared primitives:** Action buttons use `ApprovalActionButton` (shared with `ToolConfirmationBubble`), and the button row is rendered by `GuardianApprovalActionRow`. Resolved prompts collapse to `ApprovalStatusRow` showing the outcome.
+
+| File | Purpose |
+|------|---------|
+| `clients/shared/Features/Chat/GuardianDecisionBubble.swift` | Kind-aware guardian approval card with action buttons |
+| `clients/shared/Features/Chat/ApprovalActionRow.swift` | Shared `ApprovalActionButton` and `GuardianApprovalActionRow` |
+| `clients/shared/Features/Chat/ApprovalStatusRow.swift` | Collapsed resolved-state display |
+| `clients/shared/Features/Chat/ToolConfirmationBubble.swift` | Tool confirmation card (shares `ApprovalActionButton`) |
+
 ---


### PR DESCRIPTION
## Summary

Finalize trusted-contact invite/access-request UX and close integration gaps.

- Ensure access_request prompt copy/labels are guardian-actionable in macOS cards by appending deterministic text fallback instructions (request-code approve/reject directive + "open invite flow" phrase) to the questionText
- Preserve text fallback with request codes — every prompt carries a requestCode and parser-compatible directives
- Add integration tests for pending_question visibility/actionability in guardian threads via delivery destinations
- Add integration tests for access_request visibility/actionability in guardian threads via delivery destinations
- Add integration tests for text/code fallback routing (request-code approve, plain-text reject, non-consumed fallthrough)
- Update assistant/ARCHITECTURE.md with canonical "buttons first, text fallback" interaction model
- Add guardian approval card UI documentation to clients/ARCHITECTURE.md

Closes #11839
Part of #11836
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11864" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
