### PR TITLE
fix: resolve CI failures in ipc-snapshot and mcp-client-auth tests

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -451,6 +451,13 @@ exports[`IPC message snapshots ClientMessage types app_open_request serializes t
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types app_delete serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "type": "app_delete",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types apps_list serializes to expected JSON 1`] = `
 {
   "type": "apps_list",
@@ -1928,6 +1935,15 @@ exports[`IPC message snapshots ServerMessage types trust_rules_list_response ser
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types schedule_thread_created serializes to expected JSON 1`] = `
+{
+  "conversationId": "conv-sched-001",
+  "scheduleJobId": "sched-job-001",
+  "title": "Daily standup reminder",
+  "type": "schedule_thread_created",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types schedules_list_response serializes to expected JSON 1`] = `
 {
   "schedules": [
@@ -2061,6 +2077,13 @@ exports[`IPC message snapshots ServerMessage types shared_apps_list_response ser
     },
   ],
   "type": "shared_apps_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types app_delete_response serializes to expected JSON 1`] = `
+{
+  "success": true,
+  "type": "app_delete_response",
 }
 `;
 

--- a/assistant/src/__tests__/mcp-client-auth.test.ts
+++ b/assistant/src/__tests__/mcp-client-auth.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, jest, mock, test } from "bun:test";
+import { describe, expect, jest, mock, test } from "bun:test";
 
 // Mock secure-keys so McpOAuthProvider doesn't try to access the keychain
 mock.module("../security/secure-keys.js", () => ({
@@ -28,13 +28,16 @@ const httpTransport = {
 
 describe("McpClient auth error detection", () => {
   test("treats StreamableHTTPError with code 401 as auth error (does not throw)", async () => {
-    const client = new McpClient("test-server", { quiet: true });
+    const client = new McpClient("test-server");
 
     // Monkey-patch createTransport to throw a 401 StreamableHTTPError
     (client as any).createTransport = () => ({});
     (client as any).client = {
       connect: () => {
-        throw new FakeStreamableHTTPError(401, 'Error POSTing to endpoint: {"error":"invalid_token"}');
+        throw new FakeStreamableHTTPError(
+          401,
+          'Error POSTing to endpoint: {"error":"invalid_token"}',
+        );
       },
       close: async () => {},
     };
@@ -45,7 +48,7 @@ describe("McpClient auth error detection", () => {
   });
 
   test("treats StreamableHTTPError with code 403 as auth error (does not throw)", async () => {
-    const client = new McpClient("test-server", { quiet: true });
+    const client = new McpClient("test-server");
 
     (client as any).createTransport = () => ({});
     (client as any).client = {
@@ -60,7 +63,7 @@ describe("McpClient auth error detection", () => {
   });
 
   test("rethrows non-auth StreamableHTTPError for HTTP transports", async () => {
-    const client = new McpClient("test-server", { quiet: true });
+    const client = new McpClient("test-server");
 
     (client as any).createTransport = () => ({});
     (client as any).client = {
@@ -70,11 +73,13 @@ describe("McpClient auth error detection", () => {
       close: async () => {},
     };
 
-    await expect(client.connect(httpTransport)).rejects.toThrow("Internal Server Error");
+    await expect(client.connect(httpTransport)).rejects.toThrow(
+      "Internal Server Error",
+    );
   });
 
   test("treats error message containing 'unauthorized' as auth error", async () => {
-    const client = new McpClient("test-server", { quiet: true });
+    const client = new McpClient("test-server");
 
     (client as any).createTransport = () => ({});
     (client as any).client = {


### PR DESCRIPTION
## Summary
- Add missing IPC snapshot entries for `app_delete`, `schedule_thread_created`, and `app_delete_response`
- Fix `mcp-client-auth.test.ts`: remove unused `beforeEach` import (lint error) and extra constructor arg (type error)

## Original prompt
Fix these CI issues: https://github.com/vellum-ai/vellum-assistant/actions/runs/22645503503/job/65632347134

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
