### PR TITLE
fix: complete trust context rename across tests and production code

### DIFF
--- a/assistant/src/__tests__/account-registry.test.ts
+++ b/assistant/src/__tests__/account-registry.test.ts
@@ -45,7 +45,7 @@ const _ctx: ToolContext = {
   workingDir: "/tmp",
   sessionId: "test-session",
   conversationId: "test-conv",
-  guardianTrustClass: "guardian",
+  trustClass: "guardian",
 };
 
 afterAll(() => {

--- a/assistant/src/__tests__/app-builder-tool-scripts.test.ts
+++ b/assistant/src/__tests__/app-builder-tool-scripts.test.ts
@@ -53,7 +53,7 @@ function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
     workingDir: "/tmp",
     sessionId: "session-1",
     conversationId: "conv-1",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/asset-materialize-tool.test.ts
+++ b/assistant/src/__tests__/asset-materialize-tool.test.ts
@@ -79,7 +79,7 @@ const dummyContext: ToolContext = {
   workingDir: sandboxDir,
   sessionId: "sess-test",
   conversationId: "conv-test",
-  guardianTrustClass: "guardian",
+  trustClass: "guardian",
 };
 
 // ---------------------------------------------------------------------------
@@ -357,7 +357,7 @@ describe("AssetMaterializeTool visibility policy", () => {
       workingDir: sandboxDir,
       sessionId: "sess-test",
       conversationId: otherConv.id,
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     const result = await assetMaterializeTool.execute(
@@ -387,7 +387,7 @@ describe("AssetMaterializeTool visibility policy", () => {
       workingDir: sandboxDir,
       sessionId: "sess-test",
       conversationId: privateConv.id,
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     const result = await assetMaterializeTool.execute(
@@ -418,7 +418,7 @@ describe("AssetMaterializeTool visibility policy", () => {
       workingDir: sandboxDir,
       sessionId: "sess-test",
       conversationId: otherConv.id,
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     const result = await assetMaterializeTool.execute(
@@ -450,7 +450,7 @@ describe("AssetMaterializeTool visibility policy", () => {
       workingDir: sandboxDir,
       sessionId: "sess-test",
       conversationId: standardConv.id,
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     const result = await assetMaterializeTool.execute(
@@ -487,7 +487,7 @@ describe("AssetMaterializeTool visibility policy", () => {
       workingDir: sandboxDir,
       sessionId: "sess-test",
       conversationId: privateConv2.id,
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     const result = await assetMaterializeTool.execute(
@@ -522,7 +522,7 @@ describe("AssetMaterializeTool visibility policy", () => {
       workingDir: sandboxDir,
       sessionId: "sess-test",
       conversationId: otherConv.id,
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     const result = await assetMaterializeTool.execute(

--- a/assistant/src/__tests__/asset-search-tool.test.ts
+++ b/assistant/src/__tests__/asset-search-tool.test.ts
@@ -104,7 +104,7 @@ const dummyContext: ToolContext = {
   workingDir: "/tmp",
   sessionId: "sess-test",
   conversationId: "conv-test",
-  guardianTrustClass: "guardian",
+  trustClass: "guardian",
 };
 
 // ---------------------------------------------------------------------------
@@ -424,7 +424,7 @@ describe("AssetSearchTool visibility policy", () => {
       workingDir: "/tmp",
       sessionId: "sess-test",
       conversationId: otherConv.id,
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     const result = await assetSearchTool.execute({}, context);
@@ -446,7 +446,7 @@ describe("AssetSearchTool visibility policy", () => {
       workingDir: "/tmp",
       sessionId: "sess-test",
       conversationId: privateConv.id,
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     const result = await assetSearchTool.execute({}, context);
@@ -472,7 +472,7 @@ describe("AssetSearchTool visibility policy", () => {
       workingDir: "/tmp",
       sessionId: "sess-test",
       conversationId: otherPrivateConv.id,
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     const result = await assetSearchTool.execute({}, context);
@@ -495,7 +495,7 @@ describe("AssetSearchTool visibility policy", () => {
       workingDir: "/tmp",
       sessionId: "sess-test",
       conversationId: standardConv.id,
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     const result = await assetSearchTool.execute({}, context);
@@ -522,7 +522,7 @@ describe("AssetSearchTool visibility policy", () => {
       workingDir: "/tmp",
       sessionId: "sess-test",
       conversationId: otherConv.id,
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     const result = await assetSearchTool.execute({}, context);
@@ -538,7 +538,7 @@ describe("AssetSearchTool visibility policy", () => {
       workingDir: "/tmp",
       sessionId: "sess-test",
       conversationId: conv.id,
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     const result = await assetSearchTool.execute({}, context);

--- a/assistant/src/__tests__/browser-fill-credential.test.ts
+++ b/assistant/src/__tests__/browser-fill-credential.test.ts
@@ -83,7 +83,7 @@ const ctx: ToolContext = {
   sessionId: "test-session",
   conversationId: "test-conversation",
   workingDir: "/tmp",
-  guardianTrustClass: "guardian",
+  trustClass: "guardian",
 };
 
 function resetMockPage() {

--- a/assistant/src/__tests__/call-start-guardian-guard.test.ts
+++ b/assistant/src/__tests__/call-start-guardian-guard.test.ts
@@ -45,7 +45,7 @@ function makeContext(): ToolContext {
     sessionId: "session-1",
     conversationId: "conversation-1",
     assistantId: "self",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
   };
 }
 

--- a/assistant/src/__tests__/claude-code-tool-profiles.test.ts
+++ b/assistant/src/__tests__/claude-code-tool-profiles.test.ts
@@ -45,7 +45,7 @@ function makeContext(overrides?: Partial<ToolContext>): ToolContext {
   return {
     sessionId: "test-session",
     workingDir: "/tmp/test",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
     onOutput: () => {},
     ...overrides,
   } as ToolContext;

--- a/assistant/src/__tests__/computer-use-tools.test.ts
+++ b/assistant/src/__tests__/computer-use-tools.test.ts
@@ -36,7 +36,7 @@ const ctx: ToolContext = {
   workingDir: "/tmp",
   sessionId: "test-session",
   conversationId: "test-conversation",
-  guardianTrustClass: "guardian",
+  trustClass: "guardian",
 };
 
 // ── Tool definitions ────────────────────────────────────────────────

--- a/assistant/src/__tests__/contacts-tools.test.ts
+++ b/assistant/src/__tests__/contacts-tools.test.ts
@@ -60,7 +60,7 @@ const ctx: ToolContext = {
   workingDir: "/tmp",
   sessionId: "test-session",
   conversationId: "test-conversation",
-  guardianTrustClass: "guardian",
+  trustClass: "guardian",
 };
 
 function clearContacts(): void {

--- a/assistant/src/__tests__/credential-security-e2e.test.ts
+++ b/assistant/src/__tests__/credential-security-e2e.test.ts
@@ -104,7 +104,7 @@ function makeContext(overrides: Record<string, unknown> = {}) {
     workingDir: "/tmp",
     sessionId: "s1",
     conversationId: "c1",
-    guardianTrustClass: "guardian" as const,
+    trustClass: "guardian" as const,
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -70,7 +70,7 @@ const _ctx: ToolContext = {
   workingDir: "/tmp",
   sessionId: "test-session",
   conversationId: "test-conv",
-  guardianTrustClass: "guardian",
+  trustClass: "guardian",
 };
 
 afterAll(() => {

--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -77,7 +77,7 @@ const _ctx: ToolContext = {
   workingDir: "/tmp",
   sessionId: "test-session",
   conversationId: "test-conv",
-  guardianTrustClass: "guardian",
+  trustClass: "guardian",
 };
 
 // We'll manually instantiate the tool for testing

--- a/assistant/src/__tests__/delete-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/delete-managed-skill-tool.test.ts
@@ -36,7 +36,7 @@ function makeContext(): ToolContext {
     workingDir: "/tmp",
     sessionId: "test-session",
     conversationId: "test-conversation",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
   };
 }
 

--- a/assistant/src/__tests__/file-edit-tool.test.ts
+++ b/assistant/src/__tests__/file-edit-tool.test.ts
@@ -25,7 +25,7 @@ function makeContext(workingDir: string): ToolContext {
     workingDir,
     sessionId: "test-session",
     conversationId: "test-conversation",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
   };
 }
 

--- a/assistant/src/__tests__/file-read-tool.test.ts
+++ b/assistant/src/__tests__/file-read-tool.test.ts
@@ -25,7 +25,7 @@ function makeContext(workingDir: string): ToolContext {
     workingDir,
     sessionId: "test-session",
     conversationId: "test-conversation",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
   };
 }
 

--- a/assistant/src/__tests__/file-write-tool.test.ts
+++ b/assistant/src/__tests__/file-write-tool.test.ts
@@ -26,7 +26,7 @@ function makeContext(workingDir: string): ToolContext {
     workingDir,
     sessionId: "test-session",
     conversationId: "test-conversation",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
   };
 }
 

--- a/assistant/src/__tests__/followup-tools.test.ts
+++ b/assistant/src/__tests__/followup-tools.test.ts
@@ -60,7 +60,7 @@ const ctx: ToolContext = {
   workingDir: "/tmp",
   sessionId: "test-session",
   conversationId: "test-conversation",
-  guardianTrustClass: "guardian",
+  trustClass: "guardian",
 };
 
 function clearFollowups(): void {

--- a/assistant/src/__tests__/guardian-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/guardian-control-plane-policy.test.ts
@@ -118,7 +118,7 @@ function makeContext(overrides?: Partial<ToolContext>): ToolContext {
     workingDir: "/tmp/project",
     sessionId: "session-1",
     conversationId: "conversation-1",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
     ...overrides,
   };
 }
@@ -607,7 +607,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
         command:
           "curl -X POST http://localhost:3000/v1/integrations/guardian/outbound/start",
       },
-      makeContext({ guardianTrustClass: "trusted_contact" }),
+      makeContext({ trustClass: "trusted_contact" }),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("restricted to guardian users");
@@ -618,7 +618,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
     const result = await executor.execute(
       "network_request",
       { url: "https://api.example.com/v1/integrations/guardian/challenge" },
-      makeContext({ guardianTrustClass: "unknown" }),
+      makeContext({ trustClass: "unknown" }),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("restricted to guardian users");
@@ -632,7 +632,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
         command:
           "curl -X POST http://localhost:3000/v1/integrations/guardian/outbound/start",
       },
-      makeContext({ guardianTrustClass: "guardian" }),
+      makeContext({ trustClass: "guardian" }),
     );
     expect(result.isError).toBe(false);
     expect(result.content).toBe("ok");
@@ -643,7 +643,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
     const result = await executor.execute(
       "bash",
       { command: "curl http://localhost:3000/v1/integrations/guardian/status" },
-      makeContext(), // defaults to guardianTrustClass: 'guardian'
+      makeContext(), // defaults to trustClass: 'guardian'
     );
     expect(result.isError).toBe(false);
     expect(result.content).toBe("ok");
@@ -654,7 +654,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
     const result = await executor.execute(
       "bash",
       { command: "curl http://localhost:3000/v1/messages" },
-      makeContext({ guardianTrustClass: "trusted_contact" }),
+      makeContext({ trustClass: "trusted_contact" }),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("requires guardian approval");
@@ -665,7 +665,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
     const result = await executor.execute(
       "file_read",
       { path: "README.md" },
-      makeContext({ guardianTrustClass: "trusted_contact" }),
+      makeContext({ trustClass: "trusted_contact" }),
     );
     expect(result.isError).toBe(false);
     expect(result.content).toBe("ok");
@@ -681,7 +681,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
           "curl http://localhost:3000/v1/integrations/guardian/outbound/cancel",
       },
       makeContext({
-        guardianTrustClass: "trusted_contact",
+        trustClass: "trusted_contact",
         onToolLifecycleEvent: (event: ToolLifecycleEvent) => {
           if (event.type === "permission_denied") {
             capturedEvent = event as ToolPermissionDeniedEvent;
@@ -699,7 +699,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
     const result = await executor.execute(
       "web_fetch",
       { url: "http://localhost:3000/v1/integrations/guardian/outbound/resend" },
-      makeContext({ guardianTrustClass: "trusted_contact" }),
+      makeContext({ trustClass: "trusted_contact" }),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("restricted to guardian users");
@@ -710,7 +710,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
     const result = await executor.execute(
       "browser_navigate",
       { url: "http://localhost:3000/v1/integrations/guardian/status" },
-      makeContext({ guardianTrustClass: "trusted_contact" }),
+      makeContext({ trustClass: "trusted_contact" }),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("restricted to guardian users");
@@ -724,7 +724,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
         command:
           "curl -X POST https://internal:8080/v1/integrations/guardian/challenge",
       },
-      makeContext({ guardianTrustClass: "trusted_contact" }),
+      makeContext({ trustClass: "trusted_contact" }),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("restricted to guardian users");
@@ -744,7 +744,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
       const result = await executor.execute(
         "network_request",
         { url: `https://api.example.com${path}` },
-        makeContext({ guardianTrustClass: "trusted_contact" }),
+        makeContext({ trustClass: "trusted_contact" }),
       );
       expect(result.isError).toBe(true);
       expect(result.content).toContain("restricted to guardian users");
@@ -756,7 +756,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
     const result = await executor.execute(
       "host_file_read",
       { path: "/Users/noaflaherty/.ssh/config" },
-      makeContext({ guardianTrustClass: "trusted_contact" }),
+      makeContext({ trustClass: "trusted_contact" }),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("requires guardian approval");
@@ -767,7 +767,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
     const result = await executor.execute(
       "reminder_create",
       { fire_at: "2026-02-27T12:00:00-05:00", label: "test", message: "hello" },
-      makeContext({ guardianTrustClass: "unknown" }),
+      makeContext({ trustClass: "unknown" }),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("verified channel identity");
@@ -778,7 +778,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
     const result = await executor.execute(
       "reminder_create",
       { fire_at: "2026-02-27T12:00:00-05:00", label: "test", message: "hello" },
-      makeContext({ guardianTrustClass: "guardian" }),
+      makeContext({ trustClass: "guardian" }),
     );
     expect(result.isError).toBe(false);
     expect(result.content).toBe("ok");

--- a/assistant/src/__tests__/guardian-grant-minting.test.ts
+++ b/assistant/src/__tests__/guardian-grant-minting.test.ts
@@ -47,6 +47,7 @@ mock.module("../util/logger.js", () => ({
 
 import { GRANT_TTL_MS } from "../approvals/guardian-decision-primitive.js";
 import type { Session } from "../daemon/session.js";
+import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import {
   createApprovalRequest,
   type GuardianApprovalRequest,
@@ -55,7 +56,6 @@ import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import * as approvalMessageComposer from "../runtime/approval-message-composer.js";
 import * as gatewayClient from "../runtime/gateway-client.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
-import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import { handleApprovalInterception } from "../runtime/routes/guardian-approval-interception.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
 

--- a/assistant/src/__tests__/guardian-routing-state.test.ts
+++ b/assistant/src/__tests__/guardian-routing-state.test.ts
@@ -66,17 +66,17 @@ mock.module("../memory/ingress-member-store.js", () => ({
   upsertMember: () => {},
 }));
 
+import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import * as channelDeliveryStore from "../memory/channel-delivery-store.js";
 import { createBinding } from "../memory/channel-guardian-store.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { channelInboundEvents, messages } from "../memory/schema.js";
 import { sweepFailedEvents } from "../runtime/channel-retry-sweep.js";
-import type { TrustContext } from "../daemon/session-runtime-assembly.js";
+import { handleChannelInbound } from "../runtime/routes/channel-routes.js";
 import {
   resolveRoutingState,
   resolveRoutingStateFromRuntime,
 } from "../runtime/trust-context-resolver.js";
-import { handleChannelInbound } from "../runtime/routes/channel-routes.js";
 
 initializeDb();
 

--- a/assistant/src/__tests__/headless-browser-interactions.test.ts
+++ b/assistant/src/__tests__/headless-browser-interactions.test.ts
@@ -84,7 +84,7 @@ const ctx: ToolContext = {
   sessionId: "test-session",
   conversationId: "test-conversation",
   workingDir: "/tmp",
-  guardianTrustClass: "guardian",
+  trustClass: "guardian",
 };
 
 function resetMockPage() {

--- a/assistant/src/__tests__/headless-browser-navigate.test.ts
+++ b/assistant/src/__tests__/headless-browser-navigate.test.ts
@@ -59,7 +59,7 @@ const ctx: ToolContext = {
   sessionId: "test-session",
   conversationId: "test-conversation",
   workingDir: "/tmp",
-  guardianTrustClass: "guardian",
+  trustClass: "guardian",
 };
 
 function resetMockPage() {

--- a/assistant/src/__tests__/headless-browser-read-tools.test.ts
+++ b/assistant/src/__tests__/headless-browser-read-tools.test.ts
@@ -68,7 +68,7 @@ const ctx: ToolContext = {
   sessionId: "test-session",
   conversationId: "test-conversation",
   workingDir: "/tmp",
-  guardianTrustClass: "guardian",
+  trustClass: "guardian",
 };
 
 function resetMockPage() {

--- a/assistant/src/__tests__/headless-browser-snapshot.test.ts
+++ b/assistant/src/__tests__/headless-browser-snapshot.test.ts
@@ -67,7 +67,7 @@ const ctx: ToolContext = {
   sessionId: "test-session",
   conversationId: "test-conversation",
   workingDir: "/tmp",
-  guardianTrustClass: "guardian",
+  trustClass: "guardian",
 };
 
 function resetMockPage() {

--- a/assistant/src/__tests__/host-file-edit-tool.test.ts
+++ b/assistant/src/__tests__/host-file-edit-tool.test.ts
@@ -13,7 +13,7 @@ function makeContext(): ToolContext {
     workingDir: "/tmp",
     sessionId: "test-session",
     conversationId: "test-conversation",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
   };
 }
 

--- a/assistant/src/__tests__/host-file-read-tool.test.ts
+++ b/assistant/src/__tests__/host-file-read-tool.test.ts
@@ -13,7 +13,7 @@ function makeContext(): ToolContext {
     workingDir: "/tmp",
     sessionId: "test-session",
     conversationId: "test-conversation",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
   };
 }
 

--- a/assistant/src/__tests__/host-file-write-tool.test.ts
+++ b/assistant/src/__tests__/host-file-write-tool.test.ts
@@ -13,7 +13,7 @@ function makeContext(): ToolContext {
     workingDir: "/tmp",
     sessionId: "test-session",
     conversationId: "test-conversation",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
   };
 }
 

--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -78,7 +78,7 @@ function makeContext(): ToolContext {
     workingDir: "/tmp",
     sessionId: "test-session",
     conversationId: "test-conversation",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
   };
 }
 

--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -91,7 +91,7 @@ function makeContext(): ToolContext {
     workingDir: "/tmp",
     sessionId: "test-session",
     conversationId: "test-conversation",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
   };
 }
 

--- a/assistant/src/__tests__/media-reuse-story.e2e.test.ts
+++ b/assistant/src/__tests__/media-reuse-story.e2e.test.ts
@@ -264,7 +264,7 @@ describe("Story E2E: selfie yesterday -> generated image today", () => {
       workingDir: sandboxDir,
       sessionId: "sess-story",
       conversationId: threadB.id,
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     const result = await assetSearchTool.execute(
@@ -283,7 +283,7 @@ describe("Story E2E: selfie yesterday -> generated image today", () => {
       workingDir: sandboxDir,
       sessionId: "sess-story",
       conversationId: threadB.id,
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     const result = await assetSearchTool.execute(
@@ -300,7 +300,7 @@ describe("Story E2E: selfie yesterday -> generated image today", () => {
       workingDir: sandboxDir,
       sessionId: "sess-story",
       conversationId: threadB.id,
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     const result = await assetMaterializeTool.execute(
@@ -328,7 +328,7 @@ describe("Story E2E: selfie yesterday -> generated image today", () => {
       workingDir: sandboxDir,
       sessionId: "sess-story",
       conversationId: threadB.id,
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     // Step 3a: Search for the selfie
@@ -532,7 +532,7 @@ describe("Private-thread variant: cross-thread media blocking", () => {
       workingDir: sandboxDir,
       sessionId: "sess-priv-test",
       conversationId: standardThread.id,
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     const result = await assetSearchTool.execute(
@@ -560,7 +560,7 @@ describe("Private-thread variant: cross-thread media blocking", () => {
       workingDir: sandboxDir,
       sessionId: "sess-priv-test",
       conversationId: standardThread.id,
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     const result = await assetMaterializeTool.execute(
@@ -591,7 +591,7 @@ describe("Private-thread variant: cross-thread media blocking", () => {
       workingDir: sandboxDir,
       sessionId: "sess-priv-test",
       conversationId: privateThread.id,
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     const searchResult = await assetSearchTool.execute(
@@ -636,7 +636,7 @@ describe("Private-thread variant: cross-thread media blocking", () => {
       workingDir: sandboxDir,
       sessionId: "sess-priv-test",
       conversationId: privateThreadB.id,
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     const searchResult = await assetSearchTool.execute(

--- a/assistant/src/__tests__/messaging-send-tool.test.ts
+++ b/assistant/src/__tests__/messaging-send-tool.test.ts
@@ -55,7 +55,7 @@ describe("messaging-send tool", () => {
         sessionId: "sess-1",
         conversationId: "conv-1",
         assistantId: "ast-alpha",
-        guardianTrustClass: "guardian" as const,
+        trustClass: "guardian" as const,
       },
     );
 

--- a/assistant/src/__tests__/playbook-tools.test.ts
+++ b/assistant/src/__tests__/playbook-tools.test.ts
@@ -66,7 +66,7 @@ const ctx: ToolContext = {
   workingDir: "/tmp",
   sessionId: "test-session",
   conversationId: "test-conversation",
-  guardianTrustClass: "guardian",
+  trustClass: "guardian",
 };
 
 function clearPlaybooks(): void {

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -32,7 +32,7 @@ function makeContext(): ToolContext {
     workingDir: "/tmp",
     sessionId: "test-session",
     conversationId: "test-conversation",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
   };
 }
 

--- a/assistant/src/__tests__/schedule-tools.test.ts
+++ b/assistant/src/__tests__/schedule-tools.test.ts
@@ -61,7 +61,7 @@ const ctx: ToolContext = {
   workingDir: "/tmp",
   sessionId: "test-session",
   conversationId: "test-conversation",
-  guardianTrustClass: "guardian",
+  trustClass: "guardian",
 };
 
 // ── schedule_create ─────────────────────────────────────────────────

--- a/assistant/src/__tests__/secret-onetime-send.test.ts
+++ b/assistant/src/__tests__/secret-onetime-send.test.ts
@@ -69,7 +69,7 @@ describe("one-time send override", () => {
       workingDir: "/tmp",
       sessionId: "s1",
       conversationId: "c1",
-      guardianTrustClass: "guardian" as const,
+      trustClass: "guardian" as const,
       requestSecret: async () => ({
         value: "v1",
         delivery: "transient_send" as const,
@@ -92,7 +92,7 @@ describe("one-time send override", () => {
       workingDir: "/tmp",
       sessionId: "s1",
       conversationId: "c1",
-      guardianTrustClass: "guardian" as const,
+      trustClass: "guardian" as const,
       requestSecret: async () => ({
         value: "v1",
         delivery: "transient_send" as const,
@@ -115,7 +115,7 @@ describe("one-time send override", () => {
       workingDir: "/tmp",
       sessionId: "s1",
       conversationId: "c1",
-      guardianTrustClass: "guardian" as const,
+      trustClass: "guardian" as const,
       requestSecret: async () => ({ value: "v1", delivery: "store" as const }),
     };
 
@@ -135,7 +135,7 @@ describe("one-time send override", () => {
       workingDir: "/tmp",
       sessionId: "s1",
       conversationId: "c1",
-      guardianTrustClass: "guardian" as const,
+      trustClass: "guardian" as const,
       requestSecret: async () => ({
         value: secretVal,
         delivery: "transient_send" as const,

--- a/assistant/src/__tests__/secret-scanner-executor.test.ts
+++ b/assistant/src/__tests__/secret-scanner-executor.test.ts
@@ -112,7 +112,7 @@ function makeContext(
     workingDir: "/tmp",
     sessionId: "test-session",
     conversationId: "test-conversation",
-    guardianTrustClass: "guardian" as const,
+    trustClass: "guardian" as const,
     onToolLifecycleEvent: (event: ToolLifecycleEvent) => {
       auditListener(event);
       return overrides?.onToolLifecycleEvent?.(event);
@@ -348,7 +348,7 @@ describe("Secret scanner executor integration", () => {
       workingDir: "/tmp",
       sessionId: "test-session",
       conversationId: "test-conversation",
-      guardianTrustClass: "guardian" as const,
+      trustClass: "guardian" as const,
     };
 
     const result = await executor.execute("file_read", {}, ctx);

--- a/assistant/src/__tests__/send-notification-tool.test.ts
+++ b/assistant/src/__tests__/send-notification-tool.test.ts
@@ -34,7 +34,7 @@ describe("send-notification tool", () => {
         sessionId: "sess-1",
         conversationId: "conv-1",
         assistantId: "ast-alpha",
-        guardianTrustClass: "guardian" as const,
+        trustClass: "guardian" as const,
       },
     );
 
@@ -78,7 +78,7 @@ describe("send-notification tool", () => {
         sessionId: "sess-1",
         conversationId: "conv-1",
         assistantId: "ast-alpha",
-        guardianTrustClass: "guardian" as const,
+        trustClass: "guardian" as const,
       },
     );
 

--- a/assistant/src/__tests__/shell-credential-ref.test.ts
+++ b/assistant/src/__tests__/shell-credential-ref.test.ts
@@ -88,7 +88,7 @@ const ctx: ToolContext = {
   workingDir: "/tmp",
   sessionId: "test-session",
   conversationId: "test-conv",
-  guardianTrustClass: "guardian",
+  trustClass: "guardian",
 };
 
 beforeEach(() => {

--- a/assistant/src/__tests__/shell-tool-proxy-mode.test.ts
+++ b/assistant/src/__tests__/shell-tool-proxy-mode.test.ts
@@ -181,7 +181,7 @@ function makeContext(overrides?: Partial<ToolContext>): ToolContext {
     workingDir: "/tmp",
     sessionId: "test-session",
     conversationId: "test-conv",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -92,7 +92,7 @@ async function executeSkillLoad(
     workingDir: "/tmp",
     sessionId: "session-1",
     conversationId: "conversation-1",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
   });
   return { content: result.content, isError: result.isError };
 }

--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -95,7 +95,7 @@ async function executeSkillLoad(
     workingDir: "/tmp",
     sessionId: "session-1",
     conversationId: "conversation-1",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
   });
   return { content: result.content, isError: result.isError };
 }

--- a/assistant/src/__tests__/skill-script-runner-host.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-host.test.ts
@@ -16,7 +16,7 @@ function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
     workingDir: "/tmp",
     sessionId: "test-session",
     conversationId: "test-conversation",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/skill-script-runner-sandbox.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-sandbox.test.ts
@@ -67,7 +67,7 @@ function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
     workingDir: "/tmp",
     sessionId: "test-session",
     conversationId: "test-conversation",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/skill-script-runner.test.ts
+++ b/assistant/src/__tests__/skill-script-runner.test.ts
@@ -20,7 +20,7 @@ const ctx: ToolContext = {
   workingDir: "/tmp",
   sessionId: "test-session",
   conversationId: "test-conversation",
-  guardianTrustClass: "guardian",
+  trustClass: "guardian",
 };
 
 function makeSkillDir(name: string): string {

--- a/assistant/src/__tests__/skill-tool-factory.test.ts
+++ b/assistant/src/__tests__/skill-tool-factory.test.ts
@@ -38,7 +38,7 @@ function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
     workingDir: "/tmp",
     sessionId: "test-session",
     conversationId: "test-conversation",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -112,7 +112,7 @@ function makeContext(sessionId: string, extras: Record<string, unknown> = {}) {
     workingDir: "/tmp",
     sessionId,
     conversationId: "conv-1",
-    guardianTrustClass: "guardian" as const,
+    trustClass: "guardian" as const,
     ...extras,
   } as import("../tools/types.js").ToolContext;
 }

--- a/assistant/src/__tests__/swarm-recursion.test.ts
+++ b/assistant/src/__tests__/swarm-recursion.test.ts
@@ -99,7 +99,7 @@ function makeContext(overrides?: Partial<ToolContext>): ToolContext {
     sessionId: "test-session",
     conversationId: "test-conv",
     workingDir: "/tmp/test",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
     onOutput: () => {},
     ...overrides,
   } as ToolContext;

--- a/assistant/src/__tests__/swarm-session-integration.test.ts
+++ b/assistant/src/__tests__/swarm-session-integration.test.ts
@@ -89,7 +89,7 @@ function makeContext(overrides?: Partial<ToolContext>): ToolContext {
     sessionId: "test-session",
     conversationId: "test-conv",
     workingDir: "/tmp/test",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
     onOutput: () => {},
     ...overrides,
   } as ToolContext;

--- a/assistant/src/__tests__/swarm-tool.test.ts
+++ b/assistant/src/__tests__/swarm-tool.test.ts
@@ -93,7 +93,7 @@ function makeContext(overrides?: Partial<ToolContext>): ToolContext {
   return {
     sessionId: "test-session",
     workingDir: "/tmp/test",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
     onOutput: () => {},
     ...overrides,
   } as ToolContext;

--- a/assistant/src/__tests__/task-management-tools.test.ts
+++ b/assistant/src/__tests__/task-management-tools.test.ts
@@ -87,7 +87,7 @@ const ctx: ToolContext = {
   workingDir: "/tmp",
   sessionId: "test-session",
   conversationId: "test-conversation",
-  guardianTrustClass: "guardian",
+  trustClass: "guardian",
 };
 
 function clearTables() {

--- a/assistant/src/__tests__/task-tools.test.ts
+++ b/assistant/src/__tests__/task-tools.test.ts
@@ -97,7 +97,7 @@ const stubContext: ToolContext = {
   workingDir: "/tmp",
   sessionId: "test-session",
   conversationId: "test-conversation",
-  guardianTrustClass: "guardian",
+  trustClass: "guardian",
 };
 
 // ── task_save ────────────────────────────────────────────────────────

--- a/assistant/src/__tests__/terminal-tools.test.ts
+++ b/assistant/src/__tests__/terminal-tools.test.ts
@@ -597,7 +597,7 @@ describe("Shell tool input validation", () => {
     workingDir: testTmpDir,
     sessionId: "test-session-1",
     conversationId: "test-conv-1",
-    guardianTrustClass: "guardian" as const,
+    trustClass: "guardian" as const,
     onOutput: () => {},
   };
 

--- a/assistant/src/__tests__/tool-approval-handler.test.ts
+++ b/assistant/src/__tests__/tool-approval-handler.test.ts
@@ -106,7 +106,7 @@ function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
     conversationId: "conv-1",
     assistantId: "self",
     requestId: "req-1",
-    guardianTrustClass: "trusted_contact",
+    trustClass: "trusted_contact",
     ...overrides,
   };
 }
@@ -142,7 +142,7 @@ describe("ToolApprovalHandler / pre-exec gate grant check", () => {
     );
     expect(mintResult.ok).toBe(true);
 
-    const context = makeContext({ guardianTrustClass: "trusted_contact" });
+    const context = makeContext({ trustClass: "trusted_contact" });
     const result = await handler.checkPreExecutionGates(
       toolName,
       input,
@@ -163,7 +163,7 @@ describe("ToolApprovalHandler / pre-exec gate grant check", () => {
     const toolName = "bash";
     const input = { command: "rm -rf /" };
 
-    const context = makeContext({ guardianTrustClass: "trusted_contact" });
+    const context = makeContext({ trustClass: "trusted_contact" });
     const result = await handler.checkPreExecutionGates(
       toolName,
       input,
@@ -197,7 +197,7 @@ describe("ToolApprovalHandler / pre-exec gate grant check", () => {
       }),
     );
 
-    const context = makeContext({ guardianTrustClass: "unknown" });
+    const context = makeContext({ trustClass: "unknown" });
     const result = await handler.checkPreExecutionGates(
       toolName,
       input,
@@ -215,7 +215,7 @@ describe("ToolApprovalHandler / pre-exec gate grant check", () => {
     const toolName = "bash";
     const input = { command: "deploy" };
 
-    const context = makeContext({ guardianTrustClass: "unknown" });
+    const context = makeContext({ trustClass: "unknown" });
     const result = await handler.checkPreExecutionGates(
       toolName,
       input,
@@ -244,7 +244,7 @@ describe("ToolApprovalHandler / pre-exec gate grant check", () => {
       }),
     );
 
-    const context = makeContext({ guardianTrustClass: "trusted_contact" });
+    const context = makeContext({ trustClass: "trusted_contact" });
 
     // First invocation — should consume the grant and allow
     const first = await handler.checkPreExecutionGates(
@@ -285,7 +285,7 @@ describe("ToolApprovalHandler / pre-exec gate grant check", () => {
       }),
     );
 
-    const context = makeContext({ guardianTrustClass: "trusted_contact" });
+    const context = makeContext({ trustClass: "trusted_contact" });
     const result = await handler.checkPreExecutionGates(
       toolName,
       invokeInput,
@@ -314,7 +314,7 @@ describe("ToolApprovalHandler / pre-exec gate grant check", () => {
       }),
     );
 
-    const context = makeContext({ guardianTrustClass: "trusted_contact" });
+    const context = makeContext({ trustClass: "trusted_contact" });
     const result = await handler.checkPreExecutionGates(
       toolName,
       input,
@@ -333,7 +333,7 @@ describe("ToolApprovalHandler / pre-exec gate grant check", () => {
     const input = { command: "deploy" };
 
     // No grants minted at all
-    const context = makeContext({ guardianTrustClass: "guardian" });
+    const context = makeContext({ trustClass: "guardian" });
     const result = await handler.checkPreExecutionGates(
       toolName,
       input,
@@ -352,7 +352,7 @@ describe("ToolApprovalHandler / pre-exec gate grant check", () => {
     const toolName = "bash";
     const input = { command: "deploy" };
 
-    const context = makeContext({ guardianTrustClass: "guardian" });
+    const context = makeContext({ trustClass: "guardian" });
     const result = await handler.checkPreExecutionGates(
       toolName,
       input,
@@ -378,7 +378,7 @@ describe("ToolApprovalHandler / pre-exec gate grant check", () => {
     );
 
     const context = makeContext({
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       requestId: "req-1",
     });
     const result = await handler.checkPreExecutionGates(
@@ -410,7 +410,7 @@ describe("ToolApprovalHandler / pre-exec gate grant check", () => {
 
     // Context conversationId does not match the grant's conversationId
     const context = makeContext({
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       conversationId: "conv-1",
     });
     const result = await handler.checkPreExecutionGates(
@@ -432,7 +432,7 @@ describe("ToolApprovalHandler / pre-exec gate grant check", () => {
 
     // executionChannel defaults to undefined (non-voice)
     const context = makeContext({
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       executionChannel: "telegram",
     });
 
@@ -472,7 +472,7 @@ describe("ToolApprovalHandler / pre-exec gate grant check", () => {
     }, 300);
 
     const context = makeContext({
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       executionChannel: "voice",
     });
 
@@ -503,7 +503,7 @@ describe("ToolApprovalHandler / pre-exec gate grant check", () => {
     setTimeout(() => controller.abort(), 200);
 
     const context = makeContext({
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       executionChannel: "voice",
       signal: controller.signal,
     });

--- a/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
+++ b/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
@@ -111,7 +111,7 @@ function makeToolContext(workingDir: string, signal?: AbortSignal) {
     workingDir,
     sessionId: "test-session",
     conversationId: "test-conv",
-    guardianTrustClass: "guardian" as const,
+    trustClass: "guardian" as const,
     signal,
   };
 }

--- a/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
+++ b/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
@@ -434,7 +434,7 @@ describe("Tool execution pipeline benchmark", () => {
       workingDir: "/tmp",
       sessionId: "bench-session",
       conversationId: "bench-conv",
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
     };
 
     function makeTool(name: string, sleepMs: number): Tool {

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -162,7 +162,7 @@ function makeContext(events: ToolLifecycleEvent[]) {
     workingDir: "/tmp/project",
     sessionId: "session-1",
     conversationId: "conversation-1",
-    guardianTrustClass: "guardian" as const,
+    trustClass: "guardian" as const,
     onToolLifecycleEvent: (event: ToolLifecycleEvent) => {
       events.push(event);
     },
@@ -527,7 +527,7 @@ describe("ToolExecutor lifecycle events", () => {
         workingDir: "/tmp/project",
         sessionId: "session-1",
         conversationId: "conversation-1",
-        guardianTrustClass: "guardian",
+        trustClass: "guardian",
         onToolLifecycleEvent: () => new Promise<void>(() => {}),
       },
     );

--- a/assistant/src/__tests__/tool-executor-shell-integration.test.ts
+++ b/assistant/src/__tests__/tool-executor-shell-integration.test.ts
@@ -149,7 +149,7 @@ function makeContext(overrides?: Partial<ToolContext>): ToolContext {
     workingDir: "/tmp/project",
     sessionId: "session-integration",
     conversationId: "conversation-integration",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -167,7 +167,7 @@ function makeContext(overrides?: Partial<ToolContext>): ToolContext {
     workingDir: "/tmp/project",
     sessionId: "session-1",
     conversationId: "conversation-1",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/tool-grant-request-escalation.test.ts
+++ b/assistant/src/__tests__/tool-grant-request-escalation.test.ts
@@ -168,7 +168,7 @@ function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
     conversationId: "conv-1",
     assistantId: "self",
     requestId: "req-1",
-    guardianTrustClass: "trusted_contact",
+    trustClass: "trusted_contact",
     executionChannel: "telegram",
     requesterExternalUserId: "requester-1",
     ...overrides,
@@ -229,7 +229,7 @@ describe("ToolApprovalHandler / grant-miss escalation", () => {
     const toolName = "bash";
     const input = { command: "cat /etc/passwd" };
 
-    const context = makeContext({ guardianTrustClass: "trusted_contact" });
+    const context = makeContext({ trustClass: "trusted_contact" });
     const result = await handler.checkPreExecutionGates(
       toolName,
       input,
@@ -264,7 +264,7 @@ describe("ToolApprovalHandler / grant-miss escalation", () => {
     const toolName = "bash";
     const input = { command: "deploy" };
 
-    const context = makeContext({ guardianTrustClass: "trusted_contact" });
+    const context = makeContext({ trustClass: "trusted_contact" });
     const result = await handler.checkPreExecutionGates(
       toolName,
       input,
@@ -289,7 +289,7 @@ describe("ToolApprovalHandler / grant-miss escalation", () => {
     const toolName = "bash";
     const input = { command: "rm -rf /" };
 
-    const context = makeContext({ guardianTrustClass: "trusted_contact" });
+    const context = makeContext({ trustClass: "trusted_contact" });
 
     // First invocation creates the request (and waits, then times out)
     await handler.checkPreExecutionGates(
@@ -345,7 +345,7 @@ describe("ToolApprovalHandler / grant-miss escalation", () => {
     const input = { command: "ls" };
 
     const context = makeContext({
-      guardianTrustClass: "unknown",
+      trustClass: "unknown",
       executionChannel: "telegram",
       requesterExternalUserId: "unknown-user",
     });
@@ -377,7 +377,7 @@ describe("ToolApprovalHandler / grant-miss escalation", () => {
     const input = { command: "deploy" };
 
     const context = makeContext({
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       executionChannel: undefined, // no channel info
     });
     const result = await handler.checkPreExecutionGates(
@@ -528,7 +528,7 @@ describe("end-to-end: tool grant escalation -> approval -> consume", () => {
     const input = { command: "echo secret" };
     const _inputDigest = computeToolApprovalDigest(toolName, input);
 
-    const context = makeContext({ guardianTrustClass: "trusted_contact" });
+    const context = makeContext({ trustClass: "trusted_contact" });
 
     // Schedule guardian approval after 100ms — within the 2s wait window.
     // The approval happens asynchronously while checkPreExecutionGates is
@@ -583,7 +583,7 @@ describe("end-to-end: tool grant escalation -> approval -> consume", () => {
     const input = { command: "echo secret" };
     const _inputDigest = computeToolApprovalDigest(toolName, input);
 
-    const context = makeContext({ guardianTrustClass: "trusted_contact" });
+    const context = makeContext({ trustClass: "trusted_contact" });
 
     // Step 1: First invocation times out (short wait, no approval)
     const shortHandler = new ToolApprovalHandler({
@@ -813,7 +813,7 @@ describe("inline wait-and-resume", () => {
 
     const toolName = "bash";
     const input = { command: "rm -rf /" };
-    const context = makeContext({ guardianTrustClass: "trusted_contact" });
+    const context = makeContext({ trustClass: "trusted_contact" });
 
     // Schedule rejection after 100ms
     const rejectionPromise = (async () => {
@@ -861,7 +861,7 @@ describe("inline wait-and-resume", () => {
     const input = { command: "do something" };
     const controller = new AbortController();
     const context = makeContext({
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       signal: controller.signal,
     });
 
@@ -895,7 +895,7 @@ describe("inline wait-and-resume", () => {
     const toolName = "bash";
     const input = { command: "ls" };
     const context = makeContext({
-      guardianTrustClass: "unknown",
+      trustClass: "unknown",
       executionChannel: "telegram",
       requesterExternalUserId: "unknown-user",
     });

--- a/assistant/src/__tests__/trust-context-guards.test.ts
+++ b/assistant/src/__tests__/trust-context-guards.test.ts
@@ -10,7 +10,7 @@ import { describe, expect, it } from "bun:test";
  *
  *  (a) guardianPrincipalId in TrustContext must be `?: string`
  *      (optional string), NOT `string | null`.
- *  (b) guardianTrustClass in ToolContext must be a required field (no `?`).
+ *  (b) trustClass in ToolContext must be a required field (no `?`).
  *  (c) The channel retry sweep parser must not reference `actorRole`.
  *  (d) guardianPrincipalId in GuardianBinding must be `string` (non-null,
  *      non-optional).
@@ -30,9 +30,7 @@ describe("trust-context guards", () => {
     );
 
     // Extract the TrustContext interface block
-    const ifaceStart = source.indexOf(
-      "export interface TrustContext",
-    );
+    const ifaceStart = source.indexOf("export interface TrustContext");
     expect(ifaceStart).toBeGreaterThan(-1);
 
     const blockStart = source.indexOf("{", ifaceStart);
@@ -76,10 +74,10 @@ describe("trust-context guards", () => {
   });
 
   // -----------------------------------------------------------------------
-  // (b) guardianTrustClass is required in ToolContext
+  // (b) trustClass is required in ToolContext
   // -----------------------------------------------------------------------
 
-  it("guardianTrustClass is a required field in ToolContext", () => {
+  it("trustClass is a required field in ToolContext", () => {
     const source = readFileSync(join(srcDir, "tools", "types.ts"), "utf-8");
 
     // Extract the ToolContext interface block
@@ -99,18 +97,16 @@ describe("trust-context guards", () => {
     }
     const block = source.slice(blockStart, blockEnd);
 
-    const trustLine = block
-      .split("\n")
-      .find((l) => l.includes("guardianTrustClass"));
+    const trustLine = block.split("\n").find((l) => l.includes("trustClass"));
     expect(
       trustLine,
-      "Expected to find guardianTrustClass in ToolContext",
+      "Expected to find trustClass in ToolContext",
     ).toBeDefined();
 
     // The field must NOT have a `?` before the colon — it must be required.
     expect(
-      /guardianTrustClass\s*\?/.test(trustLine!),
-      "guardianTrustClass must be a required field in ToolContext (no `?`). " +
+      /trustClass\s*\?/.test(trustLine!),
+      "trustClass must be a required field in ToolContext (no `?`). " +
         "Explicit trust gates must not be optional — every tool execution " +
         `must carry a trust classification. Found: "${trustLine!.trim()}"`,
     ).toBe(false);

--- a/assistant/src/__tests__/trusted-contact-approval-notifier.test.ts
+++ b/assistant/src/__tests__/trusted-contact-approval-notifier.test.ts
@@ -156,7 +156,7 @@ async function simulateNotifierPoll(params: {
   conversationId: string;
   sourceChannel: ChannelId;
   externalChatId: string;
-  guardianTrustClass: TrustContext["trustClass"];
+  trustClass: TrustContext["trustClass"];
   guardianExternalUserId?: string;
   replyCallbackUrl: string;
   bearerToken?: string;
@@ -165,13 +165,13 @@ async function simulateNotifierPoll(params: {
 }): Promise<boolean> {
   const {
     conversationId,
-    guardianTrustClass,
+    trustClass,
     guardianExternalUserId,
     notifiedRequestIds,
   } = params;
 
   // Gate check: only trusted contacts with guardian route
-  if (guardianTrustClass !== "trusted_contact" || !guardianExternalUserId) {
+  if (trustClass !== "trusted_contact" || !guardianExternalUserId) {
     return false;
   }
 
@@ -285,7 +285,7 @@ describe("trusted-contact pending-approval notifier", () => {
       conversationId: "conv-1",
       sourceChannel: "telegram",
       externalChatId: "chat-123",
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       guardianExternalUserId: "guardian-1",
       replyCallbackUrl: "http://localhost:3000/deliver/telegram",
       bearerToken: "test-token",
@@ -322,7 +322,7 @@ describe("trusted-contact pending-approval notifier", () => {
       conversationId: "conv-1",
       sourceChannel: "telegram",
       externalChatId: "chat-123",
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       guardianExternalUserId: "guardian-1",
       replyCallbackUrl: "http://localhost:3000/deliver/telegram",
       notifiedRequestIds: notified,
@@ -355,7 +355,7 @@ describe("trusted-contact pending-approval notifier", () => {
       conversationId: "conv-1",
       sourceChannel: "telegram",
       externalChatId: "chat-123",
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       guardianExternalUserId: "guardian-1",
       replyCallbackUrl: "http://localhost:3000/deliver/telegram",
       notifiedRequestIds: notified,
@@ -384,7 +384,7 @@ describe("trusted-contact pending-approval notifier", () => {
       conversationId: "conv-1",
       sourceChannel: "telegram",
       externalChatId: "chat-123",
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       guardianExternalUserId: "guardian-1",
       replyCallbackUrl: "http://localhost:3000/deliver/telegram",
       notifiedRequestIds: notified,
@@ -416,7 +416,7 @@ describe("trusted-contact pending-approval notifier", () => {
       conversationId: "conv-1",
       sourceChannel: "telegram" as ChannelId,
       externalChatId: "chat-123",
-      guardianTrustClass: "trusted_contact" as const,
+      trustClass: "trusted_contact" as const,
       guardianExternalUserId: "guardian-1",
       replyCallbackUrl: "http://localhost:3000/deliver/telegram",
       notifiedRequestIds: notified,
@@ -444,7 +444,7 @@ describe("trusted-contact pending-approval notifier", () => {
       conversationId: "conv-1",
       sourceChannel: "telegram" as ChannelId,
       externalChatId: "chat-123",
-      guardianTrustClass: "trusted_contact" as const,
+      trustClass: "trusted_contact" as const,
       guardianExternalUserId: "guardian-1",
       replyCallbackUrl: "http://localhost:3000/deliver/telegram",
       notifiedRequestIds: notified,
@@ -497,7 +497,7 @@ describe("trusted-contact pending-approval notifier", () => {
       conversationId: "conv-A",
       sourceChannel: "telegram",
       externalChatId: "chat-A",
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       guardianExternalUserId: "guardian-1",
       replyCallbackUrl: "http://localhost:3000/deliver/telegram",
       notifiedRequestIds: notified,
@@ -512,7 +512,7 @@ describe("trusted-contact pending-approval notifier", () => {
       conversationId: "conv-B",
       sourceChannel: "telegram",
       externalChatId: "chat-B",
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       guardianExternalUserId: "guardian-1",
       replyCallbackUrl: "http://localhost:3000/deliver/telegram",
       notifiedRequestIds: notified,
@@ -535,7 +535,7 @@ describe("trusted-contact pending-approval notifier", () => {
       conversationId: "conv-A",
       sourceChannel: "telegram",
       externalChatId: "chat-A",
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       guardianExternalUserId: "guardian-1",
       replyCallbackUrl: "http://localhost:3000/deliver/telegram",
       notifiedRequestIds: notified,
@@ -559,7 +559,7 @@ describe("trusted-contact pending-approval notifier", () => {
       conversationId: "conv-1",
       sourceChannel: "telegram",
       externalChatId: "chat-123",
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
       guardianExternalUserId: "guardian-1",
       replyCallbackUrl: "http://localhost:3000/deliver/telegram",
       notifiedRequestIds: notified,
@@ -584,7 +584,7 @@ describe("trusted-contact pending-approval notifier", () => {
       conversationId: "conv-1",
       sourceChannel: "telegram",
       externalChatId: "chat-123",
-      guardianTrustClass: "unknown",
+      trustClass: "unknown",
       replyCallbackUrl: "http://localhost:3000/deliver/telegram",
       notifiedRequestIds: notified,
     });
@@ -608,7 +608,7 @@ describe("trusted-contact pending-approval notifier", () => {
       conversationId: "conv-1",
       sourceChannel: "telegram",
       externalChatId: "chat-123",
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       guardianExternalUserId: undefined,
       replyCallbackUrl: "http://localhost:3000/deliver/telegram",
       notifiedRequestIds: notified,
@@ -638,7 +638,7 @@ describe("trusted-contact pending-approval notifier", () => {
       conversationId: "conv-1",
       sourceChannel: "telegram" as ChannelId,
       externalChatId: "chat-123",
-      guardianTrustClass: "trusted_contact" as const,
+      trustClass: "trusted_contact" as const,
       guardianExternalUserId: "guardian-1",
       replyCallbackUrl: "http://localhost:3000/deliver/telegram",
       notifiedRequestIds: notified,
@@ -666,7 +666,7 @@ describe("trusted-contact pending-approval notifier", () => {
       conversationId: "conv-1",
       sourceChannel: "telegram",
       externalChatId: "chat-123",
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       guardianExternalUserId: "guardian-1",
       replyCallbackUrl: "http://localhost:3000/deliver/telegram",
       notifiedRequestIds: notified,
@@ -699,7 +699,7 @@ describe("trusted-contact pending-approval notifier", () => {
       conversationId: "conv-1",
       sourceChannel: "telegram",
       externalChatId: "chat-123",
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       guardianExternalUserId: "guardian-1",
       replyCallbackUrl: "http://localhost:3000/deliver/telegram",
       notifiedRequestIds: notified,
@@ -731,7 +731,7 @@ describe("trusted-contact pending-approval notifier", () => {
       conversationId: "conv-1",
       sourceChannel: "telegram",
       externalChatId: "chat-123",
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       guardianExternalUserId: "guardian-1",
       replyCallbackUrl: "http://localhost:3000/deliver/telegram",
       notifiedRequestIds: notified,

--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -192,10 +192,7 @@ import {
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { scopedApprovalGrants } from "../memory/schema.js";
 import { bridgeConfirmationRequestToGuardian } from "../runtime/confirmation-request-guardian-bridge.js";
-import type { TrustContext } from "../daemon/session-runtime-assembly.js";
-import {
-  resolveRoutingState,
-} from "../runtime/trust-context-resolver.js";
+import { resolveRoutingState } from "../runtime/trust-context-resolver.js";
 import {
   TC_GRANT_WAIT_MAX_MS,
   ToolApprovalHandler,
@@ -231,7 +228,7 @@ function makeToolContext(overrides: Partial<ToolContext> = {}): ToolContext {
     conversationId: "conv-1",
     assistantId: "self",
     requestId: "req-1",
-    guardianTrustClass: "trusted_contact",
+    trustClass: "trusted_contact",
     executionChannel: "telegram",
     requesterExternalUserId: "requester-1",
     ...overrides,
@@ -292,7 +289,7 @@ describe("(a) target flow: trusted-contact inline guardian approval end-to-end",
   test("trusted contact requests tool, guardian approves mid-wait, tool executes inline", async () => {
     const toolName = "bash";
     const input = { command: "echo hello" };
-    const context = makeToolContext({ guardianTrustClass: "trusted_contact" });
+    const context = makeToolContext({ trustClass: "trusted_contact" });
 
     // Schedule guardian approval after 100ms during the inline wait
     const approvalPromise = (async () => {
@@ -362,7 +359,7 @@ describe("(a) target flow: trusted-contact inline guardian approval end-to-end",
     // Step 2: Tool invocation creates escalation + waits inline + guardian approves
     const toolName = "bash";
     const input = { command: "deploy" };
-    const context = makeToolContext({ guardianTrustClass: "trusted_contact" });
+    const context = makeToolContext({ trustClass: "trusted_contact" });
 
     const approvalPromise = (async () => {
       await new Promise((r) => setTimeout(r, 80));
@@ -521,7 +518,7 @@ describe("(c) no-binding flow: trusted contact fails fast without guardian bindi
     const toolName = "bash";
     const input = { command: "ls" };
     const context = makeToolContext({
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       executionChannel: "telegram",
     });
 
@@ -614,7 +611,7 @@ describe("(d) unknown actor flow: fail-closed with no interactive approval", () 
     const toolName = "bash";
     const input = { command: "ls" };
     const context = makeToolContext({
-      guardianTrustClass: "unknown",
+      trustClass: "unknown",
       executionChannel: "telegram",
       requesterExternalUserId: "unknown-user",
     });
@@ -710,12 +707,12 @@ describe("(d) unknown actor flow: fail-closed with no interactive approval", () 
  * flags as always-false under strict literal narrowing — TS2367/TS2872).
  */
 function checkIsBoundGuardianActor(params: {
-  guardianTrustClass: string;
+  trustClass: string;
   guardianExternalUserId: string | undefined;
   requesterExternalUserId: string;
 }): boolean {
   return (
-    params.guardianTrustClass === "guardian" &&
+    params.trustClass === "guardian" &&
     !!params.guardianExternalUserId &&
     params.requesterExternalUserId === params.guardianExternalUserId
   );
@@ -741,7 +738,7 @@ describe("(e) guardian-only prompt delivery invariant", () => {
     // actors matching the binding receive the prompt.
 
     const result = checkIsBoundGuardianActor({
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       guardianExternalUserId: "guardian-1",
       requesterExternalUserId: "requester-1",
     });
@@ -752,7 +749,7 @@ describe("(e) guardian-only prompt delivery invariant", () => {
 
   test("unknown actors do NOT receive approval prompt UI", () => {
     const result = checkIsBoundGuardianActor({
-      guardianTrustClass: "unknown",
+      trustClass: "unknown",
       guardianExternalUserId: "guardian-1",
       requesterExternalUserId: "unknown-user",
     });
@@ -762,7 +759,7 @@ describe("(e) guardian-only prompt delivery invariant", () => {
 
   test("guardian actor that matches binding DOES receive approval prompt UI", () => {
     const result = checkIsBoundGuardianActor({
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
       guardianExternalUserId: "guardian-1",
       requesterExternalUserId: "guardian-1",
     });
@@ -773,7 +770,7 @@ describe("(e) guardian-only prompt delivery invariant", () => {
   test("guardian actor with identity mismatch does NOT receive approval prompt UI", () => {
     // After guardian rotation, old guardian identity should not receive prompts
     const result = checkIsBoundGuardianActor({
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
       guardianExternalUserId: "new-guardian-2",
       requesterExternalUserId: "old-guardian-1",
     });
@@ -810,7 +807,7 @@ describe("(f) timeout/stale flow: stale guardian decision after inline wait time
   test("inline wait timeout clears followupState so later approval sends retry notification", async () => {
     const toolName = "bash";
     const input = { command: "echo stale" };
-    const context = makeToolContext({ guardianTrustClass: "trusted_contact" });
+    const context = makeToolContext({ trustClass: "trusted_contact" });
 
     // Let the tool invocation time out (no guardian approval within 100ms)
     const result = await handler.checkPreExecutionGates(
@@ -966,7 +963,7 @@ describe("(f) timeout/stale flow: stale guardian decision after inline wait time
   test("denied inline wait produces explicit denial (no false success)", async () => {
     const toolName = "bash";
     const input = { command: "rm -rf /" };
-    const context = makeToolContext({ guardianTrustClass: "trusted_contact" });
+    const context = makeToolContext({ trustClass: "trusted_contact" });
 
     // Schedule guardian rejection after 80ms
     const rejectionPromise = (async () => {
@@ -1009,7 +1006,7 @@ describe("(f) timeout/stale flow: stale guardian decision after inline wait time
   test("timeout produces explicit timeout message (no false success)", async () => {
     const toolName = "bash";
     const input = { command: "curl example.com" };
-    const context = makeToolContext({ guardianTrustClass: "trusted_contact" });
+    const context = makeToolContext({ trustClass: "trusted_contact" });
 
     const result = await handler.checkPreExecutionGates(
       toolName,
@@ -1125,7 +1122,7 @@ describe("cross-milestone integration checks", () => {
     const toolName = "bash";
     const input = { command: "ls" };
     const context = makeToolContext({
-      guardianTrustClass: "guardian",
+      trustClass: "guardian",
       executionChannel: "telegram",
       requesterExternalUserId: "guardian-1",
     });
@@ -1158,7 +1155,7 @@ describe("cross-milestone integration checks", () => {
     const input = { command: "aborted-command" };
     const controller = new AbortController();
     const context = makeToolContext({
-      guardianTrustClass: "trusted_contact",
+      trustClass: "trusted_contact",
       signal: controller.signal,
     });
 

--- a/assistant/src/__tests__/view-image-tool.test.ts
+++ b/assistant/src/__tests__/view-image-tool.test.ts
@@ -60,7 +60,7 @@ function makeContext(workingDir: string = testDir): ToolContext {
     workingDir,
     sessionId: "test-session",
     conversationId: "test-conversation",
-    guardianTrustClass: "guardian",
+    trustClass: "guardian",
   };
 }
 

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -6,38 +6,38 @@
  * from Twilio and can send text tokens back for TTS.
  */
 
-import { randomInt } from 'node:crypto';
+import { randomInt } from "node:crypto";
 
-import type { ServerWebSocket } from 'bun';
+import type { ServerWebSocket } from "bun";
 
-import { getConfig } from '../config/loader.js';
-import { resolveUserReference } from '../config/user-reference.js';
-import { getAssistantName } from '../daemon/identity-helpers.js';
-import { getCanonicalGuardianRequest } from '../memory/canonical-guardian-store.js';
-import { listActiveBindingsByAssistant } from '../memory/channel-guardian-store.js';
-import * as conversationStore from '../memory/conversation-store.js';
-import { findActiveVoiceInvites } from '../memory/ingress-invite-store.js';
-import { findMember, upsertMember } from '../memory/ingress-member-store.js';
-import { revokeScopedApprovalGrantsForContext } from '../memory/scoped-approval-grants.js';
-import { emitNotificationSignal } from '../notifications/emit-signal.js';
-import { notifyGuardianOfAccessRequest } from '../runtime/access-request-helper.js';
+import { getConfig } from "../config/loader.js";
+import { resolveUserReference } from "../config/user-reference.js";
+import { getAssistantName } from "../daemon/identity-helpers.js";
+import { getCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
+import { listActiveBindingsByAssistant } from "../memory/channel-guardian-store.js";
+import * as conversationStore from "../memory/conversation-store.js";
+import { findActiveVoiceInvites } from "../memory/ingress-invite-store.js";
+import { findMember, upsertMember } from "../memory/ingress-member-store.js";
+import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-grants.js";
+import { emitNotificationSignal } from "../notifications/emit-signal.js";
+import { notifyGuardianOfAccessRequest } from "../runtime/access-request-helper.js";
 import {
   resolveActorTrust,
   toTrustContext,
-} from '../runtime/actor-trust-resolver.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
+} from "../runtime/actor-trust-resolver.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import {
   getGuardianBinding,
   getPendingChallenge,
   validateAndConsumeChallenge,
-} from '../runtime/channel-guardian-service.js';
+} from "../runtime/channel-guardian-service.js";
 import {
   composeVerificationVoice,
   GUARDIAN_VERIFY_TEMPLATE_KEYS,
-} from '../runtime/guardian-verification-templates.js';
-import { redeemVoiceInviteCode } from '../runtime/ingress-service.js';
-import { parseJsonSafe } from '../util/json.js';
-import { getLogger } from '../util/logger.js';
+} from "../runtime/guardian-verification-templates.js";
+import { redeemVoiceInviteCode } from "../runtime/ingress-service.js";
+import { parseJsonSafe } from "../util/json.js";
+import { getLogger } from "../util/logger.js";
 import {
   getAccessRequestPollIntervalMs,
   getGuardianWaitUpdateInitialIntervalMs,
@@ -46,31 +46,34 @@ import {
   getGuardianWaitUpdateSteadyMinIntervalMs,
   getTtsPlaybackDelayMs,
   getUserConsultationTimeoutMs,
-} from './call-constants.js';
-import { CallController } from './call-controller.js';
-import { persistCallCompletionMessage } from './call-conversation-messages.js';
-import { addPointerMessage, formatDuration } from './call-pointer-messages.js';
-import { fireCallCompletionNotifier,fireCallTranscriptNotifier } from './call-state.js';
-import { isTerminalState } from './call-state-machine.js';
+} from "./call-constants.js";
+import { CallController } from "./call-controller.js";
+import { persistCallCompletionMessage } from "./call-conversation-messages.js";
+import { addPointerMessage, formatDuration } from "./call-pointer-messages.js";
+import {
+  fireCallCompletionNotifier,
+  fireCallTranscriptNotifier,
+} from "./call-state.js";
+import { isTerminalState } from "./call-state-machine.js";
 import {
   expirePendingQuestions,
   getCallSession,
   recordCallEvent,
   updateCallSession,
-} from './call-store.js';
+} from "./call-store.js";
 import {
   extractPromptSpeakerMetadata,
   type PromptSpeakerContext,
   SpeakerIdentityTracker,
-} from './speaker-identification.js';
+} from "./speaker-identification.js";
 
-const log = getLogger('relay-server');
+const log = getLogger("relay-server");
 
 // ── ConversationRelay message types ──────────────────────────────────
 
 // Messages FROM Twilio
 export interface RelaySetupMessage {
-  type: 'setup';
+  type: "setup";
   callSid: string;
   from: string;
   to: string;
@@ -78,7 +81,7 @@ export interface RelaySetupMessage {
 }
 
 export interface RelayPromptMessage {
-  type: 'prompt';
+  type: "prompt";
   voicePrompt: string;
   lang: string;
   last: boolean;
@@ -102,17 +105,17 @@ export interface RelayPromptMessage {
 }
 
 export interface RelayInterruptMessage {
-  type: 'interrupt';
+  type: "interrupt";
   utteranceUntilInterrupt: string;
 }
 
 export interface RelayDtmfMessage {
-  type: 'dtmf';
+  type: "dtmf";
   digit: string;
 }
 
 export interface RelayErrorMessage {
-  type: 'error';
+  type: "error";
   description: string;
 }
 
@@ -125,13 +128,13 @@ export type RelayInboundMessage =
 
 // Messages TO Twilio
 export interface RelayTextMessage {
-  type: 'text';
+  type: "text";
   token: string;
   last: boolean;
 }
 
 export interface RelayEndMessage {
-  type: 'end';
+  type: "end";
   handoffData?: string;
 }
 
@@ -147,10 +150,14 @@ export interface RelayWebSocketData {
 export const activeRelayConnections = new Map<string, RelayConnection>();
 
 /** Module-level broadcast function, set by the HTTP server during startup. */
-let globalBroadcast: ((msg: import('../daemon/ipc-contract.js').ServerMessage) => void) | undefined;
+let globalBroadcast:
+  | ((msg: import("../daemon/ipc-contract.js").ServerMessage) => void)
+  | undefined;
 
 /** Register a broadcast function so RelayConnection can forward IPC events. */
-export function setRelayBroadcast(fn: (msg: import('../daemon/ipc-contract.js').ServerMessage) => void): void {
+export function setRelayBroadcast(
+  fn: (msg: import("../daemon/ipc-contract.js").ServerMessage) => void,
+): void {
   globalBroadcast = fn;
 }
 
@@ -159,13 +166,18 @@ export function setRelayBroadcast(fn: (msg: import('../daemon/ipc-contract.js').
 /**
  * Manages a single WebSocket connection for one call.
  */
-export type RelayConnectionState = 'connected' | 'verification_pending' | 'awaiting_name' | 'awaiting_guardian_decision' | 'disconnecting';
+export type RelayConnectionState =
+  | "connected"
+  | "verification_pending"
+  | "awaiting_name"
+  | "awaiting_guardian_decision"
+  | "disconnecting";
 
 export class RelayConnection {
   private ws: ServerWebSocket<RelayWebSocketData>;
   private callSessionId: string;
   private conversationHistory: Array<{
-    role: 'caller' | 'assistant';
+    role: "caller" | "assistant";
     text: string;
     timestamp: number;
     speaker?: PromptSpeakerContext;
@@ -175,12 +187,12 @@ export class RelayConnection {
   private speakerIdentityTracker: SpeakerIdentityTracker;
 
   // Verification state (outbound callee verification)
-  private connectionState: RelayConnectionState = 'connected';
+  private connectionState: RelayConnectionState = "connected";
   private verificationCode: string | null = null;
   private verificationAttempts = 0;
   private verificationMaxAttempts = 3;
   private verificationCodeLength = 6;
-  private dtmfBuffer = '';
+  private dtmfBuffer = "";
 
   // Inbound voice guardian verification state
   private guardianVerificationActive = false;
@@ -204,14 +216,16 @@ export class RelayConnection {
   private accessRequestAssistantId: string | null = null;
   private accessRequestFromNumber: string | null = null;
   private accessRequestPollTimer: ReturnType<typeof setInterval> | null = null;
-  private accessRequestTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
+  private accessRequestTimeoutTimer: ReturnType<typeof setTimeout> | null =
+    null;
   private accessRequestCallerName: string | null = null;
 
   // Name capture timeout (unknown inbound callers)
   private nameCaptureTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Guardian wait heartbeat state
-  private accessRequestHeartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+  private accessRequestHeartbeatTimer: ReturnType<typeof setTimeout> | null =
+    null;
   private accessRequestWaitStartedAt: number = 0;
   private heartbeatSequence = 0;
 
@@ -259,28 +273,37 @@ export class RelayConnection {
   async handleMessage(data: string): Promise<void> {
     const parsed = parseJsonSafe<RelayInboundMessage>(data);
     if (!parsed) {
-      log.warn({ callSessionId: this.callSessionId, data }, 'Failed to parse relay message');
+      log.warn(
+        { callSessionId: this.callSessionId, data },
+        "Failed to parse relay message",
+      );
       return;
     }
 
     switch (parsed.type) {
-      case 'setup':
+      case "setup":
         await this.handleSetup(parsed);
         break;
-      case 'prompt':
+      case "prompt":
         await this.handlePrompt(parsed);
         break;
-      case 'interrupt':
+      case "interrupt":
         this.handleInterrupt(parsed);
         break;
-      case 'dtmf':
+      case "dtmf":
         this.handleDtmf(parsed);
         break;
-      case 'error':
+      case "error":
         this.handleError(parsed);
         break;
       default:
-        log.warn({ callSessionId: this.callSessionId, type: (parsed as { type: unknown }).type }, 'Unknown relay message type');
+        log.warn(
+          {
+            callSessionId: this.callSessionId,
+            type: (parsed as { type: unknown }).type,
+          },
+          "Unknown relay message type",
+        );
     }
   }
 
@@ -288,11 +311,14 @@ export class RelayConnection {
    * Send a text token to the caller for TTS playback.
    */
   sendTextToken(token: string, last: boolean): void {
-    const message: RelayTextMessage = { type: 'text', token, last };
+    const message: RelayTextMessage = { type: "text", token, last };
     try {
       this.ws.send(JSON.stringify(message));
     } catch (err) {
-      log.error({ err, callSessionId: this.callSessionId }, 'Failed to send text token');
+      log.error(
+        { err, callSessionId: this.callSessionId },
+        "Failed to send text token",
+      );
     }
   }
 
@@ -300,22 +326,33 @@ export class RelayConnection {
    * End the ConversationRelay session.
    */
   endSession(reason?: string): void {
-    const message: RelayEndMessage = { type: 'end' };
+    const message: RelayEndMessage = { type: "end" };
     if (reason) {
       message.handoffData = JSON.stringify({ reason });
     }
     try {
       this.ws.send(JSON.stringify(message));
     } catch (err) {
-      log.error({ err, callSessionId: this.callSessionId }, 'Failed to send end message');
+      log.error(
+        { err, callSessionId: this.callSessionId },
+        "Failed to send end message",
+      );
     }
   }
 
   /**
    * Get the conversation history for context.
    */
-  getConversationHistory(): Array<{ role: string; text: string; speaker?: PromptSpeakerContext }> {
-    return this.conversationHistory.map(({ role, text, speaker }) => ({ role, text, speaker }));
+  getConversationHistory(): Array<{
+    role: string;
+    text: string;
+    speaker?: PromptSpeakerContext;
+  }> {
+    return this.conversationHistory.map(({ role, text, speaker }) => ({
+      role,
+      text,
+      speaker,
+    }));
   }
 
   /**
@@ -365,7 +402,10 @@ export class RelayConnection {
     }
     this.accessRequestWaitActive = false;
     this.abortController.abort();
-    log.info({ callSessionId: this.callSessionId }, 'RelayConnection destroyed');
+    log.info(
+      { callSessionId: this.callSessionId },
+      "RelayConnection destroyed",
+    );
   }
 
   /**
@@ -378,7 +418,7 @@ export class RelayConnection {
     // If the call was still in guardian-wait with callback opt-in, emit the
     // handoff notification before cleaning up wait state.
     if (this.accessRequestWaitActive && this.callbackOptIn) {
-      this.emitAccessRequestCallbackHandoff('transport_closed');
+      this.emitAccessRequestCallbackHandoff("transport_closed");
     }
 
     // Clean up access request wait state on disconnect to stop polling
@@ -395,41 +435,60 @@ export class RelayConnection {
     const isNormalClose = code === 1000;
     if (isNormalClose) {
       updateCallSession(this.callSessionId, {
-        status: 'completed',
+        status: "completed",
         endedAt: Date.now(),
       });
-      recordCallEvent(this.callSessionId, 'call_ended', {
-        reason: reason || 'relay_closed',
+      recordCallEvent(this.callSessionId, "call_ended", {
+        reason: reason || "relay_closed",
         closeCode: code,
       });
 
       // Post a pointer message in the initiating conversation
       if (session.initiatedFromConversationId) {
-        const durationMs = session.startedAt ? Date.now() - session.startedAt : 0;
-        addPointerMessage(session.initiatedFromConversationId, 'completed', session.toNumber, {
-          duration: durationMs > 0 ? formatDuration(durationMs) : undefined,
-        }).catch((err) => {
-          log.warn({ conversationId: session.initiatedFromConversationId, err }, 'Skipping pointer write — origin conversation may no longer exist');
+        const durationMs = session.startedAt
+          ? Date.now() - session.startedAt
+          : 0;
+        addPointerMessage(
+          session.initiatedFromConversationId,
+          "completed",
+          session.toNumber,
+          {
+            duration: durationMs > 0 ? formatDuration(durationMs) : undefined,
+          },
+        ).catch((err) => {
+          log.warn(
+            { conversationId: session.initiatedFromConversationId, err },
+            "Skipping pointer write — origin conversation may no longer exist",
+          );
         });
       }
     } else {
-      const detail = reason || (code ? `relay_closed_${code}` : 'relay_closed_abnormal');
+      const detail =
+        reason || (code ? `relay_closed_${code}` : "relay_closed_abnormal");
       updateCallSession(this.callSessionId, {
-        status: 'failed',
+        status: "failed",
         endedAt: Date.now(),
         lastError: `Relay websocket closed unexpectedly: ${detail}`,
       });
-      recordCallEvent(this.callSessionId, 'call_failed', {
+      recordCallEvent(this.callSessionId, "call_failed", {
         reason: detail,
         closeCode: code,
       });
 
       // Post a failure pointer message in the initiating conversation
       if (session.initiatedFromConversationId) {
-        addPointerMessage(session.initiatedFromConversationId, 'failed', session.toNumber, {
-          reason: detail,
-        }).catch((err) => {
-          log.warn({ conversationId: session.initiatedFromConversationId, err }, 'Skipping pointer write — origin conversation may no longer exist');
+        addPointerMessage(
+          session.initiatedFromConversationId,
+          "failed",
+          session.toNumber,
+          {
+            reason: detail,
+          },
+        ).catch((err) => {
+          log.warn(
+            { conversationId: session.initiatedFromConversationId, err },
+            "Skipping pointer write — origin conversation may no longer exist",
+          );
         });
       }
     }
@@ -441,14 +500,31 @@ export class RelayConnection {
     // guardian-approval-interception minting path sets callSessionId: null
     // but always sets conversationId.
     try {
-      revokeScopedApprovalGrantsForContext({ callSessionId: this.callSessionId });
-      revokeScopedApprovalGrantsForContext({ conversationId: session.conversationId });
+      revokeScopedApprovalGrantsForContext({
+        callSessionId: this.callSessionId,
+      });
+      revokeScopedApprovalGrantsForContext({
+        conversationId: session.conversationId,
+      });
     } catch (err) {
-      log.warn({ err, callSessionId: this.callSessionId }, 'Failed to revoke scoped grants on transport close');
+      log.warn(
+        { err, callSessionId: this.callSessionId },
+        "Failed to revoke scoped grants on transport close",
+      );
     }
 
-    persistCallCompletionMessage(session.conversationId, this.callSessionId).catch((err) => {
-      log.error({ err, conversationId: session.conversationId, callSessionId: this.callSessionId }, 'Failed to persist call completion message');
+    persistCallCompletionMessage(
+      session.conversationId,
+      this.callSessionId,
+    ).catch((err) => {
+      log.error(
+        {
+          err,
+          conversationId: session.conversationId,
+          callSessionId: this.callSessionId,
+        },
+        "Failed to persist call completion message",
+      );
     });
     fireCallCompletionNotifier(session.conversationId, this.callSessionId);
   }
@@ -457,8 +533,13 @@ export class RelayConnection {
 
   private async handleSetup(msg: RelaySetupMessage): Promise<void> {
     log.info(
-      { callSessionId: this.callSessionId, callSid: msg.callSid, from: msg.from, to: msg.to },
-      'ConversationRelay setup received',
+      {
+        callSessionId: this.callSessionId,
+        callSid: msg.callSid,
+        from: msg.from,
+        to: msg.to,
+      },
+      "ConversationRelay setup received",
     );
 
     // Store the callSid association on the call session
@@ -467,8 +548,12 @@ export class RelayConnection {
       const updates: Parameters<typeof updateCallSession>[1] = {
         providerCallSid: msg.callSid,
       };
-      if (!isTerminalState(session.status) && session.status !== 'in_progress' && session.status !== 'waiting_on_user') {
-        updates.status = 'in_progress';
+      if (
+        !isTerminalState(session.status) &&
+        session.status !== "in_progress" &&
+        session.status !== "waiting_on_user"
+      ) {
+        updates.status = "in_progress";
         if (!session.startedAt) {
           updates.startedAt = Date.now();
         }
@@ -481,12 +566,12 @@ export class RelayConnection {
     const safeCustomParameters = msg.customParameters
       ? Object.fromEntries(
           Object.entries(msg.customParameters).filter(
-            ([key]) => !key.toLowerCase().includes('secret'),
+            ([key]) => !key.toLowerCase().includes("secret"),
           ),
         )
       : undefined;
 
-    recordCallEvent(this.callSessionId, 'call_connected', {
+    recordCallEvent(this.callSessionId, "call_connected", {
       callSid: msg.callSid,
       from: msg.from,
       to: msg.to,
@@ -511,17 +596,25 @@ export class RelayConnection {
     const otherPartyNumber = isInbound ? msg.from : msg.to;
     const initialActorTrust = resolveActorTrust({
       assistantId,
-      sourceChannel: 'voice',
+      sourceChannel: "voice",
       conversationExternalId: otherPartyNumber,
       actorExternalId: otherPartyNumber || undefined,
     });
-    const initialTrustContext = toTrustContext(initialActorTrust, otherPartyNumber);
+    const initialTrustContext = toTrustContext(
+      initialActorTrust,
+      otherPartyNumber,
+    );
 
-    const controller = new CallController(this.callSessionId, this, session?.task ?? null, {
-      broadcast: globalBroadcast,
-      assistantId,
-      trustContext: initialTrustContext,
-    });
+    const controller = new CallController(
+      this.callSessionId,
+      this,
+      session?.task ?? null,
+      {
+        broadcast: globalBroadcast,
+        assistantId,
+        trustContext: initialTrustContext,
+      },
+    );
     this.setController(controller);
 
     // Detect outbound guardian verification call from persisted call session
@@ -529,21 +622,37 @@ export class RelayConnection {
     // as secondary signal for backward compatibility and observability.
     const persistedMode = session?.callMode;
     const persistedGvSessionId = session?.guardianVerificationSessionId;
-    const customParamGvSessionId = msg.customParameters?.guardianVerificationSessionId;
-    const guardianVerificationSessionId = persistedGvSessionId ?? customParamGvSessionId;
+    const customParamGvSessionId =
+      msg.customParameters?.guardianVerificationSessionId;
+    const guardianVerificationSessionId =
+      persistedGvSessionId ?? customParamGvSessionId;
 
-    if (persistedMode === 'guardian_verification' && guardianVerificationSessionId) {
-      this.startOutboundGuardianVerification(assistantId, guardianVerificationSessionId, msg.to);
+    if (
+      persistedMode === "guardian_verification" &&
+      guardianVerificationSessionId
+    ) {
+      this.startOutboundGuardianVerification(
+        assistantId,
+        guardianVerificationSessionId,
+        msg.to,
+      );
       return;
     }
 
     // Secondary signal: custom parameter without persisted mode (pre-migration sessions)
     if (!persistedMode && customParamGvSessionId) {
       log.warn(
-        { callSessionId: this.callSessionId, guardianVerificationSessionId: customParamGvSessionId },
-        'Guardian verification detected via setup custom parameter (no persisted call_mode) — entering verification path',
+        {
+          callSessionId: this.callSessionId,
+          guardianVerificationSessionId: customParamGvSessionId,
+        },
+        "Guardian verification detected via setup custom parameter (no persisted call_mode) — entering verification path",
       );
-      this.startOutboundGuardianVerification(assistantId, customParamGvSessionId, msg.to);
+      this.startOutboundGuardianVerification(
+        assistantId,
+        customParamGvSessionId,
+        msg.to,
+      );
       return;
     }
 
@@ -562,7 +671,7 @@ export class RelayConnection {
       // verification flow.
       const actorTrust = resolveActorTrust({
         assistantId,
-        sourceChannel: 'voice',
+        sourceChannel: "voice",
         conversationExternalId: msg.from,
         actorExternalId: msg.from || undefined,
       });
@@ -570,9 +679,9 @@ export class RelayConnection {
       // Check for a pending voice guardian challenge before the ACL deny
       // gate. An unknown caller with a pending challenge is expected —
       // they need to complete verification to establish a binding.
-      const pendingChallenge = getPendingChallenge(assistantId, 'voice');
+      const pendingChallenge = getPendingChallenge(assistantId, "voice");
 
-      if (actorTrust.trustClass === 'unknown' && !pendingChallenge) {
+      if (actorTrust.trustClass === "unknown" && !pendingChallenge) {
         // Before entering the name capture flow, check if there is an
         // active voice invite bound to the caller's phone number. If so,
         // enter the invite redemption subflow instead.
@@ -583,42 +692,54 @@ export class RelayConnection {
             expectedExternalUserId: msg.from,
           });
         } catch (err) {
-          log.warn({ err, callSessionId: this.callSessionId }, 'Failed to check voice invites for unknown caller');
+          log.warn(
+            { err, callSessionId: this.callSessionId },
+            "Failed to check voice invites for unknown caller",
+          );
         }
 
         // Exclude invites that are past their expiresAt even if the DB
         // status hasn't been lazily flipped to 'expired' yet.
         const now = Date.now();
-        const nonExpiredInvites = voiceInvites.filter(i => !i.expiresAt || i.expiresAt > now);
+        const nonExpiredInvites = voiceInvites.filter(
+          (i) => !i.expiresAt || i.expiresAt > now,
+        );
 
         // Blocked members get immediate denial — the guardian already made
         // an explicit decision to block them. This must be checked before
         // invite redemption so a blocked caller cannot bypass the block by
         // redeeming an active invite.
-        if (actorTrust.memberRecord?.status === 'blocked') {
+        if (actorTrust.memberRecord?.status === "blocked") {
           log.info(
-            { callSessionId: this.callSessionId, from: msg.from, trustClass: actorTrust.trustClass },
-            'Inbound voice ACL: blocked caller denied',
+            {
+              callSessionId: this.callSessionId,
+              from: msg.from,
+              trustClass: actorTrust.trustClass,
+            },
+            "Inbound voice ACL: blocked caller denied",
           );
 
-          recordCallEvent(this.callSessionId, 'inbound_acl_denied', {
+          recordCallEvent(this.callSessionId, "inbound_acl_denied", {
             from: msg.from,
             trustClass: actorTrust.trustClass,
             denialReason: actorTrust.denialReason,
           });
 
-          this.sendTextToken('This number is not authorized to use this assistant.', true);
+          this.sendTextToken(
+            "This number is not authorized to use this assistant.",
+            true,
+          );
 
-          this.connectionState = 'disconnecting';
+          this.connectionState = "disconnecting";
 
           updateCallSession(this.callSessionId, {
-            status: 'failed',
+            status: "failed",
             endedAt: Date.now(),
-            lastError: 'Inbound voice ACL: caller blocked',
+            lastError: "Inbound voice ACL: caller blocked",
           });
 
           setTimeout(() => {
-            this.endSession('Inbound voice ACL denied — blocked');
+            this.endSession("Inbound voice ACL denied — blocked");
           }, getTtsPlaybackDelayMs());
           return;
         }
@@ -628,23 +749,36 @@ export class RelayConnection {
           const matchedInvite = nonExpiredInvites[0];
           log.info(
             { callSessionId: this.callSessionId, from: msg.from },
-            'Inbound voice ACL: unknown caller has active voice invite — entering redemption flow',
+            "Inbound voice ACL: unknown caller has active voice invite — entering redemption flow",
           );
-          this.startInviteRedemption(assistantId, msg.from, matchedInvite.friendName, matchedInvite.guardianName);
+          this.startInviteRedemption(
+            assistantId,
+            msg.from,
+            matchedInvite.friendName,
+            matchedInvite.guardianName,
+          );
           return;
         }
 
         // Unknown/revoked/pending callers enter the name capture + guardian
         // approval wait flow instead of being hard-rejected.
         log.info(
-          { callSessionId: this.callSessionId, from: msg.from, trustClass: actorTrust.trustClass },
-          'Inbound voice ACL: unknown caller — entering name capture flow',
+          {
+            callSessionId: this.callSessionId,
+            from: msg.from,
+            trustClass: actorTrust.trustClass,
+          },
+          "Inbound voice ACL: unknown caller — entering name capture flow",
         );
 
-        recordCallEvent(this.callSessionId, 'inbound_acl_name_capture_started', {
-          from: msg.from,
-          trustClass: actorTrust.trustClass,
-        });
+        recordCallEvent(
+          this.callSessionId,
+          "inbound_acl_name_capture_started",
+          {
+            from: msg.from,
+            trustClass: actorTrust.trustClass,
+          },
+        );
 
         this.startNameCapture(assistantId, msg.from);
         return;
@@ -653,31 +787,39 @@ export class RelayConnection {
       // Members with policy: 'deny' have status: 'active' so resolveActorTrust
       // classifies them as trusted_contact, but the guardian has explicitly
       // denied their access. Block them the same way the text-channel path does.
-      if (actorTrust.memberRecord?.policy === 'deny') {
+      if (actorTrust.memberRecord?.policy === "deny") {
         log.info(
-          { callSessionId: this.callSessionId, from: msg.from, memberId: actorTrust.memberRecord.id, trustClass: actorTrust.trustClass },
-          'Inbound voice ACL: member policy deny',
+          {
+            callSessionId: this.callSessionId,
+            from: msg.from,
+            memberId: actorTrust.memberRecord.id,
+            trustClass: actorTrust.trustClass,
+          },
+          "Inbound voice ACL: member policy deny",
         );
 
-        recordCallEvent(this.callSessionId, 'inbound_acl_denied', {
+        recordCallEvent(this.callSessionId, "inbound_acl_denied", {
           from: msg.from,
           trustClass: actorTrust.trustClass,
           memberId: actorTrust.memberRecord.id,
           memberPolicy: actorTrust.memberRecord.policy,
         });
 
-        this.sendTextToken('This number is not authorized to use this assistant.', true);
+        this.sendTextToken(
+          "This number is not authorized to use this assistant.",
+          true,
+        );
 
-        this.connectionState = 'disconnecting';
+        this.connectionState = "disconnecting";
 
         updateCallSession(this.callSessionId, {
-          status: 'failed',
+          status: "failed",
           endedAt: Date.now(),
-          lastError: 'Inbound voice ACL: member policy deny',
+          lastError: "Inbound voice ACL: member policy deny",
         });
 
         setTimeout(() => {
-          this.endSession('Inbound voice ACL: member policy deny');
+          this.endSession("Inbound voice ACL: member policy deny");
         }, getTtsPlaybackDelayMs());
         return;
       }
@@ -685,31 +827,40 @@ export class RelayConnection {
       // Members with policy: 'escalate' require guardian approval, but a live
       // voice call cannot be paused for async approval. Fail-closed by denying
       // the call with an appropriate message — mirrors the deny block above.
-      if (actorTrust.memberRecord?.policy === 'escalate') {
+      if (actorTrust.memberRecord?.policy === "escalate") {
         log.info(
-          { callSessionId: this.callSessionId, from: msg.from, memberId: actorTrust.memberRecord.id, trustClass: actorTrust.trustClass },
-          'Inbound voice ACL: member policy escalate — cannot hold live call for guardian approval',
+          {
+            callSessionId: this.callSessionId,
+            from: msg.from,
+            memberId: actorTrust.memberRecord.id,
+            trustClass: actorTrust.trustClass,
+          },
+          "Inbound voice ACL: member policy escalate — cannot hold live call for guardian approval",
         );
 
-        recordCallEvent(this.callSessionId, 'inbound_acl_denied', {
+        recordCallEvent(this.callSessionId, "inbound_acl_denied", {
           from: msg.from,
           trustClass: actorTrust.trustClass,
           memberId: actorTrust.memberRecord.id,
           memberPolicy: actorTrust.memberRecord.policy,
         });
 
-        this.sendTextToken('This number requires guardian approval for calls. Please have the account guardian update your permissions.', true);
+        this.sendTextToken(
+          "This number requires guardian approval for calls. Please have the account guardian update your permissions.",
+          true,
+        );
 
-        this.connectionState = 'disconnecting';
+        this.connectionState = "disconnecting";
 
         updateCallSession(this.callSessionId, {
-          status: 'failed',
+          status: "failed",
           endedAt: Date.now(),
-          lastError: 'Inbound voice ACL: member policy escalate — voice calls cannot await guardian approval',
+          lastError:
+            "Inbound voice ACL: member policy escalate — voice calls cannot await guardian approval",
         });
 
         setTimeout(() => {
-          this.endSession('Inbound voice ACL: member policy escalate');
+          this.endSession("Inbound voice ACL: member policy escalate");
         }, getTtsPlaybackDelayMs());
         return;
       }
@@ -717,7 +868,7 @@ export class RelayConnection {
       // Guardian and trusted-contact callers proceed normally.
       // Update the controller's guardian context with the trust-resolved
       // context so downstream policy gates have accurate actor metadata.
-      if (this.controller && actorTrust.trustClass !== 'unknown') {
+      if (this.controller && actorTrust.trustClass !== "unknown") {
         const resolvedTrustContext = toTrustContext(actorTrust, msg.from);
         this.controller.setTrustContext(resolvedTrustContext);
       }
@@ -742,22 +893,27 @@ export class RelayConnection {
     this.verificationMaxAttempts = verificationConfig.maxAttempts;
     this.verificationCodeLength = verificationConfig.codeLength;
     this.verificationAttempts = 0;
-    this.dtmfBuffer = '';
+    this.dtmfBuffer = "";
 
     // Generate a random numeric code
     const maxValue = Math.pow(10, this.verificationCodeLength);
-    const code = randomInt(0, maxValue).toString().padStart(this.verificationCodeLength, '0');
+    const code = randomInt(0, maxValue)
+      .toString()
+      .padStart(this.verificationCodeLength, "0");
     this.verificationCode = code;
-    this.connectionState = 'verification_pending';
+    this.connectionState = "verification_pending";
 
-    recordCallEvent(this.callSessionId, 'callee_verification_started', {
+    recordCallEvent(this.callSessionId, "callee_verification_started", {
       codeLength: this.verificationCodeLength,
       maxAttempts: this.verificationMaxAttempts,
     });
 
     // Send a TTS prompt with the code spoken digit by digit
-    const spokenCode = code.split('').join('. ');
-    this.sendTextToken(`Please enter the verification code: ${spokenCode}.`, true);
+    const spokenCode = code.split("").join(". ");
+    this.sendTextToken(
+      `Please enter the verification code: ${spokenCode}.`,
+      true,
+    );
 
     // Post the verification code to the initiating conversation so the
     // guardian (user) can share it with the callee.
@@ -765,15 +921,23 @@ export class RelayConnection {
       const codeMsg = `\u{1F510} Verification code for call to ${session.toNumber}: ${code}`;
       await conversationStore.addMessage(
         session.initiatedFromConversationId,
-        'assistant',
-        JSON.stringify([{ type: 'text', text: codeMsg }]),
-        { userMessageChannel: 'voice', assistantMessageChannel: 'voice', userMessageInterface: 'voice', assistantMessageInterface: 'voice' },
+        "assistant",
+        JSON.stringify([{ type: "text", text: codeMsg }]),
+        {
+          userMessageChannel: "voice",
+          assistantMessageChannel: "voice",
+          userMessageInterface: "voice",
+          assistantMessageInterface: "voice",
+        },
       );
     }
 
     log.info(
-      { callSessionId: this.callSessionId, codeLength: this.verificationCodeLength },
-      'Callee verification started',
+      {
+        callSessionId: this.callSessionId,
+        codeLength: this.verificationCodeLength,
+      },
+      "Callee verification started",
     );
   }
 
@@ -781,12 +945,20 @@ export class RelayConnection {
    * Start normal call flow — fire the controller greeting unless a
    * static welcome greeting is configured.
    */
-  private startNormalCallFlow(controller: CallController, isInbound: boolean): void {
+  private startNormalCallFlow(
+    controller: CallController,
+    isInbound: boolean,
+  ): void {
     const hasStaticGreeting = !!process.env.CALL_WELCOME_GREETING?.trim();
     if (!hasStaticGreeting) {
-      controller.startInitialGreeting().catch((err) =>
-        log.error({ err, callSessionId: this.callSessionId }, `Failed to start initial ${isInbound ? 'inbound' : 'outbound'} greeting`),
-      );
+      controller
+        .startInitialGreeting()
+        .catch((err) =>
+          log.error(
+            { err, callSessionId: this.callSessionId },
+            `Failed to start initial ${isInbound ? "inbound" : "outbound"} greeting`,
+          ),
+        );
     }
   }
 
@@ -809,21 +981,24 @@ export class RelayConnection {
       try {
         upsertMember({
           assistantId,
-          sourceChannel: 'voice',
+          sourceChannel: "voice",
           externalUserId: fromNumber,
           externalChatId: fromNumber,
           displayName: callerName,
-          status: 'active',
-          policy: 'allow',
+          status: "active",
+          policy: "allow",
         });
       } catch (err) {
-        log.error({ err, callSessionId: this.callSessionId }, 'Failed to activate voice caller as trusted contact');
+        log.error(
+          { err, callSessionId: this.callSessionId },
+          "Failed to activate voice caller as trusted contact",
+        );
       }
     }
 
     const updatedTrust = resolveActorTrust({
       assistantId,
-      sourceChannel: 'voice',
+      sourceChannel: "voice",
       conversationExternalId: fromNumber,
       actorExternalId: fromNumber,
     });
@@ -834,17 +1009,24 @@ export class RelayConnection {
       );
     }
 
-    this.connectionState = 'connected';
-    updateCallSession(this.callSessionId, { status: 'in_progress' });
+    this.connectionState = "connected";
+    updateCallSession(this.callSessionId, { status: "in_progress" });
 
     const guardianLabel = this.resolveGuardianLabel();
     const handoffText = `Great! ${guardianLabel} said I can speak with you. How can I help?`;
     this.sendTextToken(handoffText, true);
 
-    recordCallEvent(this.callSessionId, 'assistant_spoke', { text: handoffText });
+    recordCallEvent(this.callSessionId, "assistant_spoke", {
+      text: handoffText,
+    });
     const session = getCallSession(this.callSessionId);
     if (session) {
-      fireCallTranscriptNotifier(session.conversationId, this.callSessionId, 'assistant', handoffText);
+      fireCallTranscriptNotifier(
+        session.conversationId,
+        this.callSessionId,
+        "assistant",
+        handoffText,
+      );
     }
 
     if (this.controller) {
@@ -857,29 +1039,32 @@ export class RelayConnection {
    * voice guardian challenge. Prompts the caller to enter their six-digit
    * verification code via DTMF or by speaking it.
    */
-  private startInboundGuardianVerification(assistantId: string, fromNumber: string): void {
+  private startInboundGuardianVerification(
+    assistantId: string,
+    fromNumber: string,
+  ): void {
     this.guardianVerificationActive = true;
     this.guardianChallengeAssistantId = assistantId;
     this.guardianVerificationFromNumber = fromNumber;
-    this.connectionState = 'verification_pending';
+    this.connectionState = "verification_pending";
     this.verificationAttempts = 0;
     this.verificationMaxAttempts = 3;
     this.verificationCodeLength = 6;
-    this.dtmfBuffer = '';
+    this.dtmfBuffer = "";
 
-    recordCallEvent(this.callSessionId, 'guardian_voice_verification_started', {
+    recordCallEvent(this.callSessionId, "guardian_voice_verification_started", {
       assistantId,
       maxAttempts: this.verificationMaxAttempts,
     });
 
     this.sendTextToken(
-      'Welcome. Please enter your six-digit verification code using your keypad, or speak the digits now.',
+      "Welcome. Please enter your six-digit verification code using your keypad, or speak the digits now.",
       true,
     );
 
     log.info(
       { callSessionId: this.callSessionId, assistantId },
-      'Inbound guardian voice verification started',
+      "Inbound guardian voice verification started",
     );
   }
 
@@ -898,17 +1083,21 @@ export class RelayConnection {
     this.guardianChallengeAssistantId = assistantId;
     // For outbound guardian calls, the "to" number is the guardian's phone
     this.guardianVerificationFromNumber = toNumber;
-    this.connectionState = 'verification_pending';
+    this.connectionState = "verification_pending";
     this.verificationAttempts = 0;
     this.verificationMaxAttempts = 3;
     this.verificationCodeLength = 6;
-    this.dtmfBuffer = '';
+    this.dtmfBuffer = "";
 
-    recordCallEvent(this.callSessionId, 'outbound_guardian_voice_verification_started', {
-      assistantId,
-      guardianVerificationSessionId,
-      maxAttempts: this.verificationMaxAttempts,
-    });
+    recordCallEvent(
+      this.callSessionId,
+      "outbound_guardian_voice_verification_started",
+      {
+        assistantId,
+        guardianVerificationSessionId,
+        maxAttempts: this.verificationMaxAttempts,
+      },
+    );
 
     const introText = composeVerificationVoice(
       GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_CALL_INTRO,
@@ -917,8 +1106,12 @@ export class RelayConnection {
     this.sendTextToken(introText, true);
 
     log.info(
-      { callSessionId: this.callSessionId, assistantId, guardianVerificationSessionId },
-      'Outbound guardian voice verification started',
+      {
+        callSessionId: this.callSessionId,
+        assistantId,
+        guardianVerificationSessionId,
+      },
+      "Outbound guardian voice verification started",
     );
   }
 
@@ -928,16 +1121,24 @@ export class RelayConnection {
    */
   private static parseDigitsFromSpeech(transcript: string): string {
     const wordToDigit: Record<string, string> = {
-      zero: '0', oh: '0', o: '0',
-      one: '1', won: '1',
-      two: '2', too: '2', to: '2',
-      three: '3',
-      four: '4', for: '4', fore: '4',
-      five: '5',
-      six: '6',
-      seven: '7',
-      eight: '8', ate: '8',
-      nine: '9',
+      zero: "0",
+      oh: "0",
+      o: "0",
+      one: "1",
+      won: "1",
+      two: "2",
+      too: "2",
+      to: "2",
+      three: "3",
+      four: "4",
+      for: "4",
+      fore: "4",
+      five: "5",
+      six: "6",
+      seven: "7",
+      eight: "8",
+      ate: "8",
+      nine: "9",
     };
 
     const digits: string[] = [];
@@ -952,11 +1153,11 @@ export class RelayConnection {
         digits.push(wordToDigit[token]);
       } else if (/^\d+$/.test(token)) {
         // Multi-digit number like "123456" — split into individual digits
-        digits.push(...token.split(''));
+        digits.push(...token.split(""));
       }
     }
 
-    return digits.join('');
+    return digits.join("");
   }
 
   /**
@@ -968,7 +1169,10 @@ export class RelayConnection {
    * On failure, enforces max attempts and terminates the call if exhausted.
    */
   private attemptGuardianCodeVerification(enteredCode: string): void {
-    if (!this.guardianChallengeAssistantId || !this.guardianVerificationFromNumber) {
+    if (
+      !this.guardianChallengeAssistantId ||
+      !this.guardianVerificationFromNumber
+    ) {
       return;
     }
 
@@ -977,7 +1181,7 @@ export class RelayConnection {
 
     const result = validateAndConsumeChallenge(
       this.guardianChallengeAssistantId,
-      'voice',
+      "voice",
       enteredCode,
       this.guardianVerificationFromNumber,
       this.guardianVerificationFromNumber,
@@ -985,21 +1189,21 @@ export class RelayConnection {
 
     if (result.success) {
       // Guardian binding was created by validateAndConsumeChallenge
-      this.connectionState = 'connected';
+      this.connectionState = "connected";
       this.guardianVerificationActive = false;
       this.verificationAttempts = 0;
-      this.dtmfBuffer = '';
+      this.dtmfBuffer = "";
 
       const eventName = isOutbound
-        ? 'outbound_guardian_voice_verification_succeeded'
-        : 'guardian_voice_verification_succeeded';
+        ? "outbound_guardian_voice_verification_succeeded"
+        : "guardian_voice_verification_succeeded";
 
       recordCallEvent(this.callSessionId, eventName, {
-        bindingId: 'bindingId' in result ? result.bindingId : undefined,
+        bindingId: "bindingId" in result ? result.bindingId : undefined,
       });
       log.info(
         { callSessionId: this.callSessionId, isOutbound },
-        'Guardian voice verification succeeded',
+        "Guardian voice verification succeeded",
       );
 
       if (isOutbound) {
@@ -1007,7 +1211,7 @@ export class RelayConnection {
         // There is no normal conversation to transition to.
         // Set disconnecting to ignore any further DTMF/speech input
         // during the brief delay before the session ends.
-        this.connectionState = 'disconnecting';
+        this.connectionState = "disconnecting";
 
         const successText = composeVerificationVoice(
           GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_SUCCESS,
@@ -1016,7 +1220,7 @@ export class RelayConnection {
         this.sendTextToken(successText, true);
 
         updateCallSession(this.callSessionId, {
-          status: 'completed',
+          status: "completed",
           endedAt: Date.now(),
         });
 
@@ -1026,18 +1230,24 @@ export class RelayConnection {
         if (successSession?.initiatedFromConversationId) {
           addPointerMessage(
             successSession.initiatedFromConversationId,
-            'guardian_verification_succeeded',
+            "guardian_verification_succeeded",
             successSession.toNumber,
-            { channel: 'voice' },
+            { channel: "voice" },
           ).catch((err) => {
-            log.warn({ conversationId: successSession.initiatedFromConversationId, err }, 'Skipping pointer write — origin conversation may no longer exist');
+            log.warn(
+              {
+                conversationId: successSession.initiatedFromConversationId,
+                err,
+              },
+              "Skipping pointer write — origin conversation may no longer exist",
+            );
           });
         }
 
         setTimeout(() => {
-          this.endSession('Guardian verification succeeded');
+          this.endSession("Guardian verification succeeded");
         }, getTtsPlaybackDelayMs());
-      } else if (result.verificationType === 'trusted_contact') {
+      } else if (result.verificationType === "trusted_contact") {
         // Inbound trusted-contact verification: activate and continue
         // the live call with the shared handoff primitive.
         this.continueCallAfterTrustedContactActivation({
@@ -1049,12 +1259,15 @@ export class RelayConnection {
         if (this.controller) {
           const verifiedActorTrust = resolveActorTrust({
             assistantId: this.guardianChallengeAssistantId,
-            sourceChannel: 'voice',
+            sourceChannel: "voice",
             conversationExternalId: this.guardianVerificationFromNumber,
             actorExternalId: this.guardianVerificationFromNumber,
           });
           this.controller.setTrustContext(
-            toTrustContext(verifiedActorTrust, this.guardianVerificationFromNumber),
+            toTrustContext(
+              verifiedActorTrust,
+              this.guardianVerificationFromNumber,
+            ),
           );
           this.startNormalCallFlow(this.controller, true);
         }
@@ -1068,61 +1281,99 @@ export class RelayConnection {
         this.guardianVerificationActive = false;
 
         const failEventName = isOutbound
-          ? 'outbound_guardian_voice_verification_failed'
-          : 'guardian_voice_verification_failed';
+          ? "outbound_guardian_voice_verification_failed"
+          : "guardian_voice_verification_failed";
 
         recordCallEvent(this.callSessionId, failEventName, {
           attempts: this.verificationAttempts,
         });
         log.warn(
-          { callSessionId: this.callSessionId, attempts: this.verificationAttempts, isOutbound },
-          'Guardian voice verification failed — max attempts reached',
+          {
+            callSessionId: this.callSessionId,
+            attempts: this.verificationAttempts,
+            isOutbound,
+          },
+          "Guardian voice verification failed — max attempts reached",
         );
 
         const failureText = isOutbound
-          ? composeVerificationVoice(GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_FAILURE, { codeDigits })
-          : 'Verification failed. Goodbye.';
+          ? composeVerificationVoice(
+              GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_FAILURE,
+              { codeDigits },
+            )
+          : "Verification failed. Goodbye.";
         this.sendTextToken(failureText, true);
 
         updateCallSession(this.callSessionId, {
-          status: 'failed',
+          status: "failed",
           endedAt: Date.now(),
-          lastError: 'Guardian voice verification failed — max attempts exceeded',
+          lastError:
+            "Guardian voice verification failed — max attempts exceeded",
         });
 
         const failSession = getCallSession(this.callSessionId);
         if (failSession) {
           expirePendingQuestions(this.callSessionId);
-          persistCallCompletionMessage(failSession.conversationId, this.callSessionId).catch((err) => {
-            log.error({ err, conversationId: failSession.conversationId, callSessionId: this.callSessionId }, 'Failed to persist call completion message');
+          persistCallCompletionMessage(
+            failSession.conversationId,
+            this.callSessionId,
+          ).catch((err) => {
+            log.error(
+              {
+                err,
+                conversationId: failSession.conversationId,
+                callSessionId: this.callSessionId,
+              },
+              "Failed to persist call completion message",
+            );
           });
-          fireCallCompletionNotifier(failSession.conversationId, this.callSessionId);
+          fireCallCompletionNotifier(
+            failSession.conversationId,
+            this.callSessionId,
+          );
 
           // Emit a pointer message to the origin conversation so the
           // requesting chat sees a deterministic failure notice.
           if (isOutbound && failSession.initiatedFromConversationId) {
             addPointerMessage(
               failSession.initiatedFromConversationId,
-              'guardian_verification_failed',
+              "guardian_verification_failed",
               failSession.toNumber,
-              { channel: 'voice', reason: 'Max verification attempts exceeded' },
+              {
+                channel: "voice",
+                reason: "Max verification attempts exceeded",
+              },
             ).catch((err) => {
-              log.warn({ conversationId: failSession.initiatedFromConversationId, err }, 'Skipping pointer write — origin conversation may no longer exist');
+              log.warn(
+                {
+                  conversationId: failSession.initiatedFromConversationId,
+                  err,
+                },
+                "Skipping pointer write — origin conversation may no longer exist",
+              );
             });
           }
         }
 
         setTimeout(() => {
-          this.endSession('Guardian verification failed');
+          this.endSession("Guardian verification failed");
         }, getTtsPlaybackDelayMs());
       } else {
         const retryText = isOutbound
-          ? composeVerificationVoice(GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_RETRY, { codeDigits })
-          : 'That code was incorrect. Please try again.';
+          ? composeVerificationVoice(
+              GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_RETRY,
+              { codeDigits },
+            )
+          : "That code was incorrect. Please try again.";
 
         log.info(
-          { callSessionId: this.callSessionId, attempt: this.verificationAttempts, maxAttempts: this.verificationMaxAttempts, isOutbound },
-          'Guardian voice verification attempt failed — retrying',
+          {
+            callSessionId: this.callSessionId,
+            attempt: this.verificationAttempts,
+            maxAttempts: this.verificationMaxAttempts,
+            isOutbound,
+          },
+          "Guardian voice verification attempt failed — retrying",
         );
         this.sendTextToken(retryText, true);
       }
@@ -1134,26 +1385,31 @@ export class RelayConnection {
    * who has an active voice invite. Prompts the caller to enter their
    * invite code via DTMF or speech.
    */
-  private startInviteRedemption(assistantId: string, fromNumber: string, friendName: string | null, guardianName: string | null): void {
+  private startInviteRedemption(
+    assistantId: string,
+    fromNumber: string,
+    friendName: string | null,
+    guardianName: string | null,
+  ): void {
     this.inviteRedemptionActive = true;
     this.inviteRedemptionAssistantId = assistantId;
     this.inviteRedemptionFromNumber = fromNumber;
     this.inviteRedemptionFriendName = friendName;
     this.inviteRedemptionGuardianName = guardianName;
-    this.connectionState = 'verification_pending';
+    this.connectionState = "verification_pending";
     this.verificationAttempts = 0;
     this.verificationMaxAttempts = 1;
     this.inviteRedemptionCodeLength = 6;
-    this.dtmfBuffer = '';
+    this.dtmfBuffer = "";
 
-    recordCallEvent(this.callSessionId, 'invite_redemption_started', {
+    recordCallEvent(this.callSessionId, "invite_redemption_started", {
       assistantId,
       codeLength: 6,
       maxAttempts: this.verificationMaxAttempts,
     });
 
-    const displayFriend = friendName ?? 'there';
-    const displayGuardian = guardianName ?? 'your contact';
+    const displayFriend = friendName ?? "there";
+    const displayGuardian = guardianName ?? "your contact";
     this.sendTextToken(
       `Welcome ${displayFriend}. Please enter the 6-digit code that ${displayGuardian} provided you to verify your identity.`,
       true,
@@ -1161,7 +1417,7 @@ export class RelayConnection {
 
     log.info(
       { callSessionId: this.callSessionId, assistantId },
-      'Inbound voice invite redemption started',
+      "Inbound voice invite redemption started",
     );
   }
 
@@ -1173,7 +1429,7 @@ export class RelayConnection {
   private startNameCapture(assistantId: string, fromNumber: string): void {
     this.accessRequestAssistantId = assistantId;
     this.accessRequestFromNumber = fromNumber;
-    this.connectionState = 'awaiting_name';
+    this.connectionState = "awaiting_name";
 
     const guardianLabel = this.resolveGuardianLabel();
     const assistantName = this.resolveAssistantLabel();
@@ -1189,13 +1445,17 @@ export class RelayConnection {
     // to avoid wasting resources on callers who never respond.
     const NAME_CAPTURE_TIMEOUT_MS = 30_000;
     this.nameCaptureTimeoutTimer = setTimeout(() => {
-      if (this.connectionState !== 'awaiting_name') return;
+      if (this.connectionState !== "awaiting_name") return;
       this.handleNameCaptureTimeout();
     }, NAME_CAPTURE_TIMEOUT_MS);
 
     log.info(
-      { callSessionId: this.callSessionId, assistantId, timeoutMs: NAME_CAPTURE_TIMEOUT_MS },
-      'Name capture started for unknown inbound caller',
+      {
+        callSessionId: this.callSessionId,
+        assistantId,
+        timeoutMs: NAME_CAPTURE_TIMEOUT_MS,
+      },
+      "Name capture started for unknown inbound caller",
     );
   }
 
@@ -1217,7 +1477,7 @@ export class RelayConnection {
 
     this.accessRequestCallerName = callerName;
 
-    recordCallEvent(this.callSessionId, 'inbound_acl_name_captured', {
+    recordCallEvent(this.callSessionId, "inbound_acl_name_captured", {
       from: this.accessRequestFromNumber,
       callerName,
     });
@@ -1227,7 +1487,7 @@ export class RelayConnection {
     try {
       const accessResult = notifyGuardianOfAccessRequest({
         canonicalAssistantId: this.accessRequestAssistantId,
-        sourceChannel: 'voice',
+        sourceChannel: "voice",
         conversationExternalId: this.accessRequestFromNumber,
         actorExternalId: this.accessRequestFromNumber,
         actorDisplayName: callerName,
@@ -1236,17 +1496,24 @@ export class RelayConnection {
       if (accessResult.notified) {
         this.accessRequestId = accessResult.requestId;
         log.info(
-          { callSessionId: this.callSessionId, requestId: accessResult.requestId, callerName },
-          'Guardian notified of voice access request with caller name',
+          {
+            callSessionId: this.callSessionId,
+            requestId: accessResult.requestId,
+            callerName,
+          },
+          "Guardian notified of voice access request with caller name",
         );
       } else {
         log.warn(
           { callSessionId: this.callSessionId },
-          'Failed to notify guardian of voice access request — no sender ID',
+          "Failed to notify guardian of voice access request — no sender ID",
         );
       }
     } catch (err) {
-      log.error({ err, callSessionId: this.callSessionId }, 'Failed to create access request for voice caller');
+      log.error(
+        { err, callSessionId: this.callSessionId },
+        "Failed to create access request for voice caller",
+      );
     }
 
     // If the access request was not successfully created (notifyGuardianOfAccessRequest
@@ -1255,7 +1522,7 @@ export class RelayConnection {
     if (!this.accessRequestId) {
       log.warn(
         { callSessionId: this.callSessionId },
-        'Access request ID is null after notification attempt — failing closed',
+        "Access request ID is null after notification attempt — failing closed",
       );
       this.handleAccessRequestTimeout();
       return;
@@ -1271,7 +1538,7 @@ export class RelayConnection {
    */
   private startAccessRequestWait(): void {
     this.accessRequestWaitActive = true;
-    this.connectionState = 'awaiting_guardian_decision';
+    this.connectionState = "awaiting_guardian_decision";
 
     const timeoutMs = getUserConsultationTimeoutMs();
     const pollIntervalMs = getAccessRequestPollIntervalMs();
@@ -1282,7 +1549,7 @@ export class RelayConnection {
       true,
     );
 
-    updateCallSession(this.callSessionId, { status: 'waiting_on_user' });
+    updateCallSession(this.callSessionId, { status: "waiting_on_user" });
 
     // Start the heartbeat timer for periodic progress updates.
     // Delay the first heartbeat by the estimated TTS playback duration so
@@ -1305,9 +1572,9 @@ export class RelayConnection {
         return;
       }
 
-      if (request.status === 'approved') {
+      if (request.status === "approved") {
         this.handleAccessRequestApproved();
-      } else if (request.status === 'denied') {
+      } else if (request.status === "denied") {
         this.handleAccessRequestDenied();
       }
       // 'pending' continues polling; 'expired'/'cancelled' handled by timeout
@@ -1319,15 +1586,19 @@ export class RelayConnection {
 
       log.info(
         { callSessionId: this.callSessionId, requestId: this.accessRequestId },
-        'Access request in-call wait timed out',
+        "Access request in-call wait timed out",
       );
 
       this.handleAccessRequestTimeout();
     }, timeoutMs);
 
     log.info(
-      { callSessionId: this.callSessionId, requestId: this.accessRequestId, timeoutMs },
-      'Access request in-call wait started',
+      {
+        callSessionId: this.callSessionId,
+        requestId: this.accessRequestId,
+        timeoutMs,
+      },
+      "Access request in-call wait started",
     );
   }
 
@@ -1361,7 +1632,7 @@ export class RelayConnection {
     const fromNumber = this.accessRequestFromNumber!;
     const callerName = this.accessRequestCallerName;
 
-    recordCallEvent(this.callSessionId, 'inbound_acl_access_approved', {
+    recordCallEvent(this.callSessionId, "inbound_acl_access_approved", {
       from: fromNumber,
       callerName,
       requestId: this.accessRequestId,
@@ -1369,7 +1640,7 @@ export class RelayConnection {
 
     log.info(
       { callSessionId: this.callSessionId, from: fromNumber },
-      'Access request approved — caller activated and continuing call',
+      "Access request approved — caller activated and continuing call",
     );
 
     this.continueCallAfterTrustedContactActivation({
@@ -1378,9 +1649,13 @@ export class RelayConnection {
       callerName: callerName ?? undefined,
     });
 
-    recordCallEvent(this.callSessionId, 'inbound_acl_post_approval_handoff_spoken', {
-      from: fromNumber,
-    });
+    recordCallEvent(
+      this.callSessionId,
+      "inbound_acl_post_approval_handoff_spoken",
+      {
+        from: fromNumber,
+      },
+    );
   }
 
   /**
@@ -1391,7 +1666,7 @@ export class RelayConnection {
 
     const guardianLabel = this.resolveGuardianLabel();
 
-    recordCallEvent(this.callSessionId, 'inbound_acl_access_denied', {
+    recordCallEvent(this.callSessionId, "inbound_acl_access_denied", {
       from: this.accessRequestFromNumber,
       requestId: this.accessRequestId,
     });
@@ -1401,21 +1676,21 @@ export class RelayConnection {
       true,
     );
 
-    this.connectionState = 'disconnecting';
+    this.connectionState = "disconnecting";
 
     updateCallSession(this.callSessionId, {
-      status: 'failed',
+      status: "failed",
       endedAt: Date.now(),
-      lastError: 'Inbound voice ACL: guardian denied access request',
+      lastError: "Inbound voice ACL: guardian denied access request",
     });
 
     log.info(
       { callSessionId: this.callSessionId },
-      'Access request denied — ending call',
+      "Access request denied — ending call",
     );
 
     setTimeout(() => {
-      this.endSession('Access request denied');
+      this.endSession("Access request denied");
     }, getTtsPlaybackDelayMs());
   }
 
@@ -1424,13 +1699,13 @@ export class RelayConnection {
    */
   private handleAccessRequestTimeout(): void {
     // Emit callback handoff notification before clearing wait state
-    this.emitAccessRequestCallbackHandoff('timeout');
+    this.emitAccessRequestCallbackHandoff("timeout");
 
     this.clearAccessRequestWait();
 
     const guardianLabel = this.resolveGuardianLabel();
 
-    recordCallEvent(this.callSessionId, 'inbound_acl_access_timeout', {
+    recordCallEvent(this.callSessionId, "inbound_acl_access_timeout", {
       from: this.accessRequestFromNumber,
       requestId: this.accessRequestId,
       callbackOptIn: this.callbackOptIn,
@@ -1438,27 +1713,27 @@ export class RelayConnection {
 
     const callbackNote = this.callbackOptIn
       ? ` I've noted that you'd like a callback — I'll pass that along to ${guardianLabel}.`
-      : '';
+      : "";
     this.sendTextToken(
       `Sorry, I can't get ahold of ${guardianLabel} right now. I'll let them know you called.${callbackNote}`,
       true,
     );
 
-    this.connectionState = 'disconnecting';
+    this.connectionState = "disconnecting";
 
     updateCallSession(this.callSessionId, {
-      status: 'failed',
+      status: "failed",
       endedAt: Date.now(),
-      lastError: 'Inbound voice ACL: guardian approval wait timed out',
+      lastError: "Inbound voice ACL: guardian approval wait timed out",
     });
 
     log.info(
       { callSessionId: this.callSessionId },
-      'Access request timed out — ending call',
+      "Access request timed out — ending call",
     );
 
     setTimeout(() => {
-      this.endSession('Access request timed out');
+      this.endSession("Access request timed out");
     }, getTtsPlaybackDelayMs());
   }
 
@@ -1470,14 +1745,17 @@ export class RelayConnection {
    * Idempotent: uses callbackHandoffNotified guard + deterministic dedupeKey
    * to ensure at most one notification per call/request.
    */
-  private emitAccessRequestCallbackHandoff(reason: 'timeout' | 'transport_closed'): void {
+  private emitAccessRequestCallbackHandoff(
+    reason: "timeout" | "transport_closed",
+  ): void {
     if (!this.callbackOptIn) return;
     if (!this.accessRequestId) return;
     if (this.callbackHandoffNotified) return;
 
     this.callbackHandoffNotified = true;
 
-    const assistantId = this.accessRequestAssistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
+    const assistantId =
+      this.accessRequestAssistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
     const fromNumber = this.accessRequestFromNumber ?? null;
 
     // Resolve canonical request for requestCode and conversationId
@@ -1491,30 +1769,34 @@ export class RelayConnection {
       try {
         const member = findMember({
           assistantId,
-          sourceChannel: 'voice',
+          sourceChannel: "voice",
           externalUserId: fromNumber,
           externalChatId: fromNumber,
         });
-        if (member && member.status === 'active' && member.policy === 'allow') {
+        if (member && member.status === "active" && member.policy === "allow") {
           requesterMemberId = member.id;
         }
       } catch (err) {
-        log.warn({ err, callSessionId: this.callSessionId }, 'Failed to resolve member for callback handoff');
+        log.warn(
+          { err, callSessionId: this.callSessionId },
+          "Failed to resolve member for callback handoff",
+        );
       }
     }
 
     const dedupeKey = `access-request-callback-handoff:${this.accessRequestId}`;
-    const sourceSessionId = canonicalRequest?.conversationId
-      ?? `access-req-callback-${this.accessRequestId}`;
+    const sourceSessionId =
+      canonicalRequest?.conversationId ??
+      `access-req-callback-${this.accessRequestId}`;
 
     void emitNotificationSignal({
-      sourceEventName: 'ingress.access_request.callback_handoff',
-      sourceChannel: 'voice',
+      sourceEventName: "ingress.access_request.callback_handoff",
+      sourceChannel: "voice",
       sourceSessionId,
       assistantId,
       attentionHints: {
         requiresAction: false,
-        urgency: 'medium',
+        urgency: "medium",
         isAsyncBackground: true,
         visibleInSourceNow: false,
       },
@@ -1522,7 +1804,7 @@ export class RelayConnection {
         requestId: this.accessRequestId,
         requestCode: canonicalRequest?.requestCode ?? null,
         callSessionId: this.callSessionId,
-        sourceChannel: 'voice',
+        sourceChannel: "voice",
         reason,
         callbackOptIn: true,
         callerPhoneNumber: fromNumber,
@@ -1530,30 +1812,40 @@ export class RelayConnection {
         requesterExternalUserId: fromNumber,
         requesterChatId: fromNumber,
         requesterMemberId,
-        requesterMemberSourceChannel: requesterMemberId ? 'voice' : null,
+        requesterMemberSourceChannel: requesterMemberId ? "voice" : null,
       },
       dedupeKey,
-    }).then(() => {
-      recordCallEvent(this.callSessionId, 'callback_handoff_notified', {
-        requestId: this.accessRequestId,
-        reason,
-        requesterMemberId,
+    })
+      .then(() => {
+        recordCallEvent(this.callSessionId, "callback_handoff_notified", {
+          requestId: this.accessRequestId,
+          reason,
+          requesterMemberId,
+        });
+        log.info(
+          {
+            callSessionId: this.callSessionId,
+            requestId: this.accessRequestId,
+            reason,
+          },
+          "Callback handoff notification emitted",
+        );
+      })
+      .catch((err) => {
+        recordCallEvent(this.callSessionId, "callback_handoff_failed", {
+          requestId: this.accessRequestId,
+          reason,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        log.error(
+          {
+            err,
+            callSessionId: this.callSessionId,
+            requestId: this.accessRequestId,
+          },
+          "Failed to emit callback handoff notification",
+        );
       });
-      log.info(
-        { callSessionId: this.callSessionId, requestId: this.accessRequestId, reason },
-        'Callback handoff notification emitted',
-      );
-    }).catch((err) => {
-      recordCallEvent(this.callSessionId, 'callback_handoff_failed', {
-        requestId: this.accessRequestId,
-        reason,
-        error: err instanceof Error ? err.message : String(err),
-      });
-      log.error(
-        { err, callSessionId: this.callSessionId, requestId: this.accessRequestId },
-        'Failed to emit callback handoff notification',
-      );
-    });
   }
 
   /**
@@ -1566,7 +1858,7 @@ export class RelayConnection {
       this.nameCaptureTimeoutTimer = null;
     }
 
-    recordCallEvent(this.callSessionId, 'inbound_acl_name_capture_timeout', {
+    recordCallEvent(this.callSessionId, "inbound_acl_name_capture_timeout", {
       from: this.accessRequestFromNumber,
     });
 
@@ -1575,21 +1867,21 @@ export class RelayConnection {
       true,
     );
 
-    this.connectionState = 'disconnecting';
+    this.connectionState = "disconnecting";
 
     updateCallSession(this.callSessionId, {
-      status: 'failed',
+      status: "failed",
       endedAt: Date.now(),
-      lastError: 'Inbound voice ACL: name capture timed out',
+      lastError: "Inbound voice ACL: name capture timed out",
     });
 
     log.info(
       { callSessionId: this.callSessionId },
-      'Name capture timed out — ending call',
+      "Name capture timed out — ending call",
     );
 
     setTimeout(() => {
-      this.endSession('Name capture timed out');
+      this.endSession("Name capture timed out");
     }, getTtsPlaybackDelayMs());
   }
 
@@ -1606,22 +1898,26 @@ export class RelayConnection {
     const result = redeemVoiceInviteCode({
       assistantId: this.inviteRedemptionAssistantId,
       callerExternalUserId: this.inviteRedemptionFromNumber,
-      sourceChannel: 'voice',
+      sourceChannel: "voice",
       code: enteredCode,
     });
 
     if (result.ok) {
       this.inviteRedemptionActive = false;
       this.verificationAttempts = 0;
-      this.dtmfBuffer = '';
+      this.dtmfBuffer = "";
 
-      recordCallEvent(this.callSessionId, 'invite_redemption_succeeded', {
+      recordCallEvent(this.callSessionId, "invite_redemption_succeeded", {
         memberId: result.memberId,
-        ...(result.type === 'redeemed' ? { inviteId: result.inviteId } : {}),
+        ...(result.type === "redeemed" ? { inviteId: result.inviteId } : {}),
       });
       log.info(
-        { callSessionId: this.callSessionId, memberId: result.memberId, type: result.type },
-        'Voice invite redemption succeeded',
+        {
+          callSessionId: this.callSessionId,
+          memberId: result.memberId,
+          type: result.type,
+        },
+        "Voice invite redemption succeeded",
       );
 
       this.continueCallAfterTrustedContactActivation({
@@ -1634,39 +1930,53 @@ export class RelayConnection {
       // On any invalid/expired code, emit exact deterministic failure copy and end call immediately.
       this.inviteRedemptionActive = false;
 
-      recordCallEvent(this.callSessionId, 'invite_redemption_failed', {
+      recordCallEvent(this.callSessionId, "invite_redemption_failed", {
         attempts: 1,
       });
       log.warn(
         { callSessionId: this.callSessionId },
-        'Voice invite redemption failed — invalid or expired code',
+        "Voice invite redemption failed — invalid or expired code",
       );
 
-      const displayGuardian = this.inviteRedemptionGuardianName ?? 'your contact';
+      const displayGuardian =
+        this.inviteRedemptionGuardianName ?? "your contact";
       this.sendTextToken(
         `Sorry, the code you provided is incorrect or has since expired. Please ask ${displayGuardian} for a new code. Goodbye.`,
         true,
       );
 
-      this.connectionState = 'disconnecting';
+      this.connectionState = "disconnecting";
 
       updateCallSession(this.callSessionId, {
-        status: 'failed',
+        status: "failed",
         endedAt: Date.now(),
-        lastError: 'Voice invite redemption failed — invalid or expired code',
+        lastError: "Voice invite redemption failed — invalid or expired code",
       });
 
       const failSession = getCallSession(this.callSessionId);
       if (failSession) {
         expirePendingQuestions(this.callSessionId);
-        persistCallCompletionMessage(failSession.conversationId, this.callSessionId).catch((err) => {
-          log.error({ err, conversationId: failSession.conversationId, callSessionId: this.callSessionId }, 'Failed to persist call completion message');
+        persistCallCompletionMessage(
+          failSession.conversationId,
+          this.callSessionId,
+        ).catch((err) => {
+          log.error(
+            {
+              err,
+              conversationId: failSession.conversationId,
+              callSessionId: this.callSessionId,
+            },
+            "Failed to persist call completion message",
+          );
         });
-        fireCallCompletionNotifier(failSession.conversationId, this.callSessionId);
+        fireCallCompletionNotifier(
+          failSession.conversationId,
+          this.callSessionId,
+        );
       }
 
       setTimeout(() => {
-        this.endSession('Invite redemption failed');
+        this.endSession("Invite redemption failed");
       }, getTtsPlaybackDelayMs());
     }
   }
@@ -1679,13 +1989,14 @@ export class RelayConnection {
    * to @username, then the user's preferred name from USER.md.
    */
   private resolveGuardianLabel(): string {
-    const assistantId = this.accessRequestAssistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
+    const assistantId =
+      this.accessRequestAssistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
 
     // Try the voice-channel binding first, then fall back to any active
     // binding for the assistant (mirrors the cross-channel fallback pattern
     // in access-request-helper.ts).
     let metadataJson: string | null = null;
-    const voiceBinding = getGuardianBinding(assistantId, 'voice');
+    const voiceBinding = getGuardianBinding(assistantId, "voice");
     if (voiceBinding?.metadataJson) {
       metadataJson = voiceBinding.metadataJson;
     } else {
@@ -1698,10 +2009,16 @@ export class RelayConnection {
     if (metadataJson) {
       try {
         const parsed = JSON.parse(metadataJson) as Record<string, unknown>;
-        if (typeof parsed.displayName === 'string' && parsed.displayName.trim().length > 0) {
+        if (
+          typeof parsed.displayName === "string" &&
+          parsed.displayName.trim().length > 0
+        ) {
           return parsed.displayName.trim();
         }
-        if (typeof parsed.username === 'string' && parsed.username.trim().length > 0) {
+        if (
+          typeof parsed.username === "string" &&
+          parsed.username.trim().length > 0
+        ) {
           return `@${parsed.username.trim()}`;
         }
       } catch {
@@ -1751,10 +2068,18 @@ export class RelayConnection {
 
     const elapsed = Date.now() - this.accessRequestWaitStartedAt;
     const initialWindow = getGuardianWaitUpdateInitialWindowMs();
-    const intervalMs = elapsed < initialWindow
-      ? getGuardianWaitUpdateInitialIntervalMs()
-      : getGuardianWaitUpdateSteadyMinIntervalMs() +
-        Math.floor(Math.random() * Math.max(0, getGuardianWaitUpdateSteadyMaxIntervalMs() - getGuardianWaitUpdateSteadyMinIntervalMs()));
+    const intervalMs =
+      elapsed < initialWindow
+        ? getGuardianWaitUpdateInitialIntervalMs()
+        : getGuardianWaitUpdateSteadyMinIntervalMs() +
+          Math.floor(
+            Math.random() *
+              Math.max(
+                0,
+                getGuardianWaitUpdateSteadyMaxIntervalMs() -
+                  getGuardianWaitUpdateSteadyMinIntervalMs(),
+              ),
+          );
 
     this.accessRequestHeartbeatTimer = setTimeout(() => {
       if (!this.accessRequestWaitActive) return;
@@ -1762,14 +2087,21 @@ export class RelayConnection {
       const message = this.getHeartbeatMessage();
       this.sendTextToken(message, true);
 
-      recordCallEvent(this.callSessionId, 'voice_guardian_wait_heartbeat_sent', {
-        sequence: this.heartbeatSequence - 1,
-        message,
-      });
+      recordCallEvent(
+        this.callSessionId,
+        "voice_guardian_wait_heartbeat_sent",
+        {
+          sequence: this.heartbeatSequence - 1,
+          message,
+        },
+      );
 
       log.debug(
-        { callSessionId: this.callSessionId, sequence: this.heartbeatSequence - 1 },
-        'Guardian wait heartbeat sent',
+        {
+          callSessionId: this.callSessionId,
+          sequence: this.heartbeatSequence - 1,
+        },
+        "Guardian wait heartbeat sent",
       );
 
       // Schedule the next heartbeat
@@ -1786,52 +2118,72 @@ export class RelayConnection {
    * - 'callback_decline': explicitly declining a callback
    * - 'neutral': anything else
    */
-  private classifyWaitUtterance(text: string): 'empty' | 'patience_check' | 'impatient' | 'callback_opt_in' | 'callback_decline' | 'neutral' {
+  private classifyWaitUtterance(
+    text: string,
+  ):
+    | "empty"
+    | "patience_check"
+    | "impatient"
+    | "callback_opt_in"
+    | "callback_decline"
+    | "neutral" {
     const lower = text.toLowerCase().trim();
-    if (lower.length === 0) return 'empty';
+    if (lower.length === 0) return "empty";
 
     // Callback opt-in patterns (check before impatience to catch "yes call me back")
     if (this.callbackOfferMade) {
-      if (/\b(yes|yeah|yep|sure|okay|ok|please)\b.*\b(call\s*(me\s*)?back|callback)\b/.test(lower)
-        || /\b(call\s*(me\s*)?back|callback)\b.*\b(yes|yeah|please|sure)\b/.test(lower)
-        || /^(yes|yeah|yep|sure|okay|ok|please)\s*[.,!]?\s*$/.test(lower)
-        || /\bcall\s*(me\s*)?back\b/.test(lower)
-        || /\bplease\s+do\b/.test(lower)) {
-        return 'callback_opt_in';
+      if (
+        /\b(yes|yeah|yep|sure|okay|ok|please)\b.*\b(call\s*(me\s*)?back|callback)\b/.test(
+          lower,
+        ) ||
+        /\b(call\s*(me\s*)?back|callback)\b.*\b(yes|yeah|please|sure)\b/.test(
+          lower,
+        ) ||
+        /^(yes|yeah|yep|sure|okay|ok|please)\s*[.,!]?\s*$/.test(lower) ||
+        /\bcall\s*(me\s*)?back\b/.test(lower) ||
+        /\bplease\s+do\b/.test(lower)
+      ) {
+        return "callback_opt_in";
       }
-      if (/\b(no|nah|nope)\b/.test(lower)
-        || /\bi('?ll| will)\s+hold\b/.test(lower)
-        || /\bi('?ll| will)\s+wait\b/.test(lower)) {
-        return 'callback_decline';
+      if (
+        /\b(no|nah|nope)\b/.test(lower) ||
+        /\bi('?ll| will)\s+hold\b/.test(lower) ||
+        /\bi('?ll| will)\s+wait\b/.test(lower)
+      ) {
+        return "callback_decline";
       }
     }
 
     // Impatience patterns
-    if (/\bhurry\s*(up)?\b/.test(lower)
-      || /\btaking\s+(too\s+|so\s+)?long\b/.test(lower)
-      || /\bforget\s+it\b/.test(lower)
-      || /\bnever\s*mind\b/.test(lower)
-      || /\bdon'?t\s+have\s+time\b/.test(lower)
-      || /\bhow\s+much\s+longer\b/.test(lower)
-      || /\bi('?m| am)\s+(getting\s+)?impatient\b/.test(lower)
-      || /\bthis\s+is\s+(ridiculous|absurd|crazy)\b/.test(lower)
-      || /\bcome\s+on\b/.test(lower)
-      || /\bi\s+(gotta|have\s+to|need\s+to)\s+go\b/.test(lower)) {
-      return 'impatient';
+    if (
+      /\bhurry\s*(up)?\b/.test(lower) ||
+      /\btaking\s+(too\s+|so\s+)?long\b/.test(lower) ||
+      /\bforget\s+it\b/.test(lower) ||
+      /\bnever\s*mind\b/.test(lower) ||
+      /\bdon'?t\s+have\s+time\b/.test(lower) ||
+      /\bhow\s+much\s+longer\b/.test(lower) ||
+      /\bi('?m| am)\s+(getting\s+)?impatient\b/.test(lower) ||
+      /\bthis\s+is\s+(ridiculous|absurd|crazy)\b/.test(lower) ||
+      /\bcome\s+on\b/.test(lower) ||
+      /\bi\s+(gotta|have\s+to|need\s+to)\s+go\b/.test(lower)
+    ) {
+      return "impatient";
     }
 
     // Patience check / status inquiry patterns
-    if (/\bhello\??\s*$/.test(lower)
-      || /\bstill\s+there\b/.test(lower)
-      || /\bany\s+(update|news)\b/.test(lower)
-      || /\bwhat('?s| is)\s+(happening|going\s+on)\b/.test(lower)
-      || /\bare\s+you\s+still\b/.test(lower)
-      || /\bhow\s+(long|much\s+longer)\b/.test(lower)
-      || /\banyone\s+there\b/.test(lower)) {
-      return 'patience_check';
+    if (
+      /\bhello\??\s*$/.test(lower) ||
+      /\bstill\s+there\b/.test(lower) ||
+      /\bany\s+(update|news)\b/.test(lower) ||
+      /\bwhat('?s| is)\s+(happening|going\s+on)\b/.test(lower) ||
+      /\bare\s+you\s+still\b/.test(lower) ||
+      /\bhow\s+(long|much\s+longer)\b/.test(lower) ||
+      /\banyone\s+there\b/.test(lower)
+    ) {
+      return "patience_check";
     }
 
-    return 'neutral';
+    return "neutral";
   }
 
   /**
@@ -1842,12 +2194,16 @@ export class RelayConnection {
     const now = Date.now();
     const classification = this.classifyWaitUtterance(text);
 
-    recordCallEvent(this.callSessionId, 'voice_guardian_wait_prompt_classified', {
-      classification,
-      transcript: text,
-    });
+    recordCallEvent(
+      this.callSessionId,
+      "voice_guardian_wait_prompt_classified",
+      {
+        classification,
+        transcript: text,
+      },
+    );
 
-    if (classification === 'empty') return;
+    if (classification === "empty") return;
 
     const guardianLabel = this.resolveGuardianLabel();
 
@@ -1855,10 +2211,14 @@ export class RelayConnection {
     // the caller is answering a direct question and dropping their response
     // would silently discard their decision.
     switch (classification) {
-      case 'callback_opt_in': {
+      case "callback_opt_in": {
         this.callbackOptIn = true;
         this.lastInWaitReplyAt = now;
-        recordCallEvent(this.callSessionId, 'voice_guardian_wait_callback_opt_in_set', {});
+        recordCallEvent(
+          this.callSessionId,
+          "voice_guardian_wait_callback_opt_in_set",
+          {},
+        );
         if (this.accessRequestHeartbeatTimer) {
           clearTimeout(this.accessRequestHeartbeatTimer);
           this.accessRequestHeartbeatTimer = null;
@@ -1870,10 +2230,14 @@ export class RelayConnection {
         this.scheduleNextHeartbeat();
         return;
       }
-      case 'callback_decline': {
+      case "callback_decline": {
         this.callbackOptIn = false;
         this.lastInWaitReplyAt = now;
-        recordCallEvent(this.callSessionId, 'voice_guardian_wait_callback_opt_in_declined', {});
+        recordCallEvent(
+          this.callSessionId,
+          "voice_guardian_wait_callback_opt_in_declined",
+          {},
+        );
         if (this.accessRequestHeartbeatTimer) {
           clearTimeout(this.accessRequestHeartbeatTimer);
           this.accessRequestHeartbeatTimer = null;
@@ -1890,21 +2254,31 @@ export class RelayConnection {
     }
 
     // Enforce cooldown on non-callback utterances to prevent spam
-    if (now - this.lastInWaitReplyAt < RelayConnection.IN_WAIT_REPLY_COOLDOWN_MS) {
-      log.debug({ callSessionId: this.callSessionId }, 'In-wait reply suppressed by cooldown');
+    if (
+      now - this.lastInWaitReplyAt <
+      RelayConnection.IN_WAIT_REPLY_COOLDOWN_MS
+    ) {
+      log.debug(
+        { callSessionId: this.callSessionId },
+        "In-wait reply suppressed by cooldown",
+      );
       return;
     }
     this.lastInWaitReplyAt = now;
 
     switch (classification) {
-      case 'impatient': {
+      case "impatient": {
         if (this.accessRequestHeartbeatTimer) {
           clearTimeout(this.accessRequestHeartbeatTimer);
           this.accessRequestHeartbeatTimer = null;
         }
         if (!this.callbackOfferMade) {
           this.callbackOfferMade = true;
-          recordCallEvent(this.callSessionId, 'voice_guardian_wait_callback_offer_sent', {});
+          recordCallEvent(
+            this.callSessionId,
+            "voice_guardian_wait_callback_offer_sent",
+            {},
+          );
           this.sendTextToken(
             `I understand this is taking a while. I can have ${guardianLabel} call you back once I hear from them. Would you like that, or would you prefer to keep holding?`,
             true,
@@ -1919,7 +2293,7 @@ export class RelayConnection {
         this.scheduleNextHeartbeat();
         break;
       }
-      case 'patience_check': {
+      case "patience_check": {
         // Immediate reassurance — reset the heartbeat timer so we
         // don't double up with a scheduled heartbeat
         if (this.accessRequestHeartbeatTimer) {
@@ -1933,7 +2307,7 @@ export class RelayConnection {
         this.scheduleNextHeartbeat();
         break;
       }
-      case 'neutral':
+      case "neutral":
       default: {
         if (this.accessRequestHeartbeatTimer) {
           clearTimeout(this.accessRequestHeartbeatTimer);
@@ -1950,7 +2324,7 @@ export class RelayConnection {
   }
 
   private async handlePrompt(msg: RelayPromptMessage): Promise<void> {
-    if (this.connectionState === 'disconnecting') {
+    if (this.connectionState === "disconnecting") {
       return;
     }
 
@@ -1960,7 +2334,7 @@ export class RelayConnection {
     }
 
     // During name capture, the caller's response is their name.
-    if (this.connectionState === 'awaiting_name') {
+    if (this.connectionState === "awaiting_name") {
       const callerName = msg.voicePrompt.trim();
       if (!callerName) {
         // Whitespace-only or empty transcript (e.g. silence/noise) —
@@ -1970,7 +2344,7 @@ export class RelayConnection {
       }
       log.info(
         { callSessionId: this.callSessionId, callerName },
-        'Name captured from unknown inbound caller',
+        "Name captured from unknown inbound caller",
       );
       this.handleNameCaptureResponse(callerName);
       return;
@@ -1978,18 +2352,27 @@ export class RelayConnection {
 
     // During guardian decision wait, classify caller speech for
     // reassurance, impatience detection, and callback offer.
-    if (this.connectionState === 'awaiting_guardian_decision') {
+    if (this.connectionState === "awaiting_guardian_decision") {
       this.handleWaitStatePrompt(msg.voicePrompt);
       return;
     }
 
     // During guardian verification (inbound or outbound), attempt to parse
     // spoken digits from the transcript and validate them.
-    if (this.connectionState === 'verification_pending' && this.guardianVerificationActive) {
-      const spokenDigits = RelayConnection.parseDigitsFromSpeech(msg.voicePrompt);
+    if (
+      this.connectionState === "verification_pending" &&
+      this.guardianVerificationActive
+    ) {
+      const spokenDigits = RelayConnection.parseDigitsFromSpeech(
+        msg.voicePrompt,
+      );
       log.info(
-        { callSessionId: this.callSessionId, transcript: msg.voicePrompt, spokenDigits },
-        'Speech received during guardian voice verification',
+        {
+          callSessionId: this.callSessionId,
+          transcript: msg.voicePrompt,
+          spokenDigits,
+        },
+        "Speech received during guardian voice verification",
       );
       if (spokenDigits.length >= this.verificationCodeLength) {
         const enteredCode = spokenDigits.slice(0, this.verificationCodeLength);
@@ -2005,14 +2388,26 @@ export class RelayConnection {
 
     // During invite redemption, attempt to parse spoken digits from the
     // transcript and validate against the caller's active voice invite.
-    if (this.connectionState === 'verification_pending' && this.inviteRedemptionActive) {
-      const spokenDigits = RelayConnection.parseDigitsFromSpeech(msg.voicePrompt);
+    if (
+      this.connectionState === "verification_pending" &&
+      this.inviteRedemptionActive
+    ) {
+      const spokenDigits = RelayConnection.parseDigitsFromSpeech(
+        msg.voicePrompt,
+      );
       log.info(
-        { callSessionId: this.callSessionId, transcript: msg.voicePrompt, spokenDigits },
-        'Speech received during invite redemption',
+        {
+          callSessionId: this.callSessionId,
+          transcript: msg.voicePrompt,
+          spokenDigits,
+        },
+        "Speech received during invite redemption",
       );
       if (spokenDigits.length >= this.inviteRedemptionCodeLength) {
-        const enteredCode = spokenDigits.slice(0, this.inviteRedemptionCodeLength);
+        const enteredCode = spokenDigits.slice(
+          0,
+          this.inviteRedemptionCodeLength,
+        );
         this.attemptInviteCodeRedemption(enteredCode);
       } else if (spokenDigits.length > 0) {
         this.sendTextToken(
@@ -2025,31 +2420,39 @@ export class RelayConnection {
 
     // During outbound callee verification, ignore voice prompts — the callee
     // should be entering DTMF digits, not speaking.
-    if (this.connectionState === 'verification_pending') {
-      log.debug({ callSessionId: this.callSessionId }, 'Ignoring voice prompt during callee verification');
+    if (this.connectionState === "verification_pending") {
+      log.debug(
+        { callSessionId: this.callSessionId },
+        "Ignoring voice prompt during callee verification",
+      );
       return;
     }
 
     log.info(
-      { callSessionId: this.callSessionId, transcript: msg.voicePrompt, lang: msg.lang },
-      'Caller transcript received (final)',
+      {
+        callSessionId: this.callSessionId,
+        transcript: msg.voicePrompt,
+        lang: msg.lang,
+      },
+      "Caller transcript received (final)",
     );
 
     // Spread to widen the typed message into a plain record — extractPromptSpeakerMetadata
     // probes for snake_case and nested property variants not on RelayPromptMessage.
     const speakerMetadata = extractPromptSpeakerMetadata({ ...msg });
-    const speaker = this.speakerIdentityTracker.identifySpeaker(speakerMetadata);
+    const speaker =
+      this.speakerIdentityTracker.identifySpeaker(speakerMetadata);
 
     // Record in conversation history
     this.conversationHistory.push({
-      role: 'caller',
+      role: "caller",
       text: msg.voicePrompt,
       timestamp: Date.now(),
       speaker,
     });
 
     // Record event
-    recordCallEvent(this.callSessionId, 'caller_spoke', {
+    recordCallEvent(this.callSessionId, "caller_spoke", {
       transcript: msg.voicePrompt,
       lang: msg.lang,
       speakerId: speaker.speakerId,
@@ -2063,7 +2466,12 @@ export class RelayConnection {
       // User message persistence is handled by the session pipeline
       // (voice-session-bridge -> session.persistUserMessage) so we only
       // need to fire the transcript notifier for UI subscribers here.
-      fireCallTranscriptNotifier(session.conversationId, this.callSessionId, 'caller', msg.voicePrompt);
+      fireCallTranscriptNotifier(
+        session.conversationId,
+        this.callSessionId,
+        "caller",
+        msg.voicePrompt,
+      );
     }
 
     // Route to controller for session-backed response
@@ -2078,24 +2486,35 @@ export class RelayConnection {
         try {
           await conversationStore.addMessage(
             session.conversationId,
-            'user',
-            JSON.stringify([{ type: 'text', text: msg.voicePrompt }]),
-            { userMessageChannel: 'voice', assistantMessageChannel: 'voice', userMessageInterface: 'voice', assistantMessageInterface: 'voice' },
+            "user",
+            JSON.stringify([{ type: "text", text: msg.voicePrompt }]),
+            {
+              userMessageChannel: "voice",
+              assistantMessageChannel: "voice",
+              userMessageInterface: "voice",
+              assistantMessageInterface: "voice",
+            },
           );
         } catch (err) {
           // Best-effort — don't let persistence failures prevent the hold
           // response from reaching the caller.
-          log.warn({ err, callSessionId: this.callSessionId }, 'Failed to persist early caller utterance');
+          log.warn(
+            { err, callSessionId: this.callSessionId },
+            "Failed to persist early caller utterance",
+          );
         }
       }
-      this.sendTextToken('I\'m still setting up. Please hold.', true);
+      this.sendTextToken("I'm still setting up. Please hold.", true);
     }
   }
 
   private handleInterrupt(msg: RelayInterruptMessage): void {
     log.info(
-      { callSessionId: this.callSessionId, utteranceUntilInterrupt: msg.utteranceUntilInterrupt },
-      'Caller interrupted assistant',
+      {
+        callSessionId: this.callSessionId,
+        utteranceUntilInterrupt: msg.utteranceUntilInterrupt,
+      },
+      "Caller interrupted assistant",
     );
 
     // Abort any in-flight processing
@@ -2109,32 +2528,41 @@ export class RelayConnection {
   }
 
   private handleDtmf(msg: RelayDtmfMessage): void {
-    if (this.connectionState === 'disconnecting') {
+    if (this.connectionState === "disconnecting") {
       return;
     }
 
     // Ignore DTMF during name capture and guardian decision wait
-    if (this.connectionState === 'awaiting_name' || this.connectionState === 'awaiting_guardian_decision') {
+    if (
+      this.connectionState === "awaiting_name" ||
+      this.connectionState === "awaiting_guardian_decision"
+    ) {
       return;
     }
 
     log.info(
       { callSessionId: this.callSessionId, digit: msg.digit },
-      'DTMF digit received',
+      "DTMF digit received",
     );
 
-    recordCallEvent(this.callSessionId, 'caller_spoke', {
+    recordCallEvent(this.callSessionId, "caller_spoke", {
       dtmfDigit: msg.digit,
     });
 
     // If guardian verification (inbound or outbound) is pending, accumulate
     // digits and validate against the challenge via the guardian service.
-    if (this.connectionState === 'verification_pending' && this.guardianVerificationActive) {
+    if (
+      this.connectionState === "verification_pending" &&
+      this.guardianVerificationActive
+    ) {
       this.dtmfBuffer += msg.digit;
 
       if (this.dtmfBuffer.length >= this.verificationCodeLength) {
-        const enteredCode = this.dtmfBuffer.slice(0, this.verificationCodeLength);
-        this.dtmfBuffer = '';
+        const enteredCode = this.dtmfBuffer.slice(
+          0,
+          this.verificationCodeLength,
+        );
+        this.dtmfBuffer = "";
         this.attemptGuardianCodeVerification(enteredCode);
       }
       return;
@@ -2142,39 +2570,63 @@ export class RelayConnection {
 
     // If invite redemption is pending, accumulate digits and validate
     // the code against the caller's active voice invite.
-    if (this.connectionState === 'verification_pending' && this.inviteRedemptionActive) {
+    if (
+      this.connectionState === "verification_pending" &&
+      this.inviteRedemptionActive
+    ) {
       this.dtmfBuffer += msg.digit;
 
       if (this.dtmfBuffer.length >= this.inviteRedemptionCodeLength) {
-        const enteredCode = this.dtmfBuffer.slice(0, this.inviteRedemptionCodeLength);
-        this.dtmfBuffer = '';
+        const enteredCode = this.dtmfBuffer.slice(
+          0,
+          this.inviteRedemptionCodeLength,
+        );
+        this.dtmfBuffer = "";
         this.attemptInviteCodeRedemption(enteredCode);
       }
       return;
     }
 
     // If outbound callee verification is pending, accumulate digits and check the code
-    if (this.connectionState === 'verification_pending' && this.verificationCode) {
+    if (
+      this.connectionState === "verification_pending" &&
+      this.verificationCode
+    ) {
       this.dtmfBuffer += msg.digit;
 
       if (this.dtmfBuffer.length >= this.verificationCodeLength) {
-        const enteredCode = this.dtmfBuffer.slice(0, this.verificationCodeLength);
-        this.dtmfBuffer = '';
+        const enteredCode = this.dtmfBuffer.slice(
+          0,
+          this.verificationCodeLength,
+        );
+        this.dtmfBuffer = "";
 
         if (enteredCode === this.verificationCode) {
           // Verification succeeded
-          this.connectionState = 'connected';
+          this.connectionState = "connected";
           this.verificationCode = null;
           this.verificationAttempts = 0;
 
-          recordCallEvent(this.callSessionId, 'callee_verification_succeeded', {});
-          log.info({ callSessionId: this.callSessionId }, 'Callee verification succeeded');
+          recordCallEvent(
+            this.callSessionId,
+            "callee_verification_succeeded",
+            {},
+          );
+          log.info(
+            { callSessionId: this.callSessionId },
+            "Callee verification succeeded",
+          );
 
           // Proceed to the normal call flow
           if (this.controller) {
-            this.controller.startInitialGreeting().catch((err) =>
-              log.error({ err, callSessionId: this.callSessionId }, 'Failed to start initial outbound greeting after verification'),
-            );
+            this.controller
+              .startInitialGreeting()
+              .catch((err) =>
+                log.error(
+                  { err, callSessionId: this.callSessionId },
+                  "Failed to start initial outbound greeting after verification",
+                ),
+              );
           }
         } else {
           // Verification failed for this attempt
@@ -2182,48 +2634,85 @@ export class RelayConnection {
 
           if (this.verificationAttempts >= this.verificationMaxAttempts) {
             // Max attempts reached — end the call
-            recordCallEvent(this.callSessionId, 'callee_verification_failed', {
+            recordCallEvent(this.callSessionId, "callee_verification_failed", {
               attempts: this.verificationAttempts,
             });
-            log.warn({ callSessionId: this.callSessionId, attempts: this.verificationAttempts }, 'Callee verification failed — max attempts reached');
+            log.warn(
+              {
+                callSessionId: this.callSessionId,
+                attempts: this.verificationAttempts,
+              },
+              "Callee verification failed — max attempts reached",
+            );
 
-            this.sendTextToken('Verification failed. Goodbye.', true);
+            this.sendTextToken("Verification failed. Goodbye.", true);
 
             // Mark failed immediately so a relay close during the goodbye TTS
             // window cannot race this into a terminal "completed" status.
             updateCallSession(this.callSessionId, {
-              status: 'failed',
+              status: "failed",
               endedAt: Date.now(),
-              lastError: 'Callee verification failed — max attempts exceeded',
+              lastError: "Callee verification failed — max attempts exceeded",
             });
 
             const session = getCallSession(this.callSessionId);
             if (session) {
               expirePendingQuestions(this.callSessionId);
-              persistCallCompletionMessage(session.conversationId, this.callSessionId).catch((err) => {
-                log.error({ err, conversationId: session.conversationId, callSessionId: this.callSessionId }, 'Failed to persist call completion message');
+              persistCallCompletionMessage(
+                session.conversationId,
+                this.callSessionId,
+              ).catch((err) => {
+                log.error(
+                  {
+                    err,
+                    conversationId: session.conversationId,
+                    callSessionId: this.callSessionId,
+                  },
+                  "Failed to persist call completion message",
+                );
               });
-              fireCallCompletionNotifier(session.conversationId, this.callSessionId);
+              fireCallCompletionNotifier(
+                session.conversationId,
+                this.callSessionId,
+              );
               if (session.initiatedFromConversationId) {
-                addPointerMessage(session.initiatedFromConversationId, 'failed', session.toNumber, {
-                  reason: 'Callee verification failed',
-                }).catch((err) => {
-                  log.warn({ conversationId: session.initiatedFromConversationId, err }, 'Skipping pointer write — origin conversation may no longer exist');
+                addPointerMessage(
+                  session.initiatedFromConversationId,
+                  "failed",
+                  session.toNumber,
+                  {
+                    reason: "Callee verification failed",
+                  },
+                ).catch((err) => {
+                  log.warn(
+                    {
+                      conversationId: session.initiatedFromConversationId,
+                      err,
+                    },
+                    "Skipping pointer write — origin conversation may no longer exist",
+                  );
                 });
               }
             }
 
             // End the call with failed status after TTS plays
             setTimeout(() => {
-              this.endSession('Verification failed');
+              this.endSession("Verification failed");
             }, getTtsPlaybackDelayMs());
           } else {
             // Allow another attempt
             log.info(
-              { callSessionId: this.callSessionId, attempt: this.verificationAttempts, maxAttempts: this.verificationMaxAttempts },
-              'Callee verification attempt failed — retrying',
+              {
+                callSessionId: this.callSessionId,
+                attempt: this.verificationAttempts,
+                maxAttempts: this.verificationMaxAttempts,
+              },
+              "Callee verification attempt failed — retrying",
             );
-            this.sendTextToken('That code was incorrect. Please try again.', true);
+            this.sendTextToken(
+              "That code was incorrect. Please try again.",
+              true,
+            );
           }
         }
       }
@@ -2233,10 +2722,10 @@ export class RelayConnection {
   private handleError(msg: RelayErrorMessage): void {
     log.error(
       { callSessionId: this.callSessionId, description: msg.description },
-      'ConversationRelay error',
+      "ConversationRelay error",
     );
 
-    recordCallEvent(this.callSessionId, 'call_failed', {
+    recordCallEvent(this.callSessionId, "call_failed", {
       error: msg.description,
     });
   }

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -7,69 +7,110 @@
  * runAgentLoop method here via the AgentLoopSessionContext interface.
  */
 
-import { v4 as uuid } from 'uuid';
+import { v4 as uuid } from "uuid";
 
-import type { AgentEvent,AgentLoop, CheckpointDecision } from '../agent/loop.js';
-import { createAssistantMessage } from '../agent/message-types.js';
-import type { ChannelId, InterfaceId, TurnChannelContext, TurnInterfaceContext } from '../channels/types.js';
-import { getConfig } from '../config/loader.js';
-import type { ContextWindowManager } from '../context/window-manager.js';
-import type { ToolProfiler } from '../events/tool-profiling-listener.js';
-import { getHookManager } from '../hooks/manager.js';
-import { commitAppTurnChanges } from '../memory/app-git-service.js';
-import { getApp, listAppFiles } from '../memory/app-store.js';
-import * as conversationStore from '../memory/conversation-store.js';
-import { getConversationOriginChannel, getConversationOriginInterface, provenanceFromTrustContext } from '../memory/conversation-store.js';
-import { isReplaceableTitle, queueGenerateConversationTitle, queueRegenerateConversationTitle, UNTITLED_FALLBACK } from '../memory/conversation-title-service.js';
-import { stripMemoryRecallMessages } from '../memory/retriever.js';
-import type { PermissionPrompter } from '../permissions/prompter.js';
-import type { ContentBlock,Message } from '../providers/types.js';
-import type { Provider } from '../providers/types.js';
-import { resolveActorTrust } from '../runtime/actor-trust-resolver.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
-import type { UsageActor } from '../usage/actors.js';
-import { getLogger } from '../util/logger.js';
-import { truncate } from '../util/truncate.js';
-import { getWorkspaceGitService } from '../workspace/git-service.js';
-import { commitTurnChanges } from '../workspace/turn-commit.js';
+import type {
+  AgentEvent,
+  AgentLoop,
+  CheckpointDecision,
+} from "../agent/loop.js";
+import { createAssistantMessage } from "../agent/message-types.js";
+import type {
+  ChannelId,
+  InterfaceId,
+  TurnChannelContext,
+  TurnInterfaceContext,
+} from "../channels/types.js";
+import { getConfig } from "../config/loader.js";
+import type { ContextWindowManager } from "../context/window-manager.js";
+import type { ToolProfiler } from "../events/tool-profiling-listener.js";
+import { getHookManager } from "../hooks/manager.js";
+import { commitAppTurnChanges } from "../memory/app-git-service.js";
+import { getApp, listAppFiles } from "../memory/app-store.js";
+import * as conversationStore from "../memory/conversation-store.js";
+import {
+  getConversationOriginChannel,
+  getConversationOriginInterface,
+  provenanceFromTrustContext,
+} from "../memory/conversation-store.js";
+import {
+  isReplaceableTitle,
+  queueGenerateConversationTitle,
+  queueRegenerateConversationTitle,
+  UNTITLED_FALLBACK,
+} from "../memory/conversation-title-service.js";
+import { stripMemoryRecallMessages } from "../memory/retriever.js";
+import type { PermissionPrompter } from "../permissions/prompter.js";
+import type { ContentBlock, Message } from "../providers/types.js";
+import type { Provider } from "../providers/types.js";
+import { resolveActorTrust } from "../runtime/actor-trust-resolver.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import type { UsageActor } from "../usage/actors.js";
+import { getLogger } from "../util/logger.js";
+import { truncate } from "../util/truncate.js";
+import { getWorkspaceGitService } from "../workspace/git-service.js";
+import { commitTurnChanges } from "../workspace/turn-commit.js";
 import {
   type AssistantAttachmentDraft,
   cleanAssistantContent,
-} from './assistant-attachments.js';
-import { buildTemporalContext, extractUserTimeZoneFromDynamicProfile } from './date-context.js';
-import { deepRepairHistory,repairHistory } from './history-repair.js';
-import type { DynamicPageSurfaceData,ServerMessage, SurfaceData, SurfaceType, UsageStats } from './ipc-protocol.js';
+} from "./assistant-attachments.js";
+import {
+  buildTemporalContext,
+  extractUserTimeZoneFromDynamicProfile,
+} from "./date-context.js";
+import { deepRepairHistory, repairHistory } from "./history-repair.js";
+import type {
+  DynamicPageSurfaceData,
+  ServerMessage,
+  SurfaceData,
+  SurfaceType,
+  UsageStats,
+} from "./ipc-protocol.js";
 import {
   createEventHandlerState,
   dispatchAgentEvent,
   type EventHandlerDeps,
-} from './session-agent-loop-handlers.js';
+} from "./session-agent-loop-handlers.js";
 import {
   approveHostAttachmentRead,
   formatAttachmentWarnings,
   resolveAssistantAttachments,
-} from './session-attachments.js';
-import type { ConflictGate } from './session-conflict-gate.js';
-import { stripDynamicProfileMessages } from './session-dynamic-profile.js';
-import { buildSessionErrorMessage,classifySessionError, isUserCancellation } from './session-error.js';
-import { consolidateAssistantMessages } from './session-history.js';
-import { raceWithTimeout,stripMediaPayloadsForRetry } from './session-media-retry.js';
-import { prepareMemoryContext } from './session-memory.js';
-import type { MessageQueue } from './session-queue-manager.js';
-import type { QueueDrainReason } from './session-queue-manager.js';
-import type { ActiveSurfaceContext, ChannelCapabilities, ChannelTurnContextParams, TrustContext, InboundActorContext, InterfaceTurnContextParams } from './session-runtime-assembly.js';
+} from "./session-attachments.js";
+import type { ConflictGate } from "./session-conflict-gate.js";
+import { stripDynamicProfileMessages } from "./session-dynamic-profile.js";
+import {
+  buildSessionErrorMessage,
+  classifySessionError,
+  isUserCancellation,
+} from "./session-error.js";
+import { consolidateAssistantMessages } from "./session-history.js";
+import {
+  raceWithTimeout,
+  stripMediaPayloadsForRetry,
+} from "./session-media-retry.js";
+import { prepareMemoryContext } from "./session-memory.js";
+import type { MessageQueue } from "./session-queue-manager.js";
+import type { QueueDrainReason } from "./session-queue-manager.js";
+import type {
+  ActiveSurfaceContext,
+  ChannelCapabilities,
+  ChannelTurnContextParams,
+  InboundActorContext,
+  InterfaceTurnContextParams,
+  TrustContext,
+} from "./session-runtime-assembly.js";
 import {
   applyRuntimeInjections,
-  inboundActorContextFromTrustContext,
   inboundActorContextFromTrust,
+  inboundActorContextFromTrustContext,
   stripInjectedContext,
-} from './session-runtime-assembly.js';
-import type { SkillProjectionCache } from './session-skill-tools.js';
-import { resolveTrustClass } from './session-tool-setup.js';
-import { recordUsage } from './session-usage.js';
-import type { TraceEmitter } from './trace-emitter.js';
+} from "./session-runtime-assembly.js";
+import type { SkillProjectionCache } from "./session-skill-tools.js";
+import { resolveTrustClass } from "./session-tool-setup.js";
+import { recordUsage } from "./session-usage.js";
+import type { TraceEmitter } from "./trace-emitter.js";
 
-const log = getLogger('session-agent-loop');
+const log = getLogger("session-agent-loop");
 
 type GitServiceInitializer = {
   ensureInitialized(): Promise<void>;
@@ -97,10 +138,20 @@ export interface AgentLoopSessionContext {
 
   currentActiveSurfaceId?: string;
   currentPage?: string;
-  readonly surfaceState: Map<string, { surfaceType: SurfaceType; data: SurfaceData; title?: string }>;
+  readonly surfaceState: Map<
+    string,
+    { surfaceType: SurfaceType; data: SurfaceData; title?: string }
+  >;
   pendingSurfaceActions: Map<string, { surfaceType: SurfaceType }>;
   surfaceActionRequestIds: Set<string>;
-  currentTurnSurfaces: Array<{ surfaceId: string; surfaceType: SurfaceType; title?: string; data: SurfaceData; actions?: Array<{ id: string; label: string; style?: string }>; display?: string }>;
+  currentTurnSurfaces: Array<{
+    surfaceId: string;
+    surfaceType: SurfaceType;
+    title?: string;
+    data: SurfaceData;
+    actions?: Array<{ id: string; label: string; style?: string }>;
+    display?: string;
+  }>;
 
   workingDir: string;
   workspaceTopLevelContext: string | null;
@@ -133,13 +184,37 @@ export interface AgentLoopSessionContext {
   readonly queue: MessageQueue;
 
   emitActivityState(
-    phase: 'idle' | 'thinking' | 'streaming' | 'tool_running' | 'awaiting_confirmation',
-    reason: 'message_dequeued' | 'thinking_delta' | 'first_text_delta' | 'tool_use_start' | 'tool_result_received' | 'confirmation_requested' | 'confirmation_resolved' | 'message_complete' | 'generation_cancelled' | 'error_terminal',
-    anchor?: 'assistant_turn' | 'user_turn' | 'global',
+    phase:
+      | "idle"
+      | "thinking"
+      | "streaming"
+      | "tool_running"
+      | "awaiting_confirmation",
+    reason:
+      | "message_dequeued"
+      | "thinking_delta"
+      | "first_text_delta"
+      | "tool_use_start"
+      | "tool_result_received"
+      | "confirmation_requested"
+      | "confirmation_resolved"
+      | "message_complete"
+      | "generation_cancelled"
+      | "error_terminal",
+    anchor?: "assistant_turn" | "user_turn" | "global",
     requestId?: string,
     statusText?: string,
   ): void;
-  emitConfirmationStateChanged(params: import('./ipc-contract/messages.js').ConfirmationStateChanged extends { type: infer _ } ? Omit<import('./ipc-contract/messages.js').ConfirmationStateChanged, 'type'> : never): void;
+  emitConfirmationStateChanged(
+    params: import("./ipc-contract/messages.js").ConfirmationStateChanged extends {
+      type: infer _;
+    }
+      ? Omit<
+          import("./ipc-contract/messages.js").ConfirmationStateChanged,
+          "type"
+        >
+      : never,
+  ): void;
 
   getWorkspaceGitService?: (workspaceDir: string) => GitServiceInitializer;
   commitTurnChanges?: typeof commitTurnChanges;
@@ -161,14 +236,22 @@ export async function runAgentLoopImpl(
   content: string,
   userMessageId: string,
   onEvent: (msg: ServerMessage) => void,
-  options?: { skipPreMessageRollback?: boolean; isInteractive?: boolean; isUserMessage?: boolean; titleText?: string },
+  options?: {
+    skipPreMessageRollback?: boolean;
+    isInteractive?: boolean;
+    isUserMessage?: boolean;
+    titleText?: string;
+  },
 ): Promise<void> {
   if (!ctx.abortController) {
-    throw new Error('runAgentLoop called without prior persistUserMessage');
+    throw new Error("runAgentLoop called without prior persistUserMessage");
   }
   const abortController = ctx.abortController;
   const reqId = ctx.currentRequestId ?? uuid();
-  const rlog = log.child({ conversationId: ctx.conversationId, requestId: reqId });
+  const rlog = log.child({
+    conversationId: ctx.conversationId,
+    requestId: reqId,
+  });
   let yieldedForHandoff = false;
 
   // Capture the turn channel context *before* any awaits so a second
@@ -179,8 +262,12 @@ export async function runAgentLoopImpl(
     const live = ctx.getTurnChannelContext();
     if (live) return live;
     const origin = getConversationOriginChannel(ctx.conversationId);
-    if (origin) return { userMessageChannel: origin, assistantMessageChannel: origin };
-    return { userMessageChannel: 'vellum' as ChannelId, assistantMessageChannel: 'vellum' as ChannelId };
+    if (origin)
+      return { userMessageChannel: origin, assistantMessageChannel: origin };
+    return {
+      userMessageChannel: "vellum" as ChannelId,
+      assistantMessageChannel: "vellum" as ChannelId,
+    };
   })();
 
   // Capture interface context with the same anti-race snapshot pattern.
@@ -191,10 +278,14 @@ export async function runAgentLoopImpl(
     const live = ctx.getTurnInterfaceContext();
     if (live) return live;
     const origin = getConversationOriginInterface(ctx.conversationId);
-    if (origin) return { userMessageInterface: origin, assistantMessageInterface: origin };
+    if (origin)
+      return {
+        userMessageInterface: origin,
+        assistantMessageInterface: origin,
+      };
     return {
-      userMessageInterface: 'vellum' as InterfaceId,
-      assistantMessageInterface: 'vellum' as InterfaceId,
+      userMessageInterface: "vellum" as InterfaceId,
+      assistantMessageInterface: "vellum" as InterfaceId,
     };
   })();
 
@@ -203,11 +294,12 @@ export async function runAgentLoopImpl(
 
   // Ensure workspace git repo is initialized before any tools run.
   try {
-    const getWorkspaceGitServiceFn = ctx.getWorkspaceGitService ?? getWorkspaceGitService;
+    const getWorkspaceGitServiceFn =
+      ctx.getWorkspaceGitService ?? getWorkspaceGitService;
     const gitService = getWorkspaceGitServiceFn(ctx.workingDir);
     await gitService.ensureInitialized();
   } catch (err) {
-    rlog.warn({ err }, 'Failed to initialize workspace git repo (non-fatal)');
+    rlog.warn({ err }, "Failed to initialize workspace git repo (non-fatal)");
   }
 
   ctx.profiler.startRequest();
@@ -221,20 +313,20 @@ export async function runAgentLoopImpl(
     // Placed inside try so the finally block still runs if onEvent throws.
     if (options?.isUserMessage && !ctx.surfaceActionRequestIds.has(reqId)) {
       for (const [surfaceId, entry] of ctx.pendingSurfaceActions) {
-        if (entry.surfaceType === 'dynamic_page') continue;
+        if (entry.surfaceType === "dynamic_page") continue;
         onEvent({
-          type: 'ui_surface_complete',
+          type: "ui_surface_complete",
           sessionId: ctx.conversationId,
           surfaceId,
-          summary: 'Dismissed',
+          summary: "Dismissed",
         });
         ctx.pendingSurfaceActions.delete(surfaceId);
       }
     }
 
-    const preMessageResult = await getHookManager().trigger('pre-message', {
+    const preMessageResult = await getHookManager().trigger("pre-message", {
       sessionId: ctx.conversationId,
-      messagePreview: truncate(content, 200, ''),
+      messagePreview: truncate(content, 200, ""),
     });
 
     if (preMessageResult.blocked) {
@@ -244,11 +336,24 @@ export async function runAgentLoopImpl(
       }
       // Replace loading placeholder so the thread isn't stuck as "Generating title..."
       const currentConv = conversationStore.getConversation(ctx.conversationId);
-      if (isReplaceableTitle(currentConv?.title ?? null) && currentConv?.title !== UNTITLED_FALLBACK) {
-        conversationStore.updateConversationTitle(ctx.conversationId, UNTITLED_FALLBACK);
-        onEvent({ type: 'session_title_updated', sessionId: ctx.conversationId, title: UNTITLED_FALLBACK });
+      if (
+        isReplaceableTitle(currentConv?.title ?? null) &&
+        currentConv?.title !== UNTITLED_FALLBACK
+      ) {
+        conversationStore.updateConversationTitle(
+          ctx.conversationId,
+          UNTITLED_FALLBACK,
+        );
+        onEvent({
+          type: "session_title_updated",
+          sessionId: ctx.conversationId,
+          title: UNTITLED_FALLBACK,
+        });
       }
-      onEvent({ type: 'error', message: `Message blocked by hook "${preMessageResult.blockedBy}"` });
+      onEvent({
+        type: "error",
+        message: `Message blocked by hook "${preMessageResult.blockedBy}"`,
+      });
       return;
     }
 
@@ -260,7 +365,11 @@ export async function runAgentLoopImpl(
     // cancels the response, since the user message is already persisted.
     // Deferred via setTimeout so the main agent loop LLM call enqueues
     // first, avoiding rate-limit slot contention on strict configs.
-    if (isReplaceableTitle(conversationStore.getConversation(ctx.conversationId)?.title ?? null)) {
+    if (
+      isReplaceableTitle(
+        conversationStore.getConversation(ctx.conversationId)?.title ?? null,
+      )
+    ) {
       setTimeout(() => {
         queueGenerateConversationTitle({
           conversationId: ctx.conversationId,
@@ -268,7 +377,7 @@ export async function runAgentLoopImpl(
           userMessage: options?.titleText ?? content,
           onTitleUpdated: (title) => {
             onEvent({
-              type: 'session_title_updated',
+              type: "session_title_updated",
               sessionId: ctx.conversationId,
               title,
             });
@@ -294,7 +403,7 @@ export async function runAgentLoopImpl(
         ctx.contextCompactedMessageCount,
       );
       onEvent({
-        type: 'context_compacted',
+        type: "context_compacted",
         previousEstimatedInputTokens: compacted.previousEstimatedInputTokens,
         estimatedInputTokens: compacted.estimatedInputTokens,
         maxInputTokens: compacted.maxInputTokens,
@@ -305,7 +414,15 @@ export async function runAgentLoopImpl(
         summaryOutputTokens: compacted.summaryOutputTokens,
         summaryModel: compacted.summaryModel,
       });
-      emitUsage(ctx, compacted.summaryInputTokens, compacted.summaryOutputTokens, compacted.summaryModel, onEvent, 'context_compactor', reqId);
+      emitUsage(
+        ctx,
+        compacted.summaryInputTokens,
+        compacted.summaryOutputTokens,
+        compacted.summaryModel,
+        onEvent,
+        "context_compactor",
+        reqId,
+      );
     }
 
     const state = createEventHandlerState();
@@ -321,7 +438,8 @@ export async function runAgentLoopImpl(
         scopeId: ctx.memoryPolicy.scopeId,
         includeDefaultFallback: ctx.memoryPolicy.includeDefaultFallback,
         trustClass: resolveTrustClass(ctx.trustContext),
-        isInteractive: options?.isInteractive ?? (!ctx.hasNoClient && !ctx.headlessLock),
+        isInteractive:
+          options?.isInteractive ?? (!ctx.hasNoClient && !ctx.headlessLock),
       },
       content,
       userMessageId,
@@ -333,40 +451,53 @@ export async function runAgentLoopImpl(
       const loopChannelMeta = {
         ...provenanceFromTrustContext(ctx.trustContext),
         userMessageChannel: capturedTurnChannelContext.userMessageChannel,
-        assistantMessageChannel: capturedTurnChannelContext.assistantMessageChannel,
+        assistantMessageChannel:
+          capturedTurnChannelContext.assistantMessageChannel,
         userMessageInterface: capturedTurnInterfaceContext.userMessageInterface,
-        assistantMessageInterface: capturedTurnInterfaceContext.assistantMessageInterface,
+        assistantMessageInterface:
+          capturedTurnInterfaceContext.assistantMessageInterface,
       };
-      const assistantMessage = createAssistantMessage(memoryResult.conflictClarification);
+      const assistantMessage = createAssistantMessage(
+        memoryResult.conflictClarification,
+      );
       await conversationStore.addMessage(
         ctx.conversationId,
-        'assistant',
+        "assistant",
         JSON.stringify(assistantMessage.content),
         loopChannelMeta,
       );
       ctx.messages.push(assistantMessage);
       onEvent({
-        type: 'assistant_text_delta',
+        type: "assistant_text_delta",
         text: memoryResult.conflictClarification,
         sessionId: ctx.conversationId,
       });
-      ctx.traceEmitter.emit('message_complete', 'Conflict clarification requested (relevant)', {
-        requestId: reqId,
-        status: 'info',
-        attributes: { conflictGate: 'relevant' },
-      });
-      onEvent({ type: 'message_complete', sessionId: ctx.conversationId });
+      ctx.traceEmitter.emit(
+        "message_complete",
+        "Conflict clarification requested (relevant)",
+        {
+          requestId: reqId,
+          status: "info",
+          attributes: { conflictGate: "relevant" },
+        },
+      );
+      onEvent({ type: "message_complete", sessionId: ctx.conversationId });
       return;
     }
 
-    const { recall, dynamicProfile, softConflictInstruction, recallInjectionStrategy } = memoryResult;
+    const {
+      recall,
+      dynamicProfile,
+      softConflictInstruction,
+      recallInjectionStrategy,
+    } = memoryResult;
     runMessages = memoryResult.runMessages;
 
     // Build active surface context
     let activeSurface: ActiveSurfaceContext | null = null;
     if (ctx.currentActiveSurfaceId) {
       const stored = ctx.surfaceState.get(ctx.currentActiveSurfaceId);
-      if (stored && stored.surfaceType === 'dynamic_page') {
+      if (stored && stored.surfaceType === "dynamic_page") {
         const data = stored.data as DynamicPageSurfaceData;
         activeSurface = {
           surfaceId: ctx.currentActiveSurfaceId,
@@ -394,7 +525,9 @@ export async function runAgentLoopImpl(
     // Absolute "now" is always anchored to assistant host clock, while local
     // date semantics prefer configured user timezone, then profile memory.
     const hostTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const userTimeZone = extractUserTimeZoneFromDynamicProfile(dynamicProfile.text);
+    const userTimeZone = extractUserTimeZoneFromDynamicProfile(
+      dynamicProfile.text,
+    );
     const configuredUserTimeZone = getConfig().ui.userTimezone ?? null;
     const temporalContext = buildTemporalContext({
       hostTimeZone,
@@ -407,12 +540,16 @@ export async function runAgentLoopImpl(
     // message, even if a newer message from a different channel arrived since.
     const channelTurnContext: ChannelTurnContextParams = {
       turnContext: capturedTurnChannelContext,
-      conversationOriginChannel: getConversationOriginChannel(ctx.conversationId),
+      conversationOriginChannel: getConversationOriginChannel(
+        ctx.conversationId,
+      ),
     };
 
     const interfaceTurnContext: InterfaceTurnContextParams = {
       turnContext: capturedTurnInterfaceContext,
-      conversationOriginInterface: getConversationOriginInterface(ctx.conversationId),
+      conversationOriginInterface: getConversationOriginInterface(
+        ctx.conversationId,
+      ),
     };
 
     // Resolve the inbound actor context for the model's <inbound_actor_context>
@@ -437,7 +574,8 @@ export async function runAgentLoopImpl(
       }
     }
 
-    const isInteractiveResolved = options?.isInteractive ?? (!ctx.hasNoClient && !ctx.headlessLock);
+    const isInteractiveResolved =
+      options?.isInteractive ?? (!ctx.hasNoClient && !ctx.headlessLock);
     runMessages = applyRuntimeInjections(runMessages, {
       softConflictInstruction,
       activeSurface,
@@ -455,8 +593,16 @@ export async function runAgentLoopImpl(
     // Pre-run repair
     let preRepairMessages = runMessages;
     const preRunRepair = repairHistory(runMessages);
-    if (preRunRepair.stats.assistantToolResultsMigrated > 0 || preRunRepair.stats.missingToolResultsInserted > 0 || preRunRepair.stats.orphanToolResultsDowngraded > 0 || preRunRepair.stats.consecutiveSameRoleMerged > 0) {
-      rlog.warn({ phase: 'pre_run', ...preRunRepair.stats }, 'Repaired runtime history before provider call');
+    if (
+      preRunRepair.stats.assistantToolResultsMigrated > 0 ||
+      preRunRepair.stats.missingToolResultsInserted > 0 ||
+      preRunRepair.stats.orphanToolResultsDowngraded > 0 ||
+      preRunRepair.stats.consecutiveSameRoleMerged > 0
+    ) {
+      rlog.warn(
+        { phase: "pre_run", ...preRunRepair.stats },
+        "Repaired runtime history before provider call",
+      );
       runMessages = preRunRepair.messages;
     }
 
@@ -476,21 +622,23 @@ export async function runAgentLoopImpl(
       turnChannelContext: capturedTurnChannelContext,
       turnInterfaceContext: capturedTurnInterfaceContext,
     };
-    const eventHandler = (event: AgentEvent) => dispatchAgentEvent(state, deps, event);
+    const eventHandler = (event: AgentEvent) =>
+      dispatchAgentEvent(state, deps, event);
 
     const onCheckpoint = (): CheckpointDecision => {
       const turnTools = state.currentTurnToolNames;
       state.currentTurnToolNames = [];
 
       if (ctx.canHandoffAtCheckpoint()) {
-        const inBrowserFlow = turnTools.length > 0
-          && turnTools.every(n => n.startsWith('browser_'));
+        const inBrowserFlow =
+          turnTools.length > 0 &&
+          turnTools.every((n) => n.startsWith("browser_"));
         if (!inBrowserFlow) {
           yieldedForHandoff = true;
-          return 'yield';
+          return "yield";
         }
       }
-      return 'continue';
+      return "continue";
     };
 
     turnStarted = true;
@@ -504,8 +652,14 @@ export async function runAgentLoopImpl(
     );
 
     // One-shot ordering error retry
-    if (state.orderingErrorDetected && updatedHistory.length === preRunHistoryLength) {
-      rlog.warn({ phase: 'retry' }, 'Provider ordering error detected, attempting one-shot deep-repair retry');
+    if (
+      state.orderingErrorDetected &&
+      updatedHistory.length === preRunHistoryLength
+    ) {
+      rlog.warn(
+        { phase: "retry" },
+        "Provider ordering error detected, attempting one-shot deep-repair retry",
+      );
       const retryRepair = deepRepairHistory(runMessages);
       runMessages = retryRepair.messages;
       preRepairMessages = retryRepair.messages;
@@ -522,13 +676,22 @@ export async function runAgentLoopImpl(
       );
 
       if (state.orderingErrorDetected) {
-        rlog.error({ phase: 'retry' }, 'Deep-repair retry also failed with ordering error. Consider starting a new conversation if this persists.');
+        rlog.error(
+          { phase: "retry" },
+          "Deep-repair retry also failed with ordering error. Consider starting a new conversation if this persists.",
+        );
       }
     }
 
     // One-shot context-too-large recovery
-    if (state.contextTooLargeDetected && updatedHistory.length === preRunHistoryLength) {
-      rlog.warn({ phase: 'retry' }, 'Context too large — attempting forced compaction and retry');
+    if (
+      state.contextTooLargeDetected &&
+      updatedHistory.length === preRunHistoryLength
+    ) {
+      rlog.warn(
+        { phase: "retry" },
+        "Context too large — attempting forced compaction and retry",
+      );
       const emergencyCompact = await ctx.contextWindowManager.maybeCompact(
         ctx.messages,
         abortController.signal,
@@ -536,7 +699,8 @@ export async function runAgentLoopImpl(
       );
       if (emergencyCompact.compacted) {
         ctx.messages = emergencyCompact.messages;
-        ctx.contextCompactedMessageCount += emergencyCompact.compactedPersistedMessages;
+        ctx.contextCompactedMessageCount +=
+          emergencyCompact.compactedPersistedMessages;
         ctx.contextCompactedAt = Date.now();
         conversationStore.updateConversationContextWindow(
           ctx.conversationId,
@@ -544,8 +708,9 @@ export async function runAgentLoopImpl(
           ctx.contextCompactedMessageCount,
         );
         onEvent({
-          type: 'context_compacted',
-          previousEstimatedInputTokens: emergencyCompact.previousEstimatedInputTokens,
+          type: "context_compacted",
+          previousEstimatedInputTokens:
+            emergencyCompact.previousEstimatedInputTokens,
           estimatedInputTokens: emergencyCompact.estimatedInputTokens,
           maxInputTokens: emergencyCompact.maxInputTokens,
           thresholdTokens: emergencyCompact.thresholdTokens,
@@ -555,7 +720,15 @@ export async function runAgentLoopImpl(
           summaryOutputTokens: emergencyCompact.summaryOutputTokens,
           summaryModel: emergencyCompact.summaryModel,
         });
-        emitUsage(ctx, emergencyCompact.summaryInputTokens, emergencyCompact.summaryOutputTokens, emergencyCompact.summaryModel, onEvent, 'context_compactor', reqId);
+        emitUsage(
+          ctx,
+          emergencyCompact.summaryInputTokens,
+          emergencyCompact.summaryOutputTokens,
+          emergencyCompact.summaryModel,
+          onEvent,
+          "context_compactor",
+          reqId,
+        );
 
         runMessages = applyRuntimeInjections(ctx.messages, {
           softConflictInstruction,
@@ -588,11 +761,11 @@ export async function runAgentLoopImpl(
         if (mediaTrimmed.modified) {
           rlog.warn(
             {
-              phase: 'retry',
+              phase: "retry",
               replacedBlocks: mediaTrimmed.replacedBlocks,
               latestUserIndex: mediaTrimmed.latestUserIndex,
             },
-            'Context still too large — retrying with older media payloads trimmed',
+            "Context still too large — retrying with older media payloads trimmed",
           );
           ctx.messages = mediaTrimmed.messages;
           runMessages = applyRuntimeInjections(ctx.messages, {
@@ -624,34 +797,44 @@ export async function runAgentLoopImpl(
 
       if (state.contextTooLargeDetected) {
         const classified = classifySessionError(
-          new Error('context_length_exceeded'),
-          { phase: 'agent_loop' },
+          new Error("context_length_exceeded"),
+          { phase: "agent_loop" },
         );
         onEvent(buildSessionErrorMessage(ctx.conversationId, classified));
       }
     } else if (state.contextTooLargeDetected) {
       // Progress was made (updatedHistory grew), so the retry path above was
       // skipped. Surface the error so clients are not left with a silent failure.
-      rlog.warn({ phase: 'post_run' }, 'Context too large after progress — surfacing error without retry');
+      rlog.warn(
+        { phase: "post_run" },
+        "Context too large after progress — surfacing error without retry",
+      );
       const classified = classifySessionError(
-        new Error('context_length_exceeded'),
-        { phase: 'agent_loop' },
+        new Error("context_length_exceeded"),
+        { phase: "agent_loop" },
       );
       onEvent(buildSessionErrorMessage(ctx.conversationId, classified));
       state.providerErrorUserMessage = classified.userMessage;
     }
 
     if (state.deferredOrderingError) {
-      const classified = classifySessionError(new Error(state.deferredOrderingError), { phase: 'agent_loop' });
+      const classified = classifySessionError(
+        new Error(state.deferredOrderingError),
+        { phase: "agent_loop" },
+      );
       onEvent(buildSessionErrorMessage(ctx.conversationId, classified));
     }
 
     // Reconcile synthesized cancellation tool_results
     for (let i = preRunHistoryLength; i < updatedHistory.length; i++) {
       const msg = updatedHistory[i];
-      if (msg.role === 'user') {
+      if (msg.role === "user") {
         for (const block of msg.content) {
-          if (block.type === 'tool_result' && !state.pendingToolResults.has(block.tool_use_id) && !state.persistedToolUseIds.has(block.tool_use_id)) {
+          if (
+            block.type === "tool_result" &&
+            !state.pendingToolResults.has(block.tool_use_id) &&
+            !state.persistedToolUseIds.has(block.tool_use_id)
+          ) {
             state.pendingToolResults.set(block.tool_use_id, {
               content: block.content,
               isError: block.is_error ?? false,
@@ -663,25 +846,29 @@ export async function runAgentLoopImpl(
 
     // Flush remaining tool results
     if (state.pendingToolResults.size > 0) {
-      const toolResultBlocks = Array.from(state.pendingToolResults.entries()).map(
-        ([toolUseId, result]) => ({
-          type: 'tool_result',
-          tool_use_id: toolUseId,
-          content: result.content,
-          is_error: result.isError,
-          ...(result.contentBlocks ? { contentBlocks: result.contentBlocks } : {}),
-        }),
-      );
+      const toolResultBlocks = Array.from(
+        state.pendingToolResults.entries(),
+      ).map(([toolUseId, result]) => ({
+        type: "tool_result",
+        tool_use_id: toolUseId,
+        content: result.content,
+        is_error: result.isError,
+        ...(result.contentBlocks
+          ? { contentBlocks: result.contentBlocks }
+          : {}),
+      }));
       const toolResultMetadata = {
         ...provenanceFromTrustContext(ctx.trustContext),
         userMessageChannel: capturedTurnChannelContext.userMessageChannel,
-        assistantMessageChannel: capturedTurnChannelContext.assistantMessageChannel,
+        assistantMessageChannel:
+          capturedTurnChannelContext.assistantMessageChannel,
         userMessageInterface: capturedTurnInterfaceContext.userMessageInterface,
-        assistantMessageInterface: capturedTurnInterfaceContext.assistantMessageInterface,
+        assistantMessageInterface:
+          capturedTurnInterfaceContext.assistantMessageInterface,
       };
       await conversationStore.addMessage(
         ctx.conversationId,
-        'user',
+        "user",
         JSON.stringify(toolResultBlocks),
         toolResultMetadata,
       );
@@ -690,31 +877,42 @@ export async function runAgentLoopImpl(
 
     // Reconstruct history
     const newMessages = updatedHistory.slice(preRunHistoryLength).map((msg) => {
-      if (msg.role !== 'assistant') return msg;
+      if (msg.role !== "assistant") return msg;
       const { cleanedContent } = cleanAssistantContent(msg.content);
       const cleanedBlocks = cleanedContent as ContentBlock[];
       return { ...msg, content: cleanedBlocks };
     });
 
-    const hasAssistantResponse = newMessages.some((msg) => msg.role === 'assistant');
-    if (!hasAssistantResponse && state.providerErrorUserMessage && !abortController.signal.aborted && !yieldedForHandoff) {
+    const hasAssistantResponse = newMessages.some(
+      (msg) => msg.role === "assistant",
+    );
+    if (
+      !hasAssistantResponse &&
+      state.providerErrorUserMessage &&
+      !abortController.signal.aborted &&
+      !yieldedForHandoff
+    ) {
       const errChannelMeta = {
         ...provenanceFromTrustContext(ctx.trustContext),
         userMessageChannel: capturedTurnChannelContext.userMessageChannel,
-        assistantMessageChannel: capturedTurnChannelContext.assistantMessageChannel,
+        assistantMessageChannel:
+          capturedTurnChannelContext.assistantMessageChannel,
         userMessageInterface: capturedTurnInterfaceContext.userMessageInterface,
-        assistantMessageInterface: capturedTurnInterfaceContext.assistantMessageInterface,
+        assistantMessageInterface:
+          capturedTurnInterfaceContext.assistantMessageInterface,
       };
-      const errorAssistantMessage = createAssistantMessage(state.providerErrorUserMessage);
+      const errorAssistantMessage = createAssistantMessage(
+        state.providerErrorUserMessage,
+      );
       await conversationStore.addMessage(
         ctx.conversationId,
-        'assistant',
+        "assistant",
         JSON.stringify(errorAssistantMessage.content),
         errChannelMeta,
       );
       newMessages.push(errorAssistantMessage);
       onEvent({
-        type: 'assistant_text_delta',
+        type: "assistant_text_delta",
         text: state.providerErrorUserMessage,
         sessionId: ctx.conversationId,
       });
@@ -722,13 +920,27 @@ export async function runAgentLoopImpl(
 
     const restoredHistory = [...preRepairMessages, ...newMessages];
     ctx.messages = stripInjectedContext(restoredHistory, {
-      stripRecall: (msgs) => stripMemoryRecallMessages(msgs, recall.injectedText, recallInjectionStrategy),
-      stripDynamicProfile: (msgs) => stripDynamicProfileMessages(msgs, dynamicProfile.text),
+      stripRecall: (msgs) =>
+        stripMemoryRecallMessages(
+          msgs,
+          recall.injectedText,
+          recallInjectionStrategy,
+        ),
+      stripDynamicProfile: (msgs) =>
+        stripDynamicProfileMessages(msgs, dynamicProfile.text),
     });
 
-    emitUsage(ctx, state.exchangeInputTokens, state.exchangeOutputTokens, state.model, onEvent, 'main_agent', reqId);
+    emitUsage(
+      ctx,
+      state.exchangeInputTokens,
+      state.exchangeOutputTokens,
+      state.model,
+      onEvent,
+      "main_agent",
+      reqId,
+    );
 
-    void getHookManager().trigger('post-message', {
+    void getHookManager().trigger("post-message", {
       sessionId: ctx.conversationId,
     });
 
@@ -738,7 +950,14 @@ export async function runAgentLoopImpl(
       state.accumulatedToolContentBlocks,
       state.directiveWarnings,
       ctx.workingDir,
-      async (filePath) => approveHostAttachmentRead(filePath, ctx.workingDir, ctx.prompter, ctx.conversationId, ctx.hasNoClient),
+      async (filePath) =>
+        approveHostAttachmentRead(
+          filePath,
+          ctx.workingDir,
+          ctx.prompter,
+          ctx.conversationId,
+          ctx.hasNoClient,
+        ),
       state.lastAssistantMessageId,
     );
     const { assistantAttachments, emittedAttachments } = attachmentResult;
@@ -746,55 +965,74 @@ export async function runAgentLoopImpl(
     ctx.lastAssistantAttachments = assistantAttachments;
     ctx.lastAttachmentWarnings = attachmentResult.directiveWarnings;
 
-    const warningText = formatAttachmentWarnings(attachmentResult.directiveWarnings);
+    const warningText = formatAttachmentWarnings(
+      attachmentResult.directiveWarnings,
+    );
     if (warningText) {
-      onEvent({ type: 'assistant_text_delta', text: warningText, sessionId: ctx.conversationId });
+      onEvent({
+        type: "assistant_text_delta",
+        text: warningText,
+        sessionId: ctx.conversationId,
+      });
     }
 
     // Emit completion event
     if (yieldedForHandoff) {
-      ctx.traceEmitter.emit('generation_handoff', 'Handing off to next queued message', {
-        requestId: reqId,
-        status: 'info',
-        attributes: { queuedCount: ctx.getQueueDepth() },
-      });
+      ctx.traceEmitter.emit(
+        "generation_handoff",
+        "Handing off to next queued message",
+        {
+          requestId: reqId,
+          status: "info",
+          attributes: { queuedCount: ctx.getQueueDepth() },
+        },
+      );
       onEvent({
-        type: 'generation_handoff',
+        type: "generation_handoff",
         sessionId: ctx.conversationId,
         requestId: reqId,
         queuedCount: ctx.getQueueDepth(),
-        ...(emittedAttachments.length > 0 ? { attachments: emittedAttachments } : {}),
+        ...(emittedAttachments.length > 0
+          ? { attachments: emittedAttachments }
+          : {}),
       });
     } else if (abortController.signal.aborted) {
-      ctx.emitActivityState('idle', 'generation_cancelled', 'global', reqId);
-      ctx.traceEmitter.emit('generation_cancelled', 'Generation cancelled by user', {
-        requestId: reqId,
-        status: 'warning',
-      });
-      onEvent({ type: 'generation_cancelled', sessionId: ctx.conversationId });
+      ctx.emitActivityState("idle", "generation_cancelled", "global", reqId);
+      ctx.traceEmitter.emit(
+        "generation_cancelled",
+        "Generation cancelled by user",
+        {
+          requestId: reqId,
+          status: "warning",
+        },
+      );
+      onEvent({ type: "generation_cancelled", sessionId: ctx.conversationId });
     } else {
-      ctx.emitActivityState('idle', 'message_complete', 'global', reqId);
-      ctx.traceEmitter.emit('message_complete', 'Message processing complete', {
+      ctx.emitActivityState("idle", "message_complete", "global", reqId);
+      ctx.traceEmitter.emit("message_complete", "Message processing complete", {
         requestId: reqId,
-        status: 'success',
+        status: "success",
       });
       onEvent({
-        type: 'message_complete',
+        type: "message_complete",
         sessionId: ctx.conversationId,
-        ...(emittedAttachments.length > 0 ? { attachments: emittedAttachments } : {}),
+        ...(emittedAttachments.length > 0
+          ? { attachments: emittedAttachments }
+          : {}),
       });
     }
 
     // Second title pass: after 3 completed turns, re-generate the title
     // using the last 3 messages for better context. Only fires when the
     // current title was auto-generated (isAutoTitle = 1).
-    if (ctx.turnCount === 2) { // turnCount is 0-indexed, incremented in finally; 2 = about to become 3rd turn
+    if (ctx.turnCount === 2) {
+      // turnCount is 0-indexed, incremented in finally; 2 = about to become 3rd turn
       queueRegenerateConversationTitle({
         conversationId: ctx.conversationId,
         provider: ctx.provider,
         onTitleUpdated: (title) => {
           onEvent({
-            type: 'session_title_updated',
+            type: "session_title_updated",
             sessionId: ctx.conversationId,
             title,
           });
@@ -803,30 +1041,37 @@ export async function runAgentLoopImpl(
       });
     }
   } catch (err) {
-    const errorCtx = { phase: 'agent_loop' as const, aborted: abortController.signal.aborted };
+    const errorCtx = {
+      phase: "agent_loop" as const,
+      aborted: abortController.signal.aborted,
+    };
     if (isUserCancellation(err, errorCtx)) {
-      ctx.emitActivityState('idle', 'generation_cancelled', 'global', reqId);
-      rlog.info('Generation cancelled by user');
-      ctx.traceEmitter.emit('generation_cancelled', 'Generation cancelled by user', {
-        requestId: reqId,
-        status: 'warning',
-      });
-      onEvent({ type: 'generation_cancelled', sessionId: ctx.conversationId });
+      ctx.emitActivityState("idle", "generation_cancelled", "global", reqId);
+      rlog.info("Generation cancelled by user");
+      ctx.traceEmitter.emit(
+        "generation_cancelled",
+        "Generation cancelled by user",
+        {
+          requestId: reqId,
+          status: "warning",
+        },
+      );
+      onEvent({ type: "generation_cancelled", sessionId: ctx.conversationId });
     } else {
-      ctx.emitActivityState('idle', 'error_terminal', 'global', reqId);
+      ctx.emitActivityState("idle", "error_terminal", "global", reqId);
       const message = err instanceof Error ? err.message : String(err);
-      const errorClass = err instanceof Error ? err.constructor.name : 'Error';
-      rlog.error({ err }, 'Session processing error');
-      ctx.traceEmitter.emit('request_error', truncate(message, 200, ''), {
+      const errorClass = err instanceof Error ? err.constructor.name : "Error";
+      rlog.error({ err }, "Session processing error");
+      ctx.traceEmitter.emit("request_error", truncate(message, 200, ""), {
         requestId: reqId,
-        status: 'error',
-        attributes: { errorClass, message: truncate(message, 500, '') },
+        status: "error",
+        attributes: { errorClass, message: truncate(message, 500, "") },
       });
       const classified = classifySessionError(err, errorCtx);
-      onEvent({ type: 'error', message: classified.userMessage });
+      onEvent({ type: "error", message: classified.userMessage });
       onEvent(buildSessionErrorMessage(ctx.conversationId, classified));
-      void getHookManager().trigger('on-error', {
-        error: err instanceof Error ? err.name : 'Error',
+      void getHookManager().trigger("on-error", {
+        error: err instanceof Error ? err.name : "Error",
         message,
         stack: err instanceof Error ? err.stack : undefined,
         sessionId: ctx.conversationId,
@@ -840,15 +1085,21 @@ export async function runAgentLoopImpl(
       const deadlineMs = Date.now() + maxWait;
       const commitTurnChangesFn = ctx.commitTurnChanges ?? commitTurnChanges;
       const commitPromise = commitTurnChangesFn(
-        ctx.workingDir, ctx.conversationId, ctx.turnCount,
+        ctx.workingDir,
+        ctx.conversationId,
+        ctx.turnCount,
         undefined,
         deadlineMs,
       );
       const outcome = await raceWithTimeout(commitPromise, maxWait);
-      if (outcome === 'timed_out') {
+      if (outcome === "timed_out") {
         rlog.warn(
-          { turnNumber: ctx.turnCount, maxWaitMs: maxWait, conversationId: ctx.conversationId },
-          'Turn-boundary commit timed out — continuing without waiting (commit still runs in background)',
+          {
+            turnNumber: ctx.turnCount,
+            maxWaitMs: maxWait,
+            conversationId: ctx.conversationId,
+          },
+          "Turn-boundary commit timed out — continuing without waiting (commit still runs in background)",
         );
       }
 
@@ -860,7 +1111,7 @@ export async function runAgentLoopImpl(
 
     ctx.abortController = null;
     ctx.processing = false;
-    ctx.surfaceActionRequestIds.delete(ctx.currentRequestId ?? '');
+    ctx.surfaceActionRequestIds.delete(ctx.currentRequestId ?? "");
     ctx.currentRequestId = undefined;
     ctx.currentActiveSurfaceId = undefined;
     ctx.allowedToolNames = undefined;
@@ -873,14 +1124,17 @@ export async function runAgentLoopImpl(
       consolidateAssistantMessages(ctx.conversationId, userMessageId);
     }
 
-    ctx.drainQueue(yieldedForHandoff ? 'checkpoint_handoff' : 'loop_complete');
+    ctx.drainQueue(yieldedForHandoff ? "checkpoint_handoff" : "loop_complete");
   }
 }
 
 // ── Helper ───────────────────────────────────────────────────────────
 
 function emitUsage(
-  ctx: Pick<AgentLoopSessionContext, 'conversationId' | 'provider' | 'usageStats'>,
+  ctx: Pick<
+    AgentLoopSessionContext,
+    "conversationId" | "provider" | "usageStats"
+  >,
   inputTokens: number,
   outputTokens: number,
   model: string,
@@ -889,7 +1143,16 @@ function emitUsage(
   requestId: string | null = null,
 ): void {
   recordUsage(
-    { conversationId: ctx.conversationId, providerName: ctx.provider.name, usageStats: ctx.usageStats },
-    inputTokens, outputTokens, model, onEvent, actor, requestId,
+    {
+      conversationId: ctx.conversationId,
+      providerName: ctx.provider.name,
+      usageStats: ctx.usageStats,
+    },
+    inputTokens,
+    outputTokens,
+    model,
+    onEvent,
+    actor,
+    requestId,
   );
 }

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -2,48 +2,76 @@
  * Periodic retry sweep for failed channel inbound events.
  */
 
-import { isChannelId, parseChannelId, parseInterfaceId } from '../channels/types.js';
-import type { TrustContext } from '../daemon/session-runtime-assembly.js';
-import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
-import { getLogger } from '../util/logger.js';
-import { deliverReplyViaCallback } from './channel-reply-delivery.js';
-import { resolveRoutingStateFromRuntime } from './trust-context-resolver.js';
-import type { MessageProcessor } from './http-types.js';
+import {
+  isChannelId,
+  parseChannelId,
+  parseInterfaceId,
+} from "../channels/types.js";
+import type { TrustContext } from "../daemon/session-runtime-assembly.js";
+import * as channelDeliveryStore from "../memory/channel-delivery-store.js";
+import { getLogger } from "../util/logger.js";
+import { deliverReplyViaCallback } from "./channel-reply-delivery.js";
+import type { MessageProcessor } from "./http-types.js";
+import { resolveRoutingStateFromRuntime } from "./trust-context-resolver.js";
 
-const log = getLogger('runtime-http');
+const log = getLogger("runtime-http");
 
 function parseTrustRuntimeContext(value: unknown): TrustContext | undefined {
-  if (!value || typeof value !== 'object') return undefined;
+  if (!value || typeof value !== "object") return undefined;
   const raw = value as Record<string, unknown>;
   const trustClass = raw.trustClass;
   if (
-    trustClass !== 'guardian'
-    && trustClass !== 'trusted_contact'
-    && trustClass !== 'unknown'
+    trustClass !== "guardian" &&
+    trustClass !== "trusted_contact" &&
+    trustClass !== "unknown"
   ) {
     return undefined;
   }
-  const rawSourceChannel = typeof raw.sourceChannel === 'string' && raw.sourceChannel.trim().length > 0
-    ? raw.sourceChannel
-    : undefined;
+  const rawSourceChannel =
+    typeof raw.sourceChannel === "string" && raw.sourceChannel.trim().length > 0
+      ? raw.sourceChannel
+      : undefined;
   if (!rawSourceChannel || !isChannelId(rawSourceChannel)) return undefined;
   const sourceChannel = rawSourceChannel;
   const denialReason =
-    raw.denialReason === 'no_binding' || raw.denialReason === 'no_identity'
+    raw.denialReason === "no_binding" || raw.denialReason === "no_identity"
       ? raw.denialReason
       : undefined;
   return {
     sourceChannel,
     trustClass,
-    guardianChatId: typeof raw.guardianChatId === 'string' ? raw.guardianChatId : undefined,
-    guardianExternalUserId: typeof raw.guardianExternalUserId === 'string' ? raw.guardianExternalUserId : undefined,
-    guardianPrincipalId: typeof raw.guardianPrincipalId === 'string' ? raw.guardianPrincipalId : undefined,
-    requesterIdentifier: typeof raw.requesterIdentifier === 'string' ? raw.requesterIdentifier : undefined,
-    requesterDisplayName: typeof raw.requesterDisplayName === 'string' ? raw.requesterDisplayName : undefined,
-    requesterSenderDisplayName: typeof raw.requesterSenderDisplayName === 'string' ? raw.requesterSenderDisplayName : undefined,
-    requesterMemberDisplayName: typeof raw.requesterMemberDisplayName === 'string' ? raw.requesterMemberDisplayName : undefined,
-    requesterExternalUserId: typeof raw.requesterExternalUserId === 'string' ? raw.requesterExternalUserId : undefined,
-    requesterChatId: typeof raw.requesterChatId === 'string' ? raw.requesterChatId : undefined,
+    guardianChatId:
+      typeof raw.guardianChatId === "string" ? raw.guardianChatId : undefined,
+    guardianExternalUserId:
+      typeof raw.guardianExternalUserId === "string"
+        ? raw.guardianExternalUserId
+        : undefined,
+    guardianPrincipalId:
+      typeof raw.guardianPrincipalId === "string"
+        ? raw.guardianPrincipalId
+        : undefined,
+    requesterIdentifier:
+      typeof raw.requesterIdentifier === "string"
+        ? raw.requesterIdentifier
+        : undefined,
+    requesterDisplayName:
+      typeof raw.requesterDisplayName === "string"
+        ? raw.requesterDisplayName
+        : undefined,
+    requesterSenderDisplayName:
+      typeof raw.requesterSenderDisplayName === "string"
+        ? raw.requesterSenderDisplayName
+        : undefined,
+    requesterMemberDisplayName:
+      typeof raw.requesterMemberDisplayName === "string"
+        ? raw.requesterMemberDisplayName
+        : undefined,
+    requesterExternalUserId:
+      typeof raw.requesterExternalUserId === "string"
+        ? raw.requesterExternalUserId
+        : undefined,
+    requesterChatId:
+      typeof raw.requesterChatId === "string" ? raw.requesterChatId : undefined,
     denialReason,
   };
 }
@@ -59,14 +87,14 @@ export async function sweepFailedEvents(
   const events = channelDeliveryStore.getRetryableEvents();
   if (events.length === 0) return;
 
-  log.info({ count: events.length }, 'Retrying failed channel inbound events');
+  log.info({ count: events.length }, "Retrying failed channel inbound events");
 
   for (const event of events) {
     if (!event.rawPayload) {
       // No payload stored -- can't replay, move to dead letter
       channelDeliveryStore.recordProcessingFailure(
         event.id,
-        new Error('No raw payload stored for replay'),
+        new Error("No raw payload stored for replay"),
       );
       continue;
     }
@@ -77,13 +105,16 @@ export async function sweepFailedEvents(
     } catch {
       channelDeliveryStore.recordProcessingFailure(
         event.id,
-        new Error('Failed to parse stored raw payload'),
+        new Error("Failed to parse stored raw payload"),
       );
       continue;
     }
 
-    const content = typeof payload.content === 'string' ? payload.content.trim() : '';
-    const attachmentIds = Array.isArray(payload.attachmentIds) ? payload.attachmentIds as string[] : undefined;
+    const content =
+      typeof payload.content === "string" ? payload.content.trim() : "";
+    const attachmentIds = Array.isArray(payload.attachmentIds)
+      ? (payload.attachmentIds as string[])
+      : undefined;
     const sourceChannel = parseChannelId(payload.sourceChannel);
     if (!sourceChannel) {
       channelDeliveryStore.recordProcessingFailure(
@@ -92,13 +123,15 @@ export async function sweepFailedEvents(
       );
       continue;
     }
-    const sourceInterface = parseInterfaceId(payload.interface)
-      ?? parseInterfaceId(payload.sourceChannel)
-      ?? 'vellum';
-    const sourceMetadata = payload.sourceMetadata as Record<string, unknown> | undefined;
-    const assistantId = typeof payload.assistantId === 'string'
-      ? payload.assistantId
-      : undefined;
+    const sourceInterface =
+      parseInterfaceId(payload.interface) ??
+      parseInterfaceId(payload.sourceChannel) ??
+      "vellum";
+    const sourceMetadata = payload.sourceMetadata as
+      | Record<string, unknown>
+      | undefined;
+    const assistantId =
+      typeof payload.assistantId === "string" ? payload.assistantId : undefined;
     const parsedTrustContext = parseTrustRuntimeContext(payload.trustCtx);
 
     // If the stored payload had guardian context data but it couldn't be parsed
@@ -109,11 +142,11 @@ export async function sweepFailedEvents(
     if (payload.trustCtx && !parsedTrustContext) {
       log.warn(
         { eventId: event.id },
-        'Stored trustCtx could not be parsed into canonical form; marking event as failed to prevent privilege escalation',
+        "Stored trustCtx could not be parsed into canonical form; marking event as failed to prevent privilege escalation",
       );
       channelDeliveryStore.markRetryableFailure(
         event.id,
-        'Unparseable guardian context in stored payload — refusing to process without trust classification',
+        "Unparseable guardian context in stored payload — refusing to process without trust classification",
       );
       continue;
     }
@@ -125,16 +158,20 @@ export async function sweepFailedEvents(
     // otherwise grant guardian-level tool access to unclassified events.
     const trustContext: TrustContext = parsedTrustContext ?? {
       sourceChannel,
-      trustClass: 'unknown',
+      trustClass: "unknown",
     };
 
     const metadataHintsRaw = sourceMetadata?.hints;
     const metadataHints = Array.isArray(metadataHintsRaw)
-      ? metadataHintsRaw.filter((h): h is string => typeof h === 'string' && h.trim().length > 0)
+      ? metadataHintsRaw.filter(
+          (h): h is string => typeof h === "string" && h.trim().length > 0,
+        )
       : [];
-    const metadataUxBrief = typeof sourceMetadata?.uxBrief === 'string' && sourceMetadata.uxBrief.trim().length > 0
-      ? sourceMetadata.uxBrief.trim()
-      : undefined;
+    const metadataUxBrief =
+      typeof sourceMetadata?.uxBrief === "string" &&
+      sourceMetadata.uxBrief.trim().length > 0
+        ? sourceMetadata.uxBrief.trim()
+        : undefined;
 
     try {
       const { messageId: userMessageId } = await processMessage(
@@ -149,22 +186,28 @@ export async function sweepFailedEvents(
           },
           assistantId,
           trustContext,
-          isInteractive: resolveRoutingStateFromRuntime(trustContext).promptWaitingAllowed,
+          isInteractive:
+            resolveRoutingStateFromRuntime(trustContext).promptWaitingAllowed,
         },
         sourceChannel,
         sourceInterface,
       );
       channelDeliveryStore.linkMessage(event.id, userMessageId);
       channelDeliveryStore.markProcessed(event.id);
-      log.info({ eventId: event.id }, 'Successfully replayed failed channel event');
+      log.info(
+        { eventId: event.id },
+        "Successfully replayed failed channel event",
+      );
 
-      const replyCallbackUrl = typeof payload.replyCallbackUrl === 'string'
-        ? payload.replyCallbackUrl
-        : undefined;
-      if (replyCallbackUrl) {
-        const externalChatId = typeof payload.externalChatId === 'string'
-          ? payload.externalChatId
+      const replyCallbackUrl =
+        typeof payload.replyCallbackUrl === "string"
+          ? payload.replyCallbackUrl
           : undefined;
+      if (replyCallbackUrl) {
+        const externalChatId =
+          typeof payload.externalChatId === "string"
+            ? payload.externalChatId
+            : undefined;
         if (externalChatId) {
           // processMessage above generated a fresh assistant response, so any
           // previously tracked segment progress belongs to the old response and
@@ -180,13 +223,16 @@ export async function sweepFailedEvents(
             {
               startFromSegment: 0,
               onSegmentDelivered: (count) =>
-                channelDeliveryStore.updateDeliveredSegmentCount(event.id, count),
+                channelDeliveryStore.updateDeliveredSegmentCount(
+                  event.id,
+                  count,
+                ),
             },
           );
         }
       }
     } catch (err) {
-      log.error({ err, eventId: event.id }, 'Retry failed for channel event');
+      log.error({ err, eventId: event.id }, "Retry failed for channel event");
       channelDeliveryStore.recordProcessingFailure(event.id, err);
     }
   }

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -11,17 +11,17 @@
  * guardian-context behavior for the vellum channel.
  */
 
-import type { ChannelId } from '../channels/types.js';
-import { buildIpcAuthContext } from '../daemon/ipc-handler.js';
-import type { TrustContext } from '../daemon/session-runtime-assembly.js';
-import { getActiveBinding } from '../memory/guardian-bindings.js';
-import { getLogger } from '../util/logger.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
-import type { AuthContext } from './auth/types.js';
-import { resolveTrustContext } from './trust-context-resolver.js';
-import { ensureVellumGuardianBinding } from './guardian-vellum-migration.js';
+import type { ChannelId } from "../channels/types.js";
+import { buildIpcAuthContext } from "../daemon/ipc-handler.js";
+import type { TrustContext } from "../daemon/session-runtime-assembly.js";
+import { getActiveBinding } from "../memory/guardian-bindings.js";
+import { getLogger } from "../util/logger.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
+import type { AuthContext } from "./auth/types.js";
+import { ensureVellumGuardianBinding } from "./guardian-vellum-migration.js";
+import { resolveTrustContext } from "./trust-context-resolver.js";
 
-const log = getLogger('local-actor-identity');
+const log = getLogger("local-actor-identity");
 
 /**
  * Resolve the guardian runtime context for a local IPC connection.
@@ -36,10 +36,10 @@ const log = getLogger('local-actor-identity');
  * user is not incorrectly denied.
  */
 export function resolveLocalIpcTrustContext(
-  sourceChannel: ChannelId = 'vellum',
+  sourceChannel: ChannelId = "vellum",
 ): TrustContext {
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
-  const binding = getActiveBinding(assistantId, 'vellum');
+  const binding = getActiveBinding(assistantId, "vellum");
 
   if (!binding) {
     // No vellum binding yet (pre-bootstrap). Eagerly create one so
@@ -47,14 +47,16 @@ export function resolveLocalIpcTrustContext(
     // (tool_approval, pending_question) always has a guardianPrincipalId
     // available. Without this, createCanonicalGuardianRequest throws
     // IntegrityError and the request is silently dropped.
-    log.debug('No vellum guardian binding found; bootstrapping binding for IPC');
+    log.debug(
+      "No vellum guardian binding found; bootstrapping binding for IPC",
+    );
     const principalId = ensureVellumGuardianBinding(assistantId);
 
     // Re-resolve through the shared pipeline now that the binding exists.
     const trustCtx = resolveTrustContext({
       assistantId,
-      sourceChannel: 'vellum',
-      conversationExternalId: 'local',
+      sourceChannel: "vellum",
+      conversationExternalId: "local",
       actorExternalId: principalId,
     });
     // Overlay the caller's actual sourceChannel onto the resolved context.
@@ -71,8 +73,8 @@ export function resolveLocalIpcTrustContext(
   // causing a 'unknown' trust classification.
   const trustCtx = resolveTrustContext({
     assistantId,
-    sourceChannel: 'vellum',
-    conversationExternalId: 'local',
+    sourceChannel: "vellum",
+    conversationExternalId: "local",
     actorExternalId: guardianPrincipalId,
   });
 
@@ -96,7 +98,7 @@ export function resolveLocalIpcAuthContext(sessionId: string): AuthContext {
   // Enrich with the guardian principal ID when a vellum binding exists,
   // so downstream guardian resolution can use authContext.actorPrincipalId.
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
-  const binding = getActiveBinding(assistantId, 'vellum');
+  const binding = getActiveBinding(assistantId, "vellum");
   if (binding) {
     return { ...authContext, actorPrincipalId: binding.guardianExternalUserId };
   }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1,38 +1,45 @@
 /**
  * Route handlers for conversation messages and suggestions.
  */
-import { existsSync, readdirSync, statSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
 
-import { createAssistantMessage, createUserMessage } from '../../agent/message-types.js';
-import { CHANNEL_IDS, INTERFACE_IDS, parseChannelId, parseInterfaceId } from '../../channels/types.js';
-import { mergeToolResults,renderHistoryContent } from '../../daemon/handlers.js';
-import type { ServerMessage } from '../../daemon/ipc-protocol.js';
-import * as attachmentsStore from '../../memory/attachments-store.js';
+import {
+  createAssistantMessage,
+  createUserMessage,
+} from "../../agent/message-types.js";
+import {
+  CHANNEL_IDS,
+  INTERFACE_IDS,
+  parseChannelId,
+  parseInterfaceId,
+} from "../../channels/types.js";
+import {
+  mergeToolResults,
+  renderHistoryContent,
+} from "../../daemon/handlers.js";
+import type { ServerMessage } from "../../daemon/ipc-protocol.js";
+import * as attachmentsStore from "../../memory/attachments-store.js";
 import {
   createCanonicalGuardianRequest,
   generateCanonicalRequestCode,
   listCanonicalGuardianRequests,
   listPendingCanonicalGuardianRequestsByDestinationConversation,
-} from '../../memory/canonical-guardian-store.js';
+} from "../../memory/canonical-guardian-store.js";
 import {
   getConversationByKey,
   getOrCreateConversation,
-} from '../../memory/conversation-key-store.js';
-import * as conversationStore from '../../memory/conversation-store.js';
-import { getConfiguredProvider } from '../../providers/provider-send-message.js';
-import type { Provider } from '../../providers/types.js';
-import { getLogger } from '../../util/logger.js';
-import { buildAssistantEvent } from '../assistant-event.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
-import type { AuthContext } from '../auth/types.js';
-import { bridgeConfirmationRequestToGuardian } from '../confirmation-request-guardian-bridge.js';
-import {
-  resolveTrustContext,
-  withSourceChannel,
-} from '../trust-context-resolver.js';
-import { routeGuardianReply } from '../guardian-reply-router.js';
-import { httpError } from '../http-errors.js';
+} from "../../memory/conversation-key-store.js";
+import * as conversationStore from "../../memory/conversation-store.js";
+import { getConfiguredProvider } from "../../providers/provider-send-message.js";
+import type { Provider } from "../../providers/types.js";
+import { getLogger } from "../../util/logger.js";
+import { buildAssistantEvent } from "../assistant-event.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
+import type { AuthContext } from "../auth/types.js";
+import { bridgeConfirmationRequestToGuardian } from "../confirmation-request-guardian-bridge.js";
+import { routeGuardianReply } from "../guardian-reply-router.js";
+import { httpError } from "../http-errors.js";
 import type {
   ApprovalConversationGenerator,
   MessageProcessor,
@@ -40,23 +47,29 @@ import type {
   RuntimeAttachmentMetadata,
   RuntimeMessagePayload,
   SendMessageDeps,
-} from '../http-types.js';
-import * as pendingInteractions from '../pending-interactions.js';
+} from "../http-types.js";
+import * as pendingInteractions from "../pending-interactions.js";
+import {
+  resolveTrustContext,
+  withSourceChannel,
+} from "../trust-context-resolver.js";
 
-const log = getLogger('conversation-routes');
+const log = getLogger("conversation-routes");
 
 const SUGGESTION_CACHE_MAX = 100;
 
 function collectCanonicalGuardianRequestHintIds(
   conversationId: string,
   sourceChannel: string,
-  session: import('../../daemon/session.js').Session,
+  session: import("../../daemon/session.js").Session,
 ): string[] {
   const requests = [
-    ...listPendingCanonicalGuardianRequestsByDestinationConversation(conversationId, sourceChannel)
-      .map((request) => ({ id: request.id, kind: request.kind })),
+    ...listPendingCanonicalGuardianRequestsByDestinationConversation(
+      conversationId,
+      sourceChannel,
+    ).map((request) => ({ id: request.id, kind: request.kind })),
     ...listCanonicalGuardianRequests({
-      status: 'pending',
+      status: "pending",
       conversationId,
     }).map((request) => ({ id: request.id, kind: request.kind })),
   ];
@@ -64,12 +77,15 @@ function collectCanonicalGuardianRequestHintIds(
   const deduped = new Map<string, string>();
   for (const request of requests) {
     if (!deduped.has(request.id)) {
-      deduped.set(request.id, request.kind ?? '');
+      deduped.set(request.id, request.kind ?? "");
     }
   }
 
   return Array.from(deduped.entries())
-    .filter(([requestId, kind]) => kind !== 'tool_approval' || session.hasPendingConfirmation(requestId))
+    .filter(
+      ([requestId, kind]) =>
+        kind !== "tool_approval" || session.hasPendingConfirmation(requestId),
+    )
     .map(([requestId]) => requestId);
 }
 
@@ -84,7 +100,7 @@ async function tryConsumeCanonicalGuardianReply(params: {
     mimeType: string;
     data: string;
   }>;
-  session: import('../../daemon/session.js').Session;
+  session: import("../../daemon/session.js").Session;
   onEvent: (msg: ServerMessage) => void;
   approvalConversationGenerator?: ApprovalConversationGenerator;
   /** Verified actor identity from actor-token middleware. */
@@ -110,8 +126,13 @@ async function tryConsumeCanonicalGuardianReply(params: {
     return { consumed: false };
   }
 
-  const pendingRequestHintIds = collectCanonicalGuardianRequestHintIds(conversationId, sourceChannel, session);
-  const pendingRequestIds = pendingRequestHintIds.length > 0 ? pendingRequestHintIds : undefined;
+  const pendingRequestHintIds = collectCanonicalGuardianRequestHintIds(
+    conversationId,
+    sourceChannel,
+    session,
+  );
+  const pendingRequestIds =
+    pendingRequestHintIds.length > 0 ? pendingRequestHintIds : undefined;
 
   const routerResult = await routeGuardianReply({
     messageText: trimmedContent,
@@ -125,12 +146,12 @@ async function tryConsumeCanonicalGuardianReply(params: {
     pendingRequestIds,
     approvalConversationGenerator,
     emissionContext: {
-      source: 'inline_nl',
+      source: "inline_nl",
       decisionText: trimmedContent,
     },
   });
 
-  if (!routerResult.consumed || routerResult.type === 'nl_keep_pending') {
+  if (!routerResult.consumed || routerResult.type === "nl_keep_pending") {
     return { consumed: false };
   }
 
@@ -142,8 +163,8 @@ async function tryConsumeCanonicalGuardianReply(params: {
     session.emitConfirmationStateChanged({
       sessionId: conversationId,
       requestId: routerResult.requestId,
-      state: 'resolved_stale',
-      source: 'inline_nl',
+      state: "resolved_stale",
+      source: "inline_nl",
       decisionText: trimmedContent,
     });
   }
@@ -158,24 +179,27 @@ async function tryConsumeCanonicalGuardianReply(params: {
       assistantMessageChannel: sourceChannel,
       userMessageInterface: sourceInterface,
       assistantMessageInterface: sourceInterface,
-      provenanceTrustClass: 'guardian' as const,
+      provenanceTrustClass: "guardian" as const,
     };
 
     const userMessage = createUserMessage(content, attachments);
     const persistedUser = await conversationStore.addMessage(
       conversationId,
-      'user',
+      "user",
       JSON.stringify(userMessage.content),
       channelMeta,
     );
     messageId = persistedUser.id;
 
-    const replyText = (routerResult.replyText?.trim())
-      || (routerResult.decisionApplied ? 'Decision applied.' : 'Request already resolved.');
+    const replyText =
+      routerResult.replyText?.trim() ||
+      (routerResult.decisionApplied
+        ? "Decision applied."
+        : "Request already resolved.");
     const assistantMessage = createAssistantMessage(replyText);
     await conversationStore.addMessage(
       conversationId,
-      'assistant',
+      "assistant",
       JSON.stringify(assistantMessage.content),
       channelMeta,
     );
@@ -183,27 +207,38 @@ async function tryConsumeCanonicalGuardianReply(params: {
     // Avoid mutating in-memory history / emitting stream deltas while a run is active.
     if (!session.isProcessing()) {
       session.getMessages().push(userMessage, assistantMessage);
-      onEvent({ type: 'assistant_text_delta', text: replyText, sessionId: conversationId });
-      onEvent({ type: 'message_complete', sessionId: conversationId });
+      onEvent({
+        type: "assistant_text_delta",
+        text: replyText,
+        sessionId: conversationId,
+      });
+      onEvent({ type: "message_complete", sessionId: conversationId });
     }
   } catch (err) {
-    log.warn({ err, conversationId }, 'Failed to persist inline approval transcript entries');
+    log.warn(
+      { err, conversationId },
+      "Failed to persist inline approval transcript entries",
+    );
   }
 
   return { consumed: true, messageId };
 }
 
-function resolveCanonicalRequestSourceType(sourceChannel: string | undefined): 'desktop' | 'channel' | 'voice' {
-  if (sourceChannel === 'voice') {
-    return 'voice';
+function resolveCanonicalRequestSourceType(
+  sourceChannel: string | undefined,
+): "desktop" | "channel" | "voice" {
+  if (sourceChannel === "voice") {
+    return "voice";
   }
-  if (sourceChannel === 'vellum') {
-    return 'desktop';
+  if (sourceChannel === "vellum") {
+    return "desktop";
   }
-  return 'channel';
+  return "channel";
 }
 
-function getInterfaceFilesWithMtimes(interfacesDir: string | null): Array<{ path: string; mtimeMs: number }> {
+function getInterfaceFilesWithMtimes(
+  interfacesDir: string | null,
+): Array<{ path: string; mtimeMs: number }> {
   if (!interfacesDir || !existsSync(interfacesDir)) return [];
   const results: Array<{ path: string; mtimeMs: number }> = [];
   const scan = (dir: string): void => {
@@ -227,8 +262,8 @@ export function handleListMessages(
   url: URL,
   interfacesDir: string | null,
 ): Response {
-  const conversationId = url.searchParams.get('conversationId');
-  const conversationKey = url.searchParams.get('conversationKey');
+  const conversationId = url.searchParams.get("conversationId");
+  const conversationKey = url.searchParams.get("conversationKey");
 
   let resolvedConversationId: string | undefined;
   if (conversationId) {
@@ -237,7 +272,11 @@ export function handleListMessages(
     const mapping = getConversationByKey(conversationKey);
     resolvedConversationId = mapping?.conversationId;
   } else {
-    return httpError('BAD_REQUEST', 'conversationKey or conversationId query parameter is required', 400);
+    return httpError(
+      "BAD_REQUEST",
+      "conversationKey or conversationId query parameter is required",
+      400,
+    );
   }
 
   if (!resolvedConversationId) {
@@ -248,7 +287,11 @@ export function handleListMessages(
   // Parse content blocks and extract text + tool calls
   const parsed = rawMessages.map((msg) => {
     let content: unknown;
-    try { content = JSON.parse(msg.content); } catch { content = msg.content; }
+    try {
+      content = JSON.parse(msg.content);
+    } catch {
+      content = msg.content;
+    }
     const rendered = renderHistoryContent(content);
     return {
       role: msg.role,
@@ -273,7 +316,7 @@ export function handleListMessages(
   let prevAssistantTimestamp = 0;
   const messages: RuntimeMessagePayload[] = merged.map((m) => {
     let msgAttachments: RuntimeAttachmentMetadata[] = [];
-    if (m.role === 'assistant' && m.id) {
+    if (m.role === "assistant" && m.id) {
       const linked = attachmentsStore.getAttachmentMetadataForMessage(m.id);
       if (linked.length > 0) {
         msgAttachments = linked.map((a) => ({
@@ -287,10 +330,13 @@ export function handleListMessages(
     }
 
     let interfaces: string[] | undefined;
-    if (m.role === 'assistant') {
+    if (m.role === "assistant") {
       const msgTimestamp = new Date(m.timestamp).getTime();
       const dirtied = interfaceFiles
-        .filter((f) => f.mtimeMs > prevAssistantTimestamp && f.mtimeMs <= msgTimestamp)
+        .filter(
+          (f) =>
+            f.mtimeMs > prevAssistantTimestamp && f.mtimeMs <= msgTimestamp,
+        )
         .map((f) => f.path);
       if (dirtied.length > 0) {
         interfaces = dirtied;
@@ -299,7 +345,7 @@ export function handleListMessages(
     }
 
     return {
-      id: m.id ?? '',
+      id: m.id ?? "",
       role: m.role,
       content: m.text,
       timestamp: new Date(m.timestamp).toISOString(),
@@ -323,16 +369,16 @@ export function handleListMessages(
 function makeHubPublisher(
   deps: SendMessageDeps,
   conversationId: string,
-  session: import('../../daemon/session.js').Session,
+  session: import("../../daemon/session.js").Session,
 ): (msg: ServerMessage) => void {
   let hubChain: Promise<void> = Promise.resolve();
   return (msg: ServerMessage) => {
     // Register pending interactions for approval events
-    if (msg.type === 'confirmation_request') {
+    if (msg.type === "confirmation_request") {
       pendingInteractions.register(msg.requestId, {
         session,
         conversationId,
-        kind: 'confirmation',
+        kind: "confirmation",
         confirmationDetails: {
           toolName: msg.toolName,
           input: msg.input,
@@ -349,10 +395,10 @@ function makeHubPublisher(
       // via applyCanonicalGuardianDecision.
       try {
         const trustContext = session.trustContext;
-        const sourceChannel = trustContext?.sourceChannel ?? 'vellum';
+        const sourceChannel = trustContext?.sourceChannel ?? "vellum";
         const canonicalRequest = createCanonicalGuardianRequest({
           id: msg.requestId,
-          kind: 'tool_approval',
+          kind: "tool_approval",
           sourceType: resolveCanonicalRequestSourceType(sourceChannel),
           sourceChannel,
           conversationId,
@@ -361,7 +407,7 @@ function makeHubPublisher(
           guardianExternalUserId: trustContext?.guardianExternalUserId,
           guardianPrincipalId: trustContext?.guardianPrincipalId ?? undefined,
           toolName: msg.toolName,
-          status: 'pending',
+          status: "pending",
           requestCode: generateCanonicalRequestCode(),
           expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
         });
@@ -380,30 +426,38 @@ function makeHubPublisher(
       } catch (err) {
         log.debug(
           { err, requestId: msg.requestId, conversationId },
-          'Failed to create canonical request from hub publisher',
+          "Failed to create canonical request from hub publisher",
         );
       }
-    } else if (msg.type === 'secret_request') {
+    } else if (msg.type === "secret_request") {
       pendingInteractions.register(msg.requestId, {
         session,
         conversationId,
-        kind: 'secret',
+        kind: "secret",
       });
     }
 
     // ServerMessage is a large union; sessionId exists on most but not all variants.
     const msgSessionId =
-      'sessionId' in msg && typeof (msg as { sessionId?: unknown }).sessionId === 'string'
+      "sessionId" in msg &&
+      typeof (msg as { sessionId?: unknown }).sessionId === "string"
         ? (msg as { sessionId: string }).sessionId
         : undefined;
     const resolvedSessionId = msgSessionId ?? conversationId;
-    const event = buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, msg, resolvedSessionId);
+    const event = buildAssistantEvent(
+      DAEMON_INTERNAL_ASSISTANT_ID,
+      msg,
+      resolvedSessionId,
+    );
     hubChain = (async () => {
       await hubChain;
       try {
         await deps.assistantEventHub.publish(event);
       } catch (err) {
-        log.warn({ err }, 'assistant-events hub subscriber threw during POST /messages');
+        log.warn(
+          { err },
+          "assistant-events hub subscriber threw during POST /messages",
+        );
       }
     })();
   };
@@ -419,7 +473,7 @@ export async function handleSendMessage(
   },
   authContext: AuthContext,
 ): Promise<Response> {
-  const body = await req.json() as {
+  const body = (await req.json()) as {
     conversationKey?: string;
     content?: string;
     attachmentIds?: string[];
@@ -428,37 +482,50 @@ export async function handleSendMessage(
   };
 
   const { conversationKey, content, attachmentIds } = body;
-  if (!body.sourceChannel || typeof body.sourceChannel !== 'string') {
-    return httpError('BAD_REQUEST', 'sourceChannel is required', 400);
+  if (!body.sourceChannel || typeof body.sourceChannel !== "string") {
+    return httpError("BAD_REQUEST", "sourceChannel is required", 400);
   }
   const sourceChannel = parseChannelId(body.sourceChannel);
 
   if (!sourceChannel) {
-    return httpError('BAD_REQUEST', `Invalid sourceChannel: ${body.sourceChannel}. Valid values: ${CHANNEL_IDS.join(', ')}`, 400);
+    return httpError(
+      "BAD_REQUEST",
+      `Invalid sourceChannel: ${body.sourceChannel}. Valid values: ${CHANNEL_IDS.join(", ")}`,
+      400,
+    );
   }
 
-  if (!body.interface || typeof body.interface !== 'string') {
-    return httpError('BAD_REQUEST', 'interface is required', 400);
+  if (!body.interface || typeof body.interface !== "string") {
+    return httpError("BAD_REQUEST", "interface is required", 400);
   }
   const sourceInterface = parseInterfaceId(body.interface);
   if (!sourceInterface) {
-    return httpError('BAD_REQUEST', `Invalid interface: ${body.interface}. Valid values: ${INTERFACE_IDS.join(', ')}`, 400);
+    return httpError(
+      "BAD_REQUEST",
+      `Invalid interface: ${body.interface}. Valid values: ${INTERFACE_IDS.join(", ")}`,
+      400,
+    );
   }
 
   if (!conversationKey) {
-    return httpError('BAD_REQUEST', 'conversationKey is required', 400);
+    return httpError("BAD_REQUEST", "conversationKey is required", 400);
   }
 
   // Reject non-string content values (numbers, objects, etc.)
-  if (content != null && typeof content !== 'string') {
-    return httpError('BAD_REQUEST', 'content must be a string', 400);
+  if (content != null && typeof content !== "string") {
+    return httpError("BAD_REQUEST", "content must be a string", 400);
   }
 
-  const trimmedContent = typeof content === 'string' ? content.trim() : '';
-  const hasAttachments = Array.isArray(attachmentIds) && attachmentIds.length > 0;
+  const trimmedContent = typeof content === "string" ? content.trim() : "";
+  const hasAttachments =
+    Array.isArray(attachmentIds) && attachmentIds.length > 0;
 
   if (trimmedContent.length === 0 && !hasAttachments) {
-    return httpError('BAD_REQUEST', 'content or attachmentIds is required', 400);
+    return httpError(
+      "BAD_REQUEST",
+      "content or attachmentIds is required",
+      400,
+    );
   }
 
   // Validate that all attachment IDs resolve
@@ -467,7 +534,11 @@ export async function handleSendMessage(
     if (resolved.length !== attachmentIds.length) {
       const resolvedIds = new Set(resolved.map((a) => a.id));
       const missing = attachmentIds.filter((id) => !resolvedIds.has(id));
-      return httpError('BAD_REQUEST', `Attachment IDs not found: ${missing.join(', ')}`, 400);
+      return httpError(
+        "BAD_REQUEST",
+        `Attachment IDs not found: ${missing.join(", ")}`,
+        400,
+      );
     }
   }
 
@@ -485,15 +556,15 @@ export async function handleSendMessage(
       const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
       const trustCtx = resolveTrustContext({
         assistantId,
-        sourceChannel: 'vellum',
-        conversationExternalId: 'local',
+        sourceChannel: "vellum",
+        conversationExternalId: "local",
         actorExternalId: authContext.actorPrincipalId,
       });
       session.setTrustContext(withSourceChannel(sourceChannel, trustCtx));
     } else {
       // Service principals (svc_gateway) or tokens without an actor ID
       // get a minimal guardian context so downstream code has something.
-      session.setTrustContext({ trustClass: 'guardian', sourceChannel });
+      session.setTrustContext({ trustClass: "guardian", sourceChannel });
     }
 
     const onEvent = makeHubPublisher(smDeps, mapping.conversationId, session);
@@ -509,8 +580,10 @@ export async function handleSendMessage(
 
     // Resolve the verified actor's external user ID and principal for inline
     // approval routing from the session's guardian context.
-    const verifiedActorExternalUserId = session.trustContext?.guardianExternalUserId;
-    const verifiedActorPrincipalId = session.trustContext?.guardianPrincipalId ?? undefined;
+    const verifiedActorExternalUserId =
+      session.trustContext?.guardianExternalUserId;
+    const verifiedActorPrincipalId =
+      session.trustContext?.guardianPrincipalId ?? undefined;
 
     // Try to consume the message as a canonical guardian approval/rejection reply.
     // On failure, degrade to the existing queue/auto-deny path rather than
@@ -520,7 +593,7 @@ export async function handleSendMessage(
         conversationId: mapping.conversationId,
         sourceChannel,
         sourceInterface,
-        content: content ?? '',
+        content: content ?? "",
         attachments,
         session,
         onEvent,
@@ -530,12 +603,20 @@ export async function handleSendMessage(
       });
       if (inlineReplyResult.consumed) {
         return Response.json(
-          { accepted: true, ...(inlineReplyResult.messageId ? { messageId: inlineReplyResult.messageId } : {}) },
+          {
+            accepted: true,
+            ...(inlineReplyResult.messageId
+              ? { messageId: inlineReplyResult.messageId }
+              : {}),
+          },
           { status: 202 },
         );
       }
     } catch (err) {
-      log.warn({ err, conversationId: mapping.conversationId }, 'Inline approval consumption failed, falling through to normal send path');
+      log.warn(
+        { err, conversationId: mapping.conversationId },
+        "Inline approval consumption failed, falling through to normal send path",
+      );
     }
 
     if (session.isProcessing()) {
@@ -544,13 +625,18 @@ export async function handleSendMessage(
       if (session.hasAnyPendingConfirmation()) {
         // Emit authoritative denial state for each pending request.
         // The onStateSignal listener routes these to the SSE hub automatically.
-        for (const interaction of pendingInteractions.getByConversation(mapping.conversationId)) {
-          if (interaction.session === session && interaction.kind === 'confirmation') {
+        for (const interaction of pendingInteractions.getByConversation(
+          mapping.conversationId,
+        )) {
+          if (
+            interaction.session === session &&
+            interaction.kind === "confirmation"
+          ) {
             session.emitConfirmationStateChanged({
               sessionId: mapping.conversationId,
               requestId: interaction.requestId,
-              state: 'denied' as const,
-              source: 'auto_deny' as const,
+              state: "denied" as const,
+              source: "auto_deny" as const,
             });
           }
         }
@@ -561,7 +647,7 @@ export async function handleSendMessage(
       // Queue the message so it's processed when the current turn completes
       const requestId = crypto.randomUUID();
       const result = session.enqueueMessage(
-        content ?? '',
+        content ?? "",
         attachments,
         onEvent,
         requestId,
@@ -576,7 +662,11 @@ export async function handleSendMessage(
         { isInteractive: false },
       );
       if (result.rejected) {
-        return httpError('RATE_LIMITED', 'Message queue is full. Please retry later.', 429);
+        return httpError(
+          "RATE_LIMITED",
+          "Message queue is full. Please retry later.",
+          429,
+        );
       }
       return Response.json({ accepted: true, queued: true }, { status: 202 });
     }
@@ -591,13 +681,25 @@ export async function handleSendMessage(
       assistantMessageInterface: sourceInterface,
     });
     const requestId = crypto.randomUUID();
-    const messageId = await session.persistUserMessage(content ?? '', attachments, requestId);
+    const messageId = await session.persistUserMessage(
+      content ?? "",
+      attachments,
+      requestId,
+    );
 
     // Fire-and-forget the agent loop; events flow to the hub via onEvent.
     // Mark non-interactive so conflict clarification doesn't block the turn.
-    session.runAgentLoop(content ?? '', messageId, onEvent, { isInteractive: false, isUserMessage: true }).catch((err) => {
-      log.error({ err, conversationId: mapping.conversationId }, 'Agent loop failed (POST /messages)');
-    });
+    session
+      .runAgentLoop(content ?? "", messageId, onEvent, {
+        isInteractive: false,
+        isUserMessage: true,
+      })
+      .catch((err) => {
+        log.error(
+          { err, conversationId: mapping.conversationId },
+          "Agent loop failed (POST /messages)",
+        );
+      });
 
     return Response.json({ accepted: true, messageId }, { status: 202 });
   }
@@ -605,61 +707,77 @@ export async function handleSendMessage(
   // ── Legacy path (fallback when sendMessageDeps not wired) ───────────
   const processor = deps.persistAndProcessMessage ?? deps.processMessage;
   if (!processor) {
-    return httpError('SERVICE_UNAVAILABLE', 'Message processing not configured', 503);
+    return httpError(
+      "SERVICE_UNAVAILABLE",
+      "Message processing not configured",
+      503,
+    );
   }
 
   // Resolve guardian context from AuthContext for the legacy path too.
-  let trustContext: import('../../daemon/session-runtime-assembly.js').TrustContext;
+  let trustContext: import("../../daemon/session-runtime-assembly.js").TrustContext;
   if (authContext.actorPrincipalId) {
     const legacyTrustCtx = resolveTrustContext({
       assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
-      sourceChannel: 'vellum',
-      conversationExternalId: 'local',
+      sourceChannel: "vellum",
+      conversationExternalId: "local",
       actorExternalId: authContext.actorPrincipalId,
     });
     trustContext = withSourceChannel(sourceChannel, legacyTrustCtx);
   } else {
-    trustContext = { trustClass: 'guardian' as const, sourceChannel };
+    trustContext = { trustClass: "guardian" as const, sourceChannel };
   }
 
   try {
     const result = await processor(
       mapping.conversationId,
-      content ?? '',
+      content ?? "",
       hasAttachments ? attachmentIds : undefined,
       { trustContext },
       sourceChannel,
       sourceInterface,
     );
-    return Response.json({ accepted: true, messageId: result.messageId }, { status: 202 });
+    return Response.json(
+      { accepted: true, messageId: result.messageId },
+      { status: 202 },
+    );
   } catch (err) {
-    if (err instanceof Error && err.message === 'Session is already processing a message') {
-      return httpError('CONFLICT', 'Session is busy processing another message. Please retry.', 409);
+    if (
+      err instanceof Error &&
+      err.message === "Session is already processing a message"
+    ) {
+      return httpError(
+        "CONFLICT",
+        "Session is busy processing another message. Please retry.",
+        409,
+      );
     }
     throw err;
   }
 }
 
-async function generateLlmSuggestion(provider: Provider, assistantText: string): Promise<string | null> {
-  const truncated = assistantText.length > 2000
-    ? assistantText.slice(-2000)
-    : assistantText;
+async function generateLlmSuggestion(
+  provider: Provider,
+  assistantText: string,
+): Promise<string | null> {
+  const truncated =
+    assistantText.length > 2000 ? assistantText.slice(-2000) : assistantText;
 
   const prompt = `Given this assistant message, write a very short tab-complete suggestion (max 50 chars) the user could send next to keep the conversation going. Be casual, curious, or actionable — like a quick reply, not a formal request. Reply with ONLY the suggestion text.\n\nAssistant's message:\n${truncated}`;
   const response = await provider.sendMessage(
-    [{ role: 'user', content: [{ type: 'text', text: prompt }] }],
+    [{ role: "user", content: [{ type: "text", text: prompt }] }],
     [], // no tools
     undefined, // no system prompt
     { config: { max_tokens: 30 } },
   );
 
-  const textBlock = response.content.find((b) => b.type === 'text');
-  const raw = textBlock && 'text' in textBlock ? textBlock.text.trim() : '';
+  const textBlock = response.content.find((b) => b.type === "text");
+  const raw = textBlock && "text" in textBlock ? textBlock.text.trim() : "";
 
   if (!raw) return null;
 
   // Take first line only, then enforce the length cap
-  const firstLine = raw.split('\n')[0].trim();
+  const firstLine = raw.split("\n")[0].trim();
   if (!firstLine || firstLine.length > 50) return null;
   return firstLine;
 }
@@ -671,31 +789,48 @@ export async function handleGetSuggestion(
     suggestionInFlight: Map<string, Promise<string | null>>;
   },
 ): Promise<Response> {
-  const conversationKey = url.searchParams.get('conversationKey');
+  const conversationKey = url.searchParams.get("conversationKey");
   if (!conversationKey) {
-    return httpError('BAD_REQUEST', 'conversationKey query parameter is required', 400);
+    return httpError(
+      "BAD_REQUEST",
+      "conversationKey query parameter is required",
+      400,
+    );
   }
 
   const mapping = getConversationByKey(conversationKey);
   if (!mapping) {
-    return Response.json({ suggestion: null, messageId: null, source: 'none' as const });
+    return Response.json({
+      suggestion: null,
+      messageId: null,
+      source: "none" as const,
+    });
   }
 
   const rawMessages = conversationStore.getMessages(mapping.conversationId);
   if (rawMessages.length === 0) {
-    return Response.json({ suggestion: null, messageId: null, source: 'none' as const });
+    return Response.json({
+      suggestion: null,
+      messageId: null,
+      source: "none" as const,
+    });
   }
 
   // Staleness check: compare requested messageId against the latest
   // assistant message BEFORE filtering by text content.  This ensures
   // that a newer tool-only assistant turn (empty text) still causes
   // older messageId requests to be correctly marked as stale.
-  const requestedMessageId = url.searchParams.get('messageId');
+  const requestedMessageId = url.searchParams.get("messageId");
   if (requestedMessageId) {
     for (let i = rawMessages.length - 1; i >= 0; i--) {
-      if (rawMessages[i].role === 'assistant') {
+      if (rawMessages[i].role === "assistant") {
         if (rawMessages[i].id !== requestedMessageId) {
-          return Response.json({ suggestion: null, messageId: null, source: 'none' as const, stale: true });
+          return Response.json({
+            suggestion: null,
+            messageId: null,
+            source: "none" as const,
+            stale: true,
+          });
         }
         break;
       }
@@ -703,15 +838,19 @@ export async function handleGetSuggestion(
   }
 
   const { suggestionCache, suggestionInFlight } = deps;
-  const log = (await import('../../util/logger.js')).getLogger('runtime-http');
+  const log = (await import("../../util/logger.js")).getLogger("runtime-http");
 
   // Walk backwards to find the last assistant message with text content
   for (let i = rawMessages.length - 1; i >= 0; i--) {
     const msg = rawMessages[i];
-    if (msg.role !== 'assistant') continue;
+    if (msg.role !== "assistant") continue;
 
     let content: unknown;
-    try { content = JSON.parse(msg.content); } catch { content = msg.content; }
+    try {
+      content = JSON.parse(msg.content);
+    } catch {
+      content = msg.content;
+    }
     const rendered = renderHistoryContent(content);
     const text = rendered.text.trim();
     if (!text) continue;
@@ -719,7 +858,12 @@ export async function handleGetSuggestion(
     // If a messageId was requested and the first text-bearing assistant
     // message is a *different* message, the request is stale.
     if (requestedMessageId && msg.id !== requestedMessageId) {
-      return Response.json({ suggestion: null, messageId: null, source: 'none' as const, stale: true });
+      return Response.json({
+        suggestion: null,
+        messageId: null,
+        source: "none" as const,
+        stale: true,
+      });
     }
 
     // Return cached suggestion if we already generated one for this message
@@ -728,7 +872,7 @@ export async function handleGetSuggestion(
       return Response.json({
         suggestion: cached,
         messageId: msg.id,
-        source: 'llm' as const,
+        source: "llm" as const,
       });
     }
 
@@ -757,19 +901,27 @@ export async function handleGetSuggestion(
           return Response.json({
             suggestion: llmSuggestion,
             messageId: msg.id,
-            source: 'llm' as const,
+            source: "llm" as const,
           });
         }
       } catch (err) {
         suggestionInFlight.delete(msg.id);
-        log.warn({ err }, 'LLM suggestion failed');
+        log.warn({ err }, "LLM suggestion failed");
       }
     }
 
-    return Response.json({ suggestion: null, messageId: null, source: 'none' as const });
+    return Response.json({
+      suggestion: null,
+      messageId: null,
+      source: "none" as const,
+    });
   }
 
-  return Response.json({ suggestion: null, messageId: null, source: 'none' as const });
+  return Response.json({
+    suggestion: null,
+    messageId: null,
+    source: "none" as const,
+  });
 }
 
 /**
@@ -779,21 +931,26 @@ export async function handleGetSuggestion(
  * Returns ranked results grouped by conversation, each with matching message excerpts.
  */
 export function handleSearchConversations(url: URL): Response {
-  const query = url.searchParams.get('q') ?? '';
+  const query = url.searchParams.get("q") ?? "";
   if (!query.trim()) {
-    return httpError('BAD_REQUEST', 'q query parameter is required', 400);
+    return httpError("BAD_REQUEST", "q query parameter is required", 400);
   }
 
-  const limit = url.searchParams.has('limit')
-    ? Number(url.searchParams.get('limit'))
+  const limit = url.searchParams.has("limit")
+    ? Number(url.searchParams.get("limit"))
     : undefined;
-  const maxMessagesPerConversation = url.searchParams.has('maxMessagesPerConversation')
-    ? Number(url.searchParams.get('maxMessagesPerConversation'))
+  const maxMessagesPerConversation = url.searchParams.has(
+    "maxMessagesPerConversation",
+  )
+    ? Number(url.searchParams.get("maxMessagesPerConversation"))
     : undefined;
 
   const results = conversationStore.searchConversations(query, {
     ...(limit !== undefined && !isNaN(limit) ? { limit } : {}),
-    ...(maxMessagesPerConversation !== undefined && !isNaN(maxMessagesPerConversation) ? { maxMessagesPerConversation } : {}),
+    ...(maxMessagesPerConversation !== undefined &&
+    !isNaN(maxMessagesPerConversation)
+      ? { maxMessagesPerConversation }
+      : {}),
   });
 
   return Response.json({ query, results });

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -2,8 +2,9 @@
  * Approval interception: checks for pending approvals and handles inbound
  * messages as decisions, reminders, or conversational follow-ups.
  */
-import { applyGuardianDecision } from '../../approvals/guardian-decision-primitive.js';
-import type { ChannelId } from '../../channels/types.js';
+import { applyGuardianDecision } from "../../approvals/guardian-decision-primitive.js";
+import type { ChannelId } from "../../channels/types.js";
+import type { TrustContext } from "../../daemon/session-runtime-assembly.js";
 import {
   getAllPendingApprovalsByGuardianChat,
   getPendingApprovalByRequestAndGuardianChat,
@@ -11,27 +12,27 @@ import {
   getUnresolvedApprovalForRequest,
   type GuardianApprovalRequest,
   updateApprovalDecision,
-} from '../../memory/channel-guardian-store.js';
-import { emitNotificationSignal } from '../../notifications/emit-signal.js';
-import { getLogger } from '../../util/logger.js';
-import { runApprovalConversationTurn } from '../approval-conversation-turn.js';
-import { composeApprovalMessageGenerative } from '../approval-message-composer.js';
-import { parseApprovalDecision } from '../channel-approval-parser.js';
+} from "../../memory/channel-guardian-store.js";
+import { emitNotificationSignal } from "../../notifications/emit-signal.js";
+import { getLogger } from "../../util/logger.js";
+import { runApprovalConversationTurn } from "../approval-conversation-turn.js";
+import { composeApprovalMessageGenerative } from "../approval-message-composer.js";
+import { parseApprovalDecision } from "../channel-approval-parser.js";
 import type {
   ApprovalAction,
   ApprovalDecisionResult,
-} from '../channel-approval-types.js';
+} from "../channel-approval-types.js";
 import {
   getApprovalInfoByConversation,
   getChannelApprovalPrompt,
   handleChannelDecision,
-} from '../channel-approvals.js';
-import { deliverChannelReply } from '../gateway-client.js';
+} from "../channel-approvals.js";
+import { deliverChannelReply } from "../gateway-client.js";
 import type {
   ApprovalConversationContext,
   ApprovalConversationGenerator,
   ApprovalCopyGenerator,
-} from '../http-types.js';
+} from "../http-types.js";
 import {
   deliverVerificationCodeToGuardian,
   type DeliveryResult,
@@ -39,14 +40,13 @@ import {
   notifyRequesterOfApproval,
   notifyRequesterOfDeliveryFailure,
   notifyRequesterOfDenial,
-} from './access-request-decision.js';
-import type { TrustContext } from '../../daemon/session-runtime-assembly.js';
+} from "./access-request-decision.js";
 import {
   buildGuardianDenyContext,
   parseCallbackData,
-} from './channel-route-shared.js';
+} from "./channel-route-shared.js";
 
-const log = getLogger('runtime-http');
+const log = getLogger("runtime-http");
 
 export interface ApprovalInterceptionParams {
   conversationId: string;
@@ -65,7 +65,11 @@ export interface ApprovalInterceptionParams {
 
 export interface ApprovalInterceptionResult {
   handled: boolean;
-  type?: 'decision_applied' | 'assistant_turn' | 'guardian_decision_applied' | 'stale_ignored';
+  type?:
+    | "decision_applied"
+    | "assistant_turn"
+    | "guardian_decision_applied"
+    | "stale_ignored";
 }
 
 /**
@@ -100,10 +104,7 @@ export async function handleApprovalInterception(
   // When the sender is the guardian and there's a pending guardian approval
   // request targeting this chat, the message might be a decision on behalf
   // of a non-guardian requester.
-  if (
-    trustCtx.trustClass === 'guardian' &&
-    actorExternalId
-  ) {
+  if (trustCtx.trustClass === "guardian" && actorExternalId) {
     // Callback/button path: deterministic and takes priority.
     let callbackDecision: ApprovalDecisionResult | null = null;
     if (callbackData) {
@@ -114,48 +115,75 @@ export async function handleApprovalInterception(
     // the decision resolves to exactly the right approval even when
     // multiple approvals target the same guardian chat.
     let guardianApproval = callbackDecision?.requestId
-      ? getPendingApprovalByRequestAndGuardianChat(callbackDecision.requestId, sourceChannel, conversationExternalId, assistantId)
+      ? getPendingApprovalByRequestAndGuardianChat(
+          callbackDecision.requestId,
+          sourceChannel,
+          conversationExternalId,
+          assistantId,
+        )
       : null;
 
     // When the scoped lookup didn't resolve an approval (either because
     // there was no callback or the requestId pointed to a stale/expired request),
     // fall back to checking all pending approvals for this guardian chat.
     if (!guardianApproval && callbackDecision) {
-      const allPending = getAllPendingApprovalsByGuardianChat(sourceChannel, conversationExternalId, assistantId);
+      const allPending = getAllPendingApprovalsByGuardianChat(
+        sourceChannel,
+        conversationExternalId,
+        assistantId,
+      );
       if (allPending.length === 1) {
         guardianApproval = allPending[0];
       } else if (allPending.length > 1) {
         // The callback targeted a stale/expired request but the guardian has other
         // pending approvals. Inform them the clicked approval is no longer valid.
         try {
-          const staleText = await composeApprovalMessageGenerative({
-            scenario: 'guardian_disambiguation',
-            pendingCount: allPending.length,
-            channel: sourceChannel,
-          }, {}, approvalCopyGenerator);
-          await deliverChannelReply(replyCallbackUrl, {
-            chatId: conversationExternalId,
-            text: staleText,
-            assistantId,
-          }, bearerToken);
+          const staleText = await composeApprovalMessageGenerative(
+            {
+              scenario: "guardian_disambiguation",
+              pendingCount: allPending.length,
+              channel: sourceChannel,
+            },
+            {},
+            approvalCopyGenerator,
+          );
+          await deliverChannelReply(
+            replyCallbackUrl,
+            {
+              chatId: conversationExternalId,
+              text: staleText,
+              assistantId,
+            },
+            bearerToken,
+          );
         } catch (err) {
-          log.error({ err, conversationExternalId }, 'Failed to deliver stale callback disambiguation notice');
+          log.error(
+            { err, conversationExternalId },
+            "Failed to deliver stale callback disambiguation notice",
+          );
         }
-        return { handled: true, type: 'stale_ignored' };
+        return { handled: true, type: "stale_ignored" };
       }
     }
 
     // For plain-text messages (no callback), check if there are any pending
     // approvals for this guardian chat to route through the conversation engine.
     if (!guardianApproval && !callbackDecision) {
-      const allPending = getAllPendingApprovalsByGuardianChat(sourceChannel, conversationExternalId, assistantId);
+      const allPending = getAllPendingApprovalsByGuardianChat(
+        sourceChannel,
+        conversationExternalId,
+        assistantId,
+      );
       if (allPending.length === 1) {
         guardianApproval = allPending[0];
       } else if (allPending.length > 1) {
         // Multiple pending — pick the first approval matching this sender as
         // primary context. The conversation engine sees all matching approvals
         // via pendingApprovals and can disambiguate.
-        guardianApproval = allPending.find(a => a.guardianExternalUserId === actorExternalId) ?? allPending[0];
+        guardianApproval =
+          allPending.find(
+            (a) => a.guardianExternalUserId === actorExternalId,
+          ) ?? allPending[0];
       }
     }
 
@@ -167,33 +195,48 @@ export async function handleApprovalInterception(
       // creation and decision.
       if (actorExternalId !== guardianApproval.guardianExternalUserId) {
         log.warn(
-          { conversationExternalId, actorExternalId, expectedGuardian: guardianApproval.guardianExternalUserId },
-          'Non-guardian sender attempted to act on guardian approval request',
+          {
+            conversationExternalId,
+            actorExternalId,
+            expectedGuardian: guardianApproval.guardianExternalUserId,
+          },
+          "Non-guardian sender attempted to act on guardian approval request",
         );
         try {
-          const mismatchText = await composeApprovalMessageGenerative({
-            scenario: 'guardian_identity_mismatch',
-            channel: sourceChannel,
-          }, {}, approvalCopyGenerator);
-          await deliverChannelReply(replyCallbackUrl, {
-            chatId: conversationExternalId,
-            text: mismatchText,
-            assistantId,
-          }, bearerToken);
+          const mismatchText = await composeApprovalMessageGenerative(
+            {
+              scenario: "guardian_identity_mismatch",
+              channel: sourceChannel,
+            },
+            {},
+            approvalCopyGenerator,
+          );
+          await deliverChannelReply(
+            replyCallbackUrl,
+            {
+              chatId: conversationExternalId,
+              text: mismatchText,
+              assistantId,
+            },
+            bearerToken,
+          );
         } catch (err) {
-          log.error({ err, conversationExternalId }, 'Failed to deliver guardian identity rejection notice');
+          log.error(
+            { err, conversationExternalId },
+            "Failed to deliver guardian identity rejection notice",
+          );
         }
-        return { handled: true, type: 'guardian_decision_applied' };
+        return { handled: true, type: "guardian_decision_applied" };
       }
 
       if (callbackDecision) {
         // Access request approvals don't have a pending interaction in the
         // session tracker, so they need a separate decision path that creates
         // a verification session instead of resuming an agent loop.
-        if (guardianApproval.toolName === 'ingress_access_request') {
+        if (guardianApproval.toolName === "ingress_access_request") {
           const accessResult = await handleAccessRequestApproval(
             guardianApproval,
-            callbackDecision.action === 'reject' ? 'deny' : 'approve',
+            callbackDecision.action === "reject" ? "deny" : "approve",
             actorExternalId,
             replyCallbackUrl,
             assistantId,
@@ -214,65 +257,103 @@ export async function handleApprovalInterception(
 
         if (result.applied) {
           // Notify the requester's chat about the outcome with the tool name
-          const effectiveAction = callbackDecision.action === 'approve_always' ? 'approve_once' : callbackDecision.action;
-          const outcomeText = await composeApprovalMessageGenerative({
-            scenario: 'guardian_decision_outcome',
-            decision: effectiveAction === 'reject' ? 'denied' : 'approved',
-            toolName: guardianApproval.toolName,
-            channel: sourceChannel,
-          }, {}, approvalCopyGenerator);
+          const effectiveAction =
+            callbackDecision.action === "approve_always"
+              ? "approve_once"
+              : callbackDecision.action;
+          const outcomeText = await composeApprovalMessageGenerative(
+            {
+              scenario: "guardian_decision_outcome",
+              decision: effectiveAction === "reject" ? "denied" : "approved",
+              toolName: guardianApproval.toolName,
+              channel: sourceChannel,
+            },
+            {},
+            approvalCopyGenerator,
+          );
           try {
-            await deliverChannelReply(replyCallbackUrl, {
-              chatId: guardianApproval.requesterChatId,
-              text: outcomeText,
-              assistantId,
-            }, bearerToken);
+            await deliverChannelReply(
+              replyCallbackUrl,
+              {
+                chatId: guardianApproval.requesterChatId,
+                text: outcomeText,
+                assistantId,
+              },
+              bearerToken,
+            );
           } catch (err) {
-            log.error({ err, conversationId: guardianApproval.conversationId }, 'Failed to notify requester of guardian decision');
+            log.error(
+              { err, conversationId: guardianApproval.conversationId },
+              "Failed to notify requester of guardian decision",
+            );
           }
 
           // Post-decision delivery is handled by the onEvent callback
           // in the session that registered the pending interaction.
-          return { handled: true, type: 'guardian_decision_applied' };
+          return { handled: true, type: "guardian_decision_applied" };
         }
 
         // Race condition: callback arrived after request was already resolved.
-        return { handled: true, type: 'stale_ignored' };
+        return { handled: true, type: "stale_ignored" };
       }
 
       // ── Conversational engine for guardian plain-text messages ──
       // Gather all pending guardian approvals for this chat so the engine
       // can handle disambiguation when multiple are pending.
-      const allGuardianPending = getAllPendingApprovalsByGuardianChat(sourceChannel, conversationExternalId, assistantId);
+      const allGuardianPending = getAllPendingApprovalsByGuardianChat(
+        sourceChannel,
+        conversationExternalId,
+        assistantId,
+      );
       // Only present approvals that belong to this sender so the engine
       // does not offer disambiguation for requests assigned to a rotated
       // guardian the sender cannot act on.
-      const senderPending = allGuardianPending.filter(a => a.guardianExternalUserId === actorExternalId);
-      const effectivePending = senderPending.length > 0 ? senderPending : allGuardianPending;
-      if (effectivePending.length > 0 && approvalConversationGenerator && content) {
-        const guardianAllowedActions = ['approve_once', 'reject'];
+      const senderPending = allGuardianPending.filter(
+        (a) => a.guardianExternalUserId === actorExternalId,
+      );
+      const effectivePending =
+        senderPending.length > 0 ? senderPending : allGuardianPending;
+      if (
+        effectivePending.length > 0 &&
+        approvalConversationGenerator &&
+        content
+      ) {
+        const guardianAllowedActions = ["approve_once", "reject"];
         const engineContext: ApprovalConversationContext = {
           toolName: guardianApproval.toolName,
           allowedActions: guardianAllowedActions,
-          role: 'guardian',
-          pendingApprovals: effectivePending.map((a) => ({ requestId: a.requestId ?? a.runId, toolName: a.toolName })),
+          role: "guardian",
+          pendingApprovals: effectivePending.map((a) => ({
+            requestId: a.requestId ?? a.runId,
+            toolName: a.toolName,
+          })),
           userMessage: content,
         };
 
-        const engineResult = await runApprovalConversationTurn(engineContext, approvalConversationGenerator);
+        const engineResult = await runApprovalConversationTurn(
+          engineContext,
+          approvalConversationGenerator,
+        );
 
-        if (engineResult.disposition === 'keep_pending') {
+        if (engineResult.disposition === "keep_pending") {
           // Non-decision follow-up (clarification, disambiguation, etc.)
           try {
-            await deliverChannelReply(replyCallbackUrl, {
-              chatId: conversationExternalId,
-              text: engineResult.replyText,
-              assistantId,
-            }, bearerToken);
+            await deliverChannelReply(
+              replyCallbackUrl,
+              {
+                chatId: conversationExternalId,
+                text: engineResult.replyText,
+                assistantId,
+              },
+              bearerToken,
+            );
           } catch (err) {
-            log.error({ err, conversationId: guardianApproval.conversationId }, 'Failed to deliver guardian conversation reply');
+            log.error(
+              { err, conversationId: guardianApproval.conversationId },
+              "Failed to deliver guardian conversation reply",
+            );
           }
-          return { handled: true, type: 'assistant_turn' };
+          return { handled: true, type: "assistant_turn" };
         }
 
         // Decision-bearing disposition from the engine
@@ -281,14 +362,20 @@ export async function handleApprovalInterception(
         // Belt-and-suspenders: guardians cannot use broad allow modes even if
         // the engine returns them (the engine's allowedActions validation should
         // already prevent this, but enforce it here too).
-        if (decisionAction === 'approve_always' || decisionAction === 'approve_10m' || decisionAction === 'approve_thread') {
-          decisionAction = 'approve_once';
+        if (
+          decisionAction === "approve_always" ||
+          decisionAction === "approve_10m" ||
+          decisionAction === "approve_thread"
+        ) {
+          decisionAction = "approve_once";
         }
 
         // Resolve the target approval: use targetRequestId from the engine if
         // provided, otherwise use the single guardian approval.
         const targetApproval = engineResult.targetRequestId
-          ? allGuardianPending.find((a) => (a.requestId ?? a.runId) === engineResult.targetRequestId) ?? guardianApproval
+          ? (allGuardianPending.find(
+              (a) => (a.requestId ?? a.runId) === engineResult.targetRequestId,
+            ) ?? guardianApproval)
           : guardianApproval;
 
         // Re-validate guardian identity against the resolved target. The
@@ -298,30 +385,46 @@ export async function handleApprovalInterception(
         // previous guardian after a binding rotation.
         if (actorExternalId !== targetApproval.guardianExternalUserId) {
           log.warn(
-            { conversationExternalId, actorExternalId, expectedGuardian: targetApproval.guardianExternalUserId, targetRequestId: engineResult.targetRequestId },
-            'Guardian identity mismatch on engine-selected target approval',
+            {
+              conversationExternalId,
+              actorExternalId,
+              expectedGuardian: targetApproval.guardianExternalUserId,
+              targetRequestId: engineResult.targetRequestId,
+            },
+            "Guardian identity mismatch on engine-selected target approval",
           );
           try {
-            const mismatchText = await composeApprovalMessageGenerative({
-              scenario: 'guardian_identity_mismatch',
-              channel: sourceChannel,
-            }, {}, approvalCopyGenerator);
-            await deliverChannelReply(replyCallbackUrl, {
-              chatId: conversationExternalId,
-              text: mismatchText,
-              assistantId,
-            }, bearerToken);
+            const mismatchText = await composeApprovalMessageGenerative(
+              {
+                scenario: "guardian_identity_mismatch",
+                channel: sourceChannel,
+              },
+              {},
+              approvalCopyGenerator,
+            );
+            await deliverChannelReply(
+              replyCallbackUrl,
+              {
+                chatId: conversationExternalId,
+                text: mismatchText,
+                assistantId,
+              },
+              bearerToken,
+            );
           } catch (err) {
-            log.error({ err, conversationExternalId }, 'Failed to deliver guardian identity mismatch notice for engine target');
+            log.error(
+              { err, conversationExternalId },
+              "Failed to deliver guardian identity mismatch notice for engine target",
+            );
           }
-          return { handled: true, type: 'guardian_decision_applied' };
+          return { handled: true, type: "guardian_decision_applied" };
         }
 
         // Access request approvals need a separate decision path.
-        if (targetApproval.toolName === 'ingress_access_request') {
+        if (targetApproval.toolName === "ingress_access_request") {
           const accessResult = await handleAccessRequestApproval(
             targetApproval,
-            decisionAction === 'reject' ? 'deny' : 'approve',
+            decisionAction === "reject" ? "deny" : "approve",
             actorExternalId,
             replyCallbackUrl,
             assistantId,
@@ -332,8 +435,10 @@ export async function handleApprovalInterception(
 
         const engineDecision: ApprovalDecisionResult = {
           action: decisionAction,
-          source: 'plain_text',
-          ...(engineResult.targetRequestId ? { requestId: engineResult.targetRequestId } : {}),
+          source: "plain_text",
+          ...(engineResult.targetRequestId
+            ? { requestId: engineResult.targetRequestId }
+            : {}),
         };
 
         // Apply the decision through the unified guardian decision primitive.
@@ -346,53 +451,82 @@ export async function handleApprovalInterception(
 
         if (result.applied) {
           // Notify the requester's chat about the outcome
-          const outcomeText = await composeApprovalMessageGenerative({
-            scenario: 'guardian_decision_outcome',
-            decision: decisionAction === 'reject' ? 'denied' : 'approved',
-            toolName: targetApproval.toolName,
-            channel: sourceChannel,
-          }, {}, approvalCopyGenerator);
+          const outcomeText = await composeApprovalMessageGenerative(
+            {
+              scenario: "guardian_decision_outcome",
+              decision: decisionAction === "reject" ? "denied" : "approved",
+              toolName: targetApproval.toolName,
+              channel: sourceChannel,
+            },
+            {},
+            approvalCopyGenerator,
+          );
           try {
-            await deliverChannelReply(replyCallbackUrl, {
-              chatId: targetApproval.requesterChatId,
-              text: outcomeText,
-              assistantId,
-            }, bearerToken);
+            await deliverChannelReply(
+              replyCallbackUrl,
+              {
+                chatId: targetApproval.requesterChatId,
+                text: outcomeText,
+                assistantId,
+              },
+              bearerToken,
+            );
           } catch (err) {
-            log.error({ err, conversationId: targetApproval.conversationId }, 'Failed to notify requester of guardian decision');
+            log.error(
+              { err, conversationId: targetApproval.conversationId },
+              "Failed to notify requester of guardian decision",
+            );
           }
 
           // Deliver the engine's reply to the guardian
           try {
-            await deliverChannelReply(replyCallbackUrl, {
-              chatId: conversationExternalId,
-              text: engineResult.replyText,
-              assistantId,
-            }, bearerToken);
+            await deliverChannelReply(
+              replyCallbackUrl,
+              {
+                chatId: conversationExternalId,
+                text: engineResult.replyText,
+                assistantId,
+              },
+              bearerToken,
+            );
           } catch (err) {
-            log.error({ err, conversationId: targetApproval.conversationId }, 'Failed to deliver guardian decision reply');
+            log.error(
+              { err, conversationId: targetApproval.conversationId },
+              "Failed to deliver guardian decision reply",
+            );
           }
 
-          return { handled: true, type: 'guardian_decision_applied' };
+          return { handled: true, type: "guardian_decision_applied" };
         }
 
         // Race condition: request was already resolved. Deliver a stale notice
         // instead of the engine's optimistic reply.
         try {
-          const staleText = await composeApprovalMessageGenerative({
-            scenario: 'approval_already_resolved',
-            channel: sourceChannel,
-          }, {}, approvalCopyGenerator);
-          await deliverChannelReply(replyCallbackUrl, {
-            chatId: conversationExternalId,
-            text: staleText,
-            assistantId,
-          }, bearerToken);
+          const staleText = await composeApprovalMessageGenerative(
+            {
+              scenario: "approval_already_resolved",
+              channel: sourceChannel,
+            },
+            {},
+            approvalCopyGenerator,
+          );
+          await deliverChannelReply(
+            replyCallbackUrl,
+            {
+              chatId: conversationExternalId,
+              text: staleText,
+              assistantId,
+            },
+            bearerToken,
+          );
         } catch (err) {
-          log.error({ err, conversationId: targetApproval.conversationId }, 'Failed to deliver stale guardian approval notice');
+          log.error(
+            { err, conversationId: targetApproval.conversationId },
+            "Failed to deliver stale guardian approval notice",
+          );
         }
 
-        return { handled: true, type: 'stale_ignored' };
+        return { handled: true, type: "stale_ignored" };
       }
 
       // ── Legacy fallback when no conversational engine is available ──
@@ -402,8 +536,8 @@ export async function handleApprovalInterception(
         const legacyGuardianDecision = parseApprovalDecision(content);
         if (legacyGuardianDecision) {
           // Guardians cannot approve_always — downgrade to approve_once.
-          if (legacyGuardianDecision.action === 'approve_always') {
-            legacyGuardianDecision.action = 'approve_once';
+          if (legacyGuardianDecision.action === "approve_always") {
+            legacyGuardianDecision.action = "approve_once";
           }
 
           // Resolve the target approval: when a [ref:<requestId>] tag is
@@ -412,29 +546,41 @@ export async function handleApprovalInterception(
           // multiple guardian approvals are pending.
           let targetLegacyApproval = guardianApproval;
           if (legacyGuardianDecision.requestId) {
-            const resolvedByRequest = getPendingApprovalByRequestAndGuardianChat(
-              legacyGuardianDecision.requestId,
-              sourceChannel,
-              conversationExternalId,
-              assistantId,
-            );
+            const resolvedByRequest =
+              getPendingApprovalByRequestAndGuardianChat(
+                legacyGuardianDecision.requestId,
+                sourceChannel,
+                conversationExternalId,
+                assistantId,
+              );
             if (!resolvedByRequest) {
               // The referenced request doesn't match any pending guardian
               // approval — it may have expired or already been resolved.
               try {
-                const staleText = await composeApprovalMessageGenerative({
-                  scenario: 'guardian_disambiguation',
-                  channel: sourceChannel,
-                }, {}, approvalCopyGenerator);
-                await deliverChannelReply(replyCallbackUrl, {
-                  chatId: conversationExternalId,
-                  text: staleText,
-                  assistantId,
-                }, bearerToken);
+                const staleText = await composeApprovalMessageGenerative(
+                  {
+                    scenario: "guardian_disambiguation",
+                    channel: sourceChannel,
+                  },
+                  {},
+                  approvalCopyGenerator,
+                );
+                await deliverChannelReply(
+                  replyCallbackUrl,
+                  {
+                    chatId: conversationExternalId,
+                    text: staleText,
+                    assistantId,
+                  },
+                  bearerToken,
+                );
               } catch (err) {
-                log.error({ err, conversationExternalId }, 'Failed to deliver stale approval notice (legacy path)');
+                log.error(
+                  { err, conversationExternalId },
+                  "Failed to deliver stale approval notice (legacy path)",
+                );
               }
-              return { handled: true, type: 'stale_ignored' };
+              return { handled: true, type: "stale_ignored" };
             }
             targetLegacyApproval = resolvedByRequest;
           }
@@ -444,30 +590,46 @@ export async function handleApprovalInterception(
           // requestId-resolved approval may belong to a different guardian.
           if (actorExternalId !== targetLegacyApproval.guardianExternalUserId) {
             log.warn(
-              { conversationExternalId, actorExternalId, expectedGuardian: targetLegacyApproval.guardianExternalUserId, requestId: legacyGuardianDecision.requestId },
-              'Guardian identity mismatch on legacy ref-resolved target approval',
+              {
+                conversationExternalId,
+                actorExternalId,
+                expectedGuardian: targetLegacyApproval.guardianExternalUserId,
+                requestId: legacyGuardianDecision.requestId,
+              },
+              "Guardian identity mismatch on legacy ref-resolved target approval",
             );
             try {
-              const mismatchText = await composeApprovalMessageGenerative({
-                scenario: 'guardian_identity_mismatch',
-                channel: sourceChannel,
-              }, {}, approvalCopyGenerator);
-              await deliverChannelReply(replyCallbackUrl, {
-                chatId: conversationExternalId,
-                text: mismatchText,
-                assistantId,
-              }, bearerToken);
+              const mismatchText = await composeApprovalMessageGenerative(
+                {
+                  scenario: "guardian_identity_mismatch",
+                  channel: sourceChannel,
+                },
+                {},
+                approvalCopyGenerator,
+              );
+              await deliverChannelReply(
+                replyCallbackUrl,
+                {
+                  chatId: conversationExternalId,
+                  text: mismatchText,
+                  assistantId,
+                },
+                bearerToken,
+              );
             } catch (err) {
-              log.error({ err, conversationExternalId }, 'Failed to deliver guardian identity mismatch notice (legacy path)');
+              log.error(
+                { err, conversationExternalId },
+                "Failed to deliver guardian identity mismatch notice (legacy path)",
+              );
             }
-            return { handled: true, type: 'guardian_decision_applied' };
+            return { handled: true, type: "guardian_decision_applied" };
           }
 
           // Access request approvals need a separate decision path.
-          if (targetLegacyApproval.toolName === 'ingress_access_request') {
+          if (targetLegacyApproval.toolName === "ingress_access_request") {
             const accessResult = await handleAccessRequestApproval(
               targetLegacyApproval,
-              legacyGuardianDecision.action === 'reject' ? 'deny' : 'approve',
+              legacyGuardianDecision.action === "reject" ? "deny" : "approve",
               actorExternalId,
               replyCallbackUrl,
               assistantId,
@@ -486,58 +648,94 @@ export async function handleApprovalInterception(
 
           if (result.applied) {
             // Notify the requester's chat about the outcome
-            const outcomeText = await composeApprovalMessageGenerative({
-              scenario: 'guardian_decision_outcome',
-              decision: legacyGuardianDecision.action === 'reject' ? 'denied' : 'approved',
-              toolName: targetLegacyApproval.toolName,
-              channel: sourceChannel,
-            }, {}, approvalCopyGenerator);
+            const outcomeText = await composeApprovalMessageGenerative(
+              {
+                scenario: "guardian_decision_outcome",
+                decision:
+                  legacyGuardianDecision.action === "reject"
+                    ? "denied"
+                    : "approved",
+                toolName: targetLegacyApproval.toolName,
+                channel: sourceChannel,
+              },
+              {},
+              approvalCopyGenerator,
+            );
             try {
-              await deliverChannelReply(replyCallbackUrl, {
-                chatId: targetLegacyApproval.requesterChatId,
-                text: outcomeText,
-                assistantId,
-              }, bearerToken);
+              await deliverChannelReply(
+                replyCallbackUrl,
+                {
+                  chatId: targetLegacyApproval.requesterChatId,
+                  text: outcomeText,
+                  assistantId,
+                },
+                bearerToken,
+              );
             } catch (err) {
-              log.error({ err, conversationId: targetLegacyApproval.conversationId }, 'Failed to notify requester of guardian decision (legacy path)');
+              log.error(
+                { err, conversationId: targetLegacyApproval.conversationId },
+                "Failed to notify requester of guardian decision (legacy path)",
+              );
             }
 
-            return { handled: true, type: 'guardian_decision_applied' };
+            return { handled: true, type: "guardian_decision_applied" };
           }
 
           // Race condition: request was already resolved. Deliver stale notice.
           try {
-            const staleText = await composeApprovalMessageGenerative({
-              scenario: 'approval_already_resolved',
-              channel: sourceChannel,
-            }, {}, approvalCopyGenerator);
-            await deliverChannelReply(replyCallbackUrl, {
-              chatId: conversationExternalId,
-              text: staleText,
-              assistantId,
-            }, bearerToken);
+            const staleText = await composeApprovalMessageGenerative(
+              {
+                scenario: "approval_already_resolved",
+                channel: sourceChannel,
+              },
+              {},
+              approvalCopyGenerator,
+            );
+            await deliverChannelReply(
+              replyCallbackUrl,
+              {
+                chatId: conversationExternalId,
+                text: staleText,
+                assistantId,
+              },
+              bearerToken,
+            );
           } catch (err) {
-            log.error({ err, conversationId: targetLegacyApproval.conversationId }, 'Failed to deliver stale guardian legacy fallback notice');
+            log.error(
+              { err, conversationId: targetLegacyApproval.conversationId },
+              "Failed to deliver stale guardian legacy fallback notice",
+            );
           }
-          return { handled: true, type: 'stale_ignored' };
+          return { handled: true, type: "stale_ignored" };
         }
 
         // No decision could be parsed — send a generic reminder to the guardian
         try {
-          const reminderText = await composeApprovalMessageGenerative({
-            scenario: 'reminder_prompt',
-            toolName: guardianApproval.toolName,
-            channel: sourceChannel,
-          }, {}, approvalCopyGenerator);
-          await deliverChannelReply(replyCallbackUrl, {
-            chatId: conversationExternalId,
-            text: reminderText,
-            assistantId,
-          }, bearerToken);
+          const reminderText = await composeApprovalMessageGenerative(
+            {
+              scenario: "reminder_prompt",
+              toolName: guardianApproval.toolName,
+              channel: sourceChannel,
+            },
+            {},
+            approvalCopyGenerator,
+          );
+          await deliverChannelReply(
+            replyCallbackUrl,
+            {
+              chatId: conversationExternalId,
+              text: reminderText,
+              assistantId,
+            },
+            bearerToken,
+          );
         } catch (err) {
-          log.error({ err, conversationId: guardianApproval.conversationId }, 'Failed to deliver guardian reminder (legacy path)');
+          log.error(
+            { err, conversationId: guardianApproval.conversationId },
+            "Failed to deliver guardian reminder (legacy path)",
+          );
         }
-        return { handled: true, type: 'assistant_turn' };
+        return { handled: true, type: "assistant_turn" };
       }
 
       // No content and no engine — nothing to do, fall through to standard
@@ -553,7 +751,8 @@ export async function handleApprovalInterception(
   // unknown trust + explicit denial reason (`no_identity` / `no_binding`).
   // Unknown without a denial reason means identity-known, non-member sender
   // in a shared channel; that case must not force-reject someone else's request.
-  const isLegacyUnverifiedSender = trustCtx.trustClass === 'unknown' && !!trustCtx.denialReason;
+  const isLegacyUnverifiedSender =
+    trustCtx.trustClass === "unknown" && !!trustCtx.denialReason;
 
   // When the sender is from a legacy-unverified channel actor, auto-deny any
   // pending confirmation and block self-approval.
@@ -562,14 +761,14 @@ export async function handleApprovalInterception(
     if (pending.length > 0) {
       handleChannelDecision(
         conversationId,
-        { action: 'reject', source: 'plain_text' },
+        { action: "reject", source: "plain_text" },
         buildGuardianDenyContext(
           pending[0].toolName,
-          trustCtx.denialReason ?? 'no_binding',
+          trustCtx.denialReason ?? "no_binding",
           sourceChannel,
         ),
       );
-      return { handled: true, type: 'decision_applied' };
+      return { handled: true, type: "decision_applied" };
     }
   }
 
@@ -579,12 +778,15 @@ export async function handleApprovalInterception(
   //
   // Include identity-known, non-member senders (`unknown` without denialReason)
   // so shared-channel participants can't approve/deny someone else's pending request.
-  const isIdentityKnownNonGuardian = trustCtx.trustClass === 'trusted_contact'
-    || (trustCtx.trustClass === 'unknown' && !trustCtx.denialReason);
+  const isIdentityKnownNonGuardian =
+    trustCtx.trustClass === "trusted_contact" ||
+    (trustCtx.trustClass === "unknown" && !trustCtx.denialReason);
   if (isIdentityKnownNonGuardian) {
     const pending = getApprovalInfoByConversation(conversationId);
     if (pending.length > 0) {
-      const guardianApprovalForRequest = getPendingApprovalForRequest(pending[0].requestId);
+      const guardianApprovalForRequest = getPendingApprovalForRequest(
+        pending[0].requestId,
+      );
       if (guardianApprovalForRequest) {
         // Allow the requester to cancel their own pending guardian request.
         // Only reject/cancel is permitted — self-approval is still blocked.
@@ -599,24 +801,30 @@ export async function handleApprovalInterception(
           if (approvalConversationGenerator) {
             const cancelContext: ApprovalConversationContext = {
               toolName: pending[0].toolName,
-              allowedActions: ['reject'],
-              role: 'requester',
-              pendingApprovals: pending.map(p => ({ requestId: p.requestId, toolName: p.toolName })),
+              allowedActions: ["reject"],
+              role: "requester",
+              pendingApprovals: pending.map((p) => ({
+                requestId: p.requestId,
+                toolName: p.toolName,
+              })),
               userMessage: content,
             };
-            const cancelResult = await runApprovalConversationTurn(cancelContext, approvalConversationGenerator);
-            if (cancelResult.disposition === 'reject') {
+            const cancelResult = await runApprovalConversationTurn(
+              cancelContext,
+              approvalConversationGenerator,
+            );
+            if (cancelResult.disposition === "reject") {
               requesterCancelIntent = true;
               cancelReplyText = cancelResult.replyText;
-            } else if (cancelResult.disposition === 'keep_pending') {
+            } else if (cancelResult.disposition === "keep_pending") {
               requesterFollowupReplyText = cancelResult.replyText;
             }
           }
 
           if (requesterCancelIntent) {
             const rejectDecision: ApprovalDecisionResult = {
-              action: 'reject',
-              source: 'plain_text',
+              action: "reject",
+              source: "plain_text",
             };
             // Apply the cancel decision through the unified primitive.
             // The primitive handles record update and (no-op) grant logic.
@@ -628,119 +836,185 @@ export async function handleApprovalInterception(
             });
             if (cancelApplyResult.applied) {
               // Notify requester
-              const replyText = cancelReplyText ?? await composeApprovalMessageGenerative({
-                scenario: 'requester_cancel',
-                toolName: pending[0].toolName,
-                channel: sourceChannel,
-              }, {}, approvalCopyGenerator);
+              const replyText =
+                cancelReplyText ??
+                (await composeApprovalMessageGenerative(
+                  {
+                    scenario: "requester_cancel",
+                    toolName: pending[0].toolName,
+                    channel: sourceChannel,
+                  },
+                  {},
+                  approvalCopyGenerator,
+                ));
               try {
-                await deliverChannelReply(replyCallbackUrl, {
-                  chatId: conversationExternalId,
-                  text: replyText,
-                  assistantId,
-                }, bearerToken);
+                await deliverChannelReply(
+                  replyCallbackUrl,
+                  {
+                    chatId: conversationExternalId,
+                    text: replyText,
+                    assistantId,
+                  },
+                  bearerToken,
+                );
               } catch (err) {
-                log.error({ err, conversationId }, 'Failed to deliver requester cancel notice');
+                log.error(
+                  { err, conversationId },
+                  "Failed to deliver requester cancel notice",
+                );
               }
 
               // Notify guardian that the request was cancelled
               try {
-                const guardianNotice = await composeApprovalMessageGenerative({
-                  scenario: 'guardian_decision_outcome',
-                  decision: 'denied',
-                  toolName: pending[0].toolName,
-                  channel: sourceChannel,
-                }, {}, approvalCopyGenerator);
-                await deliverChannelReply(replyCallbackUrl, {
-                  chatId: guardianApprovalForRequest.guardianChatId,
-                  text: guardianNotice,
-                  assistantId,
-                }, bearerToken);
+                const guardianNotice = await composeApprovalMessageGenerative(
+                  {
+                    scenario: "guardian_decision_outcome",
+                    decision: "denied",
+                    toolName: pending[0].toolName,
+                    channel: sourceChannel,
+                  },
+                  {},
+                  approvalCopyGenerator,
+                );
+                await deliverChannelReply(
+                  replyCallbackUrl,
+                  {
+                    chatId: guardianApprovalForRequest.guardianChatId,
+                    text: guardianNotice,
+                    assistantId,
+                  },
+                  bearerToken,
+                );
               } catch (err) {
-                log.error({ err, conversationId }, 'Failed to notify guardian of requester cancellation');
+                log.error(
+                  { err, conversationId },
+                  "Failed to notify guardian of requester cancellation",
+                );
               }
 
-              return { handled: true, type: 'decision_applied' };
+              return { handled: true, type: "decision_applied" };
             }
 
             // Race condition: approval was already resolved elsewhere.
             try {
-              const staleText = await composeApprovalMessageGenerative({
-                scenario: 'approval_already_resolved',
-                channel: sourceChannel,
-              }, {}, approvalCopyGenerator);
-              await deliverChannelReply(replyCallbackUrl, {
-                chatId: conversationExternalId,
-                text: staleText,
-                assistantId,
-              }, bearerToken);
+              const staleText = await composeApprovalMessageGenerative(
+                {
+                  scenario: "approval_already_resolved",
+                  channel: sourceChannel,
+                },
+                {},
+                approvalCopyGenerator,
+              );
+              await deliverChannelReply(
+                replyCallbackUrl,
+                {
+                  chatId: conversationExternalId,
+                  text: staleText,
+                  assistantId,
+                },
+                bearerToken,
+              );
             } catch (err) {
-              log.error({ err, conversationId }, 'Failed to deliver stale requester-cancel notice');
+              log.error(
+                { err, conversationId },
+                "Failed to deliver stale requester-cancel notice",
+              );
             }
-            return { handled: true, type: 'stale_ignored' };
+            return { handled: true, type: "stale_ignored" };
           }
 
           if (requesterFollowupReplyText) {
             try {
-              await deliverChannelReply(replyCallbackUrl, {
-                chatId: conversationExternalId,
-                text: requesterFollowupReplyText,
-                assistantId,
-              }, bearerToken);
+              await deliverChannelReply(
+                replyCallbackUrl,
+                {
+                  chatId: conversationExternalId,
+                  text: requesterFollowupReplyText,
+                  assistantId,
+                },
+                bearerToken,
+              );
             } catch (err) {
-              log.error({ err, conversationId }, 'Failed to deliver requester follow-up reply while awaiting guardian');
+              log.error(
+                { err, conversationId },
+                "Failed to deliver requester follow-up reply while awaiting guardian",
+              );
             }
-            return { handled: true, type: 'assistant_turn' };
+            return { handled: true, type: "assistant_turn" };
           }
         }
 
         // Not a cancel intent — tell the requester their request is pending
         try {
-          const pendingText = await composeApprovalMessageGenerative({
-            scenario: 'request_pending_guardian',
-            channel: sourceChannel,
-          }, {}, approvalCopyGenerator);
-          await deliverChannelReply(replyCallbackUrl, {
-            chatId: conversationExternalId,
-            text: pendingText,
-            assistantId,
-          }, bearerToken);
+          const pendingText = await composeApprovalMessageGenerative(
+            {
+              scenario: "request_pending_guardian",
+              channel: sourceChannel,
+            },
+            {},
+            approvalCopyGenerator,
+          );
+          await deliverChannelReply(
+            replyCallbackUrl,
+            {
+              chatId: conversationExternalId,
+              text: pendingText,
+              assistantId,
+            },
+            bearerToken,
+          );
         } catch (err) {
-          log.error({ err, conversationId }, 'Failed to deliver guardian-pending notice to requester');
+          log.error(
+            { err, conversationId },
+            "Failed to deliver guardian-pending notice to requester",
+          );
         }
-        return { handled: true, type: 'assistant_turn' };
+        return { handled: true, type: "assistant_turn" };
       }
 
       // Check for an expired-but-unresolved guardian approval. If the approval
       // expired without a guardian decision, auto-deny and transition
       // the approval to 'expired'. Without this, the requester could bypass
       // guardian-only controls by simply waiting for the TTL to elapse.
-      const unresolvedApproval = getUnresolvedApprovalForRequest(pending[0].requestId);
+      const unresolvedApproval = getUnresolvedApprovalForRequest(
+        pending[0].requestId,
+      );
       if (unresolvedApproval) {
-        updateApprovalDecision(unresolvedApproval.id, { status: 'expired' });
+        updateApprovalDecision(unresolvedApproval.id, { status: "expired" });
 
         // Auto-deny the underlying request so it does not remain actionable
         const expiredDecision: ApprovalDecisionResult = {
-          action: 'reject',
-          source: 'plain_text',
+          action: "reject",
+          source: "plain_text",
         };
         handleChannelDecision(conversationId, expiredDecision);
 
         try {
-          const expiredText = await composeApprovalMessageGenerative({
-            scenario: 'guardian_expired_requester',
-            toolName: pending[0].toolName,
-            channel: sourceChannel,
-          }, {}, approvalCopyGenerator);
-          await deliverChannelReply(replyCallbackUrl, {
-            chatId: conversationExternalId,
-            text: expiredText,
-            assistantId,
-          }, bearerToken);
+          const expiredText = await composeApprovalMessageGenerative(
+            {
+              scenario: "guardian_expired_requester",
+              toolName: pending[0].toolName,
+              channel: sourceChannel,
+            },
+            {},
+            approvalCopyGenerator,
+          );
+          await deliverChannelReply(
+            replyCallbackUrl,
+            {
+              chatId: conversationExternalId,
+              text: expiredText,
+              assistantId,
+            },
+            bearerToken,
+          );
         } catch (err) {
-          log.error({ err, conversationId }, 'Failed to deliver guardian-expiry notice to requester');
+          log.error(
+            { err, conversationId },
+            "Failed to deliver guardian-expiry notice to requester",
+          );
         }
-        return { handled: true, type: 'decision_applied' };
+        return { handled: true, type: "decision_applied" };
       }
 
       // Guard: non-guardian actors with a guardian binding must not self-approve
@@ -751,25 +1025,43 @@ export async function handleApprovalInterception(
       // persisted, any non-guardian actor could otherwise fall through to the
       // standard conversational engine / legacy parser and resolve their own
       // pending request via handleChannelDecision.
-      if (trustCtx.trustClass !== 'guardian' && trustCtx.guardianExternalUserId) {
+      if (
+        trustCtx.trustClass !== "guardian" &&
+        trustCtx.guardianExternalUserId
+      ) {
         log.info(
-          { conversationId, conversationExternalId, guardianExternalUserId: trustCtx.guardianExternalUserId },
-          'Blocking non-guardian self-approval: pending confirmation exists but guardian approval row not yet created',
+          {
+            conversationId,
+            conversationExternalId,
+            guardianExternalUserId: trustCtx.guardianExternalUserId,
+          },
+          "Blocking non-guardian self-approval: pending confirmation exists but guardian approval row not yet created",
         );
         try {
-          const pendingText = await composeApprovalMessageGenerative({
-            scenario: 'request_pending_guardian',
-            channel: sourceChannel,
-          }, {}, approvalCopyGenerator);
-          await deliverChannelReply(replyCallbackUrl, {
-            chatId: conversationExternalId,
-            text: pendingText,
-            assistantId,
-          }, bearerToken);
+          const pendingText = await composeApprovalMessageGenerative(
+            {
+              scenario: "request_pending_guardian",
+              channel: sourceChannel,
+            },
+            {},
+            approvalCopyGenerator,
+          );
+          await deliverChannelReply(
+            replyCallbackUrl,
+            {
+              chatId: conversationExternalId,
+              text: pendingText,
+              assistantId,
+            },
+            bearerToken,
+          );
         } catch (err) {
-          log.error({ err, conversationId }, 'Failed to deliver guardian-pending notice to non-guardian actor (pre-row guard)');
+          log.error(
+            { err, conversationId },
+            "Failed to deliver guardian-pending notice to non-guardian actor (pre-row guard)",
+          );
         }
-        return { handled: true, type: 'assistant_turn' };
+        return { handled: true, type: "assistant_turn" };
       }
     }
   }
@@ -784,12 +1076,15 @@ export async function handleApprovalInterception(
       // previous approval prompt) must not apply to a different pending interaction.
       if (cbDecision.requestId) {
         const pending = getApprovalInfoByConversation(conversationId);
-        if (pending.length === 0 || !pending.some(p => p.requestId === cbDecision.requestId)) {
+        if (
+          pending.length === 0 ||
+          !pending.some((p) => p.requestId === cbDecision.requestId)
+        ) {
           log.warn(
             { conversationId, callbackRequestId: cbDecision.requestId },
-            'Callback request ID does not match any pending interaction, ignoring stale button press',
+            "Callback request ID does not match any pending interaction, ignoring stale button press",
           );
-          return { handled: true, type: 'stale_ignored' };
+          return { handled: true, type: "stale_ignored" };
         }
       }
 
@@ -798,12 +1093,12 @@ export async function handleApprovalInterception(
       if (result.applied) {
         // Post-decision delivery is handled by the onEvent callback
         // in the session that registered the pending interaction.
-        return { handled: true, type: 'decision_applied' };
+        return { handled: true, type: "decision_applied" };
       }
 
       // Race condition: request was already resolved between the stale check
       // above and the decision attempt.
-      return { handled: true, type: 'stale_ignored' };
+      return { handled: true, type: "stale_ignored" };
     }
   }
 
@@ -817,33 +1112,48 @@ export async function handleApprovalInterception(
     const engineContext: ApprovalConversationContext = {
       toolName: pending[0].toolName,
       allowedActions,
-      role: 'requester',
-      pendingApprovals: pending.map((p) => ({ requestId: p.requestId, toolName: p.toolName })),
+      role: "requester",
+      pendingApprovals: pending.map((p) => ({
+        requestId: p.requestId,
+        toolName: p.toolName,
+      })),
       userMessage: content,
     };
 
-    const engineResult = await runApprovalConversationTurn(engineContext, approvalConversationGenerator);
+    const engineResult = await runApprovalConversationTurn(
+      engineContext,
+      approvalConversationGenerator,
+    );
 
-    if (engineResult.disposition === 'keep_pending') {
+    if (engineResult.disposition === "keep_pending") {
       // Non-decision follow-up — deliver the engine's reply and keep the request pending
       try {
-        await deliverChannelReply(replyCallbackUrl, {
-          chatId: conversationExternalId,
-          text: engineResult.replyText,
-          assistantId,
-        }, bearerToken);
+        await deliverChannelReply(
+          replyCallbackUrl,
+          {
+            chatId: conversationExternalId,
+            text: engineResult.replyText,
+            assistantId,
+          },
+          bearerToken,
+        );
       } catch (err) {
-        log.error({ err, conversationId }, 'Failed to deliver approval conversation reply');
+        log.error(
+          { err, conversationId },
+          "Failed to deliver approval conversation reply",
+        );
       }
-      return { handled: true, type: 'assistant_turn' };
+      return { handled: true, type: "assistant_turn" };
     }
 
     // Decision-bearing disposition — map to ApprovalDecisionResult and apply
     const decisionAction = engineResult.disposition as ApprovalAction;
     const engineDecision: ApprovalDecisionResult = {
       action: decisionAction,
-      source: 'plain_text',
-      ...(engineResult.targetRequestId ? { requestId: engineResult.targetRequestId } : {}),
+      source: "plain_text",
+      ...(engineResult.targetRequestId
+        ? { requestId: engineResult.targetRequestId }
+        : {}),
     };
 
     const result = handleChannelDecision(conversationId, engineDecision);
@@ -851,36 +1161,54 @@ export async function handleApprovalInterception(
     if (result.applied) {
       // Deliver the engine's reply text to the user
       try {
-        await deliverChannelReply(replyCallbackUrl, {
-          chatId: conversationExternalId,
-          text: engineResult.replyText,
-          assistantId,
-        }, bearerToken);
+        await deliverChannelReply(
+          replyCallbackUrl,
+          {
+            chatId: conversationExternalId,
+            text: engineResult.replyText,
+            assistantId,
+          },
+          bearerToken,
+        );
       } catch (err) {
-        log.error({ err, conversationId }, 'Failed to deliver approval decision reply');
+        log.error(
+          { err, conversationId },
+          "Failed to deliver approval decision reply",
+        );
       }
 
-      return { handled: true, type: 'decision_applied' };
+      return { handled: true, type: "decision_applied" };
     }
 
     // Race condition: request was already resolved by expiry sweep or
     // concurrent callback. Deliver a stale notice instead of the
     // engine's optimistic reply.
     try {
-      const staleText = await composeApprovalMessageGenerative({
-        scenario: 'approval_already_resolved',
-        channel: sourceChannel,
-      }, {}, approvalCopyGenerator);
-      await deliverChannelReply(replyCallbackUrl, {
-        chatId: conversationExternalId,
-        text: staleText,
-        assistantId,
-      }, bearerToken);
+      const staleText = await composeApprovalMessageGenerative(
+        {
+          scenario: "approval_already_resolved",
+          channel: sourceChannel,
+        },
+        {},
+        approvalCopyGenerator,
+      );
+      await deliverChannelReply(
+        replyCallbackUrl,
+        {
+          chatId: conversationExternalId,
+          text: staleText,
+          assistantId,
+        },
+        bearerToken,
+      );
     } catch (err) {
-      log.error({ err, conversationId }, 'Failed to deliver stale approval notice');
+      log.error(
+        { err, conversationId },
+        "Failed to deliver stale approval notice",
+      );
     }
 
-    return { handled: true, type: 'stale_ignored' };
+    return { handled: true, type: "stale_ignored" };
   }
 
   // Fallback: no conversational generator available or no content — use
@@ -890,51 +1218,76 @@ export async function handleApprovalInterception(
     const legacyDecision = parseApprovalDecision(content);
     if (legacyDecision) {
       if (legacyDecision.requestId) {
-        if (pending.length === 0 || !pending.some(p => p.requestId === legacyDecision.requestId)) {
-          return { handled: true, type: 'stale_ignored' };
+        if (
+          pending.length === 0 ||
+          !pending.some((p) => p.requestId === legacyDecision.requestId)
+        ) {
+          return { handled: true, type: "stale_ignored" };
         }
       }
       const result = handleChannelDecision(conversationId, legacyDecision);
       if (result.applied) {
-        return { handled: true, type: 'decision_applied' };
+        return { handled: true, type: "decision_applied" };
       }
 
       // Race condition: request was already resolved.
       try {
-        const staleText = await composeApprovalMessageGenerative({
-          scenario: 'approval_already_resolved',
-          channel: sourceChannel,
-        }, {}, approvalCopyGenerator);
-        await deliverChannelReply(replyCallbackUrl, {
-          chatId: conversationExternalId,
-          text: staleText,
-          assistantId,
-        }, bearerToken);
+        const staleText = await composeApprovalMessageGenerative(
+          {
+            scenario: "approval_already_resolved",
+            channel: sourceChannel,
+          },
+          {},
+          approvalCopyGenerator,
+        );
+        await deliverChannelReply(
+          replyCallbackUrl,
+          {
+            chatId: conversationExternalId,
+            text: staleText,
+            assistantId,
+          },
+          bearerToken,
+        );
       } catch (err) {
-        log.error({ err, conversationId }, 'Failed to deliver stale approval notice (legacy path)');
+        log.error(
+          { err, conversationId },
+          "Failed to deliver stale approval notice (legacy path)",
+        );
       }
-      return { handled: true, type: 'stale_ignored' };
+      return { handled: true, type: "stale_ignored" };
     }
   }
 
   // No decision could be extracted and no conversational engine is available —
   // deliver a simple status reply rather than a reminder prompt.
   try {
-    const statusText = await composeApprovalMessageGenerative({
-      scenario: 'reminder_prompt',
-      channel: sourceChannel,
-      toolName: pending.length > 0 ? pending[0].toolName : undefined,
-    }, {}, approvalCopyGenerator);
-    await deliverChannelReply(replyCallbackUrl, {
-      chatId: conversationExternalId,
-      text: statusText,
-      assistantId,
-    }, bearerToken);
+    const statusText = await composeApprovalMessageGenerative(
+      {
+        scenario: "reminder_prompt",
+        channel: sourceChannel,
+        toolName: pending.length > 0 ? pending[0].toolName : undefined,
+      },
+      {},
+      approvalCopyGenerator,
+    );
+    await deliverChannelReply(
+      replyCallbackUrl,
+      {
+        chatId: conversationExternalId,
+        text: statusText,
+        assistantId,
+      },
+      bearerToken,
+    );
   } catch (err) {
-    log.error({ err, conversationId }, 'Failed to deliver approval status reply');
+    log.error(
+      { err, conversationId },
+      "Failed to deliver approval status reply",
+    );
   }
 
-  return { handled: true, type: 'assistant_turn' };
+  return { handled: true, type: "assistant_turn" };
 }
 
 // ---------------------------------------------------------------------------
@@ -953,7 +1306,7 @@ export async function handleApprovalInterception(
  */
 async function handleAccessRequestApproval(
   approval: GuardianApprovalRequest,
-  action: 'approve' | 'deny',
+  action: "approve" | "deny",
   decidedByExternalUserId: string,
   replyCallbackUrl: string,
   assistantId: string,
@@ -965,11 +1318,11 @@ async function handleAccessRequestApproval(
     decidedByExternalUserId,
   );
 
-  if (decisionResult.type === 'stale' || decisionResult.type === 'idempotent') {
-    return { handled: true, type: 'stale_ignored' };
+  if (decisionResult.type === "stale" || decisionResult.type === "idempotent") {
+    return { handled: true, type: "stale_ignored" };
   }
 
-  if (decisionResult.type === 'denied') {
+  if (decisionResult.type === "denied") {
     await notifyRequesterOfDenial({
       replyCallbackUrl,
       requesterChatId: approval.requesterChatId,
@@ -984,17 +1337,17 @@ async function handleAccessRequestApproval(
       requesterExternalUserId: approval.requesterExternalUserId,
       requesterChatId: approval.requesterChatId,
       decidedByExternalUserId,
-      decision: 'denied' as const,
+      decision: "denied" as const,
     };
 
     void emitNotificationSignal({
-      sourceEventName: 'ingress.trusted_contact.guardian_decision',
+      sourceEventName: "ingress.trusted_contact.guardian_decision",
       sourceChannel: approval.channel,
       sourceSessionId: approval.conversationId,
       assistantId,
       attentionHints: {
         requiresAction: false,
-        urgency: 'medium',
+        urgency: "medium",
         isAsyncBackground: false,
         visibleInSourceNow: false,
       },
@@ -1003,13 +1356,13 @@ async function handleAccessRequestApproval(
     });
 
     void emitNotificationSignal({
-      sourceEventName: 'ingress.trusted_contact.denied',
+      sourceEventName: "ingress.trusted_contact.denied",
       sourceChannel: approval.channel,
       sourceSessionId: approval.conversationId,
       assistantId,
       attentionHints: {
         requiresAction: false,
-        urgency: 'low',
+        urgency: "low",
         isAsyncBackground: false,
         visibleInSourceNow: false,
       },
@@ -1017,7 +1370,7 @@ async function handleAccessRequestApproval(
       dedupeKey: `trusted-contact:denied:${approval.id}`,
     });
 
-    return { handled: true, type: 'guardian_decision_applied' };
+    return { handled: true, type: "guardian_decision_applied" };
   }
 
   // Approved: deliver the verification code to the guardian and notify the requester.
@@ -1025,18 +1378,19 @@ async function handleAccessRequestApproval(
 
   let codeDelivered = true;
   if (decisionResult.verificationCode) {
-    const deliveryResult: DeliveryResult = await deliverVerificationCodeToGuardian({
-      replyCallbackUrl,
-      guardianChatId: approval.guardianChatId,
-      requesterIdentifier,
-      verificationCode: decisionResult.verificationCode,
-      assistantId,
-      bearerToken,
-    });
+    const deliveryResult: DeliveryResult =
+      await deliverVerificationCodeToGuardian({
+        replyCallbackUrl,
+        guardianChatId: approval.guardianChatId,
+        requesterIdentifier,
+        verificationCode: decisionResult.verificationCode,
+        assistantId,
+        bearerToken,
+      });
     if (!deliveryResult.ok) {
       log.error(
         { reason: deliveryResult.reason, approvalId: approval.id },
-        'Skipping requester notification — verification code was not delivered to guardian',
+        "Skipping requester notification — verification code was not delivered to guardian",
       );
       codeDelivered = false;
     }
@@ -1067,13 +1421,13 @@ async function handleAccessRequestApproval(
   // (i.e. after code consumption), which is handled in the verification path.
   if (!decisionResult.verificationSessionId) {
     void emitNotificationSignal({
-      sourceEventName: 'ingress.trusted_contact.guardian_decision',
+      sourceEventName: "ingress.trusted_contact.guardian_decision",
       sourceChannel: approval.channel,
       sourceSessionId: approval.conversationId,
       assistantId,
       attentionHints: {
         requiresAction: false,
-        urgency: 'medium',
+        urgency: "medium",
         isAsyncBackground: false,
         visibleInSourceNow: false,
       },
@@ -1082,7 +1436,7 @@ async function handleAccessRequestApproval(
         requesterExternalUserId: approval.requesterExternalUserId,
         requesterChatId: approval.requesterChatId,
         decidedByExternalUserId,
-        decision: 'approved',
+        decision: "approved",
       },
       dedupeKey: `trusted-contact:guardian-decision:${approval.id}`,
     });
@@ -1094,13 +1448,13 @@ async function handleAccessRequestApproval(
   // a redundant LLM message like "Good news! Your request has been approved."
   if (decisionResult.verificationSessionId && codeDelivered) {
     void emitNotificationSignal({
-      sourceEventName: 'ingress.trusted_contact.verification_sent',
+      sourceEventName: "ingress.trusted_contact.verification_sent",
       sourceChannel: approval.channel,
       sourceSessionId: approval.conversationId,
       assistantId,
       attentionHints: {
         requiresAction: false,
-        urgency: 'low',
+        urgency: "low",
         isAsyncBackground: true,
         visibleInSourceNow: true,
       },
@@ -1114,5 +1468,5 @@ async function handleAccessRequestApproval(
     });
   }
 
-  return { handled: true, type: 'guardian_decision_applied' };
+  return { handled: true, type: "guardian_decision_applied" };
 }

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -6,35 +6,45 @@
  */
 // Side-effect import: registers the Telegram invite transport adapter so
 // getTransport('telegram') resolves at runtime.
-import type { ChannelId, InterfaceId } from '../../channels/types.js';
-import { CHANNEL_IDS, INTERFACE_IDS, isChannelId, parseInterfaceId } from '../../channels/types.js';
-import { getGatewayInternalBaseUrl } from '../../config/env.js';
-import { resolveUserReference } from '../../config/user-reference.js';
-import { RESEND_COOLDOWN_MS } from '../../daemon/handlers/config-channels.js';
-import * as attachmentsStore from '../../memory/attachments-store.js';
+import type { ChannelId, InterfaceId } from "../../channels/types.js";
+import {
+  CHANNEL_IDS,
+  INTERFACE_IDS,
+  isChannelId,
+  parseInterfaceId,
+} from "../../channels/types.js";
+import { getGatewayInternalBaseUrl } from "../../config/env.js";
+import { resolveUserReference } from "../../config/user-reference.js";
+import { RESEND_COOLDOWN_MS } from "../../daemon/handlers/config-channels.js";
+import type { TrustContext } from "../../daemon/session-runtime-assembly.js";
+import * as attachmentsStore from "../../memory/attachments-store.js";
 import {
   createCanonicalGuardianRequest,
   listCanonicalGuardianRequests,
   listPendingCanonicalGuardianRequestsByDestinationChat,
-} from '../../memory/canonical-guardian-store.js';
-import * as channelDeliveryStore from '../../memory/channel-delivery-store.js';
-import { recordConversationSeenSignal } from '../../memory/conversation-attention-store.js';
-import * as conversationStore from '../../memory/conversation-store.js';
-import * as externalConversationStore from '../../memory/external-conversation-store.js';
-import { findMember, updateLastSeen, upsertMember } from '../../memory/ingress-member-store.js';
-import { emitNotificationSignal } from '../../notifications/emit-signal.js';
-import { checkIngressForSecrets } from '../../security/secret-ingress.js';
-import { canonicalizeInboundIdentity } from '../../util/canonicalize-identity.js';
-import { IngressBlockedError } from '../../util/errors.js';
-import { getLogger } from '../../util/logger.js';
-import { notifyGuardianOfAccessRequest } from '../access-request-helper.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
-import { mintDaemonDeliveryToken } from '../auth/token-service.js';
+} from "../../memory/canonical-guardian-store.js";
+import * as channelDeliveryStore from "../../memory/channel-delivery-store.js";
+import { recordConversationSeenSignal } from "../../memory/conversation-attention-store.js";
+import * as conversationStore from "../../memory/conversation-store.js";
+import * as externalConversationStore from "../../memory/external-conversation-store.js";
+import {
+  findMember,
+  updateLastSeen,
+  upsertMember,
+} from "../../memory/ingress-member-store.js";
+import { emitNotificationSignal } from "../../notifications/emit-signal.js";
+import { checkIngressForSecrets } from "../../security/secret-ingress.js";
+import { canonicalizeInboundIdentity } from "../../util/canonicalize-identity.js";
+import { IngressBlockedError } from "../../util/errors.js";
+import { getLogger } from "../../util/logger.js";
+import { notifyGuardianOfAccessRequest } from "../access-request-helper.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
+import { mintDaemonDeliveryToken } from "../auth/token-service.js";
 import {
   buildApprovalUIMetadata,
   getApprovalInfoByConversation,
   getChannelApprovalPrompt,
-} from '../channel-approvals.js';
+} from "../channel-approvals.js";
 import {
   bindSessionIdentity,
   createOutboundSession,
@@ -45,40 +55,42 @@ import {
   updateSessionDelivery,
   updateSessionStatus,
   validateAndConsumeChallenge,
-} from '../channel-guardian-service.js';
-import { getTransport } from '../channel-invite-transport.js';
-import { deliverChannelReply } from '../gateway-client.js';
-import { resolveTrustContext, resolveRoutingState } from '../trust-context-resolver.js';
-import { routeGuardianReply } from '../guardian-reply-router.js';
+} from "../channel-guardian-service.js";
+import { getTransport } from "../channel-invite-transport.js";
+import { deliverChannelReply } from "../gateway-client.js";
+import { routeGuardianReply } from "../guardian-reply-router.js";
 import {
   composeChannelVerifyReply,
   composeVerificationTelegram,
   GUARDIAN_VERIFY_TEMPLATE_KEYS,
-} from '../guardian-verification-templates.js';
-import { httpError } from '../http-errors.js';
+} from "../guardian-verification-templates.js";
+import { httpError } from "../http-errors.js";
 import type {
   ApprovalConversationGenerator,
   ApprovalCopyGenerator,
   GuardianActionCopyGenerator,
   GuardianFollowUpConversationGenerator,
   MessageProcessor,
-} from '../http-types.js';
-import { redeemInvite } from '../invite-redemption-service.js';
-import { getInviteRedemptionReply } from '../invite-redemption-templates.js';
-import { deliverReplyViaCallback } from './channel-delivery-routes.js';
-import type { TrustContext } from '../../daemon/session-runtime-assembly.js';
+} from "../http-types.js";
+import { redeemInvite } from "../invite-redemption-service.js";
+import { getInviteRedemptionReply } from "../invite-redemption-templates.js";
+import {
+  resolveRoutingState,
+  resolveTrustContext,
+} from "../trust-context-resolver.js";
+import { deliverReplyViaCallback } from "./channel-delivery-routes.js";
 import {
   canonicalChannelAssistantId,
   GUARDIAN_APPROVAL_TTL_MS,
   stripVerificationFailurePrefix,
-} from './channel-route-shared.js';
-import { handleApprovalInterception } from './guardian-approval-interception.js';
-import { deliverGeneratedApprovalPrompt } from './guardian-approval-prompt.js';
+} from "./channel-route-shared.js";
+import { handleApprovalInterception } from "./guardian-approval-interception.js";
+import { deliverGeneratedApprovalPrompt } from "./guardian-approval-prompt.js";
 
-import '../channel-invite-transports/telegram.js';
-import '../channel-invite-transports/voice.js';
+import "../channel-invite-transports/telegram.js";
+import "../channel-invite-transports/voice.js";
 
-const log = getLogger('runtime-http');
+const log = getLogger("runtime-http");
 
 /**
  * Parse a guardian verification code from message content.
@@ -113,7 +125,7 @@ export async function handleChannelInbound(
   // a single token from request start.
   const mintBearerToken = (): string => mintDaemonDeliveryToken();
 
-  const body = await req.json() as {
+  const body = (await req.json()) as {
     sourceChannel?: string;
     interface?: string;
     conversationExternalId?: string;
@@ -139,63 +151,88 @@ export async function handleChannelInbound(
     sourceMetadata,
   } = body;
 
-  if (!body.sourceChannel || typeof body.sourceChannel !== 'string') {
-    return httpError('BAD_REQUEST', 'sourceChannel is required', 400);
+  if (!body.sourceChannel || typeof body.sourceChannel !== "string") {
+    return httpError("BAD_REQUEST", "sourceChannel is required", 400);
   }
   // Validate and narrow to canonical ChannelId at the boundary — the gateway
   // only sends well-known channel strings, so an unknown value is rejected.
   if (!isChannelId(body.sourceChannel)) {
-    return httpError('BAD_REQUEST', `Invalid sourceChannel: ${body.sourceChannel}. Valid values: ${CHANNEL_IDS.join(', ')}`, 400);
+    return httpError(
+      "BAD_REQUEST",
+      `Invalid sourceChannel: ${body.sourceChannel}. Valid values: ${CHANNEL_IDS.join(", ")}`,
+      400,
+    );
   }
 
   const sourceChannel = body.sourceChannel;
 
-  if (!body.interface || typeof body.interface !== 'string') {
-    return httpError('BAD_REQUEST', 'interface is required', 400);
+  if (!body.interface || typeof body.interface !== "string") {
+    return httpError("BAD_REQUEST", "interface is required", 400);
   }
   const sourceInterface = parseInterfaceId(body.interface);
   if (!sourceInterface) {
-    return httpError('BAD_REQUEST', `Invalid interface: ${body.interface}. Valid values: ${INTERFACE_IDS.join(', ')}`, 400);
+    return httpError(
+      "BAD_REQUEST",
+      `Invalid interface: ${body.interface}. Valid values: ${INTERFACE_IDS.join(", ")}`,
+      400,
+    );
   }
 
-  if (!conversationExternalId || typeof conversationExternalId !== 'string') {
-    return httpError('BAD_REQUEST', 'conversationExternalId is required', 400);
+  if (!conversationExternalId || typeof conversationExternalId !== "string") {
+    return httpError("BAD_REQUEST", "conversationExternalId is required", 400);
   }
-  if (!body.actorExternalId || typeof body.actorExternalId !== 'string' || !body.actorExternalId.trim()) {
-    return httpError('BAD_REQUEST', 'actorExternalId is required', 400);
+  if (
+    !body.actorExternalId ||
+    typeof body.actorExternalId !== "string" ||
+    !body.actorExternalId.trim()
+  ) {
+    return httpError("BAD_REQUEST", "actorExternalId is required", 400);
   }
-  if (!externalMessageId || typeof externalMessageId !== 'string') {
-    return httpError('BAD_REQUEST', 'externalMessageId is required', 400);
+  if (!externalMessageId || typeof externalMessageId !== "string") {
+    return httpError("BAD_REQUEST", "externalMessageId is required", 400);
   }
 
   // Reject non-string content regardless of whether attachments are present.
-  if (content != null && typeof content !== 'string') {
-    return httpError('BAD_REQUEST', 'content must be a string', 400);
+  if (content != null && typeof content !== "string") {
+    return httpError("BAD_REQUEST", "content must be a string", 400);
   }
 
-  const trimmedContent = typeof content === 'string' ? content.trim() : '';
-  const hasAttachments = Array.isArray(attachmentIds) && attachmentIds.length > 0;
+  const trimmedContent = typeof content === "string" ? content.trim() : "";
+  const hasAttachments =
+    Array.isArray(attachmentIds) && attachmentIds.length > 0;
 
-  const hasCallbackData = typeof body.callbackData === 'string' && body.callbackData.length > 0;
+  const hasCallbackData =
+    typeof body.callbackData === "string" && body.callbackData.length > 0;
 
-  if (trimmedContent.length === 0 && !hasAttachments && !isEdit && !hasCallbackData) {
-    return httpError('BAD_REQUEST', 'content or attachmentIds is required', 400);
+  if (
+    trimmedContent.length === 0 &&
+    !hasAttachments &&
+    !isEdit &&
+    !hasCallbackData
+  ) {
+    return httpError(
+      "BAD_REQUEST",
+      "content or attachmentIds is required",
+      400,
+    );
   }
 
   // Canonicalize the assistant ID so all DB-facing operations use the
   // consistent 'self' key regardless of what the gateway sent.
   const canonicalAssistantId = canonicalChannelAssistantId(assistantId);
   if (canonicalAssistantId !== assistantId) {
-    log.debug({ raw: assistantId, canonical: canonicalAssistantId }, 'Canonicalized channel assistant ID');
+    log.debug(
+      { raw: assistantId, canonical: canonicalAssistantId },
+      "Canonicalized channel assistant ID",
+    );
   }
 
   // Coerce actorExternalId to a string at the boundary — the field
   // comes from unvalidated JSON and may be a number, object, or other
   // non-string type. Non-string truthy values would throw inside
   // canonicalizeInboundIdentity when it calls .trim().
-  const rawSenderId = body.actorExternalId != null
-    ? String(body.actorExternalId)
-    : undefined;
+  const rawSenderId =
+    body.actorExternalId != null ? String(body.actorExternalId) : undefined;
 
   // Canonicalize the sender identity so all trust lookups, member matching,
   // and guardian binding comparisons use a normalized form. Phone-like
@@ -224,19 +261,26 @@ export async function handleChannelInbound(
   // /start gv_<token> bootstrap commands must also bypass ACL — the user
   // hasn't been verified yet and needs to complete the bootstrap handshake.
   const rawCommandIntentForAcl = sourceMetadata?.commandIntent;
-  const isBootstrapCommand = rawCommandIntentForAcl &&
-    typeof rawCommandIntentForAcl === 'object' &&
+  const isBootstrapCommand =
+    rawCommandIntentForAcl &&
+    typeof rawCommandIntentForAcl === "object" &&
     !Array.isArray(rawCommandIntentForAcl) &&
-    (rawCommandIntentForAcl as Record<string, unknown>).type === 'start' &&
-    typeof (rawCommandIntentForAcl as Record<string, unknown>).payload === 'string' &&
-    ((rawCommandIntentForAcl as Record<string, unknown>).payload as string).startsWith('gv_');
+    (rawCommandIntentForAcl as Record<string, unknown>).type === "start" &&
+    typeof (rawCommandIntentForAcl as Record<string, unknown>).payload ===
+      "string" &&
+    (
+      (rawCommandIntentForAcl as Record<string, unknown>).payload as string
+    ).startsWith("gv_");
 
   // Parse invite token from /start payloads using the channel transport
   // adapter. The token is extracted once here so both the ACL bypass and
   // the intercept handler can reference it without re-parsing.
-  const commandIntentForAcl = rawCommandIntentForAcl && typeof rawCommandIntentForAcl === 'object' && !Array.isArray(rawCommandIntentForAcl)
-    ? rawCommandIntentForAcl as Record<string, unknown>
-    : undefined;
+  const commandIntentForAcl =
+    rawCommandIntentForAcl &&
+    typeof rawCommandIntentForAcl === "object" &&
+    !Array.isArray(rawCommandIntentForAcl)
+      ? (rawCommandIntentForAcl as Record<string, unknown>)
+      : undefined;
   const inviteTransport = getTransport(sourceChannel);
   const inviteToken = inviteTransport?.extractInboundToken({
     commandIntent: commandIntentForAcl,
@@ -268,12 +312,21 @@ export async function handleChannelInbound(
         // omitted: rebind sessions create a consumable challenge while a
         // binding already exists, and the identity check inside
         // validateAndConsumeChallenge prevents unauthorized takeovers.
-        const hasPendingChallenge = !!getPendingChallenge(canonicalAssistantId, sourceChannel);
-        const hasActiveOutboundSession = !!findActiveSession(canonicalAssistantId, sourceChannel);
+        const hasPendingChallenge = !!getPendingChallenge(
+          canonicalAssistantId,
+          sourceChannel,
+        );
+        const hasActiveOutboundSession = !!findActiveSession(
+          canonicalAssistantId,
+          sourceChannel,
+        );
         if (hasPendingChallenge || hasActiveOutboundSession) {
           denyNonMember = false;
         } else {
-          log.info({ sourceChannel, hasPendingChallenge, hasActiveOutboundSession }, 'Ingress ACL: guardian verification bypass denied');
+          log.info(
+            { sourceChannel, hasPendingChallenge, hasActiveOutboundSession },
+            "Ingress ACL: guardian verification bypass denied",
+          );
         }
       }
 
@@ -282,13 +335,25 @@ export async function handleChannelInbound(
       // any `/start gv_<garbage>` would bypass the not_a_member gate and
       // fall through to normal /start processing.
       if (isBootstrapCommand) {
-        const bootstrapPayload = (rawCommandIntentForAcl as Record<string, unknown>).payload as string;
+        const bootstrapPayload = (
+          rawCommandIntentForAcl as Record<string, unknown>
+        ).payload as string;
         const bootstrapTokenForAcl = bootstrapPayload.slice(3); // strip 'gv_' prefix
-        const bootstrapSessionForAcl = resolveBootstrapToken(canonicalAssistantId, sourceChannel, bootstrapTokenForAcl);
-        if (bootstrapSessionForAcl && bootstrapSessionForAcl.status === 'pending_bootstrap') {
+        const bootstrapSessionForAcl = resolveBootstrapToken(
+          canonicalAssistantId,
+          sourceChannel,
+          bootstrapTokenForAcl,
+        );
+        if (
+          bootstrapSessionForAcl &&
+          bootstrapSessionForAcl.status === "pending_bootstrap"
+        ) {
           denyNonMember = false;
         } else {
-          log.info({ sourceChannel, hasValidBootstrapSession: false }, 'Ingress ACL: bootstrap command bypass denied — no valid pending_bootstrap session');
+          log.info(
+            { sourceChannel, hasValidBootstrapSession: false },
+            "Ingress ACL: bootstrap command bypass denied — no valid pending_bootstrap session",
+          );
         }
       }
 
@@ -314,7 +379,10 @@ export async function handleChannelInbound(
       }
 
       if (denyNonMember) {
-        log.info({ sourceChannel, externalUserId: canonicalSenderId }, 'Ingress ACL: no member record, denying');
+        log.info(
+          { sourceChannel, externalUserId: canonicalSenderId },
+          "Ingress ACL: no member record, denying",
+        );
 
         // Notify the guardian about the access request so they can approve/deny.
         // Uses the shared helper which handles guardian binding lookup,
@@ -331,7 +399,10 @@ export async function handleChannelInbound(
           });
           guardianNotified = accessResult.notified;
         } catch (err) {
-          log.error({ err, sourceChannel, conversationExternalId }, 'Failed to notify guardian of access request');
+          log.error(
+            { err, sourceChannel, conversationExternalId },
+            "Failed to notify guardian of access request",
+          );
         }
 
         if (body.replyCallbackUrl) {
@@ -339,43 +410,84 @@ export async function handleChannelInbound(
             ? "Hmm looks like you don't have access to talk to me. I'll let them know you tried talking to me and get back to you."
             : "Sorry, you haven't been approved to message this assistant.";
           try {
-            await deliverChannelReply(body.replyCallbackUrl, {
-              chatId: conversationExternalId,
-              text: replyText,
-              assistantId,
-            }, mintBearerToken());
+            await deliverChannelReply(
+              body.replyCallbackUrl,
+              {
+                chatId: conversationExternalId,
+                text: replyText,
+                assistantId,
+              },
+              mintBearerToken(),
+            );
           } catch (err) {
-            log.error({ err, conversationExternalId }, 'Failed to deliver ACL rejection reply');
+            log.error(
+              { err, conversationExternalId },
+              "Failed to deliver ACL rejection reply",
+            );
           }
         }
 
-        return Response.json({ accepted: true, denied: true, reason: 'not_a_member' });
+        return Response.json({
+          accepted: true,
+          denied: true,
+          reason: "not_a_member",
+        });
       }
     }
 
     if (resolvedMember) {
-      if (resolvedMember.status !== 'active') {
+      if (resolvedMember.status !== "active") {
         // Same bypass logic as the no-member branch: verification codes and
         // bootstrap commands must pass through even when the member record is
         // revoked/blocked — otherwise the user can never re-verify.
         let denyInactiveMember = true;
         if (isGuardianVerifyCode) {
-          const hasPendingChallenge = !!getPendingChallenge(canonicalAssistantId, sourceChannel);
-          const hasActiveOutboundSession = !!findActiveSession(canonicalAssistantId, sourceChannel);
+          const hasPendingChallenge = !!getPendingChallenge(
+            canonicalAssistantId,
+            sourceChannel,
+          );
+          const hasActiveOutboundSession = !!findActiveSession(
+            canonicalAssistantId,
+            sourceChannel,
+          );
           if (hasPendingChallenge || hasActiveOutboundSession) {
             denyInactiveMember = false;
           } else {
-            log.info({ sourceChannel, memberId: resolvedMember.id, hasPendingChallenge, hasActiveOutboundSession }, 'Ingress ACL: inactive member verification bypass denied');
+            log.info(
+              {
+                sourceChannel,
+                memberId: resolvedMember.id,
+                hasPendingChallenge,
+                hasActiveOutboundSession,
+              },
+              "Ingress ACL: inactive member verification bypass denied",
+            );
           }
         }
         if (isBootstrapCommand) {
-          const bootstrapPayload = (rawCommandIntentForAcl as Record<string, unknown>).payload as string;
+          const bootstrapPayload = (
+            rawCommandIntentForAcl as Record<string, unknown>
+          ).payload as string;
           const bootstrapTokenForAcl = bootstrapPayload.slice(3);
-          const bootstrapSessionForAcl = resolveBootstrapToken(canonicalAssistantId, sourceChannel, bootstrapTokenForAcl);
-          if (bootstrapSessionForAcl && bootstrapSessionForAcl.status === 'pending_bootstrap') {
+          const bootstrapSessionForAcl = resolveBootstrapToken(
+            canonicalAssistantId,
+            sourceChannel,
+            bootstrapTokenForAcl,
+          );
+          if (
+            bootstrapSessionForAcl &&
+            bootstrapSessionForAcl.status === "pending_bootstrap"
+          ) {
             denyInactiveMember = false;
           } else {
-            log.info({ sourceChannel, memberId: resolvedMember.id, hasValidBootstrapSession: false }, 'Ingress ACL: inactive member bootstrap bypass denied');
+            log.info(
+              {
+                sourceChannel,
+                memberId: resolvedMember.id,
+                hasValidBootstrapSession: false,
+              },
+              "Ingress ACL: inactive member bootstrap bypass denied",
+            );
           }
         }
 
@@ -400,13 +512,20 @@ export async function handleChannelInbound(
         }
 
         if (denyInactiveMember) {
-          log.info({ sourceChannel, memberId: resolvedMember.id, status: resolvedMember.status }, 'Ingress ACL: member not active, denying');
+          log.info(
+            {
+              sourceChannel,
+              memberId: resolvedMember.id,
+              status: resolvedMember.status,
+            },
+            "Ingress ACL: member not active, denying",
+          );
 
           // For revoked/pending members, notify the guardian so they can
           // re-approve. Blocked members are intentionally excluded — the
           // guardian already made an explicit decision to block them.
           let guardianNotified = false;
-          if (resolvedMember.status !== 'blocked') {
+          if (resolvedMember.status !== "blocked") {
             try {
               const accessResult = notifyGuardianOfAccessRequest({
                 canonicalAssistantId,
@@ -419,7 +538,10 @@ export async function handleChannelInbound(
               });
               guardianNotified = accessResult.notified;
             } catch (err) {
-              log.error({ err, sourceChannel, conversationExternalId }, 'Failed to notify guardian of access request');
+              log.error(
+                { err, sourceChannel, conversationExternalId },
+                "Failed to notify guardian of access request",
+              );
             }
           }
 
@@ -428,33 +550,58 @@ export async function handleChannelInbound(
               ? "Hmm looks like you don't have access to talk to me. I'll let them know you tried talking to me and get back to you."
               : "Sorry, you haven't been approved to message this assistant.";
             try {
-              await deliverChannelReply(body.replyCallbackUrl, {
-                chatId: conversationExternalId,
-                text: replyText,
-                assistantId,
-              }, mintBearerToken());
+              await deliverChannelReply(
+                body.replyCallbackUrl,
+                {
+                  chatId: conversationExternalId,
+                  text: replyText,
+                  assistantId,
+                },
+                mintBearerToken(),
+              );
             } catch (err) {
-              log.error({ err, conversationExternalId }, 'Failed to deliver ACL rejection reply');
+              log.error(
+                { err, conversationExternalId },
+                "Failed to deliver ACL rejection reply",
+              );
             }
           }
-          return Response.json({ accepted: true, denied: true, reason: `member_${resolvedMember.status}` });
+          return Response.json({
+            accepted: true,
+            denied: true,
+            reason: `member_${resolvedMember.status}`,
+          });
         }
       }
 
-      if (resolvedMember.policy === 'deny') {
-        log.info({ sourceChannel, memberId: resolvedMember.id }, 'Ingress ACL: member policy deny');
+      if (resolvedMember.policy === "deny") {
+        log.info(
+          { sourceChannel, memberId: resolvedMember.id },
+          "Ingress ACL: member policy deny",
+        );
         if (body.replyCallbackUrl) {
           try {
-            await deliverChannelReply(body.replyCallbackUrl, {
-              chatId: conversationExternalId,
-              text: "Sorry, you haven't been approved to message this assistant.",
-              assistantId,
-            }, mintBearerToken());
+            await deliverChannelReply(
+              body.replyCallbackUrl,
+              {
+                chatId: conversationExternalId,
+                text: "Sorry, you haven't been approved to message this assistant.",
+                assistantId,
+              },
+              mintBearerToken(),
+            );
           } catch (err) {
-            log.error({ err, conversationExternalId }, 'Failed to deliver ACL rejection reply');
+            log.error(
+              { err, conversationExternalId },
+              "Failed to deliver ACL rejection reply",
+            );
           }
         }
-        return Response.json({ accepted: true, denied: true, reason: 'policy_deny' });
+        return Response.json({
+          accepted: true,
+          denied: true,
+          reason: "policy_deny",
+        });
       }
 
       // 'allow' or 'escalate' — update last seen and continue
@@ -468,18 +615,23 @@ export async function handleChannelInbound(
       const resolvedIds = new Set(resolved.map((a) => a.id));
       const missing = attachmentIds.filter((id) => !resolvedIds.has(id));
       return Response.json(
-        { error: `Attachment IDs not found: ${missing.join(', ')}` },
+        { error: `Attachment IDs not found: ${missing.join(", ")}` },
         { status: 400 },
       );
     }
   }
 
-  const sourceMessageId = typeof sourceMetadata?.messageId === 'string'
-    ? sourceMetadata.messageId
-    : undefined;
+  const sourceMessageId =
+    typeof sourceMetadata?.messageId === "string"
+      ? sourceMetadata.messageId
+      : undefined;
 
   if (isEdit && !sourceMessageId) {
-    return httpError('BAD_REQUEST', 'sourceMetadata.messageId is required for edits', 400);
+    return httpError(
+      "BAD_REQUEST",
+      "sourceMetadata.messageId is required for edits",
+      400,
+    );
   }
 
   // ── Edit path: update existing message content, no new agent loop ──
@@ -516,23 +668,30 @@ export async function handleChannelInbound(
       if (original) break;
       if (attempt < EDIT_LOOKUP_RETRIES) {
         log.info(
-          { assistantId, sourceMessageId, attempt: attempt + 1, maxAttempts: EDIT_LOOKUP_RETRIES },
-          'Original message not linked yet, retrying edit lookup',
+          {
+            assistantId,
+            sourceMessageId,
+            attempt: attempt + 1,
+            maxAttempts: EDIT_LOOKUP_RETRIES,
+          },
+          "Original message not linked yet, retrying edit lookup",
         );
-        await new Promise((resolve) => setTimeout(resolve, EDIT_LOOKUP_DELAY_MS));
+        await new Promise((resolve) =>
+          setTimeout(resolve, EDIT_LOOKUP_DELAY_MS),
+        );
       }
     }
 
     if (original) {
-      conversationStore.updateMessageContent(original.messageId, content ?? '');
+      conversationStore.updateMessageContent(original.messageId, content ?? "");
       log.info(
         { assistantId, sourceMessageId, messageId: original.messageId },
-        'Updated message content from edited_message',
+        "Updated message content from edited_message",
       );
     } else {
       log.warn(
         { assistantId, sourceChannel, conversationExternalId, sourceMessageId },
-        'Could not find original message for edit after retries, ignoring',
+        "Could not find original message for edit after retries, ignoring",
       );
     }
 
@@ -558,18 +717,30 @@ export async function handleChannelInbound(
   // gateway retries (duplicates) re-attempt delivery here. On success the
   // pending marker is cleared so further duplicates short-circuit normally.
   if (result.duplicate && replyCallbackUrl) {
-    const pendingReply = channelDeliveryStore.getPendingVerificationReply(result.eventId);
+    const pendingReply = channelDeliveryStore.getPendingVerificationReply(
+      result.eventId,
+    );
     if (pendingReply) {
       try {
-        await deliverChannelReply(replyCallbackUrl, {
-          chatId: pendingReply.chatId,
-          text: pendingReply.text,
-          assistantId: pendingReply.assistantId,
-        }, mintBearerToken());
+        await deliverChannelReply(
+          replyCallbackUrl,
+          {
+            chatId: pendingReply.chatId,
+            text: pendingReply.text,
+            assistantId: pendingReply.assistantId,
+          },
+          mintBearerToken(),
+        );
         channelDeliveryStore.clearPendingVerificationReply(result.eventId);
-        log.info({ eventId: result.eventId }, 'Retried pending verification reply: delivered');
+        log.info(
+          { eventId: result.eventId },
+          "Retried pending verification reply: delivered",
+        );
       } catch (retryErr) {
-        log.error({ err: retryErr, eventId: result.eventId }, 'Retry of pending verification reply failed; will retry on next duplicate');
+        log.error(
+          { err: retryErr, eventId: result.eventId },
+          "Retry of pending verification reply failed; will retry on next duplicate",
+        );
       }
       return Response.json({
         accepted: true,
@@ -597,19 +768,31 @@ export async function handleChannelInbound(
   // When the member's policy is 'escalate', create a pending guardian
   // approval request and halt the run. This check runs after recordInbound
   // so we have a conversationId for the approval record.
-  if (resolvedMember?.policy === 'escalate') {
+  if (resolvedMember?.policy === "escalate") {
     const binding = getGuardianBinding(canonicalAssistantId, sourceChannel);
     if (!binding) {
       // Fail-closed: can't escalate without a guardian to route to
-      log.info({ sourceChannel, memberId: resolvedMember.id }, 'Ingress ACL: escalate policy but no guardian binding, denying');
-      return Response.json({ accepted: true, denied: true, reason: 'escalate_no_guardian' });
+      log.info(
+        { sourceChannel, memberId: resolvedMember.id },
+        "Ingress ACL: escalate policy but no guardian binding, denying",
+      );
+      return Response.json({
+        accepted: true,
+        denied: true,
+        reason: "escalate_no_guardian",
+      });
     }
 
     // Persist the raw payload so the decide handler can recover the original
     // message content when the escalation is approved.
     channelDeliveryStore.storePayload(result.eventId, {
-      sourceChannel, interface: sourceInterface, externalChatId: conversationExternalId, externalMessageId, content,
-      attachmentIds, sourceMetadata: body.sourceMetadata,
+      sourceChannel,
+      interface: sourceInterface,
+      externalChatId: conversationExternalId,
+      externalMessageId,
+      content,
+      attachmentIds,
+      sourceMetadata: body.sourceMetadata,
       senderName: body.actorDisplayName,
       senderExternalUserId: body.actorExternalId,
       senderUsername: body.actorUsername,
@@ -619,21 +802,23 @@ export async function handleChannelInbound(
 
     try {
       createCanonicalGuardianRequest({
-        kind: 'tool_approval',
-        sourceType: 'channel',
+        kind: "tool_approval",
+        sourceType: "channel",
         sourceChannel,
         conversationId: result.conversationId,
         requesterExternalUserId: canonicalSenderId ?? rawSenderId ?? undefined,
         guardianExternalUserId: binding.guardianExternalUserId,
         guardianPrincipalId: binding.guardianPrincipalId,
-        toolName: 'ingress_message',
-        questionText: 'Ingress policy requires guardian approval',
-        expiresAt: new Date(Date.now() + GUARDIAN_APPROVAL_TTL_MS).toISOString(),
+        toolName: "ingress_message",
+        questionText: "Ingress policy requires guardian approval",
+        expiresAt: new Date(
+          Date.now() + GUARDIAN_APPROVAL_TTL_MS,
+        ).toISOString(),
       });
     } catch (err) {
       log.warn(
         { err, conversationId: result.conversationId, sourceChannel },
-        'Failed to create canonical guardian request for ingress escalation — escalation continues via notification pipeline',
+        "Failed to create canonical guardian request for ingress escalation — escalation continues via notification pipeline",
       );
     }
 
@@ -641,13 +826,13 @@ export async function handleChannelInbound(
     // This lets the decision engine route escalation alerts to all configured
     // channels, supplementing the direct guardian notification below.
     void emitNotificationSignal({
-      sourceEventName: 'ingress.escalation',
+      sourceEventName: "ingress.escalation",
       sourceChannel: sourceChannel,
       sourceSessionId: result.conversationId,
       assistantId: canonicalAssistantId,
       attentionHints: {
         requiresAction: true,
-        urgency: 'high',
+        urgency: "high",
         isAsyncBackground: false,
         visibleInSourceNow: false,
       },
@@ -655,7 +840,11 @@ export async function handleChannelInbound(
         conversationId: result.conversationId,
         sourceChannel,
         conversationExternalId,
-        senderIdentifier: body.actorDisplayName || body.actorUsername || rawSenderId || 'Unknown sender',
+        senderIdentifier:
+          body.actorDisplayName ||
+          body.actorUsername ||
+          rawSenderId ||
+          "Unknown sender",
         eventId: result.eventId,
       },
       dedupeKey: `escalation:${result.eventId}`,
@@ -665,30 +854,44 @@ export async function handleChannelInbound(
     // pipeline — no legacy callback dispatch needed.
     log.info(
       { conversationId: result.conversationId },
-      'Guardian escalation created — notification pipeline handles channel delivery',
+      "Guardian escalation created — notification pipeline handles channel delivery",
     );
 
-    return Response.json({ accepted: true, escalated: true, reason: 'policy_escalate' });
+    return Response.json({
+      accepted: true,
+      escalated: true,
+      reason: "policy_escalate",
+    });
   }
 
   const metadataHintsRaw = sourceMetadata?.hints;
   const metadataHints = Array.isArray(metadataHintsRaw)
-    ? metadataHintsRaw.filter((hint): hint is string => typeof hint === 'string' && hint.trim().length > 0)
+    ? metadataHintsRaw.filter(
+        (hint): hint is string =>
+          typeof hint === "string" && hint.trim().length > 0,
+      )
     : [];
-  const metadataUxBrief = typeof sourceMetadata?.uxBrief === 'string' && sourceMetadata.uxBrief.trim().length > 0
-    ? sourceMetadata.uxBrief.trim()
-    : undefined;
+  const metadataUxBrief =
+    typeof sourceMetadata?.uxBrief === "string" &&
+    sourceMetadata.uxBrief.trim().length > 0
+      ? sourceMetadata.uxBrief.trim()
+      : undefined;
 
   // Extract channel command intent (e.g. /start from Telegram)
   const rawCommandIntent = sourceMetadata?.commandIntent;
-  const commandIntent = rawCommandIntent && typeof rawCommandIntent === 'object' && !Array.isArray(rawCommandIntent)
-    ? rawCommandIntent as Record<string, unknown>
-    : undefined;
+  const commandIntent =
+    rawCommandIntent &&
+    typeof rawCommandIntent === "object" &&
+    !Array.isArray(rawCommandIntent)
+      ? (rawCommandIntent as Record<string, unknown>)
+      : undefined;
 
   // Preserve locale from sourceMetadata so the model can greet in the user's language
-  const sourceLanguageCode = typeof sourceMetadata?.languageCode === 'string' && sourceMetadata.languageCode.trim().length > 0
-    ? sourceMetadata.languageCode.trim()
-    : undefined;
+  const sourceLanguageCode =
+    typeof sourceMetadata?.languageCode === "string" &&
+    sourceMetadata.languageCode.trim().length > 0
+      ? sourceMetadata.languageCode.trim()
+      : undefined;
 
   // ── Telegram bootstrap deep-link handling ──
   // Intercept /start gv_<token> commands BEFORE the verification-code intercept.
@@ -698,20 +901,28 @@ export async function handleChannelInbound(
   // identity-bound session with a fresh verification code, send it, and return.
   if (
     !result.duplicate &&
-    commandIntent?.type === 'start' &&
-    typeof commandIntent.payload === 'string' &&
-    (commandIntent.payload as string).startsWith('gv_') &&
+    commandIntent?.type === "start" &&
+    typeof commandIntent.payload === "string" &&
+    (commandIntent.payload as string).startsWith("gv_") &&
     rawSenderId
   ) {
     const bootstrapToken = (commandIntent.payload as string).slice(3);
-    const bootstrapSession = resolveBootstrapToken(canonicalAssistantId, sourceChannel, bootstrapToken);
+    const bootstrapSession = resolveBootstrapToken(
+      canonicalAssistantId,
+      sourceChannel,
+      bootstrapToken,
+    );
 
-    if (bootstrapSession && bootstrapSession.status === 'pending_bootstrap') {
+    if (bootstrapSession && bootstrapSession.status === "pending_bootstrap") {
       // Bind the pending_bootstrap session to the sender's identity
-      bindSessionIdentity(bootstrapSession.id, rawSenderId!, conversationExternalId);
+      bindSessionIdentity(
+        bootstrapSession.id,
+        rawSenderId!,
+        conversationExternalId,
+      );
 
       // Transition bootstrap session to awaiting_response
-      updateSessionStatus(bootstrapSession.id, 'awaiting_response');
+      updateSessionStatus(bootstrapSession.id, "awaiting_response");
 
       // Create a new identity-bound outbound session with a fresh secret.
       // The old bootstrap session is auto-revoked by createOutboundSession.
@@ -720,7 +931,7 @@ export async function handleChannelInbound(
         channel: sourceChannel,
         expectedExternalUserId: rawSenderId!,
         expectedChatId: conversationExternalId,
-        identityBindingStatus: 'bound',
+        identityBindingStatus: "bound",
         destinationAddress: conversationExternalId,
       });
 
@@ -729,22 +940,33 @@ export async function handleChannelInbound(
         GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST,
         {
           code: newSession.secret,
-          expiresInMinutes: Math.floor((newSession.expiresAt - Date.now()) / 60_000),
+          expiresInMinutes: Math.floor(
+            (newSession.expiresAt - Date.now()) / 60_000,
+          ),
         },
       );
 
       // Deliver verification Telegram message via the gateway (fire-and-forget)
-      deliverBootstrapVerificationTelegram(conversationExternalId, telegramBody, canonicalAssistantId);
+      deliverBootstrapVerificationTelegram(
+        conversationExternalId,
+        telegramBody,
+        canonicalAssistantId,
+      );
 
       // Update delivery tracking
       const now = Date.now();
-      updateSessionDelivery(newSession.sessionId, now, 1, now + RESEND_COOLDOWN_MS);
+      updateSessionDelivery(
+        newSession.sessionId,
+        now,
+        1,
+        now + RESEND_COOLDOWN_MS,
+      );
 
       return Response.json({
         accepted: true,
         duplicate: false,
         eventId: result.eventId,
-        guardianVerification: 'bootstrap_bound',
+        guardianVerification: "bootstrap_bound",
       });
     }
     // If not found or expired, fall through to normal /start handling
@@ -762,9 +984,10 @@ export async function handleChannelInbound(
   // Without this guard, normal 6-digit messages (zip codes, PINs, etc.)
   // would be swallowed by the verification handler and never reach the
   // agent pipeline.
-  const shouldInterceptVerification = guardianVerifyCode !== undefined &&
+  const shouldInterceptVerification =
+    guardianVerifyCode !== undefined &&
     (!!getPendingChallenge(canonicalAssistantId, sourceChannel) ||
-     !!findActiveSession(canonicalAssistantId, sourceChannel));
+      !!findActiveSession(canonicalAssistantId, sourceChannel));
 
   if (
     !result.duplicate &&
@@ -782,53 +1005,68 @@ export async function handleChannelInbound(
       body.actorDisplayName,
     );
 
-    const guardianVerifyOutcome: 'verified' | 'failed' = verifyResult.success ? 'verified' : 'failed';
+    const guardianVerifyOutcome: "verified" | "failed" = verifyResult.success
+      ? "verified"
+      : "failed";
 
     if (verifyResult.success) {
-      const existingMember = (canonicalSenderId ?? rawSenderId)
-        ? findMember({
-          assistantId: canonicalAssistantId,
-          sourceChannel,
-          externalUserId: canonicalSenderId ?? rawSenderId!,
-          externalChatId: conversationExternalId,
-        })
-        : null;
+      const existingMember =
+        (canonicalSenderId ?? rawSenderId)
+          ? findMember({
+              assistantId: canonicalAssistantId,
+              sourceChannel,
+              externalUserId: canonicalSenderId ?? rawSenderId!,
+              externalChatId: conversationExternalId,
+            })
+          : null;
       const memberMatchesSender = existingMember?.externalUserId
-        ? canonicalizeInboundIdentity(sourceChannel, existingMember.externalUserId) === (canonicalSenderId ?? rawSenderId)
+        ? canonicalizeInboundIdentity(
+            sourceChannel,
+            existingMember.externalUserId,
+          ) === (canonicalSenderId ?? rawSenderId)
         : false;
-      const preservedDisplayName = memberMatchesSender && existingMember?.displayName?.trim().length
-        ? existingMember.displayName
-        : body.actorDisplayName;
+      const preservedDisplayName =
+        memberMatchesSender && existingMember?.displayName?.trim().length
+          ? existingMember.displayName
+          : body.actorDisplayName;
 
       upsertMember({
         assistantId: canonicalAssistantId,
         sourceChannel,
         externalUserId: canonicalSenderId ?? rawSenderId!,
         externalChatId: conversationExternalId,
-        status: 'active',
-        policy: 'allow',
+        status: "active",
+        policy: "allow",
         // Keep guardian-curated member name stable across re-verification.
         displayName: preservedDisplayName,
         username: body.actorUsername,
       });
 
-      const verifyLogLabel = verifyResult.verificationType === 'trusted_contact'
-        ? 'Trusted contact verified'
-        : 'Guardian verified';
-      log.info({ sourceChannel, externalUserId: canonicalSenderId, verificationType: verifyResult.verificationType }, `${verifyLogLabel}: auto-upserted ingress member`);
+      const verifyLogLabel =
+        verifyResult.verificationType === "trusted_contact"
+          ? "Trusted contact verified"
+          : "Guardian verified";
+      log.info(
+        {
+          sourceChannel,
+          externalUserId: canonicalSenderId,
+          verificationType: verifyResult.verificationType,
+        },
+        `${verifyLogLabel}: auto-upserted ingress member`,
+      );
 
       // Emit activated signal when a trusted contact completes verification.
       // Member record is persisted above before this event fires, satisfying
       // the persistence-before-event ordering invariant.
-      if (verifyResult.verificationType === 'trusted_contact') {
+      if (verifyResult.verificationType === "trusted_contact") {
         void emitNotificationSignal({
-          sourceEventName: 'ingress.trusted_contact.activated',
+          sourceEventName: "ingress.trusted_contact.activated",
           sourceChannel,
           sourceSessionId: result.conversationId,
           assistantId: canonicalAssistantId,
           attentionHints: {
             requiresAction: false,
-            urgency: 'low',
+            urgency: "low",
             isAsyncBackground: false,
             visibleInSourceNow: false,
           },
@@ -849,26 +1087,40 @@ export async function handleChannelInbound(
     if (replyCallbackUrl) {
       let replyText: string;
       if (!verifyResult.success) {
-        replyText = composeChannelVerifyReply(GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_VERIFY_FAILED, {
-          failureReason: stripVerificationFailurePrefix(verifyResult.reason),
-        });
-      } else if (verifyResult.verificationType === 'trusted_contact') {
-        replyText = composeChannelVerifyReply(GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_TRUSTED_CONTACT_VERIFY_SUCCESS);
+        replyText = composeChannelVerifyReply(
+          GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_VERIFY_FAILED,
+          {
+            failureReason: stripVerificationFailurePrefix(verifyResult.reason),
+          },
+        );
+      } else if (verifyResult.verificationType === "trusted_contact") {
+        replyText = composeChannelVerifyReply(
+          GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_TRUSTED_CONTACT_VERIFY_SUCCESS,
+        );
       } else {
-        replyText = composeChannelVerifyReply(GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_VERIFY_SUCCESS);
+        replyText = composeChannelVerifyReply(
+          GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_VERIFY_SUCCESS,
+        );
       }
       try {
-        await deliverChannelReply(replyCallbackUrl, {
-          chatId: conversationExternalId,
-          text: replyText,
-          assistantId,
-        }, mintBearerToken());
+        await deliverChannelReply(
+          replyCallbackUrl,
+          {
+            chatId: conversationExternalId,
+            text: replyText,
+            assistantId,
+          },
+          mintBearerToken(),
+        );
       } catch (err) {
         // The challenge is already consumed and side effects applied, so
         // we cannot simply re-throw and let the gateway retry the full
         // flow. Instead, persist the reply so that gateway retries
         // (which arrive as duplicates) can re-attempt delivery.
-        log.error({ err, conversationExternalId }, 'Failed to deliver deterministic verification reply; persisting for retry');
+        log.error(
+          { err, conversationExternalId },
+          "Failed to deliver deterministic verification reply; persisting for retry",
+        );
         channelDeliveryStore.storePendingVerificationReply(result.eventId, {
           chatId: conversationExternalId,
           text: replyText,
@@ -881,15 +1133,25 @@ export async function handleChannelInbound(
         // delivery is re-attempted even without a gateway duplicate.
         setTimeout(async () => {
           try {
-            await deliverChannelReply(replyCallbackUrl, {
-              chatId: conversationExternalId,
-              text: replyText,
-              assistantId,
-            }, mintBearerToken());
-            log.info({ eventId: result.eventId }, 'Verification reply delivered on self-retry');
+            await deliverChannelReply(
+              replyCallbackUrl,
+              {
+                chatId: conversationExternalId,
+                text: replyText,
+                assistantId,
+              },
+              mintBearerToken(),
+            );
+            log.info(
+              { eventId: result.eventId },
+              "Verification reply delivered on self-retry",
+            );
             channelDeliveryStore.clearPendingVerificationReply(result.eventId);
           } catch (retryErr) {
-            log.error({ err: retryErr, eventId: result.eventId }, 'Verification reply self-retry also failed; pending reply remains as fallback');
+            log.error(
+              { err: retryErr, eventId: result.eventId },
+              "Verification reply self-retry also failed; pending reply remains as fallback",
+            );
           }
         }, 3000);
 
@@ -943,7 +1205,7 @@ export async function handleChannelInbound(
     replyCallbackUrl &&
     (trimmedContent.length > 0 || hasCallbackData) &&
     rawSenderId &&
-    trustCtx.trustClass === 'guardian'
+    trustCtx.trustClass === "guardian"
   ) {
     // Compute destination-scoped pending request hints so the router can
     // discover canonical requests delivered to this chat even when the
@@ -955,17 +1217,20 @@ export async function handleChannelInbound(
     // tool_approval requests created inline) are not silently excluded.
     // Pass undefined (not []) when there are zero combined results so the
     // router's own identity-based fallback stays active.
-    const deliveryScopedPendingRequests = listPendingCanonicalGuardianRequestsByDestinationChat(
-      sourceChannel,
-      conversationExternalId,
-    );
+    const deliveryScopedPendingRequests =
+      listPendingCanonicalGuardianRequestsByDestinationChat(
+        sourceChannel,
+        conversationExternalId,
+      );
     let pendingRequestIds: string[] | undefined;
     if (deliveryScopedPendingRequests.length > 0) {
-      const deliveryIds = new Set(deliveryScopedPendingRequests.map(r => r.id));
+      const deliveryIds = new Set(
+        deliveryScopedPendingRequests.map((r) => r.id),
+      );
       // Also include identity-based pending requests so we don't hide them
       const identityId = canonicalSenderId ?? rawSenderId!;
       const identityPending = listCanonicalGuardianRequests({
-        status: 'pending',
+        status: "pending",
         guardianExternalUserId: identityId,
       });
       for (const r of identityPending) {
@@ -998,13 +1263,20 @@ export async function handleChannelInbound(
       // Deliver reply text if the router produced one
       if (routerResult.replyText) {
         try {
-          await deliverChannelReply(replyCallbackUrl, {
-            chatId: conversationExternalId,
-            text: routerResult.replyText,
-            assistantId: canonicalAssistantId,
-          }, mintBearerToken());
+          await deliverChannelReply(
+            replyCallbackUrl,
+            {
+              chatId: conversationExternalId,
+              text: routerResult.replyText,
+              assistantId: canonicalAssistantId,
+            },
+            mintBearerToken(),
+          );
         } catch (err) {
-          log.error({ err, conversationExternalId }, 'Failed to deliver canonical router reply');
+          log.error(
+            { err, conversationExternalId },
+            "Failed to deliver canonical router reply",
+          );
         }
       }
 
@@ -1027,11 +1299,7 @@ export async function handleChannelInbound(
   // Skipped when the canonical router flagged skipApprovalInterception (e.g.
   // invite handoff bypass) to prevent the legacy interceptor from swallowing
   // messages that should reach the assistant.
-  if (
-    replyCallbackUrl &&
-    !result.duplicate &&
-    !skipApprovalInterception
-  ) {
+  if (replyCallbackUrl && !result.duplicate && !skipApprovalInterception) {
     const approvalResult = await handleApprovalInterception({
       conversationId: result.conversationId,
       callbackData: body.callbackData,
@@ -1049,37 +1317,42 @@ export async function handleChannelInbound(
 
     if (approvalResult.handled) {
       // Record inferred seen signal for all handled Telegram approval interactions
-      if (sourceChannel === 'telegram') {
+      if (sourceChannel === "telegram") {
         try {
           if (hasCallbackData) {
-            const cbPreview = body.callbackData!.length > 80
-              ? body.callbackData!.slice(0, 80) + '...'
-              : body.callbackData!;
+            const cbPreview =
+              body.callbackData!.length > 80
+                ? body.callbackData!.slice(0, 80) + "..."
+                : body.callbackData!;
             recordConversationSeenSignal({
               conversationId: result.conversationId,
               assistantId: canonicalAssistantId,
-              signalType: 'telegram_callback',
-              confidence: 'inferred',
-              sourceChannel: 'telegram',
-              source: 'inbound-message-handler',
+              signalType: "telegram_callback",
+              confidence: "inferred",
+              sourceChannel: "telegram",
+              source: "inbound-message-handler",
               evidenceText: `User tapped callback: '${cbPreview}'`,
             });
           } else {
-            const msgPreview = trimmedContent.length > 80
-              ? trimmedContent.slice(0, 80) + '...'
-              : trimmedContent;
+            const msgPreview =
+              trimmedContent.length > 80
+                ? trimmedContent.slice(0, 80) + "..."
+                : trimmedContent;
             recordConversationSeenSignal({
               conversationId: result.conversationId,
               assistantId: canonicalAssistantId,
-              signalType: 'telegram_inbound_message',
-              confidence: 'inferred',
-              sourceChannel: 'telegram',
-              source: 'inbound-message-handler',
+              signalType: "telegram_inbound_message",
+              confidence: "inferred",
+              sourceChannel: "telegram",
+              source: "inbound-message-handler",
               evidenceText: `User sent plain-text approval reply: '${msgPreview}'`,
             });
           }
         } catch (err) {
-          log.warn({ err, conversationId: result.conversationId }, 'Failed to record seen signal for Telegram approval interaction');
+          log.warn(
+            { err, conversationId: result.conversationId },
+            "Failed to record seen signal for Telegram approval interaction",
+          );
         }
       }
 
@@ -1098,22 +1371,26 @@ export async function handleChannelInbound(
     // so checking for empty content alone would miss stale callbacks.
     if (hasCallbackData) {
       // Record seen signal even for stale callbacks — the user still interacted
-      if (sourceChannel === 'telegram') {
+      if (sourceChannel === "telegram") {
         try {
-          const cbPreview = body.callbackData!.length > 80
-            ? body.callbackData!.slice(0, 80) + '...'
-            : body.callbackData!;
+          const cbPreview =
+            body.callbackData!.length > 80
+              ? body.callbackData!.slice(0, 80) + "..."
+              : body.callbackData!;
           recordConversationSeenSignal({
             conversationId: result.conversationId,
             assistantId: canonicalAssistantId,
-            signalType: 'telegram_callback',
-            confidence: 'inferred',
-            sourceChannel: 'telegram',
-            source: 'inbound-message-handler',
+            signalType: "telegram_callback",
+            confidence: "inferred",
+            sourceChannel: "telegram",
+            source: "inbound-message-handler",
             evidenceText: `User tapped stale callback: '${cbPreview}'`,
           });
         } catch (err) {
-          log.warn({ err, conversationId: result.conversationId }, 'Failed to record seen signal for stale Telegram callback');
+          log.warn(
+            { err, conversationId: result.conversationId },
+            "Failed to record seen signal for stale Telegram callback",
+          );
         }
       }
 
@@ -1121,7 +1398,7 @@ export async function handleChannelInbound(
         accepted: true,
         duplicate: false,
         eventId: result.eventId,
-        approval: 'stale_ignored',
+        approval: "stale_ignored",
       });
     }
   }
@@ -1133,8 +1410,12 @@ export async function handleChannelInbound(
     // replayed. If the ingress check later detects secrets we clear it
     // before throwing, so secret-bearing content is never left on disk.
     channelDeliveryStore.storePayload(result.eventId, {
-      sourceChannel, externalChatId: conversationExternalId, externalMessageId, content,
-      attachmentIds, sourceMetadata: body.sourceMetadata,
+      sourceChannel,
+      externalChatId: conversationExternalId,
+      externalMessageId,
+      content,
+      attachmentIds,
+      sourceMetadata: body.sourceMetadata,
       senderName: body.actorDisplayName,
       senderExternalUserId: body.actorExternalId,
       senderUsername: body.actorUsername,
@@ -1143,7 +1424,7 @@ export async function handleChannelInbound(
       assistantId: canonicalAssistantId,
     });
 
-    const contentToCheck = content ?? '';
+    const contentToCheck = content ?? "";
     let ingressCheck: ReturnType<typeof checkIngressForSecrets>;
     try {
       ingressCheck = checkIngressForSecrets(contentToCheck);
@@ -1153,29 +1434,37 @@ export async function handleChannelInbound(
     }
     if (ingressCheck.blocked) {
       channelDeliveryStore.clearPayload(result.eventId);
-      throw new IngressBlockedError(ingressCheck.userNotice!, ingressCheck.detectedTypes);
+      throw new IngressBlockedError(
+        ingressCheck.userNotice!,
+        ingressCheck.detectedTypes,
+      );
     }
 
     // Record inferred seen signal for non-duplicate Telegram inbound messages
-    if (sourceChannel === 'telegram') {
+    if (sourceChannel === "telegram") {
       try {
-        const msgPreview = trimmedContent.length > 80
-          ? trimmedContent.slice(0, 80) + '...'
-          : trimmedContent;
-        const evidence = trimmedContent.length > 0
-          ? `User sent message: '${msgPreview}'`
-          : 'User sent media attachment';
+        const msgPreview =
+          trimmedContent.length > 80
+            ? trimmedContent.slice(0, 80) + "..."
+            : trimmedContent;
+        const evidence =
+          trimmedContent.length > 0
+            ? `User sent message: '${msgPreview}'`
+            : "User sent media attachment";
         recordConversationSeenSignal({
           conversationId: result.conversationId,
           assistantId: canonicalAssistantId,
-          signalType: 'telegram_inbound_message',
-          confidence: 'inferred',
-          sourceChannel: 'telegram',
-          source: 'inbound-message-handler',
+          signalType: "telegram_inbound_message",
+          confidence: "inferred",
+          sourceChannel: "telegram",
+          source: "inbound-message-handler",
           evidenceText: evidence,
         });
       } catch (err) {
-        log.warn({ err, conversationId: result.conversationId }, 'Failed to record seen signal for Telegram inbound message');
+        log.warn(
+          { err, conversationId: result.conversationId },
+          "Failed to record seen signal for Telegram inbound message",
+        );
       }
     }
 
@@ -1187,7 +1476,7 @@ export async function handleChannelInbound(
       processMessage,
       conversationId: result.conversationId,
       eventId: result.eventId,
-      content: content ?? '',
+      content: content ?? "",
       attachmentIds: hasAttachments ? attachmentIds : undefined,
       sourceChannel,
       sourceInterface,
@@ -1280,53 +1569,87 @@ async function handleInviteTokenIntercept(params: {
   });
 
   log.info(
-    { sourceChannel, externalChatId: params.externalChatId, ok: outcome.ok, type: outcome.ok ? outcome.type : undefined, reason: !outcome.ok ? outcome.reason : undefined },
-    'Invite token intercept: redemption result',
+    {
+      sourceChannel,
+      externalChatId: params.externalChatId,
+      ok: outcome.ok,
+      type: outcome.ok ? outcome.type : undefined,
+      reason: !outcome.ok ? outcome.reason : undefined,
+    },
+    "Invite token intercept: redemption result",
   );
 
   // already_member means the user has an active record — let the normal
   // flow handle them (they passed ACL or the member is active).
-  if (outcome.ok && outcome.type === 'already_member') {
+  if (outcome.ok && outcome.type === "already_member") {
     // Deliver a quick acknowledgement and short-circuit so the user
     // does not trigger the deny gate or a duplicate agent loop.
     const replyText = getInviteRedemptionReply(outcome);
     if (replyCallbackUrl) {
       try {
-        await deliverChannelReply(replyCallbackUrl, {
-          chatId: externalChatId,
-          text: replyText,
-          assistantId,
-        }, bearerToken);
+        await deliverChannelReply(
+          replyCallbackUrl,
+          {
+            chatId: externalChatId,
+            text: replyText,
+            assistantId,
+          },
+          bearerToken,
+        );
       } catch (err) {
-        log.error({ err, externalChatId }, 'Failed to deliver invite already-member reply');
+        log.error(
+          { err, externalChatId },
+          "Failed to deliver invite already-member reply",
+        );
       }
     }
     channelDeliveryStore.markProcessed(dedupResult.eventId);
-    return Response.json({ accepted: true, eventId: dedupResult.eventId, inviteRedemption: 'already_member' });
+    return Response.json({
+      accepted: true,
+      eventId: dedupResult.eventId,
+      inviteRedemption: "already_member",
+    });
   }
 
   const replyText = getInviteRedemptionReply(outcome);
 
   if (replyCallbackUrl) {
     try {
-      await deliverChannelReply(replyCallbackUrl, {
-        chatId: externalChatId,
-        text: replyText,
-        assistantId,
-      }, bearerToken);
+      await deliverChannelReply(
+        replyCallbackUrl,
+        {
+          chatId: externalChatId,
+          text: replyText,
+          assistantId,
+        },
+        bearerToken,
+      );
     } catch (err) {
-      log.error({ err, externalChatId }, 'Failed to deliver invite redemption reply');
+      log.error(
+        { err, externalChatId },
+        "Failed to deliver invite redemption reply",
+      );
     }
   }
 
-  if (outcome.ok && outcome.type === 'redeemed') {
+  if (outcome.ok && outcome.type === "redeemed") {
     channelDeliveryStore.markProcessed(dedupResult.eventId);
-    return Response.json({ accepted: true, eventId: dedupResult.eventId, inviteRedemption: 'redeemed', memberId: outcome.memberId });
+    return Response.json({
+      accepted: true,
+      eventId: dedupResult.eventId,
+      inviteRedemption: "redeemed",
+      memberId: outcome.memberId,
+    });
   }
 
   // Failed redemption — inform the user and deny
   channelDeliveryStore.markProcessed(dedupResult.eventId);
-  return Response.json({ accepted: true, eventId: dedupResult.eventId, denied: true, inviteRedemption: outcome.reason });
+  return Response.json({
+    accepted: true,
+    eventId: dedupResult.eventId,
+    denied: true,
+    inviteRedemption: outcome.reason,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -1372,11 +1695,11 @@ function shouldEmitTelegramTyping(
   sourceChannel: ChannelId,
   replyCallbackUrl?: string,
 ): boolean {
-  if (sourceChannel !== 'telegram' || !replyCallbackUrl) return false;
+  if (sourceChannel !== "telegram" || !replyCallbackUrl) return false;
   try {
-    return new URL(replyCallbackUrl).pathname.endsWith('/deliver/telegram');
+    return new URL(replyCallbackUrl).pathname.endsWith("/deliver/telegram");
   } catch {
-    return replyCallbackUrl.endsWith('/deliver/telegram');
+    return replyCallbackUrl.endsWith("/deliver/telegram");
   }
 }
 
@@ -1394,13 +1717,18 @@ function startTelegramTypingHeartbeat(
     inFlight = true;
     void deliverChannelReply(
       callbackUrl,
-      { chatId, chatAction: 'typing', assistantId },
+      { chatId, chatAction: "typing", assistantId },
       mintBearerToken(),
-    ).catch((err) => {
-      log.debug({ err, chatId }, 'Failed to deliver Telegram typing indicator');
-    }).finally(() => {
-      inFlight = false;
-    });
+    )
+      .catch((err) => {
+        log.debug(
+          { err, chatId },
+          "Failed to deliver Telegram typing indicator",
+        );
+      })
+      .finally(() => {
+        inFlight = false;
+      });
   };
 
   emitTyping();
@@ -1418,7 +1746,7 @@ function startPendingApprovalPromptWatcher(params: {
   conversationId: string;
   sourceChannel: ChannelId;
   externalChatId: string;
-  guardianTrustClass: TrustContext['trustClass'];
+  guardianTrustClass: TrustContext["trustClass"];
   guardianExternalUserId?: string;
   requesterExternalUserId?: string;
   replyCallbackUrl: string;
@@ -1443,9 +1771,10 @@ function startPendingApprovalPromptWatcher(params: {
   // actors must never receive approval prompt broadcasts for the conversation.
   // We also require an explicit identity match against the bound guardian to
   // avoid broadcasting prompts when trustClass is stale/mis-scoped.
-  const isBoundGuardianActor = guardianTrustClass === 'guardian'
-    && !!guardianExternalUserId
-    && requesterExternalUserId === guardianExternalUserId;
+  const isBoundGuardianActor =
+    guardianTrustClass === "guardian" &&
+    !!guardianExternalUserId &&
+    requesterExternalUserId === guardianExternalUserId;
   if (!isBoundGuardianActor) {
     return () => {};
   }
@@ -1470,7 +1799,7 @@ function startPendingApprovalPromptWatcher(params: {
             prompt,
             uiMetadata: buildApprovalUIMetadata(prompt, info),
             messageContext: {
-              scenario: 'standard_prompt',
+              scenario: "standard_prompt",
               toolName: info.toolName,
               channel: sourceChannel,
             },
@@ -1483,7 +1812,10 @@ function startPendingApprovalPromptWatcher(params: {
           }
         }
       } catch (err) {
-        log.warn({ err, conversationId }, 'Pending approval prompt watcher failed');
+        log.warn(
+          { err, conversationId },
+          "Pending approval prompt watcher failed",
+        );
       }
       await delay(PENDING_APPROVAL_POLL_INTERVAL_MS);
     }
@@ -1508,10 +1840,16 @@ function resolveGuardianDisplayName(
   if (!binding?.metadataJson) return undefined;
   try {
     const parsed = JSON.parse(binding.metadataJson) as Record<string, unknown>;
-    if (typeof parsed.displayName === 'string' && parsed.displayName.trim().length > 0) {
+    if (
+      typeof parsed.displayName === "string" &&
+      parsed.displayName.trim().length > 0
+    ) {
       return parsed.displayName.trim();
     }
-    if (typeof parsed.username === 'string' && parsed.username.trim().length > 0) {
+    if (
+      typeof parsed.username === "string" &&
+      parsed.username.trim().length > 0
+    ) {
       return `@${parsed.username.trim()}`;
     }
   } catch {
@@ -1531,7 +1869,7 @@ function startTrustedContactApprovalNotifier(params: {
   conversationId: string;
   sourceChannel: ChannelId;
   externalChatId: string;
-  guardianTrustClass: TrustContext['trustClass'];
+  guardianTrustClass: TrustContext["trustClass"];
   guardianExternalUserId?: string;
   replyCallbackUrl: string;
   mintBearerToken: () => string;
@@ -1549,7 +1887,7 @@ function startTrustedContactApprovalNotifier(params: {
   } = params;
 
   // Only notify trusted contacts who have a resolvable guardian route.
-  if (guardianTrustClass !== 'trusted_contact' || !guardianExternalUserId) {
+  if (guardianTrustClass !== "trusted_contact" || !guardianExternalUserId) {
     return () => {};
   }
 
@@ -1566,7 +1904,7 @@ function startTrustedContactApprovalNotifier(params: {
         // conversations' pollers own their own entries. Without this
         // scoping, concurrent pollers would evict each other's request
         // IDs and cause duplicate notifications.
-        const currentPendingIds = new Set(pending.map(p => p.requestId));
+        const currentPendingIds = new Set(pending.map((p) => p.requestId));
         for (const [rid, cid] of globalNotifiedApprovalRequestIds) {
           if (cid === conversationId && !currentPendingIds.has(rid)) {
             globalNotifiedApprovalRequestIds.delete(rid);
@@ -1575,25 +1913,36 @@ function startTrustedContactApprovalNotifier(params: {
 
         if (info && !globalNotifiedApprovalRequestIds.has(info.requestId)) {
           globalNotifiedApprovalRequestIds.set(info.requestId, conversationId);
-          const guardianName = resolveGuardianDisplayName(
-            assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
-            sourceChannel,
-          ) ?? resolveUserReference();
+          const guardianName =
+            resolveGuardianDisplayName(
+              assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
+              sourceChannel,
+            ) ?? resolveUserReference();
           const waitingText = `Waiting for ${guardianName}'s approval...`;
           try {
-            await deliverChannelReply(replyCallbackUrl, {
-              chatId: externalChatId,
-              text: waitingText,
-              assistantId: assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
-            }, mintBearerToken());
+            await deliverChannelReply(
+              replyCallbackUrl,
+              {
+                chatId: externalChatId,
+                text: waitingText,
+                assistantId: assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
+              },
+              mintBearerToken(),
+            );
           } catch (err) {
-            log.warn({ err, conversationId }, 'Failed to deliver trusted-contact pending-approval notification');
+            log.warn(
+              { err, conversationId },
+              "Failed to deliver trusted-contact pending-approval notification",
+            );
             // Remove from notified set so delivery is retried on next poll
             globalNotifiedApprovalRequestIds.delete(info.requestId);
           }
         }
       } catch (err) {
-        log.warn({ err, conversationId }, 'Trusted-contact approval notifier poll failed');
+        log.warn(
+          { err, conversationId },
+          "Trusted-contact approval notifier poll failed",
+        );
       }
       await delay(PENDING_APPROVAL_POLL_INTERVAL_MS);
     }
@@ -1613,7 +1962,9 @@ function startTrustedContactApprovalNotifier(params: {
   };
 }
 
-function processChannelMessageInBackground(params: BackgroundProcessingParams): void {
+function processChannelMessageInBackground(
+  params: BackgroundProcessingParams,
+): void {
   const {
     processMessage,
     conversationId,
@@ -1635,43 +1986,60 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
   } = params;
 
   (async () => {
-    const typingCallbackUrl = shouldEmitTelegramTyping(sourceChannel, replyCallbackUrl)
+    const typingCallbackUrl = shouldEmitTelegramTyping(
+      sourceChannel,
+      replyCallbackUrl,
+    )
       ? replyCallbackUrl
       : undefined;
     const stopTypingHeartbeat = typingCallbackUrl
-      ? startTelegramTypingHeartbeat(typingCallbackUrl, externalChatId, mintBearerToken, assistantId)
+      ? startTelegramTypingHeartbeat(
+          typingCallbackUrl,
+          externalChatId,
+          mintBearerToken,
+          assistantId,
+        )
       : undefined;
     const stopApprovalWatcher = replyCallbackUrl
       ? startPendingApprovalPromptWatcher({
-        conversationId,
-        sourceChannel,
-        externalChatId,
-        guardianTrustClass: trustCtx.trustClass,
-        guardianExternalUserId: trustCtx.guardianExternalUserId,
-        requesterExternalUserId: trustCtx.requesterExternalUserId,
-        replyCallbackUrl,
-        mintBearerToken,
-        assistantId,
-        approvalCopyGenerator,
-      })
+          conversationId,
+          sourceChannel,
+          externalChatId,
+          guardianTrustClass: trustCtx.trustClass,
+          guardianExternalUserId: trustCtx.guardianExternalUserId,
+          requesterExternalUserId: trustCtx.requesterExternalUserId,
+          replyCallbackUrl,
+          mintBearerToken,
+          assistantId,
+          approvalCopyGenerator,
+        })
       : undefined;
     const stopTcApprovalNotifier = replyCallbackUrl
       ? startTrustedContactApprovalNotifier({
-        conversationId,
-        sourceChannel,
-        externalChatId,
-        guardianTrustClass: trustCtx.trustClass,
-        guardianExternalUserId: trustCtx.guardianExternalUserId,
-        replyCallbackUrl,
-        mintBearerToken,
-        assistantId,
-      })
+          conversationId,
+          sourceChannel,
+          externalChatId,
+          guardianTrustClass: trustCtx.trustClass,
+          guardianExternalUserId: trustCtx.guardianExternalUserId,
+          replyCallbackUrl,
+          mintBearerToken,
+          assistantId,
+        })
       : undefined;
 
     try {
-      const cmdIntent = commandIntent && typeof commandIntent.type === 'string'
-        ? { type: commandIntent.type as string, ...(typeof commandIntent.payload === 'string' ? { payload: commandIntent.payload } : {}), ...(sourceLanguageCode ? { languageCode: sourceLanguageCode } : {}) }
-        : undefined;
+      const cmdIntent =
+        commandIntent && typeof commandIntent.type === "string"
+          ? {
+              type: commandIntent.type as string,
+              ...(typeof commandIntent.payload === "string"
+                ? { payload: commandIntent.payload }
+                : {}),
+              ...(sourceLanguageCode
+                ? { languageCode: sourceLanguageCode }
+                : {}),
+            }
+          : undefined;
       const { messageId: userMessageId } = await processMessage(
         conversationId,
         content,
@@ -1707,7 +2075,10 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
         );
       }
     } catch (err) {
-      log.error({ err, conversationId }, 'Background channel message processing failed');
+      log.error(
+        { err, conversationId },
+        "Background channel message processing failed",
+      );
       channelDeliveryStore.recordProcessingFailure(eventId, err);
     } finally {
       stopTypingHeartbeat?.();
@@ -1735,16 +2106,19 @@ function deliverBootstrapVerificationTelegram(
     const bearerToken = mintDaemonDeliveryToken();
     const url = `${gatewayUrl}/deliver/telegram`;
     const resp = await fetch(url, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
         Authorization: `Bearer ${bearerToken}`,
       },
       body: JSON.stringify({ chatId, text, assistantId }),
     });
     if (!resp.ok) {
-      const body = await resp.text().catch(() => '<unreadable>');
-      log.error({ chatId, assistantId, status: resp.status, body }, 'Gateway /deliver/telegram failed for bootstrap verification');
+      const body = await resp.text().catch(() => "<unreadable>");
+      log.error(
+        { chatId, assistantId, status: resp.status, body },
+        "Gateway /deliver/telegram failed for bootstrap verification",
+      );
       return false;
     }
     return true;
@@ -1754,11 +2128,17 @@ function deliverBootstrapVerificationTelegram(
     try {
       const delivered = await attemptDelivery();
       if (delivered) {
-        log.info({ chatId, assistantId }, 'Bootstrap verification Telegram message delivered');
+        log.info(
+          { chatId, assistantId },
+          "Bootstrap verification Telegram message delivered",
+        );
         return;
       }
     } catch (err) {
-      log.error({ err, chatId, assistantId }, 'Failed to deliver bootstrap verification Telegram message');
+      log.error(
+        { err, chatId, assistantId },
+        "Failed to deliver bootstrap verification Telegram message",
+      );
     }
 
     // Self-retry after a short delay. The gateway deduplicates inbound
@@ -1769,12 +2149,21 @@ function deliverBootstrapVerificationTelegram(
       try {
         const delivered = await attemptDelivery();
         if (delivered) {
-          log.info({ chatId, assistantId }, 'Bootstrap verification Telegram message delivered on self-retry');
+          log.info(
+            { chatId, assistantId },
+            "Bootstrap verification Telegram message delivered on self-retry",
+          );
         } else {
-          log.error({ chatId, assistantId }, 'Bootstrap verification Telegram self-retry also failed');
+          log.error(
+            { chatId, assistantId },
+            "Bootstrap verification Telegram self-retry also failed",
+          );
         }
       } catch (retryErr) {
-        log.error({ err: retryErr, chatId, assistantId }, 'Bootstrap verification Telegram self-retry threw; giving up');
+        log.error(
+          { err: retryErr, chatId, assistantId },
+          "Bootstrap verification Telegram self-retry threw; giving up",
+        );
       }
     }, 3000);
   })();


### PR DESCRIPTION
## Summary
- Rename `guardianTrustClass` → `trustClass` in 61 test files that were missed by #11881
- Fix `toGuardianRuntimeContextFromTrust` → `toTrustContext` import/usage in `relay-server.ts`
- Fix `inboundActorContextFromGuardian` → `inboundActorContextFromTrustContext` in `session-agent-loop.ts`
- Remove duplicate `TrustContext` import in `trusted-contact-inline-approval-integration.test.ts`
- Fix pre-existing import sort lint errors in 7 files

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22646614394/job/65636064867

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
