### PR TITLE
M5: Add incremental progress reporting during preprocess

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
@@ -446,7 +446,8 @@ export async function preprocessForAsset(
 
     const scaleFilter = `scale='if(gt(iw,ih),-1,${config.shortEdge})':'if(gt(iw,ih),${config.shortEdge},-1)'`;
 
-    for (const seg of rawSegments) {
+    for (let i = 0; i < rawSegments.length; i++) {
+      const seg = rawSegments[i];
       const segDuration = seg.endSeconds - seg.startSeconds;
       const effectiveInterval = computeEffectiveInterval(
         segDuration,
@@ -511,6 +512,9 @@ export async function preprocessForAsset(
         framePaths,
         frameTimestamps: actualTimestamps,
       });
+
+      const segProgress = Math.round(((i + 1) / rawSegments.length) * 80);
+      updateProcessingStage(stage.id, { progress: segProgress });
     }
 
     const totalFrames = segments.reduce(
@@ -538,6 +542,7 @@ export async function preprocessForAsset(
     onProgress?.(
       `Identified ${subjectRegistry.groups.length} subject group(s).\n`,
     );
+    updateProcessingStage(stage.id, { progress: 90 });
 
     // Step 5: Section boundaries
     let sectionBoundaries: SectionBoundary[];
@@ -570,6 +575,7 @@ export async function preprocessForAsset(
     if (keyframeRows.length > 0) {
       insertKeyframesBatch(keyframeRows);
     }
+    updateProcessingStage(stage.id, { progress: 95 });
 
     // Step 7: Write manifest
     const manifest: PreprocessManifest = {


### PR DESCRIPTION
The preprocess stage now reports progress incrementally (0-80% for frame extraction, 80-90% for subject registry, 90-95% for DB, 95-100% for completion) instead of jumping from 0 to 100. Closes #12038
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
