### PR TITLE
feat: wire contact-sync into daemon startup and guardian/member writes

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -19,6 +19,7 @@ import {
 } from "../config/env.js";
 import { loadConfig } from "../config/loader.js";
 import { ensurePromptFiles } from "../config/system-prompt.js";
+import { syncAllToContacts } from "../contacts/contact-sync.js";
 import { syncUpdateBulletinOnStartup } from "../config/update-bulletin.js";
 import { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { getHookManager } from "../hooks/manager.js";
@@ -198,6 +199,16 @@ export async function runDaemon(): Promise<void> {
         { err },
         "Vellum guardian binding backfill failed — continuing startup",
       );
+    }
+
+    // Populate the contacts table from existing guardian bindings and ingress
+    // members. Runs once on each startup as a catchup pass — individual writes
+    // are forward-synced in guardian-bindings.ts and ingress-member-store.ts.
+    try {
+      syncAllToContacts("self");
+      log.info("Daemon startup: contact sync complete");
+    } catch (err) {
+      log.warn({ err }, "Contact sync failed — continuing startup");
     }
 
     try {

--- a/assistant/src/memory/guardian-bindings.ts
+++ b/assistant/src/memory/guardian-bindings.ts
@@ -8,6 +8,7 @@
 import { and, asc, desc, eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
+import { syncSingleGuardianBinding } from '../contacts/contact-sync.js';
 import { getDb } from './db.js';
 import { channelGuardianBindings } from './schema.js';
 
@@ -87,7 +88,10 @@ export function createBinding(params: {
 
   db.insert(channelGuardianBindings).values(row).run();
 
-  return rowToBinding(row);
+  const binding = rowToBinding(row);
+  syncSingleGuardianBinding(binding);
+
+  return binding;
 }
 
 export function getActiveBinding(assistantId: string, channel: string): GuardianBinding | null {

--- a/assistant/src/memory/ingress-member-store.ts
+++ b/assistant/src/memory/ingress-member-store.ts
@@ -8,6 +8,7 @@
 import { and, desc, eq, or } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
+import { syncSingleMember } from '../contacts/contact-sync.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { getDb } from './db.js';
 import { assistantIngressMembers } from './schema.js';
@@ -140,7 +141,9 @@ export function upsertMember(params: {
       .where(eq(assistantIngressMembers.id, existing.id))
       .get();
 
-    return rowToMember(updated!);
+    const member = rowToMember(updated!);
+    syncSingleMember(member);
+    return member;
   }
 
   // Create a new member
@@ -166,7 +169,9 @@ export function upsertMember(params: {
 
   db.insert(assistantIngressMembers).values(row).run();
 
-  return rowToMember(row);
+  const member = rowToMember(row);
+  syncSingleMember(member);
+  return member;
 }
 
 // ---------------------------------------------------------------------------
@@ -248,7 +253,10 @@ export function revokeMember(memberId: string, reason?: string): IngressMember |
     .where(eq(assistantIngressMembers.id, memberId))
     .get();
 
-  return updated ? rowToMember(updated) : null;
+  if (!updated) return null;
+  const member = rowToMember(updated);
+  syncSingleMember(member);
+  return member;
 }
 
 // ---------------------------------------------------------------------------
@@ -287,7 +295,10 @@ export function blockMember(memberId: string, reason?: string): IngressMember | 
     .where(eq(assistantIngressMembers.id, memberId))
     .get();
 
-  return updated ? rowToMember(updated) : null;
+  if (!updated) return null;
+  const member = rowToMember(updated);
+  syncSingleMember(member);
+  return member;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Calls syncAllToContacts() during daemon startup after migrations to backfill contacts from existing data
- Adds forward-sync hooks in guardian-bindings.ts (createBinding) and ingress-member-store.ts (upsertMember, revokeMember, blockMember)
- Ensures contacts table stays in sync as legacy tables are written to

Part of plan: contact-centric-model.md (PR 6 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
