### PR TITLE
refactor: migrate ingress member callers to contacts-first write path

### DIFF
--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -14,7 +14,7 @@
 import { answerCall } from '../calls/call-domain.js';
 import { getGatewayInternalBaseUrl } from '../config/env.js';
 import { type CanonicalGuardianRequest,getCanonicalGuardianRequest } from '../memory/canonical-guardian-store.js';
-import { upsertMember } from '../memory/ingress-member-store.js';
+import { upsertMemberContactsFirst } from '../contacts/contacts-write.js';
 import { emitNotificationSignal } from '../notifications/emit-signal.js';
 import { addRule } from '../permissions/trust-store.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
@@ -396,7 +396,7 @@ const accessRequestResolver: GuardianRequestResolver = {
     // relay server's in-call wait loop will detect the approved status.
     if (channel === 'voice') {
       try {
-        upsertMember({
+        upsertMemberContactsFirst({
           assistantId,
           sourceChannel: 'voice',
           externalUserId: requesterExternalUserId,

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -18,7 +18,8 @@ import { getCanonicalGuardianRequest } from "../memory/canonical-guardian-store.
 import { listActiveBindingsByAssistant } from "../memory/channel-guardian-store.js";
 import * as conversationStore from "../memory/conversation-store.js";
 import { findActiveVoiceInvites } from "../memory/ingress-invite-store.js";
-import { findMember, upsertMember } from "../memory/ingress-member-store.js";
+import { findMember } from "../memory/ingress-member-store.js";
+import { upsertMemberContactsFirst } from "../contacts/contacts-write.js";
 import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-grants.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import { notifyGuardianOfAccessRequest } from "../runtime/access-request-helper.js";
@@ -980,7 +981,7 @@ export class RelayConnection {
 
     if (!params.skipMemberActivation) {
       try {
-        upsertMember({
+        upsertMemberContactsFirst({
           assistantId,
           sourceChannel: "voice",
           externalUserId: fromNumber,

--- a/assistant/src/runtime/ingress-service.ts
+++ b/assistant/src/runtime/ingress-service.ts
@@ -15,14 +15,12 @@ import {
   revokeInvite,
 } from '../memory/ingress-invite-store.js';
 import {
-  blockMember,
   type IngressMember,
   listMembers,
   type MemberPolicy,
   type MemberStatus,
-  revokeMember,
-  upsertMember,
 } from '../memory/ingress-member-store.js';
+import { upsertMemberContactsFirst, revokeMemberContactsFirst, blockMemberContactsFirst } from '../contacts/contacts-write.js';
 import { isValidE164 } from '../util/phone.js';
 import { generateVoiceCode, hashVoiceCode } from '../util/voice-code.js';
 import { getTransport } from './channel-invite-transport.js';
@@ -314,7 +312,7 @@ export function upsertIngressMember(params: {
   if (!params.externalUserId && !params.externalChatId) {
     return { ok: false, error: 'At least one of externalUserId or externalChatId is required for upsert' };
   }
-  const member = upsertMember({
+  const member = upsertMemberContactsFirst({
     assistantId: params.assistantId,
     sourceChannel: params.sourceChannel,
     externalUserId: params.externalUserId,
@@ -331,7 +329,7 @@ export function revokeIngressMember(memberId?: string, reason?: string): Ingress
   if (!memberId) {
     return { ok: false, error: 'memberId is required for revoke' };
   }
-  const revoked = revokeMember(memberId, reason);
+  const revoked = revokeMemberContactsFirst(memberId, reason);
   if (!revoked) {
     return { ok: false, error: 'Member not found or cannot be revoked' };
   }
@@ -342,7 +340,7 @@ export function blockIngressMember(memberId?: string, reason?: string): IngressR
   if (!memberId) {
     return { ok: false, error: 'memberId is required for block' };
   }
-  const blocked = blockMember(memberId, reason);
+  const blocked = blockMemberContactsFirst(memberId, reason);
   if (!blocked) {
     return { ok: false, error: 'Member not found or already blocked' };
   }

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -10,7 +10,8 @@
 import type { ChannelId } from '../channels/types.js';
 import { getSqlite } from '../memory/db.js';
 import { findActiveVoiceInvites,findByTokenHash, hashToken, markInviteExpired, recordInviteUse, redeemInvite as storeRedeemInvite } from '../memory/ingress-invite-store.js';
-import { findMember, upsertMember } from '../memory/ingress-member-store.js';
+import { findMember } from '../memory/ingress-member-store.js';
+import { upsertMemberContactsFirst } from '../contacts/contacts-write.js';
 import { canonicalizeInboundIdentity } from '../util/canonicalize-identity.js';
 import { hashVoiceCode } from '../util/voice-code.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
@@ -129,10 +130,10 @@ export function redeemInvite(params: {
       ? existingMember.displayName
       : displayName;
 
-    let reactivated: ReturnType<typeof upsertMember> | undefined;
+    let reactivated: ReturnType<typeof upsertMemberContactsFirst> | undefined;
     try {
       getSqlite().transaction(() => {
-        reactivated = upsertMember({
+        reactivated = upsertMemberContactsFirst({
           assistantId: assistantId ?? invite.assistantId,
           sourceChannel,
           externalUserId,
@@ -294,7 +295,7 @@ export function redeemVoiceInviteCode(params: {
 
   try {
     getSqlite().transaction(() => {
-      const member = upsertMember({
+      const member = upsertMemberContactsFirst({
         assistantId: invite.assistantId,
         sourceChannel: 'voice',
         externalUserId: callerExternalUserId,

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -27,11 +27,8 @@ import * as channelDeliveryStore from "../../memory/channel-delivery-store.js";
 import { recordConversationSeenSignal } from "../../memory/conversation-attention-store.js";
 import * as conversationStore from "../../memory/conversation-store.js";
 import * as externalConversationStore from "../../memory/external-conversation-store.js";
-import {
-  findMember,
-  updateLastSeen,
-  upsertMember,
-} from "../../memory/ingress-member-store.js";
+import { findMember } from "../../memory/ingress-member-store.js";
+import { upsertMemberContactsFirst, touchChannelLastSeen } from '../../contacts/contacts-write.js';
 import { emitNotificationSignal } from "../../notifications/emit-signal.js";
 import { checkIngressForSecrets } from "../../security/secret-ingress.js";
 import { canonicalizeInboundIdentity } from "../../util/canonicalize-identity.js";
@@ -605,7 +602,7 @@ export async function handleChannelInbound(
       }
 
       // 'allow' or 'escalate' — update last seen and continue
-      updateLastSeen(resolvedMember.id);
+      touchChannelLastSeen(resolvedMember.id);
     }
   }
 
@@ -1030,7 +1027,7 @@ export async function handleChannelInbound(
           ? existingMember.displayName
           : body.actorDisplayName;
 
-      upsertMember({
+      upsertMemberContactsFirst({
         assistantId: canonicalAssistantId,
         sourceChannel,
         externalUserId: canonicalSenderId ?? rawSenderId!,


### PR DESCRIPTION
## Summary
- Migrate all ingress member write callers (inbound-message-handler, ingress-service, guardian-request-resolvers, relay-server, invite-redemption-service) to contacts-first write functions
- Member upsert, revoke, block, and lastSeen operations now write to contacts table first, then reverse-sync to legacy tables
- Read-only imports (findMember, listMembers) remain on legacy stores

Part of plan: contacts-first-writes.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
