### PR TITLE
fix: add per-test timeout to prevent CI hangs from leaked bun handles

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -18,6 +18,8 @@ set -uo pipefail
 EXCLUDE_EXPERIMENTAL="${EXCLUDE_EXPERIMENTAL:-false}"
 WORKERS="${TEST_WORKERS:-$(sysctl -n hw.logicalcpu 2>/dev/null || nproc 2>/dev/null || echo 8)}"
 COVERAGE="${COVERAGE:-false}"
+# Per-test timeout (seconds). Kills bun processes that pass but don't exit due to open handles.
+PER_TEST_TIMEOUT="${PER_TEST_TIMEOUT:-120}"
 
 EXPERIMENTAL_FILES=(
   "skill-load-tool.test.ts"
@@ -72,6 +74,7 @@ printf '%s\n' "${test_files[@]}" | xargs -P "${WORKERS}" -I {} bash -c '
   results_dir="$2"
   exclude_exp="$3"
   coverage_enabled="$4"
+  per_test_timeout="$5"
 
   safe_name="$(echo "${test_file}" | tr "/" "_")"
   out_file="${results_dir}/${safe_name}.out"
@@ -83,12 +86,28 @@ printf '%s\n' "${test_files[@]}" | xargs -P "${WORKERS}" -I {} bash -c '
     coverage_args="--coverage --coverage-reporter=lcov --coverage-dir=${cov_dir}"
   fi
 
+  # Resolve timeout binary (coreutils `timeout` on Linux, `gtimeout` on macOS via brew)
+  timeout_cmd=""
+  if command -v timeout &>/dev/null; then
+    timeout_cmd="timeout"
+  elif command -v gtimeout &>/dev/null; then
+    timeout_cmd="gtimeout"
+  fi
+
   start_ms=$(perl -MTime::HiRes=time -e "printf \"%d\", time*1000")
 
-  if [[ "${exclude_exp}" == "true" ]]; then
-    bun test ${coverage_args} --test-name-pattern "^(?!.*\\[experimental\\])" "${test_file}" > "${out_file}" 2>&1
+  if [[ -n "${timeout_cmd}" ]]; then
+    if [[ "${exclude_exp}" == "true" ]]; then
+      "${timeout_cmd}" "${per_test_timeout}" bun test ${coverage_args} --test-name-pattern "^(?!.*\\[experimental\\])" "${test_file}" > "${out_file}" 2>&1
+    else
+      "${timeout_cmd}" "${per_test_timeout}" bun test ${coverage_args} "${test_file}" > "${out_file}" 2>&1
+    fi
   else
-    bun test ${coverage_args} "${test_file}" > "${out_file}" 2>&1
+    if [[ "${exclude_exp}" == "true" ]]; then
+      bun test ${coverage_args} --test-name-pattern "^(?!.*\\[experimental\\])" "${test_file}" > "${out_file}" 2>&1
+    else
+      bun test ${coverage_args} "${test_file}" > "${out_file}" 2>&1
+    fi
   fi
   exit_code=$?
 
@@ -96,13 +115,17 @@ printf '%s\n' "${test_files[@]}" | xargs -P "${WORKERS}" -I {} bash -c '
   elapsed=$(( end_ms - start_ms ))
 
   base="$(basename "${test_file}")"
-  if [[ ${exit_code} -ne 0 ]]; then
+  if [[ ${exit_code} -eq 124 ]]; then
+    # timeout killed the process — tests likely passed but bun did not exit (open handles)
+    echo "${test_file}" >> "${results_dir}/failures"
+    echo "  ⚠ ${base} (killed after ${per_test_timeout}s — process hung, likely open handles)"
+  elif [[ ${exit_code} -ne 0 ]]; then
     echo "${test_file}" >> "${results_dir}/failures"
     echo "  ✗ ${base} (${elapsed}ms)"
   else
     echo "  ✓ ${base} (${elapsed}ms)"
   fi
-' _ {} "${results_dir}" "${EXCLUDE_EXPERIMENTAL}" "${COVERAGE}"
+' _ {} "${results_dir}" "${EXCLUDE_EXPERIMENTAL}" "${COVERAGE}" "${PER_TEST_TIMEOUT}"
 xargs_exit=$?
 
 # Verify tests actually ran — catch xargs startup failures (e.g. invalid TEST_WORKERS)


### PR DESCRIPTION
## Summary

- Add `PER_TEST_TIMEOUT` (default 120s) to `assistant/scripts/test.sh` that wraps each `bun test` invocation with `timeout` (Linux) / `gtimeout` (macOS)
- When a bun process hangs after completing tests (due to open handles), it gets killed and reported with a clear diagnostic message instead of stalling the entire CI pipeline
- CI was hitting the 15-minute job timeout because all tests passed but 1-2 bun processes never exited, blocking `xargs` indefinitely

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
