### PR TITLE
fix: canonicalize IDs and restore legacy fallback in invite redemption

### DIFF
--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -20,6 +20,7 @@ import {
   recordInviteUse,
   redeemInvite as storeRedeemInvite,
 } from "../memory/ingress-invite-store.js";
+import { findMember } from "../memory/ingress-member-store.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
 import { hashVoiceCode } from "../util/voice-code.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
@@ -124,14 +125,24 @@ export function redeemInvite(params: {
 
   // Token is valid — now safe to check existing membership without leaking
   // membership status to callers with bogus tokens.
+  const canonicalUserId = externalUserId
+    ? canonicalizeInboundIdentity(sourceChannel as ChannelId, externalUserId) ?? externalUserId
+    : undefined;
   const contactResult = findContactChannel({
     channelType: sourceChannel,
-    externalUserId: externalUserId,
+    externalUserId: canonicalUserId,
     externalChatId: externalChatId,
   });
+  // Fall back to legacy assistant_ingress_members table when contacts lookup
+  // misses — contacts may not be synced yet for all members during migration.
   const existingMember = contactResult
     ? contactChannelToMemberRecord(contactResult.contact, contactResult.channel)
-    : null;
+    : findMember({
+        assistantId: assistantId ?? invite.assistantId,
+        sourceChannel,
+        externalUserId,
+        externalChatId,
+      });
 
   if (existingMember && existingMember.status === "active") {
     return { ok: true, type: "already_member", memberId: existingMember.id };
@@ -316,13 +327,21 @@ export function redeemVoiceInviteCode(params: {
   }
 
   // Check for existing membership
+  const canonicalCallerId =
+    canonicalizeInboundIdentity("voice" as ChannelId, callerExternalUserId) ?? callerExternalUserId;
   const voiceContactResult = findContactChannel({
     channelType: "voice",
-    externalUserId: callerExternalUserId,
+    externalUserId: canonicalCallerId,
   });
+  // Fall back to legacy assistant_ingress_members table when contacts lookup
+  // misses — contacts may not be synced yet for all members during migration.
   const existingMember = voiceContactResult
     ? contactChannelToMemberRecord(voiceContactResult.contact, voiceContactResult.channel)
-    : null;
+    : findMember({
+        assistantId: invite.assistantId,
+        sourceChannel: "voice",
+        externalUserId: callerExternalUserId,
+      });
 
   if (existingMember && existingMember.status === "active") {
     return { ok: true, type: "already_member", memberId: existingMember.id };


### PR DESCRIPTION
## Summary
- Canonicalize externalUserId before contacts lookup in redeemInvite and redeemVoiceInviteCode
- Restore legacy findMember fallback when contacts lookup misses
- Prevents blocked user bypass and missed already_member detection during migration

Addresses feedback from #12096
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
