### PR TITLE
feat: add minimal runtime injection mode for context pressure

### DIFF
--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -429,7 +429,9 @@ describe("trust-gating via channel capabilities", () => {
     expect(injected).toContain("CHANNEL CONSTRAINTS");
     expect(injected).toContain("Do NOT reference the dashboard UI");
     expect(injected).not.toContain("Do NOT use ui_show");
-    expect(injected).not.toContain("Present information as well-formatted text");
+    expect(injected).not.toContain(
+      "Present information as well-formatted text",
+    );
     expect(injected).toContain("supports_dynamic_ui: true");
     expect(injected).toContain("dashboard_capable: false");
   });
@@ -1054,5 +1056,149 @@ describe("resolveChannelCapabilities with PTT metadata", () => {
       microphonePermissionGranted: true,
     });
     expect(caps.microphonePermissionGranted).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyRuntimeInjections — injection mode
+// ---------------------------------------------------------------------------
+
+describe("applyRuntimeInjections — injection mode", () => {
+  const baseMessages: Message[] = [
+    {
+      role: "user",
+      content: [{ type: "text", text: "Hello" }],
+    },
+  ];
+
+  const fullOptions = {
+    workspaceTopLevelContext:
+      "<workspace_top_level>\nRoot: /sandbox\n</workspace_top_level>",
+    temporalContext:
+      "<temporal_context>\nToday: 2026-03-04 (Tuesday)\n</temporal_context>",
+    channelCommandContext: { type: "start" } as const,
+    activeSurface: { surfaceId: "sf_1", html: "<div>test</div>" },
+    channelCapabilities: {
+      channel: "telegram",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+    } as ChannelCapabilities,
+    channelTurnContext: {
+      turnContext: {
+        userMessageChannel: "telegram",
+        assistantMessageChannel: "telegram",
+      },
+      conversationOriginChannel: "telegram",
+    } as ChannelTurnContextParams,
+    interfaceTurnContext: {
+      turnContext: {
+        userMessageInterface: "telegram",
+        assistantMessageInterface: "telegram",
+      },
+      conversationOriginInterface: null,
+    },
+    inboundActorContext: {
+      sourceChannel: "telegram",
+      canonicalActorIdentity: "user-1",
+      trustClass: "guardian",
+    } as InboundActorContext,
+    isNonInteractive: true,
+  };
+
+  test("full mode (default) includes all injections", () => {
+    const result = applyRuntimeInjections(baseMessages, fullOptions);
+    const allText = result[0].content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text)
+      .join("\n");
+
+    expect(allText).toContain("<workspace_top_level>");
+    expect(allText).toContain("<temporal_context>");
+    expect(allText).toContain("<channel_command_context>");
+    expect(allText).toContain("<active_workspace>");
+    expect(allText).toContain("<channel_capabilities>");
+    expect(allText).toContain("<channel_turn_context>");
+    expect(allText).toContain("<interface_turn_context>");
+    expect(allText).toContain("<inbound_actor_context>");
+    expect(allText).toContain("<non_interactive_context>");
+  });
+
+  test("explicit mode: 'full' behaves the same as default", () => {
+    const result = applyRuntimeInjections(baseMessages, {
+      ...fullOptions,
+      mode: "full",
+    });
+    const allText = result[0].content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text)
+      .join("\n");
+
+    expect(allText).toContain("<workspace_top_level>");
+    expect(allText).toContain("<temporal_context>");
+    expect(allText).toContain("<channel_command_context>");
+    expect(allText).toContain("<active_workspace>");
+  });
+
+  test("minimal mode skips high-token optional blocks", () => {
+    const result = applyRuntimeInjections(baseMessages, {
+      ...fullOptions,
+      mode: "minimal",
+    });
+    const allText = result[0].content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text)
+      .join("\n");
+
+    // Skipped in minimal mode
+    expect(allText).not.toContain("<workspace_top_level>");
+    expect(allText).not.toContain("<temporal_context>");
+    expect(allText).not.toContain("<channel_command_context>");
+    expect(allText).not.toContain("<active_workspace>");
+  });
+
+  test("minimal mode preserves safety-critical blocks", () => {
+    const result = applyRuntimeInjections(baseMessages, {
+      ...fullOptions,
+      mode: "minimal",
+    });
+    const allText = result[0].content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text)
+      .join("\n");
+
+    // Kept in minimal mode
+    expect(allText).toContain("<channel_turn_context>");
+    expect(allText).toContain("<interface_turn_context>");
+    expect(allText).toContain("<inbound_actor_context>");
+    expect(allText).toContain("<non_interactive_context>");
+    expect(allText).toContain("<channel_capabilities>");
+  });
+
+  test("minimal mode produces strictly fewer content blocks than full mode", () => {
+    const fullResult = applyRuntimeInjections(baseMessages, {
+      ...fullOptions,
+      mode: "full",
+    });
+    const minimalResult = applyRuntimeInjections(baseMessages, {
+      ...fullOptions,
+      mode: "minimal",
+    });
+
+    expect(minimalResult[0].content.length).toBeLessThan(
+      fullResult[0].content.length,
+    );
+  });
+
+  test("minimal mode still preserves the original user message text", () => {
+    const result = applyRuntimeInjections(baseMessages, {
+      ...fullOptions,
+      mode: "minimal",
+    });
+    const texts = result[0].content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text);
+
+    expect(texts).toContain("Hello");
   });
 });

--- a/assistant/src/__tests__/session-runtime-workspace.test.ts
+++ b/assistant/src/__tests__/session-runtime-workspace.test.ts
@@ -190,3 +190,43 @@ describe("applyRuntimeInjections — workspace top-level context", () => {
     expect((result[0].content[2] as { text: string }).text).toBe("Hello");
   });
 });
+
+describe("applyRuntimeInjections — minimal mode skips workspace blocks", () => {
+  test("minimal mode skips workspace top-level context", () => {
+    const messages: Message[] = [userMsg("Hello")];
+    const result = applyRuntimeInjections(messages, {
+      workspaceTopLevelContext: sampleContext,
+      mode: "minimal",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toHaveLength(1);
+    expect((result[0].content[0] as { text: string }).text).toBe("Hello");
+  });
+
+  test("minimal mode skips active surface context", () => {
+    const messages: Message[] = [userMsg("Hello")];
+    const result = applyRuntimeInjections(messages, {
+      activeSurface: { surfaceId: "sf_1", html: "<div>test</div>" },
+      mode: "minimal",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toHaveLength(1);
+    expect((result[0].content[0] as { text: string }).text).toBe("Hello");
+  });
+
+  test("full mode (default) still includes workspace blocks", () => {
+    const messages: Message[] = [userMsg("Hello")];
+    const result = applyRuntimeInjections(messages, {
+      workspaceTopLevelContext: sampleContext,
+      activeSurface: { surfaceId: "sf_1", html: "<div>test</div>" },
+    });
+
+    expect(result[0].content).toHaveLength(3);
+    expect((result[0].content[0] as { text: string }).text).toBe(sampleContext);
+    expect((result[0].content[1] as { text: string }).text).toContain(
+      "<active_workspace>",
+    );
+  });
+});

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -1042,6 +1042,18 @@ export function stripInjectedContext(
 }
 
 /**
+ * Controls which runtime injections are applied.
+ *
+ * - `'full'` (default): all injections are applied.
+ * - `'minimal'`: only safety-critical context is injected (channel turn,
+ *   interface turn, inbound actor, non-interactive marker, voice call
+ *   control, channel capabilities, soft conflict). High-token optional
+ *   blocks (workspace top-level, temporal, channel command, active surface)
+ *   are skipped to reduce context pressure.
+ */
+export type InjectionMode = "full" | "minimal";
+
+/**
  * Apply a chain of user-message injections to `runMessages`.
  *
  * Each injection is optional — pass `null`/`undefined` to skip it.
@@ -1061,8 +1073,10 @@ export function applyRuntimeInjections(
     temporalContext?: string | null;
     voiceCallControlPrompt?: string | null;
     isNonInteractive?: boolean;
+    mode?: InjectionMode;
   },
 ): Message[] {
+  const mode = options.mode ?? "full";
   let result = runMessages;
 
   // For non-interactive sessions (scheduled jobs, work items), instruct the
@@ -1109,7 +1123,7 @@ export function applyRuntimeInjections(
     }
   }
 
-  if (options.activeSurface) {
+  if (mode === "full" && options.activeSurface) {
     const userTail = result[result.length - 1];
     if (userTail && userTail.role === "user") {
       result = [
@@ -1129,7 +1143,7 @@ export function applyRuntimeInjections(
     }
   }
 
-  if (options.channelCommandContext) {
+  if (mode === "full" && options.channelCommandContext) {
     const userTail = result[result.length - 1];
     if (userTail && userTail.role === "user") {
       result = [
@@ -1172,7 +1186,7 @@ export function applyRuntimeInjections(
   // Temporal context is injected before workspace top-level so it
   // appears after workspace context in the final message content
   // (both are prepended, so later injections appear first).
-  if (options.temporalContext) {
+  if (mode === "full" && options.temporalContext) {
     const userTail = result[result.length - 1];
     if (userTail && userTail.role === "user") {
       result = [
@@ -1185,7 +1199,7 @@ export function applyRuntimeInjections(
   // Workspace top-level context is injected last so it appears first
   // (prepended) in the user message content, keeping cache breakpoints
   // anchored to the trailing blocks.
-  if (options.workspaceTopLevelContext) {
+  if (mode === "full" && options.workspaceTopLevelContext) {
     const userTail = result[result.length - 1];
     if (userTail && userTail.role === "user") {
       result = [


### PR DESCRIPTION
## Summary
- Add injection mode option ('full' | 'minimal') to applyRuntimeInjections, defaulting to 'full'
- Minimal mode preserves safety-critical context (channel turn, interface turn, inbound actor, non-interactive marker, voice call control, channel capabilities, soft conflict) but skips high-token optional blocks (workspace top-level, temporal, channel command, active surface)
- stripInjectedContext() correctly handles all prefix patterns regardless of mode (uses static prefix list)
- Add tests for mode-specific inclusion/exclusion behavior in both test files

Part of plan: guaranteed-context-overflow-recovery.md (PR 3 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
