### PR TITLE
fix: rename toGuardianRuntimeContextFromTrust → toTrustContext in relay-server

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -23,7 +23,7 @@ import { emitNotificationSignal } from '../notifications/emit-signal.js';
 import { notifyGuardianOfAccessRequest } from '../runtime/access-request-helper.js';
 import {
   resolveActorTrust,
-  toGuardianRuntimeContextFromTrust,
+  toTrustContext,
 } from '../runtime/actor-trust-resolver.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import {
@@ -515,7 +515,7 @@ export class RelayConnection {
       conversationExternalId: otherPartyNumber,
       actorExternalId: otherPartyNumber || undefined,
     });
-    const initialTrustContext = toGuardianRuntimeContextFromTrust(initialActorTrust, otherPartyNumber);
+    const initialTrustContext = toTrustContext(initialActorTrust, otherPartyNumber);
 
     const controller = new CallController(this.callSessionId, this, session?.task ?? null, {
       broadcast: globalBroadcast,
@@ -718,7 +718,7 @@ export class RelayConnection {
       // Update the controller's guardian context with the trust-resolved
       // context so downstream policy gates have accurate actor metadata.
       if (this.controller && actorTrust.trustClass !== 'unknown') {
-        const resolvedTrustContext = toGuardianRuntimeContextFromTrust(actorTrust, msg.from);
+        const resolvedTrustContext = toTrustContext(actorTrust, msg.from);
         this.controller.setTrustContext(resolvedTrustContext);
       }
 
@@ -830,7 +830,7 @@ export class RelayConnection {
 
     if (this.controller) {
       this.controller.setTrustContext(
-        toGuardianRuntimeContextFromTrust(updatedTrust, fromNumber),
+        toTrustContext(updatedTrust, fromNumber),
       );
     }
 
@@ -1054,7 +1054,7 @@ export class RelayConnection {
             actorExternalId: this.guardianVerificationFromNumber,
           });
           this.controller.setTrustContext(
-            toGuardianRuntimeContextFromTrust(verifiedActorTrust, this.guardianVerificationFromNumber),
+            toTrustContext(verifiedActorTrust, this.guardianVerificationFromNumber),
           );
           this.startNormalCallFlow(this.controller, true);
         }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for trust-class-rename-cleanup.md.

**Gap:** relay-server.ts still uses old function name
**What was expected:** Should use `toTrustContext` after PR 9 renamed it
**What was found:** Still importing and using `toGuardianRuntimeContextFromTrust`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
