### PR TITLE
test: migrate guardian test fixtures from legacy stores to contacts API

### DIFF
--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -98,7 +98,7 @@ import {
   listCanonicalGuardianRequests,
 } from "../memory/canonical-guardian-store.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
-import { createBinding } from "../memory/guardian-bindings.js";
+import { createGuardianBindingContactsFirst } from "../contacts/contacts-write.js";
 import { notifyGuardianOfAccessRequest } from "../runtime/access-request-helper.js";
 import { handleChannelInbound } from "../runtime/routes/channel-routes.js";
 
@@ -198,12 +198,13 @@ describe("non-member access request notification", () => {
 
   test("guardian is notified when a non-member messages and a guardian binding exists", async () => {
     // Set up a guardian binding for this channel
-    createBinding({
+    createGuardianBindingContactsFirst({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-user-789",
       guardianDeliveryChatId: "guardian-chat-789",
       guardianPrincipalId: "test-principal-id",
+      verifiedVia: "test",
     });
 
     const req = buildInboundRequest();
@@ -243,12 +244,13 @@ describe("non-member access request notification", () => {
   });
 
   test("no duplicate approval requests for repeated messages from same non-member", async () => {
-    createBinding({
+    createGuardianBindingContactsFirst({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-user-789",
       guardianDeliveryChatId: "guardian-chat-789",
       guardianPrincipalId: "test-principal-id",
+      verifiedVia: "test",
     });
 
     // First message
@@ -313,12 +315,13 @@ describe("non-member access request notification", () => {
 
   test("cross-channel fallback: SMS guardian binding resolves for Telegram access request", async () => {
     // Only an SMS guardian binding exists — no Telegram binding
-    createBinding({
+    createGuardianBindingContactsFirst({
       assistantId: "self",
       channel: "sms",
       guardianExternalUserId: "guardian-sms-user",
       guardianDeliveryChatId: "guardian-sms-chat",
       guardianPrincipalId: "test-principal-id",
+      verifiedVia: "test",
     });
 
     const req = buildInboundRequest();
@@ -348,12 +351,13 @@ describe("non-member access request notification", () => {
   });
 
   test("no notification when actorExternalId is absent", async () => {
-    createBinding({
+    createGuardianBindingContactsFirst({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-user-789",
       guardianDeliveryChatId: "guardian-chat-789",
       guardianPrincipalId: "test-principal-id",
+      verifiedVia: "test",
     });
 
     // Message without actorExternalId — the handler returns BAD_REQUEST.
@@ -424,12 +428,13 @@ describe("access-request-helper unit tests", () => {
 
   test("notifyGuardianOfAccessRequest uses cross-channel binding when source-channel binding is missing", () => {
     // Only SMS binding exists
-    createBinding({
+    createGuardianBindingContactsFirst({
       assistantId: "self",
       channel: "sms",
       guardianExternalUserId: "guardian-sms",
       guardianDeliveryChatId: "sms-chat",
       guardianPrincipalId: "test-principal-id",
+      verifiedVia: "test",
     });
 
     const result = notifyGuardianOfAccessRequest({
@@ -459,19 +464,21 @@ describe("access-request-helper unit tests", () => {
 
   test("notifyGuardianOfAccessRequest prefers source-channel binding over cross-channel fallback", () => {
     // Both Telegram and SMS bindings exist
-    createBinding({
+    createGuardianBindingContactsFirst({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-tg",
       guardianDeliveryChatId: "tg-chat",
       guardianPrincipalId: "test-principal-tg",
+      verifiedVia: "test",
     });
-    createBinding({
+    createGuardianBindingContactsFirst({
       assistantId: "self",
       channel: "sms",
       guardianExternalUserId: "guardian-sms",
       guardianDeliveryChatId: "sms-chat",
       guardianPrincipalId: "test-principal-sms",
+      verifiedVia: "test",
     });
 
     const result = notifyGuardianOfAccessRequest({

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -17,7 +17,7 @@ import type { ServerMessage } from "../daemon/ipc-protocol.js";
 import type { Session } from "../daemon/session.js";
 import { createCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
 import { getOrCreateConversation } from "../memory/conversation-key-store.js";
-import { createBinding } from "../memory/guardian-bindings.js";
+import { createGuardianBindingContactsFirst } from "../contacts/contacts-write.js";
 
 const testDir = realpathSync(
   mkdtempSync(join(tmpdir(), "send-endpoint-busy-test-")),
@@ -291,14 +291,17 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
     db.run("DELETE FROM canonical_guardian_deliveries");
     db.run("DELETE FROM canonical_guardian_requests");
     db.run("DELETE FROM channel_guardian_bindings");
+    db.run("DELETE FROM contact_channels");
+    db.run("DELETE FROM contacts");
     pendingInteractions.clear();
 
-    createBinding({
+    createGuardianBindingContactsFirst({
       assistantId: "self",
       channel: "vellum",
       guardianExternalUserId: "dev-bypass",
       guardianDeliveryChatId: "vellum",
       guardianPrincipalId: "test-principal-id",
+      verifiedVia: "test",
     });
 
     eventHub = new AssistantEventHub();


### PR DESCRIPTION
## Summary
- Replace createBinding with createGuardianBindingContactsFirst in guardian test fixtures
- Replace getActiveBinding/revokeBinding with contacts-based equivalents
- 4 test files migrated off legacy guardian-bindings store

Part of plan: legacy-final-cleanup.md (PR 8 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
