### PR TITLE
fix: resolve type errors in test files from contacts-first migration

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -177,10 +177,6 @@ import {
   upsertMemberContactsFirst,
 } from "../contacts/contacts-write.js";
 import {
-  createGuardianBindingContactsFirst,
-  upsertMemberContactsFirst,
-} from "../contacts/contacts-write.js";
-import {
   listCanonicalGuardianRequests,
   resolveCanonicalGuardianRequest,
 } from "../memory/canonical-guardian-store.js";


### PR DESCRIPTION
## Summary
- Remove duplicate import of `createGuardianBindingContactsFirst`/`upsertMemberContactsFirst` in relay-server.test.ts
- Fix `string | null` vs `string | undefined` mismatch in actor-token-service.test.ts
- Rename shadowed `result` variable to `contactChannel` in trusted-contact-multichannel.test.ts

## Original prompt
fix this ci issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22653989673/job/65659429215

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
