### PR TITLE
perf: split assistant CI into parallel lint, typecheck, and test jobs

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -9,14 +9,43 @@ on:
       - '.github/workflows/ci-main-assistant.yaml'
 
 jobs:
-  checks:
-    name: Lint, Type Check & Test
-    runs-on: ubuntu-latest-4-cores
-    timeout-minutes: 15
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: assistant
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.9'
+
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('assistant/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun run lint
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: assistant
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,25 +75,38 @@ jobs:
       - name: Verify Swift decoder is in sync with contract
         run: bun run ipc:check-swift-drift
 
-      - name: Lint, Type check & Test
-        run: |
-          set +e
-          bunx tsc --noEmit &
-          TSC_PID=$!
-          bun run lint &
-          LINT_PID=$!
-          bun run test:stable &
-          TEST_PID=$!
+      - name: Type check
+        run: bunx tsc --noEmit
 
-          TSC_RC=0;  wait $TSC_PID  || TSC_RC=$?
-          LINT_RC=0; wait $LINT_PID || LINT_RC=$?
-          TEST_RC=0; wait $TEST_PID || TEST_RC=$?
+  test:
+    name: Test
+    runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: assistant
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-          if [ $TSC_RC -ne 0 ];  then echo "::error::Type check failed (exit $TSC_RC)"; fi
-          if [ $LINT_RC -ne 0 ]; then echo "::error::Lint failed (exit $LINT_RC)"; fi
-          if [ $TEST_RC -ne 0 ]; then echo "::error::Tests failed (exit $TEST_RC)"; fi
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.9'
 
-          [ $TSC_RC -eq 0 ] && [ $LINT_RC -eq 0 ] && [ $TEST_RC -eq 0 ]
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('assistant/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Test
+        run: bun run test:stable
         env:
           TEST_WORKERS: '8'
 
@@ -105,7 +147,7 @@ jobs:
 
   notify:
     name: Slack Notification
-    needs: [checks]
+    needs: [lint, typecheck, test]
     if: always()
     continue-on-error: true
     runs-on: ubuntu-latest
@@ -118,11 +160,11 @@ jobs:
         run: |
           GITHUB_USER="${{ github.actor }}"
 
-          if [[ "${{ needs.checks.result }}" == "failure" ]]; then
+          if [[ "${{ needs.lint.result }}" == "failure" || "${{ needs.typecheck.result }}" == "failure" || "${{ needs.test.result }}" == "failure" ]]; then
             STATUS="failure"
-          elif [[ "${{ needs.checks.result }}" == "cancelled" ]]; then
+          elif [[ "${{ needs.lint.result }}" == "cancelled" || "${{ needs.typecheck.result }}" == "cancelled" || "${{ needs.test.result }}" == "cancelled" ]]; then
             STATUS="cancelled"
-          elif [[ "${{ needs.checks.result }}" == "skipped" ]]; then
+          elif [[ "${{ needs.lint.result }}" == "skipped" || "${{ needs.typecheck.result }}" == "skipped" || "${{ needs.test.result }}" == "skipped" ]]; then
             STATUS="skipped"
           else
             STATUS="success"

--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -12,15 +12,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  checks:
+  lint:
     if: contains(github.event.pull_request.labels.*.name, 'preview')
-    name: Lint, Type Check & Test
-    runs-on: ubuntu-latest-4-cores
-    timeout-minutes: 15
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: assistant
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.9'
+
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('assistant/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun run lint
+
+  typecheck:
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
+    name: Type Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: assistant
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -53,14 +83,52 @@ jobs:
       - name: Type check
         run: bunx tsc --noEmit
 
-      - name: Lint
-        run: bun run lint
+  test:
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
+    name: Test
+    runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: assistant
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.9'
+
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('assistant/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Test
         run: bun run test
         env:
           EXCLUDE_EXPERIMENTAL: 'true'
           TEST_WORKERS: '8'
+
+  artifact:
+    name: Upload Artifact
+    needs: [lint, typecheck, test]
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        working-directory: assistant
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Zip assistant artifact
         run: zip -r ../assistant-pr-${{ github.event.pull_request.number }}.zip . -x "node_modules/*"


### PR DESCRIPTION
## Summary
- Split monolithic `checks` job into 3 parallel jobs: `lint`, `typecheck`, `test` in both `ci-main-assistant.yaml` and `pr-assistant.yaml`
- Lint and typecheck use `ubuntu-latest` (2-core, cheaper — they're single-threaded)
- Tests use `ubuntu-latest-4-cores` (dedicated runner for parallel test workers)
- PR workflow: moved artifact upload/comment to a separate `artifact` job that runs after all checks pass
- Main workflow: updated `notify` and `track-failures` to check all 3 job results

This eliminates CPU contention between lint/typecheck/test — each gets its own runner. The PR workflow benefits most since checks were previously sequential.

## Original prompt
1 2 3 and 4 in separate PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
