### PR TITLE
perf: increase CI test workers from 4 to 8

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -58,7 +58,7 @@ jobs:
 
           [ $TSC_RC -eq 0 ] && [ $LINT_RC -eq 0 ] && [ $TEST_RC -eq 0 ]
         env:
-          TEST_WORKERS: '4'
+          TEST_WORKERS: '8'
 
       - name: Track consecutive failures
         if: always()

--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -52,6 +52,7 @@ jobs:
         run: bun run test
         env:
           EXCLUDE_EXPERIMENTAL: 'true'
+          TEST_WORKERS: '8'
 
       - name: Zip assistant artifact
         run: zip -r ../assistant-pr-${{ github.event.pull_request.number }}.zip . -x "node_modules/*"


### PR DESCRIPTION
## Summary
- Increase `TEST_WORKERS` from 4 to 8 in `ci-main-assistant.yaml`
- Add `TEST_WORKERS: '8'` to `pr-assistant.yaml` test step (was using default CPU count = 2)
- Tests are I/O-bound (SQLite + mocks), not CPU-bound, so oversubscribing is safe

## Original prompt
1 2 3 and 4 in separate PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
