### PR TITLE
Fix clip auto-open toolName matching

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1277,14 +1277,14 @@ extension ChatViewModel {
                     }
                 }
             }
-            // Auto-open clip files in the default video player
-            if let msgIndex = targetMsgIndex, let tcIndex = targetTcIndex {
-                autoOpenClipIfNeeded(
-                    toolName: messages[msgIndex].toolCalls[tcIndex].toolName,
-                    result: msg.result,
-                    isError: msg.isError ?? false
-                )
-            }
+            // Auto-open clip files in the default video player.
+            // Use msg.toolName from the event payload (stable) instead of the
+            // matched tool call's toolName (relies on last-incomplete heuristic).
+            autoOpenClipIfNeeded(
+                toolName: msg.toolName,
+                result: msg.result,
+                isError: msg.isError ?? false
+            )
 
             // Tool completed — don't re-show "Thinking..." here. The tool
             // call chip already indicates activity, and the LLM isn't actually


### PR DESCRIPTION
## Summary
- Use `msg.toolName` from the IPCToolResult event payload directly instead of `messages[msgIndex].toolCalls[tcIndex].toolName` which relies on the "last incomplete" tool call heuristic
- More robust in multi-tool turns where the heuristic could mis-match

Addresses feedback on #12126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
