### PR TITLE
fix: prevent health-port collision and fix shutdown ordering

### DIFF
--- a/proxy-sidecar/src/config.ts
+++ b/proxy-sidecar/src/config.ts
@@ -31,7 +31,13 @@ export interface SidecarConfig {
  */
 export function loadConfig(env: Record<string, string | undefined> = process.env): SidecarConfig {
   const port = parsePort(env.PROXY_PORT, 'PROXY_PORT');
-  const healthPort = parsePort(env.PROXY_HEALTH_PORT, 'PROXY_HEALTH_PORT', 8081);
+  const defaultHealthPort = port === 8081 ? 8082 : 8081;
+  const healthPort = parsePort(env.PROXY_HEALTH_PORT, 'PROXY_HEALTH_PORT', defaultHealthPort);
+  if (healthPort === port) {
+    throw new ConfigError(
+      `PROXY_HEALTH_PORT (${healthPort}) must differ from PROXY_PORT (${port})`,
+    );
+  }
   const host = env.PROXY_HOST ?? '0.0.0.0';
   const caDir = env.PROXY_CA_DIR ?? null;
   const logLevel = parseLogLevel(env.PROXY_LOG_LEVEL);

--- a/proxy-sidecar/src/main.ts
+++ b/proxy-sidecar/src/main.ts
@@ -133,16 +133,15 @@ function shutdown(signal: string): void {
     }
   };
 
-  // Close health server first so probes report not-ready during drain
-  if (healthServer) {
-    pending++;
-    healthServer.close(onClosed('health'));
-  }
-
-  // Stop accepting new proxy connections and wait for in-flight requests.
+  // Close proxy server first to drain in-flight requests while health probes remain available
   if (server) {
     pending++;
     server.close(onClosed('proxy'));
+  }
+
+  if (healthServer) {
+    pending++;
+    healthServer.close(onClosed('health'));
   }
 
   // Force-exit after 10 seconds if graceful shutdown stalls.


### PR DESCRIPTION
Address review feedback from PR #11737:\n- Prevent health-port default from colliding with proxy port (auto-derives non-conflicting default; throws if explicitly set to same port)\n- Fix shutdown ordering: close proxy server before health server so liveness/readiness probes remain available during drain
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
