### PR TITLE
feat: add contacts IPC message types and DaemonClient methods for macOS

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -503,6 +503,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `generate_avatar_response` message.
     public var onGenerateAvatarResponse: ((IPCGenerateAvatarResponse) -> Void)?
 
+    /// Called when the daemon sends a `contacts_response` message.
+    public var onContactsResponse: ((ContactsResponseMessage) -> Void)?
+
     // MARK: - Broadcast Subscribers
 
     /// Creates a new message stream for the caller. Each subscriber receives all messages
@@ -1510,6 +1513,23 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Submit a guardian action decision.
     public func sendGuardianActionDecision(requestId: String, action: String, conversationId: String? = nil) throws {
         try send(GuardianActionDecisionMessage(requestId: requestId, action: action, conversationId: conversationId))
+    }
+
+    // MARK: - Contacts Management
+
+    /// Request the list of all contacts from the daemon, optionally filtered by role.
+    public func sendListContacts(role: String? = nil, limit: Int? = nil) throws {
+        try send(ContactsRequestMessage(action: "list", role: role, limit: limit))
+    }
+
+    /// Request a single contact by ID.
+    public func sendGetContact(contactId: String) throws {
+        try send(ContactsRequestMessage(action: "get", contactId: contactId))
+    }
+
+    /// Update a contact channel's status and/or policy.
+    public func sendUpdateContactChannel(channelId: String, status: String? = nil, policy: String? = nil, reason: String? = nil) throws {
+        try send(ContactsRequestMessage(action: "update_channel", channelId: channelId, status: status, policy: policy, reason: reason))
     }
 
     // MARK: - Feature Flags

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -276,6 +276,8 @@ extension DaemonClient {
             onAvatarUpdated?(msg)
         case .generateAvatarResponse(let msg):
             onGenerateAvatarResponse?(msg)
+        case .contactsResponse(let msg):
+            onContactsResponse?(msg)
         default:
             break
         }

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -834,6 +834,105 @@ public struct IPCConfirmationSurfaceData: Codable, Sendable {
     }
 }
 
+public struct IPCContactChannelPayload: Codable, Sendable {
+    public let id: String
+    public let type: String
+    public let address: String
+    public let isPrimary: Bool
+    public let externalUserId: String?
+    public let status: String
+    public let policy: String
+    public let verifiedAt: Int?
+    public let verifiedVia: String?
+    public let lastSeenAt: Int?
+    public let revokedReason: String?
+    public let blockedReason: String?
+
+    public init(id: String, type: String, address: String, isPrimary: Bool, externalUserId: String? = nil, status: String, policy: String, verifiedAt: Int? = nil, verifiedVia: String? = nil, lastSeenAt: Int? = nil, revokedReason: String? = nil, blockedReason: String? = nil) {
+        self.id = id
+        self.type = type
+        self.address = address
+        self.isPrimary = isPrimary
+        self.externalUserId = externalUserId
+        self.status = status
+        self.policy = policy
+        self.verifiedAt = verifiedAt
+        self.verifiedVia = verifiedVia
+        self.lastSeenAt = lastSeenAt
+        self.revokedReason = revokedReason
+        self.blockedReason = blockedReason
+    }
+}
+
+public struct IPCContactPayload: Codable, Sendable {
+    public let id: String
+    public let displayName: String
+    public let role: String
+    public let relationship: String?
+    public let importance: Double
+    public let lastInteraction: Double?
+    public let interactionCount: Int
+    public let channels: [IPCContactChannelPayload]
+
+    public init(id: String, displayName: String, role: String, relationship: String? = nil, importance: Double, lastInteraction: Double? = nil, interactionCount: Int, channels: [IPCContactChannelPayload]) {
+        self.id = id
+        self.displayName = displayName
+        self.role = role
+        self.relationship = relationship
+        self.importance = importance
+        self.lastInteraction = lastInteraction
+        self.interactionCount = interactionCount
+        self.channels = channels
+    }
+}
+
+public struct IPCContactsRequest: Codable, Sendable {
+    public let type: String
+    public let action: String
+    /// Contact ID (get only).
+    public let contactId: String?
+    /// Channel ID (update_channel only).
+    public let channelId: String?
+    /// New status for channel (update_channel only).
+    public let status: String?
+    /// New policy for channel (update_channel only).
+    public let policy: String?
+    /// Reason for status change (update_channel only).
+    public let reason: String?
+    /// Filter by role (list only).
+    public let role: String?
+    /// Limit (list only).
+    public let limit: Double?
+
+    public init(type: String, action: String, contactId: String? = nil, channelId: String? = nil, status: String? = nil, policy: String? = nil, reason: String? = nil, role: String? = nil, limit: Double? = nil) {
+        self.type = type
+        self.action = action
+        self.contactId = contactId
+        self.channelId = channelId
+        self.status = status
+        self.policy = policy
+        self.reason = reason
+        self.role = role
+        self.limit = limit
+    }
+}
+
+public struct IPCContactsResponse: Codable, Sendable {
+    public let type: String
+    public let success: Bool
+    public let error: String?
+    public let contact: IPCContactPayload?
+    public let contacts: [IPCContactPayload]?
+
+    public init(type: String, success: Bool, error: String? = nil, contact: IPCContactPayload? = nil, contacts: [IPCContactPayload]? = nil) {
+        self.type = type
+        self.success = success
+        self.error = error
+        self.contact = contact
+        self.contacts = contacts
+    }
+}
+
 public struct IPCContextCompacted: Codable, Sendable {
     public let type: String
     public let previousEstimatedInputTokens: Int

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2279,6 +2279,7 @@ public enum ServerMessage: Decodable, Sendable {
     case heartbeatChecklistResponse(IPCHeartbeatChecklistResponse)
     case heartbeatChecklistWriteResponse(IPCHeartbeatChecklistWriteResponse)
     case messageContentResponse(IPCMessageContentResponse)
+    case contactsResponse(ContactsResponseMessage)
     case tokenRotated(TokenRotatedMessage)
     case identityChanged(IPCIdentityChanged)
     case pong
@@ -2716,6 +2717,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "message_content_response":
             let message = try IPCMessageContentResponse(from: decoder)
             self = .messageContentResponse(message)
+        case "contacts_response":
+            let message = try ContactsResponseMessage(from: decoder)
+            self = .contactsResponse(message)
         case "token_rotated":
             let message = try TokenRotatedMessage(from: decoder)
             self = .tokenRotated(message)
@@ -2910,6 +2914,34 @@ public struct GuardianActionDecisionMessage: Encodable, Sendable {
         self.conversationId = conversationId
     }
 }
+
+// MARK: - Contacts
+
+/// Client → Server: contacts management request.
+/// Backed by generated `IPCContactsRequest`.
+public typealias ContactsRequestMessage = IPCContactsRequest
+
+extension IPCContactsRequest {
+    public init(action: String, contactId: String? = nil, channelId: String? = nil, status: String? = nil, policy: String? = nil, reason: String? = nil, role: String? = nil, limit: Int? = nil) {
+        self.init(type: "contacts", action: action, contactId: contactId, channelId: channelId, status: status, policy: policy, reason: reason, role: role, limit: limit.map(Double.init))
+    }
+}
+
+/// Server → Client: contacts response.
+/// Backed by generated `IPCContactsResponse`.
+public typealias ContactsResponseMessage = IPCContactsResponse
+
+/// A single contact payload returned from the daemon.
+/// Backed by generated `IPCContactPayload`.
+public typealias ContactPayload = IPCContactPayload
+
+extension IPCContactPayload: Identifiable {}
+
+/// A single contact channel payload returned from the daemon.
+/// Backed by generated `IPCContactChannelPayload`.
+public typealias ContactChannelPayload = IPCContactChannelPayload
+
+extension IPCContactChannelPayload: Identifiable {}
 
 // MARK: - Work Item Helpers
 


### PR DESCRIPTION
## Summary
- Adds ContactsRequestMessage, ContactsResponseMessage, ContactPayload, and ContactChannelPayload Codable structs to the Swift IPC layer
- Adds onContactsResponse callback and message routing in DaemonClient
- Adds sendListContacts, sendGetContact, and sendUpdateContactChannel convenience methods

Part of plan: contact-centric-model.md (PR 7 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
