### PR TITLE
fix: consolidate GuardianTrustClass alias to canonical TrustClass import

### DIFF
--- a/assistant/src/daemon/session-lifecycle.ts
+++ b/assistant/src/daemon/session-lifecycle.ts
@@ -19,14 +19,12 @@ import { repairHistory } from './history-repair.js';
 import type { SurfaceData,SurfaceType, UsageStats } from './ipc-protocol.js';
 import { unregisterCallNotifiers,unregisterWatchNotifiers } from './session-notifiers.js';
 import type { MessageQueue } from './session-queue-manager.js';
-import type { TrustContext } from './session-runtime-assembly.js';
+import type { TrustClass } from '../runtime/actor-trust-resolver.js';
 import { resetSkillToolProjection } from './session-skill-tools.js';
 
 const log = getLogger('session-lifecycle');
 
-type GuardianTrustClass = TrustContext['trustClass'];
-
-function parseProvenanceTrustClass(metadata: string | null): GuardianTrustClass | undefined {
+function parseProvenanceTrustClass(metadata: string | null): TrustClass | undefined {
   if (!metadata) return undefined;
   try {
     const parsed = JSON.parse(metadata) as { provenanceTrustClass?: unknown };
@@ -40,7 +38,7 @@ function parseProvenanceTrustClass(metadata: string | null): GuardianTrustClass 
   return undefined;
 }
 
-function isUntrustedTrustClass(trustClass: GuardianTrustClass | undefined): boolean {
+function isUntrustedTrustClass(trustClass: TrustClass | undefined): boolean {
   return trustClass === 'trusted_contact' || trustClass === 'unknown';
 }
 
@@ -59,8 +57,8 @@ export interface LoadFromDbContext {
   usageStats: UsageStats;
   contextCompactedMessageCount: number;
   contextCompactedAt: number | null;
-  trustContext?: { trustClass: GuardianTrustClass };
-  loadedHistoryTrustClass?: GuardianTrustClass;
+  trustContext?: { trustClass: TrustClass };
+  loadedHistoryTrustClass?: TrustClass;
 }
 
 export interface AbortContext {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for trust-class-rename-cleanup.md.

**Gap:** Local GuardianTrustClass alias not consolidated
**What was expected:** Should use canonical `TrustClass` import
**What was found:** session-lifecycle.ts still had local `type GuardianTrustClass = TrustContext['trustClass']`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
