### PR TITLE
fix: harden connected channels check against stale contacts in emit-signal

### DIFF
--- a/assistant/src/notifications/destination-resolver.ts
+++ b/assistant/src/notifications/destination-resolver.ts
@@ -73,7 +73,10 @@ export function resolveDestinations(
       case "sms": {
         const guardianResult = findGuardianForChannel(channel);
         let binding: ReturnType<typeof getActiveBinding> = null;
-        if (guardianResult) {
+        // Only use the contacts path when the channel has a valid delivery
+        // endpoint. A partial contact record (active status but no
+        // externalChatId) should not block the legacy fallback.
+        if (guardianResult && guardianResult.channel.externalChatId) {
           result.set(channel as NotificationChannel, {
             channel: channel as NotificationChannel,
             endpoint: guardianResult.channel.externalChatId,
@@ -82,7 +85,7 @@ export function resolveDestinations(
             },
           });
         } else {
-          // Legacy fallback: contacts not yet synced
+          // Legacy fallback: contacts not yet synced or missing endpoint
           binding = getActiveBinding(assistantId, channel);
           if (binding) {
             result.set(channel as NotificationChannel, {
@@ -96,7 +99,7 @@ export function resolveDestinations(
         }
         log.debug('destination resolved', {
           channel,
-          source: guardianResult ? 'contacts' : 'legacy',
+          source: guardianResult?.channel.externalChatId ? 'contacts' : 'legacy',
           hasEndpoint: !!guardianResult?.channel.externalChatId || !!binding?.guardianDeliveryChatId,
         });
         break;

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -110,17 +110,22 @@ function getConnectedChannels(assistantId: string): NotificationChannel[] {
         channels.push(channel);
         break;
       case "telegram":
-      case "sms":
+      case "sms": {
         // A binding-based channel is connected when the guardian has an
-        // active channel entry of this type. Fall back to legacy binding
-        // check if contacts are not yet synced.
+        // active channel entry with a valid delivery endpoint. The
+        // externalChatId check ensures we don't report a channel as
+        // connected when the contacts record exists but lacks the
+        // delivery address the destination-resolver needs.
+        // Falls back to legacy binding check if contacts are not yet synced.
+        const guardian = findGuardianForChannel(channel);
         if (
-          findGuardianForChannel(channel) ||
+          (guardian && guardian.channel.externalChatId) ||
           getActiveBinding(assistantId, channel)
         ) {
           channels.push(channel);
         }
         break;
+      }
       default:
         // Future deliverable channels — skip until a connectivity check
         // is implemented for them.


### PR DESCRIPTION
Addresses feedback from both Codex and Devin on #11990: hardens the contacts-first connected channels check in emit-signal.ts against stale/revoked contact data.

## Changes

**emit-signal.ts**: The `getConnectedChannels()` check now verifies the contact channel has a valid `externalChatId` delivery endpoint before reporting telegram/sms as connected. Previously, a contacts record that existed but lacked a delivery address would cause false-positive connectivity, leading the decision engine to select a channel that the destination resolver couldn't actually route to.

**destination-resolver.ts**: The contacts-first path now falls through to the legacy binding when the contact channel exists but has no `externalChatId`. Previously, a partial contact record (active status but no delivery address) would block the working legacy fallback, resulting in a destination with a null endpoint.

Both changes ensure `getConnectedChannels()` and `resolveDestinations()` stay in sync: if one reports a channel as available, the other can resolve it to a valid delivery endpoint.

PR #12008 already fixed the root cause (stale contact data after revocation) by adding `revokeGuardianChannel()`. These changes provide an additional layer of defense for edge cases where contact records exist without complete delivery information.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12012" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
