### PR TITLE
feat: add updateChannelLastSeen to contact store and sync from legacy updateLastSeen

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -812,3 +812,24 @@ export function updateChannelStatus(
 
   return updated ? parseChannel(updated) : null;
 }
+
+/**
+ * Update the lastSeenAt timestamp on a contact channel by (type, externalUserId).
+ * Optimized for the hot path — single UPDATE with no prior SELECT.
+ */
+export function updateChannelLastSeenByExternalId(
+  channelType: string,
+  externalUserId: string,
+): void {
+  const db = getDb();
+  const now = Date.now();
+  db.update(contactChannels)
+    .set({ lastSeenAt: now, updatedAt: now })
+    .where(
+      and(
+        eq(contactChannels.type, channelType),
+        eq(contactChannels.externalUserId, externalUserId),
+      ),
+    )
+    .run();
+}

--- a/assistant/src/memory/ingress-member-store.ts
+++ b/assistant/src/memory/ingress-member-store.ts
@@ -8,6 +8,7 @@
 import { and, desc, eq, or } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
+import { updateChannelLastSeenByExternalId } from '../contacts/contact-store.js';
 import { syncSingleMember } from '../contacts/contact-sync.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
 import { getLogger } from '../util/logger.js';
@@ -379,4 +380,21 @@ export function updateLastSeen(memberId: string): void {
     .set({ lastSeenAt: now, updatedAt: now })
     .where(eq(assistantIngressMembers.id, memberId))
     .run();
+
+  // Forward-sync lastSeenAt to contacts
+  try {
+    const member = db
+      .select({
+        sourceChannel: assistantIngressMembers.sourceChannel,
+        externalUserId: assistantIngressMembers.externalUserId,
+      })
+      .from(assistantIngressMembers)
+      .where(eq(assistantIngressMembers.id, memberId))
+      .get();
+    if (member?.externalUserId) {
+      updateChannelLastSeenByExternalId(member.sourceChannel, member.externalUserId);
+    }
+  } catch (err) {
+    log.warn({ err }, 'Contact sync failed for last seen update');
+  }
 }


### PR DESCRIPTION
## Summary
- Add `updateChannelLastSeenByExternalId()` to contact-store.ts — optimized single-UPDATE function for the inbound message hot path
- Add forward-sync hook to `updateLastSeen()` in ingress-member-store.ts so contact channel lastSeenAt stays fresh

Part of plan: contacts-first-writes.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
