### PR TITLE
fix: clear contacts tables in ingress test resetTables to fix test isolation

### DIFF
--- a/assistant/src/__tests__/ingress-routes-http.test.ts
+++ b/assistant/src/__tests__/ingress-routes-http.test.ts
@@ -50,6 +50,8 @@ afterAll(() => {
 function resetTables() {
   getSqlite().run("DELETE FROM assistant_ingress_members");
   getSqlite().run("DELETE FROM assistant_ingress_invites");
+  getSqlite().run("DELETE FROM contact_channels");
+  getSqlite().run("DELETE FROM contacts");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `handleListMembers` reads from the `contacts`/`contact_channels` tables (via `listContacts()`), but `resetTables()` only cleared `assistant_ingress_members` and `assistant_ingress_invites`
- Added `DELETE FROM contact_channels` and `DELETE FROM contacts` to `resetTables()` so member counts don't bleed between tests

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22652591123/job/65655051835

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
