### PR TITLE
fix: include renames and deletes in pre-commit tsc trigger

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -709,7 +709,7 @@ while IFS= read -r -d '' FILE; do
         ASSISTANT_TS_STAGED=1
         break
     fi
-done < "$STAGED_ACM_FILE"
+done < "$STAGED_ALL_FILE"
 
 if [ $ASSISTANT_TS_STAGED -eq 1 ]; then
     if [ ! -x "$BUN" ]; then


### PR DESCRIPTION
Add R (rename) and D (delete) coverage to the tsc type-check trigger in the pre-commit hook. The trigger now reads from STAGED_ALL_FILE instead of STAGED_ACM_FILE so renames and deletes of assistant TS files also trigger the type check.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
