### PR TITLE
fix: restore ubuntu-latest-4-cores CI runner with 8 test workers

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -80,7 +80,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     timeout-minutes: 15
     defaults:
       run:
@@ -107,6 +107,8 @@ jobs:
 
       - name: Test
         run: bun run test:stable
+        env:
+          TEST_WORKERS: '8'
 
       - name: Track consecutive failures
         if: always()

--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -86,7 +86,7 @@ jobs:
   test:
     if: contains(github.event.pull_request.labels.*.name, 'preview')
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     timeout-minutes: 15
     defaults:
       run:
@@ -115,6 +115,7 @@ jobs:
         run: bun run test
         env:
           EXCLUDE_EXPERIMENTAL: 'true'
+          TEST_WORKERS: '8'
 
   artifact:
     name: Upload Artifact


### PR DESCRIPTION
## Summary
- Reverts PR #12139 — restores `ubuntu-latest-4-cores` runner for CI test jobs
- Re-adds `TEST_WORKERS: '8'` env var to both `ci-main-assistant` and `pr-assistant` workflows

## Original prompt
fix: restore ubuntu-latest-4-cores CI runner with 8 test workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
