### PR TITLE
Fix map cache ignoring transcripts

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/services/gemini-map.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/gemini-map.ts
@@ -308,8 +308,15 @@ export async function mapSegments(
 
   // Process all segments with concurrency limiting
   const promises = segments.map(async (segment) => {
-    // Resumability: check for existing result file (keyed by segment + config hash)
-    const resultPath = join(mapResultsDir, `${segment.id}-${configHash}.json`);
+    // Resumability: check for existing result file (keyed by segment + config + transcript hash)
+    const segContentHash = createHash("sha256")
+      .update(segment.transcript ?? "")
+      .digest("hex")
+      .slice(0, 8);
+    const resultPath = join(
+      mapResultsDir,
+      `${segment.id}-${configHash}-${segContentHash}.json`,
+    );
     if (await fileExists(resultPath)) {
       try {
         const existingData = await readFile(resultPath, "utf-8");


### PR DESCRIPTION
Include a per-segment transcript hash in the map cache key so toggling include_audio invalidates cached visual-only results. Addresses feedback on #12050.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
