### PR TITLE
fix: conditionally clear reason fields only when re-activating member

### DIFF
--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -203,8 +203,8 @@ export function upsertMemberContactsFirst(params: {
           status: (params.status as ChannelStatus) ?? undefined,
           policy: (params.policy as ChannelPolicy) ?? undefined,
           inviteId: params.inviteId ?? null,
-          revokedReason: null,
-          blockedReason: null,
+          revokedReason: params.status === 'active' ? null : undefined,
+          blockedReason: params.status === 'active' ? null : undefined,
         },
       ],
     });


### PR DESCRIPTION
Makes revokedReason/blockedReason clearing conditional on status being set to 'active' in upsertMemberContactsFirst, preventing metadata-only upserts from silently erasing diagnostic context on blocked/revoked members. Addresses Codex and Devin feedback on #12026.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
