### PR TITLE
fix: add active-status filter and deterministic ordering to findGuardianForChannel

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -524,8 +524,10 @@ export function findGuardianForChannel(
       and(
         eq(contacts.role, 'guardian'),
         eq(contactChannels.type, channelType),
+        eq(contactChannels.status, 'active'),
       ),
     )
+    .orderBy(desc(contactChannels.verifiedAt))
     .limit(1)
     .all();
 


### PR DESCRIPTION
Add status='active' filter to prevent returning revoked/blocked guardians. Add orderBy(desc(verifiedAt)) before limit(1) for deterministic selection of the most recently verified guardian.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
