### PR TITLE
fix: add independent anchor timeout timer and guard against premature pagination exhaustion

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -83,11 +83,12 @@ struct MessageListView: View {
     /// resign first responder exactly once per new confirmation appearance.
     @State private var lastAutoFocusedRequestId: String?
     /// Timestamp when anchorMessageId was set. Used together with pagination
-    /// exhaustion to decide when a stale anchor should be cleared. The anchor
-    /// is cleared when either (a) pagination is exhausted and the target is
-    /// still not found, or (b) a generous time-based fallback elapses (covers
-    /// cases where pagination stalls or never completes).
+    /// exhaustion to decide when a stale anchor should be cleared.
     @State private var anchorSetTime: Date?
+    /// Independent timer task that clears a stale anchor after 10 seconds,
+    /// regardless of whether messages.count changes. This covers the edge
+    /// case where pagination stalls without adding/removing messages.
+    @State private var anchorTimeoutTask: Task<Void, Never>?
 
     /// The subset of messages actually shown, honoring the pagination window.
     private var visibleMessages: [ChatMessage] {
@@ -511,10 +512,31 @@ struct MessageListView: View {
                     anchorSetTime = nil
                 } else if anchorMessageId != nil {
                     // Anchor is set but the target message isn't loaded yet.
-                    // Record the timestamp so the time-based fallback starts
+                    // Record the timestamp so the elapsed-time guard starts
                     // counting from view appearance (onChange may not fire for
                     // the initial value).
                     if anchorSetTime == nil { anchorSetTime = Date() }
+                    // Start the independent timeout if not already running
+                    // (onChange(of: anchorMessageId) may not fire for the
+                    // initial value when the view first appears).
+                    if anchorTimeoutTask == nil {
+                        anchorTimeoutTask = Task { @MainActor in
+                            do {
+                                try await Task.sleep(nanoseconds: 10_000_000_000)
+                            } catch {
+                                return
+                            }
+                            guard !Task.isCancelled, anchorMessageId != nil else { return }
+                            log.debug("Anchor message not found (timed out) — clearing stale anchor")
+                            anchorMessageId = nil
+                            anchorSetTime = nil
+                            anchorTimeoutTask = nil
+                            isNearBottom = true
+                            withAnimation(VAnimation.fast) {
+                                proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                            }
+                        }
+                    }
                 } else {
                     proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                 }
@@ -527,6 +549,8 @@ struct MessageListView: View {
                 hoverExitDebounceTask = nil
                 threadSwitchSuppressionTask?.cancel()
                 threadSwitchSuppressionTask = nil
+                anchorTimeoutTask?.cancel()
+                anchorTimeoutTask = nil
             }
             .onChange(of: isSending) {
                 if isSending {
@@ -578,24 +602,26 @@ struct MessageListView: View {
                     }
                     anchorMessageId = nil
                     anchorSetTime = nil
+                    anchorTimeoutTask?.cancel()
+                    anchorTimeoutTask = nil
                     return
                 }
                 // If anchor is set but the target message still hasn't appeared,
-                // check whether we should give up. Two conditions clear the anchor:
-                //   1. Pagination exhaustion: all history pages have been loaded
-                //      (!hasMoreMessages) and the target still isn't present — the
-                //      message genuinely doesn't exist in this thread.
-                //   2. Time-based fallback: 10 seconds have elapsed since the anchor
-                //      was set. This covers edge cases where pagination stalls or
-                //      the daemon never responds with more history.
+                // check pagination exhaustion with a minimum elapsed time guard.
+                // The guard prevents premature clearing when hasMoreMessages is
+                // still at its default `false` before the daemon history response
+                // arrives (e.g., a streaming message changes messages.count before
+                // history loads). The independent anchorTimeoutTask handles the
+                // time-based fallback separately.
                 if anchorMessageId != nil {
                     let paginationExhausted = !hasMoreMessages
-                    let timedOut = anchorSetTime.map { Date().timeIntervalSince($0) > 10 } ?? false
-                    if paginationExhausted || timedOut {
-                        let reason = paginationExhausted ? "pagination exhausted" : "timed out"
-                        log.debug("Anchor message not found (\(reason)) — clearing stale anchor")
+                    let minWaitElapsed = anchorSetTime.map { Date().timeIntervalSince($0) > 2 } ?? false
+                    if paginationExhausted && minWaitElapsed {
+                        log.debug("Anchor message not found (pagination exhausted) — clearing stale anchor")
                         anchorMessageId = nil
                         anchorSetTime = nil
+                        anchorTimeoutTask?.cancel()
+                        anchorTimeoutTask = nil
                         isNearBottom = true
                         withAnimation(VAnimation.fast) {
                             proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
@@ -628,6 +654,8 @@ struct MessageListView: View {
                 isNearBottom = true
                 hoverExitDebounceTask?.cancel()
                 hoverExitDebounceTask = nil
+                anchorTimeoutTask?.cancel()
+                anchorTimeoutTask = nil
                 threadSwitchSuppressionTask?.cancel()
                 suppressScrollbarDuringThreadSwitch = true
                 threadSwitchSuppressionTask = Task { @MainActor in
@@ -656,8 +684,11 @@ struct MessageListView: View {
             }
             .onChange(of: anchorMessageId) {
                 // Record the timestamp when a new anchor is set so the
-                // time-based fallback can measure elapsed time accurately.
+                // pagination-exhaustion guard can measure elapsed time.
                 anchorSetTime = anchorMessageId != nil ? Date() : nil
+                // Cancel any previous timeout task.
+                anchorTimeoutTask?.cancel()
+                anchorTimeoutTask = nil
                 guard let id = anchorMessageId else { return }
                 // Only scroll and clear if the target message is already loaded;
                 // otherwise leave the anchor set so the messages-change handler
@@ -667,6 +698,27 @@ struct MessageListView: View {
                         proxy.scrollTo(id, anchor: .center)
                     }
                     anchorMessageId = nil
+                    anchorSetTime = nil
+                } else {
+                    // Start an independent 10-second timeout that clears the
+                    // anchor even if messages.count never changes (e.g., pagination
+                    // stalls or the daemon never responds with more history).
+                    anchorTimeoutTask = Task { @MainActor in
+                        do {
+                            try await Task.sleep(nanoseconds: 10_000_000_000)
+                        } catch {
+                            return
+                        }
+                        guard !Task.isCancelled, anchorMessageId != nil else { return }
+                        log.debug("Anchor message not found (timed out) — clearing stale anchor")
+                        anchorMessageId = nil
+                        anchorSetTime = nil
+                        anchorTimeoutTask = nil
+                        isNearBottom = true
+                        withAnimation(VAnimation.fast) {
+                            proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                        }
+                    }
                 }
             }
             .onChange(of: currentPendingRequestId) {


### PR DESCRIPTION
Addresses feedback from both Codex (P1) and Devin on #12009: moves anchor timeout to an independent timer/task instead of relying on message-count changes, and adds a 2-second minimum elapsed time guard before honoring paginationExhausted to prevent premature anchor clearing when hasMoreMessages is still at its default false before history loads.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
