### PR TITLE
refactor: replace getActiveBinding with findGuardianForChannel in route handlers

### DIFF
--- a/assistant/src/runtime/guardian-vellum-migration.ts
+++ b/assistant/src/runtime/guardian-vellum-migration.ts
@@ -12,8 +12,8 @@
 
 import { v4 as uuid } from "uuid";
 
+import { findGuardianForChannel } from "../contacts/contact-store.js";
 import { createGuardianBindingContactsFirst } from "../contacts/contacts-write.js";
-import { getActiveBinding } from "../memory/guardian-bindings.js";
 import { getLogger } from "../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
 
@@ -29,13 +29,13 @@ const log = getLogger("guardian-vellum-migration");
 export function ensureVellumGuardianBinding(
   assistantId: string = DAEMON_INTERNAL_ASSISTANT_ID,
 ): string {
-  const existing = getActiveBinding(assistantId, "vellum");
-  if (existing) {
+  const guardianResult = findGuardianForChannel("vellum");
+  if (guardianResult && guardianResult.contact.principalId) {
     log.debug(
-      { assistantId, guardianPrincipalId: existing.guardianPrincipalId },
+      { assistantId, guardianPrincipalId: guardianResult.contact.principalId },
       "Vellum guardian binding already exists with principal",
     );
-    return existing.guardianPrincipalId;
+    return guardianResult.contact.principalId;
   }
 
   const guardianPrincipalId = `vellum-principal-${uuid()}`;

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -9,13 +9,12 @@
  * bound guardian.
  */
 import { isHttpAuthDisabled } from '../../config/env.js';
+import { findGuardianForChannel } from '../../contacts/contact-store.js';
 import { getConversationByKey } from '../../memory/conversation-key-store.js';
-import { getActiveBinding } from '../../memory/guardian-bindings.js';
 import { addRule } from '../../permissions/trust-store.js';
 import type { UserDecision } from '../../permissions/types.js';
 import { getTool } from '../../tools/registry.js';
 import { getLogger } from '../../util/logger.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import type { AuthContext } from '../auth/types.js';
 import { httpError } from '../http-errors.js';
 import * as pendingInteractions from '../pending-interactions.js';
@@ -35,12 +34,12 @@ function requireBoundGuardian(authContext: AuthContext): Response | null {
   if (!authContext.actorPrincipalId) {
     return httpError('FORBIDDEN', 'Actor is not the bound guardian for this channel', 403);
   }
-  const binding = getActiveBinding(DAEMON_INTERNAL_ASSISTANT_ID, 'vellum');
-  if (!binding) {
-    // No binding yet — in pre-bootstrap state, allow through
+  const guardianResult = findGuardianForChannel('vellum');
+  if (!guardianResult) {
+    // No guardian yet — in pre-bootstrap state, allow through
     return null;
   }
-  if (binding.guardianExternalUserId !== authContext.actorPrincipalId) {
+  if ((guardianResult.channel.externalUserId ?? guardianResult.contact.principalId) !== authContext.actorPrincipalId) {
     return httpError('FORBIDDEN', 'Actor is not the bound guardian for this channel', 403);
   }
   return null;

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -15,14 +15,13 @@ import {
   applyCanonicalGuardianDecision,
 } from '../../approvals/guardian-decision-primitive.js';
 import { isHttpAuthDisabled } from '../../config/env.js';
+import { findGuardianForChannel } from '../../contacts/contact-store.js';
 import {
   type CanonicalGuardianRequest,
   getCanonicalGuardianRequest,
   isRequestInConversationScope,
   listPendingRequestsByConversationScope,
 } from '../../memory/canonical-guardian-store.js';
-import { getActiveBinding } from '../../memory/guardian-bindings.js';
-import { DAEMON_INTERNAL_ASSISTANT_ID } from '../assistant-scope.js';
 import type { AuthContext } from '../auth/types.js';
 import type { ApprovalAction } from '../channel-approval-types.js';
 import type { GuardianDecisionPrompt } from '../guardian-decision-types.js';
@@ -69,12 +68,12 @@ function requireBoundGuardian(authContext: AuthContext): Response | null {
   if (!authContext.actorPrincipalId) {
     return httpError('FORBIDDEN', 'Actor is not the bound guardian for this channel', 403);
   }
-  const binding = getActiveBinding(DAEMON_INTERNAL_ASSISTANT_ID, 'vellum');
-  if (!binding) {
-    // No binding yet -- in pre-bootstrap state, allow through
+  const guardianResult = findGuardianForChannel('vellum');
+  if (!guardianResult) {
+    // No guardian yet — in pre-bootstrap state, allow through
     return null;
   }
-  if (binding.guardianExternalUserId !== authContext.actorPrincipalId) {
+  if ((guardianResult.channel.externalUserId ?? guardianResult.contact.principalId) !== authContext.actorPrincipalId) {
     return httpError('FORBIDDEN', 'Actor is not the bound guardian for this channel', 403);
   }
   return null;

--- a/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
+++ b/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
@@ -13,8 +13,8 @@ import { createHash } from "node:crypto";
 
 import { v4 as uuid } from "uuid";
 
+import { findGuardianForChannel } from "../../contacts/contact-store.js";
 import { createGuardianBindingContactsFirst } from "../../contacts/contacts-write.js";
-import { getActiveBinding } from "../../memory/guardian-bindings.js";
 import { getLogger } from "../../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { mintCredentialPair } from "../auth/credential-service.js";
@@ -44,10 +44,10 @@ function ensureGuardianPrincipal(assistantId: string): {
   guardianPrincipalId: string;
   isNew: boolean;
 } {
-  const existing = getActiveBinding(assistantId, "vellum");
-  if (existing) {
+  const guardianResult = findGuardianForChannel("vellum");
+  if (guardianResult && guardianResult.contact.principalId) {
     return {
-      guardianPrincipalId: existing.guardianExternalUserId,
+      guardianPrincipalId: guardianResult.contact.principalId,
       isNew: false,
     };
   }


### PR DESCRIPTION
## Summary
- Replace getActiveBinding with findGuardianForChannel in approval-routes, guardian-action-routes, guardian-bootstrap-routes, and guardian-vellum-migration
- All guardian lookups now use contacts-based findGuardianForChannel
- Pre-bootstrap behavior preserved (allow through when no guardian exists)

Part of plan: legacy-table-removal.md (PR 4 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
