### PR TITLE
fix: add legacy guardianCtx fallback in retry sweep

### DIFF
--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -132,14 +132,17 @@ export async function sweepFailedEvents(
       | undefined;
     const assistantId =
       typeof payload.assistantId === "string" ? payload.assistantId : undefined;
-    const parsedTrustContext = parseTrustRuntimeContext(payload.trustCtx);
+    // Backward-compat: events persisted before the guardianCtx → trustCtx
+    // rename still carry the old key name.
+    const rawTrustCtx = payload.trustCtx ?? payload.guardianCtx;
+    const parsedTrustContext = parseTrustRuntimeContext(rawTrustCtx);
 
     // If the stored payload had guardian context data but it couldn't be parsed
     // into a valid canonical shape (e.g., legacy actorRole-only payloads without
     // trustClass), fail the event deterministically rather than processing it
     // without guardian context. Without this check, the downstream default of
     // `trustClass ?? 'guardian'` would silently escalate privileges.
-    if (payload.trustCtx && !parsedTrustContext) {
+    if (rawTrustCtx && !parsedTrustContext) {
       log.warn(
         { eventId: event.id },
         "Stored trustCtx could not be parsed into canonical form; marking event as failed to prevent privilege escalation",


### PR DESCRIPTION
Addresses review feedback from PR #11881:

- Add backward-compatible read path for `guardianCtx` in channel-retry-sweep.ts: events persisted before the guardianCtx -> trustCtx rename still carry the old key. Now reads `payload.trustCtx ?? payload.guardianCtx` so legacy events can be retried.
- Issues 2 and 3 (incorrect function references in session-agent-loop.ts and ARCHITECTURE.md) were already fixed by PR #11884.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
