### PR TITLE
Fix reduce cost persistence failing queries

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/services/reduce.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/reduce.ts
@@ -250,7 +250,11 @@ export async function reduceForAsset(
     options.model,
     onProgress,
   );
-  await persistReduceCost(assetId, effectiveQuery, result);
+  try {
+    await persistReduceCost(assetId, effectiveQuery, result);
+  } catch {
+    // Cost tracking is best-effort; don't discard the LLM result
+  }
   return result;
 }
 


### PR DESCRIPTION
## Summary
- Wrap `persistReduceCost` in try/catch so I/O errors in cost tracking don't discard successful LLM query results
- Cost tracking is ancillary and should not be a hard dependency on the reduce path

## Test plan
- [ ] Verify reduce queries succeed even if cost file write fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
