### PR TITLE
fix: increase qdrant-manager test timeouts for CI reliability

### DIFF
--- a/assistant/src/__tests__/qdrant-manager.test.ts
+++ b/assistant/src/__tests__/qdrant-manager.test.ts
@@ -24,10 +24,10 @@ mock.module("../util/logger.js", () => ({
 
 import { QdrantManager } from "../memory/qdrant-manager.js";
 
-/** Minimal timeouts so tests complete as fast as possible. */
+/** Short timeouts so tests complete fast but with enough headroom for CI. */
 const FAST_TIMEOUTS = {
   readyzPollIntervalMs: 10,
-  readyzTimeoutMs: 500,
+  readyzTimeoutMs: 1_000,
   shutdownGraceMs: 200,
 } as const;
 


### PR DESCRIPTION
Address review feedback from PR #11862:\n- Increase readyzTimeoutMs from 500 to 1000 to provide sufficient headroom above the fixed 300ms wait\n- Prevent race condition in SIGKILL escalation test where readyzTimeoutMs equaled Bun.sleep + shutdownGraceMs on slower CI runners
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
