### PR TITLE
fix: mock notification pipeline in call-controller tests to prevent CI hangs

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -118,6 +118,19 @@ function createMockVoiceTurn(tokens: string[]) {
 
 let mockStartVoiceTurn: Mock<any>;
 
+// ── Notification pipeline mock (prevent async handle leaks from fire-and-forget dispatches) ──
+
+mock.module("../notifications/emit-signal.js", () => ({
+  emitNotificationSignal: async () => ({
+    signalId: "mock-signal",
+    deduplicated: false,
+    dispatched: true,
+    reason: "mocked",
+    deliveryResults: [],
+  }),
+  registerBroadcastFn: () => {},
+}));
+
 mock.module("../calls/voice-session-bridge.js", () => {
   mockStartVoiceTurn = mock(createMockVoiceTurn(["Hello", " there"]));
   return {


### PR DESCRIPTION
## Summary
- Mock `emitNotificationSignal` in call-controller tests to prevent leaked async handles from the notification pipeline
- The fire-and-forget `dispatchGuardianQuestion()` call runs the full notification pipeline (decision engine, broadcaster, channel delivery) which creates async work that outlives `controller.destroy()`, causing bun to hang on CI
- All 54 tests continue to pass — canonical guardian request creation still works since it happens before the mocked function is called

## Original prompt
fix this ci issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22652839255/job/65655805128

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
