### PR TITLE
fix: prevent scroll-to-bottom from overriding anchor scroll and optimize onChange trigger

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -607,14 +607,17 @@ struct MessageListView: View {
                 }
                 isThreadContentHovered = false
                 DispatchQueue.main.async {
-                    // Skip scroll-to-bottom when an anchor message is pending —
-                    // the anchorMessageId onChange handler will scroll to the
-                    // specific message instead. Stale anchors from other threads
-                    // are cleared by ThreadManager.activeThreadId.didSet, so
-                    // anchorMessageId here always belongs to the current thread.
                     if anchorMessageId == nil {
                         proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                    } else if !messages.contains(where: { $0.id == anchorMessageId }) {
+                        // Anchor is stale (belongs to a different thread) — clear
+                        // it and scroll to bottom normally.
+                        anchorMessageId = nil
+                        proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                     }
+                    // When anchorMessageId is set and belongs to this thread's
+                    // messages, skip scroll-to-bottom — the anchorMessageId
+                    // onChange handler will scroll to the specific message.
                 }
             }
             .onChange(of: anchorMessageId) {


### PR DESCRIPTION
Addresses review feedback from PR #11849:
- Guard deferred scroll-to-bottom with anchorMessageId nil check
- Clear stale anchors belonging to other threads
- Replace expensive onChange(of: messages) with onChange(of: messages.count)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
