### PR TITLE
fix: isolate reminder test DBs to prevent cross-file race conditions

### DIFF
--- a/assistant/src/__tests__/reminder-store.test.ts
+++ b/assistant/src/__tests__/reminder-store.test.ts
@@ -1,3 +1,10 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const testDir = mkdtempSync(join(tmpdir(), "reminder-store-test-"));
+process.env.BASE_DATA_DIR = testDir;
+
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
@@ -21,6 +28,7 @@ function clearReminders() {
 
 afterAll(() => {
   resetDb();
+  rmSync(testDir, { recursive: true, force: true });
 });
 
 describe("reminder-store", () => {

--- a/assistant/src/__tests__/reminder.test.ts
+++ b/assistant/src/__tests__/reminder.test.ts
@@ -1,3 +1,10 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const testDir = mkdtempSync(join(tmpdir(), "reminder-test-"));
+process.env.BASE_DATA_DIR = testDir;
+
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
@@ -17,6 +24,7 @@ function clearReminders() {
 
 afterAll(() => {
   resetDb();
+  rmSync(testDir, { recursive: true, force: true });
 });
 
 describe("reminder tool", () => {


### PR DESCRIPTION
## Summary
- Both `reminder-store.test.ts` and `reminder.test.ts` share the same SQLite DB file when running in parallel, causing `clearReminders()` in one process to race with data created by the other
- Set `BASE_DATA_DIR` to a unique temp directory in each test file before `initializeDb()` so each gets its own isolated database
- Clean up temp directories in `afterAll`

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22654157237/job/65659942536

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
