### PR TITLE
fix: fall through to legacy path when contacts-first returns null principalId in guardian dispatch

### DIFF
--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -102,12 +102,17 @@ async function dispatchGuardianQuestionInner(
     // level guardian identity. Resolve the principal from the contacts-first
     // path (canonical), falling back to the legacy vellum binding.
     let guardianPrincipalId: string | undefined;
+    let resolvedViaContacts = false;
 
     const guardianResult = findGuardianForChannel("vellum");
-    if (guardianResult) {
-      guardianPrincipalId = guardianResult.contact.principalId ?? undefined;
-    } else {
-      // Legacy fallback: contacts not yet synced
+    if (guardianResult?.contact.principalId) {
+      guardianPrincipalId = guardianResult.contact.principalId;
+      resolvedViaContacts = true;
+    }
+
+    // Legacy fallback: contacts not yet synced, or contact exists but
+    // principalId is null (partial/backfill sync state).
+    if (!guardianPrincipalId) {
       let vellumBinding = getActiveBinding(assistantId, "vellum");
       guardianPrincipalId = vellumBinding?.guardianPrincipalId;
 
@@ -127,8 +132,8 @@ async function dispatchGuardianQuestionInner(
 
     if (!guardianPrincipalId) {
       log.error(
-        { callSessionId, assistantId },
-        "Voice guardian dispatch: no guardianPrincipalId after self-heal — cannot create pending_question",
+        { callSessionId, assistantId, resolvedViaContacts },
+        "Voice guardian dispatch: no guardianPrincipalId after contacts + legacy fallback — cannot create pending_question",
       );
       return;
     }


### PR DESCRIPTION
Addresses feedback from both Codex (P1) and Devin on #11992: ensures null principalId from contacts-first path triggers the legacy fallback with self-heal, and fixes misleading error log message.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
