### PR TITLE
docs: add comprehensive JSDoc to trust system types and functions

### DIFF
--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -38,20 +38,49 @@ export interface ChannelCapabilities {
   microphonePermissionGranted?: boolean;
 }
 
-/** Identity and trust context for external chat channels. */
+/**
+ * Runtime trust context for an inbound actor session.
+ *
+ * Carries the resolved trust classification, guardian binding metadata, and
+ * requester identity for the current session. This is the canonical trust
+ * shape used by sessions, tool execution, memory gating, and channel routing.
+ *
+ * Produced by {@link resolveActorTrust} -> {@link toTrustContext}, or by
+ * the convenience wrapper {@link resolveTrustContext}.
+ *
+ * The `trustClass` field determines the actor's permission level:
+ * - `'guardian'`: full access, self-approves tool invocations
+ * - `'trusted_contact'`: can invoke tools, sensitive ops require guardian approval
+ * - `'unknown'`: fail-closed, no escalation
+ *
+ * Guardian-specific fields (`guardianChatId`, `guardianExternalUserId`,
+ * `guardianPrincipalId`) describe the guardian binding for this channel,
+ * NOT the current actor (unless the actor IS the guardian).
+ */
 export interface TrustContext {
+  /** Channel through which the inbound message arrived. */
   sourceChannel: ChannelId;
+  /** Trust classification -- see {@link TrustClass} for semantics. */
   trustClass: "guardian" | "trusted_contact" | "unknown";
+  /** Chat/conversation ID for delivering guardian notifications. */
   guardianChatId?: string;
+  /** Canonical external user ID of the guardian for this (assistant, channel) binding. */
   guardianExternalUserId?: string;
-  /** Canonical principal ID for the guardian binding. */
+  /** Internal principal ID of the guardian. */
   guardianPrincipalId?: string;
+  /** Human-readable identifier for the requester (e.g. @username or phone number). */
   requesterIdentifier?: string;
+  /** Preferred display name for the requester (member name or sender name). */
   requesterDisplayName?: string;
+  /** Raw sender display name as provided by the channel transport. */
   requesterSenderDisplayName?: string;
+  /** Guardian-managed member display name from ingress membership. */
   requesterMemberDisplayName?: string;
+  /** Canonical external user ID of the requester (the current actor). */
   requesterExternalUserId?: string;
+  /** Chat/conversation ID the requester is interacting through. */
   requesterChatId?: string;
+  /** Access denial reason, if applicable. See {@link DenialReason}. */
   denialReason?: "no_binding" | "no_identity";
 }
 

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -55,8 +55,13 @@ const log = getLogger("session-tool-setup");
 
 /**
  * Resolve the effective trust class for tool execution.
- * When HTTP auth is disabled (dev bypass), always treat the actor as
- * guardian so that control-plane gates don't block local development.
+ *
+ * When HTTP auth is disabled (dev bypass), always returns `'guardian'`
+ * so that control-plane gates don't block local development.
+ *
+ * When no trust context is available (e.g. desktop-only sessions that
+ * don't go through channel trust resolution), defaults to `'unknown'`
+ * to fail-closed.
  */
 export function resolveTrustClass(
   trustContext: TrustContext | undefined,

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -52,7 +52,12 @@ export const messageMetadataSchema = z
     userMessageInterface: interfaceIdSchema.optional(),
     assistantMessageInterface: interfaceIdSchema.optional(),
     subagentNotification: subagentNotificationSchema.optional(),
-    // Provenance fields for trust-aware memory gating (M3)
+    /**
+     * Trust class of the actor at the time this message was persisted.
+     * This is a durable snapshot -- it does NOT change if the actor's
+     * trust status changes later. Used by the memory write gate (indexer)
+     * and read gate (session history loading) to enforce trust-aware access.
+     */
     provenanceTrustClass: z
       .enum(["guardian", "trusted_contact", "unknown"])
       .optional(),

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -2,6 +2,7 @@ import { createHash } from 'crypto';
 import { desc, eq } from 'drizzle-orm';
 
 import type { MemoryConfig } from '../config/types.js';
+import type { TrustClass } from '../runtime/actor-trust-resolver.js';
 import { getLogger } from '../util/logger.js';
 import { getMemoryCheckpoint, setMemoryCheckpoint } from './checkpoints.js';
 import { getDb } from './db.js';
@@ -22,8 +23,13 @@ export interface IndexMessageInput {
   content: string;
   createdAt: number;
   scopeId?: string;
-  // Provenance for trust-aware extraction gating (M3)
-  provenanceTrustClass?: 'guardian' | 'trusted_contact' | 'unknown';
+  /**
+   * Trust class of the actor who produced this message, captured at
+   * persist time. When `'guardian'` or `undefined` (legacy), extraction
+   * and conflict resolution jobs run. Otherwise, the message is segmented
+   * and embedded but no profile mutations are triggered.
+   */
+  provenanceTrustClass?: TrustClass;
 }
 
 export interface IndexMessageResult {

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -26,9 +26,40 @@ export type { TrustContext } from '../daemon/session-runtime-assembly.js';
 // Types
 // ---------------------------------------------------------------------------
 
+/**
+ * Trust classification for an inbound actor.
+ *
+ * - `'guardian'`: The sender matches the active guardian binding for this
+ *   (assistant, channel). Guardians have full control-plane access and
+ *   self-approve tool invocations.
+ * - `'trusted_contact'`: The sender is an active ingress member (not the
+ *   guardian). Trusted contacts can invoke tools but require guardian
+ *   approval for sensitive operations.
+ * - `'unknown'`: The sender has no member record, no identity could be
+ *   established, or the sender is an inactive/revoked member. Unknown
+ *   actors are fail-closed with no escalation path.
+ */
 export type TrustClass = 'guardian' | 'trusted_contact' | 'unknown';
+/**
+ * Reason an actor was denied access during trust resolution.
+ *
+ * - `'no_binding'`: No guardian binding exists for this (assistant, channel),
+ *   so trust cannot be established for any actor.
+ * - `'no_identity'`: The inbound message carried no usable identity fields
+ *   (e.g. missing external user ID), so the sender could not be identified.
+ */
 export type DenialReason = 'no_binding' | 'no_identity';
 
+/**
+ * Fully resolved trust context from the actor trust resolver.
+ *
+ * This is the intermediate representation between raw inbound identity
+ * fields ({@link ResolveActorTrustInput}) and the runtime trust context
+ * ({@link TrustContext}). It carries the full resolution state including
+ * canonical identity, guardian binding match, member record, and trust
+ * classification. Convert to `TrustContext` via {@link toTrustContext}
+ * for use in sessions and tooling.
+ */
 export interface ActorTrustContext {
   /** Canonical (normalized) sender identity. Null when identity could not be established. */
   canonicalSenderId: string | null;
@@ -57,6 +88,11 @@ export interface ActorTrustContext {
   denialReason?: DenialReason;
 }
 
+/**
+ * Raw identity fields from an inbound channel message, used as input to
+ * {@link resolveActorTrust}. These are the channel-agnostic identity
+ * signals available at message ingress before any trust resolution.
+ */
 export interface ResolveActorTrustInput {
   assistantId: string;
   sourceChannel: ChannelId;

--- a/assistant/src/runtime/trust-context-resolver.ts
+++ b/assistant/src/runtime/trust-context-resolver.ts
@@ -1,12 +1,13 @@
 /**
  * Shared inbound trust resolution for channel actors.
  *
- * Provides routing-state helpers and a convenience wrapper around
- * resolveActorTrust that converts the result to a TrustContext.
+ * Provides routing-state helpers and a convenience wrapper
+ * ({@link resolveTrustContext}) around {@link resolveActorTrust} that
+ * converts the result to a {@link TrustContext}.
  *
- * Trust resolution itself lives in actor-trust-resolver.ts; the resolved
- * ActorTrustContext is converted to TrustContext via
- * toTrustContext.
+ * Trust resolution itself lives in `actor-trust-resolver.ts`; the resolved
+ * {@link ActorTrustContext} is converted to {@link TrustContext} via
+ * {@link toTrustContext}.
  */
 import type { TrustContext } from '../daemon/session-runtime-assembly.js';
 import {

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -1,6 +1,7 @@
 import type { SecretPromptResult } from '../permissions/secret-prompter.js';
 import type { AllowlistOption, RiskLevel, ScopeOption } from '../permissions/types.js';
 import type { ContentBlock,ToolDefinition } from '../providers/types.js';
+import type { TrustClass } from '../runtime/actor-trust-resolver.js';
 import type { SensitiveOutputBinding } from './sensitive-output-placeholders.js';
 
 export type ExecutionTarget = 'sandbox' | 'host';
@@ -137,8 +138,13 @@ export interface ToolContext {
   proxyApprovalCallback?: import('./network/script-proxy/types.js').ProxyApprovalCallback;
   /** Optional principal identifier propagated to sub-tool confirmation flows. */
   principal?: string;
-  /** Inbound trust classification for the session — used by trust/policy gates. */
-  trustClass: 'guardian' | 'trusted_contact' | 'unknown';
+  /**
+   * Trust classification of the actor who initiated this tool invocation.
+   * Determines permission level: guardians self-approve, trusted contacts
+   * may escalate to guardian for approval, unknown actors are fail-closed.
+   * See {@link TrustClass} in actor-trust-resolver.ts for value semantics.
+   */
+  trustClass: TrustClass;
   /** Channel through which the tool invocation originates (e.g. 'telegram', 'voice'). Used for scoped grant consumption. */
   executionChannel?: string;
   /** Voice/call session ID, if the invocation originates from a call. Used for scoped grant consumption. */


### PR DESCRIPTION
## Summary
- Add detailed JSDoc comments to all trust-related types: TrustClass, DenialReason, ActorTrustContext, ResolveActorTrustInput, TrustContext
- Add inline field-level JSDoc to all TrustContext fields
- Improve JSDoc on resolveTrustClass, trustClass in ToolContext, and provenanceTrustClass in memory schema
- Replace inline union types with TrustClass import where applicable

Part of plan: trust-class-rename-cleanup.md (PR 11 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
