### PR TITLE
fix: apply role filter at SQL level and clear stale reason fields in contacts handler

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -352,11 +352,12 @@ export function searchContacts(params: {
   return rows.map((r) => withChannels(parseContact(r)));
 }
 
-export function listContacts(limit = 50): ContactWithChannels[] {
+export function listContacts(limit = 50, role?: ContactRole): ContactWithChannels[] {
   const db = getDb();
   const rows = db
     .select()
     .from(contacts)
+    .where(role ? eq(contacts.role, role) : undefined)
     .orderBy(
       sql`${contacts.role} = 'guardian' DESC`,
       desc(contacts.importance),
@@ -512,8 +513,8 @@ export function updateChannelStatus(
   params: {
     status?: ChannelStatus;
     policy?: ChannelPolicy;
-    revokedReason?: string;
-    blockedReason?: string;
+    revokedReason?: string | null;
+    blockedReason?: string | null;
   },
 ): ContactChannel | null {
   const db = getDb();

--- a/assistant/src/daemon/handlers/contacts.ts
+++ b/assistant/src/daemon/handlers/contacts.ts
@@ -43,10 +43,7 @@ export function handleContacts(
   try {
     switch (msg.action) {
       case 'list': {
-        let results = listContacts(msg.limit ?? 50);
-        if (msg.role) {
-          results = results.filter((c) => c.role === msg.role);
-        }
+        const results = listContacts(msg.limit ?? 50, msg.role);
         ctx.send(socket, {
           type: 'contacts_response',
           success: true,
@@ -81,8 +78,8 @@ export function handleContacts(
         const updated = updateChannelStatus(msg.channelId, {
           status: msg.status,
           policy: msg.policy,
-          revokedReason: msg.status === 'revoked' ? msg.reason : undefined,
-          blockedReason: msg.status === 'blocked' ? msg.reason : undefined,
+          revokedReason: msg.status !== undefined ? (msg.status === 'revoked' ? msg.reason : null) : undefined,
+          blockedReason: msg.status !== undefined ? (msg.status === 'blocked' ? msg.reason : null) : undefined,
         });
         if (!updated) {
           ctx.send(socket, { type: 'contacts_response', success: false, error: `Channel "${msg.channelId}" not found` });


### PR DESCRIPTION
## Summary
- Passes role filter to `listContacts()` at the SQL level (WHERE clause) instead of filtering in JS after LIMIT, fixing incorrect truncation when many guardians consume the limit
- Clears stale `revokedReason`/`blockedReason` when status transitions away from `revoked`/`blocked` (passes `null` to clear instead of `undefined` which leaves old values)
- Widens `updateChannelStatus` type to accept `string | null` for reason fields

Addresses review feedback on #11938.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11976" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
