### PR TITLE
feat: add findContactChannel lookup and promote contactChannelToMemberRecord to shared module

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -657,6 +657,59 @@ export function findContactByChannelExternalId(
 }
 
 /**
+ * Find a contact by channel external chat ID. This is the fallback lookup path
+ * when externalUserId is not available — matches by (type, externalChatId).
+ */
+export function findContactByChannelExternalChatId(
+  channelType: string,
+  externalChatId: string,
+): ContactWithChannels | null {
+  const db = getDb();
+  const channel = db
+    .select()
+    .from(contactChannels)
+    .where(
+      and(
+        eq(contactChannels.type, channelType),
+        eq(contactChannels.externalChatId, externalChatId),
+      ),
+    )
+    .get();
+  if (!channel) return null;
+  return getContact(channel.contactId);
+}
+
+/**
+ * Find a contact and matching channel by trying externalUserId first, then
+ * falling back to externalChatId. Mirrors the findMember lookup strategy.
+ */
+export function findContactChannel(params: {
+  channelType: string;
+  externalUserId?: string;
+  externalChatId?: string;
+}): { contact: ContactWithChannels; channel: ContactChannel } | null {
+  if (params.externalUserId) {
+    const contact = findContactByChannelExternalId(params.channelType, params.externalUserId);
+    if (contact) {
+      const ch = contact.channels.find(
+        (c) => c.type === params.channelType && c.externalUserId === params.externalUserId,
+      );
+      if (ch) return { contact, channel: ch };
+    }
+  }
+  if (params.externalChatId) {
+    const contact = findContactByChannelExternalChatId(params.channelType, params.externalChatId);
+    if (contact) {
+      const ch = contact.channels.find(
+        (c) => c.type === params.channelType && c.externalChatId === params.externalChatId,
+      );
+      if (ch) return { contact, channel: ch };
+    }
+  }
+  return null;
+}
+
+/**
  * Find the guardian contact and their specific channel entry for a given channel type.
  * This is the contacts-based equivalent of getGuardianBinding(assistantId, channel).
  * Returns null if no guardian contact has a channel of the specified type.

--- a/assistant/src/contacts/member-record-shim.ts
+++ b/assistant/src/contacts/member-record-shim.ts
@@ -1,0 +1,38 @@
+/**
+ * Synthesize an IngressMember-compatible record from a Contact + ContactChannel.
+ * This shim enables callers to adopt contacts-first lookups without changing
+ * the IngressMember interface or downstream consumers.
+ */
+import type { ContactWithChannels, ContactChannel } from './types.js';
+import type { IngressMember } from '../memory/ingress-member-store.js';
+import { DAEMON_INTERNAL_ASSISTANT_ID } from '../runtime/assistant-scope.js';
+
+export function contactChannelToMemberRecord(
+  contact: ContactWithChannels,
+  channel: ContactChannel,
+): IngressMember {
+  return {
+    id: channel.id,
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+    sourceChannel: channel.type,
+    externalUserId: channel.externalUserId,
+    externalChatId: channel.externalChatId,
+    displayName: contact.displayName,
+    username: null,
+    status:
+      channel.status === 'active' ? 'active'
+      : channel.status === 'pending' ? 'pending'
+      : channel.status === 'unverified' ? 'pending'
+      : channel.status === 'revoked' ? 'revoked'
+      : channel.status === 'blocked' ? 'blocked'
+      : 'active',
+    policy: channel.policy,
+    inviteId: channel.inviteId,
+    createdBySessionId: null,
+    revokedReason: channel.revokedReason,
+    blockedReason: channel.blockedReason,
+    lastSeenAt: channel.lastSeenAt,
+    createdAt: channel.createdAt,
+    updatedAt: channel.updatedAt ?? channel.createdAt,
+  };
+}

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -19,7 +19,8 @@ import {
   findGuardianForChannel,
   hasContacts,
 } from "../contacts/contact-store.js";
-import type { ContactChannel, ContactWithChannels } from "../contacts/types.js";
+import { contactChannelToMemberRecord } from "../contacts/member-record-shim.js";
+import type { ContactWithChannels } from "../contacts/types.js";
 import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import type { IngressMember } from "../memory/ingress-member-store.js";
 import { findMember } from "../memory/ingress-member-store.js";
@@ -110,50 +111,6 @@ export interface ResolveActorTrustInput {
   actorExternalId?: string;
   actorUsername?: string;
   actorDisplayName?: string;
-}
-
-// ---------------------------------------------------------------------------
-// Contact → IngressMember shim
-// ---------------------------------------------------------------------------
-
-/**
- * Synthesize an IngressMember-compatible record from a Contact + ContactChannel.
- * This enables the contacts-first path to populate memberRecord without changing
- * the ActorTrustContext interface or downstream consumers.
- */
-function contactChannelToMemberRecord(
-  contact: ContactWithChannels,
-  channel: ContactChannel,
-): IngressMember {
-  return {
-    id: channel.id,
-    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
-    sourceChannel: channel.type,
-    externalUserId: channel.externalUserId,
-    externalChatId: channel.externalChatId,
-    displayName: contact.displayName,
-    username: null,
-    status:
-      channel.status === "active"
-        ? "active"
-        : channel.status === "pending"
-          ? "pending"
-          : channel.status === "unverified"
-            ? "pending"
-            : channel.status === "revoked"
-              ? "revoked"
-              : channel.status === "blocked"
-                ? "blocked"
-                : "active",
-    policy: channel.policy,
-    inviteId: channel.inviteId,
-    createdBySessionId: null,
-    revokedReason: channel.revokedReason,
-    blockedReason: channel.blockedReason,
-    lastSeenAt: channel.lastSeenAt,
-    createdAt: channel.createdAt,
-    updatedAt: channel.updatedAt ?? channel.createdAt,
-  };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add findContactByChannelExternalChatId and findContactChannel convenience functions to contact-store.ts
- Extract contactChannelToMemberRecord from actor-trust-resolver.ts into a shared member-record-shim.ts module
- Update actor-trust-resolver.ts to import the shim from the shared module

Part of plan: legacy-table-removal.md (PR 1 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
