### PR TITLE
feat: wire daemon server to broadcast contacts_changed on contact events

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -13,6 +13,7 @@ import {
   parseChannelId,
   parseInterfaceId,
 } from "../channels/types.js";
+import { onContactChange } from "../contacts/contact-events.js";
 import { getConfig } from "../config/loader.js";
 import { buildSystemPrompt } from "../config/system-prompt.js";
 import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
@@ -417,6 +418,12 @@ export class DaemonServer {
       () => this.evictSessionsForReload(),
       () => this.broadcastIdentityChanged(),
     );
+
+    // Broadcast contacts_changed to all clients when any contact mutation occurs.
+    onContactChange(() => {
+      this.broadcast({ type: "contacts_changed" });
+    });
+
     this.auth.initToken();
 
     let tlsCreds: { cert: string; key: string; fingerprint: string } | null =


### PR DESCRIPTION
## Summary
- Import onContactChange from contact-events module in daemon server
- Register listener in start() to broadcast contacts_changed to all clients on any contact mutation
- Follows the same pattern as broadcastIdentityChanged but using programmatic events

Part of plan: contacts-ipc-unify.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
