### PR TITLE
fix: regenerate IPC Swift code and update inventory for contacts_changed event

### DIFF
--- a/assistant/scripts/ipc/check-swift-decoder-drift.ts
+++ b/assistant/scripts/ipc/check-swift-decoder-drift.ts
@@ -62,6 +62,7 @@ const SWIFT_OMIT_ALLOWLIST = new Set<string>([
   "work_items_list_response",
   // Contact management — not yet consumed by the macOS client
   "contacts_response",
+  "contacts_changed",
 ]);
 
 /**

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -214,6 +214,7 @@
     "client_settings_update",
     "confirmation_request",
     "confirmation_state_changed",
+    "contacts_changed",
     "contacts_response",
     "context_compacted",
     "conversation_search_response",

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -886,6 +886,15 @@ public struct IPCContactPayload: Codable, Sendable {
     }
 }
 
+/// Server push — lightweight invalidation signal: the contacts table has been mutated, refetch your list.
+public struct IPCContactsChanged: Codable, Sendable {
+    public let type: String
+
+    public init(type: String) {
+        self.type = type
+    }
+}
+
 public struct IPCContactsRequest: Codable, Sendable {
     public let type: String
     public let action: String


### PR DESCRIPTION
## Summary
- Regenerate `IPCContractGenerated.swift` to include the new `IPCContactsChanged` struct added by #12069
- Update IPC contract inventory snapshot to reflect the new `contacts_changed` server message
- Add `contacts_changed` to Swift decoder drift allowlist (not yet consumed by macOS client)
- Fixes CI failure: `Generated Swift file is out of date`

## Original prompt
fix this ci issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22652293753/job/65654140444

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
