### PR TITLE
refactor: remove findMember legacy fallback in invite-redemption-service

### DIFF
--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -20,7 +20,6 @@ import {
   recordInviteUse,
   redeemInvite as storeRedeemInvite,
 } from "../memory/ingress-invite-store.js";
-import { findMember } from "../memory/ingress-member-store.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
 import { hashVoiceCode } from "../util/voice-code.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
@@ -133,16 +132,9 @@ export function redeemInvite(params: {
     externalUserId: canonicalUserId,
     externalChatId: externalChatId,
   });
-  // Fall back to legacy assistant_ingress_members table when contacts lookup
-  // misses — contacts may not be synced yet for all members during migration.
   const existingMember = contactResult
     ? contactChannelToMemberRecord(contactResult.contact, contactResult.channel)
-    : findMember({
-        assistantId: assistantId ?? invite.assistantId,
-        sourceChannel,
-        externalUserId,
-        externalChatId,
-      });
+    : null;
 
   if (existingMember && existingMember.status === "active") {
     return { ok: true, type: "already_member", memberId: existingMember.id };
@@ -333,15 +325,9 @@ export function redeemVoiceInviteCode(params: {
     channelType: "voice",
     externalUserId: canonicalCallerId,
   });
-  // Fall back to legacy assistant_ingress_members table when contacts lookup
-  // misses — contacts may not be synced yet for all members during migration.
   const existingMember = voiceContactResult
     ? contactChannelToMemberRecord(voiceContactResult.contact, voiceContactResult.channel)
-    : findMember({
-        assistantId: invite.assistantId,
-        sourceChannel: "voice",
-        externalUserId: callerExternalUserId,
-      });
+    : null;
 
   if (existingMember && existingMember.status === "active") {
     return { ok: true, type: "already_member", memberId: existingMember.id };


### PR DESCRIPTION
## Summary
- Remove findMember legacy fallback from invite-redemption-service
- Contacts-based lookup is now the sole path for member existence checks

Part of plan: legacy-final-cleanup.md (PR 1 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
