### PR TITLE
fix: add missing blank line in README architecture section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The platform has three main domains:
 - **Assistant runtime** (`assistant/`): Bun + TypeScript daemon that owns conversation history, attachment storage, and channel delivery state in a local SQLite database. Exposes a Unix domain socket (macOS) and optional TCP listener (iOS) for native clients, plus an HTTP API consumed by the gateway.
 - **Native clients** (`clients/`): Swift Package with macOS and iOS apps sharing ~45-50% of code via `VellumAssistantShared`. The macOS app is a menu bar assistant with computer-use (accessibility + CGEvent). The iOS app is a chat client supporting standalone mode (direct Anthropic API) and connected-to-Mac mode (TCP proxy through the daemon).
 - **Gateway** (`gateway/`): Standalone Bun + TypeScript service that serves as the public ingress boundary for all external webhooks and callbacks. Owns Telegram integration end-to-end (receives webhooks, routes to assistants, delivers replies). Routes Twilio voice and SMS webhooks, handles OAuth callbacks, and optionally acts as an authenticated reverse proxy for the assistant runtime API (client → gateway → runtime).
+
 Architecture docs are split by ownership domain: [`ARCHITECTURE.md`](ARCHITECTURE.md), [`assistant/ARCHITECTURE.md`](assistant/ARCHITECTURE.md), [`gateway/ARCHITECTURE.md`](gateway/ARCHITECTURE.md), and [`clients/ARCHITECTURE.md`](clients/ARCHITECTURE.md).
 
 </details>


### PR DESCRIPTION
Add blank line separator between Gateway bullet and Architecture docs paragraph to fix markdown rendering. Addresses feedback from PR #12005.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
