### PR TITLE
feat: add reason subtext to tool steps and fix dynamic page preview height

### DIFF
--- a/assistant/src/tools/apps/definitions.ts
+++ b/assistant/src/tools/apps/definitions.ts
@@ -48,6 +48,10 @@ const appOpenTool: Tool = {
             enum: ['preview', 'workspace'],
             description: "Display mode. 'preview' shows an inline preview card in chat. 'workspace' opens the full app in a workspace panel. Defaults to 'workspace'.",
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are opening and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
         required: ['app_id'],
       },

--- a/assistant/src/tools/assets/materialize.ts
+++ b/assistant/src/tools/assets/materialize.ts
@@ -87,6 +87,10 @@ const definition: ToolDefinition = {
         description:
           'Path where the file should be written, relative to (or inside) the sandbox working directory.',
       },
+      reason: {
+        type: 'string',
+        description: 'Brief non-technical explanation of what you are saving and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+      },
     },
     required: ['attachment_id', 'destination_path'],
   },

--- a/assistant/src/tools/assets/search.ts
+++ b/assistant/src/tools/assets/search.ts
@@ -275,6 +275,10 @@ const definition: ToolDefinition = {
         type: 'number',
         description: `Maximum results to return (default ${DEFAULT_LIMIT}, max ${MAX_RESULTS}).`,
       },
+      reason: {
+        type: 'string',
+        description: 'Brief non-technical explanation of what you are searching for and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+      },
     },
     required: [],
   },

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -41,6 +41,10 @@ class BrowserNavigateTool implements Tool {
             type: 'boolean',
             description: 'If true, allows navigation to localhost/private-network hosts. Disabled by default for SSRF safety.',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are navigating to and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
         required: ['url'],
       },
@@ -68,7 +72,12 @@ class BrowserSnapshotTool implements Tool {
       description: this.description,
       input_schema: {
         type: 'object',
-        properties: {},
+        properties: {
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are inspecting and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
+        },
       },
     };
   }
@@ -98,6 +107,10 @@ class BrowserScreenshotTool implements Tool {
           full_page: {
             type: 'boolean',
             description: 'Capture the full scrollable page instead of just the viewport.',
+          },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are capturing and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
           },
         },
       },
@@ -129,6 +142,10 @@ class BrowserCloseTool implements Tool {
           close_all_pages: {
             type: 'boolean',
             description: 'If true, close all browser pages and the browser context. Default: false (close only the current session page).',
+          },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are doing and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
           },
         },
       },
@@ -168,6 +185,10 @@ class BrowserClickTool implements Tool {
           timeout: {
             type: 'number',
             description: 'Max time in ms to wait for the element to be clickable (default: 10000).',
+          },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are clicking and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
           },
         },
       },
@@ -216,6 +237,10 @@ class BrowserTypeTool implements Tool {
             type: 'boolean',
             description: 'If true, press Enter after typing the text.',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are typing and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
         required: ['text'],
       },
@@ -255,6 +280,10 @@ class BrowserPressKeyTool implements Tool {
           selector: {
             type: 'string',
             description: 'Optional CSS selector to target.',
+          },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are doing and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
           },
         },
         required: ['key'],
@@ -300,6 +329,10 @@ class BrowserScrollTool implements Tool {
           selector: {
             type: 'string',
             description: 'Optional CSS selector of element to scroll within.',
+          },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are scrolling to see and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
           },
         },
         required: ['direction'],
@@ -349,6 +382,10 @@ class BrowserSelectOptionTool implements Tool {
             type: 'number',
             description: 'The zero-based index of the <option> to select.',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are selecting and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
       },
     };
@@ -383,6 +420,10 @@ class BrowserHoverTool implements Tool {
           selector: {
             type: 'string',
             description: 'A CSS selector to target. Used as fallback when element_id is not available.',
+          },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are hovering over and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
           },
         },
       },
@@ -427,6 +468,10 @@ class BrowserWaitForTool implements Tool {
             type: 'number',
             description: 'Maximum wait time in milliseconds (default and max: 30000).',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are waiting for and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
       },
     };
@@ -457,6 +502,10 @@ class BrowserExtractTool implements Tool {
           include_links: {
             type: 'boolean',
             description: 'If true, include a list of links found on the page (up to 200).',
+          },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are extracting and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
           },
         },
       },
@@ -504,6 +553,10 @@ class BrowserFillCredentialTool implements Tool {
           press_enter: {
             type: 'boolean',
             description: 'Press Enter after filling',
+          },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are filling in and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
           },
         },
         required: ['service', 'field'],

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -90,6 +90,10 @@ export const claudeCodeTool: Tool = {
             enum: ['general', 'researcher', 'coder', 'reviewer'],
             description: 'Worker profile that scopes tool access. Defaults to general (backward compatible).',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are delegating and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
       },
     };

--- a/assistant/src/tools/computer-use/request-computer-control.ts
+++ b/assistant/src/tools/computer-use/request-computer-control.ts
@@ -41,6 +41,10 @@ export const requestComputerControlTool: Tool = {
             type: 'string',
             description: 'Concise description of what computer use should accomplish',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are doing and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
         required: ['task'],
       },

--- a/assistant/src/tools/credentials/account-registry.ts
+++ b/assistant/src/tools/credentials/account-registry.ts
@@ -46,6 +46,10 @@ class AccountManageTool implements Tool {
             description: 'Service name linking to credential vault',
           },
           metadata: { type: 'object' },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are doing and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
         required: ['action'],
       },

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -166,6 +166,10 @@ class CredentialStoreTool implements Tool {
             },
             description: 'Templates describing how to inject this credential into proxied requests (only for store action)',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are doing and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
         required: ['action'],
       },

--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -37,7 +37,7 @@ class FileEditTool implements Tool {
           },
           reason: {
             type: 'string',
-            description: 'Brief human-readable explanation of why this file is being edited, shown to the user in the permission prompt',
+            description: 'Brief non-technical explanation of why this file is being edited, shown to the user as a status update. Use simple language a non-technical person would understand.',
           },
         },
         required: ['path', 'old_string', 'new_string', 'reason'],

--- a/assistant/src/tools/filesystem/read.ts
+++ b/assistant/src/tools/filesystem/read.ts
@@ -30,6 +30,10 @@ class FileReadTool implements Tool {
             type: 'number',
             description: 'Maximum number of lines to read',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are reading and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
         required: ['path'],
       },

--- a/assistant/src/tools/filesystem/view-image.ts
+++ b/assistant/src/tools/filesystem/view-image.ts
@@ -90,6 +90,10 @@ class ViewImageTool implements Tool {
             description:
               'The path to the image file (absolute or relative to working directory)',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are viewing and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
         required: ['path'],
       },

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -29,7 +29,7 @@ class FileWriteTool implements Tool {
           },
           reason: {
             type: 'string',
-            description: 'Brief human-readable explanation of why this file is being written, shown to the user in the permission prompt',
+            description: 'Brief non-technical explanation of why this file is being written, shown to the user as a status update. Use simple language a non-technical person would understand.',
           },
         },
         required: ['path', 'content', 'reason'],

--- a/assistant/src/tools/host-filesystem/edit.ts
+++ b/assistant/src/tools/host-filesystem/edit.ts
@@ -36,7 +36,7 @@ class HostFileEditTool implements Tool {
           },
           reason: {
             type: 'string',
-            description: 'Brief human-readable explanation of why this file is being edited, shown to the user in the permission prompt',
+            description: 'Brief non-technical explanation of why this file is being edited, shown to the user as a status update. Use simple language a non-technical person would understand.',
           },
         },
         required: ['path', 'old_string', 'new_string', 'reason'],

--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -31,7 +31,7 @@ class HostFileReadTool implements Tool {
           },
           reason: {
             type: 'string',
-            description: 'Brief human-readable explanation of why this file is being read, shown to the user in the permission prompt',
+            description: 'Brief non-technical explanation of why this file is being read, shown to the user as a status update. Use simple language a non-technical person would understand.',
           },
         },
         required: ['path', 'reason'],

--- a/assistant/src/tools/host-filesystem/write.ts
+++ b/assistant/src/tools/host-filesystem/write.ts
@@ -28,7 +28,7 @@ class HostFileWriteTool implements Tool {
           },
           reason: {
             type: 'string',
-            description: 'Brief human-readable explanation of why this file is being written, shown to the user in the permission prompt',
+            description: 'Brief non-technical explanation of why this file is being written, shown to the user as a status update. Use simple language a non-technical person would understand.',
           },
         },
         required: ['path', 'content', 'reason'],

--- a/assistant/src/tools/memory/definitions.ts
+++ b/assistant/src/tools/memory/definitions.ts
@@ -14,6 +14,10 @@ export const memorySearchDefinition: ToolDefinition = {
         type: 'number',
         description: 'Maximum number of results to return (default: 5)',
       },
+      reason: {
+        type: 'string',
+        description: 'Brief non-technical explanation of what you are looking up and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+      },
     },
     required: ['query'],
   },
@@ -38,6 +42,10 @@ export const memorySaveDefinition: ToolDefinition = {
         type: 'string',
         description: 'Short subject/topic label (2-8 words)',
       },
+      reason: {
+        type: 'string',
+        description: 'Brief non-technical explanation of what you are saving and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+      },
     },
     required: ['statement', 'kind'],
   },
@@ -56,6 +64,10 @@ export const memoryUpdateDefinition: ToolDefinition = {
       statement: {
         type: 'string',
         description: 'The updated statement to replace the existing one',
+      },
+      reason: {
+        type: 'string',
+        description: 'Brief non-technical explanation of what you are updating and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
       },
     },
     required: ['memory_id', 'statement'],

--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -748,6 +748,10 @@ class WebFetchTool implements Tool {
             type: 'boolean',
             description: 'If true, allows requests to localhost/private-network hosts. Disabled by default for SSRF safety.',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are fetching and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
         required: ['url'],
       },

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -247,6 +247,10 @@ class WebSearchTool implements Tool {
             type: 'string',
             description: 'Filter by recency: "pd" (past day), "pw" (past week), "pm" (past month), "py" (past year). Only used with Brave provider.',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are searching for and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
         required: ['query'],
       },

--- a/assistant/src/tools/skills/delete-managed.ts
+++ b/assistant/src/tools/skills/delete-managed.ts
@@ -25,6 +25,10 @@ export class DeleteManagedSkillTool implements Tool {
             type: 'boolean',
             description: 'Whether to remove the skill from SKILLS.md index (default: true).',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are deleting and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
         required: ['skill_id'],
       },

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -30,6 +30,10 @@ export class SkillLoadTool implements Tool {
             type: 'string',
             description: 'The skill id or skill name to load.',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are loading and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
         required: ['skill'],
       },

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -63,6 +63,10 @@ export class ScaffoldManagedSkillTool implements Tool {
             items: { type: 'string' },
             description: 'Optional list of child skill IDs that this skill includes (metadata only, no auto-activation).',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are creating and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
         required: ['skill_id', 'name', 'description', 'body_markdown'],
       },

--- a/assistant/src/tools/swarm/delegate.ts
+++ b/assistant/src/tools/swarm/delegate.ts
@@ -41,6 +41,10 @@ export const swarmDelegateTool: Tool = {
             type: 'number',
             description: 'Maximum concurrent workers (1-6, default from config)',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are doing and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
         required: ['objective'],
       },

--- a/assistant/src/tools/system/avatar-generator.ts
+++ b/assistant/src/tools/system/avatar-generator.ts
@@ -39,6 +39,10 @@ export const setAvatarTool: Tool = {
               'A text description of the desired avatar appearance, ' +
               'e.g. "a friendly purple cat with green eyes wearing a tiny hat".',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are creating and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
         required: ['description'],
       },

--- a/assistant/src/tools/system/navigate-settings.ts
+++ b/assistant/src/tools/system/navigate-settings.ts
@@ -32,6 +32,10 @@ export class NavigateSettingsTabTool implements Tool {
             enum: [...SETTINGS_TABS],
             description: 'The settings tab to navigate to',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are navigating to and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
         required: ['tab'],
       },

--- a/assistant/src/tools/system/open-system-settings.ts
+++ b/assistant/src/tools/system/open-system-settings.ts
@@ -39,6 +39,10 @@ export class OpenSystemSettingsTool implements Tool {
             enum: [...VALID_PANES],
             description: 'The System Settings pane to open',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are opening and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
         required: ['pane'],
       },

--- a/assistant/src/tools/system/version.ts
+++ b/assistant/src/tools/system/version.ts
@@ -28,7 +28,12 @@ class VersionTool implements Tool {
       description: this.description,
       input_schema: {
         type: 'object',
-        properties: {},
+        properties: {
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of why you are checking the version, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
+        },
         required: [],
       },
     };

--- a/assistant/src/tools/system/voice-config.ts
+++ b/assistant/src/tools/system/voice-config.ts
@@ -108,6 +108,10 @@ export class VoiceConfigUpdateTool implements Tool {
             type: 'string',
             description: 'Deprecated — use setting: "activation_key" with value instead',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are changing and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
       },
     };

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -114,6 +114,10 @@ export const uiShowTool: Tool = {
             type: 'boolean',
             description: 'Whether to block until the user interacts with an action. Defaults to true when actions are provided.',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are showing and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
         required: ['surface_type', 'data'],
       },
@@ -151,6 +155,10 @@ export const uiUpdateTool: Tool = {
             type: 'object',
             description: 'Partial data to merge into the existing surface data',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are updating and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
         required: ['surface_id', 'data'],
       },
@@ -181,6 +189,10 @@ export const uiDismissTool: Tool = {
           surface_id: {
             type: 'string',
             description: 'The ID of the surface to dismiss',
+          },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are dismissing and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
           },
         },
         required: ['surface_id'],
@@ -224,6 +236,10 @@ export const requestFileTool: Tool = {
           max_files: {
             type: 'number',
             description: 'Maximum number of files to accept. Defaults to 1.',
+          },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are requesting and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
           },
         },
         required: ['prompt'],

--- a/assistant/src/tools/watch/screen-watch.ts
+++ b/assistant/src/tools/watch/screen-watch.ts
@@ -41,6 +41,10 @@ class ScreenWatchTool implements Tool {
             type: 'string',
             description: 'What to focus on observing',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief non-technical explanation of what you are watching and why, shown to the user as a status update. Use simple language a non-technical person would understand.',
+          },
         },
         required: ['focus_area'],
       },

--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -12,7 +12,6 @@ struct UsedToolsList: View {
 
     private var pillLabel: String {
         let count = toolCalls.count
-        if count == 1 { return toolCalls[0].actionDescription }
 
         // If all tool calls are app-building related, show a friendly summary
         let appToolNames: Set<String> = ["app_create", "app_update", "app_file_edit", "app_file_write"]
@@ -21,7 +20,7 @@ struct UsedToolsList: View {
             return "Built your app"
         }
 
-        return "Completed \(count) steps"
+        return "Completed \(count) step\(count == 1 ? "" : "s")"
     }
 
     private var pillIcon: String { "checkmark.circle.fill" }
@@ -138,7 +137,7 @@ private struct UsedToolsRow: View {
                             .foregroundColor(.white)
                     }
 
-                    // Human-readable title + optional duration
+                    // Human-readable title + optional reason subtitle
                     VStack(alignment: .leading, spacing: VSpacing.xxs) {
                         Text(toolCall.actionDescription)
                             .font(VFont.captionMedium)
@@ -146,20 +145,31 @@ private struct UsedToolsRow: View {
                             .lineLimit(1)
                             .truncationMode(.tail)
 
-                        if let started = toolCall.startedAt, let completed = toolCall.completedAt {
-                            Text(formatDuration(completed.timeIntervalSince(started)))
+                        if let reason = toolCall.reasonDescription, !reason.isEmpty {
+                            Text(reason)
                                 .font(VFont.small)
                                 .foregroundColor(VColor.textMuted)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
                         }
                     }
 
                     Spacer()
 
-                    if hasDetails {
-                        Image(systemName: "chevron.right")
-                            .font(.system(size: 9, weight: .semibold))
-                            .foregroundColor(VColor.textMuted)
-                            .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    // Duration + chevron right-aligned
+                    HStack(spacing: VSpacing.xs) {
+                        if let started = toolCall.startedAt, let completed = toolCall.completedAt {
+                            Text(formatDuration(completed.timeIntervalSince(started)))
+                                .font(VFont.small)
+                                .foregroundColor(VColor.textMuted)
+                        }
+
+                        if hasDetails {
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 9, weight: .semibold))
+                                .foregroundColor(VColor.textMuted)
+                                .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                        }
                     }
                 }
                 .padding(.horizontal, VSpacing.md)

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -783,6 +783,8 @@ public struct ToolCallData: Identifiable, Equatable {
     public var imageData: String?
     /// Human-readable building status from app tool input (e.g. "Adding dark mode styles").
     public var buildingStatus: String?
+    /// Non-technical reason for the tool call, extracted from the `reason` field of tool input.
+    public var reasonDescription: String?
     /// Sub-tool steps for claude_code tool calls (live progress tracking).
     public var claudeCodeSteps: [ClaudeCodeSubStep] = []
     /// Pre-decoded NSImage cached to avoid repeated base64 decoding in SwiftUI body.
@@ -809,6 +811,7 @@ public struct ToolCallData: Identifiable, Equatable {
             && lhs.inputFullLength == rhs.inputFullLength
             && lhs.inputRawValueLength == rhs.inputRawValueLength
             && lhs.buildingStatus == rhs.buildingStatus
+            && lhs.reasonDescription == rhs.reasonDescription
             && lhs.claudeCodeSteps == rhs.claudeCodeSteps
     }
 

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1124,6 +1124,8 @@ extension ChatViewModel {
                 startedAt: Date()
             )
             toolCall.buildingStatus = buildingStatus
+            toolCall.reasonDescription = (msg.input["reason"]?.value as? String)
+                ?? (msg.input["reasoning"]?.value as? String)
             // Add to existing assistant message or create one.
             // Cap at 100 tool calls per message to prevent unbounded memory growth;
             // overflow falls through to create a new message.

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2068,6 +2068,8 @@ public final class ChatViewModel: ObservableObject {
                         imageData: nil
                     )
                     toolCall.cachedImage = decodedImage
+                    toolCall.reasonDescription = (tc.input["reason"]?.value as? String)
+                        ?? (tc.input["reasoning"]?.value as? String)
                     // Cap tool input size to prevent unbounded memory from large history
                     // restores. Check size synchronously to avoid a race where a deferred
                     // Task might run before self.messages is populated with these new items.

--- a/clients/shared/Features/Chat/InlineWidgets/InlineDynamicPagePreview.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineDynamicPagePreview.swift
@@ -72,7 +72,7 @@ public struct InlineDynamicPagePreview: View {
                     }
                 }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)


### PR DESCRIPTION
## Summary
- Add a `reason` parameter to all tool definitions so the model can provide a brief, non-technical explanation of each tool call. The reason is extracted from tool input and displayed as a subtitle under each step row in the completed steps list.
- Reorganize the step row layout: move duration to the right side alongside the chevron for a cleaner look.
- Fix `InlineDynamicPagePreview` stretching vertically when sibling views change height, caused by `maxHeight: .infinity` on the button label frame.

## Test plan
- [ ] Trigger tool calls and verify the reason subtitle appears under each step in the expanded steps list
- [ ] Verify step row shows duration on the right side next to the chevron
- [ ] Verify dynamic page preview cards (e.g. weather) no longer stretch when expanding/collapsing the steps section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
