### PR TITLE
fix: keep externalUserId canonical for trust resolution, use legacyAddress for dedup fallback

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -75,6 +75,8 @@ interface SyncChannelData {
   isPrimary?: boolean;
   externalUserId?: string | null;
   externalChatId?: string | null;
+  /** Raw (pre-canonicalization) address used only for dedup fallback against legacy records. */
+  legacyAddress?: string;
   status?: ChannelStatus;
   policy?: ChannelPolicy;
   verifiedAt?: number | null;
@@ -146,14 +148,14 @@ export function upsertContact(params: {
         .get();
 
       // Fallback: if the address was canonicalized, the old record may still
-      // have the raw (non-canonical) address. Try matching by externalUserId
-      // treated as an address so we update the existing contact instead of
-      // creating a duplicate.
-      if (!existingChannel && ch.externalUserId && ch.externalUserId.toLowerCase() !== ch.address.toLowerCase()) {
+      // have the raw (non-canonical) address stored. Try matching by
+      // legacyAddress so we update the existing contact instead of creating
+      // a duplicate.
+      if (!existingChannel && ch.legacyAddress && ch.legacyAddress.toLowerCase() !== ch.address.toLowerCase()) {
         existingChannel = db
           .select()
           .from(contactChannels)
-          .where(and(eq(contactChannels.type, ch.type), eq(contactChannels.address, ch.externalUserId.toLowerCase())))
+          .where(and(eq(contactChannels.type, ch.type), eq(contactChannels.address, ch.legacyAddress.toLowerCase())))
           .get();
       }
 
@@ -234,8 +236,8 @@ function syncChannels(
       .get();
 
     // Fallback: the channel may have been stored with a pre-canonicalization
-    // address. Try matching by externalUserId as the address to find it.
-    if (!existing && ch.externalUserId && ch.externalUserId.toLowerCase() !== normalizedAddress) {
+    // address. Try matching by legacyAddress to find it.
+    if (!existing && ch.legacyAddress && ch.legacyAddress.toLowerCase() !== normalizedAddress) {
       existing = db
         .select()
         .from(contactChannels)
@@ -243,7 +245,7 @@ function syncChannels(
           and(
             eq(contactChannels.contactId, contactId),
             eq(contactChannels.type, ch.type),
-            eq(contactChannels.address, ch.externalUserId.toLowerCase()),
+            eq(contactChannels.address, ch.legacyAddress.toLowerCase()),
           ),
         )
         .get();

--- a/assistant/src/contacts/contact-sync.ts
+++ b/assistant/src/contacts/contact-sync.ts
@@ -69,8 +69,9 @@ export function syncSingleGuardianBinding(binding: GuardianBinding): void {
       {
         type: binding.channel,
         address: canonicalId,
-        externalUserId: binding.guardianExternalUserId,
+        externalUserId: canonicalId,
         externalChatId: binding.guardianDeliveryChatId,
+        legacyAddress: binding.guardianExternalUserId !== canonicalId ? binding.guardianExternalUserId : undefined,
         status: "active",
         verifiedAt: binding.verifiedAt,
         verifiedVia: binding.verifiedVia,
@@ -107,6 +108,7 @@ export function syncSingleMember(member: IngressMember): void {
 
   let address: string;
   let externalUserId: string | null;
+  let legacyAddress: string | undefined;
 
   if (member.externalUserId) {
     const canonicalId =
@@ -115,7 +117,10 @@ export function syncSingleMember(member: IngressMember): void {
         member.externalUserId,
       ) ?? member.externalUserId;
     address = canonicalId;
-    externalUserId = member.externalUserId;
+    externalUserId = canonicalId;
+    if (member.externalUserId !== canonicalId) {
+      legacyAddress = member.externalUserId;
+    }
   } else {
     address = member.externalChatId!;
     externalUserId = null;
@@ -129,6 +134,7 @@ export function syncSingleMember(member: IngressMember): void {
         address,
         externalUserId,
         externalChatId: member.externalChatId,
+        legacyAddress,
         status: member.status as ChannelStatus,
         policy: member.policy as "allow" | "deny" | "escalate",
         inviteId: member.inviteId,


### PR DESCRIPTION
Reverts externalUserId to canonical form in contact-sync.ts (required by trust resolver lookups). Adds a legacyAddress field to channel params for the dedup fallback to match pre-canonicalization records without breaking trust resolution.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
