### PR TITLE
fix: invalidate contacts cache on database reset

### DIFF
--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -14,6 +14,7 @@
 import { Database } from "bun:sqlite";
 
 import { invalidateConfigCache } from "../../config/loader.js";
+import { invalidateContactsCache } from "../../contacts/contact-store.js";
 import { resetDb } from "../../memory/db-connection.js";
 import { getLogger } from "../../util/logger.js";
 import { getDbPath, getWorkspaceConfigPath } from "../../util/platform.js";
@@ -54,7 +55,7 @@ export async function handleMigrationValidate(req: Request): Promise<Response> {
         return httpError(
           "BAD_REQUEST",
           'Multipart upload requires a "file" field',
-          400,
+          400
         );
       }
       fileData = new Uint8Array(await file.arrayBuffer());
@@ -77,7 +78,7 @@ export async function handleMigrationValidate(req: Request): Promise<Response> {
     return httpError(
       "BAD_REQUEST",
       "Request body is empty — a .vbundle file is required",
-      400,
+      400
     );
   }
 
@@ -94,7 +95,7 @@ export async function handleMigrationValidate(req: Request): Promise<Response> {
     return httpError(
       "INTERNAL_ERROR",
       err instanceof Error ? err.message : "Unexpected validation error",
-      500,
+      500
     );
   }
 }
@@ -150,7 +151,7 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
         } catch (err) {
           log.warn(
             { err },
-            "WAL checkpoint failed — exporting without checkpoint",
+            "WAL checkpoint failed — exporting without checkpoint"
           );
         }
       },
@@ -161,7 +162,7 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
 
     const body = archive.buffer.slice(
       archive.byteOffset,
-      archive.byteOffset + archive.byteLength,
+      archive.byteOffset + archive.byteLength
     ) as ArrayBuffer;
 
     return new Response(body, {
@@ -179,7 +180,7 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
     return httpError(
       "INTERNAL_ERROR",
       err instanceof Error ? err.message : "Unexpected export error",
-      500,
+      500
     );
   }
 }
@@ -191,7 +192,7 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
  * Shared between validate and import-preflight handlers.
  */
 async function extractFileData(
-  req: Request,
+  req: Request
 ): Promise<{ data: Uint8Array } | { error: Response }> {
   const contentType = req.headers.get("content-type") ?? "";
 
@@ -204,7 +205,7 @@ async function extractFileData(
           error: httpError(
             "BAD_REQUEST",
             'Multipart upload requires a "file" field',
-            400,
+            400
           ),
         };
       }
@@ -256,7 +257,7 @@ async function extractFileData(
  * Auth: Requires settings.write scope. Allowed for actor, svc_gateway, ipc.
  */
 export async function handleMigrationImportPreflight(
-  req: Request,
+  req: Request
 ): Promise<Response> {
   const extracted = await extractFileData(req);
   if ("error" in extracted) {
@@ -268,7 +269,7 @@ export async function handleMigrationImportPreflight(
     return httpError(
       "BAD_REQUEST",
       "Request body is empty — a .vbundle file is required",
-      400,
+      400
     );
   }
 
@@ -289,7 +290,7 @@ export async function handleMigrationImportPreflight(
     // Step 2: Analyze what would change on import
     const pathResolver = new DefaultPathResolver(
       getDbPath(),
-      getWorkspaceConfigPath(),
+      getWorkspaceConfigPath()
     );
 
     const report = analyzeImport({
@@ -303,7 +304,7 @@ export async function handleMigrationImportPreflight(
     return httpError(
       "INTERNAL_ERROR",
       err instanceof Error ? err.message : "Unexpected import preflight error",
-      500,
+      500
     );
   }
 }
@@ -351,7 +352,7 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
     return httpError(
       "BAD_REQUEST",
       "Request body is empty — a .vbundle file is required",
-      400,
+      400
     );
   }
 
@@ -371,12 +372,13 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
 
     const pathResolver = new DefaultPathResolver(
       getDbPath(),
-      getWorkspaceConfigPath(),
+      getWorkspaceConfigPath()
     );
 
     // Close the live SQLite connection before overwriting assistant.db on disk.
     // The singleton will be lazily reopened on the next getDb() call.
     resetDb();
+    invalidateContactsCache();
 
     const result = commitImport({
       archiveData: fileData,
@@ -401,7 +403,7 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
             reason: "extraction_failed",
             message: result.message,
           },
-          { status: 500 },
+          { status: 500 }
         );
       }
 
@@ -415,7 +417,7 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
             ? { partial_report: result.partial_report }
             : {}),
         },
-        { status: 500 },
+        { status: 500 }
       );
     }
 
@@ -428,7 +430,7 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
     return httpError(
       "INTERNAL_ERROR",
       err instanceof Error ? err.message : "Unexpected import error",
-      500,
+      500
     );
   }
 }


### PR DESCRIPTION
Invalidate the contacts-populated memoization cache when the migration import flow calls resetDb(). Without this, a cached false from hasContacts() survives DB replacement, causing resolveActorTrust() to skip contacts-first lookups after importing a database with contacts. Addresses feedback from PR #11993.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
