### PR TITLE
feat: create contact-sync service to populate contacts from legacy tables

### DIFF
--- a/assistant/src/contacts/contact-sync.ts
+++ b/assistant/src/contacts/contact-sync.ts
@@ -1,0 +1,124 @@
+/**
+ * Sync service that populates the contacts table from legacy guardian-binding
+ * and ingress-member tables. Each function is idempotent — duplicates are
+ * prevented by address-based dedup in upsertContact.
+ */
+
+import { upsertContact } from './contact-store.js';
+import type { ChannelStatus } from './types.js';
+import { listActiveBindingsByAssistant } from '../memory/guardian-bindings.js';
+import type { GuardianBinding } from '../memory/guardian-bindings.js';
+import { listMembers } from '../memory/ingress-member-store.js';
+import type { IngressMember } from '../memory/ingress-member-store.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function parseDisplayNameFromMetadata(metadataJson: string | null): string | null {
+  if (!metadataJson) return null;
+  try {
+    const parsed = JSON.parse(metadataJson);
+    if (typeof parsed.displayName === 'string' && parsed.displayName.length > 0) {
+      return parsed.displayName;
+    }
+  } catch {
+    // Malformed JSON — fall through
+  }
+  return null;
+}
+
+// ── Guardian binding sync ────────────────────────────────────────────
+
+/**
+ * Sync all active guardian bindings for an assistant into the contacts table.
+ * Each binding creates (or updates) a contact with role 'guardian'.
+ */
+export function syncGuardianBindingsToContacts(assistantId: string): void {
+  const bindings = listActiveBindingsByAssistant(assistantId);
+  for (const binding of bindings) {
+    syncSingleGuardianBinding(binding);
+  }
+}
+
+/**
+ * Sync a single guardian binding into the contacts table.
+ * Useful for real-time forward-sync after a new binding is created.
+ */
+export function syncSingleGuardianBinding(binding: GuardianBinding): void {
+  const displayName =
+    parseDisplayNameFromMetadata(binding.metadataJson) ?? binding.guardianExternalUserId;
+
+  upsertContact({
+    displayName,
+    role: 'guardian',
+    principalId: binding.guardianPrincipalId,
+    channels: [
+      {
+        type: binding.channel,
+        address: binding.guardianExternalUserId,
+        externalUserId: binding.guardianExternalUserId,
+        externalChatId: binding.guardianDeliveryChatId,
+        status: 'active',
+        verifiedAt: binding.verifiedAt,
+        verifiedVia: binding.verifiedVia,
+      },
+    ],
+  });
+}
+
+// ── Ingress member sync ──────────────────────────────────────────────
+
+/**
+ * Sync all non-pending ingress members for an assistant into the contacts table.
+ * Members are always created with role 'contact' — guardian role is set only
+ * from guardian bindings.
+ */
+export function syncIngressMembersToContacts(assistantId: string): void {
+  const members = listMembers({ assistantId });
+  for (const member of members) {
+    if (member.status === 'pending') continue;
+    syncSingleMember(member);
+  }
+}
+
+/**
+ * Sync a single ingress member into the contacts table.
+ * Useful for real-time forward-sync after a member upsert.
+ */
+export function syncSingleMember(member: IngressMember): void {
+  // Skip members with no usable identity
+  if (!member.externalUserId && !member.externalChatId) return;
+
+  const displayName =
+    member.displayName ?? member.username ?? member.externalUserId ?? 'Unknown';
+
+  const address = member.externalUserId ?? member.externalChatId!;
+
+  upsertContact({
+    displayName,
+    role: 'contact',
+    channels: [
+      {
+        type: member.sourceChannel,
+        address,
+        externalUserId: member.externalUserId,
+        externalChatId: member.externalChatId,
+        status: member.status as ChannelStatus,
+        policy: member.policy as 'allow' | 'deny' | 'escalate',
+        inviteId: member.inviteId,
+      },
+    ],
+  });
+}
+
+// ── Bulk sync ────────────────────────────────────────────────────────
+
+/**
+ * Sync all guardian bindings and ingress members for an assistant.
+ * Guardian bindings are synced first so that guardian contacts exist before
+ * member sync — this lets upsertContact's address-based dedup merge them
+ * rather than creating duplicates.
+ */
+export function syncAllToContacts(assistantId: string): void {
+  syncGuardianBindingsToContacts(assistantId);
+  syncIngressMembersToContacts(assistantId);
+}


### PR DESCRIPTION
## Summary
- Creates contact-sync.ts with functions to sync guardian bindings and ingress members to the enriched contacts table
- Provides bulk sync (syncAllToContacts) for daemon startup and single-record sync helpers for real-time forward-sync
- Idempotent via address-based dedup in upsertContact

Part of plan: contact-centric-model.md (PR 4 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11934" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
