### PR TITLE
fix: error phase override when model has text response

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -48,10 +48,11 @@ struct AssistantProgressView: View {
         let hasTools = !toolCalls.isEmpty
         let hasIncompleteTools = hasTools && !allComplete
 
-        // Only enter error phase when ALL tools are done and at least one errored.
+        // Only enter error phase when ALL tools are done, at least one errored,
+        // and the model hasn't already produced a text response (i.e. it recovered).
         // While tools are still running, individual errors show as failed steps in the
         // expanded list without changing the overall phase.
-        if allComplete && toolCalls.contains(where: { $0.isError }) {
+        if allComplete && toolCalls.contains(where: { $0.isError }) && !hasText {
             return .error
         }
 


### PR DESCRIPTION
Fixes error phase unconditionally overriding complete/streaming state when a tool errored but the model recovered with a text response. Adds `&& !hasText` guard to the error phase check.

Addresses review feedback from Devin on #11930.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
