### PR TITLE
fix: set can_import false on conflicts and add skip action for unknown paths

### DIFF
--- a/assistant/src/__tests__/migration-cross-version-compatibility.test.ts
+++ b/assistant/src/__tests__/migration-cross-version-compatibility.test.ts
@@ -350,6 +350,7 @@ interface ImportDryRunResponse {
     files_to_create: number;
     files_to_overwrite: number;
     files_unchanged: number;
+    files_to_skip: number;
   };
   files?: Array<{
     path: string;

--- a/assistant/src/__tests__/migration-import-preflight-http.test.ts
+++ b/assistant/src/__tests__/migration-import-preflight-http.test.ts
@@ -274,6 +274,7 @@ interface ImportDryRunResponse {
     files_to_create: number;
     files_to_overwrite: number;
     files_unchanged: number;
+    files_to_skip: number;
   };
   files: Array<{
     path: string;
@@ -350,10 +351,12 @@ describe("handleMigrationImportPreflight", () => {
       (f) => f.action === "overwrite",
     ).length;
     const unchanged = body.files.filter((f) => f.action === "unchanged").length;
+    const skips = body.files.filter((f) => f.action === "skip").length;
 
     expect(body.summary.files_to_create).toBe(creates);
     expect(body.summary.files_to_overwrite).toBe(overwrites);
     expect(body.summary.files_unchanged).toBe(unchanged);
+    expect(body.summary.files_to_skip).toBe(skips);
   });
 
   test("detects overwrite when bundle db differs from disk", async () => {
@@ -601,7 +604,7 @@ describe("analyzeImport", () => {
     expect(report.summary.files_to_overwrite).toBe(1);
   });
 
-  test("flags unknown archive paths as conflicts", () => {
+  test("flags unknown archive paths as conflicts with skip action", () => {
     const resolver = new DefaultPathResolver(testDbPath, testConfigPath);
 
     const report = analyzeImport({
@@ -625,9 +628,18 @@ describe("analyzeImport", () => {
       pathResolver: resolver,
     });
 
+    expect(report.can_import).toBe(false);
     expect(report.conflicts.length).toBe(1);
     expect(report.conflicts[0].code).toBe("UNKNOWN_ARCHIVE_PATH");
     expect(report.conflicts[0].path).toBe("unknown/extra-file.bin");
+
+    const unknownFile = report.files.find(
+      (f) => f.path === "unknown/extra-file.bin",
+    );
+    expect(unknownFile).toBeDefined();
+    expect(unknownFile!.action).toBe("skip");
+    expect(report.summary.files_to_skip).toBe(1);
+    expect(report.summary.files_to_create).toBe(0);
   });
 
   test("includes manifest in report", () => {

--- a/assistant/src/__tests__/migration-parity-persistence.test.ts
+++ b/assistant/src/__tests__/migration-parity-persistence.test.ts
@@ -155,6 +155,7 @@ function makePreflightSuccess(): ImportPreflightResponse {
       files_to_create: 1,
       files_to_overwrite: 1,
       files_unchanged: 1,
+      files_to_skip: 0,
     },
     files: [
       {

--- a/assistant/src/__tests__/migration-transport.test.ts
+++ b/assistant/src/__tests__/migration-transport.test.ts
@@ -346,6 +346,7 @@ describe("importPreflight", () => {
         files_to_create: 0,
         files_to_overwrite: 2,
         files_unchanged: 0,
+        files_to_skip: 0,
       },
       files: [
         {
@@ -781,6 +782,7 @@ describe("Multi-step flow behavior", () => {
               files_to_create: 1,
               files_to_overwrite: 0,
               files_unchanged: 0,
+              files_to_skip: 0,
             },
             files: [],
             conflicts: [],

--- a/assistant/src/__tests__/migration-wizard.test.ts
+++ b/assistant/src/__tests__/migration-wizard.test.ts
@@ -473,6 +473,7 @@ describe("executePreflightStep", () => {
         files_to_create: 1,
         files_to_overwrite: 1,
         files_unchanged: 0,
+        files_to_skip: 0,
       },
       files: [
         {
@@ -1108,6 +1109,7 @@ describe("full wizard flow", () => {
         files_to_create: 1,
         files_to_overwrite: 0,
         files_unchanged: 0,
+        files_to_skip: 0,
       },
       files: [],
       conflicts: [],

--- a/assistant/src/__tests__/rebind-secrets-screen.test.ts
+++ b/assistant/src/__tests__/rebind-secrets-screen.test.ts
@@ -79,6 +79,7 @@ function makePreflightSuccess(): ImportPreflightResponse {
       files_to_create: 1,
       files_to_overwrite: 1,
       files_unchanged: 1,
+      files_to_skip: 0,
     },
     files: [
       {

--- a/assistant/src/__tests__/transfer-progress-screen.test.ts
+++ b/assistant/src/__tests__/transfer-progress-screen.test.ts
@@ -131,6 +131,7 @@ function makePreflightSuccess(): ImportPreflightResponse {
       files_to_create: 1,
       files_to_overwrite: 1,
       files_unchanged: 1,
+      files_to_skip: 0,
     },
     files: [
       {

--- a/assistant/src/__tests__/validation-results-screen.test.ts
+++ b/assistant/src/__tests__/validation-results-screen.test.ts
@@ -194,6 +194,7 @@ function makePreflightSuccess(): ImportPreflightResponse {
       files_to_create: 2,
       files_to_overwrite: 2,
       files_unchanged: 1,
+      files_to_skip: 0,
     },
     files: [
       {

--- a/assistant/src/runtime/migrations/migration-transport.ts
+++ b/assistant/src/runtime/migrations/migration-transport.ts
@@ -116,7 +116,7 @@ export type ExportResult = ExportRuntimeResult | ExportManagedResult;
 
 export interface ImportPreflightFileReport {
   path: string;
-  action: "create" | "overwrite" | "unchanged";
+  action: "create" | "overwrite" | "unchanged" | "skip";
   bundle_size: number;
   current_size: number | null;
   bundle_sha256: string;
@@ -136,6 +136,7 @@ export interface ImportPreflightSuccessResponse {
     files_to_create: number;
     files_to_overwrite: number;
     files_unchanged: number;
+    files_to_skip: number;
   };
   files: ImportPreflightFileReport[];
   conflicts: ImportPreflightConflict[];

--- a/assistant/src/runtime/migrations/validation-results-screen.ts
+++ b/assistant/src/runtime/migrations/validation-results-screen.ts
@@ -49,12 +49,13 @@ export interface PreflightSummary {
   filesToCreate: number;
   filesToOverwrite: number;
   filesUnchanged: number;
+  filesToSkip: number;
 }
 
 /** A file entry in the preflight analysis, normalized for display. */
 export interface PreflightFileEntry {
   path: string;
-  action: "create" | "overwrite" | "unchanged";
+  action: "create" | "overwrite" | "unchanged" | "skip";
   bundleSize: number;
   currentSize: number | null;
   bundleSha256: string;
@@ -280,6 +281,7 @@ export function deriveValidationScreenState(
           filesToCreate: preflightResult.summary.files_to_create,
           filesToOverwrite: preflightResult.summary.files_to_overwrite,
           filesUnchanged: preflightResult.summary.files_unchanged,
+          filesToSkip: preflightResult.summary.files_to_skip,
         },
         files: preflightResult.files.map(normalizeFileReport),
         conflicts: preflightResult.conflicts.map(normalizeConflict),
@@ -311,6 +313,7 @@ export function deriveValidationScreenState(
             filesToCreate: pr.summary.files_to_create,
             filesToOverwrite: pr.summary.files_to_overwrite,
             filesUnchanged: pr.summary.files_unchanged,
+            filesToSkip: pr.summary.files_to_skip,
           },
           files: pr.files.map(normalizeFileReport),
           conflicts: pr.conflicts.map(normalizeConflict),
@@ -422,10 +425,12 @@ export function groupFilesByAction(files: PreflightFileEntry[]): {
   create: PreflightFileEntry[];
   overwrite: PreflightFileEntry[];
   unchanged: PreflightFileEntry[];
+  skip: PreflightFileEntry[];
 } {
   const create: PreflightFileEntry[] = [];
   const overwrite: PreflightFileEntry[] = [];
   const unchanged: PreflightFileEntry[] = [];
+  const skip: PreflightFileEntry[] = [];
 
   for (const file of files) {
     switch (file.action) {
@@ -438,10 +443,13 @@ export function groupFilesByAction(files: PreflightFileEntry[]): {
       case "unchanged":
         unchanged.push(file);
         break;
+      case "skip":
+        skip.push(file);
+        break;
     }
   }
 
-  return { create, overwrite, unchanged };
+  return { create, overwrite, unchanged, skip };
 }
 
 /**

--- a/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
@@ -22,7 +22,7 @@ import type { ManifestType } from "./vbundle-validator.js";
 // Public types
 // ---------------------------------------------------------------------------
 
-export type ImportAction = "create" | "overwrite" | "unchanged";
+export type ImportAction = "create" | "overwrite" | "unchanged" | "skip";
 
 export interface ImportFileReport {
   /** Archive path (e.g. "data/db/assistant.db") */
@@ -54,6 +54,7 @@ export interface ImportDryRunReport {
     files_to_create: number;
     files_to_overwrite: number;
     files_unchanged: number;
+    files_to_skip: number;
   };
   /** Per-file analysis of what would change */
   files: ImportFileReport[];
@@ -136,7 +137,7 @@ export function analyzeImport(
       });
       files.push({
         path: fileEntry.path,
-        action: "create",
+        action: "skip",
         bundle_size: fileEntry.size,
         bundle_sha256: fileEntry.sha256,
         current_size: null,
@@ -198,10 +199,11 @@ export function analyzeImport(
     files_to_create: files.filter((f) => f.action === "create").length,
     files_to_overwrite: files.filter((f) => f.action === "overwrite").length,
     files_unchanged: files.filter((f) => f.action === "unchanged").length,
+    files_to_skip: files.filter((f) => f.action === "skip").length,
   };
 
   return {
-    can_import: true,
+    can_import: conflicts.length === 0,
     summary,
     files,
     conflicts,


### PR DESCRIPTION
Addresses reviewer feedback on #11781:

- Set can_import to false when conflicts are present (UNKNOWN_ARCHIVE_PATH, UNREADABLE_EXISTING_FILE)
- Add 'skip' action type for files with unknown archive paths instead of incorrectly marking them as 'create'
- Add files_to_skip count to summary, exclude skipped files from files_to_create
- Update transport types, validation-results-screen, and all test mocks to include the new field
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
