### PR TITLE
fix: pass explicit limit to sendListContacts to load all contacts

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
@@ -70,7 +70,7 @@ final class ContactsViewModel: ObservableObject {
         }
 
         do {
-            try daemonClient.sendListContacts()
+            try daemonClient.sendListContacts(limit: 500)
         } catch {
             isLoading = false
         }


### PR DESCRIPTION
Addresses review feedback from PR #11950:
- Pass explicit limit parameter to sendListContacts to prevent silent truncation at 50 contacts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
