### PR TITLE
feat: add deterministic context overflow reducer with tiered monotonic passes

### DIFF
--- a/assistant/src/__tests__/context-overflow-reducer.test.ts
+++ b/assistant/src/__tests__/context-overflow-reducer.test.ts
@@ -1,0 +1,533 @@
+import { describe, expect, test } from "bun:test";
+
+import { estimatePromptTokens } from "../context/token-estimator.js";
+import type {
+  ContextWindowCompactOptions,
+  ContextWindowResult,
+} from "../context/window-manager.js";
+import { createContextSummaryMessage } from "../context/window-manager.js";
+import {
+  createInitialReducerState,
+  reduceContextOverflow,
+  type ReducerConfig,
+  type ReducerState,
+} from "../daemon/context-overflow-reducer.js";
+import type { Message } from "../providers/types.js";
+
+function msg(role: "user" | "assistant", text: string): Message {
+  return { role, content: [{ type: "text", text }] };
+}
+
+function toolUseMsg(id: string, name: string): Message {
+  return {
+    role: "assistant",
+    content: [{ type: "tool_use", id, name, input: { path: "/tmp/test" } }],
+  };
+}
+
+function toolResultMsg(toolUseId: string, content: string): Message {
+  return {
+    role: "user",
+    content: [{ type: "tool_result", tool_use_id: toolUseId, content }],
+  };
+}
+
+function imageMsg(): Message {
+  return {
+    role: "user",
+    content: [
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: "A".repeat(10_000),
+        },
+      },
+    ],
+  };
+}
+
+const SYSTEM_PROMPT = "You are a helpful assistant.";
+
+function makeConfig(overrides?: Partial<ReducerConfig>): ReducerConfig {
+  return {
+    providerName: "mock",
+    systemPrompt: SYSTEM_PROMPT,
+    contextWindow: {
+      enabled: true,
+      maxInputTokens: 2000,
+      targetInputTokens: 1200,
+      compactThreshold: 0.6,
+      preserveRecentUserTurns: 2,
+      summaryMaxTokens: 128,
+      chunkTokens: 80,
+      overflowRecovery: {
+        enabled: true,
+        safetyMarginRatio: 0.05,
+        maxAttempts: 3,
+        interactiveLatestTurnCompression: "summarize",
+        nonInteractiveLatestTurnCompression: "truncate",
+      },
+    },
+    targetTokens: 1000,
+    ...overrides,
+  };
+}
+
+/**
+ * Create a mock compaction function that replaces messages with a summary.
+ */
+function makeCompactFn(
+  summaryText = "## Goals\n- compacted summary",
+): (
+  messages: Message[],
+  signal: AbortSignal | undefined,
+  options: ContextWindowCompactOptions,
+) => Promise<ContextWindowResult> {
+  return async (messages, _signal, _options) => {
+    const summaryMsg = createContextSummaryMessage(summaryText);
+    const compactedMessages = [summaryMsg];
+    const estimatedInputTokens = estimatePromptTokens(
+      compactedMessages,
+      SYSTEM_PROMPT,
+      { providerName: "mock" },
+    );
+    return {
+      messages: compactedMessages,
+      compacted: true,
+      previousEstimatedInputTokens: estimatePromptTokens(
+        messages,
+        SYSTEM_PROMPT,
+        { providerName: "mock" },
+      ),
+      estimatedInputTokens,
+      maxInputTokens: 2000,
+      thresholdTokens: 1200,
+      compactedMessages: messages.length,
+      compactedPersistedMessages: messages.length,
+      summaryCalls: 1,
+      summaryInputTokens: 100,
+      summaryOutputTokens: 50,
+      summaryModel: "mock-model",
+      summaryText,
+    };
+  };
+}
+
+/**
+ * Create a compact function that does not compact (simulates compaction
+ * being unable to reduce further).
+ */
+function makeNoOpCompactFn(): (
+  messages: Message[],
+  signal: AbortSignal | undefined,
+  options: ContextWindowCompactOptions,
+) => Promise<ContextWindowResult> {
+  return async (messages, _signal, _options) => {
+    const estimatedInputTokens = estimatePromptTokens(messages, SYSTEM_PROMPT, {
+      providerName: "mock",
+    });
+    return {
+      messages,
+      compacted: false,
+      previousEstimatedInputTokens: estimatedInputTokens,
+      estimatedInputTokens,
+      maxInputTokens: 2000,
+      thresholdTokens: 1200,
+      compactedMessages: 0,
+      compactedPersistedMessages: 0,
+      summaryCalls: 0,
+      summaryInputTokens: 0,
+      summaryOutputTokens: 0,
+      summaryModel: "",
+      summaryText: "",
+      reason: "unable to compact",
+    };
+  };
+}
+
+describe("context-overflow-reducer", () => {
+  describe("monotonic token reduction", () => {
+    test("each tier reduces estimated tokens or advances state without loops", async () => {
+      const longText = "x".repeat(2000);
+      const longToolResult = "r".repeat(8000);
+      const messages: Message[] = [
+        msg("user", `Question about ${longText}`),
+        toolUseMsg("tu_1", "read_file"),
+        toolResultMsg("tu_1", longToolResult),
+        msg("assistant", `Here is the answer: ${longText}`),
+        msg("user", "Follow-up question"),
+        toolUseMsg("tu_2", "write_file"),
+        toolResultMsg("tu_2", longToolResult),
+        imageMsg(),
+        msg("assistant", "Done"),
+        msg("user", "Thanks"),
+      ];
+
+      const config = makeConfig();
+      const compactFn = makeCompactFn();
+
+      let state: ReducerState | undefined;
+      let prevTokens = Infinity;
+      let currentMessages = messages;
+      const tiersApplied: string[] = [];
+
+      // Iterate through all tiers
+      for (let i = 0; i < 5; i++) {
+        const result = await reduceContextOverflow(
+          currentMessages,
+          config,
+          state,
+          compactFn,
+        );
+
+        // Each step should either reduce tokens or advance tier state
+        expect(result.estimatedTokens).toBeLessThanOrEqual(prevTokens);
+        tiersApplied.push(result.tier);
+        prevTokens = result.estimatedTokens;
+        currentMessages = result.messages;
+        state = result.state;
+
+        if (state.exhausted) break;
+      }
+
+      // All four tiers should have been applied
+      expect(tiersApplied).toContain("forced_compaction");
+      expect(tiersApplied).toContain("tool_result_truncation");
+      expect(tiersApplied).toContain("media_stubbing");
+      expect(tiersApplied).toContain("injection_downgrade");
+      expect(state!.exhausted).toBe(true);
+    });
+
+    test("step-by-step iteration produces monotonically non-increasing tokens", async () => {
+      const longToolResult = "r".repeat(12000);
+      const messages: Message[] = [
+        msg("user", "Start"),
+        toolUseMsg("tu_1", "read_file"),
+        toolResultMsg("tu_1", longToolResult),
+        msg("assistant", "Result"),
+        imageMsg(),
+        msg("user", "Next"),
+      ];
+
+      const config = makeConfig();
+      const compactFn = makeCompactFn();
+
+      let currentMessages = messages;
+      let state: ReducerState | undefined;
+      const tokenHistory: number[] = [];
+
+      while (!state?.exhausted) {
+        const result = await reduceContextOverflow(
+          currentMessages,
+          config,
+          state,
+          compactFn,
+        );
+        tokenHistory.push(result.estimatedTokens);
+        currentMessages = result.messages;
+        state = result.state;
+      }
+
+      // Verify monotonic non-increasing
+      for (let i = 1; i < tokenHistory.length; i++) {
+        expect(tokenHistory[i]).toBeLessThanOrEqual(tokenHistory[i - 1]);
+      }
+    });
+  });
+
+  describe("tier idempotency at floor", () => {
+    test("re-running the reducer on already-exhausted state returns same messages", async () => {
+      const messages: Message[] = [
+        msg("user", "Hello"),
+        msg("assistant", "Hi there"),
+      ];
+
+      const config = makeConfig();
+      const compactFn = makeCompactFn();
+
+      // Exhaust all tiers first
+      let currentMessages = messages;
+      let state: ReducerState | undefined;
+      while (!state?.exhausted) {
+        const result = await reduceContextOverflow(
+          currentMessages,
+          config,
+          state,
+          compactFn,
+        );
+        currentMessages = result.messages;
+        state = result.state;
+      }
+
+      // Run once more on exhausted state
+      const finalResult = await reduceContextOverflow(
+        currentMessages,
+        config,
+        state,
+        compactFn,
+      );
+
+      expect(finalResult.state.exhausted).toBe(true);
+      // Messages should not change further
+      expect(finalResult.estimatedTokens).toBe(
+        estimatePromptTokens(currentMessages, SYSTEM_PROMPT, {
+          providerName: "mock",
+        }),
+      );
+    });
+
+    test("when compaction cannot reduce, tier still advances", async () => {
+      const messages: Message[] = [
+        msg("user", "Hello"),
+        msg("assistant", "World"),
+      ];
+
+      const config = makeConfig();
+      const noOpCompact = makeNoOpCompactFn();
+
+      const result = await reduceContextOverflow(
+        messages,
+        config,
+        undefined,
+        noOpCompact,
+      );
+
+      expect(result.tier).toBe("forced_compaction");
+      expect(result.state.appliedTiers).toContain("forced_compaction");
+      // Messages unchanged since compaction couldn't reduce
+      expect(result.messages).toBe(messages);
+    });
+  });
+
+  describe("preserved tool-use/tool-result structural validity", () => {
+    test("tool-result blocks retain their tool_use_id after truncation", async () => {
+      const longContent = "c".repeat(10000);
+      const messages: Message[] = [
+        msg("user", "do something"),
+        toolUseMsg("tu_abc", "bash"),
+        toolResultMsg("tu_abc", longContent),
+        msg("assistant", "done"),
+        msg("user", "ok"),
+      ];
+
+      const config = makeConfig();
+      const compactFn = makeNoOpCompactFn();
+
+      // Skip compaction, apply tool-result truncation
+      const step1 = await reduceContextOverflow(
+        messages,
+        config,
+        undefined,
+        compactFn,
+      );
+      const step2 = await reduceContextOverflow(
+        step1.messages,
+        config,
+        step1.state,
+        compactFn,
+      );
+
+      expect(step2.tier).toBe("tool_result_truncation");
+
+      // Find tool_result blocks in output and verify structural integrity
+      for (const m of step2.messages) {
+        for (const block of m.content) {
+          if (block.type === "tool_result") {
+            expect(block.tool_use_id).toBe("tu_abc");
+            expect(typeof block.content).toBe("string");
+          }
+        }
+      }
+    });
+
+    test("tool-use and tool-result pairs remain matched after all tiers", async () => {
+      const messages: Message[] = [
+        msg("user", "start"),
+        toolUseMsg("tu_1", "read_file"),
+        toolResultMsg("tu_1", "x".repeat(8000)),
+        toolUseMsg("tu_2", "write_file"),
+        toolResultMsg("tu_2", "y".repeat(8000)),
+        msg("assistant", "done"),
+        msg("user", "thanks"),
+      ];
+
+      const config = makeConfig();
+      const compactFn = makeNoOpCompactFn();
+
+      let currentMessages = messages;
+      let state: ReducerState | undefined;
+      while (!state?.exhausted) {
+        const result = await reduceContextOverflow(
+          currentMessages,
+          config,
+          state,
+          compactFn,
+        );
+        currentMessages = result.messages;
+        state = result.state;
+      }
+
+      // Collect all tool_use ids and tool_result ids
+      const toolUseIds = new Set<string>();
+      const toolResultIds = new Set<string>();
+      for (const m of currentMessages) {
+        for (const block of m.content) {
+          if (block.type === "tool_use") {
+            toolUseIds.add(block.id);
+          } else if (block.type === "tool_result") {
+            toolResultIds.add(block.tool_use_id);
+          }
+        }
+      }
+
+      // Every tool_result must reference a tool_use that exists
+      for (const id of toolResultIds) {
+        expect(toolUseIds.has(id)).toBe(true);
+      }
+    });
+  });
+
+  describe("deterministic outputs", () => {
+    test("identical inputs produce identical tier progression", async () => {
+      const messages: Message[] = [
+        msg("user", "Hello"),
+        toolUseMsg("tu_1", "bash"),
+        toolResultMsg("tu_1", "output ".repeat(1000)),
+        msg("assistant", "Here you go"),
+        imageMsg(),
+        msg("user", "Next"),
+      ];
+
+      const config = makeConfig();
+      const compactFn = makeCompactFn();
+
+      // Run 1
+      const run1Tiers: string[] = [];
+      const run1Tokens: number[] = [];
+      let state1: ReducerState | undefined;
+      let msgs1 = messages;
+      while (!state1?.exhausted) {
+        const r = await reduceContextOverflow(msgs1, config, state1, compactFn);
+        run1Tiers.push(r.tier);
+        run1Tokens.push(r.estimatedTokens);
+        msgs1 = r.messages;
+        state1 = r.state;
+      }
+
+      // Run 2 (same inputs)
+      const run2Tiers: string[] = [];
+      const run2Tokens: number[] = [];
+      let state2: ReducerState | undefined;
+      let msgs2 = messages;
+      while (!state2?.exhausted) {
+        const r = await reduceContextOverflow(msgs2, config, state2, compactFn);
+        run2Tiers.push(r.tier);
+        run2Tokens.push(r.estimatedTokens);
+        msgs2 = r.messages;
+        state2 = r.state;
+      }
+
+      expect(run1Tiers).toEqual(run2Tiers);
+      expect(run1Tokens).toEqual(run2Tokens);
+    });
+  });
+
+  describe("injection mode progression", () => {
+    test("injection mode starts full and ends minimal after all tiers", async () => {
+      const messages: Message[] = [
+        msg("user", "Hello"),
+        msg("assistant", "World"),
+      ];
+
+      const config = makeConfig();
+      const compactFn = makeCompactFn();
+
+      let state: ReducerState | undefined;
+      let currentMessages = messages;
+      const injectionModes: string[] = [];
+
+      while (!state?.exhausted) {
+        const result = await reduceContextOverflow(
+          currentMessages,
+          config,
+          state,
+          compactFn,
+        );
+        injectionModes.push(result.state.injectionMode);
+        currentMessages = result.messages;
+        state = result.state;
+      }
+
+      // First three tiers keep full injection mode
+      expect(injectionModes[0]).toBe("full");
+      expect(injectionModes[1]).toBe("full");
+      expect(injectionModes[2]).toBe("full");
+      // Final tier downgrades to minimal
+      expect(injectionModes[3]).toBe("minimal");
+    });
+  });
+
+  describe("createInitialReducerState", () => {
+    test("returns a clean state with no applied tiers", () => {
+      const state = createInitialReducerState();
+      expect(state.appliedTiers).toEqual([]);
+      expect(state.injectionMode).toBe("full");
+      expect(state.exhausted).toBe(false);
+    });
+  });
+
+  describe("compaction result forwarding", () => {
+    test("forced compaction tier includes compactionResult", async () => {
+      const messages: Message[] = [
+        msg("user", "Hello"),
+        msg("assistant", "World"),
+      ];
+
+      const config = makeConfig();
+      const compactFn = makeCompactFn();
+
+      const result = await reduceContextOverflow(
+        messages,
+        config,
+        undefined,
+        compactFn,
+      );
+
+      expect(result.tier).toBe("forced_compaction");
+      expect(result.compactionResult).toBeDefined();
+      expect(result.compactionResult!.compacted).toBe(true);
+      expect(result.compactionResult!.summaryText).toBe(
+        "## Goals\n- compacted summary",
+      );
+    });
+
+    test("non-compaction tiers do not include compactionResult", async () => {
+      const messages: Message[] = [
+        msg("user", "Hello"),
+        msg("assistant", "World"),
+      ];
+
+      const config = makeConfig();
+      const compactFn = makeCompactFn();
+
+      // Skip past compaction tier
+      const step1 = await reduceContextOverflow(
+        messages,
+        config,
+        undefined,
+        compactFn,
+      );
+      const step2 = await reduceContextOverflow(
+        step1.messages,
+        config,
+        step1.state,
+        compactFn,
+      );
+
+      expect(step2.tier).toBe("tool_result_truncation");
+      expect(step2.compactionResult).toBeUndefined();
+    });
+  });
+});

--- a/assistant/src/context/tool-result-truncation.ts
+++ b/assistant/src/context/tool-result-truncation.ts
@@ -1,4 +1,8 @@
-import type { ContentBlock, ToolResultContent } from "../providers/types.js";
+import type {
+  ContentBlock,
+  Message,
+  ToolResultContent,
+} from "../providers/types.js";
 
 /**
  * Maximum share of the context window that a single tool result may occupy.
@@ -29,10 +33,7 @@ export const TRUNCATION_SUFFIX =
  * so we get a clean cut. At least `MIN_KEEP_CHARS` characters are always
  * preserved.
  */
-export function truncateToolResultText(
-  text: string,
-  maxChars: number,
-): string {
+export function truncateToolResultText(text: string, maxChars: number): string {
   if (text.length <= maxChars) {
     return text;
   }
@@ -44,8 +45,7 @@ export function truncateToolResultText(
   const threshold = Math.floor(cutPoint * 0.8);
   const lastNewline = text.lastIndexOf("\n", cutPoint);
 
-  const sliceEnd =
-    lastNewline >= threshold ? lastNewline : cutPoint;
+  const sliceEnd = lastNewline >= threshold ? lastNewline : cutPoint;
 
   // If sliceEnd covers the full text, nothing was actually removed — return
   // the original text without appending the suffix.
@@ -125,4 +125,38 @@ export function truncateOversizedToolResults(
   });
 
   return { blocks: mapped, truncatedCount };
+}
+
+/**
+ * Aggressively truncate all tool-result text across an entire message history.
+ *
+ * Unlike `truncateOversizedToolResults` (which operates on a flat block array
+ * for a single turn), this walks every message and truncates tool_result
+ * `.content` strings that exceed `maxChars`. This is used during overflow
+ * recovery where we need to shrink the overall payload, not just individual
+ * oversized results.
+ */
+export function truncateToolResultsAcrossHistory(
+  messages: Message[],
+  maxChars: number,
+): { messages: Message[]; truncatedCount: number } {
+  let truncatedCount = 0;
+
+  const mapped = messages.map((msg) => {
+    let changed = false;
+    const nextContent: ContentBlock[] = msg.content.map((block) => {
+      if (block.type !== "tool_result") return block;
+      const tr = block as ToolResultContent;
+      if (tr.content.length <= maxChars) return block;
+      changed = true;
+      truncatedCount++;
+      return {
+        ...tr,
+        content: truncateToolResultText(tr.content, maxChars),
+      } as ContentBlock;
+    });
+    return changed ? { ...msg, content: nextContent } : msg;
+  });
+
+  return { messages: truncatedCount > 0 ? mapped : messages, truncatedCount };
 }

--- a/assistant/src/daemon/context-overflow-reducer.ts
+++ b/assistant/src/daemon/context-overflow-reducer.ts
@@ -1,0 +1,298 @@
+/**
+ * Deterministic context overflow reducer.
+ *
+ * Given a message history that exceeds the provider's context limit, this
+ * module applies a sequence of monotonically more aggressive reduction tiers
+ * until the estimated token count fits within a target budget.
+ *
+ * Each tier is idempotent: re-applying the same tier to already-reduced
+ * messages is a no-op. Tiers are ordered so that less destructive
+ * transformations are tried first.
+ *
+ * Tier progression:
+ *   1. Forced compaction (emergency keep-boundary options)
+ *   2. Aggressive tool-result text truncation across retained history
+ *   3. Media/file payload stubbing (replace images/files with text stubs)
+ *   4. Runtime injection downgrade to minimal mode
+ */
+
+import type { ContextWindowConfig } from "../config/types.js";
+import { estimatePromptTokens } from "../context/token-estimator.js";
+import { truncateToolResultsAcrossHistory } from "../context/tool-result-truncation.js";
+import type {
+  ContextWindowCompactOptions,
+  ContextWindowResult,
+} from "../context/window-manager.js";
+import type { Message } from "../providers/types.js";
+import {
+  countMediaBlocks,
+  stripMediaPayloadsForRetry,
+} from "./session-media-retry.js";
+import type { InjectionMode } from "./session-runtime-assembly.js";
+
+/**
+ * Identifies which reduction tier was applied in a given step.
+ */
+export type ReducerTier =
+  | "forced_compaction"
+  | "tool_result_truncation"
+  | "media_stubbing"
+  | "injection_downgrade";
+
+/**
+ * Tracks the cumulative state of the reducer across successive calls.
+ * Callers pass this back in on each iteration so the reducer knows
+ * which tiers have already been applied.
+ */
+export interface ReducerState {
+  /** The last tier that was successfully applied. */
+  appliedTiers: ReducerTier[];
+  /** The injection mode to use for the next provider call. */
+  injectionMode: InjectionMode;
+  /** The compaction options used during forced compaction, if any. */
+  compactionOptions?: ContextWindowCompactOptions;
+  /** The max chars used for tool-result truncation, if applied. */
+  toolResultMaxChars?: number;
+  /** Whether the reducer has exhausted all tiers. */
+  exhausted: boolean;
+}
+
+/**
+ * The result of a single reducer step.
+ */
+export interface ReducerStepResult {
+  /** The reduced messages (may be identical to input if tier was a no-op). */
+  messages: Message[];
+  /** The tier that was applied in this step. */
+  tier: ReducerTier;
+  /** Updated state to pass into the next call. */
+  state: ReducerState;
+  /** Estimated prompt tokens after this step's reduction. */
+  estimatedTokens: number;
+  /**
+   * If this step used forced compaction, the compaction result is attached
+   * so the caller can persist summary text and compacted message counts.
+   */
+  compactionResult?: ContextWindowResult;
+}
+
+/**
+ * Configuration for the reducer.
+ */
+export interface ReducerConfig {
+  /** Provider name for token estimation. */
+  providerName: string;
+  /** The system prompt (needed for accurate token estimation). */
+  systemPrompt: string;
+  /** The context window config from the assistant config. */
+  contextWindow: ContextWindowConfig;
+  /** Target token budget — the reducer tries to get below this. */
+  targetTokens: number;
+}
+
+/**
+ * Compaction callback — the reducer does not own the ContextWindowManager
+ * instance, so the caller provides a function that performs compaction.
+ */
+export type CompactFn = (
+  messages: Message[],
+  signal: AbortSignal | undefined,
+  options: ContextWindowCompactOptions,
+) => Promise<ContextWindowResult>;
+
+// Aggressive truncation cap for tool results during overflow recovery.
+// Much tighter than the normal per-result budget.
+const OVERFLOW_TOOL_RESULT_MAX_CHARS = 4_000;
+
+/**
+ * Determine the next reduction step to apply.
+ *
+ * The caller invokes this repeatedly, feeding the returned state back in,
+ * until either the estimated tokens are within budget or `state.exhausted`
+ * is true.
+ */
+export async function reduceContextOverflow(
+  messages: Message[],
+  config: ReducerConfig,
+  state: ReducerState | undefined,
+  compactFn: CompactFn,
+  signal?: AbortSignal,
+): Promise<ReducerStepResult> {
+  const applied = state?.appliedTiers ?? [];
+
+  // Tier 1: forced compaction
+  if (!applied.includes("forced_compaction")) {
+    return applyForcedCompaction(messages, config, applied, compactFn, signal);
+  }
+
+  // Tier 2: aggressive tool-result truncation
+  if (!applied.includes("tool_result_truncation")) {
+    return applyToolResultTruncation(messages, config, applied);
+  }
+
+  // Tier 3: media/file payload stubbing
+  if (!applied.includes("media_stubbing")) {
+    return applyMediaStubbing(messages, config, applied, state);
+  }
+
+  // Tier 4: injection downgrade
+  if (!applied.includes("injection_downgrade")) {
+    return applyInjectionDowngrade(messages, config, applied, state);
+  }
+
+  // All tiers exhausted
+  const estimatedTokens = estimatePromptTokens(messages, config.systemPrompt, {
+    providerName: config.providerName,
+  });
+  return {
+    messages,
+    tier: "injection_downgrade",
+    state: {
+      appliedTiers: [...applied],
+      injectionMode: state?.injectionMode ?? "minimal",
+      exhausted: true,
+    },
+    estimatedTokens,
+  };
+}
+
+async function applyForcedCompaction(
+  messages: Message[],
+  config: ReducerConfig,
+  applied: ReducerTier[],
+  compactFn: CompactFn,
+  signal?: AbortSignal,
+): Promise<ReducerStepResult> {
+  const compactionOptions: ContextWindowCompactOptions = {
+    force: true,
+    minKeepRecentUserTurns: 0,
+    targetInputTokensOverride: config.targetTokens,
+  };
+
+  const result = await compactFn(messages, signal, compactionOptions);
+  const nextMessages = result.compacted ? result.messages : messages;
+  const estimatedTokens = result.compacted
+    ? result.estimatedInputTokens
+    : estimatePromptTokens(messages, config.systemPrompt, {
+        providerName: config.providerName,
+      });
+
+  const nextApplied: ReducerTier[] = [...applied, "forced_compaction"];
+  return {
+    messages: nextMessages,
+    tier: "forced_compaction",
+    state: {
+      appliedTiers: nextApplied,
+      injectionMode: "full",
+      compactionOptions,
+      exhausted: false,
+    },
+    estimatedTokens,
+    compactionResult: result,
+  };
+}
+
+function applyToolResultTruncation(
+  messages: Message[],
+  config: ReducerConfig,
+  applied: ReducerTier[],
+): ReducerStepResult {
+  const { messages: truncated, truncatedCount } =
+    truncateToolResultsAcrossHistory(messages, OVERFLOW_TOOL_RESULT_MAX_CHARS);
+
+  const nextMessages = truncatedCount > 0 ? truncated : messages;
+  const estimatedTokens = estimatePromptTokens(
+    nextMessages,
+    config.systemPrompt,
+    { providerName: config.providerName },
+  );
+
+  const nextApplied: ReducerTier[] = [...applied, "tool_result_truncation"];
+  return {
+    messages: nextMessages,
+    tier: "tool_result_truncation",
+    state: {
+      appliedTiers: nextApplied,
+      injectionMode: "full",
+      toolResultMaxChars: OVERFLOW_TOOL_RESULT_MAX_CHARS,
+      exhausted: false,
+    },
+    estimatedTokens,
+  };
+}
+
+function applyMediaStubbing(
+  messages: Message[],
+  config: ReducerConfig,
+  applied: ReducerTier[],
+  prevState: ReducerState | undefined,
+): ReducerStepResult {
+  const mediaCount = countMediaBlocks(messages);
+  let nextMessages = messages;
+
+  if (mediaCount > 0) {
+    const stripped = stripMediaPayloadsForRetry(messages);
+    if (stripped.modified) {
+      nextMessages = stripped.messages;
+    }
+  }
+
+  const estimatedTokens = estimatePromptTokens(
+    nextMessages,
+    config.systemPrompt,
+    { providerName: config.providerName },
+  );
+
+  const nextApplied: ReducerTier[] = [...applied, "media_stubbing"];
+  return {
+    messages: nextMessages,
+    tier: "media_stubbing",
+    state: {
+      appliedTiers: nextApplied,
+      injectionMode: prevState?.injectionMode ?? "full",
+      toolResultMaxChars: prevState?.toolResultMaxChars,
+      compactionOptions: prevState?.compactionOptions,
+      exhausted: false,
+    },
+    estimatedTokens,
+  };
+}
+
+function applyInjectionDowngrade(
+  messages: Message[],
+  config: ReducerConfig,
+  applied: ReducerTier[],
+  prevState: ReducerState | undefined,
+): ReducerStepResult {
+  // The injection downgrade itself does not modify messages — it signals
+  // to the caller that the next provider call should use minimal injection
+  // mode, which the caller applies via applyRuntimeInjections().
+  const estimatedTokens = estimatePromptTokens(messages, config.systemPrompt, {
+    providerName: config.providerName,
+  });
+
+  const nextApplied: ReducerTier[] = [...applied, "injection_downgrade"];
+  return {
+    messages,
+    tier: "injection_downgrade",
+    state: {
+      appliedTiers: nextApplied,
+      injectionMode: "minimal",
+      toolResultMaxChars: prevState?.toolResultMaxChars,
+      compactionOptions: prevState?.compactionOptions,
+      exhausted: true,
+    },
+    estimatedTokens,
+  };
+}
+
+/**
+ * Create the initial (empty) reducer state.
+ */
+export function createInitialReducerState(): ReducerState {
+  return {
+    appliedTiers: [],
+    injectionMode: "full",
+    exhausted: false,
+  };
+}

--- a/assistant/src/daemon/session-media-retry.ts
+++ b/assistant/src/daemon/session-media-retry.ts
@@ -6,17 +6,22 @@
  * text stubs to shrink the payload before retrying.
  */
 
-import { getSummaryFromContextMessage } from '../context/window-manager.js';
-import type { ContentBlock,Message } from '../providers/types.js';
+import { getSummaryFromContextMessage } from "../context/window-manager.js";
+import type { ContentBlock, Message } from "../providers/types.js";
 
 const RETRY_KEEP_LATEST_MEDIA_BLOCKS = 3;
 const MAX_MEDIA_STUB_TEXT = 2_000;
 
-export function stripMediaPayloadsForRetry(messages: Message[]): { messages: Message[]; modified: boolean; replacedBlocks: number; latestUserIndex: number | null } {
+export function stripMediaPayloadsForRetry(messages: Message[]): {
+  messages: Message[];
+  modified: boolean;
+  replacedBlocks: number;
+  latestUserIndex: number | null;
+} {
   let latestUserIndex: number | null = null;
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
-    if (msg.role !== 'user') continue;
+    if (msg.role !== "user") continue;
     if (getSummaryFromContextMessage(msg) != null) continue;
     if (isToolResultOnlyMessage(msg)) continue;
     latestUserIndex = i;
@@ -33,8 +38,10 @@ export function stripMediaPayloadsForRetry(messages: Message[]): { messages: Mes
       // Top-level image blocks are user-uploaded attachments. Keep the latest
       // few (in the most recent user message) and strip older ones so the
       // retry can actually reduce context size when images are the cause.
-      if (block.type === 'image') {
-        const keep = latestUserIndex === msgIndex && keptLatestMediaBlocks < RETRY_KEEP_LATEST_MEDIA_BLOCKS;
+      if (block.type === "image") {
+        const keep =
+          latestUserIndex === msgIndex &&
+          keptLatestMediaBlocks < RETRY_KEEP_LATEST_MEDIA_BLOCKS;
         if (keep) {
           keptLatestMediaBlocks += 1;
           nextContent.push(block);
@@ -46,8 +53,10 @@ export function stripMediaPayloadsForRetry(messages: Message[]): { messages: Mes
         continue;
       }
 
-      if (block.type === 'file') {
-        const keep = latestUserIndex === msgIndex && keptLatestMediaBlocks < RETRY_KEEP_LATEST_MEDIA_BLOCKS;
+      if (block.type === "file") {
+        const keep =
+          latestUserIndex === msgIndex &&
+          keptLatestMediaBlocks < RETRY_KEEP_LATEST_MEDIA_BLOCKS;
         if (keep) {
           keptLatestMediaBlocks += 1;
           nextContent.push(block);
@@ -59,23 +68,29 @@ export function stripMediaPayloadsForRetry(messages: Message[]): { messages: Mes
         continue;
       }
 
-      if (block.type === 'tool_result' && block.contentBlocks && block.contentBlocks.length > 0) {
+      if (
+        block.type === "tool_result" &&
+        block.contentBlocks &&
+        block.contentBlocks.length > 0
+      ) {
         let toolResultChanged = false;
-        const nextToolContentBlocks: ContentBlock[] = block.contentBlocks.map((cb) => {
-          if (cb.type === 'image') {
-            replacedBlocks += 1;
-            modified = true;
-            toolResultChanged = true;
-            return imageBlockToStub(cb);
-          }
-          if (cb.type === 'file') {
-            replacedBlocks += 1;
-            modified = true;
-            toolResultChanged = true;
-            return fileBlockToStub(cb);
-          }
-          return cb;
-        });
+        const nextToolContentBlocks: ContentBlock[] = block.contentBlocks.map(
+          (cb) => {
+            if (cb.type === "image") {
+              replacedBlocks += 1;
+              modified = true;
+              toolResultChanged = true;
+              return imageBlockToStub(cb);
+            }
+            if (cb.type === "file") {
+              replacedBlocks += 1;
+              modified = true;
+              toolResultChanged = true;
+              return fileBlockToStub(cb);
+            }
+            return cb;
+          },
+        );
         if (toolResultChanged) {
           nextContent.push({ ...block, contentBlocks: nextToolContentBlocks });
         } else {
@@ -97,31 +112,61 @@ export function stripMediaPayloadsForRetry(messages: Message[]): { messages: Mes
   };
 }
 
-function imageBlockToStub(block: Extract<ContentBlock, { type: 'image' }>): Extract<ContentBlock, { type: 'text' }> {
+function imageBlockToStub(
+  block: Extract<ContentBlock, { type: "image" }>,
+): Extract<ContentBlock, { type: "text" }> {
   const sizeBytes = Math.ceil(block.source.data.length / 4) * 3;
   return {
-    type: 'text',
+    type: "text",
     text: `[Image omitted from retry context: ${block.source.media_type}, ${sizeBytes} bytes]`,
   };
 }
 
-function fileBlockToStub(block: Extract<ContentBlock, { type: 'file' }>): Extract<ContentBlock, { type: 'text' }> {
+function fileBlockToStub(
+  block: Extract<ContentBlock, { type: "file" }>,
+): Extract<ContentBlock, { type: "text" }> {
   const sizeBytes = Math.ceil(block.source.data.length / 4) * 3;
-  const extracted = (block.extracted_text ?? '').trim();
-  const preview = extracted.length > MAX_MEDIA_STUB_TEXT
-    ? `${extracted.slice(0, MAX_MEDIA_STUB_TEXT)}...`
-    : extracted;
+  const extracted = (block.extracted_text ?? "").trim();
+  const preview =
+    extracted.length > MAX_MEDIA_STUB_TEXT
+      ? `${extracted.slice(0, MAX_MEDIA_STUB_TEXT)}...`
+      : extracted;
   return {
-    type: 'text',
-    text: preview.length > 0
-      ? `[File omitted from retry context: ${block.source.filename} (${block.source.media_type}, ${sizeBytes} bytes)]\n${preview}`
-      : `[File omitted from retry context: ${block.source.filename} (${block.source.media_type}, ${sizeBytes} bytes)]`,
+    type: "text",
+    text:
+      preview.length > 0
+        ? `[File omitted from retry context: ${block.source.filename} (${block.source.media_type}, ${sizeBytes} bytes)]\n${preview}`
+        : `[File omitted from retry context: ${block.source.filename} (${block.source.media_type}, ${sizeBytes} bytes)]`,
   };
 }
 
 function isToolResultOnlyMessage(message: Message): boolean {
-  return message.content.length > 0
-    && message.content.every((block) => block.type === 'tool_result');
+  return (
+    message.content.length > 0 &&
+    message.content.every((block) => block.type === "tool_result")
+  );
+}
+
+/**
+ * Count how many media (image/file) content blocks exist across a message
+ * history, both top-level and nested inside tool_result blocks.
+ */
+export function countMediaBlocks(messages: Message[]): number {
+  let count = 0;
+  for (const msg of messages) {
+    for (const block of msg.content) {
+      if (block.type === "image" || block.type === "file") {
+        count++;
+      } else if (block.type === "tool_result" && block.contentBlocks) {
+        for (const cb of block.contentBlocks) {
+          if (cb.type === "image" || cb.type === "file") {
+            count++;
+          }
+        }
+      }
+    }
+  }
+  return count;
 }
 
 /**
@@ -132,13 +177,16 @@ function isToolResultOnlyMessage(message: Message): boolean {
 export async function raceWithTimeout<T>(
   promise: Promise<T>,
   timeoutMs: number,
-): Promise<'completed' | 'timed_out'> {
+): Promise<"completed" | "timed_out"> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     const result = await Promise.race([
-      promise.then(() => 'completed' as const, () => 'completed' as const),
-      new Promise<'timed_out'>((resolve) => {
-        timer = setTimeout(() => resolve('timed_out'), timeoutMs);
+      promise.then(
+        () => "completed" as const,
+        () => "completed" as const,
+      ),
+      new Promise<"timed_out">((resolve) => {
+        timer = setTimeout(() => resolve("timed_out"), timeoutMs);
       }),
     ]);
     return result;


### PR DESCRIPTION
## Summary
- Create `context-overflow-reducer.ts` with deterministic tier progression: forced compaction, aggressive tool-result truncation, media/file payload stubbing, and injection mode downgrade
- Add `truncateToolResultsAcrossHistory` helper in `tool-result-truncation.ts` for applying truncation across all tool-result blocks in message history
- Expose `countMediaBlocks` utility from `session-media-retry.ts` for the reducer
- Add 11 tests covering monotonic token reduction, tier idempotency, deterministic outputs, preserved tool-use/tool-result structural validity, injection mode progression, and compaction result forwarding

Part of plan: guaranteed-context-overflow-recovery.md (PR 4 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
