### PR TITLE
Auto-open clips in default video player after generation

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/SKILL.md
+++ b/assistant/src/config/bundled-skills/media-processing/SKILL.md
@@ -200,13 +200,7 @@ Be specific and factual. Describe what you see, not what you infer happened betw
 
 ### Clip Delivery
 
-After `generate_clip` completes, **always open the clip in the user's default video player** using `host_bash`:
-
-```bash
-open "<clipPath>"
-```
-
-The `clipPath` field in the tool response is the absolute path to the clip file on disk. Present it to the user as: "Here's your clip — opening it now." followed by the `open` command. The clip is saved persistently in the asset's pipeline directory (`pipeline/<assetId>/clips/`) so it remains accessible after playback.
+The `generate_clip` tool automatically opens clips in the user's default video player after extraction. Clips are saved persistently in the asset's pipeline directory (`pipeline/<assetId>/clips/`). The `clipPath` field in the tool response contains the absolute file path.
 
 ## Known Limitations — Vision Analysis
 

--- a/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
@@ -192,6 +192,9 @@ export async function run(
 
     context.onOutput?.(`Clip registered as attachment ${attachment.id}.\n`);
 
+    // Auto-open in the user's default video player (fire and forget)
+    spawnWithTimeout(["open", clipPath], 5000).catch(() => {});
+
     return {
       content: JSON.stringify(
         {


### PR DESCRIPTION
## Summary
- Add fire-and-forget `open <clipPath>` call in generate-clip.ts after successful clip extraction
- Clips now automatically open in the user's default video player (e.g. QuickTime)
- Update SKILL.md to reflect the auto-open behavior (remove manual `host_bash` instruction)

## Original prompt
Make the generate_clip tool auto-open clips in the default video player.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
