### PR TITLE
fix: repair broken assistant/CLAUDE.md symlink, create assistant/AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ dist
 temp.sh
 context.md
 CLAUDE.md
+!assistant/CLAUDE.md
 .agents
 .codex
 .vellum

--- a/assistant/AGENTS.md
+++ b/assistant/AGENTS.md
@@ -1,0 +1,5 @@
+# Assistant Service — Agent Instructions
+
+For error handling conventions (throw vs result objects vs null), see [docs/error-handling.md](docs/error-handling.md).
+
+Subdirectory-scoped rules live in local AGENTS.md files: `src/runtime/`, `src/approvals/`, `src/notifications/`.

--- a/assistant/CLAUDE.md
+++ b/assistant/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Fix broken assistant/CLAUDE.md symlink (was pointing to assistant/AGENTS.md which resolved to nonexistent assistant/assistant/AGENTS.md)
- Create assistant/AGENTS.md with pointers to subdirectory docs and error-handling.md
- Recreate CLAUDE.md as correct symlink to AGENTS.md
- Add .gitignore negation for assistant/CLAUDE.md so the symlink is tracked

Part of plan: reduce-claude-md.md (PR 5 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
