### PR TITLE
fix: clear stale validation results on retry and handle negative formatFileSize

### DIFF
--- a/assistant/src/runtime/migrations/validation-results-screen.ts
+++ b/assistant/src/runtime/migrations/validation-results-screen.ts
@@ -364,7 +364,16 @@ export async function retryValidationFlow(
   state: MigrationWizardState,
   options: StepExecutorOptions,
 ): Promise<MigrationWizardState> {
-  const reset = resetStepForRetry(state);
+  let reset = resetStepForRetry(state);
+
+  // Clear stale results so a new transport error isn't misclassified
+  // as a validation/preflight failure based on the previous attempt's result.
+  if (reset.currentStep === "validate") {
+    reset = { ...reset, validateResult: undefined };
+  } else if (reset.currentStep === "preflight-review") {
+    reset = { ...reset, preflightResult: undefined };
+  }
+
   options.onStateChange?.(reset);
 
   if (reset.currentStep === "validate") {
@@ -439,10 +448,10 @@ export function groupFilesByAction(files: PreflightFileEntry[]): {
  * Format a byte size as a human-readable string.
  */
 export function formatFileSize(bytes: number): string {
-  if (bytes === 0) return "0 B";
+  if (bytes <= 0) return "0 B";
   const units = ["B", "KB", "MB", "GB"];
   const exponent = Math.min(
-    Math.floor(Math.log(bytes) / Math.log(1024)),
+    Math.max(0, Math.floor(Math.log(bytes) / Math.log(1024))),
     units.length - 1,
   );
   const value = bytes / Math.pow(1024, exponent);


### PR DESCRIPTION
Address review feedback from PR #11841:\n- Clear previous validate/preflight results when retrying to prevent stale state\n- Handle negative inputs in formatFileSize gracefully
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
