### PR TITLE
fix: add raw-ID fallback for revoke lookups in contacts-write

### DIFF
--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -240,15 +240,26 @@ export function revokeMemberContactsFirst(
         : null;
 
       if (canonicalUserId) {
-        const contact = findContactByChannelExternalId(
+        // Try canonical ID first, fall back to raw ID for legacy contacts
+        let contact = findContactByChannelExternalId(
           result.sourceChannel,
           canonicalUserId,
         );
+        let lookupId = canonicalUserId;
+
+        if (!contact && canonicalUserId !== result.externalUserId) {
+          contact = findContactByChannelExternalId(
+            result.sourceChannel,
+            result.externalUserId!,
+          );
+          lookupId = result.externalUserId!;
+        }
+
         if (contact) {
           const matchingChannel = contact.channels.find(
             (ch) =>
               ch.type === result.sourceChannel &&
-              ch.externalUserId === canonicalUserId,
+              ch.externalUserId === lookupId,
           );
           if (matchingChannel) {
             updateChannelStatus(matchingChannel.id, {


### PR DESCRIPTION
## Summary
- Adds the same raw-ID fallback pattern to revokeMemberContactsFirst that was already added to blockMemberContactsFirst and touchChannelLastSeen in #12070
- Ensures contacts with legacy (non-canonicalized) IDs are found during revoke operations

Addresses feedback from #12070
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
