### PR TITLE
feat: extend context compactor with deep emergency keep-boundary controls

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -504,4 +504,92 @@ describe("ContextWindowManager", () => {
     );
     expect(rawBase64TokenEquivalent).toBeGreaterThan(result.thresholdTokens);
   });
+
+  test("minKeepRecentUserTurns: 0 compacts all messages into summary only", async () => {
+    const provider = createProvider(() => ({
+      content: [{ type: "text", text: "## Goals\n- emergency summary" }],
+      model: "mock-model",
+      usage: { inputTokens: 60, outputTokens: 12 },
+      stopReason: "end_turn",
+    }));
+    const manager = new ContextWindowManager(
+      provider,
+      "system prompt",
+      makeConfig({
+        maxInputTokens: 260,
+        targetInputTokens: 180,
+        preserveRecentUserTurns: 2,
+      }),
+    );
+    const long = "e".repeat(220);
+    const history: Message[] = [
+      message("user", `u1 ${long}`),
+      message("assistant", `a1 ${long}`),
+      message("user", `u2 ${long}`),
+    ];
+
+    const result = await manager.maybeCompact(history, undefined, {
+      force: true,
+      minKeepRecentUserTurns: 0,
+    });
+    expect(result.compacted).toBe(true);
+    // All original messages should be compacted — only the summary remains.
+    expect(result.compactedMessages).toBe(3);
+    expect(result.messages).toHaveLength(1);
+    expect(getSummaryFromContextMessage(result.messages[0])).toContain(
+      "emergency summary",
+    );
+  });
+
+  test("targetInputTokensOverride reduces retained turns beyond normal compaction", async () => {
+    const provider = createProvider(() => ({
+      content: [{ type: "text", text: "## Goals\n- tight fit summary" }],
+      model: "mock-model",
+      usage: { inputTokens: 60, outputTokens: 12 },
+      stopReason: "end_turn",
+    }));
+
+    // Use generous default target so normal compaction would keep all 3 user turns.
+    const config = makeConfig({
+      maxInputTokens: 1200,
+      targetInputTokens: 1000,
+      preserveRecentUserTurns: 3,
+    });
+    const long = "t".repeat(220);
+    const history: Message[] = [
+      message("user", `u1 ${long}`),
+      message("assistant", `a1 ${long}`),
+      message("user", `u2 ${long}`),
+      message("assistant", `a2 ${long}`),
+      message("user", `u3 ${long}`),
+      message("assistant", `a3 ${long}`),
+    ];
+
+    // Without override: normal compaction keeps more turns.
+    const normalManager = new ContextWindowManager(
+      provider,
+      "system prompt",
+      config,
+    );
+    const normalResult = await normalManager.maybeCompact(history, undefined, {
+      force: true,
+    });
+
+    // With a very tight override target: should keep fewer turns.
+    const tightManager = new ContextWindowManager(
+      provider,
+      "system prompt",
+      config,
+    );
+    const tightResult = await tightManager.maybeCompact(history, undefined, {
+      force: true,
+      targetInputTokensOverride: 80,
+    });
+
+    expect(tightResult.compacted).toBe(true);
+    // The tight override should compact more messages than normal.
+    expect(tightResult.compactedMessages).toBeGreaterThan(
+      normalResult.compactedMessages,
+    );
+  });
 });

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -1,12 +1,12 @@
-import { createUserMessage } from '../agent/message-types.js';
-import type { ContextWindowConfig } from '../config/types.js';
-import type { ContentBlock, Message, Provider } from '../providers/types.js';
-import { getLogger } from '../util/logger.js';
-import { estimatePromptTokens, estimateTextTokens } from './token-estimator.js';
+import { createUserMessage } from "../agent/message-types.js";
+import type { ContextWindowConfig } from "../config/types.js";
+import type { ContentBlock, Message, Provider } from "../providers/types.js";
+import { getLogger } from "../util/logger.js";
+import { estimatePromptTokens, estimateTextTokens } from "./token-estimator.js";
 
-const log = getLogger('context-window');
+const log = getLogger("context-window");
 
-export const CONTEXT_SUMMARY_MARKER = '<context_summary>';
+export const CONTEXT_SUMMARY_MARKER = "<context_summary>";
 const CHUNK_MIN_TOKENS = 1000;
 const MAX_BLOCK_PREVIEW_CHARS = 3000;
 const MAX_FALLBACK_SUMMARY_CHARS = 12000;
@@ -19,18 +19,18 @@ const MAX_PRESERVED_IMAGE_BLOCKS = 5;
 const INTERNAL_CONTEXT_SUMMARY_MESSAGES = new WeakSet<Message>();
 
 const SUMMARY_SYSTEM_PROMPT = [
-  'You compress long assistant conversations into durable working memory.',
-  'Focus on actionable state, not prose.',
-  'Preserve concrete facts: goals, constraints, decisions, pending questions, file paths, commands, errors, and TODOs.',
-  'Remove repetition and stale details that were superseded.',
-  'Return concise markdown using these section headers exactly:',
-  '## Goals',
-  '## Constraints',
-  '## Decisions',
-  '## Open Threads',
-  '## Key Artifacts',
-  '## Recent Progress',
-].join('\n');
+  "You compress long assistant conversations into durable working memory.",
+  "Focus on actionable state, not prose.",
+  "Preserve concrete facts: goals, constraints, decisions, pending questions, file paths, commands, errors, and TODOs.",
+  "Remove repetition and stale details that were superseded.",
+  "Return concise markdown using these section headers exactly:",
+  "## Goals",
+  "## Constraints",
+  "## Decisions",
+  "## Open Threads",
+  "## Key Artifacts",
+  "## Recent Progress",
+].join("\n");
 
 export interface ContextWindowResult {
   messages: Message[];
@@ -53,6 +53,19 @@ export interface ContextWindowCompactOptions {
   lastCompactedAt?: number;
   /** Bypass the threshold check and force compaction. Used for context-too-large error recovery. */
   force?: boolean;
+  /**
+   * Override the minimum number of recent user turns to preserve.
+   * Set to `0` for emergency recovery that can compact the entire history
+   * (except the summary message itself). When omitted, the default floor
+   * of 1 recent user turn is enforced.
+   */
+  minKeepRecentUserTurns?: number;
+  /**
+   * Override the target input token budget used for keep-boundary
+   * projected-fit checks. Allows the caller to demand a stricter fit
+   * than the normal `config.targetInputTokens` during forced recovery.
+   */
+  targetInputTokensOverride?: number;
 }
 
 export class ContextWindowManager {
@@ -72,7 +85,9 @@ export class ContextWindowManager {
       this.systemPrompt,
       { providerName: this.provider.name },
     );
-    const thresholdTokens = Math.floor(this.config.maxInputTokens * this.config.compactThreshold);
+    const thresholdTokens = Math.floor(
+      this.config.maxInputTokens * this.config.compactThreshold,
+    );
     const existingSummary = getSummaryFromContextMessage(messages[0]);
 
     if (!this.config.enabled) {
@@ -88,9 +103,9 @@ export class ContextWindowManager {
         summaryCalls: 0,
         summaryInputTokens: 0,
         summaryOutputTokens: 0,
-        summaryModel: '',
-        summaryText: existingSummary ?? '',
-        reason: 'context window compaction disabled',
+        summaryModel: "",
+        summaryText: existingSummary ?? "",
+        reason: "context window compaction disabled",
       };
     }
 
@@ -107,9 +122,9 @@ export class ContextWindowManager {
         summaryCalls: 0,
         summaryInputTokens: 0,
         summaryOutputTokens: 0,
-        summaryModel: '',
-        summaryText: existingSummary ?? '',
-        reason: 'below compaction threshold',
+        summaryModel: "",
+        summaryText: existingSummary ?? "",
+        reason: "below compaction threshold",
       };
     }
 
@@ -128,13 +143,16 @@ export class ContextWindowManager {
         summaryCalls: 0,
         summaryInputTokens: 0,
         summaryOutputTokens: 0,
-        summaryModel: '',
-        summaryText: existingSummary ?? '',
-        reason: 'no user turns available for compaction',
+        summaryModel: "",
+        summaryText: existingSummary ?? "",
+        reason: "no user turns available for compaction",
       };
     }
 
-    const keepPlan = this.pickKeepBoundary(messages, userTurnStarts);
+    const keepPlan = this.pickKeepBoundary(messages, userTurnStarts, {
+      minKeepRecentUserTurns: options?.minKeepRecentUserTurns,
+      targetInputTokensOverride: options?.targetInputTokensOverride,
+    });
     if (keepPlan.keepFromIndex <= summaryOffset) {
       return {
         messages,
@@ -148,13 +166,16 @@ export class ContextWindowManager {
         summaryCalls: 0,
         summaryInputTokens: 0,
         summaryOutputTokens: 0,
-        summaryModel: '',
-        summaryText: existingSummary ?? '',
-        reason: 'unable to compact while keeping recent turns',
+        summaryModel: "",
+        summaryText: existingSummary ?? "",
+        reason: "unable to compact while keeping recent turns",
       };
     }
 
-    const compactableMessages = messages.slice(summaryOffset, keepPlan.keepFromIndex);
+    const compactableMessages = messages.slice(
+      summaryOffset,
+      keepPlan.keepFromIndex,
+    );
     if (compactableMessages.length === 0) {
       return {
         messages,
@@ -168,15 +189,16 @@ export class ContextWindowManager {
         summaryCalls: 0,
         summaryInputTokens: 0,
         summaryOutputTokens: 0,
-        summaryModel: '',
-        summaryText: existingSummary ?? '',
-        reason: 'no eligible messages to compact',
+        summaryModel: "",
+        summaryText: existingSummary ?? "",
+        reason: "no eligible messages to compact",
       };
     }
 
-    const compactedPersistedMessages = countPersistedMessages(compactableMessages);
+    const compactedPersistedMessages =
+      countPersistedMessages(compactableMessages);
     const projectedMessages = [
-      createContextSummaryMessage(existingSummary ?? 'Projected summary'),
+      createContextSummaryMessage(existingSummary ?? "Projected summary"),
       ...messages.slice(keepPlan.keepFromIndex),
     ];
     const projectedInputTokens = estimatePromptTokens(
@@ -184,20 +206,29 @@ export class ContextWindowManager {
       this.systemPrompt,
       { providerName: this.provider.name },
     );
-    const projectedGainTokens = Math.max(0, previousEstimatedInputTokens - projectedInputTokens);
-    const severePressure = previousEstimatedInputTokens >= Math.floor(this.config.maxInputTokens * SEVERE_PRESSURE_RATIO);
+    const projectedGainTokens = Math.max(
+      0,
+      previousEstimatedInputTokens - projectedInputTokens,
+    );
+    const severePressure =
+      previousEstimatedInputTokens >=
+      Math.floor(this.config.maxInputTokens * SEVERE_PRESSURE_RATIO);
     const lastCompactedAt = options?.lastCompactedAt;
 
     // Adaptive cooldown: conversations growing quickly (high projected gain) compact
     // sooner. Scale the cooldown inversely with the growth-rate multiplier, capped at
     // 1/4 of the base cooldown so we never check more than 4× as frequently.
-    const growthRateMultiplier = Math.max(1, projectedGainTokens / MIN_GAIN_TOKENS_DURING_COOLDOWN);
+    const growthRateMultiplier = Math.max(
+      1,
+      projectedGainTokens / MIN_GAIN_TOKENS_DURING_COOLDOWN,
+    );
     const adaptiveCooldownMs = Math.max(
       COMPACTION_COOLDOWN_MS / 4,
       COMPACTION_COOLDOWN_MS / growthRateMultiplier,
     );
-    const withinCooldown = typeof lastCompactedAt === 'number'
-      && Date.now() - lastCompactedAt < adaptiveCooldownMs;
+    const withinCooldown =
+      typeof lastCompactedAt === "number" &&
+      Date.now() - lastCompactedAt < adaptiveCooldownMs;
 
     // The adaptive cooldown is already tuned to be shorter for fast-growing
     // conversations (high projectedGainTokens → smaller adaptiveCooldownMs).
@@ -206,14 +237,18 @@ export class ContextWindowManager {
     // break out of the cooldown sooner and compact more frequently.
     // force=true bypasses the cooldown so context-too-large recovery can always
     // attempt a compaction even within the cooldown window.
-    if (
-      withinCooldown
-      && !severePressure
-      && !options?.force
-    ) {
+    if (withinCooldown && !severePressure && !options?.force) {
       log.debug(
-        { projectedGainTokens, adaptiveCooldownMs, growthRateMultiplier, msSinceCompaction: typeof lastCompactedAt === 'number' ? Date.now() - lastCompactedAt : null },
-        'Compaction cooldown active',
+        {
+          projectedGainTokens,
+          adaptiveCooldownMs,
+          growthRateMultiplier,
+          msSinceCompaction:
+            typeof lastCompactedAt === "number"
+              ? Date.now() - lastCompactedAt
+              : null,
+        },
+        "Compaction cooldown active",
       );
       return {
         messages,
@@ -227,13 +262,16 @@ export class ContextWindowManager {
         summaryCalls: 0,
         summaryInputTokens: 0,
         summaryOutputTokens: 0,
-        summaryModel: '',
-        summaryText: existingSummary ?? '',
-        reason: 'compaction cooldown active',
+        summaryModel: "",
+        summaryText: existingSummary ?? "",
+        reason: "compaction cooldown active",
       };
     }
 
-    if (compactedPersistedMessages < MIN_COMPACTABLE_PERSISTED_MESSAGES && !severePressure) {
+    if (
+      compactedPersistedMessages < MIN_COMPACTABLE_PERSISTED_MESSAGES &&
+      !severePressure
+    ) {
       return {
         messages,
         compacted: false,
@@ -246,17 +284,20 @@ export class ContextWindowManager {
         summaryCalls: 0,
         summaryInputTokens: 0,
         summaryOutputTokens: 0,
-        summaryModel: '',
-        summaryText: existingSummary ?? '',
-        reason: 'insufficient compactable persisted messages',
+        summaryModel: "",
+        summaryText: existingSummary ?? "",
+        reason: "insufficient compactable persisted messages",
       };
     }
 
-    const chunks = chunkMessages(compactableMessages, Math.max(this.config.chunkTokens, CHUNK_MIN_TOKENS));
-    let summary = existingSummary ?? 'No previous summary.';
+    const chunks = chunkMessages(
+      compactableMessages,
+      Math.max(this.config.chunkTokens, CHUNK_MIN_TOKENS),
+    );
+    let summary = existingSummary ?? "No previous summary.";
     let summaryInputTokens = 0;
     let summaryOutputTokens = 0;
-    let summaryModel = '';
+    let summaryModel = "";
     let summaryCalls = 0;
 
     for (const chunk of chunks) {
@@ -278,15 +319,15 @@ export class ContextWindowManager {
     if (existingSummary != null) {
       const summaryMsg = messages[0];
       for (const block of summaryMsg.content) {
-        if (block.type === 'image') {
+        if (block.type === "image") {
           preservedImageBlocks.push(block);
         }
       }
     }
     for (const msg of compactableMessages) {
-      if (msg.role !== 'user') continue;
+      if (msg.role !== "user") continue;
       for (const block of msg.content) {
-        if (block.type === 'image') {
+        if (block.type === "image") {
           preservedImageBlocks.push(block);
         }
       }
@@ -295,13 +336,19 @@ export class ContextWindowManager {
     // Cap preserved images to avoid unbounded accumulation across cycles.
     // Older images (carried forward) are at the front; keep the most recent.
     if (preservedImageBlocks.length > MAX_PRESERVED_IMAGE_BLOCKS) {
-      preservedImageBlocks.splice(0, preservedImageBlocks.length - MAX_PRESERVED_IMAGE_BLOCKS);
+      preservedImageBlocks.splice(
+        0,
+        preservedImageBlocks.length - MAX_PRESERVED_IMAGE_BLOCKS,
+      );
     }
 
     const summaryMessage = createContextSummaryMessage(summary);
     if (preservedImageBlocks.length > 0) {
       summaryMessage.content.push(
-        { type: 'text', text: '[The following images were uploaded by the user in earlier messages and are preserved for reference.]' },
+        {
+          type: "text",
+          text: "[The following images were uploaded by the user in earlier messages and are preserved for reference.]",
+        },
         ...preservedImageBlocks,
       );
     }
@@ -324,7 +371,7 @@ export class ContextWindowManager {
         keepTurns: keepPlan.keepTurns,
         summaryCalls,
       },
-      'Compacted conversation context window',
+      "Compacted conversation context window",
     );
 
     return {
@@ -347,14 +394,32 @@ export class ContextWindowManager {
   private pickKeepBoundary(
     messages: Message[],
     userTurnStarts: number[],
+    opts?: {
+      minKeepRecentUserTurns?: number;
+      targetInputTokensOverride?: number;
+    },
   ): { keepFromIndex: number; keepTurns: number } {
-    let keepTurns = Math.min(this.config.preserveRecentUserTurns, userTurnStarts.length);
-    keepTurns = Math.max(1, keepTurns);
-    let keepFromIndex = userTurnStarts[userTurnStarts.length - keepTurns] ?? messages.length;
+    const minFloor = opts?.minKeepRecentUserTurns ?? 1;
+    const targetTokens =
+      opts?.targetInputTokensOverride ?? this.config.targetInputTokens;
 
-    while (keepTurns > 1) {
+    let keepTurns = Math.min(
+      this.config.preserveRecentUserTurns,
+      userTurnStarts.length,
+    );
+    keepTurns = Math.max(minFloor, keepTurns);
+
+    // When minFloor is 0 and there are no user turns to keep, keepFromIndex
+    // points past the end of the array so all messages become compactable.
+    let keepFromIndex =
+      keepTurns === 0
+        ? messages.length
+        : (userTurnStarts[userTurnStarts.length - keepTurns] ??
+          messages.length);
+
+    while (keepTurns > minFloor) {
       const projectedMessages = [
-        createContextSummaryMessage('Projected summary'),
+        createContextSummaryMessage("Projected summary"),
         ...messages.slice(keepFromIndex),
       ];
       const projectedTokens = estimatePromptTokens(
@@ -362,9 +427,13 @@ export class ContextWindowManager {
         this.systemPrompt,
         { providerName: this.provider.name },
       );
-      if (projectedTokens <= this.config.targetInputTokens) break;
+      if (projectedTokens <= targetTokens) break;
       keepTurns -= 1;
-      keepFromIndex = userTurnStarts[userTurnStarts.length - keepTurns] ?? keepFromIndex;
+      keepFromIndex =
+        keepTurns === 0
+          ? messages.length
+          : (userTurnStarts[userTurnStarts.length - keepTurns] ??
+            keepFromIndex);
     }
 
     return { keepFromIndex, keepTurns };
@@ -374,7 +443,12 @@ export class ContextWindowManager {
     currentSummary: string,
     chunk: string,
     signal?: AbortSignal,
-  ): Promise<{ summary: string; inputTokens: number; outputTokens: number; model: string }> {
+  ): Promise<{
+    summary: string;
+    inputTokens: number;
+    outputTokens: number;
+    model: string;
+  }> {
     const prompt = buildSummaryPrompt(currentSummary, chunk);
     try {
       const response = await this.provider.sendMessage(
@@ -397,14 +471,14 @@ export class ContextWindowManager {
         };
       }
     } catch (err) {
-      log.warn({ err }, 'Summary generation failed, using local fallback');
+      log.warn({ err }, "Summary generation failed, using local fallback");
     }
 
     return {
       summary: fallbackSummary(currentSummary, chunk),
       inputTokens: 0,
       outputTokens: 0,
-      model: '',
+      model: "",
     };
   }
 }
@@ -413,7 +487,7 @@ function collectUserTurnStartIndexes(messages: Message[]): number[] {
   const starts: number[] = [];
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i];
-    if (message.role !== 'user') continue;
+    if (message.role !== "user") continue;
     if (getSummaryFromContextMessage(message) != null) continue;
     if (isToolResultOnly(message)) continue;
     starts.push(i);
@@ -435,11 +509,15 @@ function countPersistedMessages(messages: Message[]): number {
 
 /** A user message that contains ONLY tool_result blocks (no text or other content). */
 function isToolResultOnly(message: Message): boolean {
-  return message.content.length > 0
-    && message.content.every((block) => block.type === 'tool_result');
+  return (
+    message.content.length > 0 &&
+    message.content.every((block) => block.type === "tool_result")
+  );
 }
 
-export function getSummaryFromContextMessage(message: Message | undefined): string | null {
+export function getSummaryFromContextMessage(
+  message: Message | undefined,
+): string | null {
   if (!message) return null;
   const text = extractText(message.content).trim();
   if (!text.startsWith(CONTEXT_SUMMARY_MARKER)) return null;
@@ -447,7 +525,7 @@ export function getSummaryFromContextMessage(message: Message | undefined): stri
     return stripContextSummaryTags(text);
   }
   // Backward compatibility for older in-memory sessions that used assistant-role summaries.
-  if (message.role === 'assistant') {
+  if (message.role === "assistant") {
     return stripContextSummaryTags(text);
   }
   return null;
@@ -455,7 +533,7 @@ export function getSummaryFromContextMessage(message: Message | undefined): stri
 
 function stripContextSummaryTags(text: string): string {
   let inner = text.slice(CONTEXT_SUMMARY_MARKER.length);
-  const closeIdx = inner.lastIndexOf('</context_summary>');
+  const closeIdx = inner.lastIndexOf("</context_summary>");
   if (closeIdx !== -1) {
     inner = inner.slice(0, closeIdx);
   }
@@ -464,8 +542,15 @@ function stripContextSummaryTags(text: string): string {
 
 export function createContextSummaryMessage(summary: string): Message {
   const message: Message = {
-    role: 'user',
-    content: [{ type: 'text', text: `${CONTEXT_SUMMARY_MARKER}\n${clampSummary(summary)}\n</context_summary>` }],
+    role: "user",
+    content: [
+      {
+        type: "text",
+        text: `${CONTEXT_SUMMARY_MARKER}\n${clampSummary(
+          summary,
+        )}\n</context_summary>`,
+      },
+    ],
   };
   INTERNAL_CONTEXT_SUMMARY_MESSAGES.add(message);
   return message;
@@ -473,19 +558,22 @@ export function createContextSummaryMessage(summary: string): Message {
 
 function buildSummaryPrompt(currentSummary: string, chunk: string): string {
   return [
-    'Update the summary with new transcript data.',
-    'If new information conflicts with older notes, keep the most recent and explicit detail.',
-    'Keep all unresolved asks and next steps.',
-    '',
-    '### Existing Summary',
-    currentSummary.trim().length > 0 ? currentSummary.trim() : 'None.',
-    '',
-    '### New Transcript Chunk',
+    "Update the summary with new transcript data.",
+    "If new information conflicts with older notes, keep the most recent and explicit detail.",
+    "Keep all unresolved asks and next steps.",
+    "",
+    "### Existing Summary",
+    currentSummary.trim().length > 0 ? currentSummary.trim() : "None.",
+    "",
+    "### New Transcript Chunk",
     chunk,
-  ].join('\n');
+  ].join("\n");
 }
 
-function chunkMessages(messages: Message[], maxTokensPerChunk: number): string[] {
+function chunkMessages(
+  messages: Message[],
+  maxTokensPerChunk: number,
+): string[] {
   const chunks: string[] = [];
   let currentChunk: string[] = [];
   let currentTokens = 0;
@@ -493,8 +581,11 @@ function chunkMessages(messages: Message[], maxTokensPerChunk: number): string[]
   for (let i = 0; i < messages.length; i++) {
     const line = serializeForSummary(messages[i], i);
     const lineTokens = estimateTextTokens(line) + 1;
-    if (currentChunk.length > 0 && currentTokens + lineTokens > maxTokensPerChunk) {
-      chunks.push(currentChunk.join('\n\n'));
+    if (
+      currentChunk.length > 0 &&
+      currentTokens + lineTokens > maxTokensPerChunk
+    ) {
+      chunks.push(currentChunk.join("\n\n"));
       currentChunk = [];
       currentTokens = 0;
     }
@@ -503,7 +594,7 @@ function chunkMessages(messages: Message[], maxTokensPerChunk: number): string[]
   }
 
   if (currentChunk.length > 0) {
-    chunks.push(currentChunk.join('\n\n'));
+    chunks.push(currentChunk.join("\n\n"));
   }
 
   return chunks;
@@ -516,20 +607,24 @@ function serializeForSummary(message: Message, index: number): string {
     lines.push(serializeBlock(block));
   }
 
-  return lines.join('\n');
+  return lines.join("\n");
 }
 
 function serializeBlock(block: ContentBlock): string {
   switch (block.type) {
-    case 'text':
+    case "text":
       return `text: ${clampText(block.text)}`;
-    case 'tool_use':
+    case "tool_use":
       return `tool_use ${block.name}: ${clampText(stableJson(block.input))}`;
-    case 'tool_result':
-      return `tool_result ${block.tool_use_id}${block.is_error ? ' (error)' : ''}: ${clampText(block.content)}`;
-    case 'image':
-      return `image: ${block.source.media_type}, ${Math.ceil(block.source.data.length / 4) * 3} bytes(base64)`;
-    case 'file': {
+    case "tool_result":
+      return `tool_result ${block.tool_use_id}${
+        block.is_error ? " (error)" : ""
+      }: ${clampText(block.content)}`;
+    case "image":
+      return `image: ${block.source.media_type}, ${
+        Math.ceil(block.source.data.length / 4) * 3
+      } bytes(base64)`;
+    case "file": {
       const sizeBytes = Math.ceil(block.source.data.length / 4) * 3;
       const parts = [
         `file: ${block.source.filename}`,
@@ -539,42 +634,49 @@ function serializeBlock(block: ContentBlock): string {
       if (block.extracted_text) {
         parts.push(`text=${clampText(block.extracted_text)}`);
       }
-      return parts.join(', ');
+      return parts.join(", ");
     }
-    case 'thinking':
+    case "thinking":
       return `thinking: ${clampText(block.thinking)}`;
-    case 'redacted_thinking':
-      return 'redacted_thinking';
+    case "redacted_thinking":
+      return "redacted_thinking";
     default:
-      return 'unknown_block';
+      return "unknown_block";
   }
 }
 
 function clampText(text: string): string {
   if (text.length <= MAX_BLOCK_PREVIEW_CHARS) return text;
-  return `${text.slice(0, MAX_BLOCK_PREVIEW_CHARS)}... [truncated ${text.length - MAX_BLOCK_PREVIEW_CHARS} chars]`;
+  return `${text.slice(0, MAX_BLOCK_PREVIEW_CHARS)}... [truncated ${
+    text.length - MAX_BLOCK_PREVIEW_CHARS
+  } chars]`;
 }
 
 function fallbackSummary(currentSummary: string, chunk: string): string {
   const lines = chunk
-    .split('\n')
+    .split("\n")
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
-  const recentLines = lines.slice(-120).join('\n');
+  const recentLines = lines.slice(-120).join("\n");
   const merged = [
     currentSummary.trim(),
-    '## Recent Progress',
-    recentLines.length > 0 ? recentLines : 'No new details.',
-  ].filter((part) => part.length > 0).join('\n\n');
+    "## Recent Progress",
+    recentLines.length > 0 ? recentLines : "No new details.",
+  ]
+    .filter((part) => part.length > 0)
+    .join("\n\n");
   if (merged.length <= MAX_FALLBACK_SUMMARY_CHARS) return merged;
   return merged.slice(merged.length - MAX_FALLBACK_SUMMARY_CHARS);
 }
 
 function extractText(content: ContentBlock[]): string {
   return content
-    .filter((block): block is Extract<ContentBlock, { type: 'text' }> => block.type === 'text')
+    .filter(
+      (block): block is Extract<ContentBlock, { type: "text" }> =>
+        block.type === "text",
+    )
     .map((block) => block.text)
-    .join('\n');
+    .join("\n");
 }
 
 function clampSummary(summary: string): string {
@@ -586,6 +688,6 @@ function stableJson(value: unknown): string {
   try {
     return JSON.stringify(value);
   } catch {
-    return '[unserializable]';
+    return "[unserializable]";
   }
 }


### PR DESCRIPTION
## Summary
- Extend ContextWindowCompactOptions with minKeepRecentUserTurns and targetInputTokensOverride emergency controls
- Update pickKeepBoundary() to accept a minimum keep-turn floor including 0 for emergency recovery
- Add targetInputTokensOverride for stricter projected-fit checks during forced recovery
- Add tests for emergency compaction behavior and target override

Part of plan: guaranteed-context-overflow-recovery.md (PR 2 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11991" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
