### PR TITLE
fix: canonicalize externalUserIds when syncing to contacts table

### DIFF
--- a/assistant/src/contacts/contact-sync.ts
+++ b/assistant/src/contacts/contact-sync.ts
@@ -4,10 +4,12 @@
  * prevented by address-based dedup in upsertContact.
  */
 
+import type { ChannelId } from "../channels/types.js";
 import type { GuardianBinding } from "../memory/guardian-bindings.js";
 import { listActiveBindingsByAssistant } from "../memory/guardian-bindings.js";
 import type { IngressMember } from "../memory/ingress-member-store.js";
 import { listMembers } from "../memory/ingress-member-store.js";
+import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
 import { upsertContact } from "./contact-store.js";
 import type { ChannelStatus } from "./types.js";
 
@@ -49,6 +51,12 @@ export function syncGuardianBindingsToContacts(assistantId: string): void {
  * Useful for real-time forward-sync after a new binding is created.
  */
 export function syncSingleGuardianBinding(binding: GuardianBinding): void {
+  const canonicalId =
+    canonicalizeInboundIdentity(
+      binding.channel as ChannelId,
+      binding.guardianExternalUserId,
+    ) ?? binding.guardianExternalUserId;
+
   const displayName =
     parseDisplayNameFromMetadata(binding.metadataJson) ??
     binding.guardianExternalUserId;
@@ -60,8 +68,8 @@ export function syncSingleGuardianBinding(binding: GuardianBinding): void {
     channels: [
       {
         type: binding.channel,
-        address: binding.guardianExternalUserId,
-        externalUserId: binding.guardianExternalUserId,
+        address: canonicalId,
+        externalUserId: canonicalId,
         externalChatId: binding.guardianDeliveryChatId,
         status: "active",
         verifiedAt: binding.verifiedAt,
@@ -97,7 +105,21 @@ export function syncSingleMember(member: IngressMember): void {
   const displayName =
     member.displayName ?? member.username ?? member.externalUserId ?? "Unknown";
 
-  const address = member.externalUserId ?? member.externalChatId!;
+  let address: string;
+  let externalUserId: string | null;
+
+  if (member.externalUserId) {
+    const canonicalId =
+      canonicalizeInboundIdentity(
+        member.sourceChannel as ChannelId,
+        member.externalUserId,
+      ) ?? member.externalUserId;
+    address = canonicalId;
+    externalUserId = canonicalId;
+  } else {
+    address = member.externalChatId!;
+    externalUserId = null;
+  }
 
   upsertContact({
     displayName,
@@ -105,7 +127,7 @@ export function syncSingleMember(member: IngressMember): void {
       {
         type: member.sourceChannel,
         address,
-        externalUserId: member.externalUserId,
+        externalUserId,
         externalChatId: member.externalChatId,
         status: member.status as ChannelStatus,
         policy: member.policy as "allow" | "deny" | "escalate",


### PR DESCRIPTION
## Summary
- Canonicalizes externalUserIds (E.164 for phone channels, trimmed for others) before storing in contacts table
- Ensures trust resolver queries by canonical sender ID will find matching contacts
- Applies to both guardian binding sync and ingress member sync paths

Part of plan: trust-resolution-contacts.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11974" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
