### PR TITLE
fix: merge duplicate onChange(of: messages.count) to prevent anchor/bottom scroll race

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -555,7 +555,18 @@ struct MessageListView: View {
                 }
             }
             .onChange(of: messages.count) {
-                if isNearBottom && !isSuppressingBottomScroll {
+                // Anchor scroll takes priority: when a notification deep-link
+                // set anchorMessageId, retry scrolling to it as messages load
+                // (e.g., history arrives after a thread switch). This must run
+                // before the bottom-scroll branch to avoid competing scrollTo calls.
+                if let id = anchorMessageId, messages.contains(where: { $0.id == id }) {
+                    withAnimation {
+                        proxy.scrollTo(id, anchor: .center)
+                    }
+                    anchorMessageId = nil
+                    return
+                }
+                if isNearBottom && !isSuppressingBottomScroll && anchorMessageId == nil {
                     withAnimation(VAnimation.fast) {
                         proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                     }
@@ -611,19 +622,6 @@ struct MessageListView: View {
                 // Only scroll and clear if the target message is already loaded;
                 // otherwise leave the anchor set so the messages-change handler
                 // can retry once history finishes loading.
-                if messages.contains(where: { $0.id == id }) {
-                    withAnimation {
-                        proxy.scrollTo(id, anchor: .center)
-                    }
-                    anchorMessageId = nil
-                }
-            }
-            .onChange(of: messages.count) {
-                // Retry anchor scroll when new messages arrive (e.g., history
-                // loads after a thread switch triggered by a notification
-                // deep-link). Uses messages.count instead of messages to avoid
-                // O(n) array equality checks on every streaming token.
-                guard let id = anchorMessageId else { return }
                 if messages.contains(where: { $0.id == id }) {
                     withAnimation {
                         proxy.scrollTo(id, anchor: .center)


### PR DESCRIPTION
## Summary
- Merges two separate `onChange(of: messages.count)` handlers into one that prioritizes anchor scroll over bottom-scroll
- Prevents competing `proxy.scrollTo` calls when a notification deep-link sets `anchorMessageId` and history loads on the same `messages.count` change
- Adds `anchorMessageId == nil` guard to the bottom-scroll branch so it yields when an anchor is pending

## Original prompt
Follow-up to PR #11849 — addresses Devin's last review finding about duplicate `onChange(of: messages.count)` handlers producing competing scroll calls during notification deep-link flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
