### PR TITLE
fix: prevent unhandled promise rejection in voice turn error path

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -684,6 +684,11 @@ export class CallController {
         );
       });
 
+      // Eagerly mark the rejection as handled so runtimes (e.g. bun) don't
+      // flag it as an unhandled rejection when onError fires synchronously
+      // inside the Promise constructor before this await adds its handler.
+      // The await below still re-throws, caught by the outer try-catch.
+      turnComplete.catch(() => {});
       await turnComplete;
       if (!this.isCurrentRun(runVersion)) return;
 


### PR DESCRIPTION
## Summary
- Add an eager `.catch(() => {})` on the `turnComplete` promise in `call-controller.ts` to mark rejections as handled before the `await` statement adds its handler
- This prevents bun:test from detecting a briefly-unhandled rejection when `onError` fires synchronously inside the Promise constructor, which was causing `call-controller.test.ts` to be marked `FAIL` despite all 54 individual tests passing
- The `await` below still re-throws, caught by the outer try-catch — no behavior change

## Original prompt
fix this failing job https://github.com/vellum-ai/vellum-assistant/actions/runs/22652839255/job/65655805128

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
