### PR TITLE
fix: preserve deny-compression message in session history

### DIFF
--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -754,6 +754,8 @@ export async function runAgentLoopImpl(
 
     turnStarted = true;
 
+    let denyCompressionMessage: Message | null = null;
+
     let updatedHistory = await ctx.agentLoop.run(
       runMessages,
       eventHandler,
@@ -993,7 +995,7 @@ export async function runAgentLoopImpl(
               JSON.stringify(denyMessage.content),
               loopChannelMeta,
             );
-            ctx.messages.push(denyMessage);
+            denyCompressionMessage = denyMessage;
             onEvent({
               type: "assistant_text_delta",
               text: denyText,
@@ -1155,6 +1157,10 @@ export async function runAgentLoopImpl(
       const cleanedBlocks = cleanedContent as ContentBlock[];
       return { ...msg, content: cleanedBlocks };
     });
+
+    if (denyCompressionMessage) {
+      newMessages.push(denyCompressionMessage);
+    }
 
     const hasAssistantResponse = newMessages.some(
       (msg) => msg.role === "assistant",


### PR DESCRIPTION
Ensure the deny-path assistant message survives ctx.messages reconstruction after convergence, preventing history state mismatch. Addresses feedback from PR #12002.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
