### PR TITLE
fix: prevent CallController from creating timers after destroy()

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -204,6 +204,7 @@ export class CallController {
   private abortController: AbortController = new AbortController();
   private currentTurnHandle: VoiceTurnHandle | null = null;
   private currentTurnPromise: Promise<void> | null = null;
+  private destroyed = false;
   private silenceTimer: ReturnType<typeof setTimeout> | null = null;
   private durationTimer: ReturnType<typeof setTimeout> | null = null;
   private durationWarningTimer: ReturnType<typeof setTimeout> | null = null;
@@ -457,6 +458,7 @@ export class CallController {
    * Tear down all timers and abort any in-flight work.
    */
   destroy(): void {
+    this.destroyed = true;
     if (this.silenceTimer) clearTimeout(this.silenceTimer);
     if (this.durationTimer) clearTimeout(this.durationTimer);
     if (this.durationWarningTimer) clearTimeout(this.durationWarningTimer);
@@ -468,6 +470,7 @@ export class CallController {
       clearTimeout(this.durationEndTimer);
       this.durationEndTimer = null;
     }
+    this.pendingInstructions = [];
     this.llmRunVersion++;
     this.abortCurrentTurn();
     this.currentTurnPromise = null;
@@ -544,6 +547,7 @@ export class CallController {
   }
 
   private async runTurnInner(content: string): Promise<void> {
+    if (this.destroyed) return;
     const runVersion = ++this.llmRunVersion;
     const runSignal = this.abortController.signal;
 
@@ -1194,6 +1198,7 @@ export class CallController {
    * Drain any instructions that were queued while the LLM was active.
    */
   private flushPendingInstructions(): void {
+    if (this.destroyed) return;
     if (this.pendingInstructions.length === 0) return;
 
     const parts = this.pendingInstructions.map((instr) =>
@@ -1305,6 +1310,7 @@ export class CallController {
 
   private resetSilenceTimer(): void {
     if (this.silenceTimer) clearTimeout(this.silenceTimer);
+    if (this.destroyed) return;
     this.silenceTimer = setTimeout(() => {
       // During guardian wait states, the relay heartbeat timer handles
       // periodic updates — suppress the generic "Are you still there?"


### PR DESCRIPTION
## Summary
- Add a `destroyed` flag to `CallController` that gates `runTurnInner()`, `flushPendingInstructions()`, and `resetSilenceTimer()` — preventing orphaned timers from being created after `destroy()` is called
- Clear `pendingInstructions` in `destroy()` to prevent queued instructions from spawning new turns
- Fixes `call-controller.test.ts` hanging for 120s in CI (killed by per-test timeout due to open handles), which was consuming ~50% of the total test step time

## Original prompt
yeah can you investigate and merge a fix?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
