### PR TITLE
refactor: remove GuardianContext/ResolveGuardianContextInput aliases, rename resolver

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -14,7 +14,7 @@ This document owns assistant-runtime architecture details. The repo-level archit
 
 ### Guardian Actor Context (Unified Across Channels)
 
-- Guardian/non-guardian/unverified classification is centralized in `assistant/src/runtime/guardian-context-resolver.ts`.
+- Guardian/non-guardian/unverified classification is centralized in `assistant/src/runtime/trust-context-resolver.ts`.
 - The same resolver is used by:
   - `/channels/inbound` (Telegram/SMS/WhatsApp path) before run orchestration.
   - Inbound Twilio voice setup (`RelayConnection.handleSetup`) to seed call-time actor context.

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -335,7 +335,7 @@ Guardian verification and ingress membership are complementary but independent s
 | File | Purpose |
 |------|---------|
 | `src/runtime/channel-guardian-service.ts` | Challenge lifecycle: `createVerificationChallenge`, `validateAndConsumeChallenge`, `getGuardianBinding`, `isGuardian` |
-| `src/runtime/guardian-context-resolver.ts` | Actor role classification: guardian / non-guardian / unverified_channel |
+| `src/runtime/trust-context-resolver.ts` | Actor role classification: guardian / non-guardian / unverified_channel |
 | `src/runtime/routes/inbound-message-handler.ts` | Ingress ACL enforcement, verification-code intercept, escalation creation |
 | `src/memory/ingress-member-store.ts` | Member CRUD: `findMember`, `upsertMember`, `revokeMember`, `blockMember` |
 | `src/memory/ingress-invite-store.ts` | Invite lifecycle: `createInvite`, `redeemInvite` (atomically creates member record) |

--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -197,7 +197,7 @@ Runtime profile flow (per turn):
 
 ### Provenance-Aware Memory Pipeline
 
-Every persisted message carries provenance metadata (`provenanceTrustClass`, `provenanceSourceChannel`, etc.) derived from the `TrustContext` resolved by `guardian-context-resolver.ts`. This metadata records the trust class of the actor who produced the message and through which channel, enabling downstream trust decisions without re-resolving identity at read time.
+Every persisted message carries provenance metadata (`provenanceTrustClass`, `provenanceSourceChannel`, etc.) derived from the `TrustContext` resolved by `trust-context-resolver.ts`. This metadata records the trust class of the actor who produced the message and through which channel, enabling downstream trust decisions without re-resolving identity at read time.
 
 Two trust gates enforce trust-class-based access control over the memory pipeline:
 

--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -79,12 +79,12 @@ mock.module("../runtime/local-actor-identity.js", () => ({
   }),
 }));
 
-mock.module("../runtime/guardian-context-resolver.js", () => ({
-  resolveGuardianContext: () => ({
+mock.module("../runtime/trust-context-resolver.js", () => ({
+  resolveTrustContext: () => ({
     trustClass: "guardian",
     sourceChannel: "vellum",
   }),
-  toGuardianRuntimeContext: (sourceChannel: unknown, ctx: unknown) => ({
+  withSourceChannel: (sourceChannel: unknown, ctx: unknown) => ({
     ...(ctx as Record<string, unknown>),
     sourceChannel,
   }),

--- a/assistant/src/__tests__/conversation-routes.test.ts
+++ b/assistant/src/__tests__/conversation-routes.test.ts
@@ -20,12 +20,12 @@ mock.module("../memory/attachments-store.js", () => ({
   getAttachmentsByIds: () => [],
 }));
 
-mock.module("../runtime/guardian-context-resolver.js", () => ({
-  resolveGuardianContext: (input: { sourceChannel?: string }) => ({
+mock.module("../runtime/trust-context-resolver.js", () => ({
+  resolveTrustContext: (input: { sourceChannel?: string }) => ({
     trustClass: "guardian",
     sourceChannel: input.sourceChannel ?? "vellum",
   }),
-  toGuardianRuntimeContext: (
+  withSourceChannel: (
     sourceChannel: string,
     ctx: Record<string, unknown>,
   ) => ({

--- a/assistant/src/__tests__/guardian-grant-minting.test.ts
+++ b/assistant/src/__tests__/guardian-grant-minting.test.ts
@@ -55,7 +55,7 @@ import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import * as approvalMessageComposer from "../runtime/approval-message-composer.js";
 import * as gatewayClient from "../runtime/gateway-client.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
-import type { GuardianContext } from "../runtime/routes/channel-route-shared.js";
+import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import { handleApprovalInterception } from "../runtime/routes/guardian-approval-interception.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
 
@@ -145,7 +145,7 @@ function registerPendingInteraction(
   return handleConfirmationResponse;
 }
 
-function makeGuardianContext(): GuardianContext {
+function makeTrustContext(): TrustContext {
   return {
     sourceChannel: "telegram",
     trustClass: "guardian",
@@ -218,7 +218,7 @@ describe("guardian grant minting on tool-approval decisions", () => {
       sourceChannel: "telegram",
       actorExternalId: GUARDIAN_USER,
       replyCallbackUrl: "https://gateway.test/deliver",
-      guardianCtx: makeGuardianContext(),
+      guardianCtx: makeTrustContext(),
       assistantId: ASSISTANT_ID,
     });
 
@@ -266,7 +266,7 @@ describe("guardian grant minting on tool-approval decisions", () => {
       sourceChannel: "telegram",
       actorExternalId: GUARDIAN_USER,
       replyCallbackUrl: "https://gateway.test/deliver",
-      guardianCtx: makeGuardianContext(),
+      guardianCtx: makeTrustContext(),
       assistantId: ASSISTANT_ID,
     });
 
@@ -297,7 +297,7 @@ describe("guardian grant minting on tool-approval decisions", () => {
       sourceChannel: "telegram",
       actorExternalId: GUARDIAN_USER,
       replyCallbackUrl: "https://gateway.test/deliver",
-      guardianCtx: makeGuardianContext(),
+      guardianCtx: makeTrustContext(),
       assistantId: ASSISTANT_ID,
     });
 
@@ -341,7 +341,7 @@ describe("guardian grant minting on tool-approval decisions", () => {
       sourceChannel: "telegram",
       actorExternalId: GUARDIAN_USER,
       replyCallbackUrl: "https://gateway.test/deliver",
-      guardianCtx: makeGuardianContext(),
+      guardianCtx: makeTrustContext(),
       assistantId: ASSISTANT_ID,
     });
 
@@ -375,7 +375,7 @@ describe("guardian grant minting on tool-approval decisions", () => {
       sourceChannel: "telegram",
       actorExternalId: "wrong-guardian-user",
       replyCallbackUrl: "https://gateway.test/deliver",
-      guardianCtx: makeGuardianContext(),
+      guardianCtx: makeTrustContext(),
       assistantId: ASSISTANT_ID,
     });
 
@@ -406,7 +406,7 @@ describe("guardian grant minting on tool-approval decisions", () => {
       sourceChannel: "telegram",
       actorExternalId: GUARDIAN_USER,
       replyCallbackUrl: "https://gateway.test/deliver",
-      guardianCtx: makeGuardianContext(),
+      guardianCtx: makeTrustContext(),
       assistantId: ASSISTANT_ID,
     });
 
@@ -445,7 +445,7 @@ describe("guardian grant minting on tool-approval decisions", () => {
       sourceChannel: "telegram",
       actorExternalId: GUARDIAN_USER,
       replyCallbackUrl: "https://gateway.test/deliver",
-      guardianCtx: makeGuardianContext(),
+      guardianCtx: makeTrustContext(),
       assistantId: ASSISTANT_ID,
       approvalConversationGenerator: mockGenerator,
     });
@@ -491,7 +491,7 @@ describe("guardian grant minting on tool-approval decisions", () => {
       sourceChannel: "telegram",
       actorExternalId: GUARDIAN_USER,
       replyCallbackUrl: "https://gateway.test/deliver",
-      guardianCtx: makeGuardianContext(),
+      guardianCtx: makeTrustContext(),
       assistantId: ASSISTANT_ID,
       approvalConversationGenerator: mockGenerator,
     });
@@ -526,7 +526,7 @@ describe("guardian grant minting on tool-approval decisions", () => {
       sourceChannel: "telegram",
       actorExternalId: GUARDIAN_USER,
       replyCallbackUrl: "https://gateway.test/deliver",
-      guardianCtx: makeGuardianContext(),
+      guardianCtx: makeTrustContext(),
       assistantId: ASSISTANT_ID,
     });
 
@@ -567,7 +567,7 @@ describe("guardian grant minting on tool-approval decisions", () => {
       sourceChannel: "telegram",
       actorExternalId: GUARDIAN_USER,
       replyCallbackUrl: "https://gateway.test/deliver",
-      guardianCtx: makeGuardianContext(),
+      guardianCtx: makeTrustContext(),
       assistantId: ASSISTANT_ID,
     });
 

--- a/assistant/src/__tests__/guardian-routing-state.test.ts
+++ b/assistant/src/__tests__/guardian-routing-state.test.ts
@@ -71,11 +71,11 @@ import { createBinding } from "../memory/channel-guardian-store.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { channelInboundEvents, messages } from "../memory/schema.js";
 import { sweepFailedEvents } from "../runtime/channel-retry-sweep.js";
+import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import {
-  type GuardianContext,
   resolveRoutingState,
   resolveRoutingStateFromRuntime,
-} from "../runtime/guardian-context-resolver.js";
+} from "../runtime/trust-context-resolver.js";
 import { handleChannelInbound } from "../runtime/routes/channel-routes.js";
 
 initializeDb();
@@ -108,7 +108,7 @@ function resetTables(): void {
 
 describe("resolveRoutingState", () => {
   test("guardian actors are always interactive and route-resolvable", () => {
-    const ctx: GuardianContext = {
+    const ctx: TrustContext = {
       sourceChannel: "telegram",
       trustClass: "guardian",
       guardianExternalUserId: "guardian-123",
@@ -124,7 +124,7 @@ describe("resolveRoutingState", () => {
 
   test("guardian actors are interactive even without guardianExternalUserId", () => {
     // Edge case: guardian is chatting in their own chat, no separate binding needed
-    const ctx: GuardianContext = {
+    const ctx: TrustContext = {
       sourceChannel: "telegram",
       trustClass: "guardian",
     };
@@ -134,7 +134,7 @@ describe("resolveRoutingState", () => {
   });
 
   test("trusted contact with resolvable guardian route is interactive", () => {
-    const ctx: GuardianContext = {
+    const ctx: TrustContext = {
       sourceChannel: "telegram",
       trustClass: "trusted_contact",
       guardianExternalUserId: "guardian-456",
@@ -149,7 +149,7 @@ describe("resolveRoutingState", () => {
   });
 
   test("trusted contact without guardian route is NOT interactive (fail-fast)", () => {
-    const ctx: GuardianContext = {
+    const ctx: TrustContext = {
       sourceChannel: "telegram",
       trustClass: "trusted_contact",
       // No guardianExternalUserId — no guardian binding for this channel
@@ -163,12 +163,12 @@ describe("resolveRoutingState", () => {
   });
 
   test("unknown actors are never interactive regardless of guardian route", () => {
-    const withRoute: GuardianContext = {
+    const withRoute: TrustContext = {
       sourceChannel: "telegram",
       trustClass: "unknown",
       guardianExternalUserId: "guardian-789",
     };
-    const withoutRoute: GuardianContext = {
+    const withoutRoute: TrustContext = {
       sourceChannel: "telegram",
       trustClass: "unknown",
     };

--- a/assistant/src/__tests__/trusted-contact-approval-notifier.test.ts
+++ b/assistant/src/__tests__/trusted-contact-approval-notifier.test.ts
@@ -128,7 +128,7 @@ mock.module("../config/user-reference.js", () => ({
 // Import module under test AFTER mocks are set up
 import type { ChannelId } from "../channels/types.js";
 import { resolveUserReference } from "../config/user-reference.js";
-import type { GuardianContext } from "../runtime/guardian-context-resolver.js";
+import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 
 // We need to test the private functions by importing the module.
 // Since startTrustedContactApprovalNotifier is not exported, we test it
@@ -156,7 +156,7 @@ async function simulateNotifierPoll(params: {
   conversationId: string;
   sourceChannel: ChannelId;
   externalChatId: string;
-  guardianTrustClass: GuardianContext["trustClass"];
+  guardianTrustClass: TrustContext["trustClass"];
   guardianExternalUserId?: string;
   replyCallbackUrl: string;
   bearerToken?: string;

--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -2,7 +2,7 @@
  * End-to-end integration tests for the trusted-contact inline guardian approval feature.
  *
  * Verifies the full integration of M1-M4 milestones:
- *   M1: RoutingState (guardian-context-resolver.ts)
+ *   M1: RoutingState (trust-context-resolver.ts)
  *   M2: Confirmation request guardian bridge (confirmation-request-guardian-bridge.ts)
  *   M3: Pending approval notifier (inbound-message-handler.ts)
  *   M4: Inline grant wait-and-resume (tool-approval-handler.ts) +
@@ -192,10 +192,10 @@ import {
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { scopedApprovalGrants } from "../memory/schema.js";
 import { bridgeConfirmationRequestToGuardian } from "../runtime/confirmation-request-guardian-bridge.js";
+import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import {
-  type GuardianContext,
   resolveRoutingState,
-} from "../runtime/guardian-context-resolver.js";
+} from "../runtime/trust-context-resolver.js";
 import {
   TC_GRANT_WAIT_MAX_MS,
   ToolApprovalHandler,
@@ -247,7 +247,7 @@ function guardianActor(overrides: Partial<ActorContext> = {}): ActorContext {
   };
 }
 
-function makeTrustedContactGuardianContext(): TrustContext {
+function makeTrustedContactTrustContext(): TrustContext {
   return {
     sourceChannel: "telegram",
     trustClass: "trusted_contact",
@@ -349,7 +349,7 @@ describe("(a) target flow: trusted-contact inline guardian approval end-to-end",
 
   test("complete flow: routing state allows interactive + bridge notifies guardian + tool resumes", async () => {
     // Step 1: Verify routing state allows interactive turns for trusted contacts
-    const guardianCtx: GuardianContext = {
+    const guardianCtx: TrustContext = {
       sourceChannel: "telegram",
       trustClass: "trusted_contact",
       guardianExternalUserId: "guardian-1",
@@ -431,7 +431,7 @@ describe("(b) prompt-path flow: confirmation_request bridges to guardian", () =>
       expiresAt: new Date(Date.now() + 5 * 60_000).toISOString(),
     });
 
-    const guardianContext = makeTrustedContactGuardianContext();
+    const guardianContext = makeTrustedContactTrustContext();
 
     const result = bridgeConfirmationRequestToGuardian({
       canonicalRequest,
@@ -470,7 +470,7 @@ describe("(b) prompt-path flow: confirmation_request bridges to guardian", () =>
       expiresAt: new Date(Date.now() + 5 * 60_000).toISOString(),
     });
 
-    const guardianContext = makeTrustedContactGuardianContext();
+    const guardianContext = makeTrustedContactTrustContext();
 
     bridgeConfirmationRequestToGuardian({
       canonicalRequest,
@@ -505,7 +505,7 @@ describe("(c) no-binding flow: trusted contact fails fast without guardian bindi
   });
 
   test("routing state blocks prompt waiting when no guardian binding exists", () => {
-    const ctx: GuardianContext = {
+    const ctx: TrustContext = {
       sourceChannel: "telegram",
       trustClass: "trusted_contact",
       // No guardianExternalUserId — mirrors no binding
@@ -569,7 +569,7 @@ describe("(c) no-binding flow: trusted contact fails fast without guardian bindi
       expiresAt: new Date(Date.now() + 5 * 60_000).toISOString(),
     });
 
-    const guardianContext = makeTrustedContactGuardianContext();
+    const guardianContext = makeTrustedContactTrustContext();
 
     const result = bridgeConfirmationRequestToGuardian({
       canonicalRequest,
@@ -649,12 +649,12 @@ describe("(d) unknown actor flow: fail-closed with no interactive approval", () 
   });
 
   test("unknown actors have promptWaitingAllowed=false regardless of guardian route", () => {
-    const withRoute: GuardianContext = {
+    const withRoute: TrustContext = {
       sourceChannel: "telegram",
       trustClass: "unknown",
       guardianExternalUserId: "guardian-1",
     };
-    const withoutRoute: GuardianContext = {
+    const withoutRoute: TrustContext = {
       sourceChannel: "telegram",
       trustClass: "unknown",
     };
@@ -1054,7 +1054,7 @@ describe("cross-milestone integration checks", () => {
 
   test("M1+M4: routing state interactivity drives inline wait eligibility", async () => {
     // With guardian binding: interactive + inline wait allowed
-    const withBinding: GuardianContext = {
+    const withBinding: TrustContext = {
       sourceChannel: "telegram",
       trustClass: "trusted_contact",
       guardianExternalUserId: "guardian-1",
@@ -1062,7 +1062,7 @@ describe("cross-milestone integration checks", () => {
     expect(resolveRoutingState(withBinding).promptWaitingAllowed).toBe(true);
 
     // Without guardian binding: not interactive + inline wait should not enter dead-end
-    const withoutBinding: GuardianContext = {
+    const withoutBinding: TrustContext = {
       sourceChannel: "telegram",
       trustClass: "trusted_contact",
     };
@@ -1090,7 +1090,7 @@ describe("cross-milestone integration checks", () => {
       expiresAt: new Date(Date.now() + 5 * 60_000).toISOString(),
     });
 
-    const guardianContext = makeTrustedContactGuardianContext();
+    const guardianContext = makeTrustedContactTrustContext();
 
     const bridgeResult = bridgeConfirmationRequestToGuardian({
       canonicalRequest,

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -284,7 +284,7 @@ export async function handleUserMessage(
       session.setAssistantId(DAEMON_INTERNAL_ASSISTANT_ID);
       // Resolve local IPC actor identity through the same trust pipeline
       // used by HTTP channel ingress. The vellum guardian binding provides
-      // the guardianPrincipalId, and resolveGuardianContext classifies the
+      // the guardianPrincipalId, and resolveTrustContext classifies the
       // local user as 'guardian' via binding match.
       session.setGuardianContext(resolveLocalIpcGuardianContext(ipcChannel));
       // Align IPC sessions with the same AuthContext shape as HTTP sessions.

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -7,7 +7,7 @@ import type { TrustContext } from '../daemon/session-runtime-assembly.js';
 import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
 import { getLogger } from '../util/logger.js';
 import { deliverReplyViaCallback } from './channel-reply-delivery.js';
-import { resolveRoutingStateFromRuntime } from './guardian-context-resolver.js';
+import { resolveRoutingStateFromRuntime } from './trust-context-resolver.js';
 import type { MessageProcessor } from './http-types.js';
 
 const log = getLogger('runtime-http');

--- a/assistant/src/runtime/confirmation-request-guardian-bridge.ts
+++ b/assistant/src/runtime/confirmation-request-guardian-bridge.ts
@@ -100,7 +100,7 @@ export function bridgeConfirmationRequestToGuardian(
   // new binding would leak requester/tool metadata to the wrong recipient.
   //
   // Both sides are canonicalized before comparison because the canonical request
-  // value was normalized by resolveGuardianContext() while the binding stores the
+  // value was normalized by resolveTrustContext() while the binding stores the
   // raw identity. On phone channels the same guardian can have format variance
   // (e.g. "+1 555-123-4567" vs "+15551234567") that would cause a false mismatch.
   const canonicalBindingId = canonicalizeInboundIdentity(sourceChannel, binding.guardianExternalUserId);

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -6,7 +6,7 @@
  * deterministic local actor identity server-side by looking up the vellum
  * channel guardian binding.
  *
- * This routes IPC connections through the same `resolveGuardianContext`
+ * This routes IPC connections through the same `resolveTrustContext`
  * pathway used by HTTP channel ingress, producing equivalent
  * guardian-context behavior for the vellum channel.
  */
@@ -18,7 +18,7 @@ import { getActiveBinding } from '../memory/guardian-bindings.js';
 import { getLogger } from '../util/logger.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
 import type { AuthContext } from './auth/types.js';
-import { resolveGuardianContext } from './guardian-context-resolver.js';
+import { resolveTrustContext } from './trust-context-resolver.js';
 import { ensureVellumGuardianBinding } from './guardian-vellum-migration.js';
 
 const log = getLogger('local-actor-identity');
@@ -27,7 +27,7 @@ const log = getLogger('local-actor-identity');
  * Resolve the guardian runtime context for a local IPC connection.
  *
  * Looks up the vellum guardian binding to obtain the `guardianPrincipalId`,
- * then passes it as the sender identity through `resolveGuardianContext` --
+ * then passes it as the sender identity through `resolveTrustContext` --
  * the same pathway HTTP channel routes use. This ensures IPC and HTTP
  * produce equivalent trust classification for the vellum channel.
  *
@@ -51,7 +51,7 @@ export function resolveLocalIpcGuardianContext(
     const principalId = ensureVellumGuardianBinding(assistantId);
 
     // Re-resolve through the shared pipeline now that the binding exists.
-    const guardianCtx = resolveGuardianContext({
+    const guardianCtx = resolveTrustContext({
       assistantId,
       sourceChannel: 'vellum',
       conversationExternalId: 'local',
@@ -69,7 +69,7 @@ export function resolveLocalIpcGuardianContext(
   // 'vellum' — otherwise resolveActorTrust would look up a different
   // channel's binding (e.g. telegram/sms) and the IDs wouldn't match,
   // causing a 'unknown' trust classification.
-  const guardianCtx = resolveGuardianContext({
+  const guardianCtx = resolveTrustContext({
     assistantId,
     sourceChannel: 'vellum',
     conversationExternalId: 'local',

--- a/assistant/src/runtime/routes/channel-route-shared.ts
+++ b/assistant/src/runtime/routes/channel-route-shared.ts
@@ -8,8 +8,8 @@ import type {
   ApprovalDecisionResult,
   ApprovalUIMetadata,
 } from '../channel-approval-types.js';
-import type { DenialReason } from '../guardian-context-resolver.js';
-export type { ActorTrustClass, DenialReason, GuardianContext } from '../guardian-context-resolver.js';
+import type { DenialReason } from '../trust-context-resolver.js';
+export type { DenialReason } from '../trust-context-resolver.js';
 
 /** Canonicalize assistantId for channel ingress paths. */
 export function canonicalChannelAssistantId(_assistantId: string): string {

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -23,7 +23,5 @@ export {
 } from './channel-inbound-routes.js';
 export {
   _setTestPollMaxWait,
-  type ActorTrustClass,
   type DenialReason,
-  type GuardianContext,
 } from './channel-route-shared.js';

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -28,9 +28,9 @@ import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import type { AuthContext } from '../auth/types.js';
 import { bridgeConfirmationRequestToGuardian } from '../confirmation-request-guardian-bridge.js';
 import {
-  resolveGuardianContext,
-  toGuardianRuntimeContext,
-} from '../guardian-context-resolver.js';
+  resolveTrustContext,
+  withSourceChannel,
+} from '../trust-context-resolver.js';
 import { routeGuardianReply } from '../guardian-reply-router.js';
 import { httpError } from '../http-errors.js';
 import type {
@@ -483,13 +483,13 @@ export async function handleSendMessage(
     // the same trust resolution pipeline that channel ingress uses.
     if (authContext.actorPrincipalId) {
       const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
-      const guardianCtx = resolveGuardianContext({
+      const guardianCtx = resolveTrustContext({
         assistantId,
         sourceChannel: 'vellum',
         conversationExternalId: 'local',
         actorExternalId: authContext.actorPrincipalId,
       });
-      session.setGuardianContext(toGuardianRuntimeContext(sourceChannel, guardianCtx));
+      session.setGuardianContext(withSourceChannel(sourceChannel, guardianCtx));
     } else {
       // Service principals (svc_gateway) or tokens without an actor ID
       // get a minimal guardian context so downstream code has something.
@@ -611,13 +611,13 @@ export async function handleSendMessage(
   // Resolve guardian context from AuthContext for the legacy path too.
   let guardianContext: import('../../daemon/session-runtime-assembly.js').TrustContext;
   if (authContext.actorPrincipalId) {
-    const legacyGuardianCtx = resolveGuardianContext({
+    const legacyGuardianCtx = resolveTrustContext({
       assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
       sourceChannel: 'vellum',
       conversationExternalId: 'local',
       actorExternalId: authContext.actorPrincipalId,
     });
-    guardianContext = toGuardianRuntimeContext(sourceChannel, legacyGuardianCtx);
+    guardianContext = withSourceChannel(sourceChannel, legacyGuardianCtx);
   } else {
     guardianContext = { trustClass: 'guardian' as const, sourceChannel };
   }

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -40,9 +40,9 @@ import {
   notifyRequesterOfDeliveryFailure,
   notifyRequesterOfDenial,
 } from './access-request-decision.js';
+import type { TrustContext } from '../../daemon/session-runtime-assembly.js';
 import {
   buildGuardianDenyContext,
-  type GuardianContext,
   parseCallbackData,
 } from './channel-route-shared.js';
 
@@ -57,7 +57,7 @@ export interface ApprovalInterceptionParams {
   actorExternalId?: string;
   replyCallbackUrl: string;
   bearerToken?: string;
-  guardianCtx: GuardianContext;
+  guardianCtx: TrustContext;
   assistantId: string;
   approvalCopyGenerator?: ApprovalCopyGenerator;
   approvalConversationGenerator?: ApprovalConversationGenerator;

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -48,7 +48,7 @@ import {
 } from '../channel-guardian-service.js';
 import { getTransport } from '../channel-invite-transport.js';
 import { deliverChannelReply } from '../gateway-client.js';
-import { resolveGuardianContext, resolveRoutingState } from '../guardian-context-resolver.js';
+import { resolveTrustContext, resolveRoutingState } from '../trust-context-resolver.js';
 import { routeGuardianReply } from '../guardian-reply-router.js';
 import {
   composeChannelVerifyReply,
@@ -66,10 +66,10 @@ import type {
 import { redeemInvite } from '../invite-redemption-service.js';
 import { getInviteRedemptionReply } from '../invite-redemption-templates.js';
 import { deliverReplyViaCallback } from './channel-delivery-routes.js';
+import type { TrustContext } from '../../daemon/session-runtime-assembly.js';
 import {
   canonicalChannelAssistantId,
   GUARDIAN_APPROVAL_TTL_MS,
-  type GuardianContext,
   stripVerificationFailurePrefix,
 } from './channel-route-shared.js';
 import { handleApprovalInterception } from './guardian-approval-interception.js';
@@ -919,7 +919,7 @@ export async function handleChannelInbound(
   // ── Actor role resolution ──
   // Uses shared channel-agnostic resolution so all ingress paths classify
   // guardian vs non-guardian actors the same way.
-  const guardianCtx: GuardianContext = resolveGuardianContext({
+  const guardianCtx: TrustContext = resolveTrustContext({
     assistantId: canonicalAssistantId,
     sourceChannel,
     conversationExternalId,
@@ -1342,7 +1342,7 @@ interface BackgroundProcessingParams {
   sourceChannel: ChannelId;
   sourceInterface: InterfaceId;
   externalChatId: string;
-  guardianCtx: GuardianContext;
+  guardianCtx: TrustContext;
   metadataHints: string[];
   metadataUxBrief?: string;
   replyCallbackUrl?: string;
@@ -1418,7 +1418,7 @@ function startPendingApprovalPromptWatcher(params: {
   conversationId: string;
   sourceChannel: ChannelId;
   externalChatId: string;
-  guardianTrustClass: GuardianContext['trustClass'];
+  guardianTrustClass: TrustContext['trustClass'];
   guardianExternalUserId?: string;
   requesterExternalUserId?: string;
   replyCallbackUrl: string;
@@ -1531,7 +1531,7 @@ function startTrustedContactApprovalNotifier(params: {
   conversationId: string;
   sourceChannel: ChannelId;
   externalChatId: string;
-  guardianTrustClass: GuardianContext['trustClass'];
+  guardianTrustClass: TrustContext['trustClass'];
   guardianExternalUserId?: string;
   replyCallbackUrl: string;
   mintBearerToken: () => string;

--- a/assistant/src/runtime/trust-context-resolver.ts
+++ b/assistant/src/runtime/trust-context-resolver.ts
@@ -1,10 +1,8 @@
 /**
  * Shared inbound trust resolution for channel actors.
  *
- * GuardianContext is a type alias for TrustContext — the
- * canonical runtime trust context used by sessions, tooling, and channel
- * routes. This module re-exports the alias and provides routing-state
- * helpers that operate on the canonical type.
+ * Provides routing-state helpers and a convenience wrapper around
+ * resolveActorTrust that converts the result to a TrustContext.
  *
  * Trust resolution itself lives in actor-trust-resolver.ts; the resolved
  * ActorTrustContext is converted to TrustContext via
@@ -15,25 +13,8 @@ import {
   resolveActorTrust,
   type ResolveActorTrustInput,
   toGuardianRuntimeContextFromTrust,
-  type TrustClass,
 } from './actor-trust-resolver.js';
 export type { DenialReason } from './actor-trust-resolver.js';
-
-/** Trust classification used by route-level channel logic. */
-export type ActorTrustClass = TrustClass;
-
-/**
- * GuardianContext is the canonical runtime trust context.
- *
- * Previously this was a separate interface with extra fields (memberStatus,
- * memberPolicy). Those fields were only needed for InboundActorContext
- * construction, which now sources them directly from ActorTrustContext.
- * This alias unifies the two shapes and removes the redundant conversion
- * layer.
- */
-export type GuardianContext = TrustContext;
-
-export type ResolveGuardianContextInput = ResolveActorTrustInput;
 
 /**
  * Resolve route-level trust context from canonical identity state.
@@ -41,7 +22,7 @@ export type ResolveGuardianContextInput = ResolveActorTrustInput;
  * Delegates to resolveActorTrust for classification, then converts to
  * the canonical TrustContext via toGuardianRuntimeContextFromTrust.
  */
-export function resolveGuardianContext(input: ResolveGuardianContextInput): GuardianContext {
+export function resolveTrustContext(input: ResolveActorTrustInput): TrustContext {
   const trust = resolveActorTrust(input);
   return toGuardianRuntimeContextFromTrust(trust, input.conversationExternalId);
 }
@@ -133,7 +114,7 @@ export function resolveRoutingStateFromRuntime(ctx: TrustContext): RoutingState 
  * (e.g. the channel the gateway routed the request through). This helper
  * copies the context with the caller-supplied sourceChannel.
  */
-export function toGuardianRuntimeContext(
+export function withSourceChannel(
   sourceChannel: import('../channels/types.js').ChannelId,
   ctx: TrustContext,
 ): TrustContext {

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -437,7 +437,7 @@ flowchart TD
 
     ESCALATE_CHECK -- No --> VERIFY_CHECK{"Guardian verify<br/>code?"}
     VERIFY_CHECK -- Yes --> VERIFY["Validate challenge<br/>→ create guardian binding"]
-    VERIFY_CHECK -- No --> ROLE_RESOLVE["Resolve actor role<br/>(guardian-context-resolver)"]
+    VERIFY_CHECK -- No --> ROLE_RESOLVE["Resolve actor role<br/>(trust-context-resolver)"]
     ROLE_RESOLVE --> APPROVAL_INTERCEPT["Approval interception<br/>+ message processing"]
 ```
 
@@ -491,7 +491,7 @@ The `channelGuardianApprovalRequests` table tracks per-run approval state. Each 
 |--------|---------|
 | `assistant/src/memory/channel-guardian-store.ts` | CRUD for guardian bindings, verification challenges, and approval requests (all scoped by `assistantId`) |
 | `assistant/src/runtime/channel-guardian-service.ts` | Challenge creation/validation, guardian identity checks (`isGuardian()`, `getGuardianBinding()`) -- all accept `assistantId` |
-| `assistant/src/runtime/guardian-context-resolver.ts` | Actor role classification: guardian / non-guardian / unverified_channel based on binding state + sender identity |
+| `assistant/src/runtime/trust-context-resolver.ts` | Actor role classification: guardian / non-guardian / unverified_channel based on binding state + sender identity |
 | `assistant/src/runtime/routes/inbound-message-handler.ts` | Ingress ACL enforcement, verification-code intercept, escalation creation, actor role resolution |
 | `assistant/src/runtime/routes/channel-routes.ts` | Approval routing to guardian, proactive expiry sweep (`sweepExpiredGuardianApprovals`, `startGuardianExpirySweep`) |
 | `assistant/src/calls/guardian-dispatch.ts` | Cross-channel ASK_GUARDIAN dispatch: creates guardian_action_requests, fans out to mac/telegram/sms, manages deliveries |


### PR DESCRIPTION
## Summary
- Rename `guardian-context-resolver.ts` → `trust-context-resolver.ts`
- Remove type aliases: `GuardianContext`, `ResolveGuardianContextInput`, `ActorTrustClass`
- Rename functions: `resolveGuardianContext` → `resolveTrustContext`, `toGuardianRuntimeContext` → `withSourceChannel`
- Update all import paths and consumer references across the codebase

Part of plan: trust-class-rename-cleanup.md (PR 7 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11878" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
