### PR TITLE
fix: wire ContactsRequestMessage through HTTP transport in DaemonClient

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -167,6 +167,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "contacts", scopes: ["settings.read"] },
   { endpoint: "contacts/merge", scopes: ["settings.write"] },
   { endpoint: "contacts:GET", scopes: ["settings.read"] },
+  { endpoint: "contacts/channels", scopes: ["settings.write"] },
   { endpoint: "ingress/members", scopes: ["settings.read"] },
   { endpoint: "ingress/members:POST", scopes: ["settings.write"] },
   { endpoint: "ingress/members/block", scopes: ["settings.write"] },

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -138,6 +138,7 @@ import {
   handleGetContact,
   handleListContacts,
   handleMergeContacts,
+  handleUpdateContactChannel,
 } from "./routes/contact-routes.js";
 import { handleListConversationAttention } from "./routes/conversation-attention-routes.js";
 // Route handlers — grouped by domain
@@ -276,6 +277,8 @@ const PARAMETERIZED_ROUTE_PATTERNS: Array<{ re: RegExp; policyBase: string }> =
     { re: /^calls\/[^/]+$/, policyBase: "calls" },
     // contacts/{id}
     { re: /^contacts\/[^/]+$/, policyBase: "contacts" },
+    // contacts/channels/{id}
+    { re: /^contacts\/channels\/[^/]+$/, policyBase: "contacts/channels" },
     // ingress/members/{id}/block
     {
       re: /^ingress\/members\/[^/]+\/block$/,
@@ -1151,6 +1154,11 @@ export class RuntimeHttpServer {
         return handleListContacts(url);
       if (endpoint === "contacts/merge" && req.method === "POST")
         return await handleMergeContacts(req);
+      const contactChannelMatch = endpoint.match(
+        /^contacts\/channels\/([^/]+)$/,
+      );
+      if (contactChannelMatch && req.method === "PATCH")
+        return await handleUpdateContactChannel(req, contactChannelMatch[1]);
       const contactMatch = endpoint.match(/^contacts\/([^/]+)$/);
       if (contactMatch && req.method === "GET")
         return handleGetContact(contactMatch[1]);

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -1,20 +1,23 @@
 /**
  * Route handlers for contact management endpoints.
  *
- * GET  /v1/contacts          — list contacts
- * GET  /v1/contacts/:id      — get a contact by ID
- * POST /v1/contacts/merge    — merge two contacts
+ * GET   /v1/contacts              — list contacts
+ * GET   /v1/contacts/:id          — get a contact by ID
+ * POST  /v1/contacts/merge        — merge two contacts
+ * PATCH /v1/contacts/channels/:id — update a contact channel's status/policy
  */
 
-import { getContact, listContacts, mergeContacts } from '../../contacts/contact-store.js';
+import { getContact, listContacts, mergeContacts, updateChannelStatus } from '../../contacts/contact-store.js';
+import type { ChannelPolicy, ChannelStatus, ContactRole } from '../../contacts/types.js';
 import { httpError } from '../http-errors.js';
 
 /**
- * GET /v1/contacts?limit=50
+ * GET /v1/contacts?limit=50&role=guardian
  */
 export function handleListContacts(url: URL): Response {
   const limit = Number(url.searchParams.get('limit') ?? 50);
-  const contacts = listContacts(limit);
+  const role = url.searchParams.get('role') as ContactRole | null;
+  const contacts = listContacts(limit, role ?? undefined);
   return Response.json({ ok: true, contacts });
 }
 
@@ -46,4 +49,29 @@ export async function handleMergeContacts(req: Request): Promise<Response> {
     const message = err instanceof Error ? err.message : String(err);
     return httpError('BAD_REQUEST', message, 400);
   }
+}
+
+/**
+ * PATCH /v1/contacts/channels/:channelId { status?, policy?, reason? }
+ */
+export async function handleUpdateContactChannel(req: Request, channelId: string): Promise<Response> {
+  const body = (await req.json()) as {
+    status?: string;
+    policy?: string;
+    reason?: string;
+  };
+
+  const updated = updateChannelStatus(channelId, {
+    status: body.status as ChannelStatus | undefined,
+    policy: body.policy as ChannelPolicy | undefined,
+    revokedReason: body.status !== undefined ? (body.status === 'revoked' ? body.reason ?? null : null) : undefined,
+    blockedReason: body.status !== undefined ? (body.status === 'blocked' ? body.reason ?? null : null) : undefined,
+  });
+
+  if (!updated) {
+    return httpError('NOT_FOUND', `Channel "${channelId}" not found`, 404);
+  }
+
+  const parentContact = getContact(updated.contactId);
+  return Response.json({ ok: true, contact: parentContact ?? undefined });
 }

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -159,6 +159,9 @@ public final class HTTPTransport {
         case trustRulesManage
         case trustRuleManageById(id: String)
         case pendingInteractions(conversationKey: String?)
+        case contactsList(limit: Int, role: String?)
+        case contactsGet(id: String)
+        case contactsChannelUpdate(channelId: String)
     }
 
     /// Build a URL for the given endpoint using the current route mode.
@@ -234,6 +237,19 @@ public final class HTTPTransport {
                 return ("/v1/pending-interactions", "conversationKey=\(encoded)")
             }
             return ("/v1/pending-interactions", nil)
+        case .contactsList(let limit, let role):
+            var q = "limit=\(limit)"
+            if let role {
+                let encoded = role.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? role
+                q += "&role=\(encoded)"
+            }
+            return ("/v1/contacts", q)
+        case .contactsGet(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/contacts/\(encoded)", nil)
+        case .contactsChannelUpdate(let channelId):
+            let encoded = channelId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? channelId
+            return ("/v1/contacts/channels/\(encoded)", nil)
         }
     }
 
@@ -293,6 +309,19 @@ public final class HTTPTransport {
                 return ("\(prefix)/pending-interactions/", "conversationKey=\(encoded)")
             }
             return ("\(prefix)/pending-interactions/", nil)
+        case .contactsList(let limit, let role):
+            var q = "limit=\(limit)"
+            if let role {
+                let encoded = role.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? role
+                q += "&role=\(encoded)"
+            }
+            return ("\(prefix)/contacts/", q)
+        case .contactsGet(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/contacts/\(encoded)/", nil)
+        case .contactsChannelUpdate(let channelId):
+            let encoded = channelId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? channelId
+            return ("\(prefix)/contacts/channels/\(encoded)/", nil)
         }
     }
 
@@ -533,6 +562,8 @@ public final class HTTPTransport {
             Task { await self.sendRemoveTrustRule(msg) }
         } else if let msg = message as? UpdateTrustRuleMessage {
             Task { await self.sendUpdateTrustRule(msg) }
+        } else if let msg = message as? ContactsRequestMessage {
+            Task { await self.handleContactsRequest(msg) }
         } else if message is PingMessage {
             // No-op for HTTP transport — SSE keepalive is handled by the connection
         } else {
@@ -849,6 +880,161 @@ public final class HTTPTransport {
         } catch {
             log.error("Conversation seen signal error: \(error.localizedDescription)")
         }
+    }
+
+    // MARK: - Contacts
+
+    /// Route a `ContactsRequestMessage` to the appropriate HTTP endpoint based on its action.
+    private func handleContactsRequest(_ msg: ContactsRequestMessage) async {
+        switch msg.action {
+        case "list":
+            await fetchContactsList(limit: Int(msg.limit ?? 50), role: msg.role)
+        case "get":
+            guard let contactId = msg.contactId else {
+                onMessage?(.contactsResponse(ContactsResponseMessage(type: "contacts_response", success: false, error: "contactId is required for get")))
+                return
+            }
+            await fetchContact(contactId: contactId)
+        case "update_channel":
+            guard let channelId = msg.channelId else {
+                onMessage?(.contactsResponse(ContactsResponseMessage(type: "contacts_response", success: false, error: "channelId is required for update_channel")))
+                return
+            }
+            await updateContactChannel(channelId: channelId, status: msg.status, policy: msg.policy, reason: msg.reason)
+        default:
+            onMessage?(.contactsResponse(ContactsResponseMessage(type: "contacts_response", success: false, error: "Unknown action: \(msg.action)")))
+        }
+    }
+
+    private func fetchContactsList(limit: Int, role: String?, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .contactsList(limit: limit, role: role)) else { return }
+
+        var request = URLRequest(url: url)
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        await fetchContactsList(limit: limit, role: role, isRetry: true)
+                    }
+                    return
+                }
+                guard http.statusCode == 200 else {
+                    log.error("HTTPTransport: fetch contacts list failed (\(http.statusCode))")
+                    onMessage?(.contactsResponse(ContactsResponseMessage(type: "contacts_response", success: false, error: "HTTP \(http.statusCode)")))
+                    return
+                }
+            }
+
+            do {
+                let decoded = try decoder.decode(HTTPContactsListResponse.self, from: data)
+                onMessage?(.contactsResponse(ContactsResponseMessage(type: "contacts_response", success: true, contacts: decoded.contacts)))
+            } catch {
+                log.error("HTTPTransport: failed to decode contacts list response: \(error)")
+                onMessage?(.contactsResponse(ContactsResponseMessage(type: "contacts_response", success: false, error: error.localizedDescription)))
+            }
+        } catch {
+            log.error("HTTPTransport: fetch contacts list error: \(error.localizedDescription)")
+            onMessage?(.contactsResponse(ContactsResponseMessage(type: "contacts_response", success: false, error: error.localizedDescription)))
+        }
+    }
+
+    private func fetchContact(contactId: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .contactsGet(id: contactId)) else { return }
+
+        var request = URLRequest(url: url)
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        await fetchContact(contactId: contactId, isRetry: true)
+                    }
+                    return
+                }
+                guard http.statusCode == 200 else {
+                    log.error("HTTPTransport: fetch contact failed (\(http.statusCode))")
+                    onMessage?(.contactsResponse(ContactsResponseMessage(type: "contacts_response", success: false, error: "HTTP \(http.statusCode)")))
+                    return
+                }
+            }
+
+            do {
+                let decoded = try decoder.decode(HTTPContactResponse.self, from: data)
+                onMessage?(.contactsResponse(ContactsResponseMessage(type: "contacts_response", success: true, contact: decoded.contact)))
+            } catch {
+                log.error("HTTPTransport: failed to decode contact response: \(error)")
+                onMessage?(.contactsResponse(ContactsResponseMessage(type: "contacts_response", success: false, error: error.localizedDescription)))
+            }
+        } catch {
+            log.error("HTTPTransport: fetch contact error: \(error.localizedDescription)")
+            onMessage?(.contactsResponse(ContactsResponseMessage(type: "contacts_response", success: false, error: error.localizedDescription)))
+        }
+    }
+
+    private func updateContactChannel(channelId: String, status: String?, policy: String?, reason: String?, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .contactsChannelUpdate(channelId: channelId)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "PATCH"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        var body: [String: Any] = [:]
+        if let status { body["status"] = status }
+        if let policy { body["policy"] = policy }
+        if let reason { body["reason"] = reason }
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        await updateContactChannel(channelId: channelId, status: status, policy: policy, reason: reason, isRetry: true)
+                    }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    log.error("HTTPTransport: update contact channel failed (\(http.statusCode))")
+                    onMessage?(.contactsResponse(ContactsResponseMessage(type: "contacts_response", success: false, error: "HTTP \(http.statusCode)")))
+                    return
+                }
+            }
+
+            do {
+                let decoded = try decoder.decode(HTTPContactResponse.self, from: data)
+                onMessage?(.contactsResponse(ContactsResponseMessage(type: "contacts_response", success: true, contact: decoded.contact)))
+            } catch {
+                log.error("HTTPTransport: failed to decode update channel response: \(error)")
+                onMessage?(.contactsResponse(ContactsResponseMessage(type: "contacts_response", success: false, error: error.localizedDescription)))
+            }
+        } catch {
+            log.error("HTTPTransport: update contact channel error: \(error.localizedDescription)")
+            onMessage?(.contactsResponse(ContactsResponseMessage(type: "contacts_response", success: false, error: error.localizedDescription)))
+        }
+    }
+
+    /// Response wrapper for `GET /v1/contacts` (list).
+    private struct HTTPContactsListResponse: Decodable {
+        let ok: Bool
+        let contacts: [ContactPayload]
+    }
+
+    /// Response wrapper for `GET /v1/contacts/:id` and `PATCH /v1/contacts/channels/:id`.
+    private struct HTTPContactResponse: Decodable {
+        let ok: Bool
+        let contact: ContactPayload?
     }
 
     // MARK: - Surface Actions


### PR DESCRIPTION
Addresses Codex P1 feedback on #11946: adds ContactsRequestMessage handling to HTTPDaemonClient.send so contacts IPC works correctly in remote assistant (HTTP transport) mode.

## Changes

- **HTTPDaemonClient.swift**: Added ContactsRequestMessage branch to send() that routes list/get/update_channel actions to HTTP endpoints. Added contactsList, contactsGet, contactsChannelUpdate endpoints with both runtimeFlat and platformAssistantProxy path builders. Added fetchContactsList, fetchContact, updateContactChannel private HTTP helper methods with 401 retry handling and response-to-IPC translation.

- **contact-routes.ts**: Added handleUpdateContactChannel (PATCH /v1/contacts/channels/:id) HTTP route handler. Enhanced handleListContacts to accept optional role query parameter.

- **http-server.ts**: Registered the new PATCH /v1/contacts/channels/:id route and its parameterized policy pattern.

- **route-policy.ts**: Added contacts/channels write policy entry.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
