### PR TITLE
fix: close SQLite before overwriting and invalidate config cache after import

### DIFF
--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -11,7 +11,8 @@
  * results with is_valid flag and detailed error descriptions.
  */
 
-import { getSqlite } from "../../memory/db-connection.js";
+import { invalidateConfigCache } from "../../config/loader.js";
+import { getSqlite, resetDb } from "../../memory/db-connection.js";
 import { getLogger } from "../../util/logger.js";
 import { getDbPath, getWorkspaceConfigPath } from "../../util/platform.js";
 import { httpError } from "../http-errors.js";
@@ -343,6 +344,10 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
       getWorkspaceConfigPath(),
     );
 
+    // Close the live SQLite connection before overwriting assistant.db on disk.
+    // The singleton will be lazily reopened on the next getDb() call.
+    resetDb();
+
     const result = commitImport({
       archiveData: fileData,
       pathResolver,
@@ -381,6 +386,9 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
         { status: 500 },
       );
     }
+
+    // Invalidate in-process config cache so imported settings.json takes effect
+    invalidateConfigCache();
 
     return Response.json(result.report);
   } catch (err) {


### PR DESCRIPTION
Address review feedback from PR #11792:\n- Close the live SQLite connection before overwriting assistant.db during import\n- Invalidate config cache after successful import so new settings take effect
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
