### PR TITLE
perf(tests): reduce artificial setTimeout delays in channel-approval-routes tests

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -1404,7 +1404,7 @@ describe("expired guardian approval auto-denies via sweep", () => {
     sweepExpiredGuardianApprovals("https://gateway.test", () => "token");
 
     // Wait for async notifications
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    await new Promise((resolve) => setTimeout(resolve, 10));
 
     // The session should have been denied
     expect(sessionMock).toHaveBeenCalledWith("req-exp-1", "deny");
@@ -1461,7 +1461,7 @@ describe("expired guardian approval auto-denies via sweep", () => {
 
     sweepExpiredGuardianApprovals("https://gateway.test", () => "token");
 
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    await new Promise((resolve) => setTimeout(resolve, 10));
 
     // The session should NOT have been called
     expect(sessionMock).not.toHaveBeenCalled();
@@ -2970,7 +2970,7 @@ describe("background channel processing approval prompts", () => {
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.accepted).toBe(true);
 
-    await new Promise((resolve) => setTimeout(resolve, 700));
+    await new Promise((resolve) => setTimeout(resolve, 400));
 
     expect(processCalls.length).toBeGreaterThan(0);
     expect(processCalls[0].options?.isInteractive).toBe(true);
@@ -3039,7 +3039,7 @@ describe("background channel processing approval prompts", () => {
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.accepted).toBe(true);
 
-    await new Promise((resolve) => setTimeout(resolve, 700));
+    await new Promise((resolve) => setTimeout(resolve, 400));
 
     expect(processCalls.length).toBeGreaterThan(0);
     expect(processCalls[0].options?.isInteractive).toBe(true);
@@ -3145,7 +3145,7 @@ describe("background channel processing approval prompts", () => {
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.accepted).toBe(true);
 
-    await new Promise((resolve) => setTimeout(resolve, 700));
+    await new Promise((resolve) => setTimeout(resolve, 400));
 
     expect(processCalls.length).toBeGreaterThan(0);
     expect(processCalls[0].options?.isInteractive).toBe(false);


### PR DESCRIPTION
## Summary
- Reduce 2 sweep-settling setTimeout delays (200ms) to 10ms — pure event-loop yields in a fully mocked environment
- Reduce 3 background-processing outer waits (700ms) to 400ms — still above the 300ms polling interval + inner mock delay
- Inner processMessage delays (350ms) and the 50ms/300ms delays are left unchanged as they are coupled to the approval-prompt polling interval

Total savings: ~1.3s of artificial delays

## Original prompt
Profile slowest tests and fix opportunities

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
