### PR TITLE
fix: add -k flag to timeout commands in test runner

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -98,9 +98,9 @@ printf '%s\n' "${test_files[@]}" | xargs -P "${WORKERS}" -I {} bash -c '
 
   if [[ -n "${timeout_cmd}" ]]; then
     if [[ "${exclude_exp}" == "true" ]]; then
-      "${timeout_cmd}" "${per_test_timeout}" bun test ${coverage_args} --test-name-pattern "^(?!.*\\[experimental\\])" "${test_file}" > "${out_file}" 2>&1
+      "${timeout_cmd}" -k 10 "${per_test_timeout}" bun test ${coverage_args} --test-name-pattern "^(?!.*\\[experimental\\])" "${test_file}" > "${out_file}" 2>&1
     else
-      "${timeout_cmd}" "${per_test_timeout}" bun test ${coverage_args} "${test_file}" > "${out_file}" 2>&1
+      "${timeout_cmd}" -k 10 "${per_test_timeout}" bun test ${coverage_args} "${test_file}" > "${out_file}" 2>&1
     fi
   else
     if [[ "${exclude_exp}" == "true" ]]; then


### PR DESCRIPTION
Add -k 10 to timeout-wrapped bun test calls to send SIGKILL as fallback if SIGTERM is caught/ignored by hung processes. Addresses feedback from PR #12082.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
