### PR TITLE
fix: preserve guardian role during member contact sync

### DIFF
--- a/assistant/src/contacts/contact-sync.ts
+++ b/assistant/src/contacts/contact-sync.ts
@@ -101,7 +101,6 @@ export function syncSingleMember(member: IngressMember): void {
 
   upsertContact({
     displayName,
-    role: "contact",
     channels: [
       {
         type: member.sourceChannel,


### PR DESCRIPTION
Addresses review feedback from PR #11934:
- Remove explicit role: 'contact' from syncSingleMember's upsertContact call
- Prevents guardian contacts from being downgraded to 'contact' during member sync
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
