### PR TITLE
fix: correct guardian selection for voice and add username fallback in relay-server

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -12,7 +12,7 @@ import type { ServerWebSocket } from "bun";
 
 import { getConfig } from "../config/loader.js";
 import { resolveUserReference } from "../config/user-reference.js";
-import { listGuardianChannels } from "../contacts/contact-store.js";
+import { findGuardianForChannel, listGuardianChannels } from "../contacts/contact-store.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import { getCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
 import { listActiveBindingsByAssistant } from "../memory/channel-guardian-store.js";
@@ -1995,12 +1995,26 @@ export class RelayConnection {
     // binding for the assistant (mirrors the cross-channel fallback pattern
     // in access-request-helper.ts).
     let metadataJson: string | null = null;
-    // Contacts-first: use the guardian contact's displayName
-    const guardianChannels = listGuardianChannels();
-    if (guardianChannels) {
-      const displayName = guardianChannels.contact.displayName;
-      if (displayName) {
-        metadataJson = JSON.stringify({ displayName });
+    // Contacts-first: prefer the voice-bound guardian, then fall back to
+    // any guardian channel (mirrors the voice-first pattern in the legacy path).
+    const voiceGuardian = findGuardianForChannel("voice");
+    const guardianChannels = voiceGuardian ? null : listGuardianChannels();
+    const guardianContact = voiceGuardian?.contact ?? guardianChannels?.contact;
+    if (guardianContact) {
+      const meta: Record<string, string> = {};
+      if (guardianContact.displayName) {
+        meta.displayName = guardianContact.displayName;
+      }
+      // Preserve the username fallback: use the voice channel's externalUserId
+      // so downstream parsing can fall back to @username when displayName is a
+      // raw external ID (e.g., phone number from contact-sync).
+      const voiceChannel = voiceGuardian?.channel
+        ?? guardianChannels?.channels.find((ch) => ch.type === "voice");
+      if (voiceChannel?.externalUserId) {
+        meta.username = voiceChannel.externalUserId;
+      }
+      if (Object.keys(meta).length > 0) {
+        metadataJson = JSON.stringify(meta);
       }
     }
     if (!metadataJson) {


### PR DESCRIPTION
Addresses Codex P2 feedback on #11997: fixes guardian selection to target the voice-bound guardian specifically using findGuardianForChannel("voice") instead of listGuardianChannels() which picks an arbitrary guardian, and adds username fallback (from voice channel externalUserId) to the contacts-first path to match legacy behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
