### PR TITLE
feat: add findGuardianForChannel query for trust resolution

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -504,6 +504,39 @@ export function findContactByChannelExternalId(
 }
 
 /**
+ * Find the guardian contact and their specific channel entry for a given channel type.
+ * This is the contacts-based equivalent of getGuardianBinding(assistantId, channel).
+ * Returns null if no guardian contact has a channel of the specified type.
+ */
+export function findGuardianForChannel(
+  channelType: string,
+): { contact: Contact; channel: ContactChannel } | null {
+  const db = getDb();
+  const rows = db
+    .select({
+      contact: contacts,
+      channel: contactChannels,
+    })
+    .from(contacts)
+    .innerJoin(contactChannels, eq(contacts.id, contactChannels.contactId))
+    .where(
+      and(
+        eq(contacts.role, 'guardian'),
+        eq(contactChannels.type, channelType),
+      ),
+    )
+    .limit(1)
+    .all();
+
+  if (rows.length === 0) return null;
+  const row = rows[0];
+  return {
+    contact: parseContact(row.contact),
+    channel: parseChannel(row.channel),
+  };
+}
+
+/**
  * Update a channel's access-control fields (status, policy, reasons).
  * Returns the updated channel, or null if the channel does not exist.
  */


### PR DESCRIPTION
## Summary
- Adds findGuardianForChannel(channelType) to contact-store.ts
- Uses inner join on contacts (role=guardian) + contact_channels (type=channelType) to find the guardian's channel entry
- Returns { contact, channel } with all trust-relevant fields (principalId, externalUserId, externalChatId, etc.)

Part of plan: trust-resolution-contacts.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11975" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
