### PR TITLE
fix: restore legacy fallback and synthesize metadataJson in getGuardianBinding

### DIFF
--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -22,6 +22,8 @@ import type {
   VerificationPurpose,
 } from "../memory/channel-guardian-store.js";
 import {
+  getActiveBinding,
+  revokeBinding as legacyRevokeBinding,
   bindSessionIdentity as storeBindSessionIdentity,
   consumeChallenge,
   countRecentSendsToDestination as storeCountRecentSendsToDestination,
@@ -378,29 +380,38 @@ export function validateAndConsumeChallenge(
 
 /**
  * Look up the active guardian binding for a given assistant and channel.
- * Reads from the contacts table via findGuardianForChannel and synthesizes
- * a GuardianBinding-shaped object for backward compatibility.
+ * Reads from the contacts table via findGuardianForChannel first and
+ * synthesizes a GuardianBinding-shaped object for backward compatibility.
+ * Falls back to the legacy channelGuardianBindings table when the contacts
+ * lookup returns nothing — this covers bindings where the contacts-write
+ * failed but the legacy row was still persisted.
  */
 export function getGuardianBinding(
   assistantId: string,
   channel: string,
 ): GuardianBinding | null {
   const result = findGuardianForChannel(channel);
-  if (!result) return null;
-  return {
-    id: result.channel.id,
-    assistantId,
-    channel,
-    guardianExternalUserId: result.channel.externalUserId ?? '',
-    guardianDeliveryChatId: result.channel.externalChatId ?? '',
-    guardianPrincipalId: result.contact.principalId ?? '',
-    status: 'active' as const,
-    verifiedAt: result.channel.verifiedAt ?? 0,
-    verifiedVia: result.channel.verifiedVia ?? '',
-    metadataJson: null,
-    createdAt: result.channel.createdAt,
-    updatedAt: result.channel.updatedAt ?? result.channel.createdAt,
-  };
+  if (result) {
+    return {
+      id: result.channel.id,
+      assistantId,
+      channel,
+      guardianExternalUserId: result.channel.externalUserId ?? '',
+      guardianDeliveryChatId: result.channel.externalChatId ?? '',
+      guardianPrincipalId: result.contact.principalId ?? '',
+      status: 'active' as const,
+      verifiedAt: result.channel.verifiedAt ?? 0,
+      verifiedVia: result.channel.verifiedVia ?? '',
+      metadataJson: result.contact.displayName
+        ? JSON.stringify({ displayName: result.contact.displayName })
+        : null,
+      createdAt: result.channel.createdAt,
+      updatedAt: result.channel.updatedAt ?? result.channel.createdAt,
+    };
+  }
+
+  // Legacy fallback: contacts write may have failed but the legacy row exists
+  return getActiveBinding(assistantId, channel);
 }
 
 /**
@@ -413,14 +424,24 @@ export function isGuardian(
   externalUserId: string,
 ): boolean {
   const result = findGuardianForChannel(channel);
-  return result != null && result.channel.externalUserId === externalUserId;
+  if (result) {
+    return result.channel.externalUserId === externalUserId;
+  }
+
+  // Legacy fallback for bindings where contacts write failed
+  const legacyBinding = getActiveBinding(assistantId, channel);
+  return legacyBinding != null && legacyBinding.guardianExternalUserId === externalUserId;
 }
 
 /**
  * Revoke the active guardian binding for a given assistant and channel.
+ * Revokes both the contacts entry and the legacy channelGuardianBindings row
+ * so that the legacy fallback in getGuardianBinding does not resurface it.
  */
 export function revokeBinding(assistantId: string, channel: string): boolean {
-  return revokeGuardianBindingContactsFirst(assistantId, channel);
+  const contactsRevoked = revokeGuardianBindingContactsFirst(assistantId, channel);
+  const legacyRevoked = legacyRevokeBinding(assistantId, channel);
+  return contactsRevoked || legacyRevoked;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Restore getActiveBinding fallback when findGuardianForChannel returns null
- Synthesize metadataJson from contact displayName instead of hardcoding null
- Also revoke legacy table in revokeBinding to prevent stale fallback reads
- Ensures legacy-only bindings are still visible during migration

Addresses feedback from #12090
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
