### PR TITLE
fix: default missing trustClass to 'unknown' instead of 'guardian'

### DIFF
--- a/assistant/src/__tests__/resolve-guardian-trust-class.test.ts
+++ b/assistant/src/__tests__/resolve-guardian-trust-class.test.ts
@@ -35,8 +35,8 @@ describe("resolveGuardianTrustClass", () => {
     );
   });
 
-  test("defaults to guardian when no guardian context and auth is enabled", () => {
-    expect(resolveGuardianTrustClass(undefined)).toBe("guardian");
+  test("returns 'unknown' when guardianContext is undefined", () => {
+    expect(resolveGuardianTrustClass(undefined)).toBe("unknown");
   });
 
   test("forces guardian when HTTP auth is disabled, regardless of context trust class", () => {

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -62,7 +62,7 @@ export function resolveGuardianTrustClass(
   guardianContext: GuardianRuntimeContext | undefined,
 ): TrustClass {
   if (isHttpAuthDisabled()) return "guardian";
-  return guardianContext?.trustClass ?? "guardian";
+  return guardianContext?.trustClass ?? "unknown";
 }
 
 // ── Context Interface ────────────────────────────────────────────────
@@ -217,7 +217,7 @@ export function createToolExecutor(
         }
         // Auto-approve sub-tool confirmations when a temporary approval
         // override is active for this conversation (guardian only).
-        const guardianTrust = ctx.guardianContext?.trustClass ?? "guardian";
+        const guardianTrust = ctx.guardianContext?.trustClass ?? "unknown";
         if (
           guardianTrust === "guardian" &&
           getEffectiveMode(ctx.conversationId) !== undefined


### PR DESCRIPTION
## Summary
- Fix security vulnerability where missing guardian context silently escalated to full guardian trust
- Change both fallback sites in session-tool-setup.ts from `?? 'guardian'` to `?? 'unknown'` 
- Update test expectation to verify fail-closed behavior

Part of plan: trust-class-rename-cleanup.md (PR 1 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
