### PR TITLE
fix: make proxy-sidecar tests hermetic and clean up temp dirs

### DIFF
--- a/proxy-sidecar/src/__tests__/certs.test.ts
+++ b/proxy-sidecar/src/__tests__/certs.test.ts
@@ -15,6 +15,7 @@ let dataDir: string;
 
 beforeAll(async () => {
   dataDir = await mkdtemp(join(tmpdir(), 'proxy-sidecar-certs-test-'));
+  await ensureLocalCA(dataDir);
 });
 
 afterAll(async () => {

--- a/proxy-sidecar/src/__tests__/mitm-handler.test.ts
+++ b/proxy-sidecar/src/__tests__/mitm-handler.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import type { Server } from 'node:http';
 import { createServer as createHttpsServer } from 'node:https';
 import { connect } from 'node:net';
@@ -25,6 +25,10 @@ beforeAll(async () => {
   await ensureLocalCA(dataDir);
   caDir = join(dataDir, 'proxy-ca');
   caCert = await readFile(getCAPath(dataDir), 'utf-8');
+});
+
+afterAll(async () => {
+  await rm(dataDir, { recursive: true, force: true });
 });
 
 /**


### PR DESCRIPTION
Address review feedback from PR #11733:\n- Make cert fixture setup independent per test (initialize CA in beforeAll)\n- Add afterAll cleanup to remove temporary directory in mitm-handler tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
