### PR TITLE
fix: distinguish download vs import failures in inferFailedPhase

### DIFF
--- a/assistant/src/runtime/migrations/transfer-progress-screen.ts
+++ b/assistant/src/runtime/migrations/transfer-progress-screen.ts
@@ -146,8 +146,15 @@ function inferFailedPhase(
   if (state.exportResult && !state.importResult) {
     if ("jobId" in state.exportResult) {
       const managed = state.exportResult as ExportManagedResult;
-      // If the managed export completed, the failure was after export (download or import)
       if (managed.status === "complete") {
+        // Export completed but no importResult -- check whether the failure was
+        // during archive download (between export and import) or during import.
+        // Download failures surface as HTTP/transport errors with "download" in
+        // the message; actual import failures would have set importResult.
+        const msg = stepError.message?.toLowerCase() ?? "";
+        if (msg.includes("download") || msg.includes("http")) {
+          return "poll";
+        }
         return "import";
       }
       return "poll";


### PR DESCRIPTION
Addresses reviewer feedback on #11920:\n\n- When a managed export completes but no importResult exists, check error context to distinguish download failures from actual import failures\n- Download failures (error messages containing 'download' or 'http') are now correctly classified as poll-phase failures instead of being misattributed to the import phase\n- Fixes a failing test that expected poll phase for download failures
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
