### PR TITLE
fix: re-throw unexpected parseAsync errors in runMcp

### DIFF
--- a/assistant/src/__tests__/mcp-cli.test.ts
+++ b/assistant/src/__tests__/mcp-cli.test.ts
@@ -104,6 +104,8 @@ async function runMcp(
     // Commander exitOverride throws on parse errors
     if (e && typeof e === "object" && "exitCode" in e) {
       process.exitCode = (e as { exitCode: number }).exitCode;
+    } else {
+      throw e;
     }
   } finally {
     process.stdout.write = origWrite;


### PR DESCRIPTION
Address review feedback from PR #11863:
- Re-throw exceptions that don't expose an `exitCode` instead of swallowing them
- Prevents silent success when `parseAsync` fails unexpectedly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11933" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
