### PR TITLE
Auto-open clips from Swift client (NSWorkspace)

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
@@ -192,13 +192,6 @@ export async function run(
 
     context.onOutput?.(`Clip registered as attachment ${attachment.id}.\n`);
 
-    // Auto-open in the user's default video player (fire and forget).
-    // Use absolute path — the bundled daemon may not have `open` on its PATH.
-    Bun.spawn(["/usr/bin/open", clipPath], {
-      stdout: "ignore",
-      stderr: "ignore",
-    });
-
     return {
       content: JSON.stringify(
         {

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1277,6 +1277,15 @@ extension ChatViewModel {
                     }
                 }
             }
+            // Auto-open clip files in the default video player
+            if let msgIndex = targetMsgIndex, let tcIndex = targetTcIndex {
+                autoOpenClipIfNeeded(
+                    toolName: messages[msgIndex].toolCalls[tcIndex].toolName,
+                    result: msg.result,
+                    isError: msg.isError ?? false
+                )
+            }
+
             // Tool completed — don't re-show "Thinking..." here. The tool
             // call chip already indicates activity, and the LLM isn't actually
             // thinking yet. isThinking will be set when the user sends a new
@@ -1625,5 +1634,22 @@ extension ChatViewModel {
         default:
             break
         }
+    }
+
+    /// Auto-open generated video clips in the user's default video player.
+    private func autoOpenClipIfNeeded(toolName: String, result: String, isError: Bool) {
+        guard !isError, toolName == "generate_clip" else { return }
+        guard let jsonData = result.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+              let clipPath = json["clipPath"] as? String else {
+            return
+        }
+        guard FileManager.default.fileExists(atPath: clipPath) else {
+            log.warning("Clip file not found at path, skipping auto-open")
+            return
+        }
+        #if os(macOS)
+        NSWorkspace.shared.open(URL(fileURLWithPath: clipPath))
+        #endif
     }
 }


### PR DESCRIPTION
## Summary
- Add `autoOpenClipIfNeeded()` in ChatViewModel+MessageHandling.swift that parses the `clipPath` from `generate_clip` tool results and opens it via `NSWorkspace.shared.open()`
- Remove the dead `Bun.spawn(["/usr/bin/open", ...])` from generate-clip.ts (didn't work from bundled daemon)
- The Swift app process has full access to NSWorkspace, so `open` works reliably
- Gated behind `#if os(macOS)` for future iOS compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
