### PR TITLE
refactor: remove legacy getActiveBinding fallback from guardian-vellum-migration

### DIFF
--- a/assistant/src/runtime/guardian-vellum-migration.ts
+++ b/assistant/src/runtime/guardian-vellum-migration.ts
@@ -14,7 +14,6 @@ import { v4 as uuid } from "uuid";
 
 import { findGuardianForChannel } from "../contacts/contact-store.js";
 import { createGuardianBindingContactsFirst } from "../contacts/contacts-write.js";
-import { getActiveBinding } from "../memory/guardian-bindings.js";
 import { getLogger } from "../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
 
@@ -37,17 +36,6 @@ export function ensureVellumGuardianBinding(
       "Vellum guardian binding already exists with principal",
     );
     return guardianResult.contact.principalId;
-  }
-
-  // Fallback: check legacy table in case contacts haven't been synced yet
-  // (this runs before syncAllToContacts at startup)
-  const legacyBinding = getActiveBinding(assistantId, "vellum");
-  if (legacyBinding) {
-    log.debug(
-      { assistantId, guardianPrincipalId: legacyBinding.guardianPrincipalId },
-      "Found vellum guardian binding in legacy table (pre-sync)",
-    );
-    return legacyBinding.guardianPrincipalId;
   }
 
   const guardianPrincipalId = `vellum-principal-${uuid()}`;


### PR DESCRIPTION
## Summary
- Remove getActiveBinding legacy fallback from guardian-vellum-migration
- Function now checks contacts first, creates new binding if missing

Part of plan: legacy-final-cleanup.md (PR 4 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
