### PR TITLE
perf: fix tsc incremental cache invalidation in pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -701,7 +701,10 @@ done
 
 # --- TypeScript type-check for assistant/ ---
 # Full-project tsc catches cross-file type errors that per-file lint misses.
-# Uses --incremental for ~4s warm runs (vs ~15s cold).
+# Uses --incremental + --declaration false to keep warm runs at ~5s.
+# Without --declaration false, the tsconfig's declaration:true causes tsc to
+# mark all 1600+ files as "pending emit" on every --noEmit run, defeating
+# incremental caching and falling back to ~20s full rebuilds.
 
 ASSISTANT_TS_STAGED=0
 while IFS= read -r -d '' FILE; do
@@ -716,7 +719,7 @@ if [ $ASSISTANT_TS_STAGED -eq 1 ]; then
         echo -e "${YELLOW}⚠️  bun not found — skipping type check for assistant/${NC}"
     else
         echo "🔍 Type-checking assistant/..."
-        if ! (cd assistant && "$BUN" x tsc --noEmit --incremental --tsBuildInfoFile .tsbuildinfo) 2>&1; then
+        if ! (cd assistant && "$BUN" x tsc --noEmit --incremental --tsBuildInfoFile .tsbuildinfo --declaration false --declarationMap false) 2>&1; then
             echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
             echo -e "${RED}TypeScript type errors found in assistant/!${NC}"
             echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"


### PR DESCRIPTION
## Summary
- Added `--declaration false --declarationMap false` to pre-commit tsc invocation
- This prevents the `affectedFilesPendingEmit` backlog (1615 files) that was defeating incremental caching
- Warm runs drop from ~20s to ~5s

## Original prompt
Fix pre-commit tsc incremental invalidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
