### PR TITLE
perf: longest-first test scheduling via cached durations

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -105,10 +105,26 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Restore test durations cache
+        uses: actions/cache/restore@v4
+        with:
+          path: assistant/.test-durations
+          key: test-durations-unused
+          restore-keys: test-durations-
+
       - name: Test
         run: bun run test:stable
         env:
           TEST_WORKERS: '8'
+          TEST_DURATIONS_FILE: .test-durations
+          TEST_DURATIONS_OUTPUT: .test-durations
+
+      - name: Save test durations cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: assistant/.test-durations
+          key: test-durations-${{ github.run_id }}
 
       - name: Track consecutive failures
         if: always()

--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -20,6 +20,10 @@ WORKERS="${TEST_WORKERS:-$(sysctl -n hw.logicalcpu 2>/dev/null || nproc 2>/dev/n
 COVERAGE="${COVERAGE:-false}"
 # Per-test timeout (seconds). Kills bun processes that pass but don't exit due to open handles.
 PER_TEST_TIMEOUT="${PER_TEST_TIMEOUT:-120}"
+# Longest-first scheduling: provide a durations file from a previous run to sort
+# slow tests to the front, improving parallel utilization.
+TEST_DURATIONS_FILE="${TEST_DURATIONS_FILE:-}"
+TEST_DURATIONS_OUTPUT="${TEST_DURATIONS_OUTPUT:-}"
 
 EXPERIMENTAL_FILES=(
   "skill-load-tool.test.ts"
@@ -53,6 +57,40 @@ done < <(find src/__tests__ -maxdepth 1 -type f -name '*.test.ts' | sort)
 if [[ ${#test_files[@]} -eq 0 ]]; then
   echo "No test files found under src/__tests__"
   exit 1
+fi
+
+# Sort tests longest-first using durations from a previous run.
+# This ensures slow tests start immediately across all workers instead of
+# piling up at the end and becoming long poles.
+if [[ -n "${TEST_DURATIONS_FILE}" && -f "${TEST_DURATIONS_FILE}" ]]; then
+  sorted_files=()
+  # Build lookup: basename -> duration_ms
+  declare -A dur_map
+  while IFS=$'\t' read -r ms name; do
+    dur_map["${name}"]="${ms}"
+  done < "${TEST_DURATIONS_FILE}"
+
+  # Partition into known (with durations) and unknown
+  known=()
+  unknown=()
+  for f in "${test_files[@]}"; do
+    base="$(basename "${f}")"
+    if [[ -n "${dur_map["${base}"]:-}" ]]; then
+      known+=("${dur_map["${base}"]}"$'\t'"${f}")
+    else
+      unknown+=("${f}")
+    fi
+  done
+
+  # Sort known by duration descending
+  while IFS= read -r line; do
+    sorted_files+=("${line#*$'\t'}")
+  done < <(printf '%s\n' "${known[@]}" | sort -t$'\t' -k1 -rn)
+
+  # Append unknown files at the end
+  sorted_files+=("${unknown[@]}")
+  test_files=("${sorted_files[@]}")
+  echo "Sorted tests longest-first using ${TEST_DURATIONS_FILE} (${#known[@]} known, ${#unknown[@]} new)"
 fi
 
 echo "Running ${#test_files[@]} test files (${WORKERS} workers)"
@@ -115,6 +153,10 @@ printf '%s\n' "${test_files[@]}" | xargs -P "${WORKERS}" -I {} bash -c '
   elapsed=$(( end_ms - start_ms ))
 
   base="$(basename "${test_file}")"
+
+  # Record duration for longest-first scheduling in future runs
+  echo -e "${elapsed}\t${base}" >> "${results_dir}/durations"
+
   if [[ -n "${timeout_cmd}" && ( ${exit_code} -eq 124 || ${exit_code} -eq 137 ) ]]; then
     # timeout killed the process — tests likely passed but bun did not exit (open handles)
     echo "${test_file}" >> "${results_dir}/failures"
@@ -330,6 +372,12 @@ if [[ "${COVERAGE}" == "true" ]]; then
   else
     echo "Warning: no coverage data was generated"
   fi
+fi
+
+# Write observed durations for longest-first scheduling in future CI runs
+if [[ -n "${TEST_DURATIONS_OUTPUT}" && -f "${results_dir}/durations" ]]; then
+  sort -t$'\t' -k1 -rn "${results_dir}/durations" > "${TEST_DURATIONS_OUTPUT}"
+  echo "Wrote test durations to ${TEST_DURATIONS_OUTPUT}"
 fi
 
 echo "All ${#test_files[@]} test files passed"


### PR DESCRIPTION
## Summary
- Sort CI test files longest-first using durations cached from the previous run, avoiding slow tests becoming long poles at the end of parallel execution
- Record per-file durations after each run and persist via GHA cache (no committed file)
- Backward-compatible: without env vars set (local dev), behavior is unchanged

## Original prompt
How can we make this job faster?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
