### PR TITLE
M3: Fix inverted skip_dead_time boolean

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/SKILL.md
+++ b/assistant/src/config/bundled-skills/media-processing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "Media Processing"
 description: "Ingest and process media files (video, audio, image) through a 3-phase pipeline: preprocess, map (Gemini), and reduce (Claude)"
-metadata: {"vellum": {"emoji": "🎬"}}
+metadata: { "vellum": { "emoji": "🎬" } }
 ---
 
 Ingest and track processing of media files (video, audio, images) through a configurable 3-phase pipeline.
@@ -33,12 +33,13 @@ Query the processing status of a media asset. Returns the asset metadata along w
 Preprocess a video asset: detect dead time via mpdecimate, segment the video into windows, extract downscaled keyframes at regular intervals, build a subject registry, and write a pipeline manifest.
 
 Parameters:
+
 - `asset_id` (required) — ID of the media asset.
 - `interval_seconds` — Interval between keyframes (default: 1s). Use 0.5s for sports/action content where frame density matters.
 - `segment_duration` — Duration of each segment window (default: 15s).
 - `dead_time_threshold` — Sensitivity for dead-time detection (default: 0.02).
 - `section_config` — Path to a JSON file with manual section boundaries.
-- `skip_dead_time` — Whether to detect and skip dead time (default: false). Dead-time detection can be too aggressive for continuous action video like sports — it may incorrectly skip live play. Enable only for content with clear idle periods (e.g., lectures, surveillance footage).
+- `detect_dead_time` — Whether to detect and skip dead time (default: false). Dead-time detection can be too aggressive for continuous action video like sports — it may incorrectly skip live play. Enable only for content with clear idle periods (e.g., lectures, surveillance footage).
 - `short_edge` — Short edge resolution for downscaled frames in pixels (default: 480).
 
 ### analyze_keyframes
@@ -46,6 +47,7 @@ Parameters:
 Map video segments through Gemini's structured output API. Reads frames from the preprocess manifest, sends each segment to Gemini with assistant-provided extraction instructions and a JSON Schema for guaranteed structured output. Supports concurrency pooling, cost tracking, resumability (skips segments with existing results), and automatic retries with exponential backoff.
 
 Parameters:
+
 - `asset_id` (required) — ID of the media asset.
 - `system_prompt` (required) — Extraction instructions for Gemini.
 - `output_schema` (required) — JSON Schema for structured output.
@@ -59,6 +61,7 @@ Parameters:
 Query video analysis data using natural language. Sends map output (from analyze_keyframes) to Claude for intelligent analysis and Q&A. Supports arbitrary questions about video content.
 
 Parameters:
+
 - `asset_id` (required) — ID of the media asset.
 - `query` (required) — Natural language query about the video data.
 - `system_prompt` — Optional system prompt for Claude.
@@ -71,6 +74,7 @@ Extract a video clip from a media asset using ffmpeg. Applies configurable pre/p
 ### media_diagnostics
 
 Get a diagnostic report for a media asset. Returns:
+
 - **Processing stats**: total keyframes extracted.
 - **Per-stage status and timing**: which stages (preprocess, map, reduce) have run, how long each took, current progress.
 - **Failure reasons**: last error from any failed stage.
@@ -81,6 +85,7 @@ Get a diagnostic report for a media asset. Returns:
 ### Processing Pipeline (services/processing-pipeline.ts)
 
 Orchestrates the full processing pipeline with reliability features:
+
 - **Sequential execution**: preprocess, map, reduce.
 - **Retries**: Each stage is retried with exponential backoff and jitter (configurable max retries and base delay).
 - **Resumability**: Checks processing_stages to find the last completed stage and resumes from there. Safe to restart after crashes.
@@ -99,6 +104,7 @@ Sends video segments to Gemini 2.5 Flash with structured output schemas. Handles
 ### Reduce (services/reduce.ts)
 
 Sends Map output to Claude as text for analysis. Two modes:
+
 - **One-shot merge**: assembles all Map results and sends to Claude with a system prompt.
 - **Interactive Q&A**: loads existing map output + user query, sends to Claude.
 
@@ -173,6 +179,7 @@ The `generate_clip` tool outputs clips as temporary files. These may not deliver
 ## Known Limitations — Vision Analysis
 
 Gemini performs well at **spatial/descriptive analysis** from static keyframes:
+
 - Player positions, formations, and spacing
 - Jersey numbers and identifying features
 - Ball location and which team has possession
@@ -180,6 +187,7 @@ Gemini performs well at **spatial/descriptive analysis** from static keyframes:
 - Camera angles and scene composition
 
 Gemini **hallucinates when asked to detect fast temporal events** from static frames, regardless of frame density:
+
 - Turnovers, steals, fouls, and specific plays
 - Fast transitions and split-second actions
 - Causality between frames (what "happened" vs. what's visible)
@@ -191,6 +199,7 @@ The model is good at describing **what is there** but bad at detecting **what ha
 ### Monitoring Progress
 
 Use `media_status` to check the current state of any asset:
+
 - **registered** — Ingested but not yet processed.
 - **processing** — Pipeline is running.
 - **indexed** — All stages completed successfully.
@@ -201,6 +210,7 @@ The response includes per-stage progress (0-100%) so you can see exactly where p
 ### Diagnosing Failures
 
 Use `media_diagnostics` to get a full diagnostic report:
+
 1. Check the `stages` array for any stage with `status: "failed"`.
 2. Read the `lastError` field for that stage to understand what went wrong.
 3. Check `durationMs` to see if a stage timed out or ran unusually long.
@@ -224,14 +234,14 @@ Use `media_diagnostics` to get per-asset cost estimates. The Map phase (Gemini) 
 
 ### Troubleshooting
 
-| Symptom | Likely Cause | Fix |
-|---------|-------------|-----|
-| "No keyframes found" | extract_keyframes not run or failed | Check preprocess stage status; re-run if needed |
-| "No map output found" | analyze_keyframes not run | Run analyze_keyframes with appropriate system_prompt and output_schema |
-| "No LLM provider available" | API key not configured | Add one in Settings |
-| Map phase slow | Large video, small interval | Increase interval_seconds or reduce concurrency |
-| Gemini returns errors | Rate limits or schema issues | Check max_retries setting; simplify output_schema if needed |
-| Pipeline stuck at "processing" | Stage crashed without updating status | Use `media_diagnostics` to find the stuck stage; re-run manually |
+| Symptom                        | Likely Cause                          | Fix                                                                    |
+| ------------------------------ | ------------------------------------- | ---------------------------------------------------------------------- |
+| "No keyframes found"           | extract_keyframes not run or failed   | Check preprocess stage status; re-run if needed                        |
+| "No map output found"          | analyze_keyframes not run             | Run analyze_keyframes with appropriate system_prompt and output_schema |
+| "No LLM provider available"    | API key not configured                | Add one in Settings                                                    |
+| Map phase slow                 | Large video, small interval           | Increase interval_seconds or reduce concurrency                        |
+| Gemini returns errors          | Rate limits or schema issues          | Check max_retries setting; simplify output_schema if needed            |
+| Pipeline stuck at "processing" | Stage crashed without updating status | Use `media_diagnostics` to find the stuck stage; re-run manually       |
 
 ## Usage Notes
 

--- a/assistant/src/config/bundled-skills/media-processing/TOOLS.json
+++ b/assistant/src/config/bundled-skills/media-processing/TOOLS.json
@@ -81,9 +81,9 @@
             "type": "string",
             "description": "Path to a JSON file with manual section boundary definitions"
           },
-          "skip_dead_time": {
+          "detect_dead_time": {
             "type": "boolean",
-            "description": "Whether to detect and skip dead time. Default: false. Can be too aggressive for continuous action video like sports."
+            "description": "Whether to detect and skip dead time (static/idle frames). Default: false. Can be too aggressive for continuous action video like sports."
           },
           "short_edge": {
             "type": "number",

--- a/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
@@ -83,7 +83,7 @@ export interface PreprocessOptions {
   segmentDuration?: number;
   deadTimeThreshold?: number;
   sectionConfigPath?: string;
-  skipDeadTime?: boolean;
+  detectDeadTime?: boolean;
   shortEdge?: number;
 }
 
@@ -371,7 +371,7 @@ export async function preprocessForAsset(
     shortEdge: options.shortEdge ?? 480,
   };
 
-  const skipDeadTime = options.skipDeadTime ?? false;
+  const detectDeadTime = options.detectDeadTime ?? false;
 
   const asset = getMediaAssetById(assetId);
   if (!asset) {
@@ -404,10 +404,10 @@ export async function preprocessForAsset(
 
   try {
     // Step 1: Dead-time detection
-    onProgress?.("Detecting dead time with mpdecimate filter...\n");
     let deadTimeRanges: TimeRange[] = [];
 
-    if (skipDeadTime) {
+    if (detectDeadTime) {
+      onProgress?.("Detecting dead time with mpdecimate filter...\n");
       const mpdecimateResult = await spawnWithTimeout(
         [
           "ffmpeg",

--- a/assistant/src/config/bundled-skills/media-processing/tools/extract-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/extract-keyframes.ts
@@ -1,10 +1,19 @@
-import { dirname,join } from 'node:path';
+import { dirname, join } from "node:path";
 
-import { getKeyframesForAsset,getMediaAssetById } from '../../../../memory/media-store.js';
-import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
-import { preprocessForAsset, type PreprocessOptions } from '../services/preprocess.js';
+import {
+  getKeyframesForAsset,
+  getMediaAssetById,
+} from "../../../../memory/media-store.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import {
+  preprocessForAsset,
+  type PreprocessOptions,
+} from "../services/preprocess.js";
 
-export { preprocessForAsset } from '../services/preprocess.js';
+export { preprocessForAsset } from "../services/preprocess.js";
 
 export async function run(
   input: Record<string, unknown>,
@@ -12,7 +21,7 @@ export async function run(
 ): Promise<ToolExecutionResult> {
   const assetId = input.asset_id as string | undefined;
   if (!assetId) {
-    return { content: 'asset_id is required.', isError: true };
+    return { content: "asset_id is required.", isError: true };
   }
 
   const options: PreprocessOptions = {
@@ -20,38 +29,49 @@ export async function run(
     segmentDuration: (input.segment_duration as number) || undefined,
     deadTimeThreshold: (input.dead_time_threshold as number) || undefined,
     sectionConfigPath: (input.section_config as string) || undefined,
-    skipDeadTime: input.skip_dead_time !== undefined ? Boolean(input.skip_dead_time) : undefined,
+    detectDeadTime:
+      input.detect_dead_time !== undefined
+        ? Boolean(input.detect_dead_time)
+        : undefined,
     shortEdge: (input.short_edge as number) || undefined,
   };
 
   try {
-    const manifest = await preprocessForAsset(assetId, options, context.onOutput);
+    const manifest = await preprocessForAsset(
+      assetId,
+      options,
+      context.onOutput,
+    );
 
     const asset = getMediaAssetById(assetId);
-    const pipelineDir = join(dirname(asset!.filePath), 'pipeline', assetId);
+    const pipelineDir = join(dirname(asset!.filePath), "pipeline", assetId);
     const keyframes = getKeyframesForAsset(assetId);
 
     return {
-      content: JSON.stringify({
-        message: `Preprocessed video: ${manifest.segments.length} segments, ${keyframes.length} keyframes`,
-        assetId,
-        segmentCount: manifest.segments.length,
-        keyframeCount: keyframes.length,
-        deadTimeRanges: manifest.deadTimeRanges.length,
-        subjectGroups: manifest.subjectRegistry.groups.length,
-        manifestPath: join(pipelineDir, 'manifest.json'),
-        config: manifest.config,
-      }, null, 2),
+      content: JSON.stringify(
+        {
+          message: `Preprocessed video: ${manifest.segments.length} segments, ${keyframes.length} keyframes`,
+          assetId,
+          segmentCount: manifest.segments.length,
+          keyframeCount: keyframes.length,
+          deadTimeRanges: manifest.deadTimeRanges.length,
+          subjectGroups: manifest.subjectRegistry.groups.length,
+          manifestPath: join(pipelineDir, "manifest.json"),
+          config: manifest.config,
+        },
+        null,
+        2,
+      ),
       isError: false,
     };
   } catch (err) {
     const msg = (err as Error).message;
     if (
-      msg.startsWith('Media asset not found:') ||
-      msg.startsWith('Preprocess requires a video asset.') ||
-      msg.startsWith('Video asset has no duration') ||
-      msg.startsWith('ffmpeg failed:') ||
-      msg === 'No frames were extracted from the video.'
+      msg.startsWith("Media asset not found:") ||
+      msg.startsWith("Preprocess requires a video asset.") ||
+      msg.startsWith("Video asset has no duration") ||
+      msg.startsWith("ffmpeg failed:") ||
+      msg === "No frames were extracted from the video."
     ) {
       return { content: msg, isError: true };
     }


### PR DESCRIPTION
Rename skip_dead_time to detect_dead_time across preprocess.ts, extract-keyframes.ts, TOOLS.json, and SKILL.md. The old name was inverted — when true, detection ran, which is opposite to what skip suggests. Also fix misleading progress log that printed even when detection was skipped. Closes #12036
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
