### PR TITLE
perf(tests): reduce unnecessary 10s timeout in agent-loop abort test

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -330,7 +330,7 @@ describe("AgentLoop", () => {
       // Abort from a timer while this tool is "stuck"
       setTimeout(() => controller.abort(), 50);
       // Simulate being stuck for a long time
-      await new Promise((resolve) => setTimeout(resolve, 10_000));
+      await new Promise((resolve) => setTimeout(resolve, 100));
       return { content: "should never return", isError: false };
     };
 


### PR DESCRIPTION
## Summary
- Reduce the stuck-tool setTimeout from 10,000ms to 100ms in the abort test
- The test only needs the tool to be "stuck" long enough for the abort signal to fire (50ms), not a full 10 seconds

## Original prompt
Profile slowest tests and fix opportunities

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
