### PR TITLE
Fix remaining hardcoded video/mp4 fallback

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/services/gemini-video.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/gemini-video.ts
@@ -137,7 +137,7 @@ export async function analyzeVideoDirectly(
                 {
                   fileData: {
                     fileUri: uploadResult.uri,
-                    mimeType: uploadResult.mimeType ?? "video/mp4",
+                    mimeType: uploadResult.mimeType ?? mimeType,
                   },
                 },
                 { text: promptText },


### PR DESCRIPTION
Replace the hardcoded video/mp4 fallback in the generateContent fileData with the asset's actual mimeType parameter. Addresses feedback on #12058.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12063" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
