### PR TITLE
fix: fix stale state and error classification in transfer progress screen

### DIFF
--- a/assistant/src/runtime/migrations/migration-wizard.ts
+++ b/assistant/src/runtime/migrations/migration-wizard.ts
@@ -507,6 +507,13 @@ export async function executeTransferStep(
         { intervalMs: 2000, maxAttempts: 60 },
       );
 
+      // Update the stored export status so view models see the terminal state
+      current = {
+        ...current,
+        exportResult: { ...managedExport, status: finalStatus.status },
+      };
+      options.onStateChange?.(touch(current));
+
       if (finalStatus.status === "failed") {
         current = setStepStatus(current, "transfer", "error", {
           message: `Export job failed: ${finalStatus.error}`,

--- a/assistant/src/runtime/migrations/transfer-progress-screen.ts
+++ b/assistant/src/runtime/migrations/transfer-progress-screen.ts
@@ -144,8 +144,12 @@ function inferFailedPhase(
   // If export result exists but no import result, and error is transport-level,
   // it could be download failure or import failure
   if (state.exportResult && !state.importResult) {
-    // If it's a managed export and we have no import result, it could be polling or download
     if ("jobId" in state.exportResult) {
+      const managed = state.exportResult as ExportManagedResult;
+      // If the managed export completed, the failure was after export (download or import)
+      if (managed.status === "complete") {
+        return "import";
+      }
       return "poll";
     }
     return "import";
@@ -290,8 +294,13 @@ export async function retryTransferFlow(
   options: StepExecutorOptions,
 ): Promise<MigrationWizardState> {
   const reset = resetStepForRetry(state);
-  options.onStateChange?.(reset);
-  return executeTransferStep(reset, options);
+  const cleaned = {
+    ...reset,
+    exportResult: undefined,
+    importResult: undefined,
+  };
+  options.onStateChange?.(cleaned);
+  return executeTransferStep(cleaned, options);
 }
 
 /**


### PR DESCRIPTION
Address review feedback from PR #11843:\n- Update managed export status during polling to avoid stale state\n- Classify managed import transport errors correctly\n- Clear stale exportResult/importResult in retryTransferFlow
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
