### PR TITLE
fix: use writable DB for WAL checkpoint and rename duplicate test

### DIFF
--- a/assistant/src/__tests__/migration-wizard.test.ts
+++ b/assistant/src/__tests__/migration-wizard.test.ts
@@ -737,7 +737,7 @@ describe("executeTransferStep", () => {
     expect(result.steps.transfer.error?.retryable).toBe(true);
   });
 
-  test("import failure — sets error with reason", async () => {
+  test("import failure — sets error with validation_failed reason", async () => {
     const failResponse: ImportCommitResponse = {
       success: false,
       reason: "validation_failed",

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -141,7 +141,7 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
       checkpoint: () => {
         try {
           const dbPath = getDbPath();
-          const db = new Database(dbPath, { readonly: true });
+          const db = new Database(dbPath);
           try {
             db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
           } finally {


### PR DESCRIPTION
Addresses Codex and Devin feedback on #11956. Fixed WAL checkpoint to use writable connection so exports include WAL data, and renamed duplicate test to avoid shadowing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
