### PR TITLE
docs: move approval and guardian rules to assistant/src/approvals/AGENTS.md

### DIFF
--- a/assistant/src/approvals/AGENTS.md
+++ b/assistant/src/approvals/AGENTS.md
@@ -1,0 +1,26 @@
+# Approvals & Guardian Rules
+
+## Approval Flow Resilience
+
+- **Rich delivery failures must degrade gracefully.** If delivering a rich approval prompt (e.g., Telegram inline buttons) fails, fall back to plain text with parser-compatible instructions (e.g., `Reply "yes" to approve`) — never auto-deny.
+- **Non-rich channels** (SMS, http-api) receive plain-text approval prompts without approval metadata payloads.
+- **Race conditions:** Always check whether a decision has already been resolved before delivering the engine's optimistic reply. If `handleChannelDecision` returns `applied: false`, deliver an "already resolved" notice and return `stale_ignored`.
+- **Requester self-cancel:** A requester with a pending guardian approval must be able to cancel their own request (but not self-approve).
+- **Unified guardian decision primitive:** All guardian decision paths (callback buttons, conversational engine, legacy text parser, requester self-cancel) must route through `applyGuardianDecision()` in `assistant/src/approvals/guardian-decision-primitive.ts`. Do not inline decision logic (approve_always downgrade, approval record updates, grant minting) at individual callsites.
+
+## Guardian Verification Invariant
+
+Guardian verification consumption must be identity-bound to the expected recipient identity. Every outbound verification session stores the expected identity (phone E.164, Telegram user/chat ID), and the consume path rejects attempts where the responding actor's identity does not match.
+
+Conversational guardian verification control-plane invocation is guardian-only. Non-guardian and unverified-channel actors cannot invoke guardian verification endpoints (`/v1/integrations/guardian/*`) conversationally via tools. Enforcement is a deterministic gate in the tool execution layer (`assistant/src/tools/executor.ts`) using actor-role context — only `guardian` and `undefined` (desktop/trusted) actor roles pass. The policy module is at `assistant/src/tools/guardian-control-plane-policy.ts`.
+
+## Memory Provenance Invariant
+
+All memory extraction and retrieval decisions must consider actor-role provenance. Untrusted actors (non-guardian, unverified_channel) must not trigger profile extraction or receive memory recall/conflict disclosures. This invariant is enforced in `indexer.ts` (write gate) and `session-memory.ts` (read gate).
+
+## Guardian Privilege Isolation Invariant
+
+Untrusted actors (`non-guardian`, `unverified_channel`) must never receive privileged host/tool capabilities or privileged conversation context directly.
+
+- Tool execution gate: untrusted actors cannot execute host-target tools or side-effect tools in-band. These actions require guardian-mediated approval flow. Enforcement lives in `assistant/src/tools/tool-approval-handler.ts`.
+- History view gate: when loading session history for untrusted actors, only untrusted-provenance messages are included and compacted summaries are suppressed. This prevents replay of guardian-era context after trust downgrades. Enforcement lives in `assistant/src/daemon/session-lifecycle.ts` and actor-scoped reload wiring in `assistant/src/daemon/session.ts`.

--- a/assistant/src/approvals/CLAUDE.md
+++ b/assistant/src/approvals/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Extract approval and guardian rules from root AGENTS.md into assistant/src/approvals/AGENTS.md
- Includes: Approval Flow Resilience, Guardian Verification Invariant, Guardian Privilege Isolation, Memory Provenance Invariant
- Add CLAUDE.md symlink pointing to AGENTS.md

Part of plan: reduce-claude-md.md (PR 3 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
