### PR TITLE
refactor: migrate guardian binding callers to contacts-first write path

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -2,16 +2,16 @@ import * as net from "node:net";
 
 import type { ChannelId } from "../../channels/types.js";
 import * as externalConversationStore from "../../memory/external-conversation-store.js";
-import { findMember, revokeMember } from "../../memory/ingress-member-store.js";
+import { findMember } from "../../memory/ingress-member-store.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
 import {
   createVerificationChallenge,
   findActiveSession,
   getGuardianBinding,
   getPendingChallenge,
-  revokeBinding as revokeGuardianBinding,
   revokePendingChallenges,
 } from "../../runtime/channel-guardian-service.js";
+import { revokeGuardianBindingContactsFirst, revokeMemberContactsFirst } from "../../contacts/contacts-write.js";
 import {
   type ChannelReadinessService,
   createReadinessService,
@@ -206,7 +206,7 @@ export function revokeGuardianForChannel(
     };
   }
 
-  revokeGuardianBinding(assistantId, resolvedChannel);
+  revokeGuardianBindingContactsFirst(assistantId, resolvedChannel);
 
   const member = findMember({
     assistantId,
@@ -215,7 +215,7 @@ export function revokeGuardianForChannel(
     externalChatId: bindingBeforeRevoke.guardianDeliveryChatId,
   });
   if (member) {
-    revokeMember(member.id, "guardian_binding_revoked");
+    revokeMemberContactsFirst(member.id, "guardian_binding_revoked");
   }
 
   return {

--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -14,7 +14,6 @@ import {
   bindSessionIdentity as storeBindSessionIdentity,
   consumeChallenge,
   countRecentSendsToDestination as storeCountRecentSendsToDestination,
-  createBinding,
   createChallenge,
   createVerificationSession,
   findActiveSession as storeFindActiveSession,
@@ -26,11 +25,11 @@ import {
   getRateLimit,
   recordInvalidAttempt,
   resetRateLimit,
-  revokeBinding as storeRevokeBinding,
   revokePendingChallenges as storeRevokePendingChallenges,
   updateSessionDelivery as storeUpdateSessionDelivery,
   updateSessionStatus as storeUpdateSessionStatus,
 } from '../memory/channel-guardian-store.js';
+import { createGuardianBindingContactsFirst, revokeGuardianBindingContactsFirst } from '../contacts/contacts-write.js';
 import { composeApprovalMessage } from './approval-message-composer.js';
 
 // ---------------------------------------------------------------------------
@@ -300,7 +299,7 @@ export function validateAndConsumeChallenge(
   }
 
   // Revoke any existing active binding before creating a new one (same-user re-verification)
-  storeRevokeBinding(assistantId, channel);
+  revokeGuardianBindingContactsFirst(assistantId, channel);
 
   const metadata: Record<string, string> = {};
   if (actorUsername && actorUsername.trim().length > 0) {
@@ -316,7 +315,7 @@ export function validateAndConsumeChallenge(
   const canonicalPrincipal = vellumBinding?.guardianPrincipalId ?? actorExternalUserId;
 
   // Create the new guardian binding
-  const binding = createBinding({
+  const binding = createGuardianBindingContactsFirst({
     assistantId,
     channel,
     guardianExternalUserId: actorExternalUserId,
@@ -359,7 +358,7 @@ export function revokeBinding(
   assistantId: string,
   channel: string,
 ): boolean {
-  return storeRevokeBinding(assistantId, channel);
+  return revokeGuardianBindingContactsFirst(assistantId, channel);
 }
 
 /**

--- a/assistant/src/runtime/guardian-vellum-migration.ts
+++ b/assistant/src/runtime/guardian-vellum-migration.ts
@@ -13,9 +13,9 @@
 import { v4 as uuid } from 'uuid';
 
 import {
-  createBinding,
   getActiveBinding,
 } from '../memory/guardian-bindings.js';
+import { createGuardianBindingContactsFirst } from '../contacts/contacts-write.js';
 import { getLogger } from '../util/logger.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from './assistant-scope.js';
 
@@ -40,7 +40,7 @@ export function ensureVellumGuardianBinding(assistantId: string = DAEMON_INTERNA
 
   const guardianPrincipalId = `vellum-principal-${uuid()}`;
 
-  createBinding({
+  createGuardianBindingContactsFirst({
     assistantId,
     channel: 'vellum',
     guardianExternalUserId: guardianPrincipalId,

--- a/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
+++ b/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
@@ -14,9 +14,9 @@ import { createHash } from 'node:crypto';
 import { v4 as uuid } from 'uuid';
 
 import {
-  createBinding,
   getActiveBinding,
 } from '../../memory/guardian-bindings.js';
+import { createGuardianBindingContactsFirst } from '../../contacts/contacts-write.js';
 import { getLogger } from '../../util/logger.js';
 import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import { mintCredentialPair } from '../auth/credential-service.js';
@@ -52,7 +52,7 @@ function ensureGuardianPrincipal(assistantId: string): {
   // Mint a new principal ID for the vellum channel
   const guardianPrincipalId = `vellum-principal-${uuid()}`;
 
-  createBinding({
+  createGuardianBindingContactsFirst({
     assistantId,
     channel: 'vellum',
     guardianExternalUserId: guardianPrincipalId,


### PR DESCRIPTION
## Summary
- Migrate all guardian binding write callers (channel-guardian-service, guardian-vellum-migration, guardian-bootstrap-routes, config-channels) to use contacts-first write functions
- Guardian binding creation and revocation now write to contacts table first, then reverse-sync to legacy tables
- Read-only imports remain on legacy stores for backward compatibility

Part of plan: contacts-first-writes.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
