### PR TITLE
refactor: replace findMember with contacts lookup in relay-server and config-channels

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -13,16 +13,17 @@ import type { ServerWebSocket } from "bun";
 import { getConfig } from "../config/loader.js";
 import { resolveUserReference } from "../config/user-reference.js";
 import {
+  findContactChannel,
   findGuardianForChannel,
   listGuardianChannels,
 } from "../contacts/contact-store.js";
+import { contactChannelToMemberRecord } from "../contacts/member-record-shim.js";
 import { upsertMemberContactsFirst } from "../contacts/contacts-write.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import { getCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
 import { listActiveBindingsByAssistant } from "../memory/channel-guardian-store.js";
 import * as conversationStore from "../memory/conversation-store.js";
 import { findActiveVoiceInvites } from "../memory/ingress-invite-store.js";
-import { findMember } from "../memory/ingress-member-store.js";
 import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-grants.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import { notifyGuardianOfAccessRequest } from "../runtime/access-request-helper.js";
@@ -1770,12 +1771,14 @@ export class RelayConnection {
     let requesterMemberId: string | null = null;
     if (fromNumber) {
       try {
-        const member = findMember({
-          assistantId,
-          sourceChannel: "voice",
+        const contactResult = findContactChannel({
+          channelType: 'voice',
           externalUserId: fromNumber,
           externalChatId: fromNumber,
         });
+        const member = contactResult
+          ? contactChannelToMemberRecord(contactResult.contact, contactResult.channel)
+          : null;
         if (member && member.status === "active" && member.policy === "allow") {
           requesterMemberId = member.id;
         }

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -1,12 +1,13 @@
 import * as net from "node:net";
 
 import type { ChannelId } from "../../channels/types.js";
+import { findContactChannel } from "../../contacts/contact-store.js";
 import {
   revokeGuardianBindingContactsFirst,
   revokeMemberContactsFirst,
 } from "../../contacts/contacts-write.js";
+import { contactChannelToMemberRecord } from "../../contacts/member-record-shim.js";
 import * as externalConversationStore from "../../memory/external-conversation-store.js";
-import { findMember } from "../../memory/ingress-member-store.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
 import {
   createVerificationChallenge,
@@ -211,12 +212,14 @@ export function revokeGuardianForChannel(
 
   revokeGuardianBindingContactsFirst(assistantId, resolvedChannel);
 
-  const member = findMember({
-    assistantId,
-    sourceChannel: resolvedChannel,
+  const contactResult = findContactChannel({
+    channelType: resolvedChannel,
     externalUserId: bindingBeforeRevoke.guardianExternalUserId,
     externalChatId: bindingBeforeRevoke.guardianDeliveryChatId,
   });
+  const member = contactResult
+    ? contactChannelToMemberRecord(contactResult.contact, contactResult.channel)
+    : null;
   // Only revoke active/pending members — a blocked member must not be
   // downgraded to revoked (revokeMemberContactsFirst has its own guard,
   // but we check here to make the intent explicit at the call site).


### PR DESCRIPTION
## Summary
- Replace findMember calls with findContactChannel + contactChannelToMemberRecord in relay-server.ts and config-channels.ts
- Voice member lookup and guardian member lookup now use contacts-based lookups
- Remove findMember imports from ingress-member-store

Part of plan: legacy-table-removal.md (PR 8 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
