### PR TITLE
fix: add legacy fallback with contacts sync in ensureVellumGuardianBinding

### DIFF
--- a/assistant/src/runtime/guardian-vellum-migration.ts
+++ b/assistant/src/runtime/guardian-vellum-migration.ts
@@ -14,6 +14,7 @@ import { v4 as uuid } from "uuid";
 
 import { findGuardianForChannel } from "../contacts/contact-store.js";
 import { createGuardianBindingContactsFirst } from "../contacts/contacts-write.js";
+import { getActiveBinding } from "../memory/guardian-bindings.js";
 import { getLogger } from "../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
 
@@ -36,6 +37,28 @@ export function ensureVellumGuardianBinding(
       "Vellum guardian binding already exists with principal",
     );
     return guardianResult.contact.principalId;
+  }
+
+  // Fallback: check the legacy channel_guardian_bindings table. On first
+  // startup after the contacts migration, the contacts table may not yet
+  // have the guardian entry. If found, sync it into contacts so downstream
+  // trust resolution (which reads contacts only) sees it immediately.
+  const legacyBinding = getActiveBinding(assistantId, "vellum");
+  if (legacyBinding) {
+    createGuardianBindingContactsFirst({
+      assistantId,
+      channel: "vellum",
+      guardianExternalUserId: legacyBinding.guardianExternalUserId,
+      guardianDeliveryChatId: legacyBinding.guardianDeliveryChatId,
+      guardianPrincipalId: legacyBinding.guardianPrincipalId,
+      verifiedVia: legacyBinding.verifiedVia,
+      metadataJson: legacyBinding.metadataJson,
+    });
+    log.info(
+      { assistantId, guardianPrincipalId: legacyBinding.guardianPrincipalId },
+      "Synced legacy vellum guardian binding into contacts",
+    );
+    return legacyBinding.guardianPrincipalId;
   }
 
   const guardianPrincipalId = `vellum-principal-${uuid()}`;


### PR DESCRIPTION
Addresses review feedback from PR #12091 and the unresolved comment on PR #12116.

When ensureVellumGuardianBinding runs at daemon startup, the contacts table may not yet have the guardian entry if the install still has data only in the legacy channel_guardian_bindings table. The previous fix (PR #12116) added a legacy fallback but only returned the principalId without syncing to contacts. PR #12145 then removed the fallback entirely.

This fix restores the legacy fallback AND syncs the binding into the contacts table via createGuardianBindingContactsFirst, ensuring downstream trust resolution paths (which read contacts only) see the guardian immediately.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
