### PR TITLE
fix: resolve CI failures from contacts-first migration (#12151)

### DIFF
--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -445,7 +445,9 @@ describe("resolveLocalIpcAuthContext", () => {
     expect(guardianResult).toBeTruthy();
 
     const ctx = resolveLocalIpcAuthContext("session-123");
-    expect(ctx.actorPrincipalId).toBe(guardianResult!.contact.principalId);
+    expect(ctx.actorPrincipalId).toBe(
+      guardianResult!.contact.principalId ?? undefined,
+    );
   });
 
   test("actorPrincipalId is undefined when no vellum binding exists", () => {

--- a/assistant/src/__tests__/bundled-skill-retrieval-guard.test.ts
+++ b/assistant/src/__tests__/bundled-skill-retrieval-guard.test.ts
@@ -1,10 +1,14 @@
-import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, test } from "bun:test";
 
-import { describe, expect, test } from 'bun:test';
-
-const ASSISTANT_DIR = join(import.meta.dir, '..', '..');
-const BUNDLED_SKILLS_DIR = join(ASSISTANT_DIR, 'src', 'config', 'bundled-skills');
+const ASSISTANT_DIR = join(import.meta.dir, "..", "..");
+const BUNDLED_SKILLS_DIR = join(
+  ASSISTANT_DIR,
+  "src",
+  "config",
+  "bundled-skills",
+);
 
 function collectSkillFiles(rootDir: string): string[] {
   const pending = [rootDir];
@@ -20,7 +24,7 @@ function collectSkillFiles(rootDir: string): string[] {
         pending.push(fullPath);
         continue;
       }
-      if (entry.isFile() && entry.name === 'SKILL.md') {
+      if (entry.isFile() && entry.name === "SKILL.md") {
         files.push(fullPath);
       }
     }
@@ -36,25 +40,25 @@ const GATEWAY_RETRIEVAL_BANLIST: Array<{
   bannedSnippets: string[];
 }> = [
   {
-    skillPath: 'guardian-verify-setup/SKILL.md',
+    skillPath: "guardian-verify-setup/SKILL.md",
     bannedSnippets: [
       'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/status',
     ],
   },
   {
-    skillPath: 'telegram-setup/SKILL.md',
+    skillPath: "telegram-setup/SKILL.md",
     bannedSnippets: [
       'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/telegram/config',
     ],
   },
   {
-    skillPath: 'sms-setup/SKILL.md',
+    skillPath: "sms-setup/SKILL.md",
     bannedSnippets: [
       'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/sms/compliance"',
     ],
   },
   {
-    skillPath: 'trusted-contacts/SKILL.md',
+    skillPath: "trusted-contacts/SKILL.md",
     bannedSnippets: [
       'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/ingress/members',
       'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/ingress/invites',
@@ -62,39 +66,39 @@ const GATEWAY_RETRIEVAL_BANLIST: Array<{
     ],
   },
   {
-    skillPath: 'twilio-setup/SKILL.md',
+    skillPath: "twilio-setup/SKILL.md",
     bannedSnippets: [
       'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/config"',
       'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/numbers"',
     ],
   },
   {
-    skillPath: 'phone-calls/SKILL.md',
+    skillPath: "phone-calls/SKILL.md",
     bannedSnippets: [
       'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/config"',
     ],
   },
   {
-    skillPath: 'public-ingress/SKILL.md',
+    skillPath: "public-ingress/SKILL.md",
     bannedSnippets: [
-      'security find-generic-password',
-      'secret-tool lookup service vellum-assistant account credential:ngrok:authtoken',
-      'INTERNAL_GATEWAY_BASE_URL',
+      "security find-generic-password",
+      "secret-tool lookup service vellum-assistant account credential:ngrok:authtoken",
+      "INTERNAL_GATEWAY_BASE_URL",
     ],
   },
   {
-    skillPath: 'voice-setup/SKILL.md',
+    skillPath: "voice-setup/SKILL.md",
     bannedSnippets: [
-      'vellum config get elevenlabs.voiceId',
-      'vellum config get calls.enabled',
+      "vellum config get elevenlabs.voiceId",
+      "vellum config get calls.enabled",
     ],
   },
   {
-    skillPath: 'email-setup/SKILL.md',
+    skillPath: "email-setup/SKILL.md",
     bannedSnippets: [
-      'host_bash',
-      'vellum email create',
-      'vellum config set email.address',
+      "host_bash",
+      "vellum email create",
+      "vellum config set email.address",
     ],
   },
 ];
@@ -104,8 +108,8 @@ const KEYCHAIN_ALLOWLIST = new Set<string>([
 ]);
 
 const KEYCHAIN_PATTERNS = [
-  'security find-generic-password',
-  'secret-tool lookup service vellum-assistant account credential:',
+  "security find-generic-password",
+  "secret-tool lookup service vellum-assistant account credential:",
 ];
 
 const HOST_BASH_RETRIEVAL_ALLOWLIST = new Set<string>([
@@ -113,47 +117,49 @@ const HOST_BASH_RETRIEVAL_ALLOWLIST = new Set<string>([
 ]);
 
 const RETRIEVAL_MARKERS = [
-  'vellum integrations ',
-  'vellum config get',
-  'vellum email status',
-  'vellum email inbox list',
-  'vellum email provider get',
+  "vellum integrations ",
+  "vellum config get",
+  "vellum email status",
+  "vellum email inbox list",
+  "vellum email provider get",
 ];
 
-describe('bundled skill retrieval guard', () => {
-  test('migrated skills do not reintroduce direct gateway/keychain retrieval snippets', () => {
+describe("bundled skill retrieval guard", () => {
+  test("migrated skills do not reintroduce direct gateway/keychain retrieval snippets", () => {
     const violations: string[] = [];
 
     for (const rule of GATEWAY_RETRIEVAL_BANLIST) {
       const abs = join(BUNDLED_SKILLS_DIR, rule.skillPath);
-      const content = readFileSync(abs, 'utf-8');
+      const content = readFileSync(abs, "utf-8");
       for (const snippet of rule.bannedSnippets) {
         if (content.includes(snippet)) {
-          violations.push(`${rule.skillPath}: contains banned snippet "${snippet}"`);
+          violations.push(
+            `${rule.skillPath}: contains banned snippet "${snippet}"`,
+          );
         }
       }
     }
 
     if (violations.length > 0) {
       const message = [
-        'Bundled skill retrieval contract regression detected.',
-        'Migrated skills must not reintroduce direct gateway/keychain retrieval snippets.',
-        '',
-        'Violations:',
+        "Bundled skill retrieval contract regression detected.",
+        "Migrated skills must not reintroduce direct gateway/keychain retrieval snippets.",
+        "",
+        "Violations:",
         ...violations.map((v) => `  - ${v}`),
-      ].join('\n');
+      ].join("\n");
 
       expect(violations, message).toEqual([]);
     }
   });
 
-  test('bundled skills do not contain direct keychain lookup instructions', () => {
+  test("bundled skills do not contain direct keychain lookup instructions", () => {
     const violations: string[] = [];
 
     for (const skillFile of ALL_SKILL_FILES) {
-      const rel = relative(ASSISTANT_DIR, skillFile).replaceAll('\\', '/');
+      const rel = relative(ASSISTANT_DIR, skillFile).replaceAll("\\", "/");
       if (KEYCHAIN_ALLOWLIST.has(rel)) continue;
-      const content = readFileSync(skillFile, 'utf-8');
+      const content = readFileSync(skillFile, "utf-8");
       for (const pattern of KEYCHAIN_PATTERNS) {
         if (content.includes(pattern)) {
           violations.push(`${rel}: contains "${pattern}"`);
@@ -163,45 +169,47 @@ describe('bundled skill retrieval guard', () => {
 
     if (violations.length > 0) {
       const message = [
-        'Direct keychain lookup instructions were found in bundled skills.',
-        'Use credential_store and CLI/proxied flows instead.',
-        '',
-        'Violations:',
+        "Direct keychain lookup instructions were found in bundled skills.",
+        "Use credential_store and CLI/proxied flows instead.",
+        "",
+        "Violations:",
         ...violations.map((v) => `  - ${v}`),
-        '',
-        'Add intentional exceptions to KEYCHAIN_ALLOWLIST only when required.',
-      ].join('\n');
+        "",
+        "Add intentional exceptions to KEYCHAIN_ALLOWLIST only when required.",
+      ].join("\n");
 
       expect(violations, message).toEqual([]);
     }
   });
 
-  test('bundled skills do not require host_bash for Vellum CLI retrieval commands', () => {
+  test("bundled skills do not require host_bash for Vellum CLI retrieval commands", () => {
     const violations: string[] = [];
 
     for (const skillFile of ALL_SKILL_FILES) {
-      const rel = relative(ASSISTANT_DIR, skillFile).replaceAll('\\', '/');
+      const rel = relative(ASSISTANT_DIR, skillFile).replaceAll("\\", "/");
       if (HOST_BASH_RETRIEVAL_ALLOWLIST.has(rel)) continue;
-      const content = readFileSync(skillFile, 'utf-8');
-      const hasHostBash = content.includes('host_bash');
+      const content = readFileSync(skillFile, "utf-8");
+      const hasHostBash = content.includes("host_bash");
       if (!hasHostBash) continue;
-      const hasRetrievalMarker = RETRIEVAL_MARKERS.some((marker) => content.includes(marker));
+      const hasRetrievalMarker = RETRIEVAL_MARKERS.some((marker) =>
+        content.includes(marker),
+      );
       if (!hasRetrievalMarker) continue;
       violations.push(
-        `${rel}: contains host_bash with Vellum CLI retrieval markers (${RETRIEVAL_MARKERS.join(', ')})`,
+        `${rel}: contains host_bash with Vellum CLI retrieval markers (${RETRIEVAL_MARKERS.join(", ")})`,
       );
     }
 
     if (violations.length > 0) {
       const message = [
-        'Bundled skills must not require host_bash for Vellum CLI retrieval commands.',
-        'Use sandboxed bash for retrieval flows unless an explicit exception is documented.',
-        '',
-        'Violations:',
+        "Bundled skills must not require host_bash for Vellum CLI retrieval commands.",
+        "Use sandboxed bash for retrieval flows unless an explicit exception is documented.",
+        "",
+        "Violations:",
         ...violations.map((v) => `  - ${v}`),
-        '',
-        'Add intentional exceptions to HOST_BASH_RETRIEVAL_ALLOWLIST only when required.',
-      ].join('\n');
+        "",
+        "Add intentional exceptions to HOST_BASH_RETRIEVAL_ALLOWLIST only when required.",
+      ].join("\n");
 
       expect(violations, message).toEqual([]);
     }

--- a/assistant/src/__tests__/integrations-cli.test.ts
+++ b/assistant/src/__tests__/integrations-cli.test.ts
@@ -1,26 +1,27 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
-import { Command } from 'commander';
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-let gatewayBase = 'http://gateway.test';
+import { Command } from "commander";
+
+let gatewayBase = "http://gateway.test";
 let signingKeyInitialized = false;
 let initCalls = 0;
 let loadCalls = 0;
 let mintCalls = 0;
 let rawConfig: Record<string, unknown> = {};
 
-mock.module('../config/env.js', () => ({
+mock.module("../config/env.js", () => ({
   getGatewayInternalBaseUrl: () => gatewayBase,
 }));
 
-mock.module('../config/loader.js', () => ({
+mock.module("../config/loader.js", () => ({
   loadRawConfig: () => rawConfig,
 }));
 
-mock.module('../config/elevenlabs-schema.js', () => ({
-  DEFAULT_ELEVENLABS_VOICE_ID: '21m00Tcm4TlvDq8ikWAM',
+mock.module("../config/elevenlabs-schema.js", () => ({
+  DEFAULT_ELEVENLABS_VOICE_ID: "21m00Tcm4TlvDq8ikWAM",
 }));
 
-mock.module('../runtime/auth/token-service.js', () => ({
+mock.module("../runtime/auth/token-service.js", () => ({
   isSigningKeyInitialized: () => signingKeyInitialized,
   initAuthSigningKey: (_key: Buffer) => {
     signingKeyInitialized = true;
@@ -32,11 +33,11 @@ mock.module('../runtime/auth/token-service.js', () => ({
   },
   mintEdgeRelayToken: () => {
     mintCalls += 1;
-    return 'minted-edge-token';
+    return "minted-edge-token";
   },
 }));
 
-const { registerIntegrationsCommand } = await import('../cli/integrations.js');
+const { registerIntegrationsCommand } = await import("../cli/integrations.js");
 
 type FetchCall = { url: string; authHeader: string | null };
 
@@ -53,20 +54,20 @@ async function runCli(
   const stdoutChunks: string[] = [];
 
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-    const url = typeof input === 'string' ? input : input.toString();
+    const url = typeof input === "string" ? input : input.toString();
     const headers = new Headers(init?.headers);
     fetchCalls.push({
       url,
-      authHeader: headers.get('authorization'),
+      authHeader: headers.get("authorization"),
     });
     return new Response(JSON.stringify(responseBody), {
       status: responseStatus,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { "Content-Type": "application/json" },
     });
   }) as typeof fetch;
 
   process.stdout.write = ((chunk: unknown) => {
-    stdoutChunks.push(typeof chunk === 'string' ? chunk : String(chunk));
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
     return true;
   }) as typeof process.stdout.write;
 
@@ -75,7 +76,7 @@ async function runCli(
   try {
     const program = new Command();
     registerIntegrationsCommand(program);
-    await program.parseAsync(['node', 'vellum', 'integrations', ...args]);
+    await program.parseAsync(["node", "vellum", "integrations", ...args]);
   } finally {
     process.stdout.write = originalWrite;
     globalThis.fetch = originalFetch;
@@ -88,14 +89,14 @@ async function runCli(
 
   return {
     exitCode: process.exitCode ?? 0,
-    stdout: stdoutChunks.join(''),
+    stdout: stdoutChunks.join(""),
     fetchCalls,
   };
 }
 
-describe('vellum integrations CLI', () => {
+describe("vellum integrations CLI", () => {
   beforeEach(() => {
-    gatewayBase = 'http://gateway.test';
+    gatewayBase = "http://gateway.test";
     signingKeyInitialized = false;
     initCalls = 0;
     loadCalls = 0;
@@ -111,125 +112,144 @@ describe('vellum integrations CLI', () => {
     process.exitCode = 0;
   });
 
-  test('uses GATEWAY_AUTH_TOKEN from env when present', async () => {
-    process.env.GATEWAY_AUTH_TOKEN = 'env-token';
-    const result = await runCli(['--json', 'twilio', 'config'], { success: true });
+  test("uses GATEWAY_AUTH_TOKEN from env when present", async () => {
+    process.env.GATEWAY_AUTH_TOKEN = "env-token";
+    const result = await runCli(["--json", "twilio", "config"], {
+      success: true,
+    });
 
     expect(result.exitCode).toBe(0);
     expect(result.fetchCalls.length).toBe(1);
-    expect(result.fetchCalls[0]?.url).toBe('http://gateway.test/v1/integrations/twilio/config');
-    expect(result.fetchCalls[0]?.authHeader).toBe('Bearer env-token');
+    expect(result.fetchCalls[0]?.url).toBe(
+      "http://gateway.test/v1/integrations/twilio/config",
+    );
+    expect(result.fetchCalls[0]?.authHeader).toBe("Bearer env-token");
     expect(loadCalls).toBe(0);
     expect(initCalls).toBe(0);
     expect(mintCalls).toBe(0);
   });
 
-  test('mints a gateway token when no env token is provided', async () => {
-    const result = await runCli(['--json', 'telegram', 'config'], { success: true });
+  test("mints a gateway token when no env token is provided", async () => {
+    const result = await runCli(["--json", "telegram", "config"], {
+      success: true,
+    });
 
     expect(result.exitCode).toBe(0);
-    expect(result.fetchCalls[0]?.authHeader).toBe('Bearer minted-edge-token');
+    expect(result.fetchCalls[0]?.authHeader).toBe("Bearer minted-edge-token");
     expect(loadCalls).toBe(1);
     expect(initCalls).toBe(1);
     expect(mintCalls).toBe(1);
   });
 
-  test('prefers INTERNAL_GATEWAY_BASE_URL when it is injected', async () => {
-    process.env.INTERNAL_GATEWAY_BASE_URL = 'http://gateway.internal:9900/';
-    const result = await runCli(['--json', 'twilio', 'config'], { success: true });
+  test("prefers INTERNAL_GATEWAY_BASE_URL when it is injected", async () => {
+    process.env.INTERNAL_GATEWAY_BASE_URL = "http://gateway.internal:9900/";
+    const result = await runCli(["--json", "twilio", "config"], {
+      success: true,
+    });
     expect(result.exitCode).toBe(0);
-    expect(result.fetchCalls[0]?.url).toBe('http://gateway.internal:9900/v1/integrations/twilio/config');
+    expect(result.fetchCalls[0]?.url).toBe(
+      "http://gateway.internal:9900/v1/integrations/twilio/config",
+    );
   });
 
-  test('passes channel query for guardian status', async () => {
-    const result = await runCli(['--json', 'guardian', 'status', '--channel', 'telegram'], { success: true });
+  test("passes channel query for guardian status", async () => {
+    const result = await runCli(
+      ["--json", "guardian", "status", "--channel", "telegram"],
+      { success: true },
+    );
     expect(result.exitCode).toBe(0);
-    expect(result.fetchCalls[0]?.url).toBe('http://gateway.test/v1/integrations/guardian/status?channel=telegram');
+    expect(result.fetchCalls[0]?.url).toBe(
+      "http://gateway.test/v1/integrations/guardian/status?channel=telegram",
+    );
   });
 
-  test('passes filters for ingress members', async () => {
+  test("passes filters for ingress members", async () => {
     const result = await runCli(
       [
-        '--json',
-        'ingress',
-        'members',
-        '--assistant-id',
-        'assistant-1',
-        '--source-channel',
-        'voice',
-        '--status',
-        'active',
+        "--json",
+        "ingress",
+        "members",
+        "--assistant-id",
+        "assistant-1",
+        "--source-channel",
+        "voice",
+        "--status",
+        "active",
       ],
       { ok: true, members: [] },
     );
     expect(result.exitCode).toBe(0);
     expect(result.fetchCalls[0]?.url).toBe(
-      'http://gateway.test/v1/ingress/members?assistantId=assistant-1&sourceChannel=voice&status=active',
+      "http://gateway.test/v1/ingress/members?assistantId=assistant-1&sourceChannel=voice&status=active",
     );
   });
 
-  test('reads ingress config without gateway fetch', async () => {
+  test("reads ingress config without gateway fetch", async () => {
     rawConfig = {
       ingress: {
         enabled: true,
-        publicBaseUrl: 'https://public.example.com',
+        publicBaseUrl: "https://public.example.com",
       },
     };
-    process.env.INTERNAL_GATEWAY_BASE_URL = 'http://gateway.internal:9900/';
-    const result = await runCli(['--json', 'ingress', 'config'], { ok: true });
+    process.env.INTERNAL_GATEWAY_BASE_URL = "http://gateway.internal:9900/";
+    const result = await runCli(["--json", "ingress", "config"], { ok: true });
 
     expect(result.exitCode).toBe(0);
     expect(result.fetchCalls.length).toBe(0);
     expect(JSON.parse(result.stdout)).toEqual({
       success: true,
       enabled: true,
-      publicBaseUrl: 'https://public.example.com',
-      localGatewayTarget: 'http://gateway.internal:9900',
+      publicBaseUrl: "https://public.example.com",
+      localGatewayTarget: "http://gateway.internal:9900",
     });
   });
 
-  test('reads voice config without gateway fetch', async () => {
+  test("reads voice config without gateway fetch", async () => {
     rawConfig = {
       calls: {
         enabled: true,
       },
       elevenlabs: {
-        voiceId: 'EXAVITQu4vr4xnSDxMaL',
+        voiceId: "EXAVITQu4vr4xnSDxMaL",
       },
     };
-    const result = await runCli(['--json', 'voice', 'config'], { ok: true });
+    const result = await runCli(["--json", "voice", "config"], { ok: true });
 
     expect(result.exitCode).toBe(0);
     expect(result.fetchCalls.length).toBe(0);
     expect(JSON.parse(result.stdout)).toEqual({
       success: true,
       callsEnabled: true,
-      voiceId: 'EXAVITQu4vr4xnSDxMaL',
-      configuredVoiceId: 'EXAVITQu4vr4xnSDxMaL',
+      voiceId: "EXAVITQu4vr4xnSDxMaL",
+      configuredVoiceId: "EXAVITQu4vr4xnSDxMaL",
       usesDefaultVoice: false,
     });
   });
 
-  test('voice config reports default voice when unset', async () => {
+  test("voice config reports default voice when unset", async () => {
     rawConfig = {};
-    const result = await runCli(['--json', 'voice', 'config'], { ok: true });
+    const result = await runCli(["--json", "voice", "config"], { ok: true });
 
     expect(result.exitCode).toBe(0);
     expect(result.fetchCalls.length).toBe(0);
     expect(JSON.parse(result.stdout)).toEqual({
       success: true,
       callsEnabled: false,
-      voiceId: '21m00Tcm4TlvDq8ikWAM',
+      voiceId: "21m00Tcm4TlvDq8ikWAM",
       usesDefaultVoice: true,
     });
   });
 
-  test('returns structured error output when gateway request fails', async () => {
-    const result = await runCli(['--json', 'twilio', 'numbers'], { error: 'Unauthorized' }, 401);
+  test("returns structured error output when gateway request fails", async () => {
+    const result = await runCli(
+      ["--json", "twilio", "numbers"],
+      { error: "Unauthorized" },
+      401,
+    );
     expect(result.exitCode).toBe(1);
     expect(JSON.parse(result.stdout)).toEqual({
       ok: false,
-      error: 'Unauthorized [401]',
+      error: "Unauthorized [401]",
     });
   });
 });

--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -24,12 +24,12 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+import { upsertMemberContactsFirst } from "../contacts/contacts-write.js";
 import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
 import {
   createInvite,
   revokeInvite as revokeStoreFn,
 } from "../memory/ingress-invite-store.js";
-import { upsertMemberContactsFirst } from "../contacts/contacts-write.js";
 import {
   type InviteRedemptionOutcome,
   redeemInvite,

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -93,12 +93,12 @@ mock.module("../runtime/gateway-client.js", () => ({
   },
 }));
 
+import { createGuardianBindingContactsFirst } from "../contacts/contacts-write.js";
 import {
   listCanonicalGuardianDeliveries,
   listCanonicalGuardianRequests,
 } from "../memory/canonical-guardian-store.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
-import { createGuardianBindingContactsFirst } from "../contacts/contacts-write.js";
 import { notifyGuardianOfAccessRequest } from "../runtime/access-request-helper.js";
 import { handleChannelInbound } from "../runtime/routes/channel-routes.js";
 

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -185,10 +185,6 @@ import {
   createVerificationSession,
 } from "../memory/channel-guardian-store.js";
 import { addMessage, getMessages } from "../memory/conversation-store.js";
-import {
-  createGuardianBindingContactsFirst,
-  upsertMemberContactsFirst,
-} from "../contacts/contacts-write.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { createInvite } from "../memory/ingress-invite-store.js";
 import { conversations } from "../memory/schema.js";

--- a/assistant/src/__tests__/trusted-contact-multichannel.test.ts
+++ b/assistant/src/__tests__/trusted-contact-multichannel.test.ts
@@ -270,7 +270,7 @@ for (const config of CHANNEL_CONFIGS) {
         verificationPurpose: "trusted_contact",
       });
 
-      const result = validateAndConsumeChallenge(
+      const challengeResult = validateAndConsumeChallenge(
         "self",
         config.channel,
         session.secret,
@@ -280,9 +280,9 @@ for (const config of CHANNEL_CONFIGS) {
         "Test Requester",
       );
 
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.verificationType).toBe("trusted_contact");
+      expect(challengeResult.success).toBe(true);
+      if (challengeResult.success) {
+        expect(challengeResult.verificationType).toBe("trusted_contact");
       }
 
       upsertMemberContactsFirst({
@@ -296,15 +296,15 @@ for (const config of CHANNEL_CONFIGS) {
         username: "test_requester",
       });
 
-      const result = findContactChannel({
+      const contactResult = findContactChannel({
         channelType: config.channel,
         externalUserId: config.senderExternalUserId,
       });
 
-      expect(result).not.toBeNull();
-      expect(result!.channel.status).toBe("active");
-      expect(result!.channel.policy).toBe("allow");
-      expect(result!.channel.type).toBe(config.channel);
+      expect(contactResult).not.toBeNull();
+      expect(contactResult!.channel.status).toBe("active");
+      expect(contactResult!.channel.policy).toBe("allow");
+      expect(contactResult!.channel.type).toBe(config.channel);
     });
 
     test("no cross-channel leakage between member records", () => {

--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -24,9 +24,9 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+import { upsertMemberContactsFirst } from "../contacts/contacts-write.js";
 import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
 import { createInvite, revokeInvite } from "../memory/ingress-invite-store.js";
-import { upsertMemberContactsFirst } from "../contacts/contacts-write.js";
 import { redeemVoiceInviteCode } from "../runtime/invite-redemption-service.js";
 import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
 

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -10,7 +10,6 @@ import { setRelayBroadcast } from "../calls/relay-server.js";
 import { TwilioConversationRelayProvider } from "../calls/twilio-provider.js";
 import { setVoiceBridgeDeps } from "../calls/voice-session-bridge.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
-import { migrateContactsFromLegacyTables } from "../contacts/startup-migration.js";
 import {
   getQdrantUrlEnv,
   getRuntimeHttpHost,
@@ -21,6 +20,7 @@ import {
 import { loadConfig } from "../config/loader.js";
 import { ensurePromptFiles } from "../config/system-prompt.js";
 import { syncUpdateBulletinOnStartup } from "../config/update-bulletin.js";
+import { migrateContactsFromLegacyTables } from "../contacts/startup-migration.js";
 import { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { getHookManager } from "../hooks/manager.js";
 import { installTemplates } from "../hooks/templates.js";

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -18,7 +18,6 @@ import {
   hashToken,
   markInviteExpired,
   recordInviteUse,
-  redeemInvite as storeRedeemInvite,
 } from "../memory/ingress-invite-store.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
 import { hashVoiceCode } from "../util/voice-code.js";
@@ -125,7 +124,10 @@ export function redeemInvite(params: {
   // Token is valid — now safe to check existing membership without leaking
   // membership status to callers with bogus tokens.
   const canonicalUserId = externalUserId
-    ? canonicalizeInboundIdentity(sourceChannel as ChannelId, externalUserId) ?? externalUserId
+    ? (canonicalizeInboundIdentity(
+        sourceChannel as ChannelId,
+        externalUserId,
+      ) ?? externalUserId)
     : undefined;
   const contactResult = findContactChannel({
     channelType: sourceChannel,
@@ -149,9 +151,8 @@ export function redeemInvite(params: {
 
   // Inactive member reactivation: when the user already has a member record
   // in a non-active state (revoked/pending), reactivate it via upsertMember
-  // and consume an invite use atomically. Falling through to storeRedeemInvite
-  // would try to INSERT a new member row, hitting the unique-key constraint
-  // on the members table.
+  // and consume an invite use atomically. The fresh-member path below also
+  // uses upsertMemberContactsFirst to keep contacts in sync.
   if (existingMember) {
     // Sentinel error used to trigger a transaction rollback when the invite
     // was concurrently revoked/expired between pre-validation and write time.
@@ -219,30 +220,46 @@ export function redeemInvite(params: {
     };
   }
 
-  // Delegate to the store-level redeem which handles token lookup, expiry,
-  // use-count, and transactional member creation. Channel enforcement is
-  // applied by passing sourceChannel so the store checks it.
-  const result = storeRedeemInvite({
-    rawToken,
-    sourceChannel,
-    externalUserId,
-    externalChatId,
-    displayName,
-    username,
-  });
+  // Fresh member creation: upsert into contacts tables and consume an invite
+  // use atomically, mirroring the reactivation path above.
+  const STALE_INVITE_FRESH = Symbol("stale_invite_fresh");
+  let freshMember: ReturnType<typeof upsertMemberContactsFirst> | undefined;
+  try {
+    getSqlite()
+      .transaction(() => {
+        freshMember = upsertMemberContactsFirst({
+          assistantId: assistantId ?? invite.assistantId,
+          sourceChannel,
+          externalUserId,
+          externalChatId,
+          displayName,
+          username,
+          status: "active",
+          policy: "allow",
+          inviteId: invite.id,
+        });
 
-  if ("error" in result) {
-    const mapped = STORE_ERROR_TO_REASON[result.error];
-    if (mapped) return mapped;
-    // Fallback for any unrecognized store error
-    return { ok: false, reason: "invalid_token" };
+        const recorded = recordInviteUse({
+          inviteId: invite.id,
+          externalUserId,
+          externalChatId,
+        });
+
+        if (!recorded) throw STALE_INVITE_FRESH;
+      })
+      .immediate();
+  } catch (err) {
+    if (err === STALE_INVITE_FRESH) {
+      return { ok: false, reason: "invalid_token" };
+    }
+    throw err;
   }
 
   return {
     ok: true,
     type: "redeemed",
-    memberId: result.member.id,
-    inviteId: result.invite.id,
+    memberId: freshMember!.id,
+    inviteId: invite.id,
   };
 }
 
@@ -320,13 +337,17 @@ export function redeemVoiceInviteCode(params: {
 
   // Check for existing membership
   const canonicalCallerId =
-    canonicalizeInboundIdentity("voice" as ChannelId, callerExternalUserId) ?? callerExternalUserId;
+    canonicalizeInboundIdentity("voice" as ChannelId, callerExternalUserId) ??
+    callerExternalUserId;
   const voiceContactResult = findContactChannel({
     channelType: "voice",
     externalUserId: canonicalCallerId,
   });
   const existingMember = voiceContactResult
-    ? contactChannelToMemberRecord(voiceContactResult.contact, voiceContactResult.channel)
+    ? contactChannelToMemberRecord(
+        voiceContactResult.contact,
+        voiceContactResult.channel,
+      )
     : null;
 
   if (existingMember && existingMember.status === "active") {


### PR DESCRIPTION
## Summary
- Fixes test, lint, and type-check CI failures introduced by #12151 (contacts-first migration)
- Migrates the fresh-member invite redemption path to use `upsertMemberContactsFirst` instead of the legacy `storeRedeemInvite`, ensuring contacts tables are populated for `findContactChannel` queries
- Fixes duplicate variable declarations, duplicate imports, unused imports, import sorting, and type mismatches across 9 files

## Original prompt
fix this ci issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22653989673/job/65659429189

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
