### PR TITLE
fix: broken imports in channel-guardian-service after re-export hub pruning

### DIFF
--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -22,8 +22,6 @@ import type {
   VerificationPurpose,
 } from "../memory/channel-guardian-store.js";
 import {
-  getActiveBinding,
-  revokeBinding as legacyRevokeBinding,
   bindSessionIdentity as storeBindSessionIdentity,
   consumeChallenge,
   countRecentSendsToDestination as storeCountRecentSendsToDestination,
@@ -41,6 +39,10 @@ import {
   updateSessionDelivery as storeUpdateSessionDelivery,
   updateSessionStatus as storeUpdateSessionStatus,
 } from "../memory/channel-guardian-store.js";
+import {
+  getActiveBinding,
+  revokeBinding as legacyRevokeBinding,
+} from "../memory/guardian-bindings.js";
 import { composeApprovalMessage } from "./approval-message-composer.js";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for legacy-table-removal.md.

**Gap:** Broken imports in channel-guardian-service.ts
**What was expected:** channel-guardian-store.ts no longer re-exports binding CRUD functions
**What was found:** channel-guardian-service.ts still imports getActiveBinding and revokeBinding from channel-guardian-store.js

**Fix:** Updated imports to source `getActiveBinding` and `revokeBinding` (aliased as `legacyRevokeBinding`) directly from `../memory/guardian-bindings.js` instead of from the re-export hub `channel-guardian-store.js`, which was pruned to only re-export types.

These legacy fallback calls were intentionally restored in PR #12122 to handle edge cases where the contacts write failed but the legacy row still exists — they are not redundant with the contacts-based path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
