### PR TITLE
fix: sync gateway feature-flag-registry with canonical copy

### DIFF
--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -72,6 +72,14 @@
       "label": "Local HTTP Enabled",
       "description": "Enable local HTTP transport mode in macOS app",
       "defaultEnabled": false
+    },
+    {
+      "id": "command-palette",
+      "scope": "assistant",
+      "key": "feature_flags.command-palette.enabled",
+      "label": "Command Palette",
+      "description": "Enable the CMD+K command palette for unified search across conversations, memories, schedules, and contacts",
+      "defaultEnabled": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add missing `command-palette` feature flag entry to `gateway/src/feature-flag-registry.json` to match the canonical `meta/feature-flags/feature-flag-registry.json`

## Original prompt
fix this ci issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22648170326/job/65641112061

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
