### PR TITLE
Fix clip delivery — save to pipeline dir instead of tmpdir

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/SKILL.md
+++ b/assistant/src/config/bundled-skills/media-processing/SKILL.md
@@ -200,7 +200,7 @@ Be specific and factual. Describe what you see, not what you infer happened betw
 
 ### Clip Delivery
 
-The `generate_clip` tool outputs clips as temporary files. These may not deliver reliably via sandbox attachments. For reliable delivery, use `host_bash` + ffmpeg to save clips to a user-specified location as a fallback.
+The `generate_clip` tool saves clips to the asset's pipeline directory (`pipeline/<assetId>/clips/`) so they persist for attachment delivery. The clip file path is included in the tool response for direct file access if needed.
 
 ## Known Limitations — Vision Analysis
 

--- a/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
@@ -6,11 +6,9 @@
  * This is a generic media-processing primitive with no domain-specific logic.
  */
 
-import { randomUUID } from "node:crypto";
-import { mkdir, rmdir, stat, unlink } from "node:fs/promises";
+import { mkdir, stat } from "node:fs/promises";
 import { readFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { uploadAttachment } from "../../../../memory/attachments-store.js";
 import { getMediaAssetById } from "../../../../memory/media-store.js";
@@ -120,8 +118,10 @@ export async function run(
       : endTime + postRoll;
   const clipDuration = clipEnd - clipStart;
 
-  // Prepare output path
-  const clipDir = join(tmpdir(), `vellum-clips-${randomUUID()}`);
+  // Save clips to the asset's pipeline directory so they persist for
+  // attachment delivery (tmpdir files get cleaned up before the sandbox
+  // attachment system can serve them).
+  const clipDir = join(dirname(asset.filePath), "pipeline", assetId, "clips");
   await mkdir(clipDir, { recursive: true });
 
   const clipFilename = `clip-${formatTimestamp(startTime).replace(/:/g, "")}-${formatTimestamp(endTime).replace(/:/g, "")}.${outputFormat}`;
@@ -197,6 +197,7 @@ export async function run(
             preRoll,
             postRoll,
           },
+          clipPath,
           assetId,
         },
         null,
@@ -209,17 +210,5 @@ export async function run(
       content: `Clip generation failed: ${(err as Error).message}`,
       isError: true,
     };
-  } finally {
-    // Clean up temp file and directory
-    try {
-      await unlink(clipPath);
-    } catch {
-      /* ignore */
-    }
-    try {
-      await rmdir(clipDir);
-    } catch {
-      /* ignore */
-    }
   }
 }


### PR DESCRIPTION
## Summary
- Save generated clips to the asset's pipeline directory (`pipeline/<assetId>/clips/`) instead of tmpdir so they persist long enough for the sandbox attachment system to deliver them
- Remove the `finally` block that immediately deleted the clip file after registration
- Include `clipPath` in the tool response so the assistant can reference the file directly
- Update SKILL.md to remove the stale "clips may not deliver reliably" warning

## Original prompt
Fix clip delivery in generate-clip.ts. The clip is saved to tmpdir, then immediately deleted in the finally block before the sandbox attachment system can deliver it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
