### PR TITLE
refactor: remove legacy fallbacks in access-request-helper

### DIFF
--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -10,8 +10,7 @@
  * exists. Guardian identity resolution uses a contacts-first fallback strategy:
  *   1. Source-channel guardian contact channel.
  *   2. Any active guardian channel (deterministic, most-recently-verified).
- *   3. Legacy fallback to getGuardianBinding + listActiveBindingsByAssistant.
- *   4. No guardian identity (trusted/vellum-only resolution path).
+ *   3. No guardian identity (trusted/vellum-only resolution path).
  */
 
 import type { ChannelId } from "../channels/types.js";
@@ -25,12 +24,10 @@ import {
   listCanonicalGuardianRequests,
   updateCanonicalGuardianDelivery,
 } from "../memory/canonical-guardian-store.js";
-import { listActiveBindingsByAssistant } from "../memory/guardian-bindings.js";
 import type { MemberStatus } from "../memory/ingress-member-store.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import type { NotificationDeliveryResult } from "../notifications/types.js";
 import { getLogger } from "../util/logger.js";
-import { getGuardianBinding } from "./channel-guardian-service.js";
 import { ensureVellumGuardianBinding } from "./guardian-vellum-migration.js";
 import { GUARDIAN_APPROVAL_TTL_MS } from "./routes/channel-route-shared.js";
 
@@ -77,8 +74,8 @@ export type AccessRequestResult =
  * a new request was created or an existing one was deduped.
  *
  * Guardian identity resolution: contacts-first for source channel, then any
- * active guardian channel, then legacy bindings, then null (notification
- * pipeline handles delivery via trusted/vellum channels when no binding exists).
+ * active guardian channel, then null (notification pipeline handles delivery
+ * via trusted/vellum channels when no binding exists).
  *
  * This is intentionally synchronous with respect to the canonical store writes
  * and fire-and-forget for the notification signal emission.
@@ -103,15 +100,13 @@ export function notifyGuardianOfAccessRequest(
   // Resolve guardian identity with contacts-first strategy:
   // 1. Source-channel guardian contact channel
   // 2. Any active guardian channel (deterministic, most-recently-verified)
-  // 3. Legacy fallback to getGuardianBinding + listActiveBindingsByAssistant
-  // 4. null (notification pipeline handles delivery via trusted channels)
+  // 3. null (notification pipeline handles delivery via trusted channels)
   let guardianExternalUserId: string | null = null;
   let guardianPrincipalId: string | null = null;
   let guardianBindingChannel: string | null = null;
   let guardianResolutionSource:
     | "contacts"
     | "contacts-fallback"
-    | "legacy"
     | "none" = "none";
 
   // Try contacts-first: source channel
@@ -138,39 +133,12 @@ export function notifyGuardianOfAccessRequest(
         },
         "Using cross-channel guardian contact fallback for access request",
       );
-    } else {
-      // Legacy fallback: contacts not yet synced
-      const sourceBinding = getGuardianBinding(
-        canonicalAssistantId,
-        sourceChannel,
-      );
-      if (sourceBinding) {
-        guardianExternalUserId = sourceBinding.guardianExternalUserId;
-        guardianPrincipalId = sourceBinding.guardianPrincipalId;
-        guardianBindingChannel = sourceBinding.channel;
-        guardianResolutionSource = "legacy";
-      } else {
-        const allBindings = listActiveBindingsByAssistant(canonicalAssistantId);
-        if (allBindings.length > 0) {
-          guardianExternalUserId = allBindings[0].guardianExternalUserId;
-          guardianPrincipalId = allBindings[0].guardianPrincipalId;
-          guardianBindingChannel = allBindings[0].channel;
-          guardianResolutionSource = "legacy";
-          log.debug(
-            {
-              sourceChannel,
-              fallbackChannel: guardianBindingChannel,
-              canonicalAssistantId,
-            },
-            "Using cross-channel guardian binding fallback for access request",
-          );
-        }
-      }
     }
+    // If no guardian found via contacts, guardianResolutionSource stays "none"
   }
 
   // Self-heal: access_request requires a principal. If none found via
-  // contacts or legacy, bootstrap the vellum binding.
+  // contacts, bootstrap the vellum binding.
   if (!guardianPrincipalId) {
     log.info(
       { sourceChannel, canonicalAssistantId },
@@ -185,11 +153,7 @@ export function notifyGuardianOfAccessRequest(
         vellumGuardian.contact.principalId ?? healedPrincipalId;
       guardianBindingChannel = guardianBindingChannel ?? "vellum";
     } else {
-      const vellumBinding = getGuardianBinding(canonicalAssistantId, "vellum");
-      guardianExternalUserId =
-        vellumBinding?.guardianExternalUserId ?? guardianExternalUserId;
-      guardianPrincipalId =
-        vellumBinding?.guardianPrincipalId ?? healedPrincipalId;
+      guardianPrincipalId = healedPrincipalId;
       guardianBindingChannel = guardianBindingChannel ?? "vellum";
     }
   }


### PR DESCRIPTION
## Summary
- Remove getGuardianBinding + listActiveBindingsByAssistant legacy fallback from access-request-helper
- Guardian resolution is now contacts-only: source-channel, any-channel fallback, or none

Part of plan: legacy-final-cleanup.md (PR 2 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
