### PR TITLE
fix: restore strict failure-reason assertions in migration import test

### DIFF
--- a/assistant/src/__tests__/migration-import-commit-http.test.ts
+++ b/assistant/src/__tests__/migration-import-commit-http.test.ts
@@ -665,8 +665,11 @@ describe("commitImport", () => {
     });
 
     expect(result.ok).toBe(false);
-    if (!result.ok && result.reason === "validation_failed") {
-      expect(result.errors.length).toBeGreaterThan(0);
+    if (!result.ok) {
+      expect(result.reason).toBe("validation_failed");
+      if (result.reason === "validation_failed") {
+        expect(result.errors.length).toBeGreaterThan(0);
+      }
     }
   });
 


### PR DESCRIPTION
Address review feedback from PR #11798:
- Make validation_failed assertion unconditional instead of guarded
- Ensures test fails if commitImport returns an unexpected reason
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
