### PR TITLE
fix: validate bundle before closing DB to avoid unnecessary reset on invalid imports

### DIFF
--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -339,6 +339,17 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
   }
 
   try {
+    // Validate the bundle before closing the DB to avoid an unnecessary
+    // close/reopen cycle when the bundle is invalid.
+    const validation = validateVBundle(fileData);
+    if (!validation.is_valid) {
+      return Response.json({
+        success: false,
+        reason: "validation_failed",
+        errors: validation.errors,
+      });
+    }
+
     const pathResolver = new DefaultPathResolver(
       getDbPath(),
       getWorkspaceConfigPath(),


### PR DESCRIPTION
Addresses reviewer feedback on #11926:

- Call validateVBundle() before resetDb() so invalid bundles are rejected without disrupting the live SQLite connection
- Only close the DB connection when validation passes and we're about to write files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
