### PR TITLE
fix: add DB index for type+externalChatId on guardian_channels

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -26,6 +26,7 @@ import {
   migrateCanonicalGuardianRequesterChatId,
   migrateChannelInboundDeliveredSegments,
   migrateContactChannelsAccessFields,
+  migrateContactChannelsTypeChatIdIndex,
   migrateContactsRolePrincipal,
   migrateConversationsThreadTypeIndex,
   migrateFkCascadeRebuilds,
@@ -196,6 +197,9 @@ export function initializeDb(): void {
 
   // 33. Add verification and access-control columns to contact_channels
   migrateContactChannelsAccessFields(database);
+
+  // 34. Composite index on (type, external_chat_id) for updateChannelLastSeenByExternalChatId
+  migrateContactChannelsTypeChatIdIndex(database);
 
   validateMigrationState(database);
 }

--- a/assistant/src/memory/migrations/130-contact-channels-type-ext-chat-id-index.ts
+++ b/assistant/src/memory/migrations/130-contact-channels-type-ext-chat-id-index.ts
@@ -1,0 +1,14 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Add a composite index on (type, external_chat_id) for contact_channels.
+ *
+ * updateChannelLastSeenByExternalChatId filters on this column pair on every
+ * inbound message for chat-id-only members; without the index each call
+ * performs a table scan.
+ */
+export function migrateContactChannelsTypeChatIdIndex(database: DrizzleDb): void {
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_contact_channels_type_ext_chat ON contact_channels(type, external_chat_id)`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -71,6 +71,7 @@ export { migrateBackfillGuardianPrincipalId } from './126-backfill-guardian-prin
 export { migrateGuardianPrincipalIdNotNull } from './127-guardian-principal-id-not-null.js';
 export { migrateContactsRolePrincipal } from './128-contacts-role-principal.js';
 export { migrateContactChannelsAccessFields } from './129-contact-channels-access-fields.js';
+export { migrateContactChannelsTypeChatIdIndex } from './130-contact-channels-type-ext-chat-id-index.js';
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -448,6 +448,10 @@ export const contactChannels = sqliteTable(
       table.type,
       table.externalUserId,
     ),
+    index("idx_contact_channels_type_ext_chat").on(
+      table.type,
+      table.externalChatId,
+    ),
   ],
 );
 


### PR DESCRIPTION
Adds a composite index on contact_channels(type, external_chat_id) to eliminate table scans in updateChannelLastSeenByExternalChatId, which is called on every inbound message for chat-id-only members. Addresses Codex feedback on #12020.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
