### PR TITLE
fix: revert to ubuntu-latest runners for assistant CI

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -80,7 +80,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
       run:

--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -86,7 +86,7 @@ jobs:
   test:
     if: contains(github.event.pull_request.labels.*.name, 'preview')
     name: Test
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
       run:


### PR DESCRIPTION
## Summary
- Revert `runs-on` from `ubuntu-latest-4-cores` back to `ubuntu-latest` in both `ci-main-assistant.yaml` and `pr-assistant.yaml`
- Larger runners aren't enabled for the org, causing jobs to hang at "Waiting for a runner to pick up this job..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
