### PR TITLE
feat: migrate voice guardian dispatch to contacts-first principal resolution

### DIFF
--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -14,6 +14,7 @@ import {
   listCanonicalGuardianRequests,
   updateCanonicalGuardianDelivery,
 } from '../memory/canonical-guardian-store.js';
+import { findGuardianForChannel } from '../contacts/contact-store.js';
 import { getActiveBinding } from '../memory/guardian-bindings.js';
 import { emitNotificationSignal } from '../notifications/emit-signal.js';
 import type { NotificationDeliveryResult } from '../notifications/types.js';
@@ -91,22 +92,29 @@ async function dispatchGuardianQuestionInner(params: GuardianDispatchParams): Pr
     const expiresAt = Date.now() + getUserConsultationTimeoutMs();
 
     // Voice decisions are handled in guardian threads tied to the assistant-
-    // level guardian identity. Resolve the principal from the vellum binding
-    // (the canonical assistant-level binding) so the request is attributed to
-    // the assistant's guardian principal.
-    let vellumBinding = getActiveBinding(assistantId, 'vellum');
-    let guardianPrincipalId = vellumBinding?.guardianPrincipalId;
+    // level guardian identity. Resolve the principal from the contacts-first
+    // path (canonical), falling back to the legacy vellum binding.
+    let guardianPrincipalId: string | undefined;
 
-    // Self-heal: if the vellum binding is missing, bootstrap it so
-    // the pending_question request can be attributed.
-    if (!guardianPrincipalId) {
-      log.info(
-        { callSessionId, assistantId, hadBinding: !!vellumBinding },
-        'Vellum binding missing — self-healing for voice dispatch',
-      );
-      const healedPrincipalId = ensureVellumGuardianBinding(assistantId);
-      vellumBinding = getActiveBinding(assistantId, 'vellum');
-      guardianPrincipalId = vellumBinding?.guardianPrincipalId ?? healedPrincipalId;
+    const guardianResult = findGuardianForChannel('vellum');
+    if (guardianResult) {
+      guardianPrincipalId = guardianResult.contact.principalId ?? undefined;
+    } else {
+      // Legacy fallback: contacts not yet synced
+      let vellumBinding = getActiveBinding(assistantId, 'vellum');
+      guardianPrincipalId = vellumBinding?.guardianPrincipalId;
+
+      // Self-heal: if the vellum binding is missing, bootstrap it so
+      // the pending_question request can be attributed.
+      if (!guardianPrincipalId) {
+        log.info(
+          { callSessionId, assistantId, hadBinding: !!vellumBinding },
+          'Vellum binding missing — self-healing for voice dispatch',
+        );
+        const healedPrincipalId = ensureVellumGuardianBinding(assistantId);
+        vellumBinding = getActiveBinding(assistantId, 'vellum');
+        guardianPrincipalId = vellumBinding?.guardianPrincipalId ?? healedPrincipalId;
+      }
     }
 
     if (!guardianPrincipalId) {


### PR DESCRIPTION
## Summary
- Migrate guardian-dispatch to resolve guardianPrincipalId from contacts first
- Falls back to legacy vellum binding when contacts not yet synced
- Self-heal bootstrap preserved on legacy fallback path only

Part of plan: notif-delivery-contacts.md (PR 4 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
