### PR TITLE
perf(tests): reduce artificial delays in commit-enrichment-service tests

### DIFF
--- a/assistant/src/__tests__/commit-message-enrichment-service.test.ts
+++ b/assistant/src/__tests__/commit-message-enrichment-service.test.ts
@@ -94,7 +94,7 @@ describe("CommitEnrichmentService", () => {
           `Timed out waiting for enrichment queue to drain after ${timeoutMs}ms`,
         );
       }
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await new Promise((resolve) => setTimeout(resolve, 10));
     }
   }
 
@@ -536,7 +536,7 @@ describe("CommitEnrichmentService", () => {
         const timer = setTimeout(() => {
           enrichmentCompleted = true;
           resolve();
-        }, 2000);
+        }, 200);
         signal?.addEventListener(
           "abort",
           () => {
@@ -558,10 +558,10 @@ describe("CommitEnrichmentService", () => {
     await waitForDrain(service, 5000);
     await service.shutdown();
 
-    // Allow any zombie work to settle — if abort didn't work, the 2s timer
+    // Allow any zombie work to settle — if abort didn't work, the 200ms timer
     // would still be running and would set enrichmentCompleted=true. Wait
-    // longer than the 2000ms mock delay to reliably catch the regression.
-    await new Promise((resolve) => setTimeout(resolve, 2500));
+    // longer than the 200ms mock delay to reliably catch the regression.
+    await new Promise((resolve) => setTimeout(resolve, 300));
 
     // The job should have timed out and been counted as failed
     expect(service._getFailedCount()).toBe(1);


### PR DESCRIPTION
## Summary
- Reduce waitForDrain polling interval from 50ms to 10ms
- Reduce mock work delay from 2000ms to 200ms and verification sleep from 2500ms to 300ms in abort signal test
- Expected savings of several seconds in CI

## Original prompt
Profile slowest tests and fix opportunities

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
