### PR TITLE
Fix clip auto-open in bundled daemon

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
@@ -192,8 +192,12 @@ export async function run(
 
     context.onOutput?.(`Clip registered as attachment ${attachment.id}.\n`);
 
-    // Auto-open in the user's default video player (fire and forget)
-    spawnWithTimeout(["open", clipPath], 5000).catch(() => {});
+    // Auto-open in the user's default video player (fire and forget).
+    // Use absolute path — the bundled daemon may not have `open` on its PATH.
+    Bun.spawn(["/usr/bin/open", clipPath], {
+      stdout: "ignore",
+      stderr: "ignore",
+    });
 
     return {
       content: JSON.stringify(


### PR DESCRIPTION
## Summary
- Use `/usr/bin/open` (absolute path) and `Bun.spawn` directly instead of `spawnWithTimeout(["open", ...])` for auto-opening clips
- The bundled daemon binary doesn't have `open` on its PATH, so the relative command silently failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
