### PR TITLE
fix: clear stale revokedReason/blockedReason on member re-activation in contacts-write

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -117,6 +117,7 @@ interface SyncChannelData {
   verifiedVia?: string | null;
   inviteId?: string | null;
   revokedReason?: string | null;
+  blockedReason?: string | null;
 }
 
 // ── CRUD ─────────────────────────────────────────────────────────────
@@ -350,6 +351,8 @@ function syncChannels(
       if (ch.inviteId !== undefined) updateSet.inviteId = ch.inviteId;
       if (ch.revokedReason !== undefined)
         updateSet.revokedReason = ch.revokedReason;
+      if (ch.blockedReason !== undefined)
+        updateSet.blockedReason = ch.blockedReason;
 
       if (Object.keys(updateSet).length > 0) {
         updateSet.updatedAt = now;

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -199,6 +199,8 @@ export function upsertMemberContactsFirst(params: {
           status: (params.status as ChannelStatus) ?? undefined,
           policy: (params.policy as ChannelPolicy) ?? undefined,
           inviteId: params.inviteId ?? null,
+          revokedReason: null,
+          blockedReason: null,
         },
       ],
     });


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for contacts-first-writes.md.

**Gap:** Stale revokedReason/blockedReason not cleared on member re-activation
**What was expected:** When a member is re-activated via upsertMemberContactsFirst, stale reason fields should be cleared
**What was found:** upsertMemberContactsFirst didn't pass revokedReason/blockedReason to upsertContact, and blockedReason wasn't in SyncChannelData

- Add blockedReason to SyncChannelData interface and syncChannels handler in contact-store.ts
- Pass revokedReason: null and blockedReason: null in upsertMemberContactsFirst channel data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
