### PR TITLE
fix: preserve existing output_config when adding effort

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -521,16 +521,22 @@ export class AnthropicProvider implements Provider {
       }
 
       sentMessages = ensureToolPairing(formatted);
-      const { effort, ...restConfig } = (config ?? {}) as Record<
+      const { effort, output_config, ...restConfig } = (config ?? {}) as Record<
         string,
         unknown
-      > & { effort?: string };
+      > & { effort?: string; output_config?: Record<string, unknown> };
+      const mergedOutputConfig = {
+        ...(output_config ?? {}),
+        ...(effort ? { effort } : {}),
+      };
       const params: Anthropic.MessageCreateParams = {
         model: this.model,
         max_tokens: 64000,
         messages: sentMessages,
         ...restConfig,
-        ...(effort ? { output_config: { effort } } : {}),
+        ...(Object.keys(mergedOutputConfig).length > 0
+          ? { output_config: mergedOutputConfig }
+          : {}),
       };
 
       if (systemPrompt) {
@@ -752,7 +758,9 @@ export class AnthropicProvider implements Provider {
         );
       }
       throw new ProviderError(
-        `Anthropic request failed: ${error instanceof Error ? error.message : String(error)}`,
+        `Anthropic request failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
         "anthropic",
         undefined,
         { cause: error },


### PR DESCRIPTION
Address review feedback from PR #11760:
- Spread existing output_config fields when adding effort instead of replacing the entire object
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
