### PR TITLE
fix: raise decompression limit and fix Step 7 archive-exists check

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-validator.ts
@@ -174,8 +174,8 @@ function canonicalizeJson(obj: unknown): string {
 
 const REQUIRED_ENTRIES = ["manifest.json", "data/db/assistant.db"];
 
-// 500 MB — reasonable upper bound for a decompressed vbundle tar
-const MAX_DECOMPRESSED_SIZE = 500 * 1024 * 1024;
+// 2 GB — must accommodate large but valid migrations from buildExportVBundle()
+const MAX_DECOMPRESSED_SIZE = 2 * 1024 * 1024 * 1024;
 
 /**
  * Validate a .vbundle archive from raw bytes.
@@ -328,6 +328,7 @@ export function validateVBundle(data: Uint8Array): VBundleValidationResult {
   // checksum in the manifest — presence in the archive alone is not enough.
   for (const required of REQUIRED_ENTRIES) {
     if (required === "manifest.json") continue;
+    if (!entryMap.has(required)) continue;
     if (!manifestFilePaths.has(required)) {
       errors.push({
         code: "REQUIRED_FILE_NOT_IN_MANIFEST",


### PR DESCRIPTION
Addresses reviewer feedback on #11924:

- Increase MAX_DECOMPRESSED_SIZE from 500MB to 2GB to avoid rejecting valid large migrations
- Guard Step 7 with entryMap.has(required) check to prevent misleading 'exists in archive' error when file is actually missing from both archive and manifest
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
