### PR TITLE
fix: move CI failure tracking to dedicated job spanning all check jobs

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -110,9 +110,14 @@ jobs:
         env:
           TEST_WORKERS: '8'
 
+  track-failures:
+    name: Track Consecutive Failures
+    needs: [lint, typecheck, test]
+    if: always()
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
       - name: Track consecutive failures
-        if: always()
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -136,8 +141,8 @@ jobs:
             fi
           done
 
-          # Add current run result
-          if [ "${{ job.status }}" = "failure" ]; then
+          # Check all upstream job results instead of just job.status
+          if [[ "${{ needs.lint.result }}" == "failure" || "${{ needs.typecheck.result }}" == "failure" || "${{ needs.test.result }}" == "failure" ]]; then
             CONSECUTIVE=$((CONSECUTIVE + 1))
           else
             CONSECUTIVE=0


### PR DESCRIPTION
The 'Track consecutive failures' step was incorrectly scoped to the test job after splitting CI into parallel jobs. This meant lint/typecheck failures would reset the counter. Moved it to a dedicated job that observes all three jobs (lint, typecheck, test) via needs context.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
