### PR TITLE
refactor: redirect ingress_member list IPC to read from contacts table

### DIFF
--- a/assistant/src/runtime/ingress-service.ts
+++ b/assistant/src/runtime/ingress-service.ts
@@ -6,6 +6,8 @@
  */
 
 import { isChannelId } from '../channels/types.js';
+import { listContacts } from '../contacts/contact-store.js';
+import type { ContactWithChannels } from '../contacts/types.js';
 import {
   createInvite,
   type IngressInvite,
@@ -16,7 +18,6 @@ import {
 } from '../memory/ingress-invite-store.js';
 import {
   type IngressMember,
-  listMembers,
   type MemberPolicy,
   type MemberStatus,
 } from '../memory/ingress-member-store.js';
@@ -129,6 +130,21 @@ export function memberToResponse(m: IngressMember): MemberResponseData {
     lastSeenAt: m.lastSeenAt ?? undefined,
     createdAt: m.createdAt,
   };
+}
+
+function contactToMemberResponse(contact: ContactWithChannels): MemberResponseData[] {
+  return contact.channels.map((ch) => ({
+    id: `${contact.id}:${ch.id}`,
+    sourceChannel: ch.type,
+    externalUserId: ch.externalUserId ?? undefined,
+    externalChatId: ch.externalChatId ?? undefined,
+    displayName: contact.displayName,
+    username: undefined,
+    status: ch.status,
+    policy: ch.policy,
+    lastSeenAt: ch.lastSeenAt ?? undefined,
+    createdAt: ch.createdAt,
+  }));
 }
 
 // ---------------------------------------------------------------------------
@@ -284,16 +300,17 @@ export function listIngressMembers(params: {
   status?: string;
   policy?: string;
 }): IngressResult<MemberResponseData[]> {
-  const members = listMembers({
-    assistantId: params.assistantId,
-    sourceChannel: params.sourceChannel,
-    status: params.status as MemberStatus | undefined,
-    policy: params.policy as MemberPolicy | undefined,
+  const allContacts = listContacts(200, 'contact');
+  const members = allContacts.flatMap(contactToMemberResponse);
+
+  const filtered = members.filter((m) => {
+    if (params.sourceChannel && m.sourceChannel !== params.sourceChannel) return false;
+    if (params.status && m.status !== params.status) return false;
+    if (params.policy && m.policy !== params.policy) return false;
+    return true;
   });
-  return {
-    ok: true,
-    data: members.map(memberToResponse),
-  };
+
+  return { ok: true, data: filtered };
 }
 
 export function upsertIngressMember(params: {


### PR DESCRIPTION
## Summary
- Redirect listIngressMembers() to read from contacts table via listContacts() instead of legacy listMembers()
- Add contactToMemberResponse helper to map ContactWithChannels to MemberResponseData for backward compatibility
- Remove unused listMembers import from ingress-member-store

Part of plan: contacts-ipc-unify.md (PR 6 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
