### PR TITLE
fix: remove duplicate imports in channel-guardian-service

### DIFF
--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -41,10 +41,6 @@ import {
   updateSessionDelivery as storeUpdateSessionDelivery,
   updateSessionStatus as storeUpdateSessionStatus,
 } from "../memory/channel-guardian-store.js";
-import {
-  getActiveBinding,
-  revokeBinding as legacyRevokeBinding,
-} from "../memory/guardian-bindings.js";
 import { composeApprovalMessage } from "./approval-message-composer.js";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Remove duplicate imports of `getActiveBinding` and `revokeBinding` from `guardian-bindings.js` in `channel-guardian-service.ts` — these are already imported via the `channel-guardian-store.js` re-export hub, causing TS2300 duplicate identifier errors.

## Original prompt
fix this issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22653547183/job/65658119457

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
