### PR TITLE
feat: migrate relay-server guardian metadata lookup to contacts-first

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -12,6 +12,7 @@ import type { ServerWebSocket } from "bun";
 
 import { getConfig } from "../config/loader.js";
 import { resolveUserReference } from "../config/user-reference.js";
+import { listGuardianChannels } from "../contacts/contact-store.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import { getCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
 import { listActiveBindingsByAssistant } from "../memory/channel-guardian-store.js";
@@ -1994,13 +1995,24 @@ export class RelayConnection {
     // binding for the assistant (mirrors the cross-channel fallback pattern
     // in access-request-helper.ts).
     let metadataJson: string | null = null;
-    const voiceBinding = getGuardianBinding(assistantId, "voice");
-    if (voiceBinding?.metadataJson) {
-      metadataJson = voiceBinding.metadataJson;
-    } else {
-      const allBindings = listActiveBindingsByAssistant(assistantId);
-      if (allBindings.length > 0 && allBindings[0].metadataJson) {
-        metadataJson = allBindings[0].metadataJson;
+    // Contacts-first: use the guardian contact's displayName
+    const guardianChannels = listGuardianChannels();
+    if (guardianChannels) {
+      const displayName = guardianChannels.contact.displayName;
+      if (displayName) {
+        metadataJson = JSON.stringify({ displayName });
+      }
+    }
+    if (!metadataJson) {
+      // Legacy fallback
+      const voiceBinding = getGuardianBinding(assistantId, "voice");
+      if (voiceBinding?.metadataJson) {
+        metadataJson = voiceBinding.metadataJson;
+      } else {
+        const allBindings = listActiveBindingsByAssistant(assistantId);
+        if (allBindings.length > 0 && allBindings[0].metadataJson) {
+          metadataJson = allBindings[0].metadataJson;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Migrate voice greeting metadata resolution to read guardian displayName from contacts first
- Falls back to legacy binding metadataJson when contacts not yet synced
- Produces same JSON structure consumed downstream

Part of plan: notif-delivery-contacts.md (PR 7 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/11997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
