### PR TITLE
Fix ffmpeg not found in bundled daemon PATH

### DIFF
--- a/assistant/src/util/spawn.ts
+++ b/assistant/src/util/spawn.ts
@@ -22,7 +22,18 @@ export function spawnWithTimeout(
   timeoutMs: number,
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
-    const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe" });
+    // Augment PATH so Homebrew-installed tools (ffmpeg, ffprobe, whisper-cpp)
+    // are found even when the daemon runs as a bundled binary with minimal PATH.
+    const proc = Bun.spawn(cmd, {
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        PATH: [process.env.PATH, "/opt/homebrew/bin", "/usr/local/bin"]
+          .filter(Boolean)
+          .join(":"),
+      },
+    });
     const timer = setTimeout(() => {
       proc.kill();
       reject(new Error(`Process timed out after ${timeoutMs}ms: ${cmd[0]}`));


### PR DESCRIPTION
## Summary
- Augment PATH in `spawnWithTimeout` to include `/opt/homebrew/bin` and `/usr/local/bin`
- The bundled daemon binary inherits a minimal PATH that doesn't include Homebrew, causing ffmpeg/ffprobe/whisper-cpp to not be found
- All media-processing tools (clip generation, keyframe extraction, transcription) go through this function

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
