### PR TITLE
fix: handle can_import false from conflicts without crashing on missing validation

### DIFF
--- a/assistant/src/runtime/migrations/migration-transport.ts
+++ b/assistant/src/runtime/migrations/migration-transport.ts
@@ -151,9 +151,24 @@ export interface ImportPreflightValidationFailedResponse {
   };
 }
 
+export interface ImportPreflightConflictResponse {
+  can_import: false;
+  summary: {
+    total_files: number;
+    files_to_create: number;
+    files_to_overwrite: number;
+    files_unchanged: number;
+    files_to_skip: number;
+  };
+  files: ImportPreflightFileReport[];
+  conflicts: ImportPreflightConflict[];
+  manifest: Manifest;
+}
+
 export type ImportPreflightResponse =
   | ImportPreflightSuccessResponse
-  | ImportPreflightValidationFailedResponse;
+  | ImportPreflightValidationFailedResponse
+  | ImportPreflightConflictResponse;
 
 // ---------------------------------------------------------------------------
 // Import commit

--- a/assistant/src/runtime/migrations/migration-wizard.ts
+++ b/assistant/src/runtime/migrations/migration-wizard.ts
@@ -429,12 +429,21 @@ export async function executePreflightStep(
         preflightResult: result,
         currentStep: "transfer",
       };
-    } else {
+    } else if ("validation" in result) {
       current = setStepStatus(current, "preflight-review", "error", {
         message:
           result.validation.errors.map((e) => e.message).join("; ") ||
           "Import preflight validation failed",
         code: result.validation.errors[0]?.code,
+        retryable: true,
+      });
+      current = { ...current, preflightResult: result };
+    } else {
+      current = setStepStatus(current, "preflight-review", "error", {
+        message:
+          result.conflicts.map((c) => c.message).join("; ") ||
+          "Import blocked by conflicts",
+        code: result.conflicts[0]?.code,
         retryable: true,
       });
       current = { ...current, preflightResult: result };


### PR DESCRIPTION
Both reviewers on #11944 flagged that when can_import is false due to conflicts (not validation), the wizard crashes trying to access result.validation.errors. Add a new ImportPreflightConflictResponse variant and update wizard handler to distinguish conflicts from validation failures via 'validation' in result check.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11951" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
