### PR TITLE
fix: preserve healedPrincipalId fallback in contacts-first access request path

### DIFF
--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -158,8 +158,8 @@ export function notifyGuardianOfAccessRequest(
     const healedPrincipalId = ensureVellumGuardianBinding(canonicalAssistantId);
     const vellumGuardian = findGuardianForChannel('vellum');
     if (vellumGuardian) {
-      guardianExternalUserId = vellumGuardian.channel.externalUserId;
-      guardianPrincipalId = vellumGuardian.contact.principalId;
+      guardianExternalUserId = vellumGuardian.channel.externalUserId ?? guardianExternalUserId;
+      guardianPrincipalId = vellumGuardian.contact.principalId ?? healedPrincipalId;
       guardianBindingChannel = guardianBindingChannel ?? 'vellum';
     } else {
       const vellumBinding = getGuardianBinding(canonicalAssistantId, 'vellum');


### PR DESCRIPTION
Addresses feedback from both Codex and Devin on #11998: adds null-coalescing fallback to healedPrincipalId when the contacts-first path returns a null principalId, preserving the self-heal behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
