### PR TITLE
fix: resolve CI test failures in guardian endpoint tests

### DIFF
--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -360,7 +360,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
     const persistUserMessage = mock(async () => "should-not-be-called");
     const runAgentLoop = mock(async () => undefined);
     const session = {
-      setGuardianContext: () => {},
+      setTrustContext: () => {},
       setStateSignalListener: () => {},
       emitConfirmationStateChanged: () => {},
       emitActivityState: () => {},
@@ -374,7 +374,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       runAgentLoop,
       getMessages: () => [] as unknown[],
       assistantId: "self",
-      guardianContext: undefined,
+      trustContext: undefined,
       hasPendingConfirmation: (id: string) => id === "tool-req-code-1",
     } as unknown as import("../daemon/session.js").Session;
 
@@ -427,7 +427,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
     const persistUserMessage = mock(async () => "should-not-be-called");
     const runAgentLoop = mock(async () => undefined);
     const session = {
-      setGuardianContext: () => {},
+      setTrustContext: () => {},
       setStateSignalListener: () => {},
       emitConfirmationStateChanged: () => {},
       emitActivityState: () => {},
@@ -441,7 +441,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       runAgentLoop,
       getMessages: () => [] as unknown[],
       assistantId: "self",
-      guardianContext: undefined,
+      trustContext: undefined,
       hasPendingConfirmation: (id: string) => id === "pending-reject-1",
     } as unknown as import("../daemon/session.js").Session;
 
@@ -488,7 +488,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
     const persistUserMessage = mock(async () => "persisted-user-id");
     const runAgentLoop = mock(async () => undefined);
     const session = {
-      setGuardianContext: () => {},
+      setTrustContext: () => {},
       setStateSignalListener: () => {},
       emitConfirmationStateChanged: () => {},
       emitActivityState: () => {},
@@ -502,7 +502,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       runAgentLoop,
       getMessages: () => [] as unknown[],
       assistantId: "self",
-      guardianContext: undefined,
+      trustContext: undefined,
       hasPendingConfirmation: (id: string) => id === "pending-1",
     } as unknown as import("../daemon/session.js").Session;
 

--- a/assistant/src/__tests__/guardian-actions-endpoint.test.ts
+++ b/assistant/src/__tests__/guardian-actions-endpoint.test.ts
@@ -36,6 +36,24 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+// Bypass HTTP auth so requireBoundGuardian does not reject the test principal.
+mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
+
+// Prevent the IPC handler's resolveLocalIpcTrustContext from creating a real
+// guardian binding via ensureVellumGuardianBinding. Return a stable trust
+// context that the IPC handler tests can assert against.
+mock.module("../runtime/guardian-vellum-migration.js", () => ({
+  ensureVellumGuardianBinding: () => "test-principal",
+}));
+mock.module("../runtime/local-actor-identity.js", () => ({
+  resolveLocalIpcTrustContext: () => ({
+    trustClass: "guardian" as const,
+    sourceChannel: "vellum",
+    guardianExternalUserId: "test-principal",
+    guardianPrincipalId: "test-principal",
+  }),
+}));
+
 // Mock applyCanonicalGuardianDecision — the single decision write path.
 const mockApplyCanonicalGuardianDecision = mock(
   (
@@ -103,6 +121,7 @@ function resetTables(): void {
   db.run("DELETE FROM canonical_guardian_deliveries");
   db.run("DELETE FROM canonical_guardian_requests");
   db.run("DELETE FROM channel_guardian_approval_requests");
+  db.run("DELETE FROM channel_guardian_bindings");
   db.run("DELETE FROM conversations");
   mockApplyCanonicalGuardianDecision.mockClear();
 }


### PR DESCRIPTION
## Summary
- Fix 3 `conversation-routes-guardian-reply` tests that used old `setGuardianContext`/`guardianContext` API names (renamed to `setTrustContext`/`trustContext`)
- Fix `guardian-actions-endpoint` tests where IPC handler tests created real guardian bindings via `ensureVellumGuardianBinding`, contaminating subsequent HTTP tests with 403 auth failures
- Added mocks for `isHttpAuthDisabled`, `guardian-vellum-migration.js`, and `local-actor-identity.js` to isolate test state

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22647588434/job/65639256224

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
