### PR TITLE
Migrate twilio-setup and phone-calls retrieval to Vellum CLI

### DIFF
--- a/assistant/src/__tests__/integrations-cli.test.ts
+++ b/assistant/src/__tests__/integrations-cli.test.ts
@@ -97,6 +97,7 @@ describe('vellum integrations CLI', () => {
 
   afterEach(() => {
     delete process.env.GATEWAY_AUTH_TOKEN;
+    delete process.env.INTERNAL_GATEWAY_BASE_URL;
     process.exitCode = 0;
   });
 
@@ -121,6 +122,13 @@ describe('vellum integrations CLI', () => {
     expect(loadCalls).toBe(1);
     expect(initCalls).toBe(1);
     expect(mintCalls).toBe(1);
+  });
+
+  test('prefers INTERNAL_GATEWAY_BASE_URL when it is injected', async () => {
+    process.env.INTERNAL_GATEWAY_BASE_URL = 'http://gateway.internal:9900/';
+    const result = await runCli(['--json', 'twilio', 'config'], { success: true });
+    expect(result.exitCode).toBe(0);
+    expect(result.fetchCalls[0]?.url).toBe('http://gateway.internal:9900/v1/integrations/twilio/config');
   });
 
   test('passes channel query for guardian status', async () => {

--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -48,7 +48,10 @@ function toQueryString(params: Record<string, string | undefined>): string {
 }
 
 async function gatewayGet(path: string): Promise<unknown> {
-  const gatewayBase = getGatewayInternalBaseUrl();
+  const injectedGatewayBase = process.env.INTERNAL_GATEWAY_BASE_URL?.trim();
+  const gatewayBase = injectedGatewayBase && injectedGatewayBase.length > 0
+    ? injectedGatewayBase.replace(/\/+$/, '')
+    : getGatewayInternalBaseUrl();
   const token = getGatewayToken();
 
   const response = await fetch(`${gatewayBase}${path}`, {

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -41,8 +41,7 @@ The user's assistant gets its own personal phone number through Twilio. All impl
 Check whether Twilio credentials, phone number, and public ingress are already configured:
 
 ```bash
-curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/config" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
+vellum integrations twilio config --json
 ```
 
 ```bash
@@ -138,7 +137,7 @@ voice_config_update setting="tts_voice_id" value="<selected-voice-id>"
 
 Before making real calls, offer a quick verification:
 
-1. Confirm credentials are stored: check the Twilio config endpoint for `hasCredentials: true` and `phoneNumber`
+1. Confirm credentials are stored: run `vellum integrations twilio config --json` and verify `hasCredentials: true` plus `phoneNumber`
 2. Confirm ingress is running: `ingress.publicBaseUrl` must be set and the tunnel active
 3. Confirm calls are enabled: `calls.enabled` must be `true`
 4. Confirm voice is configured: `elevenlabs.voiceId` should be set
@@ -642,4 +641,3 @@ The system has a 30-second silence timeout. If nobody speaks for 30 seconds duri
 - Keep `elevenlabs.voiceModelId` empty first (bare `voiceId` mode)
 - If you set `voiceModelId`, try clearing it and retesting:
   `vellum config set elevenlabs.voiceModelId ""`
-

--- a/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
@@ -12,8 +12,7 @@ You are helping your user configure Twilio for voice calls and SMS messaging. Tw
 
 ```bash
 # 1. Check current status
-curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/config" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
+vellum integrations twilio config --json
 # 2. Store credentials (after collecting via credential_store prompt)
 curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/credentials" \
   -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" -H "Content-Type: application/json" \
@@ -35,7 +34,7 @@ This skill manages the full Twilio lifecycle:
 - **Phone number assignment** — Assign an existing Twilio number to the assistant
 - **Status checking** — Verify credentials and assigned number
 
-All operations go through the Twilio HTTP control-plane endpoints on the gateway, which validates inputs, stores credentials securely, and manages phone number state.
+Mutating operations use Twilio HTTP control-plane endpoints on the gateway. Status/list retrieval uses `vellum integrations ...` CLI reads.
 
 ### Multi-Assistant Setups
 
@@ -66,8 +65,7 @@ All HTTP examples below include the optional `assistantId` query parameter in as
 First, check whether Twilio is already configured:
 
 ```bash
-curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/config" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
+vellum integrations twilio config --json
 ```
 
 The response includes:
@@ -139,8 +137,7 @@ If ingress is not yet configured, webhook setup is skipped gracefully — the nu
 If the user already has a Twilio phone number, first list available numbers:
 
 ```bash
-curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/numbers" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
+vellum integrations twilio numbers --json
 ```
 
 The response includes a `numbers` array with each number's `phoneNumber`, `friendlyName`, and `capabilities` (voice, SMS). Present these to the user and let them choose.
@@ -204,8 +201,7 @@ Webhook URLs are automatically configured on the Twilio phone number when provis
 After configuration, verify by checking the config endpoint again.
 
 ```bash
-curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/config" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
+vellum integrations twilio config --json
 ```
 
 Confirm:
@@ -241,8 +237,7 @@ After the guardian-verify-setup skill completes (or the user skips), continue to
 To re-check guardian status later:
 
 ```bash
-curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/status?channel=voice" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
+vellum integrations guardian status --channel voice --json
 ```
 
 ## Step 6: Enable Features


### PR DESCRIPTION
## Summary
- migrate Twilio status/list retrieval snippets in `twilio-setup` to `vellum integrations twilio ...` reads
- migrate voice guardian-status recheck in `twilio-setup` to `vellum integrations guardian status`
- migrate `phone-calls` Twilio readiness retrieval to `vellum integrations twilio config`

## Validation
- verified retrieval snippets in these files now use Vellum CLI read commands instead of direct gateway curls

Part of #11903
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
