### PR TITLE
fix: unsubscribe contact-change listener on daemon server stop (#12069)

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -233,6 +233,7 @@ export class DaemonServer {
   private socketPath: string;
   private httpPort: number | undefined;
   private blobSweepTimer: ReturnType<typeof setInterval> | null = null;
+  private unsubscribeContactChange: (() => void) | null = null;
   private static readonly MAX_CONNECTIONS = 50;
   private evictor: SessionEvictor;
 
@@ -420,7 +421,7 @@ export class DaemonServer {
     );
 
     // Broadcast contacts_changed to all clients when any contact mutation occurs.
-    onContactChange(() => {
+    this.unsubscribeContactChange = onContactChange(() => {
       this.broadcast({ type: "contacts_changed" });
     });
 
@@ -526,6 +527,10 @@ export class DaemonServer {
       this.blobSweepTimer = null;
     }
     this.configWatcher.stop();
+    if (this.unsubscribeContactChange) {
+      this.unsubscribeContactChange();
+      this.unsubscribeContactChange = null;
+    }
     this.auth.cleanupAll();
 
     const serverClosed = new Promise<void>((resolve) => {


### PR DESCRIPTION
## Summary
- Store the onContactChange() unsubscribe function as a private field
- Call it during stop() to prevent resource leaks and stale broadcasts
- Matches cleanup patterns used by other resources (blobSweepTimer, configWatcher)

## Original PR
Addresses feedback on #12069

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
