### PR TITLE
fix: apply role filter before limit in searchContacts

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -309,7 +309,8 @@ export function searchContacts(params: {
     if (contactIds.length === 0) return [];
 
     const results: ContactWithChannels[] = [];
-    for (const id of contactIds.slice(0, limit)) {
+    for (const id of contactIds) {
+      if (results.length >= limit) break;
       const contact = getContact(id);
       if (contact && (!params.role || contact.role === params.role)) {
         results.push(contact);


### PR DESCRIPTION
Addresses review feedback from PR #11932:
- Iterate all contactIds and apply role filter before limit truncation
- Prevents returning fewer results than expected when role-filtered contacts appear after the slice boundary
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
