### PR TITLE
fix: restore strict reason assertions in cross-version compatibility tests

### DIFF
--- a/assistant/src/__tests__/migration-cross-version-compatibility.test.ts
+++ b/assistant/src/__tests__/migration-cross-version-compatibility.test.ts
@@ -905,10 +905,8 @@ describe("partial failure scenarios", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.reason).toBe("write_failed");
-      if (result.reason === "write_failed") {
-        expect(result.message).toBeDefined();
-        expect(result.message.length).toBeGreaterThan(0);
-      }
+      expect((result as { message: string }).message).toBeDefined();
+      expect((result as { message: string }).message.length).toBeGreaterThan(0);
     }
 
     // Clean up
@@ -925,11 +923,14 @@ describe("partial failure scenarios", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.reason).toBe("validation_failed");
-      if (result.reason === "validation_failed") {
-        expect(result.errors).toBeDefined();
-        expect(result.errors.length).toBeGreaterThan(0);
-        expect(result.errors[0].code).toBe("INVALID_GZIP");
-      }
+      const errors = (
+        result as {
+          errors: Array<{ code: string; message: string }>;
+        }
+      ).errors;
+      expect(errors).toBeDefined();
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].code).toBe("INVALID_GZIP");
     }
   });
 


### PR DESCRIPTION
Address review feedback from PR #11807:\n- Make write_failed and validation_failed assertions unconditional\n- Ensures tests fail if commitImport returns unexpected reasons
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
