### PR TITLE
fix: use legacy member IDs for revoke/block in config-channels and relay-server

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -210,8 +210,10 @@ export function revokeGuardianForChannel(
     };
   }
 
-  revokeGuardianBindingContactsFirst(assistantId, resolvedChannel);
-
+  // Look up the member channel BEFORE revoking the guardian binding so the
+  // channel status is still active/pending — revokeGuardianBindingContactsFirst
+  // marks the channel as revoked, which would cause the status guard below to
+  // skip the revoke call.
   const contactResult = findContactChannel({
     channelType: resolvedChannel,
     externalUserId: bindingBeforeRevoke.guardianExternalUserId,
@@ -220,6 +222,9 @@ export function revokeGuardianForChannel(
   const member = contactResult
     ? contactChannelToMemberRecord(contactResult.contact, contactResult.channel)
     : null;
+
+  revokeGuardianBindingContactsFirst(assistantId, resolvedChannel);
+
   // Only revoke active/pending members — a blocked member must not be
   // downgraded to revoked (revokeMemberContactsFirst has its own guard,
   // but we check here to make the intent explicit at the call site).


### PR DESCRIPTION
## Summary
- Fix member ID mismatch: use legacy ingress member IDs for revoke/block operations
- Look up member before guardian revocation to avoid status guard issues
- Ensures guardian unbinding correctly cascades to ingress member revocation

Addresses feedback from #12100
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
