### PR TITLE
M2: Centralize ffmpeg timeout constants

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
@@ -18,13 +18,16 @@ import {
   type ProcessingStage,
   updateProcessingStage,
 } from "../../../../memory/media-store.js";
-import { spawnWithTimeout } from "../../../../util/spawn.js";
+import {
+  FFMPEG_PREPROCESS_TIMEOUT_MS,
+  FFPROBE_TIMEOUT_MS,
+  spawnWithTimeout,
+} from "../../../../util/spawn.js";
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-const FFMPEG_TIMEOUT_MS = 600_000;
 const MIN_FRAMES_PER_SEGMENT = 4;
 
 // ---------------------------------------------------------------------------
@@ -304,7 +307,7 @@ async function extractDominantColors(framePath: string): Promise<string[]> {
       "null",
       "-",
     ],
-    30_000,
+    FFPROBE_TIMEOUT_MS,
   );
 
   // Fallback: return empty if analysis fails
@@ -421,7 +424,7 @@ export async function preprocessForAsset(
           "null",
           "-",
         ],
-        FFMPEG_TIMEOUT_MS,
+        FFMPEG_PREPROCESS_TIMEOUT_MS,
       );
 
       const droppedTimestamps = parseDroppedFrameTimestamps(
@@ -480,7 +483,7 @@ export async function preprocessForAsset(
           "2",
           join(segTempDir, "frame-%06d.jpg"),
         ],
-        FFMPEG_TIMEOUT_MS,
+        FFMPEG_PREPROCESS_TIMEOUT_MS,
       );
 
       if (result.exitCode !== 0) {

--- a/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
@@ -18,9 +18,11 @@ import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
-import { spawnWithTimeout } from "../../../../util/spawn.js";
-
-const FFMPEG_TIMEOUT_MS = 300_000;
+import {
+  FFMPEG_CLIP_TIMEOUT_MS,
+  FFPROBE_TIMEOUT_MS,
+  spawnWithTimeout,
+} from "../../../../util/spawn.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -41,7 +43,7 @@ async function getMediaDuration(filePath: string): Promise<number> {
       "csv=p=0",
       filePath,
     ],
-    10_000,
+    FFPROBE_TIMEOUT_MS,
   );
   if (result.exitCode !== 0) return 0;
   return parseFloat(result.stdout.trim()) || 0;
@@ -147,7 +149,7 @@ export async function run(
       clipPath,
     ];
 
-    const result = await spawnWithTimeout(ffmpegArgs, FFMPEG_TIMEOUT_MS);
+    const result = await spawnWithTimeout(ffmpegArgs, FFMPEG_CLIP_TIMEOUT_MS);
 
     if (result.exitCode !== 0) {
       return {

--- a/assistant/src/config/bundled-skills/media-processing/tools/ingest-media.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/ingest-media.ts
@@ -14,7 +14,10 @@ import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
-import { spawnWithTimeout } from "../../../../util/spawn.js";
+import {
+  FFPROBE_TIMEOUT_MS,
+  spawnWithTimeout,
+} from "../../../../util/spawn.js";
 
 // ---------------------------------------------------------------------------
 // MIME detection
@@ -83,7 +86,7 @@ async function extractDuration(filePath: string): Promise<number | null> {
         "csv=p=0",
         filePath,
       ],
-      15_000,
+      FFPROBE_TIMEOUT_MS,
     );
     if (result.exitCode !== 0) return null;
     const duration = parseFloat(result.stdout.trim());

--- a/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
+++ b/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
@@ -16,7 +16,11 @@ import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
-import { spawnWithTimeout } from "../../../../util/spawn.js";
+import {
+  FFMPEG_TRANSCODE_TIMEOUT_MS,
+  FFPROBE_TIMEOUT_MS,
+  spawnWithTimeout,
+} from "../../../../util/spawn.js";
 
 const VIDEO_EXTENSIONS = new Set([
   ".mp4",
@@ -38,9 +42,6 @@ const AUDIO_EXTENSIONS = new Set([
   ".aiff",
   ".wma",
 ]);
-
-/** Timeout for ffmpeg operations. */
-const FFMPEG_TIMEOUT_MS = 120_000;
 
 /** Max file size for a single OpenAI Whisper API request (25MB). */
 const WHISPER_API_MAX_BYTES = 25 * 1024 * 1024;
@@ -70,7 +71,7 @@ async function getAudioDuration(audioPath: string): Promise<number> {
       "csv=p=0",
       audioPath,
     ],
-    10_000,
+    FFPROBE_TIMEOUT_MS,
   );
   if (result.exitCode !== 0) return 0;
   return parseFloat(result.stdout.trim()) || 0;
@@ -100,7 +101,7 @@ async function splitAudio(
       "1",
       chunkPattern,
     ],
-    FFMPEG_TIMEOUT_MS,
+    FFMPEG_TRANSCODE_TIMEOUT_MS,
   );
   if (result.exitCode !== 0) {
     throw new Error(`Failed to split audio: ${result.stderr.slice(0, 300)}`);
@@ -184,7 +185,7 @@ async function toWav(inputPath: string, isVideo: boolean): Promise<string> {
   const args = ["ffmpeg", "-y", "-i", inputPath];
   if (isVideo) args.push("-vn");
   args.push("-acodec", "pcm_s16le", "-ar", "16000", "-ac", "1", wavPath);
-  const result = await spawnWithTimeout(args, FFMPEG_TIMEOUT_MS);
+  const result = await spawnWithTimeout(args, FFMPEG_TRANSCODE_TIMEOUT_MS);
   if (result.exitCode !== 0) {
     throw new Error(`ffmpeg failed: ${result.stderr.slice(0, 500)}`);
   }

--- a/assistant/src/util/spawn.ts
+++ b/assistant/src/util/spawn.ts
@@ -2,6 +2,18 @@
  * Shared spawn-with-timeout helper used by media-processing and transcribe tools.
  */
 
+/** Full video preprocessing: mpdecimate analysis, frame extraction, palette analysis. Longest operation. */
+export const FFMPEG_PREPROCESS_TIMEOUT_MS = 600_000;
+
+/** Clip extraction via stream copy. Moderate timeout — no re-encoding needed. */
+export const FFMPEG_CLIP_TIMEOUT_MS = 300_000;
+
+/** Audio transcoding/splitting to WAV for Whisper. Relatively fast operation. */
+export const FFMPEG_TRANSCODE_TIMEOUT_MS = 120_000;
+
+/** Metadata extraction via ffprobe. Very fast — just reads headers. */
+export const FFPROBE_TIMEOUT_MS = 15_000;
+
 export function spawnWithTimeout(
   cmd: string[],
   timeoutMs: number,


### PR DESCRIPTION
Add named, documented timeout constants to util/spawn.ts and replace scattered magic numbers across media-processing and transcribe tools. Closes #12035
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
