### PR TITLE
fix: remove unused createBinding imports in test files

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -89,7 +89,6 @@ import {
   getAllPendingApprovalsByGuardianChat,
 } from "../memory/channel-guardian-store.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
-import { createBinding } from "../memory/guardian-bindings.js";
 import {
   conversations,
   externalConversationBindings,

--- a/assistant/src/__tests__/guardian-routing-state.test.ts
+++ b/assistant/src/__tests__/guardian-routing-state.test.ts
@@ -71,7 +71,6 @@ import { createGuardianBindingContactsFirst } from "../contacts/contacts-write.j
 import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import * as channelDeliveryStore from "../memory/channel-delivery-store.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
-import { createBinding } from "../memory/guardian-bindings.js";
 import { channelInboundEvents, messages } from "../memory/schema.js";
 import { sweepFailedEvents } from "../runtime/channel-retry-sweep.js";
 import { handleChannelInbound } from "../runtime/routes/channel-routes.js";


### PR DESCRIPTION
## Summary
- Remove unused `createBinding` imports from `channel-approval-routes.test.ts` and `guardian-routing-state.test.ts` that were causing lint failures in CI

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22653652073/job/65658429553

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
