### PR TITLE
Migrate SMS and trusted-contact retrieval steps to Vellum CLI

### DIFF
--- a/assistant/src/config/bundled-skills/sms-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/sms-setup/SKILL.md
@@ -9,11 +9,10 @@ You are helping your user set up SMS messaging. This skill orchestrates Twilio s
 
 ## Step 1: Check Channel Readiness
 
-First, check the current SMS channel readiness state via the gateway:
+First, check the current SMS channel readiness state via Vellum CLI:
 
 ```bash
-curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/config" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
+vellum integrations twilio config --json
 ```
 
 Inspect the response for `hasCredentials` and `phoneNumber`.
@@ -31,11 +30,10 @@ skill_load skill=twilio-setup
 
 Tell the user: _"SMS needs Twilio configured first. I've loaded the Twilio setup guide — let's walk through it."_
 
-After twilio-setup completes, re-check readiness by calling the config endpoint again:
+After twilio-setup completes, re-check readiness:
 
 ```bash
-curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/config" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
+vellum integrations twilio config --json
 ```
 
 If baseline is still not ready, report the specific failures and ask the user to address them before continuing.
@@ -45,8 +43,7 @@ If baseline is still not ready, report the specific failures and ask the user to
 Once baseline is ready, check SMS compliance status including remote (Twilio API) checks:
 
 ```bash
-curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/sms/compliance" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
+vellum integrations twilio sms compliance --json
 ```
 
 Examine the compliance results:

--- a/assistant/src/config/bundled-skills/trusted-contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/trusted-contacts/SKILL.md
@@ -5,13 +5,13 @@ user-invocable: true
 metadata: {"vellum": {"emoji": "\ud83d\udc65"}}
 ---
 
-You are helping your user manage trusted contacts and invite links for the Vellum Assistant. Trusted contacts control who is allowed to send messages to the assistant through external channels like Telegram, SMS, and voice (phone calls). Invite links let the guardian share a Telegram deep link that automatically grants access when opened. Voice invites let the guardian authorize a specific phone number to call in — the invitee must call from that phone number AND enter a one-time numeric code. All operations go through the gateway HTTP API using `curl` with bearer auth.
+You are helping your user manage trusted contacts and invite links for the Vellum Assistant. Trusted contacts control who is allowed to send messages to the assistant through external channels like Telegram, SMS, and voice (phone calls). Invite links let the guardian share a Telegram deep link that automatically grants access when opened. Voice invites let the guardian authorize a specific phone number to call in — the invitee must call from that phone number AND enter a one-time numeric code. Use Vellum CLI for status/list retrieval, and use gateway control-plane `curl` calls for mutating actions.
 
 ## Prerequisites
 
 - Use the injected `INTERNAL_GATEWAY_BASE_URL` for gateway API calls.
 - Use gateway control-plane routes only: this skill calls `/v1/ingress/*` and `/v1/integrations/telegram/config` on the gateway, never the daemon runtime port directly.
-- The bearer token is available as the `$GATEWAY_AUTH_TOKEN` environment variable.
+- The bearer token is available as the `$GATEWAY_AUTH_TOKEN` environment variable for control-plane `curl` requests.
 
 ## Concepts
 
@@ -29,8 +29,7 @@ You are helping your user manage trusted contacts and invite links for the Vellu
 Use this to show the user who currently has access, or to look up a specific contact.
 
 ```bash
-curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/ingress/members" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
+vellum integrations ingress members --json
 ```
 
 Optional query parameters for filtering:
@@ -40,8 +39,7 @@ Optional query parameters for filtering:
 
 Example with filters:
 ```bash
-curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/ingress/members?sourceChannel=telegram&status=active" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
+vellum integrations ingress members --source-channel telegram --status active --json
 ```
 
 The response contains `{ ok: true, members: [...] }` where each member has:
@@ -153,8 +151,7 @@ fi
 
 # Prefer backend-provided canonical link when available.
 if [ -z "$INVITE_URL" ]; then
-  BOT_CONFIG_JSON=$(curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/telegram/config" \
-    -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN")
+  BOT_CONFIG_JSON=$(vellum integrations telegram config --json)
   BOT_USERNAME=$(printf '%s' "$BOT_CONFIG_JSON" | tr -d '\n' | sed -n 's/.*"botUsername"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
   if [ -z "$BOT_USERNAME" ]; then
     echo "error:no_share_url_or_bot_username"
@@ -195,8 +192,7 @@ If the Telegram bot username is not available (integration not set up), tell the
 Use this to show the guardian their active (and optionally all) invite links.
 
 ```bash
-curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/ingress/invites?sourceChannel=telegram" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
+vellum integrations ingress invites --source-channel telegram --json
 ```
 
 Optional query parameters:
@@ -293,8 +289,7 @@ If the user provides a phone number without the `+` country code prefix, ask the
 Use this to show the guardian their active voice invites.
 
 ```bash
-curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/ingress/invites?sourceChannel=voice" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
+vellum integrations ingress invites --source-channel voice --json
 ```
 
 Optional query parameters:


### PR DESCRIPTION
## Summary
- replace SMS baseline/compliance retrieval snippets with `vellum integrations twilio ...` CLI commands
- replace trusted-contact member/invite retrieval snippets with `vellum integrations ingress ...` CLI commands
- replace Telegram bot config lookup in invite-link fallback flow with `vellum integrations telegram config --json`

## Validation
- verified updated docs no longer use direct gateway curl for retrieval/list/status steps in these two skills

Part of #11902
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
