### PR TITLE
chore: regenerate Swift IPC types for contacts_changed broadcast

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -886,6 +886,15 @@ public struct IPCContactPayload: Codable, Sendable {
     }
 }
 
+/// Server push — lightweight invalidation signal: the contacts table has been mutated, refetch your list.
+public struct IPCContactsChanged: Codable, Sendable {
+    public let type: String
+
+    public init(type: String) {
+        self.type = type
+    }
+}
+
 public struct IPCContactsRequest: Codable, Sendable {
     public let type: String
     public let action: String

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2244,6 +2244,7 @@ public enum ServerMessage: Decodable, Sendable {
     case workItemsListResponse(IPCWorkItemsListResponse)
     case workItemStatusChanged(IPCWorkItemStatusChanged)
     case tasksChanged(IPCTasksChanged)
+    case contactsChanged(IPCContactsChanged)
     case workItemDeleteResponse(IPCWorkItemDeleteResponse)
     case workItemRunTaskResponse(IPCWorkItemRunTaskResponse)
     case workItemOutputResponse(IPCWorkItemOutputResponse)
@@ -2612,6 +2613,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "tasks_changed":
             let message = try IPCTasksChanged(from: decoder)
             self = .tasksChanged(message)
+        case "contacts_changed":
+            let message = try IPCContactsChanged(from: decoder)
+            self = .contactsChanged(message)
         case "work_item_delete_response":
             let message = try IPCWorkItemDeleteResponse(from: decoder)
             self = .workItemDeleteResponse(message)


### PR DESCRIPTION
## Summary
- Regenerate IPCContractGenerated.swift to include new IPCContactsChanged struct
- ServerMessage enum now includes .contactsChanged case for decoding the broadcast
- Codegen check passes cleanly

Part of plan: contacts-ipc-unify.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
