### PR TITLE
fix: mark messageId(from:) as nonisolated to fix CI build error

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -200,7 +200,7 @@ extension AppDelegate {
         return nil
     }
 
-    private func messageId(from userInfo: [AnyHashable: Any]) -> String? {
+    private nonisolated func messageId(from userInfo: [AnyHashable: Any]) -> String? {
         if let direct = userInfo["messageId"] as? String {
             return direct
         }


### PR DESCRIPTION
## Summary
- Mark `messageId(from:)` as `nonisolated` in `AppDelegate+Notifications.swift` — it's a pure dictionary lookup that doesn't touch `@MainActor` state, but was being called from the `nonisolated` `userNotificationCenter(_:didReceive:)` delegate method, causing a Swift strict concurrency error on CI.

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22647588442/job/65639256180

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
