### PR TITLE
test: migrate trusted contact and relay-server test fixtures from legacy stores

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -185,6 +185,10 @@ import {
   createVerificationSession,
 } from "../memory/channel-guardian-store.js";
 import { addMessage, getMessages } from "../memory/conversation-store.js";
+import {
+  createGuardianBindingContactsFirst,
+  upsertMemberContactsFirst,
+} from "../contacts/contacts-write.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { createInvite } from "../memory/ingress-invite-store.js";
 import { conversations } from "../memory/schema.js";
@@ -275,9 +279,10 @@ function resetTables() {
 
 function addTrustedVoiceContact(
   phoneNumber: string,
-  _assistantId: string = "self",
+  assistantId: string = "self",
 ): void {
   upsertMemberContactsFirst({
+    assistantId,
     sourceChannel: "voice",
     externalUserId: phoneNumber,
     externalChatId: phoneNumber,
@@ -1472,6 +1477,7 @@ describe("relay-server", () => {
       guardianExternalUserId: "+15550001111",
       guardianDeliveryChatId: "+15550001111",
       guardianPrincipalId: "+15550001111",
+      verifiedVia: "test",
     });
 
     mockSendMessage.mockImplementation(
@@ -1521,6 +1527,7 @@ describe("relay-server", () => {
       guardianExternalUserId: "+15550009999",
       guardianDeliveryChatId: "+15550009999",
       guardianPrincipalId: "+15550009999",
+      verifiedVia: "test",
     });
     addTrustedVoiceContact("+15550002222", "self");
 
@@ -1575,6 +1582,7 @@ describe("relay-server", () => {
       guardianExternalUserId: "+15550001111",
       guardianDeliveryChatId: "+15550001111",
       guardianPrincipalId: "+15550001111",
+      verifiedVia: "test",
     });
 
     mockSendMessage.mockImplementation(
@@ -1626,6 +1634,7 @@ describe("relay-server", () => {
       guardianExternalUserId: "tg-guardian-user",
       guardianDeliveryChatId: "tg-guardian-chat",
       guardianPrincipalId: "tg-guardian-user",
+      verifiedVia: "test",
     });
 
     // Number matches the configured owner number, but there is no active
@@ -2470,6 +2479,7 @@ describe("relay-server", () => {
 
     // Create a blocked member
     upsertMemberContactsFirst({
+      assistantId: "self",
       sourceChannel: "voice",
       externalUserId: "+15558881111",
       externalChatId: "+15558881111",

--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -176,8 +176,10 @@ describe("trusted contact lifecycle notification signals", () => {
       guardianExternalUserId: "guardian-user-789",
       guardianDeliveryChatId: "guardian-chat-789",
       guardianPrincipalId: "guardian-user-789",
+      verifiedVia: "test",
     });
     upsertMemberContactsFirst({
+      assistantId: "self",
       sourceChannel: "telegram",
       externalUserId: "guardian-user-789",
       externalChatId: "guardian-chat-789",
@@ -256,8 +258,10 @@ describe("trusted contact lifecycle notification signals", () => {
       guardianExternalUserId: "guardian-user-789",
       guardianDeliveryChatId: "guardian-chat-789",
       guardianPrincipalId: "guardian-user-789",
+      verifiedVia: "test",
     });
     upsertMemberContactsFirst({
+      assistantId: "self",
       sourceChannel: "telegram",
       externalUserId: "guardian-user-789",
       externalChatId: "guardian-chat-789",
@@ -332,8 +336,10 @@ describe("trusted contact lifecycle notification signals", () => {
       guardianExternalUserId: "guardian-user-789",
       guardianDeliveryChatId: "guardian-chat-789",
       guardianPrincipalId: "guardian-user-789",
+      verifiedVia: "test",
     });
     upsertMemberContactsFirst({
+      assistantId: "self",
       sourceChannel: "telegram",
       externalUserId: "guardian-user-789",
       externalChatId: "guardian-chat-789",
@@ -397,6 +403,7 @@ describe("trusted contact activated notification signal", () => {
       guardianExternalUserId: "guardian-user-789",
       guardianDeliveryChatId: "guardian-chat-789",
       guardianPrincipalId: "guardian-user-789",
+      verifiedVia: "test",
     });
 
     // Create an identity-bound outbound session (simulates M3 approval flow)
@@ -453,9 +460,11 @@ describe("trusted contact activated notification signal", () => {
       guardianExternalUserId: "guardian-user-789",
       guardianDeliveryChatId: "guardian-chat-789",
       guardianPrincipalId: "guardian-user-789",
+      verifiedVia: "test",
     });
 
     upsertMemberContactsFirst({
+      assistantId: "self",
       sourceChannel: "telegram",
       externalUserId: "requester-user-456",
       externalChatId: "chat-123",
@@ -483,13 +492,13 @@ describe("trusted contact activated notification signal", () => {
 
     await handleChannelInbound(verifyReq, undefined, TEST_BEARER_TOKEN);
 
-    const contactResult = findContactChannel({
+    const result = findContactChannel({
       channelType: "telegram",
       externalUserId: "requester-user-456",
     });
-    expect(contactResult).not.toBeNull();
-    expect(contactResult!.channel.status).toBe("active");
-    expect(contactResult!.contact.displayName).toBe("Jeff");
+    expect(result).not.toBeNull();
+    expect(result!.channel.status).toBe("active");
+    expect(result!.contact.displayName).toBe("Jeff");
   });
 
   test("guardian verification does NOT emit activated signal", async () => {
@@ -532,6 +541,7 @@ describe("trusted contact activated notification signal", () => {
       guardianExternalUserId: "guardian-user-789",
       guardianDeliveryChatId: "guardian-chat-789",
       guardianPrincipalId: "guardian-user-789",
+      verifiedVia: "test",
     });
 
     const session = createOutboundSession({
@@ -559,12 +569,12 @@ describe("trusted contact activated notification signal", () => {
     expect(activatedSignals.length).toBe(1);
 
     // Verify the member was already persisted (the signal fires after upsertMemberContactsFirst)
-    const contactResult = findContactChannel({
+    const result = findContactChannel({
       channelType: "telegram",
       externalUserId: "requester-user-456",
     });
-    expect(contactResult).not.toBeNull();
-    expect(contactResult!.channel.status).toBe("active");
-    expect(contactResult!.channel.policy).toBe("allow");
+    expect(result).not.toBeNull();
+    expect(result!.channel.status).toBe("active");
+    expect(result!.channel.policy).toBe("allow");
   });
 });

--- a/assistant/src/__tests__/trusted-contact-multichannel.test.ts
+++ b/assistant/src/__tests__/trusted-contact-multichannel.test.ts
@@ -96,9 +96,12 @@ mock.module("../runtime/approval-message-composer.js", () => ({
   composeApprovalMessageGenerative: async () => "mock generative message",
 }));
 
+import { findContactChannel } from "../contacts/contact-store.js";
+import {
+  createGuardianBindingContactsFirst,
+  upsertMemberContactsFirst,
+} from "../contacts/contacts-write.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
-import { createBinding } from "../memory/guardian-bindings.js";
-import { findMember, upsertMember } from "../memory/ingress-member-store.js";
 import {
   createOutboundSession,
   validateAndConsumeChallenge,
@@ -229,12 +232,13 @@ for (const config of CHANNEL_CONFIGS) {
     });
 
     test("guardian is notified when a non-member messages", async () => {
-      createBinding({
+      createGuardianBindingContactsFirst({
         assistantId: "self",
         channel: config.channel,
         guardianExternalUserId: config.guardianExternalUserId,
         guardianDeliveryChatId: config.guardianChatId,
         guardianPrincipalId: config.guardianExternalUserId,
+        verifiedVia: "test",
       });
 
       const req = buildInboundRequest(config);
@@ -281,7 +285,7 @@ for (const config of CHANNEL_CONFIGS) {
         expect(result.verificationType).toBe("trusted_contact");
       }
 
-      upsertMember({
+      upsertMemberContactsFirst({
         assistantId: "self",
         sourceChannel: config.channel,
         externalUserId: config.senderExternalUserId,
@@ -292,21 +296,20 @@ for (const config of CHANNEL_CONFIGS) {
         username: "test_requester",
       });
 
-      const member = findMember({
-        assistantId: "self",
-        sourceChannel: config.channel,
+      const result = findContactChannel({
+        channelType: config.channel,
         externalUserId: config.senderExternalUserId,
       });
 
-      expect(member).not.toBeNull();
-      expect(member!.status).toBe("active");
-      expect(member!.policy).toBe("allow");
-      expect(member!.sourceChannel).toBe(config.channel);
+      expect(result).not.toBeNull();
+      expect(result!.channel.status).toBe("active");
+      expect(result!.channel.policy).toBe("allow");
+      expect(result!.channel.type).toBe(config.channel);
     });
 
     test("no cross-channel leakage between member records", () => {
       // Create a member for this channel
-      upsertMember({
+      upsertMemberContactsFirst({
         assistantId: "self",
         sourceChannel: config.channel,
         externalUserId: config.senderExternalUserId,
@@ -316,21 +319,19 @@ for (const config of CHANNEL_CONFIGS) {
       });
 
       // Should be found on this channel
-      const sameChanMember = findMember({
-        assistantId: "self",
-        sourceChannel: config.channel,
+      const sameChanResult = findContactChannel({
+        channelType: config.channel,
         externalUserId: config.senderExternalUserId,
       });
-      expect(sameChanMember).not.toBeNull();
+      expect(sameChanResult).not.toBeNull();
 
       // Should NOT be found on a different channel
       const otherChannel = config.channel === "telegram" ? "sms" : "telegram";
-      const crossChanMember = findMember({
-        assistantId: "self",
-        sourceChannel: otherChannel,
+      const crossChanResult = findContactChannel({
+        channelType: otherChannel,
         externalUserId: config.senderExternalUserId,
       });
-      expect(crossChanMember).toBeNull();
+      expect(crossChanResult).toBeNull();
     });
   });
 }


### PR DESCRIPTION
## Summary
- Replace upsertMember with upsertMemberContactsFirst in trusted contact and relay-server tests
- Replace createBinding with createGuardianBindingContactsFirst
- Replace findMember with findContactChannel for assertions
- 3 test files migrated off legacy stores

Part of plan: legacy-final-cleanup.md (PR 7 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
