### PR TITLE
chore: add squash-merge hash to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,5 +1,5 @@
 # Bulk prettier formatting — formatting-only, no logic changes.
 # To use: git config blame.ignoreRevsFile .git-blame-ignore-revs
 
-# chore: bulk prettier format all TS source files
-# (hash will be the squash-merge commit on main)
+# chore: bulk prettier format all TS source files (#12093)
+cb76abd542b04840a29a7d259bb24397b15b15d0


### PR DESCRIPTION
## Summary
- Adds the actual squash-merge commit hash from #12093 to `.git-blame-ignore-revs` so `git blame` skips the bulk prettier formatting commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
