### PR TITLE
fix(macos): match Things page padding to IntelligencePanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -69,7 +69,7 @@ struct AppsGridView: View {
                         .padding(.top, VSpacing.lg)
                     }
                 }
-                .padding(VSpacing.lg)
+                .padding(VSpacing.xl)
             }
         }
         .background(VColor.backgroundSubtle)


### PR DESCRIPTION
## Summary
- Update Things page container padding from `VSpacing.lg` (16pt) to `VSpacing.xl` (24pt) to match the IntelligencePanel

## Test plan
- [ ] Things page has consistent padding with IntelligencePanel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
