### PR TITLE
refactor: rename GuardianRuntimeContext → TrustContext

### DIFF
--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -38,8 +38,8 @@ export interface ChannelCapabilities {
   microphonePermissionGranted?: boolean;
 }
 
-/** Guardian identity/trust context for external chat channels. */
-export interface GuardianRuntimeContext {
+/** Identity and trust context for external chat channels. */
+export interface TrustContext {
   sourceChannel: ChannelId;
   trustClass: "guardian" | "trusted_contact" | "unknown";
   guardianChatId?: string;
@@ -54,6 +54,9 @@ export interface GuardianRuntimeContext {
   requesterChatId?: string;
   denialReason?: "no_binding" | "no_identity";
 }
+
+/** @deprecated Use `TrustContext` instead. */
+export type GuardianRuntimeContext = TrustContext;
 
 /**
  * Inbound actor context for the `<inbound_actor_context>` block.
@@ -93,7 +96,7 @@ export interface InboundActorContext {
  * Maps the runtime trust class into the model-facing inbound actor context.
  */
 export function inboundActorContextFromGuardian(
-  ctx: GuardianRuntimeContext,
+  ctx: TrustContext,
 ): InboundActorContext {
   return {
     sourceChannel: ctx.sourceChannel,

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -13,14 +13,14 @@
  */
 
 import type { ChannelId } from '../channels/types.js';
-import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
+import type { TrustContext } from '../daemon/session-runtime-assembly.js';
 import type { IngressMember } from '../memory/ingress-member-store.js';
 import { findMember } from '../memory/ingress-member-store.js';
 import { canonicalizeInboundIdentity } from '../util/canonicalize-identity.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
 import { getGuardianBinding } from './channel-guardian-service.js';
 
-export type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
+export type { TrustContext, GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -213,7 +213,7 @@ export function resolveActorTrust(input: ResolveActorTrustInput): ActorTrustCont
 export function toGuardianRuntimeContextFromTrust(
   ctx: ActorTrustContext,
   conversationExternalId: string,
-): GuardianRuntimeContext {
+): TrustContext {
   const canonicalGuardianExternalUserId = ctx.guardianBindingMatch?.guardianExternalUserId
     ? canonicalizeInboundIdentity(ctx.actorMetadata.channel, ctx.guardianBindingMatch.guardianExternalUserId) ?? undefined
     : undefined;


### PR DESCRIPTION
## Summary
- Rename `GuardianRuntimeContext` to `TrustContext` at the definition site in session-runtime-assembly.ts
- Update import and return types in actor-trust-resolver.ts
- Add deprecated `GuardianRuntimeContext` re-export alias for backward compatibility

Part of plan: trust-class-rename-cleanup.md (PR 4 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
