### PR TITLE
fix: correct minKeepRecentUserTurns: 0 test to force zero-floor compaction

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -517,7 +517,7 @@ describe("ContextWindowManager", () => {
       "system prompt",
       makeConfig({
         maxInputTokens: 260,
-        targetInputTokens: 180,
+        targetInputTokens: 60,
         preserveRecentUserTurns: 2,
       }),
     );


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for guaranteed-context-overflow-recovery.md.

**Gap:** Test expectation mismatch in minKeepRecentUserTurns: 0 test
**What was expected:** Test should validate that all messages can be compacted when minKeepRecentUserTurns is 0
**What was found:** Token budget was too generous (targetInputTokens: 180), causing keepTurns to stop at 1 instead of reaching 0 — keeping 1 user turn fit within the budget, so the while loop broke early

**Fix:** Reduced targetInputTokens from 180 to 60 so that even keeping 1 user turn (~94 projected tokens) exceeds the target, forcing the algorithm to continue reducing keepTurns down to 0 and compacting all 3 messages as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
