### PR TITLE
fix: clear stale exportResult on transfer retry to prevent phase misclassification

### DIFF
--- a/assistant/src/runtime/migrations/transfer-progress-screen.ts
+++ b/assistant/src/runtime/migrations/transfer-progress-screen.ts
@@ -289,6 +289,7 @@ export async function retryTransferFlow(
   const reset = resetStepForRetry(state);
   const cleaned = {
     ...reset,
+    exportResult: undefined,
     importResult: undefined,
   };
   options.onStateChange?.(cleaned);


### PR DESCRIPTION
Codex review on #11947 flagged that retryTransferFlow() preserves exportResult, but stale export metadata from a previous managed flow can cause inferFailedPhase() to misclassify import-only failures as poll/export. Reset exportResult on retry.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11954" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
