### PR TITLE
fix: restore inboundActorContextFromTrustContext rename in session-agent-loop

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -18,7 +18,7 @@ This document owns assistant-runtime architecture details. The repo-level archit
 - The same resolver is used by:
   - `/channels/inbound` (Telegram/SMS/WhatsApp path) before run orchestration.
   - Inbound Twilio voice setup (`RelayConnection.handleSetup`) to seed call-time actor context.
-- Runtime channel runs pass this as `trustContext`, and session runtime assembly injects `<inbound_actor_context>` (via `inboundActorContextFromGuardian()`) into provider-facing prompts.
+- Runtime channel runs pass this as `trustContext`, and session runtime assembly injects `<inbound_actor_context>` (via `inboundActorContextFromTrustContext()`) into provider-facing prompts.
 - Voice calls mirror the same prompt contract: `CallController` receives guardian context on setup and refreshes it immediately after successful voice challenge verification, so the first post-verification turn is grounded as `actor_role: guardian`.
 - Voice-specific behavior (DTMF/speech verification flow, relay state machine) remains voice-local; only actor-role resolution is shared.
 

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -60,7 +60,7 @@ import type { QueueDrainReason } from './session-queue-manager.js';
 import type { ActiveSurfaceContext, ChannelCapabilities, ChannelTurnContextParams, TrustContext, InboundActorContext, InterfaceTurnContextParams } from './session-runtime-assembly.js';
 import {
   applyRuntimeInjections,
-  inboundActorContextFromGuardian,
+  inboundActorContextFromTrustContext,
   inboundActorContextFromTrust,
   stripInjectedContext,
 } from './session-runtime-assembly.js';
@@ -433,7 +433,7 @@ export async function runAgentLoopImpl(
         });
         resolvedInboundActorContext = inboundActorContextFromTrust(actorTrust);
       } else {
-        resolvedInboundActorContext = inboundActorContextFromGuardian(gc);
+        resolvedInboundActorContext = inboundActorContextFromTrustContext(gc);
       }
     }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for trust-class-rename-cleanup.md.

**Gap:** session-agent-loop.ts reverted to old function name
**What was expected:** Should use `inboundActorContextFromTrustContext` after PR 9
**What was found:** PR 8 reverted to `inboundActorContextFromGuardian` during merge conflict

Also fixes a stale reference in `assistant/ARCHITECTURE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
