### PR TITLE
refactor: remove getActiveBinding legacy fallbacks in notification and identity modules

### DIFF
--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -15,7 +15,6 @@ import {
   listCanonicalGuardianRequests,
   updateCanonicalGuardianDelivery,
 } from "../memory/canonical-guardian-store.js";
-import { getActiveBinding } from "../memory/guardian-bindings.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import type { NotificationDeliveryResult } from "../notifications/types.js";
 import { ensureVellumGuardianBinding } from "../runtime/guardian-vellum-migration.js";
@@ -99,41 +98,29 @@ async function dispatchGuardianQuestionInner(
     const expiresAt = Date.now() + getUserConsultationTimeoutMs();
 
     // Voice decisions are handled in guardian threads tied to the assistant-
-    // level guardian identity. Resolve the principal from the contacts-first
-    // path (canonical), falling back to the legacy vellum binding.
+    // level guardian identity. Resolve the principal from the contacts table.
     let guardianPrincipalId: string | undefined;
-    let resolvedViaContacts = false;
 
     const guardianResult = findGuardianForChannel("vellum");
     if (guardianResult?.contact.principalId) {
       guardianPrincipalId = guardianResult.contact.principalId;
-      resolvedViaContacts = true;
     }
 
-    // Legacy fallback: contacts not yet synced, or contact exists but
-    // principalId is null (partial/backfill sync state).
+    // Self-heal: if contacts don't have a principalId, bootstrap via
+    // ensureVellumGuardianBinding so the pending_question request can
+    // be attributed.
     if (!guardianPrincipalId) {
-      let vellumBinding = getActiveBinding(assistantId, "vellum");
-      guardianPrincipalId = vellumBinding?.guardianPrincipalId;
-
-      // Self-heal: if the vellum binding is missing, bootstrap it so
-      // the pending_question request can be attributed.
-      if (!guardianPrincipalId) {
-        log.info(
-          { callSessionId, assistantId, hadBinding: !!vellumBinding },
-          "Vellum binding missing — self-healing for voice dispatch",
-        );
-        const healedPrincipalId = ensureVellumGuardianBinding(assistantId);
-        vellumBinding = getActiveBinding(assistantId, "vellum");
-        guardianPrincipalId =
-          vellumBinding?.guardianPrincipalId ?? healedPrincipalId;
-      }
+      log.info(
+        { callSessionId, assistantId },
+        "No guardian principal from contacts — self-healing for voice dispatch",
+      );
+      guardianPrincipalId = ensureVellumGuardianBinding(assistantId);
     }
 
     if (!guardianPrincipalId) {
       log.error(
-        { callSessionId, assistantId, resolvedViaContacts },
-        "Voice guardian dispatch: no guardianPrincipalId after contacts + legacy fallback — cannot create pending_question",
+        { callSessionId, assistantId },
+        "Voice guardian dispatch: no guardianPrincipalId after contacts + self-heal — cannot create pending_question",
       );
       return;
     }

--- a/assistant/src/notifications/destination-resolver.ts
+++ b/assistant/src/notifications/destination-resolver.ts
@@ -1,22 +1,19 @@
 /**
  * Resolves per-channel destination endpoints for notification delivery.
  *
- * Uses a contacts-first approach: reads guardian delivery info from the
- * contacts table, falling back to the legacy channel-guardian bindings
- * when contacts have not yet been synced.
+ * Reads guardian delivery info from the contacts table.
  *
  * - Vellum: no external endpoint needed — delivery goes through the IPC
  *   broadcast mechanism to connected desktop/mobile clients. The
  *   guardianPrincipalId is included in metadata so downstream adapters
  *   can scope guardian-sensitive notifications to bound guardian devices.
  * - Binding-based channels (telegram, sms): require a chat/delivery ID
- *   sourced from the guardian contact's channel record (or legacy binding).
+ *   sourced from the guardian contact's channel record.
  */
 
 import { isNotificationDeliverable } from "../channels/config.js";
 import type { ChannelId } from "../channels/types.js";
 import { findGuardianForChannel } from "../contacts/contact-store.js";
-import { getActiveBinding } from "../memory/channel-guardian-store.js";
 import { getLogger } from "../util/logger.js";
 import type { ChannelDestination, NotificationChannel } from "./types.js";
 
@@ -51,12 +48,6 @@ export function resolveDestinations(
         const metadata: Record<string, unknown> = {};
         if (guardianResult) {
           metadata.guardianPrincipalId = guardianResult.contact.principalId;
-        } else {
-          // Legacy fallback: contacts not yet synced
-          const vellumBinding = getActiveBinding(assistantId, "vellum");
-          if (vellumBinding) {
-            metadata.guardianPrincipalId = vellumBinding.guardianExternalUserId;
-          }
         }
         result.set("vellum", {
           channel: "vellum",
@@ -65,7 +56,7 @@ export function resolveDestinations(
         log.debug(
           {
             channel: "vellum",
-            source: guardianResult ? "contacts" : "legacy",
+            source: "contacts",
             hasEndpoint: false,
           },
           "destination resolved",
@@ -75,10 +66,6 @@ export function resolveDestinations(
       case "telegram":
       case "sms": {
         const guardianResult = findGuardianForChannel(channel);
-        let binding: ReturnType<typeof getActiveBinding> = null;
-        // Only use the contacts path when the channel has a valid delivery
-        // endpoint. A partial contact record (active status but no
-        // externalChatId) should not block the legacy fallback.
         if (guardianResult && guardianResult.channel.externalChatId) {
           result.set(channel as NotificationChannel, {
             channel: channel as NotificationChannel,
@@ -87,28 +74,12 @@ export function resolveDestinations(
               externalUserId: guardianResult.channel.externalUserId,
             },
           });
-        } else {
-          // Legacy fallback: contacts not yet synced or missing endpoint
-          binding = getActiveBinding(assistantId, channel);
-          if (binding) {
-            result.set(channel as NotificationChannel, {
-              channel: channel as NotificationChannel,
-              endpoint: binding.guardianDeliveryChatId,
-              metadata: {
-                externalUserId: binding.guardianExternalUserId,
-              },
-            });
-          }
         }
         log.debug(
           {
             channel,
-            source: guardianResult?.channel.externalChatId
-              ? "contacts"
-              : "legacy",
-            hasEndpoint:
-              !!guardianResult?.channel.externalChatId ||
-              !!binding?.guardianDeliveryChatId,
+            source: "contacts",
+            hasEndpoint: !!guardianResult?.channel.externalChatId,
           },
           "destination resolved",
         );

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -13,7 +13,6 @@ import { v4 as uuid } from "uuid";
 
 import { getDeliverableChannels } from "../channels/config.js";
 import { findGuardianForChannel } from "../contacts/contact-store.js";
-import { getActiveBinding } from "../memory/channel-guardian-store.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
 import { type BroadcastFn, VellumAdapter } from "./adapters/macos.js";
@@ -116,12 +115,8 @@ function getConnectedChannels(assistantId: string): NotificationChannel[] {
         // externalChatId check ensures we don't report a channel as
         // connected when the contacts record exists but lacks the
         // delivery address the destination-resolver needs.
-        // Falls back to legacy binding check if contacts are not yet synced.
         const guardian = findGuardianForChannel(channel);
-        if (
-          (guardian && guardian.channel.externalChatId) ||
-          getActiveBinding(assistantId, channel)
-        ) {
+        if (guardian && guardian.channel.externalChatId) {
           channels.push(channel);
         }
         break;

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -15,7 +15,6 @@ import type { ChannelId } from "../channels/types.js";
 import { findGuardianForChannel } from "../contacts/contact-store.js";
 import { buildIpcAuthContext } from "../daemon/ipc-handler.js";
 import type { TrustContext } from "../daemon/session-runtime-assembly.js";
-import { getActiveBinding } from "../memory/guardian-bindings.js";
 import { getLogger } from "../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
 import type { AuthContext } from "./auth/types.js";
@@ -54,30 +53,17 @@ export function resolveLocalIpcTrustContext(
     return { ...trustCtx, sourceChannel };
   }
 
-  // Legacy fallback: contacts not yet synced
-  const binding = getActiveBinding(assistantId, "vellum");
-
-  if (!binding) {
-    // No vellum binding yet (pre-bootstrap). Eagerly create one.
-    log.debug(
-      "No vellum guardian binding found; bootstrapping binding for IPC",
-    );
-    const principalId = ensureVellumGuardianBinding(assistantId);
-    const trustCtx = resolveTrustContext({
-      assistantId,
-      sourceChannel: "vellum",
-      conversationExternalId: "local",
-      actorExternalId: principalId,
-    });
-    return { ...trustCtx, sourceChannel };
-  }
-
-  const guardianPrincipalId = binding.guardianExternalUserId;
+  // No guardian contact with a principalId — bootstrap via ensureVellumGuardianBinding
+  // to self-heal (creates the binding + contact if missing).
+  log.debug(
+    "No vellum guardian contact found; bootstrapping binding for IPC",
+  );
+  const principalId = ensureVellumGuardianBinding(assistantId);
   const trustCtx = resolveTrustContext({
     assistantId,
     sourceChannel: "vellum",
     conversationExternalId: "local",
-    actorExternalId: guardianPrincipalId,
+    actorExternalId: principalId,
   });
   return { ...trustCtx, sourceChannel };
 }
@@ -101,13 +87,6 @@ export function resolveLocalIpcAuthContext(sessionId: string): AuthContext {
       ...authContext,
       actorPrincipalId: guardianResult.contact.principalId,
     };
-  }
-
-  // Legacy fallback
-  const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
-  const binding = getActiveBinding(assistantId, "vellum");
-  if (binding) {
-    return { ...authContext, actorPrincipalId: binding.guardianExternalUserId };
   }
 
   return authContext;


### PR DESCRIPTION
## Summary
- Remove getActiveBinding legacy fallbacks from local-actor-identity.ts, destination-resolver.ts, emit-signal.ts, and guardian-dispatch.ts
- All guardian lookups now use findGuardianForChannel (contacts-based) exclusively
- Preserve self-healing behavior via ensureVellumGuardianBinding

Part of plan: legacy-table-removal.md (PR 2 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
