### PR TITLE
fix: prevent nested ScrollView in Contacts tab and fix stale detail view

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -39,6 +39,7 @@ struct ContactsContainerView: View {
                     contact: contact,
                     daemonClient: daemonClient
                 )
+                .id(contactId)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             } else {
                 VStack(spacing: VSpacing.md) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -105,13 +105,22 @@ struct SettingsPanel: View {
                 .frame(width: 200)
 
             // Right: tab content — panel background on content only, nav floats on window chrome
-            ScrollView {
+            // Contacts tab is a master-detail split that needs full height; wrapping it in
+            // a ScrollView would collapse maxHeight: .infinity to minimum content size.
+            if selectedTab == .contacts {
                 selectedTabContent
-                    .padding(VSpacing.lg)
-                    .frame(maxWidth: .infinity, alignment: .top)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                    .background(VColor.backgroundSubtle)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+            } else {
+                ScrollView {
+                    selectedTabContent
+                        .padding(VSpacing.lg)
+                        .frame(maxWidth: .infinity, alignment: .top)
+                }
+                .background(VColor.backgroundSubtle)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
             }
-            .background(VColor.backgroundSubtle)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         }
         .task {
             // Refresh permission status when the view appears


### PR DESCRIPTION
Addresses review feedback from PR #11955:
- Conditionally skip outer ScrollView for Contacts tab to fix collapsed layout
- Add .id(contactId) to ContactDetailView to prevent stale data on selection change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
