### PR TITLE
Migrate public-ingress and voice-setup retrieval to integrations CLI

### DIFF
--- a/assistant/src/__tests__/integrations-cli.test.ts
+++ b/assistant/src/__tests__/integrations-cli.test.ts
@@ -6,9 +6,18 @@ let signingKeyInitialized = false;
 let initCalls = 0;
 let loadCalls = 0;
 let mintCalls = 0;
+let rawConfig: Record<string, unknown> = {};
 
 mock.module('../config/env.js', () => ({
   getGatewayInternalBaseUrl: () => gatewayBase,
+}));
+
+mock.module('../config/loader.js', () => ({
+  loadRawConfig: () => rawConfig,
+}));
+
+mock.module('../config/elevenlabs-schema.js', () => ({
+  DEFAULT_ELEVENLABS_VOICE_ID: '21m00Tcm4TlvDq8ikWAM',
 }));
 
 mock.module('../runtime/auth/token-service.js', () => ({
@@ -91,6 +100,7 @@ describe('vellum integrations CLI', () => {
     initCalls = 0;
     loadCalls = 0;
     mintCalls = 0;
+    rawConfig = {};
     delete process.env.GATEWAY_AUTH_TOKEN;
     process.exitCode = 0;
   });
@@ -156,6 +166,62 @@ describe('vellum integrations CLI', () => {
     expect(result.fetchCalls[0]?.url).toBe(
       'http://gateway.test/v1/ingress/members?assistantId=assistant-1&sourceChannel=voice&status=active',
     );
+  });
+
+  test('reads ingress config without gateway fetch', async () => {
+    rawConfig = {
+      ingress: {
+        enabled: true,
+        publicBaseUrl: 'https://public.example.com',
+      },
+    };
+    process.env.INTERNAL_GATEWAY_BASE_URL = 'http://gateway.internal:9900/';
+    const result = await runCli(['--json', 'ingress', 'config'], { ok: true });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.fetchCalls.length).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      success: true,
+      enabled: true,
+      publicBaseUrl: 'https://public.example.com',
+      localGatewayTarget: 'http://gateway.internal:9900',
+    });
+  });
+
+  test('reads voice config without gateway fetch', async () => {
+    rawConfig = {
+      calls: {
+        enabled: true,
+      },
+      elevenlabs: {
+        voiceId: 'EXAVITQu4vr4xnSDxMaL',
+      },
+    };
+    const result = await runCli(['--json', 'voice', 'config'], { ok: true });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.fetchCalls.length).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      success: true,
+      callsEnabled: true,
+      voiceId: 'EXAVITQu4vr4xnSDxMaL',
+      configuredVoiceId: 'EXAVITQu4vr4xnSDxMaL',
+      usesDefaultVoice: false,
+    });
+  });
+
+  test('voice config reports default voice when unset', async () => {
+    rawConfig = {};
+    const result = await runCli(['--json', 'voice', 'config'], { ok: true });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.fetchCalls.length).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      success: true,
+      callsEnabled: false,
+      voiceId: '21m00Tcm4TlvDq8ikWAM',
+      usesDefaultVoice: true,
+    });
   });
 
   test('returns structured error output when gateway request fails', async () => {

--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -1,6 +1,8 @@
 import type { Command } from 'commander';
 
+import { DEFAULT_ELEVENLABS_VOICE_ID } from '../config/elevenlabs-schema.js';
 import { getGatewayInternalBaseUrl } from '../config/env.js';
+import { loadRawConfig } from '../config/loader.js';
 import {
   initAuthSigningKey,
   isSigningKeyInitialized,
@@ -10,6 +12,13 @@ import {
 
 type IngressChannel = 'telegram' | 'voice' | 'sms';
 type GuardianChannel = 'telegram' | 'voice' | 'sms';
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
 
 function shouldOutputJson(cmd: Command): boolean {
   let current: Command | null = cmd;
@@ -47,11 +56,63 @@ function toQueryString(params: Record<string, string | undefined>): string {
   return encoded ? `?${encoded}` : '';
 }
 
-async function gatewayGet(path: string): Promise<unknown> {
+function resolveGatewayBaseUrl(): string {
   const injectedGatewayBase = process.env.INTERNAL_GATEWAY_BASE_URL?.trim();
-  const gatewayBase = injectedGatewayBase && injectedGatewayBase.length > 0
-    ? injectedGatewayBase.replace(/\/+$/, '')
-    : getGatewayInternalBaseUrl();
+  if (injectedGatewayBase && injectedGatewayBase.length > 0) {
+    return injectedGatewayBase.replace(/\/+$/, '');
+  }
+  return getGatewayInternalBaseUrl();
+}
+
+function readIngressConfig(): {
+  success: true;
+  enabled: boolean;
+  publicBaseUrl?: string;
+  localGatewayTarget: string;
+} {
+  const raw = loadRawConfig();
+  const ingress = asRecord(raw.ingress);
+  const configuredUrl = typeof ingress.publicBaseUrl === 'string'
+    ? ingress.publicBaseUrl.trim()
+    : '';
+  const explicitEnabled = typeof ingress.enabled === 'boolean'
+    ? ingress.enabled
+    : undefined;
+  const enabled = explicitEnabled ?? (configuredUrl.length > 0);
+
+  return {
+    success: true,
+    enabled,
+    publicBaseUrl: configuredUrl || undefined,
+    localGatewayTarget: resolveGatewayBaseUrl(),
+  };
+}
+
+function readVoiceConfig(): {
+  success: true;
+  callsEnabled: boolean;
+  voiceId: string;
+  configuredVoiceId?: string;
+  usesDefaultVoice: boolean;
+} {
+  const raw = loadRawConfig();
+  const calls = asRecord(raw.calls);
+  const elevenlabs = asRecord(raw.elevenlabs);
+  const configuredVoiceId = typeof elevenlabs.voiceId === 'string'
+    ? elevenlabs.voiceId.trim()
+    : '';
+
+  return {
+    success: true,
+    callsEnabled: calls.enabled === true,
+    voiceId: configuredVoiceId || DEFAULT_ELEVENLABS_VOICE_ID,
+    configuredVoiceId: configuredVoiceId || undefined,
+    usesDefaultVoice: configuredVoiceId.length === 0,
+  };
+}
+
+async function gatewayGet(path: string): Promise<unknown> {
+  const gatewayBase = resolveGatewayBaseUrl();
   const token = getGatewayToken();
 
   const response = await fetch(`${gatewayBase}${path}`, {
@@ -169,6 +230,13 @@ export function registerIntegrationsCommand(program: Command): void {
     .description('Trusted contact membership and invite status');
 
   ingress
+    .command('config')
+    .description('Get public ingress URL and local gateway target')
+    .action(async (_opts: unknown, cmd: Command) => {
+      await runRead(cmd, async () => readIngressConfig());
+    });
+
+  ingress
     .command('members')
     .description('List trusted ingress members')
     .option('--assistant-id <assistantId>', 'Filter by assistant ID')
@@ -201,5 +269,16 @@ export function registerIntegrationsCommand(program: Command): void {
         status: opts.status,
       });
       await runRead(cmd, async () => gatewayGet(`/v1/ingress/invites${query}`));
+    });
+
+  const voice = integrations
+    .command('voice')
+    .description('Voice setup status');
+
+  voice
+    .command('config')
+    .description('Get voice and call readiness config')
+    .action(async (_opts: unknown, cmd: Command) => {
+      await runRead(cmd, async () => readVoiceConfig());
     });
 }

--- a/assistant/src/config/bundled-skills/public-ingress/SKILL.md
+++ b/assistant/src/config/bundled-skills/public-ingress/SKILL.md
@@ -21,12 +21,15 @@ This skill installs ngrok, configures authentication, starts a tunnel, discovers
 First, check whether ingress is already configured:
 
 ```bash
-vellum config get ingress.publicBaseUrl
+vellum integrations ingress config --json
 ```
 
-Use the injected `INTERNAL_GATEWAY_BASE_URL` as the local gateway target before proceeding.
+The response includes:
+- `publicBaseUrl` — currently configured public ingress URL (if any)
+- `enabled` — whether ingress is enabled
+- `localGatewayTarget` — local gateway URL ngrok should forward to
 
-If `ingress.publicBaseUrl` is already set and the tunnel is running (check via `curl -s http://127.0.0.1:4040/api/tunnels`), tell the user the current status and ask if they want to reconfigure or if this is sufficient.
+If `publicBaseUrl` is already set and the tunnel is running (check via `curl -s http://127.0.0.1:4040/api/tunnels`), tell the user the current status and ask if they want to reconfigure or if this is sufficient.
 
 ## Step 2: Install ngrok
 
@@ -78,19 +81,14 @@ If not authenticated:
    - description: `Get your auth token from https://dashboard.ngrok.com/get-started/your-authtoken`
    - usage_description: `ngrok authentication token for creating public tunnels`
 
-3. Once the credential is stored, configure ngrok by reading the token directly from the OS keychain and piping it to ngrok so the plaintext never enters the conversation:
+3. Once the credential is stored, retrieve it via `credential_store` and apply it to ngrok:
 
-   **macOS:**
    ```bash
-   ngrok config add-authtoken "$(security find-generic-password -s vellum-assistant -a credential:ngrok:authtoken -w)"
+   credential_store action=get service=ngrok field=authtoken
+   ngrok config add-authtoken "<authtoken_from_credential_store>"
    ```
 
-   **Linux:**
-   ```bash
-   ngrok config add-authtoken "$(secret-tool lookup service vellum-assistant account credential:ngrok:authtoken)"
-   ```
-
-   If the keychain command fails (e.g., headless environment without a keyring), fall back to asking the user to re-enter the token via `credential_store prompt` and then paste it into `ngrok config add-authtoken` manually as a last resort.
+   If no value is returned, re-run `credential_store` with `action: "prompt"` and try again.
 
 Verify authentication succeeded by checking `ngrok config check` again.
 
@@ -112,7 +110,7 @@ sleep 1
 Start ngrok in the background, tunneling to the local gateway target:
 
 ```bash
-nohup ngrok http "$INTERNAL_GATEWAY_BASE_URL" --log=stdout > /tmp/ngrok.log 2>&1 &
+nohup ngrok http "<localGatewayTarget from Step 1>" --log=stdout > /tmp/ngrok.log 2>&1 &
 echo $! > /tmp/ngrok.pid
 ```
 
@@ -160,8 +158,7 @@ vellum config set ingress.enabled true
 Verify it was saved:
 
 ```bash
-vellum config get ingress.publicBaseUrl
-vellum config get ingress.enabled
+vellum integrations ingress config --json
 ```
 
 ## Step 7: Report Completion
@@ -169,14 +166,14 @@ vellum config get ingress.enabled
 Summarize the setup:
 
 - **Public URL:** `<the-url>` (this is your `ingress.publicBaseUrl`)
-- **Local gateway target:** `$INTERNAL_GATEWAY_BASE_URL`
+- **Local gateway target:** `<localGatewayTarget from vellum integrations ingress config --json>`
 - **ngrok dashboard:** http://127.0.0.1:4040
 
 Provide useful follow-up commands:
 
 - **Check tunnel status:** `curl -s http://127.0.0.1:4040/api/tunnels | python3 -c "import sys,json; [print(t['public_url']) for t in json.load(sys.stdin)['tunnels']]"`
 - **View ngrok logs:** `cat /tmp/ngrok.log`
-- **Restart tunnel:** `pkill -f ngrok; sleep 1; nohup ngrok http "$INTERNAL_GATEWAY_BASE_URL" --log=stdout > /tmp/ngrok.log 2>&1 &`
+- **Restart tunnel:** `pkill -f ngrok; sleep 1; nohup ngrok http "<localGatewayTarget>" --log=stdout > /tmp/ngrok.log 2>&1 &`
 - **Stop tunnel:** `pkill -f ngrok`
 - **Rotate URL:** Stop and restart ngrok (free tier assigns a new URL each time; update `ingress.publicBaseUrl` afterward)
 
@@ -194,7 +191,7 @@ Sign in to https://dashboard.ngrok.com, copy a fresh token from the "Your Authto
 The ngrok process may not be running. Check with `ps aux | grep ngrok`. If not running, start it per Step 4. If running but 4040 is unresponsive, check `/tmp/ngrok.log` for errors.
 
 ### Gateway not reachable on local target
-Ensure the Vellum gateway is running on `$INTERNAL_GATEWAY_BASE_URL`. Check with `curl -s "$INTERNAL_GATEWAY_BASE_URL/healthz"`. If not running, start the assistant daemon first.
+Re-check local gateway target with `vellum integrations ingress config --json`, then run `curl -s "<localGatewayTarget>/healthz"`. If the gateway is not running, start the assistant daemon first.
 
 ### "Too many connections" or tunnel limit errors
 ngrok's free tier allows one tunnel at a time. Stop any other ngrok tunnels before starting a new one.

--- a/assistant/src/config/bundled-skills/voice-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/voice-setup/SKILL.md
@@ -73,10 +73,10 @@ After storing the API key, let the user pick their preferred voice. The shared c
 Check the current voice:
 
 ```bash
-vellum config get elevenlabs.voiceId
+vellum integrations voice config --json
 ```
 
-Ask the user if they want to change their TTS voice. If yes, use `voice_config_update` with `setting: "tts_voice_id"` and the chosen voice ID. This writes to both the config file (`elevenlabs.voiceId`) and pushes to the macOS app via IPC in one call.
+Use `voiceId` from the response as the current selection (and `usesDefaultVoice` to know if Rachel is still in use by default). Ask the user if they want to change their TTS voice. If yes, use `voice_config_update` with `setting: "tts_voice_id"` and the chosen voice ID. This writes to both the config file (`elevenlabs.voiceId`) and pushes to the macOS app via IPC in one call.
 
 Common choices from the curated ElevenLabs list:
 - **Rachel** (`21m00Tcm4TlvDq8ikWAM`) — Calm, warm, conversational (default)
@@ -92,13 +92,13 @@ If the user wants to browse more voices, they can search at https://elevenlabs.i
 After setting the voice, check whether phone calls are configured:
 
 ```bash
-vellum config get calls.enabled
+vellum integrations voice config --json
 ```
 
-**If phone calls are enabled** (`calls.enabled` is `true`):
+**If phone calls are enabled** (`callsEnabled` is `true`):
 - Tell the user their phone calls will automatically use the same voice they just chose, since both in-app TTS and phone calls read from `elevenlabs.voiceId`.
 
-**If phone calls are not yet configured** (`calls.enabled` is `false` or not set):
+**If phone calls are not yet configured** (`callsEnabled` is `false`):
 - Tell the user: "When you set up phone calls later, they'll automatically use the same voice for a consistent experience."
 
 ### 5. Verification


### PR DESCRIPTION
## Summary
- add `vellum integrations ingress config` and `vellum integrations voice config` domain read commands
- migrate `public-ingress` and `voice-setup` bundled skills away from direct `vellum config get` and OS keychain retrieval snippets
- standardize retrieval guidance on `vellum integrations ... --json` reads and proxied credential-store patterns

## Testing
- cd assistant && bun test src/__tests__/integrations-cli.test.ts
- cd assistant && bunx tsc --noEmit

Closes #11904
