### PR TITLE
feat: migrate connected channels check to contacts-first with legacy fallback

### DIFF
--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -12,6 +12,7 @@
 import { v4 as uuid } from 'uuid';
 
 import { getDeliverableChannels } from '../channels/config.js';
+import { findGuardianForChannel } from '../contacts/contact-store.js';
 import { getActiveBinding } from '../memory/channel-guardian-store.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { getLogger } from '../util/logger.js';
@@ -101,13 +102,10 @@ function getConnectedChannels(assistantId: string): NotificationChannel[] {
         break;
       case 'telegram':
       case 'sms':
-        // Only report binding-based channels as connected when there is
-        // an active guardian binding for this assistant. Without a
-        // binding, the destination resolver will fail to resolve a
-        // delivery endpoint and dispatch will silently drop the
-        // message — which is worse than the decision engine knowing up
-        // front that the channel is unavailable.
-        if (getActiveBinding(assistantId, channel)) {
+        // A binding-based channel is connected when the guardian has an
+        // active channel entry of this type. Fall back to legacy binding
+        // check if contacts are not yet synced.
+        if (findGuardianForChannel(channel) || getActiveBinding(assistantId, channel)) {
           channels.push(channel);
         }
         break;


### PR DESCRIPTION
## Summary
- Migrate getConnectedChannels() to check contacts table first for telegram/sms
- Falls back to legacy getActiveBinding when contacts not yet synced
- Simple OR logic avoids false negatives during transition period

Part of plan: notif-delivery-contacts.md (PR 3 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
