### PR TITLE
fix: handle exit code 137 (SIGKILL) as timeout in test runner

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -115,7 +115,7 @@ printf '%s\n' "${test_files[@]}" | xargs -P "${WORKERS}" -I {} bash -c '
   elapsed=$(( end_ms - start_ms ))
 
   base="$(basename "${test_file}")"
-  if [[ ${exit_code} -eq 124 ]]; then
+  if [[ ${exit_code} -eq 124 || ${exit_code} -eq 137 ]]; then
     # timeout killed the process — tests likely passed but bun did not exit (open handles)
     echo "${test_file}" >> "${results_dir}/failures"
     echo "  ⚠ ${base} (killed after ${per_test_timeout}s — process hung, likely open handles)"


### PR DESCRIPTION
When `-k 10` triggers SIGKILL on a hung process, `timeout` returns exit code 137 instead of 124. Update the exit code check to recognize both codes as timeout conditions so hung processes are correctly reported as timeouts, not generic test failures.

Addresses feedback from PR #12104.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
