### PR TITLE
Fix palettegen timeout regression

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
@@ -20,7 +20,7 @@ import {
 } from "../../../../memory/media-store.js";
 import {
   FFMPEG_PREPROCESS_TIMEOUT_MS,
-  FFPROBE_TIMEOUT_MS,
+  FFMPEG_PALETTE_TIMEOUT_MS,
   spawnWithTimeout,
 } from "../../../../util/spawn.js";
 import { transcribeSegmentAudio } from "./audio-transcribe.js";
@@ -312,7 +312,7 @@ async function extractDominantColors(framePath: string): Promise<string[]> {
       "null",
       "-",
     ],
-    FFPROBE_TIMEOUT_MS,
+    FFMPEG_PALETTE_TIMEOUT_MS,
   );
 
   // Fallback: return empty if analysis fails

--- a/assistant/src/util/spawn.ts
+++ b/assistant/src/util/spawn.ts
@@ -14,6 +14,9 @@ export const FFMPEG_TRANSCODE_TIMEOUT_MS = 120_000;
 /** Metadata extraction via ffprobe. Very fast — just reads headers. */
 export const FFPROBE_TIMEOUT_MS = 15_000;
 
+/** Palette/color analysis on a single frame via ffmpeg. Moderate — heavier than metadata reads. */
+export const FFMPEG_PALETTE_TIMEOUT_MS = 30_000;
+
 export function spawnWithTimeout(
   cmd: string[],
   timeoutMs: number,


### PR DESCRIPTION
Add FFMPEG_PALETTE_TIMEOUT_MS (30s) to util/spawn.ts and use it for extractDominantColors instead of FFPROBE_TIMEOUT_MS (15s). Restores the original timeout. Addresses feedback on #12052.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
