### PR TITLE
refactor: rename guardianTrustClass → trustClass in ToolContext

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -2156,7 +2156,7 @@ The guardian trust system uses a three-valued `TrustClass` — `'guardian'`, `'t
 
 **`GuardianRuntimeContext`** (in `src/daemon/session-runtime-assembly.ts`) is the single runtime carrier for trust state on channel-originated turns. It carries `trustClass`, guardian identity fields, and requester metadata. The `guardianPrincipalId` field is typed as `?: string` (optional but non-nullable) — a principal ID is present when a guardian binding exists but is never `null`.
 
-**Explicit trust gates:** `guardianTrustClass` is a **required** field in `ToolContext` (in `src/tools/types.ts`). Every tool execution must carry a trust classification — the field is not optional. This ensures trust-gated tool policies (guardian control-plane restrictions, host-tool blocking for untrusted actors) cannot be bypassed by omitting the classification.
+**Explicit trust gates:** `trustClass` is a **required** field in `ToolContext` (in `src/tools/types.ts`). Every tool execution must carry a trust classification — the field is not optional. This ensures trust-gated tool policies (guardian control-plane restrictions, host-tool blocking for untrusted actors) cannot be bypassed by omitting the classification.
 
 **Guardian bindings** (in `src/memory/guardian-bindings.ts`) always carry `guardianPrincipalId: string` as a required, non-null field. A binding without a principal ID is invalid and cannot be created.
 
@@ -2169,7 +2169,7 @@ The guardian trust system uses a three-valued `TrustClass` — `'guardian'`, `'t
 | File                                         | Purpose                                                |
 | -------------------------------------------- | ------------------------------------------------------ |
 | `src/daemon/session-runtime-assembly.ts`     | `GuardianRuntimeContext` type definition               |
-| `src/tools/types.ts`                         | `ToolContext.guardianTrustClass` (required trust gate) |
+| `src/tools/types.ts`                         | `ToolContext.trustClass` (required trust gate)         |
 | `src/runtime/channel-retry-sweep.ts`         | Strict `trustClass` parser for retry sweep             |
 | `src/memory/guardian-bindings.ts`            | `GuardianBinding` with required `guardianPrincipalId`  |
 | `src/__tests__/trust-context-guards.test.ts` | Guard tests enforcing trust-context type invariants    |

--- a/assistant/src/__tests__/playbook-execution.test.ts
+++ b/assistant/src/__tests__/playbook-execution.test.ts
@@ -75,7 +75,7 @@ const ctx: ToolContext = {
   workingDir: "/tmp",
   sessionId: "test-session",
   conversationId: "test-conversation",
-  guardianTrustClass: "guardian",
+  trustClass: "guardian",
 };
 
 function insertPlaybookRow(

--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -501,7 +501,7 @@ export class ComputerUseSession {
         workingDir: getSandboxWorkingDir(),
         sessionId: this.sessionId,
         conversationId: this.sessionId,
-        guardianTrustClass: 'guardian',
+        trustClass: 'guardian',
         proxyToolResolver: proxyResolver,
         allowedToolNames,
         requestSecret: async (params) => {

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -320,7 +320,7 @@ export async function runAgentLoopImpl(
         conflictGate: ctx.conflictGate,
         scopeId: ctx.memoryPolicy.scopeId,
         includeDefaultFallback: ctx.memoryPolicy.includeDefaultFallback,
-        guardianTrustClass: resolveGuardianTrustClass(ctx.guardianContext),
+        trustClass: resolveGuardianTrustClass(ctx.guardianContext),
         isInteractive: options?.isInteractive ?? (!ctx.hasNoClient && !ctx.headlessLock),
       },
       content,

--- a/assistant/src/daemon/session-memory.ts
+++ b/assistant/src/daemon/session-memory.ts
@@ -34,7 +34,7 @@ export interface MemoryPrepareContext {
   conflictGate: ConflictGate;
   scopeId: string;
   includeDefaultFallback: boolean;
-  guardianTrustClass: 'guardian' | 'trusted_contact' | 'unknown';
+  trustClass: 'guardian' | 'trusted_contact' | 'unknown';
   /** When false (e.g. scheduled tasks), skip conflict clarification prompts. */
   isInteractive?: boolean;
 }
@@ -64,7 +64,7 @@ export async function prepareMemoryContext(
   // Provenance-based trust gating: untrusted actors skip all memory operations
   // (recall, dynamic profile, conflict gate) to prevent untrusted content from
   // influencing memory-augmented responses.
-  const isTrustedActor = ctx.guardianTrustClass === 'guardian';
+  const isTrustedActor = ctx.trustClass === 'guardian';
 
   if (!isTrustedActor) {
     return {

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -151,7 +151,7 @@ export function createToolExecutor(
       assistantId: ctx.assistantId,
       requestId: ctx.currentRequestId,
       taskRunId: ctx.taskRunId,
-      guardianTrustClass: resolveGuardianTrustClass(ctx.guardianContext),
+      trustClass: resolveGuardianTrustClass(ctx.guardianContext),
       executionChannel: ctx.guardianContext?.sourceChannel,
       callSessionId: ctx.callSessionId,
       triggeredBySurfaceAction:

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -169,7 +169,7 @@ export class PermissionChecker {
           name === "bash" && input.network_mode === "proxied"
         );
         if (
-          context.guardianTrustClass === "guardian" &&
+          context.trustClass === "guardian" &&
           persistentDecisionsAllowedForOverride &&
           getEffectiveMode(context.conversationId) !== undefined
         ) {
@@ -219,7 +219,7 @@ export class PermissionChecker {
           | Array<"allow_10m" | "allow_thread">
           | undefined =
           persistentDecisionsAllowed &&
-          context.guardianTrustClass === "guardian"
+          context.trustClass === "guardian"
             ? ["allow_10m", "allow_thread"]
             : undefined;
 

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -118,7 +118,7 @@ export async function waitForInlineGrant(
   return { outcome: 'timeout', requestId: escalationRequestId };
 }
 
-function isUntrustedGuardianTrustClass(role: ToolContext['guardianTrustClass']): boolean {
+function isUntrustedTrustClass(role: ToolContext['trustClass']): boolean {
   return role === 'trusted_contact' || role === 'unknown';
 }
 
@@ -134,7 +134,7 @@ function requiresGuardianApprovalForActor(
 }
 
 function guardianApprovalDeniedMessage(
-  trustClass: ToolContext['guardianTrustClass'],
+  trustClass: ToolContext['trustClass'],
   toolName: string,
 ): string {
   if (trustClass === 'unknown') {
@@ -204,13 +204,13 @@ export class ToolApprovalHandler {
     }
 
     // Reject tool invocations targeting guardian control-plane endpoints from non-guardian actors.
-    const guardianCheck = enforceGuardianOnlyPolicy(name, input, context.guardianTrustClass);
+    const guardianCheck = enforceGuardianOnlyPolicy(name, input, context.trustClass);
     if (guardianCheck.denied) {
       log.warn({
         toolName: name,
         sessionId: context.sessionId,
         conversationId: context.conversationId,
-        trustClass: context.guardianTrustClass,
+        trustClass: context.trustClass,
         reason: 'guardian_only_policy',
       }, 'Guardian-only policy blocked tool invocation');
       const durationMs = Date.now() - startTime;
@@ -240,7 +240,7 @@ export class ToolApprovalHandler {
     let deferredConsumeParams: Parameters<typeof consumeGrantForInvocation>[0] | null = null;
 
     if (
-      isUntrustedGuardianTrustClass(context.guardianTrustClass)
+      isUntrustedTrustClass(context.trustClass)
       && requiresGuardianApprovalForActor(name, input, executionTarget)
     ) {
       const inputDigest = computeToolApprovalDigest(name, input);
@@ -355,7 +355,7 @@ export class ToolApprovalHandler {
           toolName: name,
           sessionId: context.sessionId,
           conversationId: context.conversationId,
-          trustClass: context.guardianTrustClass,
+          trustClass: context.trustClass,
           executionTarget,
           grantId: grantResult.grant.id,
         }, 'Scoped grant consumed — allowing untrusted actor tool invocation');
@@ -398,7 +398,7 @@ export class ToolApprovalHandler {
       //
       // Unverified actors remain fail-closed with no escalation or wait.
       if (
-        context.guardianTrustClass === 'trusted_contact'
+        context.trustClass === 'trusted_contact'
         && context.assistantId
         && context.executionChannel
         && context.requesterExternalUserId
@@ -447,7 +447,7 @@ export class ToolApprovalHandler {
               toolName: name,
               sessionId: context.sessionId,
               conversationId: context.conversationId,
-              trustClass: context.guardianTrustClass,
+              trustClass: context.trustClass,
               executionTarget,
               grantId: waitResult.grant.id,
               escalationRequestId: escalation.requestId,
@@ -505,7 +505,7 @@ export class ToolApprovalHandler {
             toolName: name,
             sessionId: context.sessionId,
             conversationId: context.conversationId,
-            trustClass: context.guardianTrustClass,
+            trustClass: context.trustClass,
             executionTarget,
             reason: 'guardian_approval_required',
             grantMissReason: grantResult.reason,
@@ -533,12 +533,12 @@ export class ToolApprovalHandler {
       }
 
       // Unknown/unverified actors or escalation failures — generic denial.
-      const reason = guardianApprovalDeniedMessage(context.guardianTrustClass, name);
+      const reason = guardianApprovalDeniedMessage(context.trustClass, name);
       log.warn({
         toolName: name,
         sessionId: context.sessionId,
         conversationId: context.conversationId,
-        trustClass: context.guardianTrustClass,
+        trustClass: context.trustClass,
         executionTarget,
         reason: 'guardian_approval_required',
         grantMissReason: grantResult.reason,

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -138,7 +138,7 @@ export interface ToolContext {
   /** Optional principal identifier propagated to sub-tool confirmation flows. */
   principal?: string;
   /** Inbound trust classification for the session — used by trust/policy gates. */
-  guardianTrustClass: 'guardian' | 'trusted_contact' | 'unknown';
+  trustClass: 'guardian' | 'trusted_contact' | 'unknown';
   /** Channel through which the tool invocation originates (e.g. 'telegram', 'voice'). Used for scoped grant consumption. */
   executionChannel?: string;
   /** Voice/call session ID, if the invocation originates from a call. Used for scoped grant consumption. */


### PR DESCRIPTION
## Summary
- Rename `guardianTrustClass` field to `trustClass` in `ToolContext` interface and all consumers
- Rename `isUntrustedGuardianTrustClass` → `isUntrustedTrustClass` helper
- Update all references across session-tool-setup, session-agent-loop, computer-use-session, session-memory, tool-approval-handler, permission-checker, and tests

Part of plan: trust-class-rename-cleanup.md (PR 2 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
