### PR TITLE
feat: add diagnostic logging for contacts-first trust resolution path

### DIFF
--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -20,8 +20,11 @@ import type { TrustContext } from '../daemon/session-runtime-assembly.js';
 import type { IngressMember } from '../memory/ingress-member-store.js';
 import { findMember } from '../memory/ingress-member-store.js';
 import { canonicalizeInboundIdentity } from '../util/canonicalize-identity.js';
+import { getLogger } from '../util/logger.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
 import { getGuardianBinding } from './channel-guardian-service.js';
+
+const log = getLogger('actor-trust-resolver');
 
 export type { TrustContext } from '../daemon/session-runtime-assembly.js';
 
@@ -226,6 +229,12 @@ export function resolveActorTrust(input: ResolveActorTrustInput): ActorTrustCont
     }
   }
 
+  log.debug('trust-resolver guardian lookup', {
+    channel: input.sourceChannel,
+    source: guardianResult ? 'contacts' : 'legacy',
+    found: !!guardianBindingMatch,
+  });
+
   // --- Member lookup: contacts-first, legacy fallback ---
   let memberRecord: IngressMember | null = null;
   const contactMatch = findContactByChannelExternalId(input.sourceChannel, canonicalSenderId);
@@ -247,6 +256,13 @@ export function resolveActorTrust(input: ResolveActorTrustInput): ActorTrustCont
       externalChatId: input.conversationExternalId,
     });
   }
+
+  log.debug('trust-resolver member lookup', {
+    channel: input.sourceChannel,
+    canonicalSenderId,
+    source: contactMatch ? 'contacts' : 'legacy',
+    found: !!memberRecord,
+  });
 
   // In group chats, findMember may match on externalChatId and return a
   // record for a different user. Only use member metadata when the record's


### PR DESCRIPTION
## Summary
- Adds debug-level logging to resolveActorTrust() indicating whether guardian and member lookups used the contacts or legacy path
- Helps diagnose mismatches during the contacts-first transition period
- Debug-only — no noise at info/warn/error level

Part of plan: trust-resolution-contacts.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
