### PR TITLE
fix: swap revoke ordering so member revocation runs before guardian binding revocation

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -210,10 +210,11 @@ export function revokeGuardianForChannel(
     };
   }
 
-  // Look up the member channel BEFORE revoking the guardian binding so the
-  // channel status is still active/pending — revokeGuardianBindingContactsFirst
-  // marks the channel as revoked, which would cause the status guard below to
-  // skip the revoke call.
+  // Revoke the member BEFORE the guardian binding so that
+  // revokeMemberContactsFirst sees the channel as active/pending and sets the
+  // correct revokedReason ("guardian_binding_revoked"). If the guardian binding
+  // is revoked first, the channel is already marked revoked and the member
+  // revocation becomes a no-op (wrong reason or skipped entirely).
   const contactResult = findContactChannel({
     channelType: resolvedChannel,
     externalUserId: bindingBeforeRevoke.guardianExternalUserId,
@@ -223,14 +224,11 @@ export function revokeGuardianForChannel(
     ? contactChannelToMemberRecord(contactResult.contact, contactResult.channel)
     : null;
 
-  revokeGuardianBindingContactsFirst(assistantId, resolvedChannel);
-
-  // Only revoke active/pending members — a blocked member must not be
-  // downgraded to revoked (revokeMemberContactsFirst has its own guard,
-  // but we check here to make the intent explicit at the call site).
   if (member && (member.status === "active" || member.status === "pending")) {
     revokeMemberContactsFirst(member.id, "guardian_binding_revoked");
   }
+
+  revokeGuardianBindingContactsFirst(assistantId, resolvedChannel);
 
   return {
     success: true,


### PR DESCRIPTION
revokeMemberContactsFirst was always a no-op because revokeGuardianBindingContactsFirst ran first and already revoked the channel. Swaps the order so the member revocation sets the correct revokedReason before the guardian cleanup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
