### PR TITLE
fix: add raw-ID fallback for canonical lookups in block and last-seen paths

### DIFF
--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -295,15 +295,26 @@ export function blockMemberContactsFirst(
         : null;
 
       if (canonicalUserId) {
-        const contact = findContactByChannelExternalId(
+        // Try canonical ID first, fall back to raw ID for legacy contacts
+        let contact = findContactByChannelExternalId(
           result.sourceChannel,
           canonicalUserId,
         );
+        let lookupId = canonicalUserId;
+
+        if (!contact && canonicalUserId !== result.externalUserId) {
+          contact = findContactByChannelExternalId(
+            result.sourceChannel,
+            result.externalUserId,
+          );
+          lookupId = result.externalUserId;
+        }
+
         if (contact) {
           const matchingChannel = contact.channels.find(
             (ch) =>
               ch.type === result.sourceChannel &&
-              ch.externalUserId === canonicalUserId,
+              ch.externalUserId === lookupId,
           );
           if (matchingChannel) {
             updateChannelStatus(matchingChannel.id, {
@@ -336,10 +347,19 @@ export function touchChannelLastSeen(memberId: string): void {
           member.externalUserId,
         ) ?? member.externalUserId;
 
+      // Try canonical ID first
       updateChannelLastSeenByExternalId(
         member.sourceChannel,
         canonicalUserId,
       );
+
+      // Also try raw ID for legacy contacts that haven't been rewritten yet
+      if (canonicalUserId !== member.externalUserId) {
+        updateChannelLastSeenByExternalId(
+          member.sourceChannel,
+          member.externalUserId,
+        );
+      }
     }
   } catch (err) {
     log.warn({ err }, "Contacts write failed for touchChannelLastSeen");


### PR DESCRIPTION
Adds fallback to raw externalUserId when canonical-only lookup misses legacy contacts in blockMemberContactsFirst and touchChannelLastSeen. Ensures pre-canonical contacts still get blocked/last-seen updates during the migration. Addresses Codex feedback on #12028.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
