### PR TITLE
fix: update contact channel status on guardian binding revocation

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -685,6 +685,48 @@ export function findGuardianForChannel(
 }
 
 /**
+ * Revoke the guardian's active channel of the given type by setting its
+ * status to 'revoked'. This is the contacts-side counterpart to
+ * revokeBinding() in guardian-bindings.ts — it ensures findGuardianForChannel()
+ * no longer returns stale data after a binding is revoked.
+ *
+ * Returns true if a channel was found and revoked, false otherwise.
+ */
+export function revokeGuardianChannel(channelType: string): boolean {
+  const db = getDb();
+  const rows = db
+    .select({
+      channelId: contactChannels.id,
+    })
+    .from(contacts)
+    .innerJoin(contactChannels, eq(contacts.id, contactChannels.contactId))
+    .where(
+      and(
+        eq(contacts.role, "guardian"),
+        eq(contactChannels.type, channelType),
+        eq(contactChannels.status, "active"),
+      ),
+    )
+    .all();
+
+  if (rows.length === 0) return false;
+
+  const now = Date.now();
+  for (const row of rows) {
+    db.update(contactChannels)
+      .set({
+        status: "revoked",
+        revokedReason: "guardian_binding_revoked",
+        updatedAt: now,
+      })
+      .where(eq(contactChannels.id, row.channelId))
+      .run();
+  }
+
+  return true;
+}
+
+/**
  * List all active channels for guardian contacts.
  * This is the contacts-based equivalent of listActiveBindingsByAssistant(assistantId).
  * Joins contacts+channels with status='active' in a single query so we never

--- a/assistant/src/memory/guardian-bindings.ts
+++ b/assistant/src/memory/guardian-bindings.ts
@@ -9,6 +9,7 @@ import { and, asc, desc, eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
 import { syncSingleGuardianBinding } from '../contacts/contact-sync.js';
+import { revokeGuardianChannel } from '../contacts/contact-store.js';
 import { getLogger } from '../util/logger.js';
 import { getDb } from './db.js';
 import { channelGuardianBindings } from './schema.js';
@@ -164,6 +165,14 @@ export function revokeBinding(assistantId: string, channel: string): boolean {
     .set({ status: 'revoked', updatedAt: now })
     .where(eq(channelGuardianBindings.id, existing.id))
     .run();
+
+  // Sync revocation to the contacts table so findGuardianForChannel()
+  // no longer returns stale data for revoked bindings.
+  try {
+    revokeGuardianChannel(channel);
+  } catch (err) {
+    log.warn({ err }, 'Failed to revoke contact channel for guardian binding');
+  }
 
   return true;
 }


### PR DESCRIPTION
Addresses feedback from both Codex and Devin on #11989: ensures revokeBinding() also updates the contact channel status so findGuardianForChannel() doesn't return stale data for revoked guardians. This is security-relevant — without this fix, revoked guardians could continue receiving notifications.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
