### PR TITLE
perf: use 4-core runners for assistant CI

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   checks:
     name: Lint, Type Check & Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     timeout-minutes: 15
     defaults:
       run:

--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -15,7 +15,7 @@ jobs:
   checks:
     if: contains(github.event.pull_request.labels.*.name, 'preview')
     name: Lint, Type Check & Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     timeout-minutes: 15
     defaults:
       run:


### PR DESCRIPTION
## Summary
- Switch `runs-on` from `ubuntu-latest` (2 vCPU) to `ubuntu-latest-4-cores` in both `ci-main-assistant.yaml` and `pr-assistant.yaml`
- More cores = faster tsc/lint + better parallelism for test workers
- Requires GitHub Team/Enterprise plan (standard larger runners)

## Original prompt
1 2 3 and 4 in separate PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
