### PR TITLE
feat: auto-refresh macOS Contacts UI on contacts_changed broadcast

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
@@ -69,6 +69,10 @@ final class ContactsViewModel: ObservableObject {
             }
         }
 
+        daemonClient.onContactsChanged = { [weak self] _ in
+            self?.loadContacts()
+        }
+
         do {
             try daemonClient.sendListContacts(limit: 500)
         } catch {

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -506,6 +506,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `contacts_response` message.
     public var onContactsResponse: ((ContactsResponseMessage) -> Void)?
 
+    /// Called when the daemon broadcasts a `contacts_changed` event (contact table mutated).
+    public var onContactsChanged: ((IPCContactsChanged) -> Void)?
+
     // MARK: - Broadcast Subscribers
 
     /// Creates a new message stream for the caller. Each subscriber receives all messages

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -278,6 +278,8 @@ extension DaemonClient {
             onGenerateAvatarResponse?(msg)
         case .contactsResponse(let msg):
             onContactsResponse?(msg)
+        case .contactsChanged(let msg):
+            onContactsChanged?(msg)
         default:
             break
         }


### PR DESCRIPTION
## Summary
- Add onContactsChanged callback to DaemonClient for contacts_changed broadcasts
- Route .contactsChanged messages in DaemonMessageRouter to the callback
- ContactsViewModel registers the callback in loadContacts() to auto-refresh the UI on any contact mutation

Part of plan: contacts-ipc-unify.md (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
