### PR TITLE
perf(tests): lower PBKDF2 iterations to 1 in test env

### DIFF
--- a/assistant/src/security/encrypted-store.ts
+++ b/assistant/src/security/encrypted-store.ts
@@ -31,7 +31,10 @@ const ALGORITHM = "aes-256-gcm";
 const KEY_LENGTH = 32; // bytes (256 bits)
 const IV_LENGTH = 16; // bytes (128 bits)
 const AUTH_TAG_LENGTH = 16; // bytes
-const PBKDF2_ITERATIONS = 100_000;
+const PBKDF2_ITERATIONS =
+  // In tests, PBKDF2 key derivation dominates runtime (~1-2s per file).
+  // 1 iteration is sufficient for correctness; 100k is for brute-force resistance.
+  process.env.BUN_TEST === "1" ? 1 : 100_000;
 const SALT_LENGTH = 32; // bytes
 
 /** On-disk format for the encrypted store. */


### PR DESCRIPTION
## Summary
- Reduces PBKDF2 iterations from 100,000 to 1 when `BUN_TEST=1` is set
- Saves ~1-2s per test file that touches the encrypted store (credential-vault, encrypted-store, credential-broker tests)
- No production behavior change — the 100k iteration count is preserved for non-test environments

## Original prompt
all of these in separate PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
