### PR TITLE
refactor: rename resolveGuardianTrustClass → resolveTrustClass

### DIFF
--- a/assistant/src/__tests__/resolve-trust-class.test.ts
+++ b/assistant/src/__tests__/resolve-trust-class.test.ts
@@ -13,7 +13,7 @@ mock.module("../config/env.js", () => ({
 
 // ── Real imports (after mocks) ───────────────────────────────────────
 
-import { resolveGuardianTrustClass } from "../daemon/session-tool-setup.js";
+import { resolveTrustClass } from "../daemon/session-tool-setup.js";
 
 afterAll(() => {
   mock.restore();
@@ -21,7 +21,7 @@ afterAll(() => {
 
 // ── Tests ────────────────────────────────────────────────────────────
 
-describe("resolveGuardianTrustClass", () => {
+describe("resolveTrustClass", () => {
   beforeEach(() => {
     fakeHttpAuthDisabled = false;
   });
@@ -30,13 +30,13 @@ describe("resolveGuardianTrustClass", () => {
     const ctx: Pick<TrustContext, "trustClass"> = {
       trustClass: "trusted_contact",
     };
-    expect(resolveGuardianTrustClass(ctx as TrustContext)).toBe(
+    expect(resolveTrustClass(ctx as TrustContext)).toBe(
       "trusted_contact",
     );
   });
 
   test("returns 'unknown' when guardianContext is undefined", () => {
-    expect(resolveGuardianTrustClass(undefined)).toBe("unknown");
+    expect(resolveTrustClass(undefined)).toBe("unknown");
   });
 
   test("forces guardian when HTTP auth is disabled, regardless of context trust class", () => {
@@ -44,7 +44,7 @@ describe("resolveGuardianTrustClass", () => {
     const ctx: Pick<TrustContext, "trustClass"> = {
       trustClass: "trusted_contact",
     };
-    expect(resolveGuardianTrustClass(ctx as TrustContext)).toBe(
+    expect(resolveTrustClass(ctx as TrustContext)).toBe(
       "guardian",
     );
   });
@@ -54,7 +54,7 @@ describe("resolveGuardianTrustClass", () => {
     const ctx: Pick<TrustContext, "trustClass"> = {
       trustClass: "unknown",
     };
-    expect(resolveGuardianTrustClass(ctx as TrustContext)).toBe(
+    expect(resolveTrustClass(ctx as TrustContext)).toBe(
       "guardian",
     );
   });

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -65,7 +65,7 @@ import {
   stripInjectedContext,
 } from './session-runtime-assembly.js';
 import type { SkillProjectionCache } from './session-skill-tools.js';
-import { resolveGuardianTrustClass } from './session-tool-setup.js';
+import { resolveTrustClass } from './session-tool-setup.js';
 import { recordUsage } from './session-usage.js';
 import type { TraceEmitter } from './trace-emitter.js';
 
@@ -320,7 +320,7 @@ export async function runAgentLoopImpl(
         conflictGate: ctx.conflictGate,
         scopeId: ctx.memoryPolicy.scopeId,
         includeDefaultFallback: ctx.memoryPolicy.includeDefaultFallback,
-        trustClass: resolveGuardianTrustClass(ctx.guardianContext),
+        trustClass: resolveTrustClass(ctx.guardianContext),
         isInteractive: options?.isInteractive ?? (!ctx.hasNoClient && !ctx.headlessLock),
       },
       content,

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -54,11 +54,11 @@ import { runPostExecutionSideEffects } from "./tool-side-effects.js";
 const log = getLogger("session-tool-setup");
 
 /**
- * Resolve the effective guardian trust class for tool execution.
+ * Resolve the effective trust class for tool execution.
  * When HTTP auth is disabled (dev bypass), always treat the actor as
  * guardian so that control-plane gates don't block local development.
  */
-export function resolveGuardianTrustClass(
+export function resolveTrustClass(
   guardianContext: TrustContext | undefined,
 ): TrustClass {
   if (isHttpAuthDisabled()) return "guardian";
@@ -151,7 +151,7 @@ export function createToolExecutor(
       assistantId: ctx.assistantId,
       requestId: ctx.currentRequestId,
       taskRunId: ctx.taskRunId,
-      trustClass: resolveGuardianTrustClass(ctx.guardianContext),
+      trustClass: resolveTrustClass(ctx.guardianContext),
       executionChannel: ctx.guardianContext?.sourceChannel,
       callSessionId: ctx.callSessionId,
       triggeredBySurfaceAction:


### PR DESCRIPTION
## Summary
- Rename `resolveGuardianTrustClass` function to `resolveTrustClass`
- Update all call sites in session-tool-setup.ts and session-agent-loop.ts
- Rename test file from resolve-guardian-trust-class.test.ts to resolve-trust-class.test.ts

Part of plan: trust-class-rename-cleanup.md (PR 3 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
