### PR TITLE
refactor: remove legacy fallbacks in actor-trust-resolver, always use contacts

### DIFF
--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -3,9 +3,7 @@
  *
  * Produces a single trust-resolved actor context from raw inbound identity
  * fields. Normalizes sender identity via channel-agnostic canonicalization,
- * then resolves trust classification by checking contacts/contact_channels
- * first, falling back to legacy guardian_bindings/ingress_members tables
- * when contacts are empty (e.g., fresh install before first sync).
+ * then resolves trust classification via contacts/contact_channels.
  *
  * Trust classifications:
  * - `guardian`: sender matches the guardian contact's channel for this channel type.
@@ -17,17 +15,12 @@ import type { ChannelId } from "../channels/types.js";
 import {
   findContactByChannelExternalId,
   findGuardianForChannel,
-  hasContacts,
 } from "../contacts/contact-store.js";
 import { contactChannelToMemberRecord } from "../contacts/member-record-shim.js";
-import type { ContactWithChannels } from "../contacts/types.js";
 import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import type { IngressMember } from "../memory/ingress-member-store.js";
-import { findMember } from "../memory/ingress-member-store.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
 import { getLogger } from "../util/logger.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
-import { getGuardianBinding } from "./channel-guardian-service.js";
 
 const log = getLogger("actor-trust-resolver");
 
@@ -129,8 +122,6 @@ export interface ResolveActorTrustInput {
 export function resolveActorTrust(
   input: ResolveActorTrustInput,
 ): ActorTrustContext {
-  const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
-
   const rawUserId =
     typeof input.actorExternalId === "string" &&
     input.actorExternalId.trim().length > 0
@@ -179,21 +170,13 @@ export function resolveActorTrust(
     };
   }
 
-  // Skip contacts-first queries when the contacts table is empty.
-  // This avoids two JOIN queries per trust resolution call when no
-  // contact-sync has happened yet (fresh install, test environments).
-  const useContacts = hasContacts();
-
-  // --- Guardian lookup: contacts-first, legacy fallback ---
-  const guardianResult = useContacts
-    ? findGuardianForChannel(input.sourceChannel)
-    : null;
+  // --- Guardian lookup ---
+  const guardianResult = findGuardianForChannel(input.sourceChannel);
   let guardianBindingMatch: ActorTrustContext["guardianBindingMatch"] = null;
   let guardianPrincipalId: string | undefined;
   let isGuardian = false;
 
   if (guardianResult) {
-    // Contacts-based guardian resolution
     const { contact: guardianContact, channel: guardianChannel } =
       guardianResult;
     const canonicalGuardianId = guardianChannel.externalUserId
@@ -209,78 +192,49 @@ export function resolveActorTrust(
     guardianPrincipalId = guardianContact.principalId ?? undefined;
     isGuardian =
       canonicalGuardianId != null && canonicalGuardianId === canonicalSenderId;
-  } else {
-    // Legacy fallback: guardian binding not yet synced to contacts
-    const binding = getGuardianBinding(assistantId, input.sourceChannel);
-    if (binding) {
-      guardianBindingMatch = {
-        guardianExternalUserId: binding.guardianExternalUserId,
-        guardianDeliveryChatId: binding.guardianDeliveryChatId,
-      };
-      guardianPrincipalId = binding.guardianPrincipalId;
-      const canonicalGuardianId = canonicalizeInboundIdentity(
-        input.sourceChannel,
-        binding.guardianExternalUserId,
-      );
-      isGuardian = canonicalGuardianId === canonicalSenderId;
-    }
   }
 
   log.debug(
     {
       channel: input.sourceChannel,
-      source: guardianResult ? "contacts" : "legacy",
+      source: "contacts",
       found: !!guardianBindingMatch,
     },
     "trust-resolver guardian lookup",
   );
 
-  // --- Member lookup: contacts-first, legacy fallback ---
+  // --- Member lookup ---
   let memberRecord: IngressMember | null = null;
-  let contactMatch: ContactWithChannels | null = null;
-  if (useContacts) {
-    contactMatch = findContactByChannelExternalId(
-      input.sourceChannel,
-      canonicalSenderId,
+  const contactMatch = findContactByChannelExternalId(
+    input.sourceChannel,
+    canonicalSenderId,
+  );
+  if (contactMatch) {
+    const matchingChannel = contactMatch.channels.find(
+      (ch) =>
+        ch.type === input.sourceChannel &&
+        ch.externalUserId === canonicalSenderId,
     );
-    if (contactMatch) {
-      // Find the specific channel entry matching the sender's channel type + canonical ID
-      const matchingChannel = contactMatch.channels.find(
-        (ch) =>
-          ch.type === input.sourceChannel &&
-          ch.externalUserId === canonicalSenderId,
+    if (matchingChannel) {
+      memberRecord = contactChannelToMemberRecord(
+        contactMatch,
+        matchingChannel,
       );
-      if (matchingChannel) {
-        memberRecord = contactChannelToMemberRecord(
-          contactMatch,
-          matchingChannel,
-        );
-      }
     }
-  }
-  if (!memberRecord) {
-    // Legacy fallback: member not yet synced to contacts
-    memberRecord = findMember({
-      assistantId,
-      sourceChannel: input.sourceChannel,
-      externalUserId: canonicalSenderId,
-      externalChatId: input.conversationExternalId,
-    });
   }
 
   log.debug(
     {
       channel: input.sourceChannel,
       canonicalSenderId,
-      source: contactMatch ? "contacts" : "legacy",
+      source: "contacts",
       found: !!memberRecord,
     },
     "trust-resolver member lookup",
   );
 
-  // In group chats, findMember may match on externalChatId and return a
-  // record for a different user. Only use member metadata when the record's
-  // externalUserId matches the current sender to avoid misidentification.
+  // Only use member metadata when the record's externalUserId matches the
+  // current sender to avoid misidentification in group chats.
   // Canonicalize the stored member ID to handle formatting variance (e.g.
   // phone numbers stored without E.164 normalization).
   const memberMatchesSender = memberRecord?.externalUserId


### PR DESCRIPTION
## Summary
- Remove hasContacts() gate and useContacts conditional
- Always use findGuardianForChannel for guardian lookups (remove getGuardianBinding fallback)
- Always use findContactByChannelExternalId for member lookups (remove findMember fallback)
- Remove unused imports from ingress-member-store and channel-guardian-service
- Remove dead code: assistantId variable, ContactWithChannels import, DAEMON_INTERNAL_ASSISTANT_ID import

Part of plan: legacy-table-removal.md (PR 5 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
