### PR TITLE
fix: clear stale revokedReason when re-activating contact channel

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -116,6 +116,7 @@ interface SyncChannelData {
   verifiedAt?: number | null;
   verifiedVia?: string | null;
   inviteId?: string | null;
+  revokedReason?: string | null;
 }
 
 // ── CRUD ─────────────────────────────────────────────────────────────
@@ -347,6 +348,8 @@ function syncChannels(
       if (ch.verifiedAt !== undefined) updateSet.verifiedAt = ch.verifiedAt;
       if (ch.verifiedVia !== undefined) updateSet.verifiedVia = ch.verifiedVia;
       if (ch.inviteId !== undefined) updateSet.inviteId = ch.inviteId;
+      if (ch.revokedReason !== undefined)
+        updateSet.revokedReason = ch.revokedReason;
 
       if (Object.keys(updateSet).length > 0) {
         updateSet.updatedAt = now;

--- a/assistant/src/contacts/contact-sync.ts
+++ b/assistant/src/contacts/contact-sync.ts
@@ -76,6 +76,7 @@ export function syncSingleGuardianBinding(binding: GuardianBinding): void {
             ? binding.guardianExternalUserId
             : undefined,
         status: "active",
+        revokedReason: null,
         verifiedAt: binding.verifiedAt,
         verifiedVia: binding.verifiedVia,
       },


### PR DESCRIPTION
Addresses Devin feedback on #12008: adds revokedReason to SyncChannelData interface and clears it during syncSingleGuardianBinding() so re-verification doesn't leave stale revoked metadata on active channels.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
