### PR TITLE
refactor: remove listActiveBindingsByAssistant legacy fallback in relay-server

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -22,7 +22,6 @@ import { contactChannelToMemberRecord } from "../contacts/member-record-shim.js"
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import { getCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
 import * as conversationStore from "../memory/conversation-store.js";
-import { listActiveBindingsByAssistant } from "../memory/guardian-bindings.js";
 import { findActiveVoiceInvites } from "../memory/ingress-invite-store.js";
 import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-grants.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
@@ -2029,15 +2028,9 @@ export class RelayConnection {
       }
     }
     if (!metadataJson) {
-      // Legacy fallback
       const voiceBinding = getGuardianBinding(assistantId, "voice");
       if (voiceBinding?.metadataJson) {
         metadataJson = voiceBinding.metadataJson;
-      } else {
-        const allBindings = listActiveBindingsByAssistant(assistantId);
-        if (allBindings.length > 0 && allBindings[0].metadataJson) {
-          metadataJson = allBindings[0].metadataJson;
-        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Remove listActiveBindingsByAssistant legacy fallback from relay-server voice call metadata resolution
- getGuardianBinding (which reads from contacts) is the sole fallback path

Part of plan: legacy-final-cleanup.md (PR 3 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
