### PR TITLE
perf(tests): batch filesystem ops to beforeAll/afterAll in slow tests

### DIFF
--- a/assistant/src/__tests__/credential-broker-browser-fill.test.ts
+++ b/assistant/src/__tests__/credential-broker-browser-fill.test.ts
@@ -1,10 +1,11 @@
 import { randomBytes } from "node:crypto";
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   afterAll,
   afterEach,
+  beforeAll,
   beforeEach,
   describe,
   expect,
@@ -71,8 +72,15 @@ afterAll(() => {
 describe("CredentialBroker.browserFill", () => {
   let broker: CredentialBroker;
 
-  beforeEach(() => {
+  beforeAll(() => {
     mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  beforeEach(() => {
+    // Clear content files but preserve the directory structure
+    for (const entry of readdirSync(TEST_DIR)) {
+      rmSync(join(TEST_DIR, entry), { recursive: true, force: true });
+    }
     _setStorePath(STORE_PATH);
     _resetBackend();
     _setMetadataPath(join(TEST_DIR, "metadata.json"));
@@ -83,6 +91,9 @@ describe("CredentialBroker.browserFill", () => {
     _setMetadataPath(null);
     _setStorePath(null);
     _resetBackend();
+  });
+
+  afterAll(() => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 

--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -1,10 +1,11 @@
 import { randomBytes } from "node:crypto";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   afterAll,
   afterEach,
+  beforeAll,
   beforeEach,
   describe,
   expect,
@@ -184,12 +185,16 @@ afterAll(() => {
 });
 
 describe("credential_store tool", () => {
+  beforeAll(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
   beforeEach(() => {
     _resetBackend();
-    if (existsSync(TEST_DIR)) {
-      rmSync(TEST_DIR, { recursive: true });
+    // Clear content files but preserve the directory structure
+    for (const entry of readdirSync(TEST_DIR)) {
+      rmSync(join(TEST_DIR, entry), { recursive: true, force: true });
     }
-    mkdirSync(TEST_DIR, { recursive: true });
     _setStorePath(STORE_PATH);
     _setMetadataPath(join(TEST_DIR, "metadata.json"));
   });
@@ -202,9 +207,7 @@ describe("credential_store tool", () => {
 
   afterAll(() => {
     _resetDeps();
-    if (existsSync(TEST_DIR)) {
-      rmSync(TEST_DIR, { recursive: true });
-    }
+    rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/__tests__/encrypted-store.test.ts
+++ b/assistant/src/__tests__/encrypted-store.test.ts
@@ -3,6 +3,7 @@ import {
   chmodSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   rmSync,
   statSync,
@@ -13,6 +14,7 @@ import { join } from "node:path";
 import {
   afterAll,
   afterEach,
+  beforeAll,
   beforeEach,
   describe,
   expect,
@@ -54,12 +56,15 @@ const STORE_PATH = join(TEST_DIR, "keys.enc");
 // ---------------------------------------------------------------------------
 
 describe("encrypted-store", () => {
-  beforeEach(() => {
-    // Ensure clean temp directory and point store at it
-    if (existsSync(TEST_DIR)) {
-      rmSync(TEST_DIR, { recursive: true });
-    }
+  beforeAll(() => {
     mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  beforeEach(() => {
+    // Clear content files but preserve the directory structure
+    for (const entry of readdirSync(TEST_DIR)) {
+      rmSync(join(TEST_DIR, entry), { recursive: true, force: true });
+    }
     _setStorePath(STORE_PATH);
   });
 
@@ -68,9 +73,7 @@ describe("encrypted-store", () => {
   });
 
   afterAll(() => {
-    if (existsSync(TEST_DIR)) {
-      rmSync(TEST_DIR, { recursive: true });
-    }
+    rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/__tests__/qdrant-manager.test.ts
+++ b/assistant/src/__tests__/qdrant-manager.test.ts
@@ -2,12 +2,22 @@ import {
   chmodSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 
 const testDataDir = "/tmp/qdrant-manager-test-" + process.pid;
 
@@ -43,14 +53,33 @@ function getTestPort(): number {
   return nextPort++;
 }
 
+const qdrantDir = join(testDataDir, "qdrant");
+const qdrantBinDir = join(qdrantDir, "bin");
+
+beforeAll(() => {
+  mkdirSync(qdrantBinDir, { recursive: true });
+});
+
 beforeEach(() => {
-  rmSync(testDataDir, { recursive: true, force: true });
-  mkdirSync(join(testDataDir, "qdrant", "bin"), { recursive: true });
+  // Clear content files but preserve the directory structure
+  for (const entry of readdirSync(qdrantDir)) {
+    if (entry === "bin") {
+      // Clear bin contents but keep the directory
+      for (const binEntry of readdirSync(qdrantBinDir)) {
+        rmSync(join(qdrantBinDir, binEntry), { force: true });
+      }
+    } else {
+      rmSync(join(qdrantDir, entry), { recursive: true, force: true });
+    }
+  }
   delete process.env.QDRANT_URL;
 });
 
 afterEach(() => {
   delete process.env.QDRANT_URL;
+});
+
+afterAll(() => {
   rmSync(testDataDir, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary
- Move rmSync/mkdirSync from beforeEach to beforeAll/afterAll in encrypted-store, credential-vault, credential-broker-browser-fill, and qdrant-manager tests
- Per-test cleanup now only removes content files, preserving directory structure

## Original prompt
Profile slowest tests and fix opportunities

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
