### PR TITLE
Fix preprocess progress stalling on failed segments

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
@@ -495,6 +495,8 @@ export async function preprocessForAsset(
         onProgress?.(
           `Warning: frame extraction failed for ${seg.id}: ${result.stderr.slice(0, 200)}\n`,
         );
+        const segProgress = Math.round(((i + 1) / rawSegments.length) * 80);
+        updateProcessingStage(stage.id, { progress: segProgress });
         continue;
       }
 


### PR DESCRIPTION
Move progress update to run for both successful and failed segment extractions so progress reporting doesn't stall when ffmpeg fails on a segment. Addresses feedback on #12048.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
