### PR TITLE
fix: only treat exit code 137 as timeout when timeout command is used

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -115,7 +115,7 @@ printf '%s\n' "${test_files[@]}" | xargs -P "${WORKERS}" -I {} bash -c '
   elapsed=$(( end_ms - start_ms ))
 
   base="$(basename "${test_file}")"
-  if [[ ${exit_code} -eq 124 || ${exit_code} -eq 137 ]]; then
+  if [[ ${exit_code} -eq 124 || ( -n "${timeout_cmd}" && ${exit_code} -eq 137 ) ]]; then
     # timeout killed the process — tests likely passed but bun did not exit (open handles)
     echo "${test_file}" >> "${results_dir}/failures"
     echo "  ⚠ ${base} (killed after ${per_test_timeout}s — process hung, likely open handles)"


### PR DESCRIPTION
Guard the exit code 137 check with -n timeout_cmd so SIGKILL from non-timeout sources (OOM killer, external kill) is not misreported as a timeout. Addresses feedback from PR #12113.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
