### PR TITLE
fix: clamp minKeepRecentUserTurns to available user turns

### DIFF
--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -399,7 +399,10 @@ export class ContextWindowManager {
       targetInputTokensOverride?: number;
     },
   ): { keepFromIndex: number; keepTurns: number } {
-    const minFloor = opts?.minKeepRecentUserTurns ?? 1;
+    const minFloor = Math.min(
+      Math.max(0, Math.floor(opts?.minKeepRecentUserTurns ?? 1)),
+      userTurnStarts.length,
+    );
     const targetTokens =
       opts?.targetInputTokensOverride ?? this.config.targetInputTokens;
 


### PR DESCRIPTION
Clamp minKeepRecentUserTurns floor to [0, userTurnStarts.length] to prevent fallback to messages.length when the floor exceeds available turns. Addresses feedback from PR #11991.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
