### PR TITLE
M6: Add cost tracking in reduce/query phase

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/services/reduce.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/reduce.ts
@@ -11,17 +11,17 @@
  * it works with whatever LLM provider is configured.
  */
 
-import { readFile } from 'node:fs/promises';
-import { dirname,join } from 'node:path';
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 
-import { getMediaAssetById } from '../../../../memory/media-store.js';
+import { getMediaAssetById } from "../../../../memory/media-store.js";
 import {
   createTimeout,
   extractAllText,
   getConfiguredProvider,
   userMessage,
-} from '../../../../providers/provider-send-message.js';
-import type { MapOutput } from './gemini-map.js';
+} from "../../../../providers/provider-send-message.js";
+import type { MapOutput } from "./gemini-map.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -58,15 +58,15 @@ async function loadMapOutput(assetId: string): Promise<MapOutput> {
     throw new Error(`Media asset not found: ${assetId}`);
   }
 
-  const pipelineDir = join(dirname(asset.filePath), 'pipeline', assetId);
-  const mapOutputPath = join(pipelineDir, 'map-output.json');
+  const pipelineDir = join(dirname(asset.filePath), "pipeline", assetId);
+  const mapOutputPath = join(pipelineDir, "map-output.json");
 
   let raw: string;
   try {
-    raw = await readFile(mapOutputPath, 'utf-8');
+    raw = await readFile(mapOutputPath, "utf-8");
   } catch {
     throw new Error(
-      'No map output found. Run analyze_keyframes first to generate map-output.json.',
+      "No map output found. Run analyze_keyframes first to generate map-output.json.",
     );
   }
 
@@ -82,30 +82,87 @@ function formatMapOutputAsText(mapOutput: MapOutput): string {
 
   lines.push(`Video Analysis Data (asset: ${mapOutput.assetId})`);
   lines.push(`Model: ${mapOutput.model}`);
-  lines.push(`Segments analyzed: ${mapOutput.successCount}/${mapOutput.segmentCount}`);
+  lines.push(
+    `Segments analyzed: ${mapOutput.successCount}/${mapOutput.segmentCount}`,
+  );
   if (mapOutput.failedCount > 0) {
     lines.push(`Failed segments: ${mapOutput.failedCount}`);
   }
   if (mapOutput.skippedCount > 0) {
     lines.push(`Skipped segments: ${mapOutput.skippedCount}`);
   }
-  lines.push('');
-  lines.push('--- Segment Results ---');
-  lines.push('');
+  lines.push("");
+  lines.push("--- Segment Results ---");
+  lines.push("");
 
   for (const segment of mapOutput.segments) {
     const startMin = Math.floor(segment.startSeconds / 60);
     const startSec = Math.floor(segment.startSeconds % 60);
     const endMin = Math.floor(segment.endSeconds / 60);
     const endSec = Math.floor(segment.endSeconds % 60);
-    const timeRange = `${startMin}:${String(startSec).padStart(2, '0')} - ${endMin}:${String(endSec).padStart(2, '0')}`;
+    const timeRange = `${startMin}:${String(startSec).padStart(2, "0")} - ${endMin}:${String(endSec).padStart(2, "0")}`;
 
     lines.push(`[Segment ${segment.segmentId}] ${timeRange}`);
     lines.push(JSON.stringify(segment.result, null, 2));
-    lines.push('');
+    lines.push("");
   }
 
-  return lines.join('\n');
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Reduce cost tracking
+// ---------------------------------------------------------------------------
+
+export interface ReduceCostEntry {
+  query: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  timestamp: string;
+}
+
+export interface ReduceCostData {
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  entries: ReduceCostEntry[];
+}
+
+async function persistReduceCost(
+  assetId: string,
+  query: string,
+  result: ReduceResult,
+): Promise<void> {
+  const asset = getMediaAssetById(assetId);
+  if (!asset) return;
+
+  const pipelineDir = join(dirname(asset.filePath), "pipeline", assetId);
+  const costPath = join(pipelineDir, "reduce-cost.json");
+
+  let existing: ReduceCostData = {
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    entries: [],
+  };
+  try {
+    const raw = await readFile(costPath, "utf-8");
+    existing = JSON.parse(raw) as ReduceCostData;
+  } catch {
+    // First query — start fresh
+  }
+
+  existing.entries.push({
+    query,
+    model: result.model,
+    inputTokens: result.inputTokens,
+    outputTokens: result.outputTokens,
+    timestamp: new Date().toISOString(),
+  });
+  existing.totalInputTokens += result.inputTokens;
+  existing.totalOutputTokens += result.outputTokens;
+
+  await mkdir(pipelineDir, { recursive: true });
+  await writeFile(costPath, JSON.stringify(existing, null, 2));
 }
 
 // ---------------------------------------------------------------------------
@@ -121,15 +178,16 @@ async function sendToClaude(
 ): Promise<ReduceResult> {
   const provider = getConfiguredProvider();
   if (!provider) {
-    throw new Error('No LLM provider available. Please configure an API key.');
+    throw new Error("No LLM provider available. Please configure an API key.");
   }
 
-  const effectiveSystemPrompt = systemPrompt
-    ?? 'You are an expert video analyst. You have been given structured analysis data extracted from a video. Answer the user\'s question based on this data. Be specific, reference timestamps when relevant, and provide clear, actionable insights.';
+  const effectiveSystemPrompt =
+    systemPrompt ??
+    "You are an expert video analyst. You have been given structured analysis data extracted from a video. Answer the user's question based on this data. Be specific, reference timestamps when relevant, and provide clear, actionable insights.";
 
   const userContent = `Here is the video analysis data:\n\n${mapText}\n\n---\n\nUser query: ${query}`;
 
-  onProgress?.('Sending map output to Claude for analysis...\n');
+  onProgress?.("Sending map output to Claude for analysis...\n");
 
   const { signal, cleanup } = createTimeout(REDUCE_TIMEOUT_MS);
 
@@ -147,7 +205,9 @@ async function sendToClaude(
 
     const answer = extractAllText(response);
 
-    onProgress?.(`Reduce complete (${response.usage.inputTokens} input + ${response.usage.outputTokens} output tokens).\n`);
+    onProgress?.(
+      `Reduce complete (${response.usage.inputTokens} input + ${response.usage.outputTokens} output tokens).\n`,
+    );
 
     return {
       answer,
@@ -176,12 +236,22 @@ export async function reduceForAsset(
   const mapOutput = await loadMapOutput(assetId);
 
   if (mapOutput.segments.length === 0) {
-    throw new Error('Map output contains no segments. Run analyze_keyframes first.');
+    throw new Error(
+      "Map output contains no segments. Run analyze_keyframes first.",
+    );
   }
 
   const mapText = formatMapOutputAsText(mapOutput);
-  const effectiveQuery = options.query ?? 'Summarize the video content.';
-  return sendToClaude(mapText, effectiveQuery, options.systemPrompt, options.model, onProgress);
+  const effectiveQuery = options.query ?? "Summarize the video content.";
+  const result = await sendToClaude(
+    mapText,
+    effectiveQuery,
+    options.systemPrompt,
+    options.model,
+    onProgress,
+  );
+  await persistReduceCost(assetId, effectiveQuery, result);
+  return result;
 }
 
 /**

--- a/assistant/src/config/bundled-skills/media-processing/tools/media-diagnostics.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/media-diagnostics.ts
@@ -6,17 +6,21 @@
  * All metrics are generic media-processing infrastructure.
  */
 
-import { readFile } from 'node:fs/promises';
-import { dirname,join } from 'node:path';
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 
 import {
   getKeyframesForAsset,
   getMediaAssetById,
   getProcessingStagesForAsset,
   type ProcessingStage,
-} from '../../../../memory/media-store.js';
-import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
-import type { PreprocessManifest } from '../services/preprocess.js';
+} from "../../../../memory/media-store.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import type { PreprocessManifest } from "../services/preprocess.js";
+import type { ReduceCostData } from "../services/reduce.js";
 // ---------------------------------------------------------------------------
 // Cost estimation constants (Gemini 2.5 Flash pricing)
 // ---------------------------------------------------------------------------
@@ -47,9 +51,13 @@ interface DiagnosticReport {
   };
   stages: StageDiagnostic[];
   costEstimate: {
-    keyframeCount: number;
-    estimatedSegments: number;
-    estimatedCostPerSegment: number;
+    mapPhase: {
+      keyframeCount: number;
+      estimatedSegments: number;
+      estimatedCostPerSegment: number;
+      estimatedMapCost: number;
+    };
+    reduceCost: ReduceCostData | null;
     estimatedTotalCost: number;
     currency: string;
     note: string;
@@ -64,7 +72,7 @@ function computeStageDuration(stage: ProcessingStage): number | null {
   if (stage.startedAt == null) return null;
   if (stage.completedAt != null) return stage.completedAt - stage.startedAt;
   // Only use Date.now() as a fallback for currently running stages
-  if (stage.status === 'running') return Date.now() - stage.startedAt;
+  if (stage.status === "running") return Date.now() - stage.startedAt;
   // For failed/pending stages without completedAt, duration is unknown
   return null;
 }
@@ -79,7 +87,7 @@ export async function run(
 ): Promise<ToolExecutionResult> {
   const assetId = input.asset_id as string | undefined;
   if (!assetId) {
-    return { content: 'asset_id is required.', isError: true };
+    return { content: "asset_id is required.", isError: true };
   }
 
   const asset = getMediaAssetById(assetId);
@@ -105,9 +113,14 @@ export async function run(
 
   // Prefer actual segment count from preprocess manifest when available
   let estimatedSegments: number;
-  const manifestPath = join(dirname(asset.filePath), 'pipeline', asset.id, 'manifest.json');
+  const manifestPath = join(
+    dirname(asset.filePath),
+    "pipeline",
+    asset.id,
+    "manifest.json",
+  );
   try {
-    const raw = await readFile(manifestPath, 'utf-8');
+    const raw = await readFile(manifestPath, "utf-8");
     const manifest: PreprocessManifest = JSON.parse(raw);
     estimatedSegments = manifest.segments.length;
   } catch {
@@ -115,7 +128,30 @@ export async function run(
     estimatedSegments = Math.ceil(keyframeCount / 10);
   }
 
-  const estimatedTotalCost = estimatedSegments * ESTIMATED_COST_PER_SEGMENT_USD;
+  const estimatedMapCost = estimatedSegments * ESTIMATED_COST_PER_SEGMENT_USD;
+
+  // Load reduce cost data if available
+  const reduceCostPath = join(
+    dirname(asset.filePath),
+    "pipeline",
+    asset.id,
+    "reduce-cost.json",
+  );
+  let reduceCost: ReduceCostData | null = null;
+  try {
+    const raw = await readFile(reduceCostPath, "utf-8");
+    reduceCost = JSON.parse(raw) as ReduceCostData;
+  } catch {
+    // No reduce cost data yet
+  }
+
+  // Combine map + reduce costs for the total estimate
+  // Reduce cost is token-based; use a rough estimate of $3/M input + $15/M output (Claude Sonnet-class)
+  const reduceEstimatedCost = reduceCost
+    ? (reduceCost.totalInputTokens * 3 + reduceCost.totalOutputTokens * 15) /
+      1_000_000
+    : 0;
+  const estimatedTotalCost = estimatedMapCost + reduceEstimatedCost;
 
   const report: DiagnosticReport = {
     assetId: asset.id,
@@ -128,12 +164,16 @@ export async function run(
     },
     stages: stageDiagnostics,
     costEstimate: {
-      keyframeCount,
-      estimatedSegments,
-      estimatedCostPerSegment: ESTIMATED_COST_PER_SEGMENT_USD,
-      estimatedTotalCost: Math.round(estimatedTotalCost * 1000) / 1000,
-      currency: 'USD',
-      note: 'Gemini 2.5 Flash for Map phase; Claude for Reduce phase (additional cost).',
+      mapPhase: {
+        keyframeCount,
+        estimatedSegments,
+        estimatedCostPerSegment: ESTIMATED_COST_PER_SEGMENT_USD,
+        estimatedMapCost: Math.round(estimatedMapCost * 1000) / 1000,
+      },
+      reduceCost,
+      estimatedTotalCost: Math.round(estimatedTotalCost * 1000000) / 1000000,
+      currency: "USD",
+      note: "Map: Gemini 2.5 Flash per segment. Reduce: Claude token-based ($3/M input, $15/M output).",
     },
   };
 


### PR DESCRIPTION
Persist reduce/query phase token usage to reduce-cost.json (cumulative per query). Surface these costs in media_diagnostics alongside existing map phase costs. Closes #12039
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
