### PR TITLE
feat: add context overflow recovery config schema and defaults

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -102,6 +102,13 @@ describe("AssistantConfigSchema", () => {
       preserveRecentUserTurns: 8,
       summaryMaxTokens: 1200,
       chunkTokens: 12000,
+      overflowRecovery: {
+        enabled: true,
+        safetyMarginRatio: 0.05,
+        maxAttempts: 3,
+        interactiveLatestTurnCompression: "summarize",
+        nonInteractiveLatestTurnCompression: "truncate",
+      },
     });
     expect(result.timeouts).toEqual({
       shellDefaultTimeoutSec: 120,
@@ -337,6 +344,54 @@ describe("AssistantConfigSchema", () => {
             issue.message.includes(
               "must be less than contextWindow.maxInputTokens",
             ),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("rejects overflowRecovery safetyMarginRatio out of (0,1) range", () => {
+    for (const bad of [0, 1, -0.1, 1.5]) {
+      const result = AssistantConfigSchema.safeParse({
+        contextWindow: { overflowRecovery: { safetyMarginRatio: bad } },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some((issue) =>
+            issue.path.join(".").includes("safetyMarginRatio"),
+          ),
+        ).toBe(true);
+      }
+    }
+  });
+
+  test("rejects invalid overflowRecovery interactiveLatestTurnCompression", () => {
+    const result = AssistantConfigSchema.safeParse({
+      contextWindow: {
+        overflowRecovery: { interactiveLatestTurnCompression: "explode" },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) =>
+          issue.path.join(".").includes("interactiveLatestTurnCompression"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("rejects invalid overflowRecovery nonInteractiveLatestTurnCompression", () => {
+    const result = AssistantConfigSchema.safeParse({
+      contextWindow: {
+        overflowRecovery: { nonInteractiveLatestTurnCompression: "nope" },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) =>
+          issue.path.join(".").includes("nonInteractiveLatestTurnCompression"),
         ),
       ).toBe(true);
     }
@@ -1060,6 +1115,13 @@ describe("loadConfig with schema validation", () => {
       preserveRecentUserTurns: 8,
       summaryMaxTokens: 1200,
       chunkTokens: 12000,
+      overflowRecovery: {
+        enabled: true,
+        safetyMarginRatio: 0.05,
+        maxAttempts: 3,
+        interactiveLatestTurnCompression: "summarize",
+        nonInteractiveLatestTurnCompression: "truncate",
+      },
     });
   });
 

--- a/assistant/src/config/core-schema.ts
+++ b/assistant/src/config/core-schema.ts
@@ -125,6 +125,58 @@ export const EffortSchema = z
 
 export type Effort = z.infer<typeof EffortSchema>;
 
+const VALID_LATEST_TURN_COMPRESSION_POLICIES = [
+  "truncate",
+  "summarize",
+  "drop",
+] as const;
+
+export const ContextOverflowRecoveryConfigSchema = z.object({
+  enabled: z
+    .boolean({
+      error: "contextWindow.overflowRecovery.enabled must be a boolean",
+    })
+    .default(true),
+  safetyMarginRatio: z
+    .number({
+      error:
+        "contextWindow.overflowRecovery.safetyMarginRatio must be a number",
+    })
+    .finite("contextWindow.overflowRecovery.safetyMarginRatio must be finite")
+    .gt(
+      0,
+      "contextWindow.overflowRecovery.safetyMarginRatio must be greater than 0",
+    )
+    .lt(
+      1,
+      "contextWindow.overflowRecovery.safetyMarginRatio must be less than 1",
+    )
+    .default(0.05),
+  maxAttempts: z
+    .number({
+      error: "contextWindow.overflowRecovery.maxAttempts must be a number",
+    })
+    .int("contextWindow.overflowRecovery.maxAttempts must be an integer")
+    .positive(
+      "contextWindow.overflowRecovery.maxAttempts must be a positive integer",
+    )
+    .default(3),
+  interactiveLatestTurnCompression: z
+    .enum(VALID_LATEST_TURN_COMPRESSION_POLICIES, {
+      error: `contextWindow.overflowRecovery.interactiveLatestTurnCompression must be one of: ${VALID_LATEST_TURN_COMPRESSION_POLICIES.join(
+        ", ",
+      )}`,
+    })
+    .default("summarize"),
+  nonInteractiveLatestTurnCompression: z
+    .enum(VALID_LATEST_TURN_COMPRESSION_POLICIES, {
+      error: `contextWindow.overflowRecovery.nonInteractiveLatestTurnCompression must be one of: ${VALID_LATEST_TURN_COMPRESSION_POLICIES.join(
+        ", ",
+      )}`,
+    })
+    .default("truncate"),
+});
+
 export const ContextWindowConfigSchema = z.object({
   enabled: z
     .boolean({ error: "contextWindow.enabled must be a boolean" })
@@ -162,6 +214,9 @@ export const ContextWindowConfigSchema = z.object({
     .int("contextWindow.chunkTokens must be an integer")
     .positive("contextWindow.chunkTokens must be a positive integer")
     .default(12000),
+  overflowRecovery: ContextOverflowRecoveryConfigSchema.default(
+    ContextOverflowRecoveryConfigSchema.parse({}),
+  ),
 });
 
 export const ModelPricingOverrideSchema = z.object({
@@ -331,6 +386,9 @@ export type PermissionsConfig = z.infer<typeof PermissionsConfigSchema>;
 export type AuditLogConfig = z.infer<typeof AuditLogConfigSchema>;
 export type LogFileConfig = z.infer<typeof LogFileConfigSchema>;
 export type ThinkingConfig = z.infer<typeof ThinkingConfigSchema>;
+export type ContextOverflowRecoveryConfig = z.infer<
+  typeof ContextOverflowRecoveryConfigSchema
+>;
 export type ContextWindowConfig = z.infer<typeof ContextWindowConfigSchema>;
 export type ModelPricingOverride = z.infer<typeof ModelPricingOverrideSchema>;
 export type SmsConfig = z.infer<typeof SmsConfigSchema>;

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -32,6 +32,7 @@ export {
 } from "./calls-schema.js";
 export type {
   AuditLogConfig,
+  ContextOverflowRecoveryConfig,
   ContextWindowConfig,
   DaemonConfig,
   Effort,
@@ -51,6 +52,7 @@ export type {
 } from "./core-schema.js";
 export {
   AuditLogConfigSchema,
+  ContextOverflowRecoveryConfigSchema,
   ContextWindowConfigSchema,
   DaemonConfigSchema,
   EffortSchema,


### PR DESCRIPTION
## Summary
- Add ContextOverflowRecoveryConfigSchema with controls for deterministic overflow recovery: enabled, safetyMarginRatio, maxAttempts, and latest-turn-compression policies
- Wire into ContextWindowConfigSchema with backward-compatible defaults
- Add schema validation tests for defaults and invalid values

Part of plan: guaranteed-context-overflow-recovery.md (PR 1 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
