### PR TITLE
refactor: replace findMember with contacts lookup in invite-redemption-service

### DIFF
--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -8,7 +8,9 @@
  */
 
 import type { ChannelId } from "../channels/types.js";
+import { findContactChannel } from "../contacts/contact-store.js";
 import { upsertMemberContactsFirst } from "../contacts/contacts-write.js";
+import { contactChannelToMemberRecord } from "../contacts/member-record-shim.js";
 import { getSqlite } from "../memory/db.js";
 import {
   findActiveVoiceInvites,
@@ -18,7 +20,6 @@ import {
   recordInviteUse,
   redeemInvite as storeRedeemInvite,
 } from "../memory/ingress-invite-store.js";
-import { findMember } from "../memory/ingress-member-store.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
 import { hashVoiceCode } from "../util/voice-code.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
@@ -123,12 +124,14 @@ export function redeemInvite(params: {
 
   // Token is valid — now safe to check existing membership without leaking
   // membership status to callers with bogus tokens.
-  const existingMember = findMember({
-    assistantId: assistantId ?? invite.assistantId,
-    sourceChannel,
-    externalUserId,
-    externalChatId,
+  const contactResult = findContactChannel({
+    channelType: sourceChannel,
+    externalUserId: externalUserId,
+    externalChatId: externalChatId,
   });
+  const existingMember = contactResult
+    ? contactChannelToMemberRecord(contactResult.contact, contactResult.channel)
+    : null;
 
   if (existingMember && existingMember.status === "active") {
     return { ok: true, type: "already_member", memberId: existingMember.id };
@@ -313,11 +316,13 @@ export function redeemVoiceInviteCode(params: {
   }
 
   // Check for existing membership
-  const existingMember = findMember({
-    assistantId: invite.assistantId,
-    sourceChannel: "voice",
+  const voiceContactResult = findContactChannel({
+    channelType: "voice",
     externalUserId: callerExternalUserId,
   });
+  const existingMember = voiceContactResult
+    ? contactChannelToMemberRecord(voiceContactResult.contact, voiceContactResult.channel)
+    : null;
 
   if (existingMember && existingMember.status === "active") {
     return { ok: true, type: "already_member", memberId: existingMember.id };


### PR DESCRIPTION
## Summary
- Replace both findMember calls with findContactChannel + contactChannelToMemberRecord
- Member existence and blocked status checks now use contacts-based lookups
- Remove findMember import from ingress-member-store

Part of plan: legacy-table-removal.md (PR 7 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
