### PR TITLE
fix: reset rebind checklist state when returning to transfer

### DIFF
--- a/assistant/src/__tests__/rebind-secrets-screen.test.ts
+++ b/assistant/src/__tests__/rebind-secrets-screen.test.ts
@@ -546,9 +546,9 @@ describe("completeMigration", () => {
 describe("goBackToTransfer", () => {
   test("navigates back to transfer from rebind-secrets", () => {
     const state = advanceTo("rebind-secrets");
-    const result = goBackToTransfer(state);
-    expect(result.currentStep).toBe("transfer");
-    expect(result.steps["rebind-secrets"].status).toBe("idle");
+    const { wizardState } = goBackToTransfer(state);
+    expect(wizardState.currentStep).toBe("transfer");
+    expect(wizardState.steps["rebind-secrets"].status).toBe("idle");
   });
 
   test("clears export and import results when going back to transfer", () => {
@@ -563,9 +563,9 @@ describe("goBackToTransfer", () => {
       },
       importResult: makeImportSuccess(),
     };
-    const result = goBackToTransfer(state);
-    expect(result.exportResult).toBeUndefined();
-    expect(result.importResult).toBeUndefined();
+    const { wizardState } = goBackToTransfer(state);
+    expect(wizardState.exportResult).toBeUndefined();
+    expect(wizardState.importResult).toBeUndefined();
   });
 
   test("preserves validation and preflight results when going back to transfer", () => {
@@ -575,9 +575,18 @@ describe("goBackToTransfer", () => {
       validateResult: makeValidateSuccess(),
       preflightResult: makePreflightSuccess(),
     };
-    const result = goBackToTransfer(state);
-    expect(result.validateResult).toBeDefined();
-    expect(result.preflightResult).toBeDefined();
+    const { wizardState } = goBackToTransfer(state);
+    expect(wizardState.validateResult).toBeDefined();
+    expect(wizardState.preflightResult).toBeDefined();
+  });
+
+  test("resets task completion state when going back to transfer", () => {
+    const state = advanceTo("rebind-secrets");
+    const { completionState } = goBackToTransfer(state);
+    const taskIds = getTaskIds();
+    for (const id of taskIds) {
+      expect(completionState[id]).toBe(false);
+    }
   });
 });
 

--- a/assistant/src/runtime/migrations/rebind-secrets-screen.ts
+++ b/assistant/src/runtime/migrations/rebind-secrets-screen.ts
@@ -298,12 +298,19 @@ export function completeMigration(
 }
 
 /**
- * Navigate back to the transfer step.
+ * Navigate back to the transfer step and reset the rebind checklist.
+ *
+ * Returns both the rewound wizard state and a fresh completion state so
+ * callers clear stale task progress from a previous transfer attempt.
  */
-export function goBackToTransfer(
-  state: MigrationWizardState,
-): MigrationWizardState {
-  return goBackTo(state, "transfer");
+export function goBackToTransfer(state: MigrationWizardState): {
+  wizardState: MigrationWizardState;
+  completionState: RebindTaskCompletionState;
+} {
+  return {
+    wizardState: goBackTo(state, "transfer"),
+    completionState: createTaskCompletionState(),
+  };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Address review feedback from PR #11847:\n- Clear RebindTaskCompletionState in goBackToTransfer to prevent stale completion state on retry
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11928" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
