### PR TITLE
Open clips in default video player after generation

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/SKILL.md
+++ b/assistant/src/config/bundled-skills/media-processing/SKILL.md
@@ -200,7 +200,13 @@ Be specific and factual. Describe what you see, not what you infer happened betw
 
 ### Clip Delivery
 
-The `generate_clip` tool saves clips to the asset's pipeline directory (`pipeline/<assetId>/clips/`) so they persist for attachment delivery. The clip file path is included in the tool response for direct file access if needed.
+After `generate_clip` completes, **always open the clip in the user's default video player** using `host_bash`:
+
+```bash
+open "<clipPath>"
+```
+
+The `clipPath` field in the tool response is the absolute path to the clip file on disk. Present it to the user as: "Here's your clip — opening it now." followed by the `open` command. The clip is saved persistently in the asset's pipeline directory (`pipeline/<assetId>/clips/`) so it remains accessible after playback.
 
 ## Known Limitations — Vision Analysis
 


### PR DESCRIPTION
## Summary
- Update SKILL.md clip delivery guidance to instruct the assistant to always run `open <clipPath>` via host_bash after generating a clip
- The assistant presents "Here's your clip — opening it now" and launches the user's default video player
- Works around in-chat video playback issues with a better UX — native player with full controls

## Original prompt
Update the clip delivery guidance in SKILL.md so the assistant opens clips in the user's default video player after generating them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
