### PR TITLE
fix: remove overly broad http heuristic from inferFailedPhase

### DIFF
--- a/assistant/src/runtime/migrations/transfer-progress-screen.ts
+++ b/assistant/src/runtime/migrations/transfer-progress-screen.ts
@@ -135,10 +135,10 @@ function inferFailedPhase(
       if (managed.status === "complete") {
         // Export completed but no importResult -- check whether the failure was
         // during archive download (between export and import) or during import.
-        // Download failures surface as HTTP/transport errors with "download" in
-        // the message; actual import failures would have set importResult.
+        // Download failures surface with "download" in the message; actual
+        // import failures would have set importResult.
         const msg = stepError.message?.toLowerCase() ?? "";
-        if (msg.includes("download") || msg.includes("http")) {
+        if (msg.includes("download")) {
           return "poll";
         }
         return "import";


### PR DESCRIPTION
Both reviewers on #11941 flagged that msg.includes('http') misclassifies import HTTP errors (e.g. 'import: HTTP 500') as poll-phase failures. Remove the http check and keep only the download check.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
