### PR TITLE
fix: restore legacy member fallback in actor trust resolver

### DIFF
--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -3,7 +3,9 @@
  *
  * Produces a single trust-resolved actor context from raw inbound identity
  * fields. Normalizes sender identity via channel-agnostic canonicalization,
- * then resolves trust classification via contacts/contact_channels.
+ * then resolves trust classification by checking contacts/contact_channels
+ * first, falling back to the legacy assistant_ingress_members table when
+ * contacts sync has not yet propagated a record.
  *
  * Trust classifications:
  * - `guardian`: sender matches the guardian contact's channel for this channel type.
@@ -19,6 +21,8 @@ import {
 import { contactChannelToMemberRecord } from "../contacts/member-record-shim.js";
 import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import type { IngressMember } from "../memory/ingress-member-store.js";
+import { findMember } from "../memory/ingress-member-store.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
 import { getLogger } from "../util/logger.js";
 
@@ -203,7 +207,7 @@ export function resolveActorTrust(
     "trust-resolver guardian lookup",
   );
 
-  // --- Member lookup ---
+  // --- Member lookup: contacts-first, legacy fallback ---
   let memberRecord: IngressMember | null = null;
   const contactMatch = findContactByChannelExternalId(
     input.sourceChannel,
@@ -222,12 +226,23 @@ export function resolveActorTrust(
       );
     }
   }
+  if (!memberRecord) {
+    // Legacy fallback: contacts sync is best-effort and can fail silently,
+    // so an active trusted contact may exist in assistant_ingress_members
+    // without a corresponding contacts row.
+    memberRecord = findMember({
+      assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+      sourceChannel: input.sourceChannel,
+      externalUserId: canonicalSenderId,
+      externalChatId: input.conversationExternalId,
+    });
+  }
 
   log.debug(
     {
       channel: input.sourceChannel,
       canonicalSenderId,
-      source: "contacts",
+      source: contactMatch ? "contacts" : "legacy",
       found: !!memberRecord,
     },
     "trust-resolver member lookup",


### PR DESCRIPTION
## Summary
- Restore findMember fallback when findContactByChannelExternalId returns null
- Prevents active trusted contacts from being classified as unknown during sync failures
- Follows contacts-first, legacy fallback pattern

Addresses feedback from #12098
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
