### PR TITLE
fix: rename guardianTrustClass params to trustClass in inbound-message-handler

### DIFF
--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -138,7 +138,7 @@ export async function sweepFailedEvents(
     // into a valid canonical shape (e.g., legacy actorRole-only payloads without
     // trustClass), fail the event deterministically rather than processing it
     // without guardian context. Without this check, the downstream default of
-    // `guardianTrustClass ?? 'guardian'` would silently escalate privileges.
+    // `trustClass ?? 'guardian'` would silently escalate privileges.
     if (payload.trustCtx && !parsedTrustContext) {
       log.warn(
         { eventId: event.id },
@@ -154,7 +154,7 @@ export async function sweepFailedEvents(
     // When trustCtx is entirely absent (pre-guardian events or events stored
     // before trust context was added), synthesize an explicit 'unknown' context.
     // This ensures replay never proceeds without an explicit trust classification
-    // — downstream defaults like `guardianTrustClass ?? 'guardian'` would
+    // — downstream defaults like `trustClass ?? 'guardian'` would
     // otherwise grant guardian-level tool access to unclassified events.
     const trustContext: TrustContext = parsedTrustContext ?? {
       sourceChannel,

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1746,7 +1746,7 @@ function startPendingApprovalPromptWatcher(params: {
   conversationId: string;
   sourceChannel: ChannelId;
   externalChatId: string;
-  guardianTrustClass: TrustContext["trustClass"];
+  trustClass: TrustContext["trustClass"];
   guardianExternalUserId?: string;
   requesterExternalUserId?: string;
   replyCallbackUrl: string;
@@ -1758,7 +1758,7 @@ function startPendingApprovalPromptWatcher(params: {
     conversationId,
     sourceChannel,
     externalChatId,
-    guardianTrustClass,
+    trustClass,
     guardianExternalUserId,
     requesterExternalUserId,
     replyCallbackUrl,
@@ -1772,7 +1772,7 @@ function startPendingApprovalPromptWatcher(params: {
   // We also require an explicit identity match against the bound guardian to
   // avoid broadcasting prompts when trustClass is stale/mis-scoped.
   const isBoundGuardianActor =
-    guardianTrustClass === "guardian" &&
+    trustClass === "guardian" &&
     !!guardianExternalUserId &&
     requesterExternalUserId === guardianExternalUserId;
   if (!isBoundGuardianActor) {
@@ -1869,7 +1869,7 @@ function startTrustedContactApprovalNotifier(params: {
   conversationId: string;
   sourceChannel: ChannelId;
   externalChatId: string;
-  guardianTrustClass: TrustContext["trustClass"];
+  trustClass: TrustContext["trustClass"];
   guardianExternalUserId?: string;
   replyCallbackUrl: string;
   mintBearerToken: () => string;
@@ -1879,7 +1879,7 @@ function startTrustedContactApprovalNotifier(params: {
     conversationId,
     sourceChannel,
     externalChatId,
-    guardianTrustClass,
+    trustClass,
     guardianExternalUserId,
     replyCallbackUrl,
     mintBearerToken,
@@ -1887,7 +1887,7 @@ function startTrustedContactApprovalNotifier(params: {
   } = params;
 
   // Only notify trusted contacts who have a resolvable guardian route.
-  if (guardianTrustClass !== "trusted_contact" || !guardianExternalUserId) {
+  if (trustClass !== "trusted_contact" || !guardianExternalUserId) {
     return () => {};
   }
 
@@ -2005,7 +2005,7 @@ function processChannelMessageInBackground(
           conversationId,
           sourceChannel,
           externalChatId,
-          guardianTrustClass: trustCtx.trustClass,
+          trustClass: trustCtx.trustClass,
           guardianExternalUserId: trustCtx.guardianExternalUserId,
           requesterExternalUserId: trustCtx.requesterExternalUserId,
           replyCallbackUrl,
@@ -2019,7 +2019,7 @@ function processChannelMessageInBackground(
           conversationId,
           sourceChannel,
           externalChatId,
-          guardianTrustClass: trustCtx.trustClass,
+          trustClass: trustCtx.trustClass,
           guardianExternalUserId: trustCtx.guardianExternalUserId,
           replyCallbackUrl,
           mintBearerToken,


### PR DESCRIPTION
## Summary
Fixes gap from plan review round 2.

**Gap:** Function parameters still using old `guardianTrustClass` name
**What was found:** Two functions in inbound-message-handler.ts had parameters named `guardianTrustClass` and two comments in channel-retry-sweep.ts referenced the old name

- Renamed `guardianTrustClass` parameter to `trustClass` in `startPendingApprovalPromptWatcher()`
- Renamed `guardianTrustClass` parameter to `trustClass` in `startTrustedContactApprovalNotifier()`
- Updated call sites to use `trustClass` property name
- Updated comments in channel-retry-sweep.ts to reference `trustClass`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
