### PR TITLE
fix: wrap contact-sync calls in try-catch to prevent primary operations from crashing

### DIFF
--- a/assistant/src/memory/guardian-bindings.ts
+++ b/assistant/src/memory/guardian-bindings.ts
@@ -9,8 +9,11 @@ import { and, asc, desc, eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
 import { syncSingleGuardianBinding } from '../contacts/contact-sync.js';
+import { getLogger } from '../util/logger.js';
 import { getDb } from './db.js';
 import { channelGuardianBindings } from './schema.js';
+
+const log = getLogger('guardian-bindings');
 
 // ---------------------------------------------------------------------------
 // Types
@@ -89,7 +92,11 @@ export function createBinding(params: {
   db.insert(channelGuardianBindings).values(row).run();
 
   const binding = rowToBinding(row);
-  syncSingleGuardianBinding(binding);
+  try {
+    syncSingleGuardianBinding(binding);
+  } catch (err) {
+    log.warn({ err }, 'Contact sync failed for guardian binding');
+  }
 
   return binding;
 }

--- a/assistant/src/memory/ingress-member-store.ts
+++ b/assistant/src/memory/ingress-member-store.ts
@@ -10,8 +10,11 @@ import { v4 as uuid } from 'uuid';
 
 import { syncSingleMember } from '../contacts/contact-sync.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
+import { getLogger } from '../util/logger.js';
 import { getDb } from './db.js';
 import { assistantIngressMembers } from './schema.js';
+
+const log = getLogger('ingress-member-store');
 
 // ---------------------------------------------------------------------------
 // Types
@@ -142,7 +145,11 @@ export function upsertMember(params: {
       .get();
 
     const member = rowToMember(updated!);
-    syncSingleMember(member);
+    try {
+      syncSingleMember(member);
+    } catch (err) {
+      log.warn({ err }, 'Contact sync failed for ingress member update');
+    }
     return member;
   }
 
@@ -170,7 +177,11 @@ export function upsertMember(params: {
   db.insert(assistantIngressMembers).values(row).run();
 
   const member = rowToMember(row);
-  syncSingleMember(member);
+  try {
+    syncSingleMember(member);
+  } catch (err) {
+    log.warn({ err }, 'Contact sync failed for ingress member insert');
+  }
   return member;
 }
 
@@ -255,7 +266,11 @@ export function revokeMember(memberId: string, reason?: string): IngressMember |
 
   if (!updated) return null;
   const member = rowToMember(updated);
-  syncSingleMember(member);
+  try {
+    syncSingleMember(member);
+  } catch (err) {
+    log.warn({ err }, 'Contact sync failed for ingress member revoke');
+  }
   return member;
 }
 
@@ -297,7 +312,11 @@ export function blockMember(memberId: string, reason?: string): IngressMember | 
 
   if (!updated) return null;
   const member = rowToMember(updated);
-  syncSingleMember(member);
+  try {
+    syncSingleMember(member);
+  } catch (err) {
+    log.warn({ err }, 'Contact sync failed for ingress member block');
+  }
   return member;
 }
 


### PR DESCRIPTION
Addresses review feedback from PR #11939:
- Wrap syncSingleGuardianBinding in try-catch in guardian-bindings.ts
- Wrap all syncSingleMember calls in try-catch in ingress-member-store.ts
- Matches defensive pattern used in lifecycle.ts for syncAllToContacts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
