### PR TITLE
fix: update test imports for deleted legacy store files

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -51,30 +51,7 @@ mock.module("../daemon/handlers.js", () => ({
   }),
 }));
 
-// Mock ingress member store to return an active member for all lookups.
-// The ingress ACL is always-on and requires member records, but approval
-// route tests focus on approval orchestration, not ACL enforcement.
-mock.module("../memory/ingress-member-store.js", () => ({
-  findMember: () => ({
-    id: "member-test-default",
-    assistantId: "self",
-    sourceChannel: "telegram",
-    externalUserId: "telegram-user-default",
-    externalChatId: null,
-    displayName: null,
-    username: null,
-    status: "active",
-    policy: "allow",
-    inviteId: null,
-    createdBySessionId: null,
-    revokedReason: null,
-    blockedReason: null,
-    lastSeenAt: null,
-    createdAt: Date.now(),
-    updatedAt: Date.now(),
-  }),
-  updateLastSeen: () => {},
-}));
+
 import { upsertContact } from "../contacts/contact-store.js";
 import { createGuardianBindingContactsFirst } from "../contacts/contacts-write.js";
 import type { Session } from "../daemon/session.js";

--- a/assistant/src/__tests__/conversation-attention-telegram.test.ts
+++ b/assistant/src/__tests__/conversation-attention-telegram.test.ts
@@ -47,30 +47,6 @@ mock.module("../daemon/handlers.js", () => ({
   }),
 }));
 
-// Mock ingress member store to return an active member for all lookups
-mock.module("../memory/ingress-member-store.js", () => ({
-  findMember: () => ({
-    id: "member-test-default",
-    assistantId: "self",
-    sourceChannel: "telegram",
-    externalUserId: "telegram-user-default",
-    externalChatId: null,
-    displayName: null,
-    username: null,
-    status: "active",
-    policy: "allow",
-    inviteId: null,
-    createdBySessionId: null,
-    revokedReason: null,
-    blockedReason: null,
-    lastSeenAt: null,
-    createdAt: Date.now(),
-    updatedAt: Date.now(),
-  }),
-  updateLastSeen: () => {},
-  upsertMember: () => {},
-}));
-
 import { eq } from "drizzle-orm";
 
 import { upsertContact } from "../contacts/contact-store.js";

--- a/assistant/src/__tests__/guardian-routing-state.test.ts
+++ b/assistant/src/__tests__/guardian-routing-state.test.ts
@@ -37,35 +37,6 @@ mock.module("../security/secret-ingress.js", () => ({
   checkIngressForSecrets: () => ({ blocked: false }),
 }));
 
-// Mock ingress member store with a configurable member lookup.
-// By default returns an active member so ACL passes.
-let mockFindMember: (() => unknown) | null = null;
-mock.module("../memory/ingress-member-store.js", () => ({
-  findMember: (..._args: unknown[]) => {
-    if (mockFindMember) return mockFindMember();
-    return {
-      id: "member-test-default",
-      assistantId: "self",
-      sourceChannel: "telegram",
-      externalUserId: "telegram-user-default",
-      externalChatId: null,
-      displayName: null,
-      username: null,
-      status: "active",
-      policy: "allow",
-      inviteId: null,
-      createdBySessionId: null,
-      revokedReason: null,
-      blockedReason: null,
-      lastSeenAt: null,
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-    };
-  },
-  updateLastSeen: () => {},
-  upsertMember: () => {},
-}));
-
 import { upsertContact } from "../contacts/contact-store.js";
 import { createGuardianBindingContactsFirst } from "../contacts/contacts-write.js";
 import type { TrustContext } from "../daemon/session-runtime-assembly.js";
@@ -211,7 +182,6 @@ describe("resolveRoutingStateFromRuntime", () => {
 describe("inbound-message-handler trusted-contact interactivity", () => {
   beforeEach(() => {
     resetTables();
-    mockFindMember = null;
     // Insert a test contact so the contacts-based ACL lookup passes
     upsertContact({
       displayName: "Test User",
@@ -405,10 +375,8 @@ describe("inbound-message-handler trusted-contact interactivity", () => {
   });
 
   test("unknown actors remain non-interactive (denied at gate)", async () => {
-    // No member record => non-member denied at the ACL gate,
+    // No contact record => non-member denied at the ACL gate,
     // which is the strongest form of "not interactive".
-    mockFindMember = () => null;
-
     const req = makeInboundRequest({
       externalMessageId: `msg-unknown-${Date.now()}`,
       actorExternalId: "unknown-user-no-member",
@@ -430,7 +398,6 @@ describe("inbound-message-handler trusted-contact interactivity", () => {
 describe("channel-retry-sweep routing state", () => {
   beforeEach(() => {
     resetTables();
-    mockFindMember = null;
   });
 
   function seedFailedEvent(

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -44,14 +44,6 @@ mock.module("../security/secret-ingress.js", () => ({
   checkIngressForSecrets: () => ({ blocked: false }),
 }));
 
-// Mock ingress member store: findMember always returns null (non-member),
-// updateLastSeen is a no-op.
-mock.module("../memory/ingress-member-store.js", () => ({
-  findMember: () => null,
-  updateLastSeen: () => {},
-  upsertMember: () => {},
-}));
-
 mock.module("../config/env.js", () => ({
   isHttpAuthDisabled: () => true,
   getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",

--- a/assistant/src/__tests__/trust-context-guards.test.ts
+++ b/assistant/src/__tests__/trust-context-guards.test.ts
@@ -168,7 +168,7 @@ describe("trust-context guards", () => {
 
   it("guardianPrincipalId is typed as string (non-null) in GuardianBinding", () => {
     const source = readFileSync(
-      join(srcDir, "memory", "guardian-bindings.ts"),
+      join(srcDir, "memory", "channel-guardian-store.ts"),
       "utf-8",
     );
 


### PR DESCRIPTION
## Summary
- Fix trust-context-guards.test.ts import from deleted guardian-bindings.ts to use channel-guardian-store.ts
- Remove orphaned mock.module declarations for deleted ingress-member-store.js from 4 test files
- Clean up dangling mockFindMember variable references in guardian-routing-state.test.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
