### PR TITLE
fix: align transfer progress view model with import-only transfer flow

### DIFF
--- a/assistant/src/__tests__/transfer-progress-screen.test.ts
+++ b/assistant/src/__tests__/transfer-progress-screen.test.ts
@@ -279,29 +279,29 @@ describe("deriveTransferScreenState -- disabled", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Exporting state
+// Importing state (default phase -- import-only flow)
 // ---------------------------------------------------------------------------
 
-describe("deriveTransferScreenState -- exporting", () => {
-  test("shows exporting when transfer step is idle (preparing)", () => {
+describe("deriveTransferScreenState -- importing (default)", () => {
+  test("shows importing when transfer step is idle (preparing)", () => {
     const state = advanceTo("transfer");
     const screen = deriveTransferScreenState(state);
-    expect(screen.phase).toBe("exporting");
-    if (screen.phase === "exporting") {
-      expect(screen.message).toContain("Exporting");
+    expect(screen.phase).toBe("importing");
+    if (screen.phase === "importing") {
+      expect(screen.message).toContain("Importing");
     }
   });
 
-  test("shows exporting when transfer step is loading with no export result", () => {
+  test("shows importing when transfer step is loading with no export result", () => {
     let state = advanceTo("transfer");
     state = {
       ...state,
       steps: { ...state.steps, transfer: { status: "loading" } },
     };
     const screen = deriveTransferScreenState(state);
-    expect(screen.phase).toBe("exporting");
-    if (screen.phase === "exporting") {
-      expect(screen.message).toContain("Exporting");
+    expect(screen.phase).toBe("importing");
+    if (screen.phase === "importing") {
+      expect(screen.message).toContain("Importing");
     }
   });
 });
@@ -494,7 +494,7 @@ describe("deriveTransferScreenState -- error", () => {
     }
   });
 
-  test("infers failed phase as export when no export result exists", () => {
+  test("infers failed phase as import when no export result exists (import-only flow)", () => {
     let state = advanceTo("transfer");
     state = {
       ...state,
@@ -503,7 +503,7 @@ describe("deriveTransferScreenState -- error", () => {
         transfer: {
           status: "error",
           error: {
-            message: "export: HTTP 503",
+            message: "import: HTTP 503",
             code: "HTTP_503",
             retryable: true,
           },
@@ -512,7 +512,7 @@ describe("deriveTransferScreenState -- error", () => {
     };
     const screen = deriveTransferScreenState(state);
     if (screen.phase === "error") {
-      expect(screen.failedPhase).toBe("export");
+      expect(screen.failedPhase).toBe("import");
     }
   });
 
@@ -885,7 +885,7 @@ describe("executeTransferFlow", () => {
     expect(result.currentStep).toBe("rebind-secrets");
   });
 
-  test("export failure sets error state", async () => {
+  test("transfer failure sets error state with import phase", async () => {
     const state = advanceTo("transfer");
     const options = makeExecutorOptions({
       sourceConfig: runtimeConfig({ fetchFn: mockFetch(500, "Server Error") }),
@@ -898,7 +898,7 @@ describe("executeTransferFlow", () => {
     expect(screen.phase).toBe("error");
     if (screen.phase === "error") {
       expect(screen.canRetry).toBe(true);
-      expect(screen.failedPhase).toBe("export");
+      expect(screen.failedPhase).toBe("import");
     }
   });
 
@@ -1023,7 +1023,7 @@ describe("executeTransferFlow -- onStateChange callbacks", () => {
 
     // Should have gone through at least the loading state
     const phases = stateChanges.map((s) => s.phase);
-    expect(phases).toContain("exporting");
+    expect(phases).toContain("importing");
   });
 });
 

--- a/assistant/src/runtime/migrations/transfer-progress-screen.ts
+++ b/assistant/src/runtime/migrations/transfer-progress-screen.ts
@@ -5,16 +5,17 @@
  * a transfer/import progress UI. Usable from macOS/iOS web views, CLI, or
  * any TypeScript consumer.
  *
- * The transfer step involves two phases:
- *   1. Export -- export data from the source (runtime: synchronous, managed: async with polling)
- *   2. Import -- commit the exported bundle to the destination
+ * The transfer step is import-only: it commits a pre-uploaded bundle to
+ * the destination. The export/poll phases are retained in the type system
+ * for managed-source flows that still use them, but the default phase is
+ * "import".
  *
  * View model states:
  *   - disabled: step is not yet accessible (earlier steps incomplete)
- *   - exporting: export phase is in progress
+ *   - exporting: export phase is in progress (managed-source flows only)
  *   - polling: managed async export job is being polled for completion
- *   - importing: import phase is in progress (export completed, importing bundle)
- *   - success: both export and import completed successfully
+ *   - importing: import phase is in progress
+ *   - success: import completed successfully
  *   - error: an error occurred (with retry capability info)
  */
 
@@ -81,34 +82,19 @@ export type TransferScreenState =
 /**
  * Infer which transfer sub-phase is active based on wizard state.
  *
- * Heuristic:
- * - If exportResult exists and has a jobId (managed) but no importResult,
- *   we are in the polling/download phase.
- * - If exportResult exists (runtime or managed complete) but no importResult,
- *   we are in the import phase.
- * - Otherwise we are in the export phase.
+ * The default flow is import-only (bundleData provided directly). Managed
+ * export flows that populate exportResult still get poll/export phases.
  */
 function inferActivePhase(state: MigrationWizardState): TransferPhase {
-  if (!state.exportResult) {
-    return "export";
-  }
-
-  // Managed export that may still be polling
-  if ("jobId" in state.exportResult) {
+  // Managed export flows that populate exportResult
+  if (state.exportResult && "jobId" in state.exportResult) {
     const managed = state.exportResult as ExportManagedResult;
-    // If we have an importResult, polling is done and import has started/finished
     if (state.importResult) {
       return "import";
     }
-    // Still in polling/export phase
     if (managed.status !== "complete") {
       return "poll";
     }
-  }
-
-  // Export is done; if no import result yet, we are importing
-  if (!state.importResult) {
-    return "import";
   }
 
   return "import";
@@ -131,9 +117,9 @@ function inferFailedPhase(
     return "export";
   }
 
-  // If we have no export result, the export itself failed
+  // No exportResult means this is the import-only flow; attribute to import
   if (!state.exportResult) {
-    return "export";
+    return "import";
   }
 
   // If we have an export result but the error mentions import
@@ -221,17 +207,17 @@ export function deriveTransferScreenState(
       };
     }
 
-    if (activePhase === "import") {
+    if (activePhase === "export") {
       return {
-        phase: "importing",
-        message: "Importing bundle to destination...",
+        phase: "exporting",
+        message: "Exporting data from source...",
       };
     }
 
-    // Default: export phase
+    // Default: import phase
     return {
-      phase: "exporting",
-      message: "Exporting data from source...",
+      phase: "importing",
+      message: "Importing bundle to destination...",
     };
   }
 
@@ -303,7 +289,6 @@ export async function retryTransferFlow(
   const reset = resetStepForRetry(state);
   const cleaned = {
     ...reset,
-    exportResult: undefined,
     importResult: undefined,
   };
   options.onStateChange?.(cleaned);


### PR DESCRIPTION
Addresses reviewer feedback on #11925:\n\n- Update inferActivePhase() to return 'import' as default phase since export phase was removed\n- Update inferFailedPhase() to attribute failures to 'import' when exportResult is absent\n- Change default loading message from 'Exporting data from source...' to 'Importing bundle to destination...'\n- Remove no-op exportResult clearing in retryTransferFlow()\n- Update tests to match new behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11947" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
