### PR TITLE
fix: use managed source config in managed-to-self-hosted test

### DIFF
--- a/assistant/src/__tests__/migration-parity-persistence.test.ts
+++ b/assistant/src/__tests__/migration-parity-persistence.test.ts
@@ -819,19 +819,62 @@ describe("full end-to-end — managed-to-self-hosted migration", () => {
       expect(valScreen.preflight.summary.totalFiles).toBe(3);
     }
 
-    // Step 4: Transfer (runtime export + import)
+    // Step 4: Transfer (managed export via async polling + runtime import)
     const archiveBytes = new ArrayBuffer(32);
     const importResponse = makeImportSuccess();
 
-    const sourceFetch = (async () => {
-      return new Response(archiveBytes, {
-        status: 200,
-        headers: {
-          "Content-Disposition": 'attachment; filename="export.vbundle"',
-          "X-Vbundle-Schema-Version": "1.0",
-          "X-Vbundle-Manifest-Sha256": "abc",
-        },
-      });
+    let exportCallCount = 0;
+    const sourceFetch = (async (url: string | URL | Request) => {
+      const urlStr = String(url);
+      if (urlStr.endsWith("/export/")) {
+        // Managed export: initiate async job
+        return new Response(
+          JSON.stringify({ job_id: "exp-m2sh", status: "pending" }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+      if (urlStr.includes("/export/") && urlStr.includes("/status/")) {
+        exportCallCount++;
+        if (exportCallCount === 1) {
+          // First poll: still in progress
+          return new Response(
+            JSON.stringify({
+              job_id: "exp-m2sh",
+              status: "in_progress",
+              progress: 50,
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        }
+        // Second poll: complete with download URL
+        return new Response(
+          JSON.stringify({
+            job_id: "exp-m2sh",
+            status: "complete",
+            download_url: "https://platform.vellum.ai/downloads/exp-m2sh",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+      if (urlStr.includes("/downloads/")) {
+        // Download the exported archive
+        return new Response(archiveBytes, {
+          status: 200,
+          headers: {
+            "Content-Disposition": 'attachment; filename="export.vbundle"',
+          },
+        });
+      }
+      return new Response("Not found", { status: 404 });
     }) as unknown as typeof fetch;
 
     const destFetch = (async () => {
@@ -842,7 +885,7 @@ describe("full end-to-end — managed-to-self-hosted migration", () => {
     }) as unknown as typeof fetch;
 
     const transferOptions = makeExecutorOptions({
-      sourceConfig: runtimeConfig({ fetchFn: sourceFetch }),
+      sourceConfig: managedConfig({ fetchFn: sourceFetch }),
       destConfig: runtimeConfig({ fetchFn: destFetch }),
     });
 


### PR DESCRIPTION
Address review feedback from PR #11854:\n- Use managedConfig() instead of runtimeConfig() for sourceConfig in the managed-to-self-hosted flow test\n- Update sourceFetch mock to simulate the managed export path (async job creation + polling + download)\n- This ensures the test exercises the managed export/polling code path rather than the runtime export shortcut
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
