### PR TITLE
Forward Slack thread replies in active bot threads

### DIFF
--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -5,7 +5,10 @@ import { checkDeliverAuth } from "../middleware/deliver-auth.js";
 
 const log = getLogger("slack-deliver");
 
-export function createSlackDeliverHandler(config: GatewayConfig) {
+export function createSlackDeliverHandler(
+  config: GatewayConfig,
+  onThreadReply?: (threadTs: string) => void,
+) {
   return async (req: Request): Promise<Response> => {
     const traceId = req.headers.get("x-trace-id") ?? undefined;
     const tlog = traceId ? log.child({ traceId }) : log;
@@ -14,7 +17,11 @@ export function createSlackDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "Method not allowed" }, { status: 405 });
     }
 
-    const authResponse = checkDeliverAuth(req, config, "slackDeliverAuthBypass");
+    const authResponse = checkDeliverAuth(
+      req,
+      config,
+      "slackDeliverAuthBypass",
+    );
     if (authResponse) return authResponse;
 
     if (!config.slackChannelBotToken) {
@@ -38,11 +45,15 @@ export function createSlackDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "Invalid JSON" }, { status: 400 });
     }
 
-    if (typeof body !== 'object' || body === null) {
+    if (typeof body !== "object" || body === null) {
       return Response.json({ error: "Invalid request body" }, { status: 400 });
     }
 
-    if (body.attachments && Array.isArray(body.attachments) && body.attachments.length > 0) {
+    if (
+      body.attachments &&
+      Array.isArray(body.attachments) &&
+      body.attachments.length > 0
+    ) {
       return Response.json(
         { error: "Slack attachments not supported in MVP" },
         { status: 400 },
@@ -74,19 +85,25 @@ export function createSlackDeliverHandler(config: GatewayConfig) {
         slackBody.thread_ts = threadTs;
       }
 
-      const response = await fetchImpl("https://slack.com/api/chat.postMessage", {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${config.slackChannelBotToken}`,
-          "Content-Type": "application/json",
+      const response = await fetchImpl(
+        "https://slack.com/api/chat.postMessage",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${config.slackChannelBotToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(slackBody),
         },
-        body: JSON.stringify(slackBody),
-      });
+      );
 
       const data = (await response.json()) as { ok?: boolean; error?: string };
 
       if (!data.ok) {
-        tlog.error({ chatId, slackError: data.error }, "Slack API returned error");
+        tlog.error(
+          { chatId, slackError: data.error },
+          "Slack API returned error",
+        );
         return Response.json({ error: "Delivery failed" }, { status: 502 });
       }
     } catch (err) {
@@ -95,6 +112,12 @@ export function createSlackDeliverHandler(config: GatewayConfig) {
     }
 
     tlog.info({ chatId, hasThreadTs: !!threadTs }, "Slack message sent");
+
+    // Track the thread so future replies without @mention are forwarded
+    if (threadTs && onThreadReply) {
+      onThreadReply(threadTs);
+    }
+
     return Response.json({ ok: true });
   };
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -2,7 +2,10 @@ process.title = "vellum-gateway";
 
 import { randomBytes } from "node:crypto";
 import { AuthRateLimiter } from "./auth-rate-limiter.js";
-import { loadOrCreateSigningKey, initSigningKey } from "./auth/token-service.js";
+import {
+  loadOrCreateSigningKey,
+  initSigningKey,
+} from "./auth/token-service.js";
 import { validateEdgeToken } from "./auth/token-exchange.js";
 import { resolveScopeProfile } from "./auth/scopes.js";
 import type { Scope } from "./auth/types.js";
@@ -21,7 +24,10 @@ import { createTelegramWebhookHandler } from "./http/routes/telegram-webhook.js"
 import { createTwilioVoiceWebhookHandler } from "./http/routes/twilio-voice-webhook.js";
 import { createTwilioStatusWebhookHandler } from "./http/routes/twilio-status-webhook.js";
 import { createTwilioConnectActionWebhookHandler } from "./http/routes/twilio-connect-action-webhook.js";
-import { createTwilioRelayWebsocketHandler, getRelayWebsocketHandlers } from "./http/routes/twilio-relay-websocket.js";
+import {
+  createTwilioRelayWebsocketHandler,
+  getRelayWebsocketHandlers,
+} from "./http/routes/twilio-relay-websocket.js";
 import { createTwilioSmsWebhookHandler } from "./http/routes/twilio-sms-webhook.js";
 import { createSmsDeliverHandler } from "./http/routes/sms-deliver.js";
 import { createWhatsAppWebhookHandler } from "./http/routes/whatsapp-webhook.js";
@@ -29,7 +35,10 @@ import { createWhatsAppDeliverHandler } from "./http/routes/whatsapp-deliver.js"
 import { createSlackDeliverHandler } from "./http/routes/slack-deliver.js";
 import { createOAuthCallbackHandler } from "./http/routes/oauth-callback.js";
 import { createPairingProxyHandler } from "./http/routes/pairing-proxy.js";
-import { createFeatureFlagsGetHandler, createFeatureFlagsPatchHandler } from "./http/routes/feature-flags.js";
+import {
+  createFeatureFlagsGetHandler,
+  createFeatureFlagsPatchHandler,
+} from "./http/routes/feature-flags.js";
 import { createGuardianControlPlaneProxyHandler } from "./http/routes/guardian-control-plane-proxy.js";
 import { createTelegramControlPlaneProxyHandler } from "./http/routes/telegram-control-plane-proxy.js";
 import { createIngressControlPlaneProxyHandler } from "./http/routes/ingress-control-plane-proxy.js";
@@ -41,7 +50,10 @@ import { createBrainGraphProxyHandler } from "./http/routes/brain-graph-proxy.js
 import { getLogger, initLogger } from "./logger.js";
 import { CircuitBreakerOpenError } from "./runtime/client.js";
 import { buildSchema } from "./schema.js";
-import { createSlackSocketModeClient, type SlackSocketModeClient } from "./slack/socket-mode.js";
+import {
+  createSlackSocketModeClient,
+  type SlackSocketModeClient,
+} from "./slack/socket-mode.js";
 import { handleInbound } from "./handlers/handle-inbound.js";
 import { callTelegramApi } from "./telegram/api.js";
 import { reconcileTelegramWebhook } from "./telegram/webhook-manager.js";
@@ -57,11 +69,21 @@ let draining = false;
 // Shared rate limiter for auth failures and unauthenticated endpoints
 const authRateLimiter = new AuthRateLimiter();
 
-function isBrowserRelaySocketData(data: unknown): data is BrowserRelaySocketData {
-  return !!data && typeof data === "object" && (data as { wsType?: unknown }).wsType === "browser-relay";
+function isBrowserRelaySocketData(
+  data: unknown,
+): data is BrowserRelaySocketData {
+  return (
+    !!data &&
+    typeof data === "object" &&
+    (data as { wsType?: unknown }).wsType === "browser-relay"
+  );
 }
 
-function getClientIp(req: Request, server: ReturnType<typeof Bun.serve>, trustProxy: boolean): string {
+function getClientIp(
+  req: Request,
+  server: ReturnType<typeof Bun.serve>,
+  trustProxy: boolean,
+): string {
   if (trustProxy) {
     const forwarded = req.headers.get("x-forwarded-for");
     if (forwarded) {
@@ -85,7 +107,8 @@ function main() {
   initSigningKey(signingKey);
   log.info("JWT signing key initialized");
 
-  const { handler: handleTelegramWebhook, dedupCache: telegramDedupCache } = createTelegramWebhookHandler(config);
+  const { handler: handleTelegramWebhook, dedupCache: telegramDedupCache } =
+    createTelegramWebhookHandler(config);
   const handleTelegramDeliver = createTelegramDeliverHandler(config);
   const handleTelegramReconcile = createTelegramReconcileHandler(config);
 
@@ -97,21 +120,29 @@ function main() {
 
   const handleTwilioVoiceWebhook = createTwilioVoiceWebhookHandler(config);
   const handleTwilioStatusWebhook = createTwilioStatusWebhookHandler(config);
-  const handleTwilioConnectActionWebhook = createTwilioConnectActionWebhookHandler(config);
+  const handleTwilioConnectActionWebhook =
+    createTwilioConnectActionWebhookHandler(config);
   const handleTwilioRelayWs = createTwilioRelayWebsocketHandler(config);
   const handleBrowserRelayWs = createBrowserRelayWebsocketHandler(config);
   const twilioRelayWebsocketHandlers = getRelayWebsocketHandlers();
   const browserRelayWebsocketHandlers = getBrowserRelayWebsocketHandlers();
-  const { handler: handleTwilioSmsWebhook, dedupCache: smsDedupCache } = createTwilioSmsWebhookHandler(config);
+  const { handler: handleTwilioSmsWebhook, dedupCache: smsDedupCache } =
+    createTwilioSmsWebhookHandler(config);
   const handleSmsDeliver = createSmsDeliverHandler(config);
-  const { handler: handleWhatsAppWebhook, dedupCache: whatsappDedupCache } = createWhatsAppWebhookHandler(config);
+  const { handler: handleWhatsAppWebhook, dedupCache: whatsappDedupCache } =
+    createWhatsAppWebhookHandler(config);
   const handleWhatsAppDeliver = createWhatsAppDeliverHandler(config);
-  const handleSlackDeliver = createSlackDeliverHandler(config);
+  const handleSlackDeliver = createSlackDeliverHandler(config, (threadTs) => {
+    slackSocketClient?.trackThread(threadTs);
+  });
   const handleOAuthCallback = createOAuthCallbackHandler(config);
   const pairingProxy = createPairingProxyHandler(config);
-  const guardianControlPlaneProxy = createGuardianControlPlaneProxyHandler(config);
-  const telegramControlPlaneProxy = createTelegramControlPlaneProxyHandler(config);
-  const ingressControlPlaneProxy = createIngressControlPlaneProxyHandler(config);
+  const guardianControlPlaneProxy =
+    createGuardianControlPlaneProxyHandler(config);
+  const telegramControlPlaneProxy =
+    createTelegramControlPlaneProxyHandler(config);
+  const ingressControlPlaneProxy =
+    createIngressControlPlaneProxyHandler(config);
   const twilioControlPlaneProxy = createTwilioControlPlaneProxyHandler(config);
   const channelReadinessProxy = createChannelReadinessProxyHandler(config);
   const runtimeHealthProxy = createRuntimeHealthProxyHandler(config);
@@ -153,7 +184,10 @@ function main() {
       if (err instanceof CircuitBreakerOpenError) {
         return Response.json(
           { error: "Service temporarily unavailable — runtime is unreachable" },
-          { status: 503, headers: { "Retry-After": String(err.retryAfterSecs) } },
+          {
+            status: 503,
+            headers: { "Retry-After": String(err.retryAfterSecs) },
+          },
         );
       }
       log.error({ err }, "Unhandled gateway error");
@@ -181,7 +215,8 @@ function main() {
       // Rate-limit check for auth-protected, pairing, and unauthenticated
       // endpoints that forward to the runtime (OAuth callback is publicly
       // reachable and forwards every valid-looking request).
-      const isRateLimitedRoute = url.pathname === "/integrations/status" ||
+      const isRateLimitedRoute =
+        url.pathname === "/integrations/status" ||
         url.pathname === "/deliver/telegram" ||
         url.pathname === "/deliver/sms" ||
         url.pathname === "/deliver/whatsapp" ||
@@ -197,7 +232,10 @@ function main() {
       if (isRateLimitedRoute) {
         const clientIp = getClientIp(req, svr, config.trustProxy);
         if (authRateLimiter.isBlocked(clientIp)) {
-          log.warn({ ip: clientIp, path: url.pathname }, "Auth rate limit exceeded");
+          log.warn(
+            { ip: clientIp, path: url.pathname },
+            "Auth rate limit exceeded",
+          );
           return Response.json(
             { error: "Too many failed attempts. Try again later." },
             { status: 429, headers: { "Retry-After": "60" } },
@@ -235,7 +273,9 @@ function main() {
         }
         const res = await handleTelegramDeliver(tracedReq);
         if (res.status === 401) {
-          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+          authRateLimiter.recordFailure(
+            getClientIp(req, svr, config.trustProxy),
+          );
         }
         return res;
       }
@@ -268,7 +308,9 @@ function main() {
       if (url.pathname === "/deliver/sms") {
         const res = await handleSmsDeliver(tracedReq);
         if (res.status === 401) {
-          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+          authRateLimiter.recordFailure(
+            getClientIp(req, svr, config.trustProxy),
+          );
         }
         return res;
       }
@@ -292,7 +334,9 @@ function main() {
         }
         const res = await handleWhatsAppDeliver(tracedReq);
         if (res.status === 401) {
-          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+          authRateLimiter.recordFailure(
+            getClientIp(req, svr, config.trustProxy),
+          );
         }
         return res;
       }
@@ -306,12 +350,17 @@ function main() {
         }
         const res = await handleSlackDeliver(tracedReq);
         if (res.status === 401) {
-          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+          authRateLimiter.recordFailure(
+            getClientIp(req, svr, config.trustProxy),
+          );
         }
         return res;
       }
 
-      if (url.pathname === "/webhooks/twilio/relay" || url.pathname === "/v1/calls/relay") {
+      if (
+        url.pathname === "/webhooks/twilio/relay" ||
+        url.pathname === "/v1/calls/relay"
+      ) {
         const upgradeResult = handleTwilioRelayWs(req, server);
         if (upgradeResult !== undefined) return upgradeResult;
         // If upgrade was handled, Bun doesn't need a response
@@ -325,10 +374,15 @@ function main() {
         return undefined as unknown as Response;
       }
 
-      if (url.pathname === "/webhooks/oauth/callback" && tracedReq.method === "GET") {
+      if (
+        url.pathname === "/webhooks/oauth/callback" &&
+        tracedReq.method === "GET"
+      ) {
         const res = await handleOAuthCallback(tracedReq);
         if (res.status === 400) {
-          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+          authRateLimiter.recordFailure(
+            getClientIp(req, svr, config.trustProxy),
+          );
         }
         return res;
       }
@@ -340,13 +394,17 @@ function main() {
       function requireEdgeAuth(): Response | null {
         const authHeader = tracedReq.headers.get("authorization");
         if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
-          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+          authRateLimiter.recordFailure(
+            getClientIp(req, svr, config.trustProxy),
+          );
           return Response.json({ error: "Unauthorized" }, { status: 401 });
         }
         const token = authHeader.slice(7);
         const result = validateEdgeToken(token);
         if (!result.ok) {
-          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+          authRateLimiter.recordFailure(
+            getClientIp(req, svr, config.trustProxy),
+          );
           return Response.json({ error: "Unauthorized" }, { status: 401 });
         }
         return null;
@@ -359,13 +417,17 @@ function main() {
       function requireEdgeAuthWithScope(scope: Scope): Response | null {
         const authHeader = tracedReq.headers.get("authorization");
         if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
-          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+          authRateLimiter.recordFailure(
+            getClientIp(req, svr, config.trustProxy),
+          );
           return Response.json({ error: "Unauthorized" }, { status: 401 });
         }
         const token = authHeader.slice(7);
         const result = validateEdgeToken(token);
         if (!result.ok) {
-          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+          authRateLimiter.recordFailure(
+            getClientIp(req, svr, config.trustProxy),
+          );
           return Response.json({ error: "Unauthorized" }, { status: 401 });
         }
         const scopes = resolveScopeProfile(result.claims.scope_profile);
@@ -401,22 +463,36 @@ function main() {
 
       // ── Telegram integration control-plane proxy ──
       if (
-        (url.pathname === "/v1/integrations/telegram/config" && req.method === "GET")
-        || (url.pathname === "/v1/integrations/telegram/config" && req.method === "POST")
-        || (url.pathname === "/v1/integrations/telegram/config" && req.method === "DELETE")
-        || (url.pathname === "/v1/integrations/telegram/commands" && req.method === "POST")
-        || (url.pathname === "/v1/integrations/telegram/setup" && req.method === "POST")
+        (url.pathname === "/v1/integrations/telegram/config" &&
+          req.method === "GET") ||
+        (url.pathname === "/v1/integrations/telegram/config" &&
+          req.method === "POST") ||
+        (url.pathname === "/v1/integrations/telegram/config" &&
+          req.method === "DELETE") ||
+        (url.pathname === "/v1/integrations/telegram/commands" &&
+          req.method === "POST") ||
+        (url.pathname === "/v1/integrations/telegram/setup" &&
+          req.method === "POST")
       ) {
         const authError = requireEdgeAuth();
         if (authError) return authError;
 
-        if (url.pathname === "/v1/integrations/telegram/config" && req.method === "GET") {
+        if (
+          url.pathname === "/v1/integrations/telegram/config" &&
+          req.method === "GET"
+        ) {
           return telegramControlPlaneProxy.handleGetTelegramConfig(tracedReq);
         }
-        if (url.pathname === "/v1/integrations/telegram/config" && req.method === "POST") {
+        if (
+          url.pathname === "/v1/integrations/telegram/config" &&
+          req.method === "POST"
+        ) {
           return telegramControlPlaneProxy.handleSetTelegramConfig(tracedReq);
         }
-        if (url.pathname === "/v1/integrations/telegram/config" && req.method === "DELETE") {
+        if (
+          url.pathname === "/v1/integrations/telegram/config" &&
+          req.method === "DELETE"
+        ) {
           return telegramControlPlaneProxy.handleClearTelegramConfig(tracedReq);
         }
         if (url.pathname === "/v1/integrations/telegram/commands") {
@@ -426,7 +502,10 @@ function main() {
       }
 
       // ── Ingress members/invites control-plane proxy ──
-      const ingressRoute = matchIngressControlPlaneRoute(url.pathname, req.method);
+      const ingressRoute = matchIngressControlPlaneRoute(
+        url.pathname,
+        req.method,
+      );
       if (ingressRoute) {
         const authError = requireEdgeAuth();
         if (authError) return authError;
@@ -437,9 +516,15 @@ function main() {
           case "upsertMember":
             return ingressControlPlaneProxy.handleUpsertMember(tracedReq);
           case "blockMember":
-            return ingressControlPlaneProxy.handleBlockMember(tracedReq, ingressRoute.memberId);
+            return ingressControlPlaneProxy.handleBlockMember(
+              tracedReq,
+              ingressRoute.memberId,
+            );
           case "revokeMember":
-            return ingressControlPlaneProxy.handleRevokeMember(tracedReq, ingressRoute.memberId);
+            return ingressControlPlaneProxy.handleRevokeMember(
+              tracedReq,
+              ingressRoute.memberId,
+            );
           case "listInvites":
             return ingressControlPlaneProxy.handleListInvites(tracedReq);
           case "createInvite":
@@ -447,15 +532,23 @@ function main() {
           case "redeemInvite":
             return ingressControlPlaneProxy.handleRedeemInvite(tracedReq);
           case "revokeInvite":
-            return ingressControlPlaneProxy.handleRevokeInvite(tracedReq, ingressRoute.inviteId);
+            return ingressControlPlaneProxy.handleRevokeInvite(
+              tracedReq,
+              ingressRoute.inviteId,
+            );
         }
       }
 
       // ── Guardian vellum bootstrap (actor token) ──
-      if (url.pathname === "/v1/integrations/guardian/vellum/bootstrap" && req.method === "POST") {
+      if (
+        url.pathname === "/v1/integrations/guardian/vellum/bootstrap" &&
+        req.method === "POST"
+      ) {
         const authError = requireEdgeAuth();
         if (authError) return authError;
-        return guardianControlPlaneProxy.handleGuardianVellumBootstrap(tracedReq);
+        return guardianControlPlaneProxy.handleGuardianVellumBootstrap(
+          tracedReq,
+        );
       }
 
       // ── Guardian verification control-plane proxy ──
@@ -471,7 +564,9 @@ function main() {
         if (authError) return authError;
 
         if (url.pathname === "/v1/integrations/guardian/challenge") {
-          return guardianControlPlaneProxy.handleCreateGuardianChallenge(tracedReq);
+          return guardianControlPlaneProxy.handleCreateGuardianChallenge(
+            tracedReq,
+          );
         }
         if (url.pathname === "/v1/integrations/guardian/status") {
           return guardianControlPlaneProxy.handleGetGuardianStatus(tracedReq);
@@ -480,12 +575,18 @@ function main() {
           return guardianControlPlaneProxy.handleRevokeGuardian(tracedReq);
         }
         if (url.pathname === "/v1/integrations/guardian/outbound/start") {
-          return guardianControlPlaneProxy.handleStartGuardianOutbound(tracedReq);
+          return guardianControlPlaneProxy.handleStartGuardianOutbound(
+            tracedReq,
+          );
         }
         if (url.pathname === "/v1/integrations/guardian/outbound/resend") {
-          return guardianControlPlaneProxy.handleResendGuardianOutbound(tracedReq);
+          return guardianControlPlaneProxy.handleResendGuardianOutbound(
+            tracedReq,
+          );
         }
-        return guardianControlPlaneProxy.handleCancelGuardianOutbound(tracedReq);
+        return guardianControlPlaneProxy.handleCancelGuardianOutbound(
+          tracedReq,
+        );
       }
 
       // ── Guardian vellum refresh proxy ──
@@ -494,16 +595,23 @@ function main() {
       // so rejecting expired tokens here would create a deadlock once
       // the JWT expires. Signature, audience, and policy epoch are still
       // verified — only the expiration check is relaxed.
-      if (url.pathname === "/v1/integrations/guardian/vellum/refresh" && req.method === "POST") {
+      if (
+        url.pathname === "/v1/integrations/guardian/vellum/refresh" &&
+        req.method === "POST"
+      ) {
         const authHeader = tracedReq.headers.get("authorization");
         if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
-          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+          authRateLimiter.recordFailure(
+            getClientIp(req, svr, config.trustProxy),
+          );
           return Response.json({ error: "Unauthorized" }, { status: 401 });
         }
         const token = authHeader.slice(7);
         const result = validateEdgeToken(token, { allowExpired: true });
         if (!result.ok) {
-          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+          authRateLimiter.recordFailure(
+            getClientIp(req, svr, config.trustProxy),
+          );
           return Response.json({ error: "Unauthorized" }, { status: 401 });
         }
         return guardianControlPlaneProxy.handleGuardianRefresh(tracedReq);
@@ -511,31 +619,56 @@ function main() {
 
       // ── Twilio integration control-plane proxy ──
       if (
-        (url.pathname === "/v1/integrations/twilio/config" && req.method === "GET")
-        || (url.pathname === "/v1/integrations/twilio/credentials" && req.method === "POST")
-        || (url.pathname === "/v1/integrations/twilio/credentials" && req.method === "DELETE")
-        || (url.pathname === "/v1/integrations/twilio/numbers" && req.method === "GET")
-        || (url.pathname === "/v1/integrations/twilio/numbers/provision" && req.method === "POST")
-        || (url.pathname === "/v1/integrations/twilio/numbers/assign" && req.method === "POST")
-        || (url.pathname === "/v1/integrations/twilio/numbers/release" && req.method === "POST")
-        || (url.pathname === "/v1/integrations/twilio/sms/compliance" && req.method === "GET")
-        || (url.pathname === "/v1/integrations/twilio/sms/compliance/tollfree" && req.method === "POST")
-        || (url.pathname === "/v1/integrations/twilio/sms/test" && req.method === "POST")
-        || (url.pathname === "/v1/integrations/twilio/sms/doctor" && req.method === "POST")
+        (url.pathname === "/v1/integrations/twilio/config" &&
+          req.method === "GET") ||
+        (url.pathname === "/v1/integrations/twilio/credentials" &&
+          req.method === "POST") ||
+        (url.pathname === "/v1/integrations/twilio/credentials" &&
+          req.method === "DELETE") ||
+        (url.pathname === "/v1/integrations/twilio/numbers" &&
+          req.method === "GET") ||
+        (url.pathname === "/v1/integrations/twilio/numbers/provision" &&
+          req.method === "POST") ||
+        (url.pathname === "/v1/integrations/twilio/numbers/assign" &&
+          req.method === "POST") ||
+        (url.pathname === "/v1/integrations/twilio/numbers/release" &&
+          req.method === "POST") ||
+        (url.pathname === "/v1/integrations/twilio/sms/compliance" &&
+          req.method === "GET") ||
+        (url.pathname === "/v1/integrations/twilio/sms/compliance/tollfree" &&
+          req.method === "POST") ||
+        (url.pathname === "/v1/integrations/twilio/sms/test" &&
+          req.method === "POST") ||
+        (url.pathname === "/v1/integrations/twilio/sms/doctor" &&
+          req.method === "POST")
       ) {
         const authError = requireEdgeAuth();
         if (authError) return authError;
 
-        if (url.pathname === "/v1/integrations/twilio/config" && req.method === "GET") {
+        if (
+          url.pathname === "/v1/integrations/twilio/config" &&
+          req.method === "GET"
+        ) {
           return twilioControlPlaneProxy.handleGetTwilioConfig(tracedReq);
         }
-        if (url.pathname === "/v1/integrations/twilio/credentials" && req.method === "POST") {
+        if (
+          url.pathname === "/v1/integrations/twilio/credentials" &&
+          req.method === "POST"
+        ) {
           return twilioControlPlaneProxy.handleSetTwilioCredentials(tracedReq);
         }
-        if (url.pathname === "/v1/integrations/twilio/credentials" && req.method === "DELETE") {
-          return twilioControlPlaneProxy.handleClearTwilioCredentials(tracedReq);
+        if (
+          url.pathname === "/v1/integrations/twilio/credentials" &&
+          req.method === "DELETE"
+        ) {
+          return twilioControlPlaneProxy.handleClearTwilioCredentials(
+            tracedReq,
+          );
         }
-        if (url.pathname === "/v1/integrations/twilio/numbers" && req.method === "GET") {
+        if (
+          url.pathname === "/v1/integrations/twilio/numbers" &&
+          req.method === "GET"
+        ) {
           return twilioControlPlaneProxy.handleListTwilioNumbers(tracedReq);
         }
         if (url.pathname === "/v1/integrations/twilio/numbers/provision") {
@@ -547,11 +680,18 @@ function main() {
         if (url.pathname === "/v1/integrations/twilio/numbers/release") {
           return twilioControlPlaneProxy.handleReleaseTwilioNumber(tracedReq);
         }
-        if (url.pathname === "/v1/integrations/twilio/sms/compliance" && req.method === "GET") {
+        if (
+          url.pathname === "/v1/integrations/twilio/sms/compliance" &&
+          req.method === "GET"
+        ) {
           return twilioControlPlaneProxy.handleGetSmsCompliance(tracedReq);
         }
-        if (url.pathname === "/v1/integrations/twilio/sms/compliance/tollfree") {
-          return twilioControlPlaneProxy.handleSubmitTollfreeVerification(tracedReq);
+        if (
+          url.pathname === "/v1/integrations/twilio/sms/compliance/tollfree"
+        ) {
+          return twilioControlPlaneProxy.handleSubmitTollfreeVerification(
+            tracedReq,
+          );
         }
         if (url.pathname === "/v1/integrations/twilio/sms/test") {
           return twilioControlPlaneProxy.handleSmsSendTest(tracedReq);
@@ -563,21 +703,33 @@ function main() {
       const tollfreeVerificationMatch = url.pathname.match(
         /^\/v1\/integrations\/twilio\/sms\/compliance\/tollfree\/([^/]+)$/,
       );
-      if (tollfreeVerificationMatch && (req.method === "PATCH" || req.method === "DELETE")) {
+      if (
+        tollfreeVerificationMatch &&
+        (req.method === "PATCH" || req.method === "DELETE")
+      ) {
         const authError = requireEdgeAuth();
         if (authError) return authError;
 
-        const verificationSid = decodeURIComponent(tollfreeVerificationMatch[1]);
+        const verificationSid = decodeURIComponent(
+          tollfreeVerificationMatch[1],
+        );
         if (req.method === "PATCH") {
-          return twilioControlPlaneProxy.handleUpdateTollfreeVerification(tracedReq, verificationSid);
+          return twilioControlPlaneProxy.handleUpdateTollfreeVerification(
+            tracedReq,
+            verificationSid,
+          );
         }
-        return twilioControlPlaneProxy.handleDeleteTollfreeVerification(tracedReq, verificationSid);
+        return twilioControlPlaneProxy.handleDeleteTollfreeVerification(
+          tracedReq,
+          verificationSid,
+        );
       }
 
       // ── Channel readiness proxy ──
       if (
-        (url.pathname === "/v1/channels/readiness" && req.method === "GET")
-        || (url.pathname === "/v1/channels/readiness/refresh" && req.method === "POST")
+        (url.pathname === "/v1/channels/readiness" && req.method === "GET") ||
+        (url.pathname === "/v1/channels/readiness/refresh" &&
+          req.method === "POST")
       ) {
         const authError = requireEdgeAuth();
         if (authError) return authError;
@@ -610,14 +762,18 @@ function main() {
       if (url.pathname === "/pairing/request" && tracedReq.method === "POST") {
         const res = await pairingProxy.handlePairingRequest(tracedReq);
         if (res.status === 401 || res.status === 403) {
-          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+          authRateLimiter.recordFailure(
+            getClientIp(req, svr, config.trustProxy),
+          );
         }
         return res;
       }
       if (url.pathname === "/pairing/status" && tracedReq.method === "GET") {
         const res = await pairingProxy.handlePairingStatus(tracedReq);
         if (res.status === 401 || res.status === 403) {
-          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+          authRateLimiter.recordFailure(
+            getClientIp(req, svr, config.trustProxy),
+          );
         }
         return res;
       }
@@ -626,33 +782,46 @@ function main() {
       // Feature flag access is scope-based: actor_client_v1 includes
       // feature_flags.read/write. No separate feature flag token needed.
       if (url.pathname === "/v1/feature-flags" && req.method === "GET") {
-        const authError = requireEdgeAuthWithScope('feature_flags.read');
+        const authError = requireEdgeAuthWithScope("feature_flags.read");
         if (authError) return authError;
         return handleFeatureFlagsGet(tracedReq);
       }
 
-      const featureFlagPatchMatch = url.pathname.match(/^\/v1\/feature-flags\/(.+)$/);
+      const featureFlagPatchMatch = url.pathname.match(
+        /^\/v1\/feature-flags\/(.+)$/,
+      );
       if (featureFlagPatchMatch && req.method === "PATCH") {
-        const authError = requireEdgeAuthWithScope('feature_flags.write');
+        const authError = requireEdgeAuthWithScope("feature_flags.write");
         if (authError) return authError;
         let flagKey: string;
         try {
           flagKey = decodeURIComponent(featureFlagPatchMatch[1]);
         } catch {
-          return Response.json({ error: "Invalid flag key encoding" }, { status: 400 });
+          return Response.json(
+            { error: "Invalid flag key encoding" },
+            { status: 400 },
+          );
         }
         return handleFeatureFlagsPatch(tracedReq, flagKey);
       }
 
       if (handleRuntimeProxy) {
-        const res = await handleRuntimeProxy(tracedReq, getClientIp(req, svr, config.trustProxy));
+        const res = await handleRuntimeProxy(
+          tracedReq,
+          getClientIp(req, svr, config.trustProxy),
+        );
         if (res.status === 401) {
-          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+          authRateLimiter.recordFailure(
+            getClientIp(req, svr, config.trustProxy),
+          );
         }
         return res;
       }
 
-      return Response.json({ error: "Not found", source: "gateway" }, { status: 404 });
+      return Response.json(
+        { error: "Not found", source: "gateway" },
+        { status: 404 },
+      );
     },
   });
 
@@ -699,14 +868,16 @@ function main() {
       },
       (normalized) => {
         const { threadTs, channel } = normalized;
-        const replyCallbackUrl =
-          `${config.gatewayInternalBaseUrl}/deliver/slack?threadTs=${encodeURIComponent(threadTs)}&channel=${encodeURIComponent(channel)}`;
+        const replyCallbackUrl = `${config.gatewayInternalBaseUrl}/deliver/slack?threadTs=${encodeURIComponent(threadTs)}&channel=${encodeURIComponent(channel)}`;
 
         handleInbound(config, normalized.event, {
           replyCallbackUrl,
           routingOverride: normalized.routing,
         }).catch((err) => {
-          log.error({ err, channel, threadTs }, "Failed to forward Slack event to runtime");
+          log.error(
+            { err, channel, threadTs },
+            "Failed to forward Slack event to runtime",
+          );
         });
       },
     );
@@ -722,7 +893,9 @@ function main() {
   }
 
   const telegramFromEnv = isTelegramConfigured();
-  const slackFromEnv = !!(process.env.SLACK_CHANNEL_BOT_TOKEN && process.env.SLACK_CHANNEL_APP_TOKEN);
+  const slackFromEnv = !!(
+    process.env.SLACK_CHANNEL_BOT_TOKEN && process.env.SLACK_CHANNEL_APP_TOKEN
+  );
 
   const credentialWatcher = new CredentialWatcher((event) => {
     if (event.telegramChanged && !telegramFromEnv) {
@@ -732,7 +905,10 @@ function main() {
         log.info("Telegram credentials loaded from credential vault");
         registerTelegramCommands();
         reconcileTelegramWebhook(config).catch((err) => {
-          log.error({ err }, "Failed to reconcile Telegram webhook after credential change");
+          log.error(
+            { err },
+            "Failed to reconcile Telegram webhook after credential change",
+          );
         });
       } else {
         config.telegramBotToken = undefined;
@@ -758,7 +934,8 @@ function main() {
         config.whatsappPhoneNumberId = event.whatsappCredentials.phoneNumberId;
         config.whatsappAccessToken = event.whatsappCredentials.accessToken;
         config.whatsappAppSecret = event.whatsappCredentials.appSecret;
-        config.whatsappWebhookVerifyToken = event.whatsappCredentials.webhookVerifyToken;
+        config.whatsappWebhookVerifyToken =
+          event.whatsappCredentials.webhookVerifyToken;
         log.info("WhatsApp credentials loaded from credential vault");
       } else {
         config.whatsappPhoneNumberId = undefined;
@@ -802,7 +979,10 @@ function main() {
       config.ingressPublicBaseUrl = event.ingressPublicBaseUrl;
       if (isTelegramConfigured()) {
         reconcileTelegramWebhook(config).catch((err) => {
-          log.error({ err }, "Failed to reconcile Telegram webhook after ingress URL change");
+          log.error(
+            { err },
+            "Failed to reconcile Telegram webhook after ingress URL change",
+          );
         });
       }
     }

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -34,6 +34,23 @@ export interface SlackDirectMessageEvent {
 }
 
 /**
+ * Slack `message` event shape for channel/group messages (non-DM).
+ * Used to pick up thread replies in threads the bot is already participating in.
+ */
+export interface SlackChannelMessageEvent {
+  type: "message";
+  subtype?: string;
+  user?: string;
+  text: string;
+  ts: string;
+  channel: string;
+  channel_type: "channel" | "group" | "mpim";
+  thread_ts?: string;
+  client_msg_id?: string;
+  event_ts?: string;
+}
+
+/**
  * Strip leading bot-mention tokens (`<@U...>`) from the message text.
  * Slack wraps mentions as `<@UXXXXXX>`, often at the start of an
  * app_mention event's text field. We remove all leading occurrences
@@ -106,6 +123,55 @@ export function normalizeSlackDirectMessage(
       },
       source: {
         updateId: eventId,
+      },
+      raw: event as unknown as Record<string, unknown>,
+    },
+    routing,
+    threadTs: event.thread_ts ?? event.ts,
+    channel: event.channel,
+  };
+}
+
+/**
+ * Normalize a Slack channel `message` event (thread reply in an active bot
+ * thread) into the gateway's canonical inbound event shape.
+ *
+ * Returns null if the event should be ignored (bot's own messages, subtypes,
+ * missing user, or unroutable channels).
+ */
+export function normalizeSlackChannelMessage(
+  event: SlackChannelMessageEvent,
+  eventId: string,
+  config: GatewayConfig,
+  botUserId?: string,
+): NormalizedSlackEvent | null {
+  if (botUserId && event.user === botUserId) return null;
+  if (event.subtype) return null;
+  if (!event.user) return null;
+
+  const routing = resolveAssistant(config, event.channel, event.user);
+  if (isRejection(routing)) return null;
+
+  const content = stripBotMention(event.text);
+  const externalMessageId =
+    event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
+
+  return {
+    event: {
+      version: "v1",
+      sourceChannel: "slack",
+      receivedAt: new Date().toISOString(),
+      message: {
+        content,
+        conversationExternalId: event.channel,
+        externalMessageId,
+      },
+      actor: {
+        actorExternalId: event.user,
+      },
+      source: {
+        updateId: eventId,
+        chatType: "channel",
       },
       raw: event as unknown as Record<string, unknown>,
     },

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -244,9 +244,13 @@ export class SlackSocketModeClient {
 
     const isAppMention = event.type === "app_mention";
     const isDm = event.type === "message" && dmEvent.channel_type === "im";
+    const mentionsBot =
+      this.config.botUserId &&
+      channelEvent.text?.includes(`<@${this.config.botUserId}>`);
     const isActiveThreadReply =
       event.type === "message" &&
       !isDm &&
+      !mentionsBot &&
       !!channelEvent.thread_ts &&
       this.activeThreads.has(channelEvent.thread_ts);
 

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -4,8 +4,10 @@ import type { GatewayConfig } from "../config.js";
 import {
   normalizeSlackAppMention,
   normalizeSlackDirectMessage,
+  normalizeSlackChannelMessage,
   type SlackAppMentionEvent,
   type SlackDirectMessageEvent,
+  type SlackChannelMessageEvent,
   type NormalizedSlackEvent,
 } from "./normalize.js";
 
@@ -15,6 +17,7 @@ const BASE_BACKOFF_MS = 1_000;
 const MAX_BACKOFF_MS = 30_000;
 const DEDUP_TTL_MS = 24 * 60 * 60 * 1_000;
 const DEDUP_CLEANUP_INTERVAL_MS = 60 * 60 * 1_000;
+const ACTIVE_THREAD_TTL_MS = 24 * 60 * 60 * 1_000;
 
 export type SlackSocketModeConfig = {
   appToken: string;
@@ -41,6 +44,7 @@ export class SlackSocketModeClient {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private dedupMap = new Map<string, number>();
   private dedupCleanupTimer: ReturnType<typeof setInterval> | null = null;
+  private activeThreads = new Map<string, number>();
 
   constructor(
     config: SlackSocketModeConfig,
@@ -90,6 +94,13 @@ export class SlackSocketModeClient {
       }
       this.ws = null;
     }
+  }
+
+  /**
+   * Register a thread as active so future replies (without @mention) are forwarded.
+   */
+  trackThread(threadTs: string): void {
+    this.activeThreads.set(threadTs, Date.now());
   }
 
   private async connect(): Promise<void> {
@@ -177,7 +188,10 @@ export class SlackSocketModeClient {
       type?: string;
       payload?: {
         event_id?: string;
-        event?: SlackAppMentionEvent | SlackDirectMessageEvent;
+        event?:
+          | SlackAppMentionEvent
+          | SlackDirectMessageEvent
+          | SlackChannelMessageEvent;
       };
       reason?: string;
     };
@@ -226,12 +240,18 @@ export class SlackSocketModeClient {
 
     const event = eventPayload.event;
     const dmEvent = event as SlackDirectMessageEvent;
+    const channelEvent = event as SlackChannelMessageEvent;
 
-    // Process app_mention events and DM (message with channel_type: "im") events
-    if (
-      event.type !== "app_mention" &&
-      !(event.type === "message" && dmEvent.channel_type === "im")
-    ) {
+    const isAppMention = event.type === "app_mention";
+    const isDm = event.type === "message" && dmEvent.channel_type === "im";
+    const isActiveThreadReply =
+      event.type === "message" &&
+      !isDm &&
+      !!channelEvent.thread_ts &&
+      this.activeThreads.has(channelEvent.thread_ts);
+
+    // Process app_mention events, DMs, and replies in active bot threads
+    if (!isAppMention && !isDm && !isActiveThreadReply) {
       return;
     }
 
@@ -244,11 +264,18 @@ export class SlackSocketModeClient {
     this.dedupMap.set(eventId, Date.now());
 
     let normalized: NormalizedSlackEvent | null;
-    if (event.type === "app_mention") {
+    if (isAppMention) {
       normalized = normalizeSlackAppMention(
         event as SlackAppMentionEvent,
         eventId,
         this.config.gatewayConfig,
+      );
+    } else if (isActiveThreadReply) {
+      normalized = normalizeSlackChannelMessage(
+        event as SlackChannelMessageEvent,
+        eventId,
+        this.config.gatewayConfig,
+        this.config.botUserId,
       );
     } else {
       normalized = normalizeSlackDirectMessage(
@@ -309,6 +336,17 @@ export class SlackSocketModeClient {
       }
       if (evicted > 0) {
         log.debug({ evicted }, "Evicted expired Slack event dedup entries");
+      }
+      // Also clean up expired active threads
+      let threadEvicted = 0;
+      for (const [key, timestamp] of this.activeThreads) {
+        if (now - timestamp > ACTIVE_THREAD_TTL_MS) {
+          this.activeThreads.delete(key);
+          threadEvicted++;
+        }
+      }
+      if (threadEvicted > 0) {
+        log.debug({ threadEvicted }, "Evicted expired active thread entries");
       }
     }, DEDUP_CLEANUP_INTERVAL_MS);
   }


### PR DESCRIPTION
## Summary
- Track threads where the bot has replied via an in-memory `activeThreads` map (24h TTL) in the socket mode client
- When a channel message arrives with a `thread_ts` matching an active thread, forward it to the runtime — no `@mention` needed
- After successful `chat.postMessage` to a thread, register it as active via `trackThread()`
- Add `SlackChannelMessageEvent` interface and `normalizeSlackChannelMessage()` normalizer

## Test plan
- [x] Manually verified: @mention bot in channel → bot replies in thread → subsequent thread replies reach bot without @mention
- [ ] Verify thread TTL cleanup works after 24h
- [ ] Verify bot's own messages in threads are filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
