### PR TITLE
fix: gate contact change emissions on actual mutations (#12067)

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -809,17 +809,19 @@ export function updateChannelStatus(
       .set(updateSet)
       .where(eq(contactChannels.id, channelId))
       .run();
+
+    const updated = db
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, channelId))
+      .get();
+
+    const result = updated ? parseChannel(updated) : null;
+    emitContactChange();
+    return result;
   }
 
-  const updated = db
-    .select()
-    .from(contactChannels)
-    .where(eq(contactChannels.id, channelId))
-    .get();
-
-  const result = updated ? parseChannel(updated) : null;
-  emitContactChange();
-  return result;
+  return parseChannel(existing);
 }
 
 /**

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -145,9 +145,7 @@ export function revokeGuardianBindingContactsFirst(
     log.warn({ err }, "Contacts write failed for revokeGuardianBinding");
   }
 
-  const result = revokeBinding(assistantId, channel);
-  emitContactChange();
-  return result;
+  return revokeBinding(assistantId, channel);
 }
 
 // ── Member operations ────────────────────────────────────────────────
@@ -268,7 +266,6 @@ export function revokeMemberContactsFirst(
     }
   }
 
-  emitContactChange();
   return result;
 }
 
@@ -329,7 +326,6 @@ export function blockMemberContactsFirst(
     }
   }
 
-  emitContactChange();
   return result;
 }
 


### PR DESCRIPTION
## Summary
- Only emit contactChange when revokeMember/blockMember actually finds and mutates a member
- Only emit contactChange in updateChannelStatus when updateSet is non-empty
- Prevents spurious/duplicate contacts_changed broadcasts to clients

## Original PR
Addresses feedback on #12067

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
