### PR TITLE
feat: add contact change event emitter with emissions from contacts-write and contact-store

### DIFF
--- a/assistant/src/contacts/contact-events.ts
+++ b/assistant/src/contacts/contact-events.ts
@@ -1,0 +1,21 @@
+/**
+ * Lightweight event emitter for contact mutations.
+ * The daemon server subscribes to this to broadcast `contacts_changed`
+ * to all connected clients.
+ */
+import { EventEmitter } from "node:events";
+
+const emitter = new EventEmitter();
+
+/** Register a listener for contact change events. Returns an unsubscribe function. */
+export function onContactChange(listener: () => void): () => void {
+  emitter.on("changed", listener);
+  return () => {
+    emitter.off("changed", listener);
+  };
+}
+
+/** Emit a contact change event. Called after successful contact writes. */
+export function emitContactChange(): void {
+  emitter.emit("changed");
+}

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -3,6 +3,7 @@ import { v4 as uuid } from "uuid";
 
 import { getDb } from "../memory/db.js";
 import { contactChannels, contacts } from "../memory/schema.js";
+import { emitContactChange } from "./contact-events.js";
 import type {
   ChannelPolicy,
   ChannelStatus,
@@ -816,7 +817,9 @@ export function updateChannelStatus(
     .where(eq(contactChannels.id, channelId))
     .get();
 
-  return updated ? parseChannel(updated) : null;
+  const result = updated ? parseChannel(updated) : null;
+  emitContactChange();
+  return result;
 }
 
 /**

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -13,6 +13,7 @@
 import { eq } from "drizzle-orm";
 
 import type { ChannelId } from "../channels/types.js";
+import { emitContactChange } from "./contact-events.js";
 import type { GuardianBinding } from "../memory/guardian-bindings.js";
 import {
   createBinding,
@@ -118,7 +119,9 @@ export function createGuardianBindingContactsFirst(params: {
     log.warn({ err }, "Contacts write failed for createGuardianBinding");
   }
 
-  return createBinding(params);
+  const result = createBinding(params);
+  emitContactChange();
+  return result;
 }
 
 /**
@@ -142,7 +145,9 @@ export function revokeGuardianBindingContactsFirst(
     log.warn({ err }, "Contacts write failed for revokeGuardianBinding");
   }
 
-  return revokeBinding(assistantId, channel);
+  const result = revokeBinding(assistantId, channel);
+  emitContactChange();
+  return result;
 }
 
 // ── Member operations ────────────────────────────────────────────────
@@ -212,7 +217,9 @@ export function upsertMemberContactsFirst(params: {
     log.warn({ err }, "Contacts write failed for upsertMember");
   }
 
-  return upsertMember(params as Parameters<typeof upsertMember>[0]);
+  const result = upsertMember(params as Parameters<typeof upsertMember>[0]);
+  emitContactChange();
+  return result;
 }
 
 /**
@@ -261,6 +268,7 @@ export function revokeMemberContactsFirst(
     }
   }
 
+  emitContactChange();
   return result;
 }
 
@@ -310,6 +318,7 @@ export function blockMemberContactsFirst(
     }
   }
 
+  emitContactChange();
   return result;
 }
 


### PR DESCRIPTION
## Summary
- Create contact-events.ts with lightweight EventEmitter for contact mutations
- Emit contact change events from 5 mutation functions in contacts-write.ts (excluding touchChannelLastSeen)
- Emit from updateChannelStatus in contact-store.ts for direct update_channel IPC path

Part of plan: contacts-ipc-unify.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
