### PR TITLE
perf: reuse git repo across enrichment service tests

### DIFF
--- a/assistant/src/__tests__/commit-message-enrichment-service.test.ts
+++ b/assistant/src/__tests__/commit-message-enrichment-service.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   afterAll,
   afterEach,
+  beforeAll,
   beforeEach,
   describe,
   expect,
@@ -26,7 +27,7 @@ describe("CommitEnrichmentService", () => {
   let testDir: string;
   let gitService: WorkspaceGitService;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     testDir = join(
       tmpdir(),
       `vellum-enrichment-test-${Date.now()}-${Math.random()
@@ -34,11 +35,13 @@ describe("CommitEnrichmentService", () => {
         .slice(2)}`,
     );
     mkdirSync(testDir, { recursive: true });
-    _resetGitServiceRegistry();
-    _resetEnrichmentService();
-
     gitService = new WorkspaceGitService(testDir);
     await gitService.ensureInitialized();
+  });
+
+  beforeEach(() => {
+    _resetGitServiceRegistry();
+    _resetEnrichmentService();
   });
 
   afterEach(async () => {
@@ -48,9 +51,6 @@ describe("CommitEnrichmentService", () => {
       /* ignore */
     }
     _resetEnrichmentService();
-    if (existsSync(testDir)) {
-      rmSync(testDir, { recursive: true, force: true });
-    }
   });
 
   afterAll(async () => {
@@ -60,6 +60,9 @@ describe("CommitEnrichmentService", () => {
       /* ignore */
     }
     _resetEnrichmentService();
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
   });
 
   function makeContext(overrides?: Partial<CommitContext>): CommitContext {


### PR DESCRIPTION
## Summary
- Move git repo initialization from `beforeEach` to `beforeAll` in `commit-message-enrichment-service.test.ts`
- Each test was creating a fresh git repo (~680ms overhead × 15 tests). Now the repo is created once and reused — commits use unique file names and git notes are per-commit, so there's no cross-test interference.
- Dir cleanup moved from `afterEach` to `afterAll`

## Original prompt
all of these in separate PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
