### PR TITLE
fix: revert PR CI workflow to ubuntu-latest

### DIFF
--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -86,7 +86,7 @@ jobs:
   test:
     if: contains(github.event.pull_request.labels.*.name, 'preview')
     name: Test
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
       run:
@@ -115,7 +115,6 @@ jobs:
         run: bun run test
         env:
           EXCLUDE_EXPERIMENTAL: 'true'
-          TEST_WORKERS: '8'
 
   artifact:
     name: Upload Artifact


### PR DESCRIPTION
## Summary
- Reverts PR CI test job back to `ubuntu-latest` (without 4-cores runner)
- Removes `TEST_WORKERS: '8'` from PR workflow — only the main CI job needs the larger runner

## Original prompt
fix: revert PR CI workflow to ubuntu-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
