### PR TITLE
fix: map unverified channel status to pending in trust resolver shim

### DIFF
--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -129,7 +129,7 @@ function contactChannelToMemberRecord(
     externalChatId: channel.externalChatId,
     displayName: contact.displayName,
     username: null,
-    status: channel.status === 'active' ? 'active' : channel.status === 'pending' ? 'pending' : channel.status === 'revoked' ? 'revoked' : channel.status === 'blocked' ? 'blocked' : 'active',
+    status: channel.status === 'active' ? 'active' : channel.status === 'pending' ? 'pending' : channel.status === 'unverified' ? 'pending' : channel.status === 'revoked' ? 'revoked' : channel.status === 'blocked' ? 'blocked' : 'active',
     policy: channel.policy,
     inviteId: channel.inviteId,
     createdBySessionId: null,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for trust-resolution-contacts.md.

**Gap:** 'unverified' channel status mapped to 'active' in contactChannelToMemberRecord shim
**What was expected:** 'unverified' ChannelStatus should map to 'pending' MemberStatus
**What was found:** 'unverified' fell through to the default 'active' case, potentially granting trust to unverified contacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
