### PR TITLE
M8: Add Gemini Video API support

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/SKILL.md
+++ b/assistant/src/config/bundled-skills/media-processing/SKILL.md
@@ -44,16 +44,22 @@ Parameters:
 
 ### analyze_keyframes
 
-Map video segments through Gemini's structured output API. Reads frames from the preprocess manifest, sends each segment to Gemini with assistant-provided extraction instructions and a JSON Schema for guaranteed structured output. Supports concurrency pooling, cost tracking, resumability (skips segments with existing results), and automatic retries with exponential backoff.
+Map video segments through Gemini's structured output API. Supports two modes:
+
+- **`keyframes`** (default) — Reads frames from the preprocess manifest, sends each segment's images to Gemini. Requires `extract_keyframes` to be run first. Best for longer videos (> 1 hour) or when you need fine-grained control over frame selection (interval, segment duration, dead-time skipping).
+- **`direct_video`** — Uploads the video file directly to Gemini's Files API. Gemini sees actual motion and temporal context instead of static frames. Best for shorter videos (< 1 hour) where temporal context matters (detecting actions, transitions, motion patterns). Has a 2 GB file size limit. Does not require `extract_keyframes` preprocessing.
+
+Both modes produce the same `MapOutput` format, so `query_media` works identically regardless of which mode was used.
 
 Parameters:
 
 - `asset_id` (required) — ID of the media asset.
 - `system_prompt` (required) — Extraction instructions for Gemini.
 - `output_schema` (required) — JSON Schema for structured output.
+- `mode` — Analysis mode: `'keyframes'` (default) or `'direct_video'`.
 - `context` — Additional context to include in the prompt.
 - `model` — Gemini model to use (default: `gemini-2.5-flash`).
-- `concurrency` — Maximum concurrent API requests (default: 10).
+- `concurrency` — Maximum concurrent API requests (default: 10, keyframes mode only).
 - `max_retries` — Retry attempts per segment on failure (default: 3).
 
 ### query_media
@@ -186,13 +192,13 @@ Gemini performs well at **spatial/descriptive analysis** from static keyframes:
 - Score and on-screen text
 - Camera angles and scene composition
 
-Gemini **hallucinates when asked to detect fast temporal events** from static frames, regardless of frame density:
+Gemini **hallucinates when asked to detect fast temporal events** from static frames (keyframes mode), regardless of frame density:
 
 - Turnovers, steals, fouls, and specific plays
 - Fast transitions and split-second actions
 - Causality between frames (what "happened" vs. what's visible)
 
-The model is good at describing **what is there** but bad at detecting **what happened**. Structure your map prompts and queries accordingly — ask the model to describe scenes, then use `query_media` (Claude) to reason about patterns and events across the descriptive data.
+The model is good at describing **what is there** but bad at detecting **what happened** from static frames. For content where temporal context matters, consider using `mode: 'direct_video'` which lets Gemini see actual motion. For keyframes mode, structure your map prompts and queries accordingly — ask the model to describe scenes, then use `query_media` (Claude) to reason about patterns and events across the descriptive data.
 
 ## Operator Runbook
 

--- a/assistant/src/config/bundled-skills/media-processing/TOOLS.json
+++ b/assistant/src/config/bundled-skills/media-processing/TOOLS.json
@@ -107,6 +107,11 @@
             "type": "string",
             "description": "ID of the media asset whose segments to analyze"
           },
+          "mode": {
+            "type": "string",
+            "enum": ["keyframes", "direct_video"],
+            "description": "Analysis mode: 'keyframes' extracts frames and sends images (default), 'direct_video' uploads video directly to Gemini. Direct video lets Gemini see motion/temporal context but has a 2GB file size limit."
+          },
           "system_prompt": {
             "type": "string",
             "description": "Assistant-provided extraction instructions for Gemini (e.g., what to look for in the frames)"

--- a/assistant/src/config/bundled-skills/media-processing/services/gemini-video.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/gemini-video.ts
@@ -1,0 +1,257 @@
+/**
+ * Gemini Video service — uploads video directly to Gemini's Files API for
+ * analysis, letting Gemini see actual motion and temporal context instead
+ * of static keyframes.
+ *
+ * Uses @google/genai SDK directly (same as gemini-map.ts) to leverage
+ * the Files API, responseMimeType, responseSchema, and usageMetadata.
+ */
+
+import { mkdir, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { ApiError, GoogleGenAI } from "@google/genai";
+
+import { computeRetryDelay, sleep } from "../../../../util/retry.js";
+import { CostTracker } from "./cost-tracker.js";
+import type { MapOutput, SegmentMapResult } from "./gemini-map.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface GeminiVideoOptions {
+  apiKey: string;
+  systemPrompt: string;
+  outputSchema: Record<string, unknown>;
+  context?: Record<string, unknown>;
+  model?: string;
+  maxRetries?: number;
+}
+
+// 2 GB file size limit for Gemini Files API
+const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024 * 1024;
+
+// Polling interval for file processing status (seconds)
+const FILE_POLL_INTERVAL_MS = 2000;
+const FILE_POLL_MAX_ATTEMPTS = 300; // 10 minutes max
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function waitForFileActive(
+  client: GoogleGenAI,
+  fileName: string,
+  onProgress?: (msg: string) => void,
+): Promise<void> {
+  for (let i = 0; i < FILE_POLL_MAX_ATTEMPTS; i++) {
+    const fileInfo = await client.files.get({ name: fileName });
+    if (fileInfo.state === "ACTIVE") {
+      return;
+    }
+    if (fileInfo.state === "FAILED") {
+      throw new Error(`Gemini file processing failed for ${fileName}`);
+    }
+    if (i % 5 === 0) {
+      onProgress?.(
+        `  Waiting for Gemini to process video (state: ${fileInfo.state})...\n`,
+      );
+    }
+    await sleep(FILE_POLL_INTERVAL_MS);
+  }
+  throw new Error(`Timed out waiting for Gemini to process file ${fileName}`);
+}
+
+// ---------------------------------------------------------------------------
+// Main: analyzeVideoDirectly
+// ---------------------------------------------------------------------------
+
+export async function analyzeVideoDirectly(
+  assetId: string,
+  pipelineDir: string,
+  options: GeminiVideoOptions,
+  filePath: string,
+  durationSeconds: number,
+  onProgress?: (msg: string) => void,
+): Promise<MapOutput> {
+  const model = options.model ?? "gemini-2.5-flash";
+  const maxRetries = options.maxRetries ?? 3;
+
+  // Check file size before uploading
+  const fileStat = await stat(filePath);
+  if (fileStat.size > MAX_FILE_SIZE_BYTES) {
+    throw new Error(
+      `Video file is ${(fileStat.size / (1024 * 1024 * 1024)).toFixed(1)} GB, ` +
+        `which exceeds Gemini's 2 GB file size limit. Use mode: 'keyframes' instead.`,
+    );
+  }
+
+  const client = new GoogleGenAI({ apiKey: options.apiKey });
+  const costTracker = new CostTracker();
+
+  await mkdir(pipelineDir, { recursive: true });
+
+  onProgress?.(
+    `Uploading video to Gemini Files API (${(fileStat.size / (1024 * 1024)).toFixed(1)} MB)...\n`,
+  );
+
+  let uploadedFileName: string | undefined;
+
+  try {
+    // Upload the video file
+    const uploadResult = await client.files.upload({
+      file: filePath,
+      config: { mimeType: "video/mp4" },
+    });
+
+    if (!uploadResult.name || !uploadResult.uri) {
+      throw new Error("Gemini Files API upload returned no file name or URI");
+    }
+
+    uploadedFileName = uploadResult.name;
+    onProgress?.(
+      `Video uploaded: ${uploadResult.name}. Waiting for processing...\n`,
+    );
+
+    // Wait for file to be processed
+    await waitForFileActive(client, uploadResult.name, onProgress);
+    onProgress?.(`Video processed. Sending to ${model} for analysis...\n`);
+
+    // Send to generateContent with retries
+    let lastError: string | undefined;
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        let promptText = `Analyzing full video (${durationSeconds.toFixed(1)}s duration).`;
+        if (options.context) {
+          promptText += `\n\nAdditional context:\n${JSON.stringify(options.context, null, 2)}`;
+        }
+
+        const response = await client.models.generateContent({
+          model,
+          contents: [
+            {
+              role: "user" as const,
+              parts: [
+                {
+                  fileData: {
+                    fileUri: uploadResult.uri,
+                    mimeType: uploadResult.mimeType ?? "video/mp4",
+                  },
+                },
+                { text: promptText },
+              ] as never,
+            },
+          ],
+          config: {
+            systemInstruction: options.systemPrompt,
+            responseMimeType: "application/json",
+            responseSchema: options.outputSchema as never,
+          },
+        });
+
+        const responseText = response.text ?? "{}";
+        const parsed = JSON.parse(responseText);
+
+        const inputTokens = response.usageMetadata?.promptTokenCount ?? 0;
+        const outputTokens = response.usageMetadata?.candidatesTokenCount ?? 0;
+        const responseModel = response.modelVersion ?? model;
+
+        costTracker.record({
+          segmentId: "full-video",
+          model: responseModel,
+          inputTokens,
+          outputTokens,
+        });
+
+        // Build a single-segment MapOutput covering the full duration
+        const segmentResult: SegmentMapResult = {
+          segmentId: "full-video",
+          startSeconds: 0,
+          endSeconds: durationSeconds,
+          result: parsed,
+          model: responseModel,
+          inputTokens,
+          outputTokens,
+        };
+
+        const output: MapOutput = {
+          assetId,
+          model: responseModel,
+          segmentCount: 1,
+          successCount: 1,
+          failedCount: 0,
+          skippedCount: 0,
+          costSummary: costTracker.getSummary(),
+          segments: [segmentResult],
+        };
+
+        // Write output for compatibility with reduce/query pipeline
+        const outputPath = join(pipelineDir, "map-output.json");
+        await writeFile(outputPath, JSON.stringify(output, null, 2));
+
+        onProgress?.(
+          `Analysis complete (${inputTokens + outputTokens} tokens).\n`,
+        );
+        onProgress?.(
+          `Cost: $${output.costSummary.totalEstimatedUSD.toFixed(4)} (${inputTokens} input + ${outputTokens} output tokens).\n`,
+        );
+
+        return output;
+      } catch (err) {
+        if (err instanceof ApiError) {
+          const message = err.message ?? "";
+
+          // Safety blocks are not retryable
+          if (message.includes("SAFETY") || message.includes("safety")) {
+            throw new Error("Video was blocked by Gemini safety filter.");
+          }
+
+          // Non-retryable client errors
+          if (
+            err.status !== undefined &&
+            err.status < 500 &&
+            err.status !== 429
+          ) {
+            throw err;
+          }
+
+          // Retryable errors (429, 5xx)
+          if (attempt < maxRetries) {
+            const delay = computeRetryDelay(attempt);
+            const reason =
+              err.status === 429
+                ? "rate limited"
+                : `server error (${err.status})`;
+            onProgress?.(
+              `  ${reason}, retrying in ${Math.round(delay)}ms (attempt ${attempt + 1}/${maxRetries})...\n`,
+            );
+            await sleep(delay);
+            continue;
+          }
+        }
+
+        // Generic retry for unknown errors
+        if (attempt < maxRetries) {
+          const delay = computeRetryDelay(attempt);
+          await sleep(delay);
+          continue;
+        }
+
+        lastError = err instanceof Error ? err.message : String(err);
+      }
+    }
+
+    throw new Error(`Failed after ${maxRetries + 1} attempts: ${lastError}`);
+  } finally {
+    // Clean up uploaded file
+    if (uploadedFileName) {
+      try {
+        await client.files.delete({ name: uploadedFileName });
+        onProgress?.(`Cleaned up uploaded file from Gemini.\n`);
+      } catch {
+        // Best-effort cleanup — don't fail the operation
+      }
+    }
+  }
+}

--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -1,13 +1,15 @@
-import { readFile } from 'node:fs/promises';
-import { dirname,join } from 'node:path';
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 
-import { getConfig } from '../../../../config/loader.js';
-import {
-  getMediaAssetById,
-} from '../../../../memory/media-store.js';
-import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
-import { type MapOutput,mapSegments } from '../services/gemini-map.js';
-import type { PreprocessManifest } from '../services/preprocess.js';
+import { getConfig } from "../../../../config/loader.js";
+import { getMediaAssetById } from "../../../../memory/media-store.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { type MapOutput, mapSegments } from "../services/gemini-map.js";
+import { analyzeVideoDirectly } from "../services/gemini-video.js";
+import type { PreprocessManifest } from "../services/preprocess.js";
 
 // ---------------------------------------------------------------------------
 // Exported function for job handler use
@@ -31,7 +33,9 @@ export async function mapSegmentsForAsset(
   const apiKey = config.apiKeys.gemini;
 
   if (!apiKey) {
-    throw new Error('No Gemini API key configured. Please set your Gemini API key to use keyframe analysis.');
+    throw new Error(
+      "No Gemini API key configured. Please set your Gemini API key to use keyframe analysis.",
+    );
   }
 
   const asset = getMediaAssetById(assetId);
@@ -40,30 +44,40 @@ export async function mapSegmentsForAsset(
   }
 
   // Load preprocess manifest
-  const pipelineDir = join(dirname(asset.filePath), 'pipeline', assetId);
-  const manifestPath = join(pipelineDir, 'manifest.json');
+  const pipelineDir = join(dirname(asset.filePath), "pipeline", assetId);
+  const manifestPath = join(pipelineDir, "manifest.json");
 
   let manifest: PreprocessManifest;
   try {
-    const raw = await readFile(manifestPath, 'utf-8');
+    const raw = await readFile(manifestPath, "utf-8");
     manifest = JSON.parse(raw) as PreprocessManifest;
   } catch {
-    throw new Error('No preprocess manifest found. Run extract_keyframes first.');
+    throw new Error(
+      "No preprocess manifest found. Run extract_keyframes first.",
+    );
   }
 
   if (manifest.segments.length === 0) {
-    throw new Error('No segments found in preprocess manifest. Run extract_keyframes first.');
+    throw new Error(
+      "No segments found in preprocess manifest. Run extract_keyframes first.",
+    );
   }
 
-  return mapSegments(assetId, pipelineDir, manifest.segments, {
-    apiKey,
-    systemPrompt: options.systemPrompt,
-    outputSchema: options.outputSchema,
-    context: options.context,
-    model: options.model,
-    concurrency: options.concurrency,
-    maxRetries: options.maxRetries,
-  }, onProgress);
+  return mapSegments(
+    assetId,
+    pipelineDir,
+    manifest.segments,
+    {
+      apiKey,
+      systemPrompt: options.systemPrompt,
+      outputSchema: options.outputSchema,
+      context: options.context,
+      model: options.model,
+      concurrency: options.concurrency,
+      maxRetries: options.maxRetries,
+    },
+    onProgress,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -76,58 +90,109 @@ export async function run(
 ): Promise<ToolExecutionResult> {
   const assetId = input.asset_id as string | undefined;
   if (!assetId) {
-    return { content: 'asset_id is required.', isError: true };
+    return { content: "asset_id is required.", isError: true };
   }
 
   const systemPrompt = input.system_prompt as string | undefined;
   if (!systemPrompt) {
-    return { content: 'system_prompt is required.', isError: true };
+    return { content: "system_prompt is required.", isError: true };
   }
 
-  const outputSchema = input.output_schema as Record<string, unknown> | undefined;
+  const outputSchema = input.output_schema as
+    | Record<string, unknown>
+    | undefined;
   if (!outputSchema) {
-    return { content: 'output_schema is required.', isError: true };
+    return { content: "output_schema is required.", isError: true };
   }
 
+  const mode = (input.mode as string | undefined) ?? "keyframes";
   const contextObj = input.context as Record<string, unknown> | undefined;
   const model = input.model as string | undefined;
   const concurrency = input.concurrency as number | undefined;
   const maxRetries = input.max_retries as number | undefined;
 
   if (concurrency !== undefined && concurrency < 1) {
-    return { content: 'concurrency must be at least 1.', isError: true };
+    return { content: "concurrency must be at least 1.", isError: true };
   }
   if (maxRetries !== undefined && maxRetries < 0) {
-    return { content: 'max_retries must be non-negative.', isError: true };
+    return { content: "max_retries must be non-negative.", isError: true };
   }
 
   try {
-    const output = await mapSegmentsForAsset(
-      assetId,
-      {
-        systemPrompt,
-        outputSchema,
-        context: contextObj,
-        model,
-        concurrency,
-        maxRetries,
-      },
-      context.onOutput,
-    );
+    let output: MapOutput;
+
+    if (mode === "direct_video") {
+      const config = getConfig();
+      const apiKey = config.apiKeys.gemini;
+      if (!apiKey) {
+        return {
+          content:
+            "No Gemini API key configured. Please set your Gemini API key to use video analysis.",
+          isError: true,
+        };
+      }
+
+      const asset = getMediaAssetById(assetId);
+      if (!asset) {
+        return { content: `Media asset not found: ${assetId}`, isError: true };
+      }
+      if (asset.mediaType !== "video") {
+        return {
+          content: `Asset ${assetId} is not a video (type: ${asset.mediaType}). Direct video mode requires a video asset.`,
+          isError: true,
+        };
+      }
+
+      const pipelineDir = join(dirname(asset.filePath), "pipeline", assetId);
+
+      output = await analyzeVideoDirectly(
+        assetId,
+        pipelineDir,
+        {
+          apiKey,
+          systemPrompt,
+          outputSchema,
+          context: contextObj,
+          model,
+          maxRetries,
+        },
+        asset.filePath,
+        asset.durationSeconds ?? 0,
+        context.onOutput,
+      );
+    } else {
+      output = await mapSegmentsForAsset(
+        assetId,
+        {
+          systemPrompt,
+          outputSchema,
+          context: contextObj,
+          model,
+          concurrency,
+          maxRetries,
+        },
+        context.onOutput,
+      );
+    }
 
     return {
-      content: JSON.stringify({
-        message: `Map ${output.failedCount === 0 ? 'completed' : 'completed with errors'}`,
-        assetId,
-        model: output.model,
-        segmentCount: output.segmentCount,
-        successCount: output.successCount,
-        failedCount: output.failedCount,
-        skippedCount: output.skippedCount,
-        totalInputTokens: output.costSummary.totalInputTokens,
-        totalOutputTokens: output.costSummary.totalOutputTokens,
-        estimatedCostUSD: output.costSummary.totalEstimatedUSD,
-      }, null, 2),
+      content: JSON.stringify(
+        {
+          message: `Map ${output.failedCount === 0 ? "completed" : "completed with errors"}`,
+          assetId,
+          mode,
+          model: output.model,
+          segmentCount: output.segmentCount,
+          successCount: output.successCount,
+          failedCount: output.failedCount,
+          skippedCount: output.skippedCount,
+          totalInputTokens: output.costSummary.totalInputTokens,
+          totalOutputTokens: output.costSummary.totalOutputTokens,
+          estimatedCostUSD: output.costSummary.totalEstimatedUSD,
+        },
+        null,
+        2,
+      ),
       isError: false,
     };
   } catch (err) {


### PR DESCRIPTION
Add mode: direct_video to analyze_keyframes that uploads video directly to Gemini's Files API. Gemini sees actual motion/temporal context instead of static frames. Falls back gracefully for files >2GB. Output is compatible with existing reduce/query pipeline. Closes #12041
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
