### PR TITLE
feat: add diagnostic logging for contacts-first notification delivery paths

### DIFF
--- a/assistant/src/notifications/destination-resolver.ts
+++ b/assistant/src/notifications/destination-resolver.ts
@@ -17,7 +17,10 @@ import { isNotificationDeliverable } from "../channels/config.js";
 import type { ChannelId } from "../channels/types.js";
 import { findGuardianForChannel } from "../contacts/contact-store.js";
 import { getActiveBinding } from "../memory/channel-guardian-store.js";
+import { getLogger } from "../util/logger.js";
 import type { ChannelDestination, NotificationChannel } from "./types.js";
+
+const log = getLogger("destination-resolver");
 
 /**
  * Resolve destination information for each requested channel.
@@ -59,11 +62,17 @@ export function resolveDestinations(
           channel: "vellum",
           metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
         });
+        log.debug('destination resolved', {
+          channel: 'vellum',
+          source: guardianResult ? 'contacts' : 'legacy',
+          hasEndpoint: false,
+        });
         break;
       }
       case "telegram":
       case "sms": {
         const guardianResult = findGuardianForChannel(channel);
+        let binding: ReturnType<typeof getActiveBinding> = null;
         if (guardianResult) {
           result.set(channel as NotificationChannel, {
             channel: channel as NotificationChannel,
@@ -74,7 +83,7 @@ export function resolveDestinations(
           });
         } else {
           // Legacy fallback: contacts not yet synced
-          const binding = getActiveBinding(assistantId, channel);
+          binding = getActiveBinding(assistantId, channel);
           if (binding) {
             result.set(channel as NotificationChannel, {
               channel: channel as NotificationChannel,
@@ -85,6 +94,11 @@ export function resolveDestinations(
             });
           }
         }
+        log.debug('destination resolved', {
+          channel,
+          source: guardianResult ? 'contacts' : 'legacy',
+          hasEndpoint: !!guardianResult?.channel.externalChatId || !!binding?.guardianDeliveryChatId,
+        });
         break;
       }
       default: {

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -236,6 +236,11 @@ export async function emitNotificationSignal<TEventName extends string>(
     // Step 2: Evaluate the signal through the decision engine
     const connectedChannels = getConnectedChannels(assistantId);
 
+    log.debug('connected channels resolved', {
+      channels: connectedChannels,
+      assistantId,
+    });
+
     let decision = await evaluateSignal(signal, connectedChannels);
 
     // Step 2.5: Enforce routing intent policy (fire-time guard)

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -102,6 +102,7 @@ export function notifyGuardianOfAccessRequest(
   let guardianExternalUserId: string | null = null;
   let guardianPrincipalId: string | null = null;
   let guardianBindingChannel: string | null = null;
+  let guardianResolutionSource: 'contacts' | 'contacts-fallback' | 'legacy' | 'none' = 'none';
 
   // Try contacts-first: source channel
   const sourceGuardian = findGuardianForChannel(sourceChannel);
@@ -109,6 +110,7 @@ export function notifyGuardianOfAccessRequest(
     guardianExternalUserId = sourceGuardian.channel.externalUserId;
     guardianPrincipalId = sourceGuardian.contact.principalId;
     guardianBindingChannel = sourceGuardian.channel.type;
+    guardianResolutionSource = 'contacts';
   } else {
     // Try contacts-first: any active guardian channel
     const allGuardianChannels = listGuardianChannels();
@@ -117,6 +119,7 @@ export function notifyGuardianOfAccessRequest(
       guardianExternalUserId = fallbackChannel.externalUserId;
       guardianPrincipalId = allGuardianChannels.contact.principalId;
       guardianBindingChannel = fallbackChannel.type;
+      guardianResolutionSource = 'contacts-fallback';
       log.debug(
         { sourceChannel, fallbackChannel: guardianBindingChannel, canonicalAssistantId },
         'Using cross-channel guardian contact fallback for access request',
@@ -128,12 +131,14 @@ export function notifyGuardianOfAccessRequest(
         guardianExternalUserId = sourceBinding.guardianExternalUserId;
         guardianPrincipalId = sourceBinding.guardianPrincipalId;
         guardianBindingChannel = sourceBinding.channel;
+        guardianResolutionSource = 'legacy';
       } else {
         const allBindings = listActiveBindingsByAssistant(canonicalAssistantId);
         if (allBindings.length > 0) {
           guardianExternalUserId = allBindings[0].guardianExternalUserId;
           guardianPrincipalId = allBindings[0].guardianPrincipalId;
           guardianBindingChannel = allBindings[0].channel;
+          guardianResolutionSource = 'legacy';
           log.debug(
             { sourceChannel, fallbackChannel: guardianBindingChannel, canonicalAssistantId },
             'Using cross-channel guardian binding fallback for access request',
@@ -163,6 +168,13 @@ export function notifyGuardianOfAccessRequest(
       guardianBindingChannel = guardianBindingChannel ?? 'vellum';
     }
   }
+
+  log.debug('access request guardian resolved', {
+    sourceChannel,
+    source: guardianResolutionSource,
+    hasGuardianPrincipal: !!guardianPrincipalId,
+    guardianBindingChannel,
+  });
 
   // The conversationId is assistant-scoped so the dedupe query below only
   // matches requests for the same assistant. Without this, a pending request


### PR DESCRIPTION
## Summary
- Add debug-level logging to destination-resolver, emit-signal, and access-request-helper
- Logs indicate whether contacts or legacy path was used for each resolution
- Helps diagnose mismatches during the contacts migration transition period

Part of plan: notif-delivery-contacts.md (PR 8 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
