### PR TITLE
feat: migrate local IPC identity resolution to contacts-first

### DIFF
--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -12,6 +12,7 @@
  */
 
 import type { ChannelId } from "../channels/types.js";
+import { findGuardianForChannel } from "../contacts/contact-store.js";
 import { buildIpcAuthContext } from "../daemon/ipc-handler.js";
 import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import { getActiveBinding } from "../memory/guardian-bindings.js";
@@ -39,47 +40,45 @@ export function resolveLocalIpcTrustContext(
   sourceChannel: ChannelId = "vellum",
 ): TrustContext {
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
+
+  // Try contacts-first for the vellum guardian channel
+  const guardianResult = findGuardianForChannel("vellum");
+  if (guardianResult && guardianResult.contact.principalId) {
+    const guardianPrincipalId = guardianResult.contact.principalId;
+    const trustCtx = resolveTrustContext({
+      assistantId,
+      sourceChannel: "vellum",
+      conversationExternalId: "local",
+      actorExternalId: guardianPrincipalId,
+    });
+    return { ...trustCtx, sourceChannel };
+  }
+
+  // Legacy fallback: contacts not yet synced
   const binding = getActiveBinding(assistantId, "vellum");
 
   if (!binding) {
-    // No vellum binding yet (pre-bootstrap). Eagerly create one so
-    // downstream code that creates decisionable canonical requests
-    // (tool_approval, pending_question) always has a guardianPrincipalId
-    // available. Without this, createCanonicalGuardianRequest throws
-    // IntegrityError and the request is silently dropped.
+    // No vellum binding yet (pre-bootstrap). Eagerly create one.
     log.debug(
       "No vellum guardian binding found; bootstrapping binding for IPC",
     );
     const principalId = ensureVellumGuardianBinding(assistantId);
-
-    // Re-resolve through the shared pipeline now that the binding exists.
     const trustCtx = resolveTrustContext({
       assistantId,
       sourceChannel: "vellum",
       conversationExternalId: "local",
       actorExternalId: principalId,
     });
-    // Overlay the caller's actual sourceChannel onto the resolved context.
     return { ...trustCtx, sourceChannel };
   }
 
   const guardianPrincipalId = binding.guardianExternalUserId;
-
-  // Route through the shared trust resolution pipeline using 'vellum'
-  // as the channel for binding lookup. The guardianPrincipalId comes
-  // from the vellum binding, so the binding lookup must also target
-  // 'vellum' — otherwise resolveActorTrust would look up a different
-  // channel's binding (e.g. telegram/sms) and the IDs wouldn't match,
-  // causing a 'unknown' trust classification.
   const trustCtx = resolveTrustContext({
     assistantId,
     sourceChannel: "vellum",
     conversationExternalId: "local",
     actorExternalId: guardianPrincipalId,
   });
-
-  // Overlay the caller's actual sourceChannel onto the resolved context
-  // so downstream consumers see the correct channel provenance.
   return { ...trustCtx, sourceChannel };
 }
 
@@ -95,8 +94,16 @@ export function resolveLocalIpcTrustContext(
 export function resolveLocalIpcAuthContext(sessionId: string): AuthContext {
   const authContext = buildIpcAuthContext(sessionId);
 
-  // Enrich with the guardian principal ID when a vellum binding exists,
-  // so downstream guardian resolution can use authContext.actorPrincipalId.
+  // Enrich with the guardian principal ID from contacts-first path
+  const guardianResult = findGuardianForChannel("vellum");
+  if (guardianResult && guardianResult.contact.principalId) {
+    return {
+      ...authContext,
+      actorPrincipalId: guardianResult.contact.principalId,
+    };
+  }
+
+  // Legacy fallback
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const binding = getActiveBinding(assistantId, "vellum");
   if (binding) {


### PR DESCRIPTION
## Summary
- Migrate resolveLocalIpcTrustContext to read guardian principal from contacts first
- Migrate resolveLocalIpcAuthContext to read guardian principal from contacts first
- Falls back to legacy binding and pre-bootstrap self-heal when contacts empty

Part of plan: notif-delivery-contacts.md (PR 6 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
