### PR TITLE
assistant: add channel scoping to guardian conversation scope helpers

### DIFF
--- a/assistant/src/daemon/handlers/guardian-actions.ts
+++ b/assistant/src/daemon/handlers/guardian-actions.ts
@@ -12,7 +12,7 @@ const VALID_ACTIONS = new Set<string>(['approve_once', 'approve_10m', 'approve_t
 
 export const guardianActionsHandlers = defineHandlers({
   guardian_actions_pending_request: (msg: GuardianActionsPendingRequest, socket, ctx) => {
-    const prompts = listGuardianDecisionPrompts({ conversationId: msg.conversationId });
+    const prompts = listGuardianDecisionPrompts({ conversationId: msg.conversationId, channel: 'vellum' });
     ctx.send(socket, { type: 'guardian_actions_pending_response', conversationId: msg.conversationId, prompts });
   },
 
@@ -35,7 +35,7 @@ export const guardianActionsHandlers = defineHandlers({
     // source conversation OR a recorded delivery destination conversation.
     if (msg.conversationId) {
       const canonicalRequest = getCanonicalGuardianRequest(msg.requestId);
-      if (canonicalRequest && canonicalRequest.conversationId && !isRequestInConversationScope(msg.requestId, msg.conversationId)) {
+      if (canonicalRequest && canonicalRequest.conversationId && !isRequestInConversationScope(msg.requestId, msg.conversationId, 'vellum')) {
         log.warn({ requestId: msg.requestId, expected: canonicalRequest.conversationId, got: msg.conversationId }, 'conversationId not in scope');
         ctx.send(socket, {
           type: 'guardian_action_decision_response',

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -361,7 +361,7 @@ export async function processMessage(
   session.currentPage = currentPage;
   const trimmedContent = content.trim();
   const canonicalPendingRequestHintIdsForConversation = trimmedContent.length > 0
-    ? listPendingRequestsByConversationScope(session.conversationId).map((request) => request.id)
+    ? listPendingRequestsByConversationScope(session.conversationId, 'vellum').map((request) => request.id)
     : [];
   const canonicalPendingRequestIdsForConversation = canonicalPendingRequestHintIdsForConversation.length > 0
     ? canonicalPendingRequestHintIdsForConversation

--- a/assistant/src/memory/canonical-guardian-store.ts
+++ b/assistant/src/memory/canonical-guardian-store.ts
@@ -542,18 +542,23 @@ export function listPendingCanonicalGuardianRequestsByDestinationChat(
  *   1. Requests whose source `conversationId` matches the queried thread.
  *   2. Requests that have a delivery whose `destinationConversationId` matches.
  *
+ * When `channel` is provided the delivery-scoped lookup is narrowed to that
+ * channel, preventing cross-channel leakage when conversation ID namespaces
+ * overlap across channels.
+ *
  * Deduplicates by request ID so a request that was both sourced from and
  * delivered to the same conversation only appears once.
  */
 export function listPendingRequestsByConversationScope(
   conversationId: string,
+  channel?: string,
 ): CanonicalGuardianRequest[] {
   const bySource = listCanonicalGuardianRequests({
     conversationId,
     status: 'pending',
   });
 
-  const byDestination = listPendingCanonicalGuardianRequestsByDestinationConversation(conversationId);
+  const byDestination = listPendingCanonicalGuardianRequestsByDestinationConversation(conversationId, channel);
 
   const seen = new Set<string>();
   const result: CanonicalGuardianRequest[] = [];
@@ -579,13 +584,16 @@ export function listPendingRequestsByConversationScope(
  * Check whether a guardian decision's `conversationId` is in scope for a
  * canonical request. A decision is in scope when:
  *   - The request's source `conversationId` matches, OR
- *   - Any recorded delivery has `destinationConversationId` matching.
+ *   - Any recorded delivery has `destinationConversationId` matching
+ *     (optionally scoped by `channel` to prevent cross-channel approval
+ *     when conversation ID namespaces overlap across channels).
  *
  * Returns `true` when the decision is allowed from the given conversation.
  */
 export function isRequestInConversationScope(
   requestId: string,
   conversationId: string,
+  channel?: string,
 ): boolean {
   const request = getCanonicalGuardianRequest(requestId);
   if (!request) return false;
@@ -593,9 +601,12 @@ export function isRequestInConversationScope(
   // Source conversation match
   if (request.conversationId === conversationId) return true;
 
-  // Destination delivery match
+  // Destination delivery match, optionally scoped by channel
   const deliveries = listCanonicalGuardianDeliveries(requestId);
-  return deliveries.some((d) => d.destinationConversationId === conversationId);
+  return deliveries.some((d) =>
+    d.destinationConversationId === conversationId &&
+    (!channel || d.destinationChannel === channel),
+  );
 }
 
 export interface UpdateCanonicalGuardianDeliveryParams {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -48,10 +48,10 @@ const SUGGESTION_CACHE_MAX = 100;
 
 function collectCanonicalGuardianRequestHintIds(
   conversationId: string,
-  _sourceChannel: string,
+  sourceChannel: string,
   session: import('../../daemon/session.js').Session,
 ): string[] {
-  const requests = listPendingRequestsByConversationScope(conversationId);
+  const requests = listPendingRequestsByConversationScope(conversationId, sourceChannel);
 
   return requests
     .filter((req) => req.kind !== 'tool_approval' || session.hasPendingConfirmation(req.id))

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -48,7 +48,7 @@ export function handleGuardianActionsPending(url: URL, _authContext: AuthContext
     return httpError('BAD_REQUEST', 'conversationId query parameter is required', 400);
   }
 
-  const prompts = listGuardianDecisionPrompts({ conversationId });
+  const prompts = listGuardianDecisionPrompts({ conversationId, channel: 'vellum' });
   return Response.json({ conversationId, prompts });
 }
 
@@ -116,9 +116,11 @@ export async function handleGuardianActionDecision(req: Request, authContext: Au
   // Verify conversationId scoping before applying the canonical decision.
   // The decision is allowed when the conversationId matches the request's
   // source conversation OR a recorded delivery destination conversation.
+  // Channel is scoped to 'vellum' to prevent cross-channel approval when
+  // conversation ID namespaces overlap.
   if (conversationId) {
     const canonicalRequest = getCanonicalGuardianRequest(requestId);
-    if (canonicalRequest && canonicalRequest.conversationId && !isRequestInConversationScope(requestId, conversationId)) {
+    if (canonicalRequest && canonicalRequest.conversationId && !isRequestInConversationScope(requestId, conversationId, 'vellum')) {
       return httpError('NOT_FOUND', 'No pending guardian action found for this requestId', 404);
     }
   }
@@ -184,11 +186,12 @@ export async function handleGuardianActionDecision(req: Request, authContext: Au
  */
 export function listGuardianDecisionPrompts(params: {
   conversationId: string;
+  channel?: string;
 }): GuardianDecisionPrompt[] {
-  const { conversationId } = params;
+  const { conversationId, channel } = params;
   const prompts: GuardianDecisionPrompt[] = [];
 
-  const canonicalRequests = listPendingRequestsByConversationScope(conversationId);
+  const canonicalRequests = listPendingRequestsByConversationScope(conversationId, channel);
 
   for (const req of canonicalRequests) {
     // Skip expired canonical requests


### PR DESCRIPTION
## Summary

Address Codex review feedback from #11844.

- Add destinationChannel parameter to isRequestInConversationScope to prevent cross-channel approval
- Add channel parameter to listPendingRequestsByConversationScope for delivery-scoped lookups
- Pass channel through at all callsites

Part of #11836
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
