### PR TITLE
fix: add ROLLBACK on error in resetTestTables

### DIFF
--- a/assistant/src/memory/raw-query.ts
+++ b/assistant/src/memory/raw-query.ts
@@ -156,6 +156,14 @@ export function rawPrepareFrom(
  * test files that clear 10-15 tables in every `beforeEach`.
  */
 export function resetTestTables(...tables: string[]): void {
+  const sqlite = getSqlite();
   const deletes = tables.map((t) => `DELETE FROM "${t}"`).join(";\n");
-  getSqlite().exec(`BEGIN;\n${deletes};\nCOMMIT;`);
+  sqlite.exec("BEGIN");
+  try {
+    sqlite.exec(deletes);
+    sqlite.exec("COMMIT");
+  } catch (e) {
+    sqlite.exec("ROLLBACK");
+    throw e;
+  }
 }


### PR DESCRIPTION
Wrap batched table resets in try/catch with ROLLBACK to prevent cascading test failures from open transactions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
