### PR TITLE
fix: always use composite contact:channel IDs in contactToMemberResponse

### DIFF
--- a/assistant/src/runtime/ingress-service.ts
+++ b/assistant/src/runtime/ingress-service.ts
@@ -208,7 +208,7 @@ function contactToMemberResponse(
         : undefined);
 
     return {
-      id: legacyMember?.id ?? `${contact.id}:${ch.id}`,
+      id: `${contact.id}:${ch.id}`,
       sourceChannel: ch.type,
       externalUserId: ch.externalUserId ?? undefined,
       externalChatId: ch.externalChatId ?? undefined,


### PR DESCRIPTION
contactToMemberResponse was still returning legacy ingress_members UUIDs for pre-existing members, causing revoke/block to fail in contacts-first write functions that expect composite IDs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
