### PR TITLE
feat: integrate Contacts view into macOS Settings with list-detail navigation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Master-detail container for the Contacts tab in Settings.
+/// Left pane shows the contacts list; right pane shows detail for the
+/// selected contact, or a placeholder when nothing is selected.
+@MainActor
+struct ContactsContainerView: View {
+    var daemonClient: DaemonClient?
+
+    @StateObject private var viewModel: ContactsViewModel
+    @State private var selectedContactId: String?
+
+    init(daemonClient: DaemonClient?) {
+        self.daemonClient = daemonClient
+        _viewModel = StateObject(wrappedValue: ContactsViewModel(daemonClient: daemonClient))
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 0) {
+            // Left pane: contacts list
+            ScrollView {
+                ContactsListView(
+                    viewModel: viewModel,
+                    selectedContactId: $selectedContactId
+                )
+                .padding(VSpacing.lg)
+            }
+            .frame(width: 320)
+            .background(VColor.background)
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            // Right pane: detail or placeholder
+            if let contactId = selectedContactId,
+               let contact = viewModel.contacts.first(where: { $0.id == contactId }) {
+                ContactDetailView(
+                    contact: contact,
+                    daemonClient: daemonClient
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            } else {
+                VStack(spacing: VSpacing.md) {
+                    Image(systemName: "person.2.fill")
+                        .font(.system(size: 36))
+                        .foregroundColor(VColor.textMuted)
+                    Text("Select a contact")
+                        .font(VFont.headline)
+                        .foregroundColor(VColor.textSecondary)
+                    Text("Choose a contact from the list to view their details.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: 240)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(VColor.background)
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -10,14 +10,18 @@ enum SettingsTab: String {
     case automation = "Automation"
     case appearance = "Appearance"
     case privacy = "Privacy"
+    case contacts = "Contacts"
     case advanced = "Advanced"
 
-    /// Tabs shown in the sidebar. Advanced is only visible in dev mode.
+    /// Tabs shown in the sidebar. Contacts requires a feature flag; Advanced is only visible in dev mode.
     static func visibleTabs(isDevMode: Bool) -> [SettingsTab] {
         var tabs: [SettingsTab] = [
             .account, .channels, .modelsAndServices, .voice,
             .automation, .appearance, .permissions, .privacy
         ]
+        if MacOSClientFeatureFlagManager.shared.isEnabled("contacts_tab") {
+            tabs.append(.contacts)
+        }
         if isDevMode {
             tabs.append(.advanced)
         }
@@ -44,6 +48,8 @@ enum SettingsTab: String {
             default: tab = nil
             }
         }
+        // Block feature-flagged tabs when disabled
+        if tab == .contacts && !MacOSClientFeatureFlagManager.shared.isEnabled("contacts_tab") { return nil }
         // Block dev-only tabs when dev mode is disabled
         if tab == .advanced && !isDevMode { return nil }
         return tab
@@ -120,7 +126,7 @@ struct SettingsPanel: View {
             setupIntegrationCallbacks()
             try? daemonClient?.sendIntegrationList()
             if let pending = store.pendingSettingsTab {
-                if pending != .advanced || store.isDevMode {
+                if SettingsTab.visibleTabs(isDevMode: store.isDevMode).contains(pending) {
                     selectedTab = pending
                 }
                 store.pendingSettingsTab = nil
@@ -128,7 +134,7 @@ struct SettingsPanel: View {
         }
         .onChange(of: store.pendingSettingsTab) { _, newTab in
             if let tab = newTab {
-                if tab != .advanced || store.isDevMode {
+                if SettingsTab.visibleTabs(isDevMode: store.isDevMode).contains(tab) {
                     selectedTab = tab
                 }
                 store.pendingSettingsTab = nil
@@ -141,7 +147,7 @@ struct SettingsPanel: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .navigateToSettingsTab)) { notification in
             if let tab = notification.object as? SettingsTab {
-                if tab == .advanced && !store.isDevMode { return }
+                guard SettingsTab.visibleTabs(isDevMode: store.isDevMode).contains(tab) else { return }
                 selectedTab = tab
             }
         }
@@ -235,6 +241,8 @@ struct SettingsPanel: View {
             SettingsAppearanceTab(store: store)
         case .privacy:
             SettingsPrivacyTab(daemonClient: daemonClient)
+        case .contacts:
+            ContactsContainerView(daemonClient: daemonClient)
         case .advanced:
             if store.isDevMode {
                 SettingsAdvancedDevTab(store: store, daemonClient: daemonClient)


### PR DESCRIPTION
## Summary
- Creates ContactsContainerView with list-detail split layout
- Adds .contacts case to SettingsTab enum, gated behind contacts_tab feature flag (defaults off)
- Wires ContactsListView and ContactDetailView into the Settings panel navigation

Part of plan: contact-centric-model.md (PR 10 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
