### PR TITLE
fix: restore missing guardian-bindings re-exports in channel-guardian-store

### DIFF
--- a/assistant/src/memory/channel-guardian-store.ts
+++ b/assistant/src/memory/channel-guardian-store.ts
@@ -34,7 +34,10 @@ export {
 } from "./guardian-approvals.js";
 export {
   type BindingStatus,
+  createBinding,
+  getActiveBinding,
   type GuardianBinding,
+  revokeBinding,
 } from "./guardian-bindings.js";
 export {
   getRateLimit,


### PR DESCRIPTION
## Summary
- Restores `createBinding`, `getActiveBinding`, and `revokeBinding` re-exports from `guardian-bindings.ts` in the `channel-guardian-store.ts` re-export hub
- These were accidentally pruned in #12127, breaking the typecheck CI job

## Original prompt
Fix typecheck CI failure: restore missing re-exports (createBinding, getActiveBinding, revokeBinding) in channel-guardian-store.ts that were accidentally pruned in #12127

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
