### PR TITLE
refactor: remove deprecated GuardianRuntimeContext type alias

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -2154,7 +2154,7 @@ The daemon uses a single fixed internal scope constant — `DAEMON_INTERNAL_ASSI
 
 The guardian trust system uses a three-valued `TrustClass` — `'guardian'`, `'trusted_contact'`, or `'unknown'` — as the single vocabulary for actor trust classification across all channels and runtime paths. There is no legacy `actorRole` concept; all trust decisions flow through `TrustClass`.
 
-**`GuardianRuntimeContext`** (in `src/daemon/session-runtime-assembly.ts`) is the single runtime carrier for trust state on channel-originated turns. It carries `trustClass`, guardian identity fields, and requester metadata. The `guardianPrincipalId` field is typed as `?: string` (optional but non-nullable) — a principal ID is present when a guardian binding exists but is never `null`.
+**`TrustContext`** (in `src/daemon/session-runtime-assembly.ts`) is the single runtime carrier for trust state on channel-originated turns. It carries `trustClass`, guardian identity fields, and requester metadata. The `guardianPrincipalId` field is typed as `?: string` (optional but non-nullable) — a principal ID is present when a guardian binding exists but is never `null`.
 
 **Explicit trust gates:** `trustClass` is a **required** field in `ToolContext` (in `src/tools/types.ts`). Every tool execution must carry a trust classification — the field is not optional. This ensures trust-gated tool policies (guardian control-plane restrictions, host-tool blocking for untrusted actors) cannot be bypassed by omitting the classification.
 
@@ -2168,7 +2168,7 @@ The guardian trust system uses a three-valued `TrustClass` — `'guardian'`, `'t
 
 | File                                         | Purpose                                                |
 | -------------------------------------------- | ------------------------------------------------------ |
-| `src/daemon/session-runtime-assembly.ts`     | `GuardianRuntimeContext` type definition               |
+| `src/daemon/session-runtime-assembly.ts`     | `TrustContext` type definition                        |
 | `src/tools/types.ts`                         | `ToolContext.trustClass` (required trust gate)         |
 | `src/runtime/channel-retry-sweep.ts`         | Strict `trustClass` parser for retry sweep             |
 | `src/memory/guardian-bindings.ts`            | `GuardianBinding` with required `guardianPrincipalId`  |

--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -197,7 +197,7 @@ Runtime profile flow (per turn):
 
 ### Provenance-Aware Memory Pipeline
 
-Every persisted message carries provenance metadata (`provenanceTrustClass`, `provenanceSourceChannel`, etc.) derived from the `GuardianRuntimeContext` resolved by `guardian-context-resolver.ts`. This metadata records the trust class of the actor who produced the message and through which channel, enabling downstream trust decisions without re-resolving identity at read time.
+Every persisted message carries provenance metadata (`provenanceTrustClass`, `provenanceSourceChannel`, etc.) derived from the `TrustContext` resolved by `guardian-context-resolver.ts`. This metadata records the trust class of the actor who produced the message and through which channel, enabling downstream trust decisions without re-resolving identity at read time.
 
 Two trust gates enforce trust-class-based access control over the memory pipeline:
 

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -55,9 +55,6 @@ export interface TrustContext {
   denialReason?: "no_binding" | "no_identity";
 }
 
-/** @deprecated Use `TrustContext` instead. */
-export type GuardianRuntimeContext = TrustContext;
-
 /**
  * Inbound actor context for the `<inbound_actor_context>` block.
  *
@@ -91,7 +88,7 @@ export interface InboundActorContext {
 }
 
 /**
- * Construct an InboundActorContext from a legacy GuardianRuntimeContext.
+ * Construct an InboundActorContext from a TrustContext.
  *
  * Maps the runtime trust class into the model-facing inbound actor context.
  */


### PR DESCRIPTION
## Summary
- Remove the deprecated `GuardianRuntimeContext` re-export alias from session-runtime-assembly.ts
- Clean up any remaining references to `GuardianRuntimeContext` across the codebase

Part of plan: trust-class-rename-cleanup.md (PR 6 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
