### PR TITLE
Add descriptive clip filenames via title parameter

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/SKILL.md
+++ b/assistant/src/config/bundled-skills/media-processing/SKILL.md
@@ -202,6 +202,8 @@ Be specific and factual. Describe what you see, not what you infer happened betw
 
 The `generate_clip` tool automatically opens clips in the user's default video player after extraction. Clips are saved persistently in the asset's pipeline directory (`pipeline/<assetId>/clips/`). The `clipPath` field in the tool response contains the absolute file path.
 
+Always provide a descriptive `title` parameter (e.g. `"snow-dive-closeup"`, `"goal-celebration"`) so clips get meaningful filenames instead of timestamp-based names.
+
 ## Known Limitations — Vision Analysis
 
 Gemini performs well at **spatial/descriptive analysis** from static keyframes:

--- a/assistant/src/config/bundled-skills/media-processing/TOOLS.json
+++ b/assistant/src/config/bundled-skills/media-processing/TOOLS.json
@@ -215,6 +215,10 @@
             "type": "string",
             "enum": ["mp4", "webm", "mov"],
             "description": "Output video format. Default: 'mp4'"
+          },
+          "title": {
+            "type": "string",
+            "description": "Short descriptive title for the clip (e.g. 'snow-dive-closeup', 'goal-celebration'). Used as the filename. If omitted, falls back to timestamp-based naming."
           }
         },
         "required": ["asset_id", "start_time", "end_time"]

--- a/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
@@ -56,6 +56,16 @@ function formatTimestamp(seconds: number): string {
     .padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
 }
 
+function sanitizeFilename(title: string): string {
+  return (
+    title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "")
+      .slice(0, 50) || "clip"
+  );
+}
+
 const MIME_BY_FORMAT: Record<string, string> = {
   mp4: "video/mp4",
   webm: "video/webm",
@@ -95,6 +105,7 @@ export async function run(
   const preRoll = (input.pre_roll as number) ?? 3;
   const postRoll = (input.post_roll as number) ?? 2;
   const outputFormat = (input.output_format as string) ?? "mp4";
+  const title = input.title as string | undefined;
 
   const asset = getMediaAssetById(assetId);
   if (!asset) {
@@ -126,10 +137,9 @@ export async function run(
   const clipDir = join(dirname(asset.filePath), "pipeline", assetId, "clips");
   await mkdir(clipDir, { recursive: true });
 
-  const clipFilename = `clip-${formatTimestamp(startTime).replace(
-    /:/g,
-    "",
-  )}-${formatTimestamp(endTime).replace(/:/g, "")}.${outputFormat}`;
+  const clipFilename = title
+    ? `${sanitizeFilename(title)}.${outputFormat}`
+    : `clip-${formatTimestamp(startTime).replace(/:/g, "")}-${formatTimestamp(endTime).replace(/:/g, "")}.${outputFormat}`;
   const clipPath = join(clipDir, clipFilename);
 
   try {


### PR DESCRIPTION
## Summary
- Add optional `title` parameter to `generate_clip` tool (e.g. "snow-dive-closeup")
- When provided, sanitize and use as filename instead of timestamp-based `clip-HHMMSS-HHMMSS.mp4`
- Falls back to timestamp naming when title is omitted
- Update SKILL.md to instruct always providing a descriptive title

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
