### PR TITLE
fix: canonicalize externalUserId and add chat-id fallback in updateLastSeen forward-sync

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -833,3 +833,24 @@ export function updateChannelLastSeenByExternalId(
     )
     .run();
 }
+
+/**
+ * Update the lastSeenAt timestamp on a contact channel by (type, externalChatId).
+ * Fallback for members that only have a chat ID and no external user ID.
+ */
+export function updateChannelLastSeenByExternalChatId(
+  channelType: string,
+  externalChatId: string,
+): void {
+  const db = getDb();
+  const now = Date.now();
+  db.update(contactChannels)
+    .set({ lastSeenAt: now, updatedAt: now })
+    .where(
+      and(
+        eq(contactChannels.type, channelType),
+        eq(contactChannels.externalChatId, externalChatId),
+      ),
+    )
+    .run();
+}

--- a/assistant/src/memory/ingress-member-store.ts
+++ b/assistant/src/memory/ingress-member-store.ts
@@ -8,9 +8,11 @@
 import { and, desc, eq, or } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
-import { updateChannelLastSeenByExternalId } from '../contacts/contact-store.js';
+import type { ChannelId } from '../channels/types.js';
+import { updateChannelLastSeenByExternalChatId, updateChannelLastSeenByExternalId } from '../contacts/contact-store.js';
 import { syncSingleMember } from '../contacts/contact-sync.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
+import { canonicalizeInboundIdentity } from '../util/canonicalize-identity.js';
 import { getLogger } from '../util/logger.js';
 import { getDb } from './db.js';
 import { assistantIngressMembers } from './schema.js';
@@ -387,12 +389,20 @@ export function updateLastSeen(memberId: string): void {
       .select({
         sourceChannel: assistantIngressMembers.sourceChannel,
         externalUserId: assistantIngressMembers.externalUserId,
+        externalChatId: assistantIngressMembers.externalChatId,
       })
       .from(assistantIngressMembers)
       .where(eq(assistantIngressMembers.id, memberId))
       .get();
     if (member?.externalUserId) {
-      updateChannelLastSeenByExternalId(member.sourceChannel, member.externalUserId);
+      // Canonicalize to match the form stored in contactChannels (e.g. E.164 for phone channels)
+      const canonicalId =
+        canonicalizeInboundIdentity(member.sourceChannel as ChannelId, member.externalUserId)
+        ?? member.externalUserId;
+      updateChannelLastSeenByExternalId(member.sourceChannel, canonicalId);
+    } else if (member?.externalChatId) {
+      // Fallback for members created with only a chat ID (no externalUserId)
+      updateChannelLastSeenByExternalChatId(member.sourceChannel, member.externalChatId);
     }
   } catch (err) {
     log.warn({ err }, 'Contact sync failed for last seen update');


### PR DESCRIPTION
Addresses feedback from both Codex (P2) and Devin on #12013: canonicalizes externalUserId before forward-syncing lastSeenAt to contacts, and adds a fallback path for chat-id-only members.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
