### PR TITLE
fix: remove premature stale-anchor clearing in thread switch handler

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -607,17 +607,14 @@ struct MessageListView: View {
                 }
                 isThreadContentHovered = false
                 DispatchQueue.main.async {
+                    // Skip scroll-to-bottom when an anchor message is pending —
+                    // the anchorMessageId onChange handler will scroll to the
+                    // specific message instead. Stale anchors from other threads
+                    // are cleared by ThreadManager.activeThreadId.didSet, so
+                    // anchorMessageId here always belongs to the current thread.
                     if anchorMessageId == nil {
                         proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
-                    } else if !messages.contains(where: { $0.id == anchorMessageId }) {
-                        // Anchor is stale (belongs to a different thread) — clear
-                        // it and scroll to bottom normally.
-                        anchorMessageId = nil
-                        proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                     }
-                    // When anchorMessageId is set and belongs to this thread's
-                    // messages, skip scroll-to-bottom — the anchorMessageId
-                    // onChange handler will scroll to the specific message.
                 }
             }
             .onChange(of: anchorMessageId) {


### PR DESCRIPTION
Remove the else-if branch that cleared anchorMessageId when the message wasn't found in the current messages array. This conflated 'not yet loaded' with 'stale from another thread', defeating the retry mechanism in onChange(of: messages.count). ThreadManager.activeThreadId.didSet already handles clearing stale anchors from other threads.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
