### PR TITLE
docs: sync guardian-verify-setup SKILL.md with revoke endpoint behavior

### DIFF
--- a/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
@@ -169,13 +169,10 @@ Replace `<channel>` with the channel to unbind from (e.g. `voice`, `telegram`).
 
 ### On success (`success: true`)
 
-Confirm to the user: "Guardian binding revoked for [channel]. The previous guardian no longer has access to this channel."
+The response includes `bound: false` after the operation completes. Check the previous binding state to tailor the message:
 
-### On error (`success: false`)
-
-| Error code | Action |
-|---|---|
-| `not_bound` | Tell the user there is no active guardian binding for this channel — nothing to revoke. |
+- If a binding was previously active (i.e., the user explicitly asked to revoke their guardian): "Guardian binding revoked for [channel]. The previous guardian no longer has access to this channel."
+- If no binding existed (`bound: false` and there was nothing to revoke): "There is no active guardian binding for [channel] — nothing to revoke. Any pending verification challenges have been cleared."
 
 ## Important Notes
 


### PR DESCRIPTION
## Summary
- Remove stale `not_bound` error code from the revoke section of guardian-verify-setup SKILL.md
- Document the new `{ success: true, bound: false }` response shape the revoke endpoint returns when no binding exists
- Addresses review feedback from PR #11805 (Devin review)

## Test plan
- [x] Type-check passes
- [x] No remaining references to `not_bound` in the codebase
- [x] SKILL.md revoke section now accurately describes both revoke outcomes (binding existed vs. nothing to revoke)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
