### PR TITLE
fix: revert CI test runner to ubuntu-latest

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -80,7 +80,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
       run:
@@ -107,8 +107,6 @@ jobs:
 
       - name: Test
         run: bun run test:stable
-        env:
-          TEST_WORKERS: '8'
 
       - name: Track consecutive failures
         if: always()

--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -86,7 +86,7 @@ jobs:
   test:
     if: contains(github.event.pull_request.labels.*.name, 'preview')
     name: Test
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
       run:
@@ -115,7 +115,6 @@ jobs:
         run: bun run test
         env:
           EXCLUDE_EXPERIMENTAL: 'true'
-          TEST_WORKERS: '8'
 
   artifact:
     name: Upload Artifact


### PR DESCRIPTION
Reverts the ubuntu-latest-4-cores runner label back to ubuntu-latest in both ci-main-assistant.yaml and pr-assistant.yaml. The 4-core runner label requires larger runners to be enabled in the GitHub org — without them CI test jobs hang indefinitely. Addresses feedback from PR #12133.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
