### PR TITLE
Fix hardcoded MIME type in Gemini video upload

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/services/gemini-video.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/gemini-video.ts
@@ -73,6 +73,7 @@ export async function analyzeVideoDirectly(
   options: GeminiVideoOptions,
   filePath: string,
   durationSeconds: number,
+  mimeType: string,
   onProgress?: (msg: string) => void,
 ): Promise<MapOutput> {
   const model = options.model ?? "gemini-2.5-flash";
@@ -102,7 +103,7 @@ export async function analyzeVideoDirectly(
     // Upload the video file
     const uploadResult = await client.files.upload({
       file: filePath,
-      config: { mimeType: "video/mp4" },
+      config: { mimeType },
     });
 
     if (!uploadResult.name || !uploadResult.uri) {

--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -158,6 +158,7 @@ export async function run(
         },
         asset.filePath,
         asset.durationSeconds ?? 0,
+        asset.mimeType,
         context.onOutput,
       );
     } else {


### PR DESCRIPTION
Use the asset's actual mimeType from the DB when uploading to Gemini's Files API instead of hardcoding video/mp4. Supports MOV, MKV, WebM, and other video formats. Addresses feedback on #12053.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
