### PR TITLE
refactor: migrate all GuardianRuntimeContext imports to TrustContext

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -243,7 +243,7 @@ function setupController(
   task?: string,
   opts?: {
     assistantId?: string;
-    guardianContext?: import("../daemon/session-runtime-assembly.js").GuardianRuntimeContext;
+    guardianContext?: import("../daemon/session-runtime-assembly.js").TrustContext;
   },
 ) {
   ensureConversation("conv-ctrl-test");

--- a/assistant/src/__tests__/confirmation-request-guardian-bridge.test.ts
+++ b/assistant/src/__tests__/confirmation-request-guardian-bridge.test.ts
@@ -90,7 +90,7 @@ mock.module("../runtime/channel-guardian-service.js", () => ({
   },
 }));
 
-import type { GuardianRuntimeContext } from "../daemon/session-runtime-assembly.js";
+import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import {
   createCanonicalGuardianRequest,
   generateCanonicalRequestCode,
@@ -139,8 +139,8 @@ function makeCanonicalRequest(overrides: Record<string, unknown> = {}) {
 }
 
 function makeTrustedContactContext(
-  overrides: Partial<GuardianRuntimeContext> = {},
-): GuardianRuntimeContext {
+  overrides: Partial<TrustContext> = {},
+): TrustContext {
   return {
     sourceChannel: "telegram",
     trustClass: "trusted_contact",
@@ -191,7 +191,7 @@ describe("bridgeConfirmationRequestToGuardian", () => {
 
   test("skips guardian actor sessions (self-approve)", () => {
     const canonicalRequest = makeCanonicalRequest();
-    const guardianContext: GuardianRuntimeContext = {
+    const guardianContext: TrustContext = {
       sourceChannel: "telegram",
       trustClass: "guardian",
       guardianExternalUserId: "guardian-1",
@@ -213,7 +213,7 @@ describe("bridgeConfirmationRequestToGuardian", () => {
 
   test("skips unknown actor sessions", () => {
     const canonicalRequest = makeCanonicalRequest();
-    const guardianContext: GuardianRuntimeContext = {
+    const guardianContext: TrustContext = {
       sourceChannel: "telegram",
       trustClass: "unknown",
     };

--- a/assistant/src/__tests__/resolve-guardian-trust-class.test.ts
+++ b/assistant/src/__tests__/resolve-guardian-trust-class.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { GuardianRuntimeContext } from "../daemon/session-runtime-assembly.js";
+import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 
 // ── Module mocks ─────────────────────────────────────────────────────
 
@@ -27,10 +27,10 @@ describe("resolveGuardianTrustClass", () => {
   });
 
   test("returns guardian context trust class when auth is enabled", () => {
-    const ctx: Pick<GuardianRuntimeContext, "trustClass"> = {
+    const ctx: Pick<TrustContext, "trustClass"> = {
       trustClass: "trusted_contact",
     };
-    expect(resolveGuardianTrustClass(ctx as GuardianRuntimeContext)).toBe(
+    expect(resolveGuardianTrustClass(ctx as TrustContext)).toBe(
       "trusted_contact",
     );
   });
@@ -41,20 +41,20 @@ describe("resolveGuardianTrustClass", () => {
 
   test("forces guardian when HTTP auth is disabled, regardless of context trust class", () => {
     fakeHttpAuthDisabled = true;
-    const ctx: Pick<GuardianRuntimeContext, "trustClass"> = {
+    const ctx: Pick<TrustContext, "trustClass"> = {
       trustClass: "trusted_contact",
     };
-    expect(resolveGuardianTrustClass(ctx as GuardianRuntimeContext)).toBe(
+    expect(resolveGuardianTrustClass(ctx as TrustContext)).toBe(
       "guardian",
     );
   });
 
   test("forces guardian for unknown trust class when HTTP auth is disabled", () => {
     fakeHttpAuthDisabled = true;
-    const ctx: Pick<GuardianRuntimeContext, "trustClass"> = {
+    const ctx: Pick<TrustContext, "trustClass"> = {
       trustClass: "unknown",
     };
-    expect(resolveGuardianTrustClass(ctx as GuardianRuntimeContext)).toBe(
+    expect(resolveGuardianTrustClass(ctx as TrustContext)).toBe(
       "guardian",
     );
   });

--- a/assistant/src/__tests__/trust-context-guards.test.ts
+++ b/assistant/src/__tests__/trust-context-guards.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "bun:test";
  * These tests prevent reintroduction of removed compatibility patterns
  * by scanning source files for type invariants:
  *
- *  (a) guardianPrincipalId in GuardianRuntimeContext must be `?: string`
+ *  (a) guardianPrincipalId in TrustContext must be `?: string`
  *      (optional string), NOT `string | null`.
  *  (b) guardianTrustClass in ToolContext must be a required field (no `?`).
  *  (c) The channel retry sweep parser must not reference `actorRole`.
@@ -23,15 +23,15 @@ describe("trust-context guards", () => {
   // (a) No `string | null` for guardianPrincipalId in runtime types
   // -----------------------------------------------------------------------
 
-  it("guardianPrincipalId is not typed as string | null in GuardianRuntimeContext", () => {
+  it("guardianPrincipalId is not typed as string | null in TrustContext", () => {
     const source = readFileSync(
       join(srcDir, "daemon", "session-runtime-assembly.ts"),
       "utf-8",
     );
 
-    // Extract the GuardianRuntimeContext interface block
+    // Extract the TrustContext interface block
     const ifaceStart = source.indexOf(
-      "export interface GuardianRuntimeContext",
+      "export interface TrustContext",
     );
     expect(ifaceStart).toBeGreaterThan(-1);
 
@@ -54,13 +54,13 @@ describe("trust-context guards", () => {
       .find((l) => l.includes("guardianPrincipalId"));
     expect(
       principalLine,
-      "Expected to find guardianPrincipalId in GuardianRuntimeContext",
+      "Expected to find guardianPrincipalId in TrustContext",
     ).toBeDefined();
 
     expect(
       principalLine!.includes("string | null") ||
         principalLine!.includes("null | string"),
-      "guardianPrincipalId must not be typed as nullable in GuardianRuntimeContext. " +
+      "guardianPrincipalId must not be typed as nullable in TrustContext. " +
         "Use `guardianPrincipalId?: string` (optional, non-nullable) instead. " +
         `Found: "${principalLine!.trim()}"`,
     ).toBe(false);
@@ -69,7 +69,7 @@ describe("trust-context guards", () => {
     // principal exists should be able to omit it.
     expect(
       /guardianPrincipalId\s*\?/.test(principalLine!),
-      "guardianPrincipalId must remain optional (`?:`) in GuardianRuntimeContext. " +
+      "guardianPrincipalId must remain optional (`?:`) in TrustContext. " +
         "Channels without a guardian principal need to omit this field. " +
         `Found: "${principalLine!.trim()}"`,
     ).toBe(true);
@@ -156,7 +156,7 @@ describe("trust-context guards", () => {
     // The sweep must synthesize a trust context when guardianCtx is absent,
     // so `guardianContext` should never be conditionally undefined at the
     // processMessage callsite. Look for the pattern that ensures this:
-    // a `const guardianContext: GuardianRuntimeContext = parsedGuardianContext ?? {`
+    // a `const guardianContext: TrustContext = parsedGuardianContext ?? {`
     // fallback that synthesizes trustClass: 'unknown'.
     expect(
       source.includes("trustClass: 'unknown'"),

--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -182,7 +182,7 @@ mock.module("../config/env.js", () => ({
 import { applyCanonicalGuardianDecision } from "../approvals/guardian-decision-primitive.js";
 import type { ActorContext } from "../approvals/guardian-request-resolvers.js";
 import { getResolver } from "../approvals/guardian-request-resolvers.js";
-import type { GuardianRuntimeContext } from "../daemon/session-runtime-assembly.js";
+import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import {
   createCanonicalGuardianRequest,
   getCanonicalGuardianRequest,
@@ -247,7 +247,7 @@ function guardianActor(overrides: Partial<ActorContext> = {}): ActorContext {
   };
 }
 
-function makeTrustedContactGuardianContext(): GuardianRuntimeContext {
+function makeTrustedContactGuardianContext(): TrustContext {
   return {
     sourceChannel: "telegram",
     trustClass: "trusted_contact",
@@ -680,7 +680,7 @@ describe("(d) unknown actor flow: fail-closed with no interactive approval", () 
       expiresAt: new Date(Date.now() + 5 * 60_000).toISOString(),
     });
 
-    const guardianContext: GuardianRuntimeContext = {
+    const guardianContext: TrustContext = {
       sourceChannel: "telegram",
       trustClass: "unknown",
     };

--- a/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
+++ b/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
@@ -111,7 +111,7 @@ import {
   startVoiceTurn,
 } from "../calls/voice-session-bridge.js";
 import type { ServerMessage } from "../daemon/ipc-protocol.js";
-import type { GuardianRuntimeContext } from "../daemon/session-runtime-assembly.js";
+import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { scopedApprovalGrants } from "../memory/schema.js";
 import {
@@ -286,7 +286,7 @@ describe("voice bridge confirmation handling (grant consumption via primitive)",
     const mockData = createMockSession();
     setupBridgeDeps(() => mockData.session);
 
-    const guardianContext: GuardianRuntimeContext = {
+    const guardianContext: TrustContext = {
       sourceChannel: "voice",
       trustClass: "trusted_contact",
       requesterExternalUserId: "caller-123",
@@ -330,7 +330,7 @@ describe("voice bridge confirmation handling (grant consumption via primitive)",
     const mockData = createMockSession();
     setupBridgeDeps(() => mockData.session);
 
-    const guardianContext: GuardianRuntimeContext = {
+    const guardianContext: TrustContext = {
       sourceChannel: "voice",
       trustClass: "trusted_contact",
       requesterExternalUserId: "caller-123",
@@ -368,7 +368,7 @@ describe("voice bridge confirmation handling (grant consumption via primitive)",
     const mockData = createMockSession();
     setupBridgeDeps(() => mockData.session);
 
-    const guardianContext: GuardianRuntimeContext = {
+    const guardianContext: TrustContext = {
       sourceChannel: "voice",
       trustClass: "trusted_contact",
     };
@@ -398,7 +398,7 @@ describe("voice bridge confirmation handling (grant consumption via primitive)",
     const mockData = createMockSession();
     setupBridgeDeps(() => mockData.session);
 
-    const guardianContext: GuardianRuntimeContext = {
+    const guardianContext: TrustContext = {
       sourceChannel: "voice",
       trustClass: "guardian",
     };
@@ -434,7 +434,7 @@ describe("voice bridge confirmation handling (grant consumption via primitive)",
     const mockData = createMockSession();
     setupBridgeDeps(() => mockData.session);
 
-    const guardianContext: GuardianRuntimeContext = {
+    const guardianContext: TrustContext = {
       sourceChannel: "voice",
       trustClass: "trusted_contact",
       requesterExternalUserId: "caller-123",

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -10,7 +10,7 @@
 
 import { getGatewayInternalBaseUrl } from '../config/env.js';
 import type { ServerMessage } from '../daemon/ipc-contract.js';
-import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
+import type { TrustContext } from '../daemon/session-runtime-assembly.js';
 import {
   expireCanonicalGuardianRequest,
   getCanonicalRequestByPendingQuestionId,
@@ -216,7 +216,7 @@ export class CallController {
   /** Assistant identity for scoping guardian bindings. */
   private assistantId: string;
   /** Guardian trust context for the current caller, when available. */
-  private guardianContext: GuardianRuntimeContext | null;
+  private guardianContext: TrustContext | null;
   /** Conversation ID for the voice session. */
   private conversationId: string;
   /**
@@ -241,7 +241,7 @@ export class CallController {
     opts?: {
       broadcast?: (msg: ServerMessage) => void;
       assistantId?: string;
-      guardianContext?: GuardianRuntimeContext;
+      guardianContext?: TrustContext;
     },
   ) {
     this.callSessionId = callSessionId;
@@ -280,7 +280,7 @@ export class CallController {
   /**
    * Update guardian trust context for subsequent LLM turns.
    */
-  setGuardianContext(ctx: GuardianRuntimeContext | null): void {
+  setGuardianContext(ctx: TrustContext | null): void {
     this.guardianContext = ctx;
   }
 

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -15,7 +15,7 @@ import type { ChannelId } from '../channels/types.js';
 import { getConfig } from '../config/loader.js';
 import type { ServerMessage } from '../daemon/ipc-protocol.js';
 import type { Session } from '../daemon/session.js';
-import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
+import type { TrustContext } from '../daemon/session-runtime-assembly.js';
 import { resolveChannelCapabilities } from '../daemon/session-runtime-assembly.js';
 import { buildAssistantEvent } from '../runtime/assistant-event.js';
 import { assistantEventHub } from '../runtime/assistant-event-hub.js';
@@ -91,7 +91,7 @@ export interface VoiceTurnOptions {
   /** Assistant scope for multi-assistant channels. */
   assistantId?: string;
   /** Guardian trust context for the caller. */
-  guardianContext?: GuardianRuntimeContext;
+  guardianContext?: TrustContext;
   /** Whether this is an inbound call (no outbound task). */
   isInbound: boolean;
   /** The outbound call task, if any. */

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -13,7 +13,7 @@ import { estimateBase64Bytes } from '../assistant-attachments.js';
 import { ComputerUseSession } from '../computer-use-session.js';
 import type { ClientMessage, CuSessionCreate, ServerMessage, SessionTransportMetadata } from '../ipc-protocol.js';
 import { Session } from '../session.js';
-import type { GuardianRuntimeContext } from '../session-runtime-assembly.js';
+import type { TrustContext } from '../session-runtime-assembly.js';
 
 const log = getLogger('handlers');
 
@@ -105,7 +105,7 @@ export interface SessionCreateOptions {
   maxResponseTokens?: number;
   transport?: SessionTransportMetadata;
   assistantId?: string;
-  guardianContext?: GuardianRuntimeContext;
+  guardianContext?: TrustContext;
   /** Normalized auth context for the session (IPC or HTTP-derived). */
   authContext?: AuthContext;
   /** Whether this turn can block on interactive approval prompts. */

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -57,7 +57,7 @@ import { raceWithTimeout,stripMediaPayloadsForRetry } from './session-media-retr
 import { prepareMemoryContext } from './session-memory.js';
 import type { MessageQueue } from './session-queue-manager.js';
 import type { QueueDrainReason } from './session-queue-manager.js';
-import type { ActiveSurfaceContext, ChannelCapabilities, ChannelTurnContextParams, GuardianRuntimeContext, InboundActorContext, InterfaceTurnContextParams } from './session-runtime-assembly.js';
+import type { ActiveSurfaceContext, ChannelCapabilities, ChannelTurnContextParams, TrustContext, InboundActorContext, InterfaceTurnContextParams } from './session-runtime-assembly.js';
 import {
   applyRuntimeInjections,
   inboundActorContextFromGuardian,
@@ -107,7 +107,7 @@ export interface AgentLoopSessionContext {
   workspaceTopLevelDirty: boolean;
   channelCapabilities?: ChannelCapabilities;
   commandIntent?: { type: string; payload?: string; languageCode?: string };
-  guardianContext?: GuardianRuntimeContext;
+  guardianContext?: TrustContext;
   assistantId?: string;
   voiceCallControlPrompt?: string;
 

--- a/assistant/src/daemon/session-lifecycle.ts
+++ b/assistant/src/daemon/session-lifecycle.ts
@@ -19,12 +19,12 @@ import { repairHistory } from './history-repair.js';
 import type { SurfaceData,SurfaceType, UsageStats } from './ipc-protocol.js';
 import { unregisterCallNotifiers,unregisterWatchNotifiers } from './session-notifiers.js';
 import type { MessageQueue } from './session-queue-manager.js';
-import type { GuardianRuntimeContext } from './session-runtime-assembly.js';
+import type { TrustContext } from './session-runtime-assembly.js';
 import { resetSkillToolProjection } from './session-skill-tools.js';
 
 const log = getLogger('session-lifecycle');
 
-type GuardianTrustClass = GuardianRuntimeContext['trustClass'];
+type GuardianTrustClass = TrustContext['trustClass'];
 
 function parseProvenanceTrustClass(metadata: string | null): GuardianTrustClass | undefined {
   if (!metadata) return undefined;

--- a/assistant/src/daemon/session-messaging.ts
+++ b/assistant/src/daemon/session-messaging.ts
@@ -18,7 +18,7 @@ import type { Message } from '../providers/types.js';
 import { getLogger } from '../util/logger.js';
 import type { ServerMessage, UserMessageAttachment } from './ipc-protocol.js';
 import type { MessageQueue } from './session-queue-manager.js';
-import type { GuardianRuntimeContext } from './session-runtime-assembly.js';
+import type { TrustContext } from './session-runtime-assembly.js';
 
 const log = getLogger('session-messaging');
 
@@ -92,7 +92,7 @@ export interface MessagingSessionContext {
   abortController: AbortController | null;
   currentRequestId?: string;
   readonly queue: MessageQueue;
-  guardianContext?: GuardianRuntimeContext;
+  guardianContext?: TrustContext;
   getTurnChannelContext(): TurnChannelContext | null;
   getTurnInterfaceContext(): TurnInterfaceContext | null;
 }

--- a/assistant/src/daemon/session-notifiers.ts
+++ b/assistant/src/daemon/session-notifiers.ts
@@ -32,7 +32,7 @@ import {
   unregisterWatchStartNotifier,
 } from '../tools/watch/watch-state.js';
 import type { ServerMessage } from './ipc-protocol.js';
-import type { GuardianRuntimeContext } from './session-runtime-assembly.js';
+import type { TrustContext } from './session-runtime-assembly.js';
 import { lastCommentaryBySession, lastSummaryBySession } from './watch-handler.js';
 
 /**
@@ -42,7 +42,7 @@ import { lastCommentaryBySession, lastSummaryBySession } from './watch-handler.j
 export interface NotifierSessionContext {
   sendToClient: (msg: ServerMessage) => void;
   messages: Message[];
-  guardianContext?: GuardianRuntimeContext;
+  guardianContext?: TrustContext;
 }
 
 /**

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -26,7 +26,7 @@ import type { UsageStats } from './ipc-contract.js';
 import type { ServerMessage, UserMessageAttachment } from './ipc-protocol.js';
 import type { MessageQueue } from './session-queue-manager.js';
 import type { QueueDrainReason } from './session-queue-manager.js';
-import type { GuardianRuntimeContext } from './session-runtime-assembly.js';
+import type { TrustContext } from './session-runtime-assembly.js';
 import { resolveSlash, type SlashContext } from './session-slash.js';
 import type { TraceEmitter } from './trace-emitter.js';
 
@@ -74,7 +74,7 @@ export interface ProcessSessionContext {
   preactivatedSkillIds?: string[];
   /** Assistant identity — used for scoping notification preferences. */
   readonly assistantId?: string;
-  guardianContext?: GuardianRuntimeContext;
+  guardianContext?: TrustContext;
   ensureActorScopedHistory(): Promise<void>;
   persistUserMessage(content: string, attachments: UserMessageAttachment[], requestId?: string, metadata?: Record<string, unknown>, displayContent?: string): Promise<string>;
   runAgentLoop(

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -42,7 +42,7 @@ import {
   markDoordashStepInProgress,
 } from "./doordash-steps.js";
 import type { ServerMessage, UiSurfaceShow } from "./ipc-protocol.js";
-import type { GuardianRuntimeContext } from "./session-runtime-assembly.js";
+import type { TrustContext } from "./session-runtime-assembly.js";
 import {
   projectSkillTools,
   type SkillProjectionCache,
@@ -59,7 +59,7 @@ const log = getLogger("session-tool-setup");
  * guardian so that control-plane gates don't block local development.
  */
 export function resolveGuardianTrustClass(
-  guardianContext: GuardianRuntimeContext | undefined,
+  guardianContext: TrustContext | undefined,
 ): TrustClass {
   if (isHttpAuthDisabled()) return "guardian";
   return guardianContext?.trustClass ?? "unknown";
@@ -90,7 +90,7 @@ export interface ToolSetupContext extends SurfaceSessionContext {
   /** When set, this session is executing a task run. Used to retrieve ephemeral permission rules. */
   taskRunId?: string;
   /** Guardian runtime context for the session — trustClass is propagated into ToolContext for control-plane policy enforcement. */
-  guardianContext?: GuardianRuntimeContext;
+  guardianContext?: TrustContext;
   /** Voice/call session ID, if the session originates from a call. Propagated into ToolContext for scoped grant consumption. */
   callSessionId?: string;
 }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -88,7 +88,7 @@ import type {
 import { MessageQueue } from "./session-queue-manager.js";
 import type {
   ChannelCapabilities,
-  GuardianRuntimeContext,
+  TrustContext,
 } from "./session-runtime-assembly.js";
 import type { SkillProjectionCache } from "./session-skill-tools.js";
 import {
@@ -163,9 +163,9 @@ export class Session {
   /** @internal */ currentActiveSurfaceId?: string;
   /** @internal */ currentPage?: string;
   /** @internal */ channelCapabilities?: ChannelCapabilities;
-  /** @internal */ guardianContext?: GuardianRuntimeContext;
+  /** @internal */ guardianContext?: TrustContext;
   /** @internal */ authContext?: AuthContext;
-  /** @internal */ loadedHistoryTrustClass?: GuardianRuntimeContext["trustClass"];
+  /** @internal */ loadedHistoryTrustClass?: TrustContext["trustClass"];
   /** @internal */ voiceCallControlPrompt?: string;
   /** @internal */ assistantId?: string;
   /** @internal */ commandIntent?: {
@@ -610,7 +610,7 @@ export class Session {
     this.channelCapabilities = caps ?? undefined;
   }
 
-  setGuardianContext(ctx: GuardianRuntimeContext | null): void {
+  setGuardianContext(ctx: TrustContext | null): void {
     this.guardianContext = ctx ?? undefined;
   }
 

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -6,7 +6,7 @@ import type { ChannelId, InterfaceId } from "../channels/types.js";
 import { parseChannelId, parseInterfaceId } from "../channels/types.js";
 import { CHANNEL_IDS, INTERFACE_IDS, isChannelId } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
-import type { GuardianRuntimeContext } from "../daemon/session-runtime-assembly.js";
+import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
 import { createRowMapper } from "../util/row-mapper.js";
@@ -65,13 +65,13 @@ export const messageMetadataSchema = z
 export type MessageMetadata = z.infer<typeof messageMetadataSchema>;
 
 /**
- * Extract provenance metadata fields from a GuardianRuntimeContext.
+ * Extract provenance metadata fields from a TrustContext.
  * When no guardian context is provided, defaults to 'unknown' because the
  * absence of trust context means we cannot verify trust —
  * callers with actual guardian trust should always supply a real context.
  */
 export function provenanceFromGuardianContext(
-  ctx: GuardianRuntimeContext | null | undefined,
+  ctx: TrustContext | null | undefined,
 ): Record<string, unknown> {
   if (!ctx) return { provenanceTrustClass: "unknown" };
   return {

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -20,7 +20,7 @@ import { canonicalizeInboundIdentity } from '../util/canonicalize-identity.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
 import { getGuardianBinding } from './channel-guardian-service.js';
 
-export type { TrustContext, GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
+export type { TrustContext } from '../daemon/session-runtime-assembly.js';
 
 // ---------------------------------------------------------------------------
 // Types

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -3,7 +3,7 @@
  */
 
 import { isChannelId, parseChannelId, parseInterfaceId } from '../channels/types.js';
-import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
+import type { TrustContext } from '../daemon/session-runtime-assembly.js';
 import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
 import { getLogger } from '../util/logger.js';
 import { deliverReplyViaCallback } from './channel-reply-delivery.js';
@@ -12,7 +12,7 @@ import type { MessageProcessor } from './http-types.js';
 
 const log = getLogger('runtime-http');
 
-function parseGuardianRuntimeContext(value: unknown): GuardianRuntimeContext | undefined {
+function parseGuardianRuntimeContext(value: unknown): TrustContext | undefined {
   if (!value || typeof value !== 'object') return undefined;
   const raw = value as Record<string, unknown>;
   const trustClass = raw.trustClass;
@@ -123,7 +123,7 @@ export async function sweepFailedEvents(
     // This ensures replay never proceeds without an explicit trust classification
     // — downstream defaults like `guardianTrustClass ?? 'guardian'` would
     // otherwise grant guardian-level tool access to unclassified events.
-    const guardianContext: GuardianRuntimeContext = parsedGuardianContext ?? {
+    const guardianContext: TrustContext = parsedGuardianContext ?? {
       sourceChannel,
       trustClass: 'unknown',
     };

--- a/assistant/src/runtime/confirmation-request-guardian-bridge.ts
+++ b/assistant/src/runtime/confirmation-request-guardian-bridge.ts
@@ -12,7 +12,7 @@
  * canonical records.
  */
 
-import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
+import type { TrustContext } from '../daemon/session-runtime-assembly.js';
 import {
   type CanonicalGuardianRequest,
   createCanonicalGuardianDelivery,
@@ -33,7 +33,7 @@ export interface BridgeConfirmationRequestParams {
   /** The canonical guardian request already persisted for this confirmation_request. */
   canonicalRequest: CanonicalGuardianRequest;
   /** Guardian runtime context from the session. */
-  guardianContext: GuardianRuntimeContext;
+  guardianContext: TrustContext;
   /** Conversation ID where the confirmation_request was emitted. */
   conversationId: string;
   /** Tool name from the confirmation_request. */

--- a/assistant/src/runtime/guardian-context-resolver.ts
+++ b/assistant/src/runtime/guardian-context-resolver.ts
@@ -1,16 +1,16 @@
 /**
  * Shared inbound trust resolution for channel actors.
  *
- * GuardianContext is a type alias for GuardianRuntimeContext — the
+ * GuardianContext is a type alias for TrustContext — the
  * canonical runtime trust context used by sessions, tooling, and channel
  * routes. This module re-exports the alias and provides routing-state
  * helpers that operate on the canonical type.
  *
  * Trust resolution itself lives in actor-trust-resolver.ts; the resolved
- * ActorTrustContext is converted to GuardianRuntimeContext via
+ * ActorTrustContext is converted to TrustContext via
  * toGuardianRuntimeContextFromTrust.
  */
-import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
+import type { TrustContext } from '../daemon/session-runtime-assembly.js';
 import {
   resolveActorTrust,
   type ResolveActorTrustInput,
@@ -31,7 +31,7 @@ export type ActorTrustClass = TrustClass;
  * This alias unifies the two shapes and removes the redundant conversion
  * layer.
  */
-export type GuardianContext = GuardianRuntimeContext;
+export type GuardianContext = TrustContext;
 
 export type ResolveGuardianContextInput = ResolveActorTrustInput;
 
@@ -39,7 +39,7 @@ export type ResolveGuardianContextInput = ResolveActorTrustInput;
  * Resolve route-level trust context from canonical identity state.
  *
  * Delegates to resolveActorTrust for classification, then converts to
- * the canonical GuardianRuntimeContext via toGuardianRuntimeContextFromTrust.
+ * the canonical TrustContext via toGuardianRuntimeContextFromTrust.
  */
 export function resolveGuardianContext(input: ResolveGuardianContextInput): GuardianContext {
   const trust = resolveActorTrust(input);
@@ -83,7 +83,7 @@ export interface RoutingState {
  * Trusted contacts are only interactive when a guardian binding exists
  * to receive approval notifications. Unknown actors are never interactive.
  */
-export function resolveRoutingState(ctx: Pick<GuardianRuntimeContext, 'trustClass' | 'guardianExternalUserId'>): RoutingState {
+export function resolveRoutingState(ctx: Pick<TrustContext, 'trustClass' | 'guardianExternalUserId'>): RoutingState {
   const isGuardian = ctx.trustClass === 'guardian';
   const isTrustedContact = ctx.trustClass === 'trusted_contact';
 
@@ -118,15 +118,15 @@ export function resolveRoutingState(ctx: Pick<GuardianRuntimeContext, 'trustClas
 }
 
 /**
- * Convenience: compute routing state from a GuardianRuntimeContext
+ * Convenience: compute routing state from a TrustContext
  * (the shape persisted in stored payloads and used by the retry sweep).
  */
-export function resolveRoutingStateFromRuntime(ctx: GuardianRuntimeContext): RoutingState {
+export function resolveRoutingStateFromRuntime(ctx: TrustContext): RoutingState {
   return resolveRoutingState(ctx);
 }
 
 /**
- * Override the sourceChannel on a resolved GuardianRuntimeContext.
+ * Override the sourceChannel on a resolved TrustContext.
  *
  * The HTTP /messages endpoint resolves trust against a fixed internal
  * channel ('vellum') but the request body carries the actual sourceChannel
@@ -135,7 +135,7 @@ export function resolveRoutingStateFromRuntime(ctx: GuardianRuntimeContext): Rou
  */
 export function toGuardianRuntimeContext(
   sourceChannel: import('../channels/types.js').ChannelId,
-  ctx: GuardianRuntimeContext,
-): GuardianRuntimeContext {
+  ctx: TrustContext,
+): TrustContext {
   return { ...ctx, sourceChannel };
 }

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -3,7 +3,7 @@
  */
 import type { ChannelId, InterfaceId } from "../channels/types.js";
 import type { Session } from "../daemon/session.js";
-import type { GuardianRuntimeContext } from "../daemon/session-runtime-assembly.js";
+import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import type {
   ApprovalMessageContext,
   ComposeApprovalMessageGenerativeOptions,
@@ -112,7 +112,7 @@ export interface RuntimeMessageSessionOptions {
     uxBrief?: string;
   };
   assistantId?: string;
-  guardianContext?: GuardianRuntimeContext;
+  guardianContext?: TrustContext;
   /**
    * Whether this turn should permit interactive approval prompts.
    * Channel ingress sets this true so confirmations can be resolved

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -13,7 +13,7 @@
 
 import type { ChannelId } from '../channels/types.js';
 import { buildIpcAuthContext } from '../daemon/ipc-handler.js';
-import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
+import type { TrustContext } from '../daemon/session-runtime-assembly.js';
 import { getActiveBinding } from '../memory/guardian-bindings.js';
 import { getLogger } from '../util/logger.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
@@ -37,7 +37,7 @@ const log = getLogger('local-actor-identity');
  */
 export function resolveLocalIpcGuardianContext(
   sourceChannel: ChannelId = 'vellum',
-): GuardianRuntimeContext {
+): TrustContext {
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const binding = getActiveBinding(assistantId, 'vellum');
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -609,7 +609,7 @@ export async function handleSendMessage(
   }
 
   // Resolve guardian context from AuthContext for the legacy path too.
-  let guardianContext: import('../../daemon/session-runtime-assembly.js').GuardianRuntimeContext;
+  let guardianContext: import('../../daemon/session-runtime-assembly.js').TrustContext;
   if (authContext.actorPrincipalId) {
     const legacyGuardianCtx = resolveGuardianContext({
       assistantId: DAEMON_INTERNAL_ASSISTANT_ID,


### PR DESCRIPTION
## Summary
- Replace all `GuardianRuntimeContext` imports and type annotations with `TrustContext`
- Update all source files and test files that referenced the old type name
- The deprecated re-export in session-runtime-assembly.ts remains for now (removed in PR 6)

Part of plan: trust-class-rename-cleanup.md (PR 5 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
