### PR TITLE
fix: add missing IPC snapshot entries for app_delete and schedule_thread_created

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -289,6 +289,10 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: "app_open_request",
     appId: "app-001",
   },
+  app_delete: {
+    type: "app_delete",
+    appId: "app-001",
+  },
   apps_list: {
     type: "apps_list",
   },
@@ -1221,6 +1225,12 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
       },
     ],
   },
+  schedule_thread_created: {
+    type: "schedule_thread_created",
+    conversationId: "conv-sched-001",
+    scheduleJobId: "sched-job-001",
+    title: "Daily standup reminder",
+  },
   schedules_list_response: {
     type: "schedules_list_response",
     schedules: [
@@ -1332,6 +1342,10 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
         updateAvailable: true,
       },
     ],
+  },
+  app_delete_response: {
+    type: "app_delete_response",
+    success: true,
   },
   shared_app_delete_response: {
     type: "shared_app_delete_response",


### PR DESCRIPTION
## Summary
- Add missing `app_delete` client message and `app_delete_response` server message to `ipc-snapshot.test.ts`
- Add missing `schedule_thread_created` server message to `ipc-snapshot.test.ts`
- Fixes type check failure in CI caused by snapshot test not covering newly added IPC message types

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22645091476/job/65630956216

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
