### PR TITLE
feat: add role and principalId columns to contacts table

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -25,6 +25,8 @@ function parseContact(row: typeof contacts.$inferSelect): Contact {
     interactionCount: row.interactionCount,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
+    role: row.role as Contact['role'],
+    principalId: row.principalId,
   };
 }
 

--- a/assistant/src/contacts/types.ts
+++ b/assistant/src/contacts/types.ts
@@ -1,3 +1,5 @@
+export type ContactRole = 'guardian' | 'contact';
+
 export interface Contact {
   id: string;
   displayName: string;
@@ -9,6 +11,8 @@ export interface Contact {
   interactionCount: number;
   createdAt: number;
   updatedAt: number;
+  role: ContactRole;
+  principalId: string | null;
 }
 
 export interface ContactChannel {

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -22,6 +22,7 @@ import {
   createWatchersAndLogsTables,
   migrateBackfillGuardianPrincipalId,
   migrateCallSessionMode,
+  migrateContactsRolePrincipal,
   migrateCanonicalGuardianDeliveriesDestinationIndex,
   migrateCanonicalGuardianRequesterChatId,
   migrateChannelInboundDeliveredSegments,
@@ -188,6 +189,9 @@ export function initializeDb(): void {
 
   // 31. Enforce NOT NULL on channel_guardian_bindings.guardian_principal_id
   migrateGuardianPrincipalIdNotNull(database);
+
+  // 32. Add role and principal_id columns to contacts table
+  migrateContactsRolePrincipal(database);
 
   validateMigrationState(database);
 }

--- a/assistant/src/memory/migrations/128-contacts-role-principal.ts
+++ b/assistant/src/memory/migrations/128-contacts-role-principal.ts
@@ -1,0 +1,16 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Add role and principal_id columns to the contacts table.
+ *
+ * - role: discriminates guardian vs regular contact (defaults to 'contact'
+ *   so existing rows are unaffected).
+ * - principal_id: nullable internal auth principal ID, linking the contact
+ *   to a guardian principal when applicable.
+ *
+ * Uses ALTER TABLE ADD COLUMN with try/catch for idempotency.
+ */
+export function migrateContactsRolePrincipal(database: DrizzleDb): void {
+  try { database.run(/*sql*/ `ALTER TABLE contacts ADD COLUMN role TEXT NOT NULL DEFAULT 'contact'`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE contacts ADD COLUMN principal_id TEXT`); } catch { /* already exists */ }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -69,6 +69,7 @@ export { migrateVoiceInviteDisplayMetadata } from './124-voice-invite-display-me
 export { migrateGuardianPrincipalIdColumns } from './125-guardian-principal-id-columns.js';
 export { migrateBackfillGuardianPrincipalId } from './126-backfill-guardian-principal-id.js';
 export { migrateGuardianPrincipalIdNotNull } from './127-guardian-principal-id-not-null.js';
+export { migrateContactsRolePrincipal } from './128-contacts-role-principal.js';
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -414,6 +414,8 @@ export const contacts = sqliteTable("contacts", {
   interactionCount: integer("interaction_count").notNull().default(0),
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
+  role: text("role").notNull().default("contact"), // 'guardian' | 'contact'
+  principalId: text("principal_id"), // internal auth principal (nullable)
 });
 
 export const contactChannels = sqliteTable("contact_channels", {


### PR DESCRIPTION
## Summary
- Add `role` (guardian/contact) and `principal_id` columns to the contacts table via migration
- Update Drizzle schema definition to include new columns
- Export `ContactRole` type and extend `Contact` interface with role and principalId fields

Part of plan: contact-centric-model.md (PR 1 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
