### PR TITLE
fix: correct pino log argument order in contacts-first diagnostic logging

### DIFF
--- a/assistant/src/notifications/destination-resolver.ts
+++ b/assistant/src/notifications/destination-resolver.ts
@@ -62,11 +62,11 @@ export function resolveDestinations(
           channel: "vellum",
           metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
         });
-        log.debug('destination resolved', {
+        log.debug({
           channel: 'vellum',
           source: guardianResult ? 'contacts' : 'legacy',
           hasEndpoint: false,
-        });
+        }, 'destination resolved');
         break;
       }
       case "telegram":
@@ -97,11 +97,11 @@ export function resolveDestinations(
             });
           }
         }
-        log.debug('destination resolved', {
+        log.debug({
           channel,
           source: guardianResult?.channel.externalChatId ? 'contacts' : 'legacy',
           hasEndpoint: !!guardianResult?.channel.externalChatId || !!binding?.guardianDeliveryChatId,
-        });
+        }, 'destination resolved');
         break;
       }
       default: {

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -241,10 +241,10 @@ export async function emitNotificationSignal<TEventName extends string>(
     // Step 2: Evaluate the signal through the decision engine
     const connectedChannels = getConnectedChannels(assistantId);
 
-    log.debug('connected channels resolved', {
+    log.debug({
       channels: connectedChannels,
       assistantId,
-    });
+    }, 'connected channels resolved');
 
     let decision = await evaluateSignal(signal, connectedChannels);
 

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -169,12 +169,12 @@ export function notifyGuardianOfAccessRequest(
     }
   }
 
-  log.debug('access request guardian resolved', {
+  log.debug({
     sourceChannel,
     source: guardianResolutionSource,
     hasGuardianPrincipal: !!guardianPrincipalId,
     guardianBindingChannel,
-  });
+  }, 'access request guardian resolved');
 
   // The conversationId is assistant-scoped so the dedupe query below only
   // matches requests for the same assistant. Without this, a pending request


### PR DESCRIPTION
Addresses feedback from both Codex and Devin on #12001: swaps pino log.debug() arguments from (message, object) to (object, message) in destination-resolver.ts, emit-signal.ts, and access-request-helper.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
