### PR TITLE
Fix video attachment playback (accept 206 Partial Content)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -590,7 +590,7 @@ private func fetchAttachmentContent(gatewayBaseUrl: String, attachmentId: String
     request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
 
     let (data, response) = try await URLSession.shared.data(for: request)
-    guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+    guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
         let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
         log.error("Attachment fetch failed with HTTP \(statusCode) for \(attachmentId)")
         throw URLError(.badServerResponse)


### PR DESCRIPTION
## Summary
- Accept any 2xx status code (not just 200) when fetching attachment content in the macOS client
- Fixes video playback failing with NSURLErrorDomain -1011 because the server correctly returns 206 Partial Content for Range requests (video seeking), but the client rejected anything other than 200

## Original prompt
Fix video attachment playback in macOS client. Change `http.statusCode == 200` to `(200...299).contains(http.statusCode)` so that HTTP 206 Partial Content responses are accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
