### PR TITLE
feat: add listGuardianChannels query for notification fallback resolution

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -572,6 +572,46 @@ export function findGuardianForChannel(
 }
 
 /**
+ * List all active channels for the guardian contact.
+ * This is the contacts-based equivalent of listActiveBindingsByAssistant(assistantId).
+ * Returns channels ordered by most-recently-verified first.
+ */
+export function listGuardianChannels(): { contact: Contact; channels: ContactChannel[] } | null {
+  const db = getDb();
+  // Find the guardian contact
+  const guardianRow = db
+    .select()
+    .from(contacts)
+    .where(eq(contacts.role, 'guardian'))
+    .limit(1)
+    .get();
+
+  if (!guardianRow) return null;
+
+  const guardian = parseContact(guardianRow);
+
+  // Get all active channels for the guardian, ordered by verifiedAt desc
+  const channelRows = db
+    .select()
+    .from(contactChannels)
+    .where(
+      and(
+        eq(contactChannels.contactId, guardian.id),
+        eq(contactChannels.status, 'active'),
+      ),
+    )
+    .orderBy(desc(contactChannels.verifiedAt))
+    .all();
+
+  if (channelRows.length === 0) return null;
+
+  return {
+    contact: guardian,
+    channels: channelRows.map(parseChannel),
+  };
+}
+
+/**
  * Update a channel's access-control fields (status, policy, reasons).
  * Returns the updated channel, or null if the channel does not exist.
  */


### PR DESCRIPTION
## Summary
- Add listGuardianChannels() to contact-store.ts for notification delivery fallback resolution
- Returns the guardian contact plus all active channels ordered by verifiedAt desc
- Contacts-based equivalent of listActiveBindingsByAssistant()

Part of plan: notif-delivery-contacts.md (PR 1 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
