### PR TITLE
Fix clip auto-open when tool runs inside claude_code

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1637,8 +1637,10 @@ extension ChatViewModel {
     }
 
     /// Auto-open generated video clips in the user's default video player.
+    /// Scans the result for a `clipPath` field rather than checking toolName,
+    /// because generate_clip runs inside claude_code (toolName is "claude_code").
     private func autoOpenClipIfNeeded(toolName: String, result: String, isError: Bool) {
-        guard !isError, toolName == "generate_clip" else { return }
+        guard !isError else { return }
         guard let jsonData = result.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
               let clipPath = json["clipPath"] as? String else {


### PR DESCRIPTION
## Summary
- Remove `toolName == "generate_clip"` guard from `autoOpenClipIfNeeded` — the tool runs inside `claude_code` so `msg.toolName` is always `"claude_code"`
- Instead, rely on the presence of `clipPath` in the result JSON, which is unique to `generate_clip` output
- The file existence check provides sufficient validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
