### PR TITLE
Migrate configure-settings and email-setup to domain CLI patterns

### DIFF
--- a/assistant/src/config/bundled-skills/configure-settings/SKILL.md
+++ b/assistant/src/config/bundled-skills/configure-settings/SKILL.md
@@ -5,7 +5,20 @@ user-invocable: true
 metadata: {"vellum": {"emoji": "⚙️"}}
 ---
 
-You are helping the user view or change assistant configuration. All configuration is managed through the `vellum config` CLI which reads and writes `~/.vellum/workspace/config.json`.
+You are helping the user view or change assistant configuration through the `vellum` CLI. Treat CLI commands as the canonical interface. Do **not** read or edit config files directly.
+
+## Domain Status Reads First
+
+When a user asks for setup/status of a specific capability, prefer domain commands before generic `vellum config get`:
+
+```bash
+vellum integrations voice config --json
+vellum integrations ingress config --json
+vellum integrations twilio config --json
+vellum email status --json
+```
+
+Use `vellum config get` for generic keys that do not have a domain command.
 
 ## Reading a value
 
@@ -18,7 +31,6 @@ Examples:
 vellum config get platform.baseUrl
 vellum config get memory.qdrant.url
 vellum config get provider
-vellum config get calls.enabled
 ```
 
 If the result is empty, the compiled default is in effect.

--- a/assistant/src/config/bundled-skills/email-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/email-setup/SKILL.md
@@ -16,34 +16,34 @@ Only proceed if the user explicitly asks you to create or set up **your own** (t
 Before doing anything, check whether you already have an email address configured:
 
 ```bash
-vellum email status
+vellum email status --json
 ```
 
-This will return your email address, the callback URL that inbound email will hit, and the path to the inbox locally. If you already have an email address, tell the user your existing email address and stop — do NOT create another one.
+Inspect `health.inboxes` in the response. If at least one inbox exists, tell the user the existing address and stop — do NOT create another one.
 
 ## Step 2: Create Your Email
 
-Call the Vellum hosted API to provision your email. Use `host_bash` to make the request:
+Create a new inbox through the domain CLI:
 
 ```bash
-vellum email create <your-username>
+vellum email inbox create --username <your-username> --json
 ```
 
 For `<your-username>`, use your assistant name (lowercased, alphanumeric only). Check your identity from `IDENTITY.md` or `USER.md` to determine your name. If you don't have a name yet, ask the user what username they'd like for your email.
 
-## Step 3: Persist Your Email
+Use the returned `inbox.address` (or `inbox.id` if `address` is empty) as the created email address.
 
-After the inbox is created successfully, persist your email address to the workspace config so the desktop app can display it:
+## Step 3: Verify Status
 
 ```bash
-vellum config set email.address <your-new-email-address>
+vellum email status --json
 ```
 
-Replace `<your-new-email-address>` with the full email address returned from the create command (e.g. `sam@agentmail.to`).
+Confirm the created inbox appears in `health.inboxes`.
 
 ## Step 4: Confirm Setup
 
-After the inbox is created and persisted:
+After the inbox is created and visible in status:
 
 1. Tell the user your new email address.
 2. Store a note in your memory or `USER.md` that your email has been provisioned so you remember it in future conversations.


### PR DESCRIPTION
## Summary
- refactor `configure-settings` to treat `vellum` CLI as the canonical settings interface instead of config-file framing
- update `email-setup` to use domain `vellum email ...` commands (`status --json`, `inbox create --username ... --json`) for retrieval/provisioning
- remove stale `host_bash` and manual `vellum config set email.address ...` guidance

## Testing
- cd assistant && bun test src/__tests__/skills.test.ts

Closes #11905

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
