### PR TITLE
fix: scope guardian bindings by assistantId in contacts table

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -146,7 +146,10 @@ import {
 } from "../memory/channel-guardian-store.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { upsertBinding as upsertExternalBinding } from "../memory/external-conversation-store.js";
-import { channelGuardianVerificationChallenges } from "../memory/schema.js";
+import {
+  channelGuardianVerificationChallenges,
+  conversations,
+} from "../memory/schema.js";
 import {
   bindSessionIdentity as serviceBindSessionIdentity,
   createOutboundSession,
@@ -1559,6 +1562,15 @@ describe("IPC handler channel-aware guardian status", () => {
     // The contacts table stores displayName but not username.
     // The handler falls back to externalConversationStore for username,
     // so populate it here to ensure identity data is fully surfaced.
+    const now = Date.now();
+    getDb()
+      .insert(conversations)
+      .values({
+        id: "conv-guardian-43",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
     upsertExternalBinding({
       conversationId: "conv-guardian-43",
       sourceChannel: "telegram",

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -35,6 +35,7 @@ function parseContact(row: typeof contacts.$inferSelect): Contact {
     updatedAt: row.updatedAt,
     role: row.role as Contact["role"],
     principalId: row.principalId,
+    assistantId: row.assistantId ?? null,
   };
 }
 
@@ -109,9 +110,7 @@ export function getContact(id: string): ContactWithChannels | null {
  * Look up a single contact channel by its primary key.
  * Returns the parsed channel row, or null if it does not exist.
  */
-export function getChannelById(
-  channelId: string,
-): ContactChannel | null {
+export function getChannelById(channelId: string): ContactChannel | null {
   const db = getDb();
   const row = db
     .select()
@@ -130,6 +129,7 @@ export function upsertContact(params: {
   preferredTone?: string | null;
   role?: ContactRole;
   principalId?: string | null;
+  assistantId?: string | null;
   channels?: SyncChannelData[];
 }): ContactWithChannels & { created: boolean } {
   const db = getDb();
@@ -168,6 +168,8 @@ export function upsertContact(params: {
       if (params.role !== undefined) updateSet.role = params.role;
       if (params.principalId !== undefined)
         updateSet.principalId = params.principalId;
+      if (params.assistantId !== undefined)
+        updateSet.assistantId = params.assistantId;
 
       db.update(contacts)
         .set(updateSet)
@@ -239,6 +241,8 @@ export function upsertContact(params: {
         if (params.role !== undefined) updateSet.role = params.role;
         if (params.principalId !== undefined)
           updateSet.principalId = params.principalId;
+        if (params.assistantId !== undefined)
+          updateSet.assistantId = params.assistantId;
 
         db.update(contacts)
           .set(updateSet)
@@ -265,6 +269,7 @@ export function upsertContact(params: {
       interactionCount: 0,
       role: params.role ?? "contact",
       principalId: params.principalId ?? null,
+      assistantId: params.assistantId ?? null,
       createdAt: now,
       updatedAt: now,
     })
@@ -681,19 +686,29 @@ export function findContactChannel(params: {
   externalChatId?: string;
 }): { contact: ContactWithChannels; channel: ContactChannel } | null {
   if (params.externalUserId) {
-    const contact = findContactByChannelExternalId(params.channelType, params.externalUserId);
+    const contact = findContactByChannelExternalId(
+      params.channelType,
+      params.externalUserId,
+    );
     if (contact) {
       const ch = contact.channels.find(
-        (c) => c.type === params.channelType && c.externalUserId === params.externalUserId,
+        (c) =>
+          c.type === params.channelType &&
+          c.externalUserId === params.externalUserId,
       );
       if (ch) return { contact, channel: ch };
     }
   }
   if (params.externalChatId) {
-    const contact = findContactByChannelExternalChatId(params.channelType, params.externalChatId);
+    const contact = findContactByChannelExternalChatId(
+      params.channelType,
+      params.externalChatId,
+    );
     if (contact) {
       const ch = contact.channels.find(
-        (c) => c.type === params.channelType && c.externalChatId === params.externalChatId,
+        (c) =>
+          c.type === params.channelType &&
+          c.externalChatId === params.externalChatId,
       );
       if (ch) return { contact, channel: ch };
     }
@@ -708,8 +723,17 @@ export function findContactChannel(params: {
  */
 export function findGuardianForChannel(
   channelType: string,
+  assistantId?: string,
 ): { contact: Contact; channel: ContactChannel } | null {
   const db = getDb();
+  const conditions = [
+    eq(contacts.role, "guardian"),
+    eq(contactChannels.type, channelType),
+    eq(contactChannels.status, "active"),
+  ];
+  if (assistantId) {
+    conditions.push(eq(contacts.assistantId, assistantId));
+  }
   const rows = db
     .select({
       contact: contacts,
@@ -717,13 +741,7 @@ export function findGuardianForChannel(
     })
     .from(contacts)
     .innerJoin(contactChannels, eq(contacts.id, contactChannels.contactId))
-    .where(
-      and(
-        eq(contacts.role, "guardian"),
-        eq(contactChannels.type, channelType),
-        eq(contactChannels.status, "active"),
-      ),
-    )
+    .where(and(...conditions))
     .orderBy(desc(contactChannels.verifiedAt))
     .limit(1)
     .all();
@@ -744,21 +762,26 @@ export function findGuardianForChannel(
  *
  * Returns true if a channel was found and revoked, false otherwise.
  */
-export function revokeGuardianChannel(channelType: string): boolean {
+export function revokeGuardianChannel(
+  channelType: string,
+  assistantId?: string,
+): boolean {
   const db = getDb();
+  const conditions = [
+    eq(contacts.role, "guardian"),
+    eq(contactChannels.type, channelType),
+    eq(contactChannels.status, "active"),
+  ];
+  if (assistantId) {
+    conditions.push(eq(contacts.assistantId, assistantId));
+  }
   const rows = db
     .select({
       channelId: contactChannels.id,
     })
     .from(contacts)
     .innerJoin(contactChannels, eq(contacts.id, contactChannels.contactId))
-    .where(
-      and(
-        eq(contacts.role, "guardian"),
-        eq(contactChannels.type, channelType),
-        eq(contactChannels.status, "active"),
-      ),
-    )
+    .where(and(...conditions))
     .all();
 
   if (rows.length === 0) return false;

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -77,6 +77,7 @@ export function createGuardianBindingContactsFirst(params: {
     displayName,
     role: "guardian",
     principalId: params.guardianPrincipalId,
+    assistantId: params.assistantId,
     channels: [
       {
         type: params.channel,
@@ -115,10 +116,10 @@ export function createGuardianBindingContactsFirst(params: {
  * Returns true when a guardian channel was found and revoked, false otherwise.
  */
 export function revokeGuardianBindingContactsFirst(
-  _assistantId: string,
+  assistantId: string,
   channel: string,
 ): boolean {
-  const guardian = findGuardianForChannel(channel);
+  const guardian = findGuardianForChannel(channel, assistantId);
   if (!guardian) return false;
 
   updateChannelStatus(guardian.channel.id, {

--- a/assistant/src/contacts/types.ts
+++ b/assistant/src/contacts/types.ts
@@ -13,6 +13,7 @@ export interface Contact {
   updatedAt: number;
   role: ContactRole;
   principalId: string | null;
+  assistantId: string | null;
 }
 
 export type ChannelStatus =

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -33,6 +33,7 @@ import {
   migrateChannelInboundDeliveredSegments,
   migrateContactChannelsAccessFields,
   migrateContactChannelsTypeChatIdIndex,
+  migrateContactsAssistantId,
   migrateContactsRolePrincipal,
   migrateConversationsThreadTypeIndex,
   migrateDropLegacyMemberGuardianTables,
@@ -249,6 +250,9 @@ export function initializeDb(): void {
 
   // 35. Safety-sync remaining legacy data then drop assistant_ingress_members and channel_guardian_bindings
   migrateDropLegacyMemberGuardianTables(database);
+
+  // 36. Add assistant_id to contacts for per-assistant guardian scoping
+  migrateContactsAssistantId(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/132-contacts-assistant-id.ts
+++ b/assistant/src/memory/migrations/132-contacts-assistant-id.ts
@@ -1,0 +1,14 @@
+/**
+ * Add assistant_id column to contacts table so guardian bindings
+ * can be scoped per assistant.
+ */
+
+import type { DrizzleDb } from "../db-connection.js";
+
+export function migrateContactsAssistantId(database: DrizzleDb): void {
+  try {
+    database.run(/*sql*/ `ALTER TABLE contacts ADD COLUMN assistant_id TEXT`);
+  } catch {
+    /* already exists */
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -73,6 +73,7 @@ export { migrateContactsRolePrincipal } from "./128-contacts-role-principal.js";
 export { migrateContactChannelsAccessFields } from "./129-contact-channels-access-fields.js";
 export { migrateContactChannelsTypeChatIdIndex } from "./130-contact-channels-type-ext-chat-id-index.js";
 export { migrateDropLegacyMemberGuardianTables } from "./131-drop-legacy-member-guardian-tables.js";
+export { migrateContactsAssistantId } from "./132-contacts-assistant-id.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -416,6 +416,7 @@ export const contacts = sqliteTable("contacts", {
   updatedAt: integer("updated_at").notNull(),
   role: text("role").notNull().default("contact"), // 'guardian' | 'contact'
   principalId: text("principal_id"), // internal auth principal (nullable)
+  assistantId: text("assistant_id"), // which assistant this guardian is for (nullable, daemon default is 'self')
 });
 
 export const contactChannels = sqliteTable(

--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -386,7 +386,7 @@ export function getGuardianBinding(
   assistantId: string,
   channel: string,
 ): GuardianBinding | null {
-  const result = findGuardianForChannel(channel);
+  const result = findGuardianForChannel(channel, assistantId);
   if (result) {
     return {
       id: result.channel.id,
@@ -414,11 +414,11 @@ export function getGuardianBinding(
  * the specified assistant and channel.
  */
 export function isGuardian(
-  _assistantId: string,
+  assistantId: string,
   channel: string,
   externalUserId: string,
 ): boolean {
-  const result = findGuardianForChannel(channel);
+  const result = findGuardianForChannel(channel, assistantId);
   if (result) {
     return result.channel.externalUserId === externalUserId;
   }


### PR DESCRIPTION
## Summary
- Added `assistant_id` column to `contacts` table (with migration) so guardian bindings are scoped per assistant
- Updated `findGuardianForChannel`, `revokeGuardianChannel` to accept optional `assistantId` filter
- Updated `getGuardianBinding`, `isGuardian`, `revokeGuardianBindingContactsFirst`, `createGuardianBindingContactsFirst` to pass `assistantId` through
- Fixed FK constraint failure in test by creating a conversation record before `upsertExternalBinding`

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22654862017/job/65662332580

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
