### PR TITLE
test: migrate invite test fixtures from legacy stores to contacts API

### DIFF
--- a/assistant/src/__tests__/inbound-invite-redemption.test.ts
+++ b/assistant/src/__tests__/inbound-invite-redemption.test.ts
@@ -89,10 +89,8 @@ mock.module("../runtime/approval-message-composer.js", () => ({
 
 import { findContactChannel } from "../contacts/contact-store.js";
 import { upsertMemberContactsFirst } from "../contacts/contacts-write.js";
-import { contactChannelToMemberRecord } from "../contacts/member-record-shim.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { createInvite, revokeInvite } from "../memory/ingress-invite-store.js";
-import { findMember } from "../memory/ingress-member-store.js";
 import { handleChannelInbound } from "../runtime/routes/channel-routes.js";
 
 initializeDb();
@@ -196,15 +194,13 @@ describe("inbound invite redemption intercept", () => {
     expect(json.memberId).toEqual(expect.any(String));
     expect(json.denied).toBeUndefined();
 
-    // Verify the user is now an active member (invite redemption for new
-    // members writes to the legacy table via storeRedeemInvite)
-    const member = findMember({
-      assistantId: "self",
-      sourceChannel: "telegram",
+    // Verify the user is now an active member
+    const result = findContactChannel({
+      channelType: "telegram",
       externalUserId: "user-invite-123",
     });
-    expect(member).not.toBeNull();
-    expect(member!.status).toBe("active");
+    expect(result).not.toBeNull();
+    expect(result!.channel.status).toBe("active");
 
     // Verify a welcome reply was delivered
     expect(deliverReplyCalls.length).toBe(1);
@@ -231,12 +227,11 @@ describe("inbound invite redemption intercept", () => {
     expect(replyText).toContain("no longer valid");
 
     // Verify the user was NOT made a member
-    const member = findMember({
-      assistantId: "self",
-      sourceChannel: "telegram",
+    const result = findContactChannel({
+      channelType: "telegram",
       externalUserId: "user-invite-123",
     });
-    expect(member).toBeNull();
+    expect(result).toBeNull();
   });
 
   test("non-member with expired token gets appropriate message", async () => {
@@ -434,17 +429,13 @@ describe("inbound invite redemption intercept", () => {
     expect(json.accepted).toBe(true);
     expect(json.inviteRedemption).toBe("redeemed");
 
-    const contactResult = findContactChannel({
+    const result = findContactChannel({
       channelType: "telegram",
       externalUserId: "user-invite-123",
       externalChatId: "chat-invite-test",
     });
-    expect(contactResult).not.toBeNull();
-    const member = contactChannelToMemberRecord(
-      contactResult!.contact,
-      contactResult!.channel,
-    );
-    expect(member.status).toBe("active");
-    expect(contactResult!.contact.displayName).toBe("Jeff");
+    expect(result).not.toBeNull();
+    expect(result!.channel.status).toBe("active");
+    expect(result!.contact.displayName).toBe("Jeff");
   });
 });

--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -29,7 +29,7 @@ import {
   createInvite,
   revokeInvite as revokeStoreFn,
 } from "../memory/ingress-invite-store.js";
-import { upsertMember } from "../memory/ingress-member-store.js";
+import { upsertMemberContactsFirst } from "../contacts/contacts-write.js";
 import {
   type InviteRedemptionOutcome,
   redeemInvite,
@@ -49,6 +49,8 @@ afterAll(() => {
 function resetTables() {
   getSqlite().run("DELETE FROM assistant_ingress_members");
   getSqlite().run("DELETE FROM assistant_ingress_invites");
+  getSqlite().run("DELETE FROM contact_channels");
+  getSqlite().run("DELETE FROM contacts");
 }
 
 describe("invite-redemption-service", () => {
@@ -178,7 +180,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Pre-create an active member
-    upsertMember({
+    upsertMemberContactsFirst({
       sourceChannel: "telegram",
       externalUserId: "existing-user",
       status: "active",
@@ -208,7 +210,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Pre-create a blocked member — simulates a guardian-initiated block
-    upsertMember({
+    upsertMemberContactsFirst({
       sourceChannel: "telegram",
       externalUserId: "blocked-user",
       status: "blocked",
@@ -230,7 +232,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Pre-create a revoked member
-    const member = upsertMember({
+    const member = upsertMemberContactsFirst({
       sourceChannel: "telegram",
       externalUserId: "revoked-user",
       status: "revoked",
@@ -281,7 +283,7 @@ describe("invite-redemption-service", () => {
 
   test("returns invalid_token for an active member with a bogus token (no membership probing)", () => {
     // Pre-create an active member
-    upsertMember({
+    upsertMemberContactsFirst({
       sourceChannel: "telegram",
       externalUserId: "probed-user",
       status: "active",
@@ -306,7 +308,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Pre-create an active member
-    upsertMember({
+    upsertMemberContactsFirst({
       sourceChannel: "telegram",
       externalUserId: "expired-token-user",
       status: "active",
@@ -330,7 +332,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Pre-create an active member on telegram
-    upsertMember({
+    upsertMemberContactsFirst({
       sourceChannel: "telegram",
       externalUserId: "cross-channel-user",
       status: "active",

--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -26,7 +26,7 @@ mock.module("../util/logger.js", () => ({
 
 import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
 import { createInvite, revokeInvite } from "../memory/ingress-invite-store.js";
-import { upsertMember } from "../memory/ingress-member-store.js";
+import { upsertMemberContactsFirst } from "../contacts/contacts-write.js";
 import { redeemVoiceInviteCode } from "../runtime/invite-redemption-service.js";
 import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
 
@@ -283,7 +283,7 @@ describe("redeemVoiceInviteCode", () => {
     const { code } = createVoiceInvite({ callerPhone: phone });
 
     // Pre-create an active member for this phone on voice channel
-    upsertMember({
+    upsertMemberContactsFirst({
       sourceChannel: "voice",
       externalUserId: phone,
       status: "active",
@@ -308,7 +308,7 @@ describe("redeemVoiceInviteCode", () => {
     const phone = "+15551234567";
     const { code } = createVoiceInvite({ callerPhone: phone });
 
-    upsertMember({
+    upsertMemberContactsFirst({
       sourceChannel: "voice",
       externalUserId: phone,
       status: "blocked",


### PR DESCRIPTION
## Summary
- Replace upsertMember with upsertMemberContactsFirst in invite test fixtures
- Replace findMember with findContactChannel where used for assertions
- 3 test files migrated off legacy ingress-member-store

Part of plan: legacy-final-cleanup.md (PR 6 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
