### PR TITLE
fix: prevent blocked→revoked downgrade in config-channels guardian revoke

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -214,7 +214,10 @@ export function revokeGuardianForChannel(
     externalUserId: bindingBeforeRevoke.guardianExternalUserId,
     externalChatId: bindingBeforeRevoke.guardianDeliveryChatId,
   });
-  if (member) {
+  // Only revoke active/pending members — a blocked member must not be
+  // downgraded to revoked (revokeMemberContactsFirst has its own guard,
+  // but we check here to make the intent explicit at the call site).
+  if (member && (member.status === "active" || member.status === "pending")) {
     revokeMemberContactsFirst(member.id, "guardian_binding_revoked");
   }
 


### PR DESCRIPTION
Fixes the contacts-first path in config-channels.ts to prevent downgrading a blocked member to revoked status during guardian channel revocation. Addresses Codex feedback on #12022.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
