### PR TITLE
fix: forward compactionOptions through applyToolResultTruncation

### DIFF
--- a/assistant/src/daemon/context-overflow-reducer.ts
+++ b/assistant/src/daemon/context-overflow-reducer.ts
@@ -127,7 +127,7 @@ export async function reduceContextOverflow(
 
   // Tier 2: aggressive tool-result truncation
   if (!applied.includes("tool_result_truncation")) {
-    return applyToolResultTruncation(messages, config, applied);
+    return applyToolResultTruncation(messages, config, applied, state);
   }
 
   // Tier 3: media/file payload stubbing
@@ -196,6 +196,7 @@ function applyToolResultTruncation(
   messages: Message[],
   config: ReducerConfig,
   applied: ReducerTier[],
+  prevState: ReducerState | undefined,
 ): ReducerStepResult {
   const { messages: truncated, truncatedCount } =
     truncateToolResultsAcrossHistory(messages, OVERFLOW_TOOL_RESULT_MAX_CHARS);
@@ -213,8 +214,9 @@ function applyToolResultTruncation(
     tier: "tool_result_truncation",
     state: {
       appliedTiers: nextApplied,
-      injectionMode: "full",
+      injectionMode: prevState?.injectionMode ?? "full",
       toolResultMaxChars: OVERFLOW_TOOL_RESULT_MAX_CHARS,
+      compactionOptions: prevState?.compactionOptions,
       exhausted: false,
     },
     estimatedTokens,


### PR DESCRIPTION
Add prevState parameter to applyToolResultTruncation and forward compactionOptions/injectionMode to maintain consistent state forwarding across all reducer tiers. Addresses feedback from PR #12000.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
