### PR TITLE
Migrate guardian and telegram status checks to Vellum CLI

### DIFF
--- a/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
+++ b/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
@@ -49,13 +49,13 @@ describe("guardian-verify-setup skill — voice auto-followup", () => {
     expect(skillContent).toContain("## Voice Auto-Check Polling");
   });
 
-  test("polling section specifies the correct status endpoint for voice", () => {
+  test("polling section specifies the correct status command for voice", () => {
     const pollingSection =
       skillContent
         .split("## Voice Auto-Check Polling")[1]
         ?.split("## Step 6")[0] ?? "";
     expect(pollingSection).toContain(
-      "/v1/integrations/guardian/status?channel=voice",
+      "vellum integrations guardian status --channel voice --json",
     );
   });
 

--- a/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
@@ -5,14 +5,14 @@ user-invocable: true
 metadata: {"vellum": {"emoji": "\ud83d\udd10"}}
 ---
 
-You are helping your user set up guardian verification for a messaging channel (voice or Telegram). This links their identity as the trusted guardian for the chosen channel. All API calls go through the gateway HTTP API using `curl` with bearer auth.
+You are helping your user set up guardian verification for a messaging channel (voice or Telegram). This links their identity as the trusted guardian for the chosen channel. Use gateway control-plane APIs for outbound actions, and use `vellum integrations guardian status` for status reads.
 
 ## Prerequisites
 
 - Use the injected `INTERNAL_GATEWAY_BASE_URL` for gateway API calls.
 - Never call the daemon runtime port directly; always call the gateway URL.
-- The bearer token is available as the `$GATEWAY_AUTH_TOKEN` environment variable.
-- Run shell commands for this skill with `host_bash` (not sandbox `bash`) so host auth/token and gateway routing are reliable.
+- The bearer token is available as the `$GATEWAY_AUTH_TOKEN` environment variable for control-plane `curl` requests.
+- Run shell commands for this skill with `bash`.
 - Keep narration minimal: execute required calls first, then provide a concise status update. Do not narrate internal install/check/load chatter unless something fails.
 
 ## Step 1: Confirm Channel
@@ -117,11 +117,10 @@ For **voice** verification only: after telling the user their code and instructi
 **Polling procedure:**
 
 1. Wait ~15 seconds after delivering the code (to give the user time to answer the call and enter the code).
-2. Check the binding status:
+2. Check the binding status via Vellum CLI:
 
 ```bash
-curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/status?channel=voice" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
+vellum integrations guardian status --channel voice --json
 ```
 
 3. If the response shows `bound: true`: immediately send a proactive success message in the current chat — "Voice verification complete! Your phone number is now the trusted guardian." Stop polling.
@@ -146,8 +145,7 @@ When in a **rebind flow** (i.e., the `start_outbound` request included `"rebind"
 After the user reports entering the code, verify the binding was created:
 
 ```bash
-curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/status?channel=<channel>" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
+vellum integrations guardian status --channel <channel> --json
 ```
 
 If the response shows the guardian is bound, confirm success: "Guardian verified! Your [channel] identity is now the trusted guardian."

--- a/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
@@ -145,7 +145,8 @@ When in a **rebind flow** (i.e., the `start_outbound` request included `"rebind"
 After the user reports entering the code, verify the binding was created:
 
 ```bash
-vellum integrations guardian status --channel <channel> --json
+CHANNEL="<channel>"
+vellum integrations guardian status --channel "$CHANNEL" --json
 ```
 
 If the response shows the guardian is bound, confirm success: "Guardian verified! Your [channel] identity is now the trusted guardian."

--- a/assistant/src/config/bundled-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/telegram-setup/SKILL.md
@@ -97,11 +97,10 @@ If routing is misconfigured, inbound Telegram messages will be rejected and the 
 
 ### Step 6: Verify Binding State
 
-Before reporting success, confirm the guardian binding was actually created. Check the guardian binding status:
+Before reporting success, confirm the guardian binding was actually created. Check guardian binding status via Vellum CLI:
 
 ```bash
-curl -sf "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/status?channel=telegram" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
+vellum integrations guardian status --channel telegram --json
 ```
 
 If the binding is absent and the user said they completed the verification:
@@ -120,7 +119,7 @@ Summarize what was done:
 - Guardian identity: {verified | not configured}
 - Guardian verification status: {verified via outbound flow | skipped}
 - Routing configuration validated
-- To re-check guardian status later, use: `curl -sf "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/status?channel=telegram" -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"`
+- To re-check guardian status later, use: `vellum integrations guardian status --channel telegram --json`
 
 The gateway automatically detects credentials from the vault, reconciles the Telegram webhook registration, and begins accepting Telegram webhooks shortly. In single-assistant mode, routing is automatically configured — no manual environment variable configuration or webhook registration is needed. If the webhook secret changes later, the gateway's credential watcher will automatically re-register the webhook. If the ingress URL changes (e.g., tunnel restart), the assistant daemon triggers an immediate internal reconcile so the webhook re-registers automatically without a gateway restart.
 


### PR DESCRIPTION
## Summary
- migrate guardian status retrieval instructions in guardian-verify-setup to `vellum integrations guardian status`
- migrate telegram guardian-status verification/readback instructions to the same CLI read command
- update guardian skill regression test to assert the CLI-based status check command

## Validation
- cd assistant && bun test src/__tests__/guardian-verify-setup-skill-regression.test.ts

Part of #11901
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
