### PR TITLE
fix: eliminate double decompression in vbundle import by reusing validated entries

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -1,15 +1,10 @@
 /**
  * Commits a validated .vbundle archive to disk.
  *
- * Given a valid .vbundle archive (already validated), this module:
- * 1. Re-validates the bundle for safety (validation before mutation)
- * 2. Extracts files from the archive
- * 3. Backs up existing files before overwriting
- * 4. Writes bundle files to their target disk locations
- * 5. Verifies written files match expected checksums (post-write integrity)
- * 6. Returns a detailed import report
- *
- * Backup files are stored alongside the originals with a timestamped suffix.
+ * Accepts pre-validated entries from a prior validateVBundle call to avoid
+ * redundant decompression, or validates internally when entries are not provided.
+ * Backs up existing files, writes bundle files to disk, verifies post-write
+ * integrity, and returns a detailed import report.
  */
 
 import { createHash } from "node:crypto";
@@ -21,10 +16,9 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname } from "node:path";
-import { gunzipSync } from "node:zlib";
 
 import type { PathResolver } from "./vbundle-import-analyzer.js";
-import type { ManifestType } from "./vbundle-validator.js";
+import type { ManifestType, TarEntry } from "./vbundle-validator.js";
 import { validateVBundle } from "./vbundle-validator.js";
 
 // ---------------------------------------------------------------------------
@@ -83,80 +77,6 @@ export type ImportCommitResult =
     };
 
 // ---------------------------------------------------------------------------
-// Tar parsing (duplicated from validator — the validator's parser is private)
-// ---------------------------------------------------------------------------
-
-interface TarEntry {
-  name: string;
-  data: Uint8Array;
-  size: number;
-}
-
-function parseTar(buffer: Uint8Array): TarEntry[] {
-  const entries: TarEntry[] = [];
-  let offset = 0;
-  const BLOCK_SIZE = 512;
-  let longName: string | null = null;
-
-  while (offset + BLOCK_SIZE <= buffer.length) {
-    const header = buffer.subarray(offset, offset + BLOCK_SIZE);
-
-    if (header.every((b) => b === 0)) {
-      break;
-    }
-
-    let name: string;
-    if (longName) {
-      name = longName;
-      longName = null;
-    } else {
-      const rawName = decodeNullTerminated(header, 0, 100);
-      const prefix = decodeNullTerminated(header, 345, 155);
-      name = prefix ? `${prefix}/${rawName}` : rawName;
-    }
-
-    const typeFlag = String.fromCharCode(header[156]);
-
-    const sizeStr = decodeNullTerminated(header, 124, 12);
-    const size = parseInt(sizeStr, 8) || 0;
-
-    const dataBlocks = Math.ceil(size / BLOCK_SIZE);
-    const dataStart = offset + BLOCK_SIZE;
-    const data = buffer.subarray(dataStart, dataStart + size);
-
-    if (typeFlag === "L") {
-      longName = new TextDecoder().decode(data).replace(/\0+$/, "");
-      offset = dataStart + dataBlocks * BLOCK_SIZE;
-      continue;
-    }
-
-    if (typeFlag === "0" || typeFlag === "\0" || typeFlag === "") {
-      entries.push({ name: normalizePath(name), data, size });
-    }
-
-    offset = dataStart + dataBlocks * BLOCK_SIZE;
-  }
-
-  return entries;
-}
-
-function decodeNullTerminated(
-  buf: Uint8Array,
-  start: number,
-  maxLen: number,
-): string {
-  let end = start;
-  while (end < start + maxLen && buf[end] !== 0) {
-    end++;
-  }
-  return new TextDecoder().decode(buf.subarray(start, end));
-}
-
-function normalizePath(p: string): string {
-  return p.replace(/^\.\//, "").replace(/\/+$/, "");
-}
-
-// ---------------------------------------------------------------------------
 // Hash helper
 // ---------------------------------------------------------------------------
 
@@ -182,6 +102,10 @@ export interface ImportCommitOptions {
   archiveData: Uint8Array;
   /** Resolves archive paths to disk paths */
   pathResolver: PathResolver;
+  /** Pre-validated manifest — when provided with `preValidatedEntries`, skips re-validation and re-decompression. */
+  preValidatedManifest?: ManifestType;
+  /** Pre-parsed tar entries from a prior validateVBundle call — avoids redundant decompression. */
+  preValidatedEntries?: Map<string, TarEntry>;
 }
 
 /**
@@ -192,46 +116,33 @@ export interface ImportCommitOptions {
  * re-validated before any state mutation to prevent writing corrupt data.
  */
 export function commitImport(options: ImportCommitOptions): ImportCommitResult {
-  const { archiveData, pathResolver } = options;
+  const {
+    archiveData,
+    pathResolver,
+    preValidatedManifest,
+    preValidatedEntries,
+  } = options;
 
-  // Step 1: Validate the bundle (validation before mutation)
-  const validation = validateVBundle(archiveData);
-  if (!validation.is_valid || !validation.manifest) {
-    return {
-      ok: false,
-      reason: "validation_failed",
-      errors: validation.errors,
-    };
-  }
+  let manifest: ManifestType;
+  let entryMap: Map<string, TarEntry>;
 
-  const manifest = validation.manifest;
+  if (preValidatedManifest && preValidatedEntries) {
+    // Caller already validated and decompressed — reuse directly
+    manifest = preValidatedManifest;
+    entryMap = preValidatedEntries;
+  } else {
+    // Step 1: Validate the bundle (validation before mutation)
+    const validation = validateVBundle(archiveData, { includeEntries: true });
+    if (!validation.is_valid || !validation.manifest || !validation.entries) {
+      return {
+        ok: false,
+        reason: "validation_failed",
+        errors: validation.errors,
+      };
+    }
 
-  // Step 2: Extract tar entries
-  let tarData: Uint8Array;
-  try {
-    tarData = gunzipSync(archiveData);
-  } catch (err) {
-    return {
-      ok: false,
-      reason: "extraction_failed",
-      message: `Failed to decompress archive: ${err instanceof Error ? err.message : String(err)}`,
-    };
-  }
-
-  let entries: TarEntry[];
-  try {
-    entries = parseTar(tarData);
-  } catch (err) {
-    return {
-      ok: false,
-      reason: "extraction_failed",
-      message: `Failed to parse tar archive: ${err instanceof Error ? err.message : String(err)}`,
-    };
-  }
-
-  const entryMap = new Map<string, TarEntry>();
-  for (const entry of entries) {
-    entryMap.set(entry.name, entry);
+    manifest = validation.manifest;
+    entryMap = validation.entries;
   }
 
   // Step 3: Write files to disk with backups
@@ -290,7 +201,9 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
         return {
           ok: false,
           reason: "write_failed",
-          message: `Failed to create backup of "${diskPath}": ${err instanceof Error ? err.message : String(err)}`,
+          message: `Failed to create backup of "${diskPath}": ${
+            err instanceof Error ? err.message : String(err)
+          }`,
           partial_report: buildPartialReport(
             importedFiles,
             manifest,
@@ -313,7 +226,9 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
         return {
           ok: false,
           reason: "write_failed",
-          message: `Failed to create directory "${parentDir}": ${err instanceof Error ? err.message : String(err)}`,
+          message: `Failed to create directory "${parentDir}": ${
+            err instanceof Error ? err.message : String(err)
+          }`,
           partial_report: buildPartialReport(
             importedFiles,
             manifest,
@@ -331,7 +246,9 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
       return {
         ok: false,
         reason: "write_failed",
-        message: `Failed to write "${diskPath}": ${err instanceof Error ? err.message : String(err)}`,
+        message: `Failed to write "${diskPath}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
         partial_report: buildPartialReport(
           importedFiles,
           manifest,

--- a/assistant/src/runtime/migrations/vbundle-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-validator.ts
@@ -54,13 +54,20 @@ export interface VBundleValidationResult {
   is_valid: boolean;
   errors: ValidationError[];
   manifest?: ManifestType;
+  /** Parsed tar entries, only populated when `includeEntries` option is set. */
+  entries?: Map<string, TarEntry>;
+}
+
+export interface ValidateVBundleOptions {
+  /** When true, include parsed tar entries in the result for downstream reuse. */
+  includeEntries?: boolean;
 }
 
 // ---------------------------------------------------------------------------
 // Tar parsing (minimal, spec-compliant for ustar/GNU tar)
 // ---------------------------------------------------------------------------
 
-interface TarEntry {
+export interface TarEntry {
   name: string;
   data: Uint8Array;
   size: number;
@@ -186,7 +193,10 @@ const MAX_DECOMPRESSED_SIZE = 2 * 1024 * 1024 * 1024;
  * 3. Manifest checksum (SHA-256 of canonicalized JSON without manifest_sha256)
  * 4. Per-file content integrity (SHA-256 of each file vs manifest declaration)
  */
-export function validateVBundle(data: Uint8Array): VBundleValidationResult {
+export function validateVBundle(
+  data: Uint8Array,
+  options?: ValidateVBundleOptions,
+): VBundleValidationResult {
   const errors: ValidationError[] = [];
 
   // Step 1: Decompress gzip with size cap to prevent zip-bomb DoS
@@ -338,9 +348,11 @@ export function validateVBundle(data: Uint8Array): VBundleValidationResult {
     }
   }
 
+  const isValid = errors.length === 0;
   return {
-    is_valid: errors.length === 0,
+    is_valid: isValid,
     errors,
-    manifest: errors.length === 0 ? manifest : undefined,
+    manifest: isValid ? manifest : undefined,
+    entries: isValid && options?.includeEntries ? entryMap : undefined,
   };
 }

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -357,8 +357,9 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
 
   try {
     // Validate the bundle before closing the DB to avoid an unnecessary
-    // close/reopen cycle when the bundle is invalid.
-    const validation = validateVBundle(fileData);
+    // close/reopen cycle when the bundle is invalid. Request parsed entries
+    // so commitImport can reuse them without re-decompressing.
+    const validation = validateVBundle(fileData, { includeEntries: true });
     if (!validation.is_valid) {
       return Response.json({
         success: false,
@@ -379,6 +380,8 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
     const result = commitImport({
       archiveData: fileData,
       pathResolver,
+      preValidatedManifest: validation.manifest,
+      preValidatedEntries: validation.entries,
     });
 
     if (!result.ok) {


### PR DESCRIPTION
Address review feedback from PR #11962. The pre-validation in the import route now passes its validated entries to commitImport, avoiding a second decompression pass. Also removes duplicated tar parsing code from the importer since it now reuses the validator's entries.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
