### PR TITLE
refactor: rename remaining guardian-prefixed conversion functions

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -18,7 +18,7 @@ This document owns assistant-runtime architecture details. The repo-level archit
 - The same resolver is used by:
   - `/channels/inbound` (Telegram/SMS/WhatsApp path) before run orchestration.
   - Inbound Twilio voice setup (`RelayConnection.handleSetup`) to seed call-time actor context.
-- Runtime channel runs pass this as `guardianContext`, and session runtime assembly injects `<inbound_actor_context>` (via `inboundActorContextFromGuardian()`) into provider-facing prompts.
+- Runtime channel runs pass this as `guardianContext`, and session runtime assembly injects `<inbound_actor_context>` (via `inboundActorContextFromTrustContext()`) into provider-facing prompts.
 - Voice calls mirror the same prompt contract: `CallController` receives guardian context on setup and refreshes it immediately after successful voice challenge verification, so the first post-verification turn is grounded as `actor_role: guardian`.
 - Voice-specific behavior (DTMF/speech verification flow, relay state machine) remains voice-local; only actor-role resolution is shared.
 

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -23,7 +23,7 @@ import { emitNotificationSignal } from '../notifications/emit-signal.js';
 import { notifyGuardianOfAccessRequest } from '../runtime/access-request-helper.js';
 import {
   resolveActorTrust,
-  toGuardianRuntimeContextFromTrust,
+  toTrustContext,
 } from '../runtime/actor-trust-resolver.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import {
@@ -515,7 +515,7 @@ export class RelayConnection {
       conversationExternalId: otherPartyNumber,
       actorExternalId: otherPartyNumber || undefined,
     });
-    const initialGuardianContext = toGuardianRuntimeContextFromTrust(initialActorTrust, otherPartyNumber);
+    const initialGuardianContext = toTrustContext(initialActorTrust, otherPartyNumber);
 
     const controller = new CallController(this.callSessionId, this, session?.task ?? null, {
       broadcast: globalBroadcast,
@@ -718,7 +718,7 @@ export class RelayConnection {
       // Update the controller's guardian context with the trust-resolved
       // context so downstream policy gates have accurate actor metadata.
       if (this.controller && actorTrust.trustClass !== 'unknown') {
-        const resolvedGuardianContext = toGuardianRuntimeContextFromTrust(actorTrust, msg.from);
+        const resolvedGuardianContext = toTrustContext(actorTrust, msg.from);
         this.controller.setGuardianContext(resolvedGuardianContext);
       }
 
@@ -830,7 +830,7 @@ export class RelayConnection {
 
     if (this.controller) {
       this.controller.setGuardianContext(
-        toGuardianRuntimeContextFromTrust(updatedTrust, fromNumber),
+        toTrustContext(updatedTrust, fromNumber),
       );
     }
 
@@ -1054,7 +1054,7 @@ export class RelayConnection {
             actorExternalId: this.guardianVerificationFromNumber,
           });
           this.controller.setGuardianContext(
-            toGuardianRuntimeContextFromTrust(verifiedActorTrust, this.guardianVerificationFromNumber),
+            toTrustContext(verifiedActorTrust, this.guardianVerificationFromNumber),
           );
           this.startNormalCallFlow(this.controller, true);
         }

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -60,7 +60,7 @@ import type { QueueDrainReason } from './session-queue-manager.js';
 import type { ActiveSurfaceContext, ChannelCapabilities, ChannelTurnContextParams, TrustContext, InboundActorContext, InterfaceTurnContextParams } from './session-runtime-assembly.js';
 import {
   applyRuntimeInjections,
-  inboundActorContextFromGuardian,
+  inboundActorContextFromTrustContext,
   inboundActorContextFromTrust,
   stripInjectedContext,
 } from './session-runtime-assembly.js';
@@ -433,7 +433,7 @@ export async function runAgentLoopImpl(
         });
         resolvedInboundActorContext = inboundActorContextFromTrust(actorTrust);
       } else {
-        resolvedInboundActorContext = inboundActorContextFromGuardian(gc);
+        resolvedInboundActorContext = inboundActorContextFromTrustContext(gc);
       }
     }
 

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -92,7 +92,7 @@ export interface InboundActorContext {
  *
  * Maps the runtime trust class into the model-facing inbound actor context.
  */
-export function inboundActorContextFromGuardian(
+export function inboundActorContextFromTrustContext(
   ctx: TrustContext,
 ): InboundActorContext {
   return {

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -203,14 +203,14 @@ export function resolveActorTrust(input: ResolveActorTrustInput): ActorTrustCont
 }
 
 /**
- * Convert an ActorTrustContext into the runtime trust context shape used by
+ * Convert an ActorTrustContext into the runtime TrustContext shape used by
  * sessions/tooling.
  *
  * This is the single canonical conversion from resolved trust to runtime
  * context. The guardianExternalUserId is canonicalized to handle phone-
  * channel formatting variance (e.g. stored binding vs E.164).
  */
-export function toGuardianRuntimeContextFromTrust(
+export function toTrustContext(
   ctx: ActorTrustContext,
   conversationExternalId: string,
 ): TrustContext {

--- a/assistant/src/runtime/trust-context-resolver.ts
+++ b/assistant/src/runtime/trust-context-resolver.ts
@@ -6,13 +6,13 @@
  *
  * Trust resolution itself lives in actor-trust-resolver.ts; the resolved
  * ActorTrustContext is converted to TrustContext via
- * toGuardianRuntimeContextFromTrust.
+ * toTrustContext.
  */
 import type { TrustContext } from '../daemon/session-runtime-assembly.js';
 import {
   resolveActorTrust,
   type ResolveActorTrustInput,
-  toGuardianRuntimeContextFromTrust,
+  toTrustContext,
 } from './actor-trust-resolver.js';
 export type { DenialReason } from './actor-trust-resolver.js';
 
@@ -20,11 +20,11 @@ export type { DenialReason } from './actor-trust-resolver.js';
  * Resolve route-level trust context from canonical identity state.
  *
  * Delegates to resolveActorTrust for classification, then converts to
- * the canonical TrustContext via toGuardianRuntimeContextFromTrust.
+ * the canonical TrustContext via toTrustContext.
  */
 export function resolveTrustContext(input: ResolveActorTrustInput): TrustContext {
   const trust = resolveActorTrust(input);
-  return toGuardianRuntimeContextFromTrust(trust, input.conversationExternalId);
+  return toTrustContext(trust, input.conversationExternalId);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Rename `inboundActorContextFromGuardian` → `inboundActorContextFromTrustContext` in session-runtime-assembly.ts (avoids collision with existing `inboundActorContextFromTrust` which takes `ActorTrustContext`)
- Rename `toGuardianRuntimeContextFromTrust` → `toTrustContext` in actor-trust-resolver.ts
- Update all imports and call sites across the codebase (session-agent-loop.ts, trust-context-resolver.ts, relay-server.ts, ARCHITECTURE.md)

Part of plan: trust-class-rename-cleanup.md (PR 9 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
