### PR TITLE
fix: checkpoint WAL before exporting SQLite database

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -243,6 +243,13 @@ export interface BuildExportVBundleOptions {
   source?: string;
   /** Human-readable description. */
   description?: string;
+  /**
+   * Optional callback to checkpoint the WAL before reading the database file.
+   * In WAL mode, committed rows may live in the -wal file and not yet be
+   * flushed to the main .db file. Callers should pass a function that runs
+   * PRAGMA wal_checkpoint(TRUNCATE) on the live database connection.
+   */
+  checkpoint?: () => void;
 }
 
 /**
@@ -259,11 +266,15 @@ export interface BuildExportVBundleOptions {
 export function buildExportVBundle(
   options: BuildExportVBundleOptions,
 ): BuildVBundleResult {
-  const { dbPath, configPath, source, description } = options;
+  const { dbPath, configPath, source, description, checkpoint } = options;
 
-  // Read the actual SQLite database file. The database contains all
-  // conversation history, messages, memory segments, embeddings, and
-  // other persistent assistant state in a single file.
+  // Flush WAL to the main database file before reading so the export
+  // captures all committed rows (SQLite WAL mode keeps recent writes
+  // in a separate -wal file until checkpoint).
+  if (checkpoint) {
+    checkpoint();
+  }
+
   const dbData = existsSync(dbPath)
     ? new Uint8Array(readFileSync(dbPath))
     : new Uint8Array(0);

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -11,6 +11,7 @@
  * results with is_valid flag and detailed error descriptions.
  */
 
+import { getSqlite } from "../../memory/db-connection.js";
 import { getLogger } from "../../util/logger.js";
 import { getDbPath, getWorkspaceConfigPath } from "../../util/platform.js";
 import { httpError } from "../http-errors.js";
@@ -134,6 +135,7 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
       configPath: getWorkspaceConfigPath(),
       source: "runtime-export",
       description,
+      checkpoint: () => getSqlite().exec("PRAGMA wal_checkpoint(TRUNCATE)"),
     });
 
     const timestamp = manifest.created_at.replace(/[:.]/g, "-");


### PR DESCRIPTION
Address review feedback from PR #11778:
- Run PRAGMA wal_checkpoint(TRUNCATE) before reading assistant.db to ensure all committed rows are flushed from WAL to the main database file
- Add optional checkpoint callback to BuildExportVBundleOptions to keep the builder decoupled from db-connection
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
