### PR TITLE
Add gateway-backed integration retrieval commands

### DIFF
--- a/assistant/src/__tests__/integrations-cli.test.ts
+++ b/assistant/src/__tests__/integrations-cli.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { Command } from 'commander';
+
+let gatewayBase = 'http://gateway.test';
+let signingKeyInitialized = false;
+let initCalls = 0;
+let loadCalls = 0;
+let mintCalls = 0;
+
+mock.module('../config/env.js', () => ({
+  getGatewayInternalBaseUrl: () => gatewayBase,
+}));
+
+mock.module('../runtime/auth/token-service.js', () => ({
+  isSigningKeyInitialized: () => signingKeyInitialized,
+  initAuthSigningKey: (_key: Buffer) => {
+    signingKeyInitialized = true;
+    initCalls += 1;
+  },
+  loadOrCreateSigningKey: () => {
+    loadCalls += 1;
+    return Buffer.alloc(32, 7);
+  },
+  mintEdgeRelayToken: () => {
+    mintCalls += 1;
+    return 'minted-edge-token';
+  },
+}));
+
+const { registerIntegrationsCommand } = await import('../cli/integrations.js');
+
+type FetchCall = { url: string; authHeader: string | null };
+
+async function runCli(
+  args: string[],
+  responseBody: unknown,
+  responseStatus = 200,
+): Promise<{ exitCode: number; stdout: string; fetchCalls: FetchCall[] }> {
+  const originalFetch = globalThis.fetch;
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  const originalEnvToken = process.env.GATEWAY_AUTH_TOKEN;
+
+  const fetchCalls: FetchCall[] = [];
+  const stdoutChunks: string[] = [];
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const headers = new Headers(init?.headers);
+    fetchCalls.push({
+      url,
+      authHeader: headers.get('authorization'),
+    });
+    return new Response(JSON.stringify(responseBody), {
+      status: responseStatus,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    registerIntegrationsCommand(program);
+    await program.parseAsync(['node', 'vellum', 'integrations', ...args]);
+  } finally {
+    process.stdout.write = originalWrite;
+    globalThis.fetch = originalFetch;
+    if (originalEnvToken === undefined) {
+      delete process.env.GATEWAY_AUTH_TOKEN;
+    } else {
+      process.env.GATEWAY_AUTH_TOKEN = originalEnvToken;
+    }
+  }
+
+  return {
+    exitCode: process.exitCode ?? 0,
+    stdout: stdoutChunks.join(''),
+    fetchCalls,
+  };
+}
+
+describe('vellum integrations CLI', () => {
+  beforeEach(() => {
+    gatewayBase = 'http://gateway.test';
+    signingKeyInitialized = false;
+    initCalls = 0;
+    loadCalls = 0;
+    mintCalls = 0;
+    delete process.env.GATEWAY_AUTH_TOKEN;
+    process.exitCode = 0;
+  });
+
+  afterEach(() => {
+    delete process.env.GATEWAY_AUTH_TOKEN;
+    process.exitCode = 0;
+  });
+
+  test('uses GATEWAY_AUTH_TOKEN from env when present', async () => {
+    process.env.GATEWAY_AUTH_TOKEN = 'env-token';
+    const result = await runCli(['--json', 'twilio', 'config'], { success: true });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.fetchCalls.length).toBe(1);
+    expect(result.fetchCalls[0]?.url).toBe('http://gateway.test/v1/integrations/twilio/config');
+    expect(result.fetchCalls[0]?.authHeader).toBe('Bearer env-token');
+    expect(loadCalls).toBe(0);
+    expect(initCalls).toBe(0);
+    expect(mintCalls).toBe(0);
+  });
+
+  test('mints a gateway token when no env token is provided', async () => {
+    const result = await runCli(['--json', 'telegram', 'config'], { success: true });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.fetchCalls[0]?.authHeader).toBe('Bearer minted-edge-token');
+    expect(loadCalls).toBe(1);
+    expect(initCalls).toBe(1);
+    expect(mintCalls).toBe(1);
+  });
+
+  test('passes channel query for guardian status', async () => {
+    const result = await runCli(['--json', 'guardian', 'status', '--channel', 'telegram'], { success: true });
+    expect(result.exitCode).toBe(0);
+    expect(result.fetchCalls[0]?.url).toBe('http://gateway.test/v1/integrations/guardian/status?channel=telegram');
+  });
+
+  test('passes filters for ingress members', async () => {
+    const result = await runCli(
+      [
+        '--json',
+        'ingress',
+        'members',
+        '--assistant-id',
+        'assistant-1',
+        '--source-channel',
+        'voice',
+        '--status',
+        'active',
+      ],
+      { ok: true, members: [] },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.fetchCalls[0]?.url).toBe(
+      'http://gateway.test/v1/ingress/members?assistantId=assistant-1&sourceChannel=voice&status=active',
+    );
+  });
+
+  test('returns structured error output when gateway request fails', async () => {
+    const result = await runCli(['--json', 'twilio', 'numbers'], { error: 'Unauthorized' }, 401);
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stdout)).toEqual({
+      ok: false,
+      error: 'Unauthorized [401]',
+    });
+  });
+});

--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -1,0 +1,202 @@
+import type { Command } from 'commander';
+
+import { getGatewayInternalBaseUrl } from '../config/env.js';
+import {
+  initAuthSigningKey,
+  isSigningKeyInitialized,
+  loadOrCreateSigningKey,
+  mintEdgeRelayToken,
+} from '../runtime/auth/token-service.js';
+
+type IngressChannel = 'telegram' | 'voice' | 'sms';
+type GuardianChannel = 'telegram' | 'voice' | 'sms';
+
+function shouldOutputJson(cmd: Command): boolean {
+  let current: Command | null = cmd;
+  while (current) {
+    if ((current.opts() as { json?: boolean }).json) return true;
+    current = current.parent;
+  }
+  return false;
+}
+
+function writeOutput(cmd: Command, payload: unknown): void {
+  const compact = shouldOutputJson(cmd);
+  process.stdout.write(
+    compact ? JSON.stringify(payload) + '\n' : JSON.stringify(payload, null, 2) + '\n',
+  );
+}
+
+function getGatewayToken(): string {
+  const existing = process.env.GATEWAY_AUTH_TOKEN?.trim();
+  if (existing) return existing;
+
+  if (!isSigningKeyInitialized()) {
+    initAuthSigningKey(loadOrCreateSigningKey());
+  }
+
+  return mintEdgeRelayToken();
+}
+
+function toQueryString(params: Record<string, string | undefined>): string {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value) query.set(key, value);
+  }
+  const encoded = query.toString();
+  return encoded ? `?${encoded}` : '';
+}
+
+async function gatewayGet(path: string): Promise<unknown> {
+  const gatewayBase = getGatewayInternalBaseUrl();
+  const token = getGatewayToken();
+
+  const response = await fetch(`${gatewayBase}${path}`, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  const rawBody = await response.text();
+  let parsed: unknown = { ok: false, error: rawBody };
+
+  if (rawBody.length > 0) {
+    try {
+      parsed = JSON.parse(rawBody) as unknown;
+    } catch {
+      parsed = { ok: false, error: rawBody };
+    }
+  }
+
+  if (!response.ok) {
+    const message = typeof parsed === 'object' && parsed && 'error' in parsed
+      ? String((parsed as { error?: unknown }).error)
+      : `Gateway request failed (${response.status})`;
+    throw new Error(`${message} [${response.status}]`);
+  }
+
+  return parsed;
+}
+
+async function runRead(
+  cmd: Command,
+  reader: () => Promise<unknown>,
+): Promise<void> {
+  try {
+    const result = await reader();
+    writeOutput(cmd, result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    writeOutput(cmd, { ok: false, error: message });
+    process.exitCode = 1;
+  }
+}
+
+export function registerIntegrationsCommand(program: Command): void {
+  const integrations = program
+    .command('integrations')
+    .description('Read integration and ingress status through the gateway API')
+    .option('--json', 'Machine-readable compact JSON output');
+
+  const telegram = integrations
+    .command('telegram')
+    .description('Telegram integration status');
+
+  telegram
+    .command('config')
+    .description('Get Telegram integration configuration status')
+    .action(async (_opts: unknown, cmd: Command) => {
+      await runRead(cmd, async () => gatewayGet('/v1/integrations/telegram/config'));
+    });
+
+  const guardian = integrations
+    .command('guardian')
+    .description('Guardian verification status');
+
+  guardian
+    .command('status')
+    .description('Get guardian status for a channel')
+    .option('--channel <channel>', 'Channel: telegram|voice|sms', 'voice')
+    .action(async (opts: { channel?: GuardianChannel }, cmd: Command) => {
+      const channel = opts.channel ?? 'voice';
+      await runRead(cmd, async () =>
+        gatewayGet(`/v1/integrations/guardian/status${toQueryString({ channel })}`));
+    });
+
+  const twilio = integrations
+    .command('twilio')
+    .description('Twilio integration status');
+
+  twilio
+    .command('config')
+    .description('Get Twilio credential and phone number status')
+    .action(async (_opts: unknown, cmd: Command) => {
+      await runRead(cmd, async () => gatewayGet('/v1/integrations/twilio/config'));
+    });
+
+  twilio
+    .command('numbers')
+    .description('List Twilio incoming phone numbers')
+    .action(async (_opts: unknown, cmd: Command) => {
+      await runRead(cmd, async () => gatewayGet('/v1/integrations/twilio/numbers'));
+    });
+
+  const twilioSms = twilio
+    .command('sms')
+    .description('Twilio SMS status');
+
+  twilioSms
+    .command('compliance')
+    .description('Get Twilio SMS compliance status')
+    .action(async (_opts: unknown, cmd: Command) => {
+      await runRead(cmd, async () => gatewayGet('/v1/integrations/twilio/sms/compliance'));
+    });
+
+  twilio
+    .command('sms-compliance')
+    .description('Alias for "vellum integrations twilio sms compliance"')
+    .action(async (_opts: unknown, cmd: Command) => {
+      await runRead(cmd, async () => gatewayGet('/v1/integrations/twilio/sms/compliance'));
+    });
+
+  const ingress = integrations
+    .command('ingress')
+    .description('Trusted contact membership and invite status');
+
+  ingress
+    .command('members')
+    .description('List trusted ingress members')
+    .option('--assistant-id <assistantId>', 'Filter by assistant ID')
+    .option('--source-channel <sourceChannel>', 'Filter by source channel')
+    .option('--status <status>', 'Filter by member status')
+    .option('--policy <policy>', 'Filter by policy')
+    .action(async (opts: {
+      assistantId?: string;
+      sourceChannel?: IngressChannel;
+      status?: string;
+      policy?: string;
+    }, cmd: Command) => {
+      const query = toQueryString({
+        assistantId: opts.assistantId,
+        sourceChannel: opts.sourceChannel,
+        status: opts.status,
+        policy: opts.policy,
+      });
+      await runRead(cmd, async () => gatewayGet(`/v1/ingress/members${query}`));
+    });
+
+  ingress
+    .command('invites')
+    .description('List trusted ingress invites')
+    .option('--source-channel <sourceChannel>', 'Filter by source channel')
+    .option('--status <status>', 'Filter by invite status')
+    .action(async (opts: { sourceChannel?: IngressChannel; status?: string }, cmd: Command) => {
+      const query = toQueryString({
+        sourceChannel: opts.sourceChannel,
+        status: opts.status,
+      });
+      await runRead(cmd, async () => gatewayGet(`/v1/ingress/invites${query}`));
+    });
+}

--- a/assistant/src/config/bundled-skills/_shared/CLI_RETRIEVAL_PATTERN.md
+++ b/assistant/src/config/bundled-skills/_shared/CLI_RETRIEVAL_PATTERN.md
@@ -1,0 +1,19 @@
+# Bundled Skill CLI Retrieval Pattern
+
+Use this pattern for setup/status reads in bundled skills:
+
+1. Run Vellum CLI reads through `bash` (not `host_bash`).
+2. Use domain commands (for example `vellum integrations twilio config`) instead of direct gateway `curl`.
+3. Let the CLI handle gateway auth internally; do not instruct manual bearer headers for read paths.
+
+When a skill needs outbound API calls with a stored credential (outside of Vellum CLI reads), use proxied bash:
+
+```yaml
+bash:
+  network_mode: proxied
+  credential_ids:
+    - "<credential-id>"
+  command: |
+    curl -s https://api.example.com/resource
+```
+

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -25,6 +25,7 @@ import {
 } from './cli/core-commands.js';
 import { registerEmailCommand } from './cli/email.js';
 import { registerInfluencerCommand } from './cli/influencer.js';
+import { registerIntegrationsCommand } from './cli/integrations.js';
 import { registerMapCommand } from './cli/map.js';
 import { registerMcpCommand } from './cli/mcp.js';
 import { registerSequenceCommand } from './cli/sequence.js';
@@ -51,6 +52,7 @@ registerDoctorCommand(program);
 registerHooksCommand(program);
 registerMcpCommand(program);
 registerEmailCommand(program);
+registerIntegrationsCommand(program);
 registerAmazonCommand(program);
 registerCompletionsCommand(program);
 


### PR DESCRIPTION
## Summary
- add a new "vellum integrations" CLI command group for gateway-backed status reads
- support telegram config, guardian status, twilio config/numbers/sms compliance, and ingress members/invites reads
- add command tests and a shared bundled-skill retrieval pattern doc snippet

## Validation
- cd assistant && bun test src/__tests__/integrations-cli.test.ts
- cd assistant && bunx tsc --noEmit

Part of #11900
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
