### PR TITLE
perf: skip tsc type-checking in git worktrees

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -715,7 +715,13 @@ while IFS= read -r -d '' FILE; do
 done < "$STAGED_ALL_FILE"
 
 if [ $ASSISTANT_TS_STAGED -eq 1 ]; then
-    if [ ! -x "$BUN" ]; then
+    # Skip tsc in worktrees — the cold cache costs ~20s and CI catches errors.
+    # git rev-parse --git-common-dir differs from --git-dir only in worktrees.
+    _GIT_DIR="$(git rev-parse --git-dir 2>/dev/null)"
+    _GIT_COMMON="$(git rev-parse --git-common-dir 2>/dev/null)"
+    if [ "$_GIT_DIR" != "$_GIT_COMMON" ]; then
+        echo "⏩ Skipping type check in worktree (CI will catch errors)"
+    elif [ ! -x "$BUN" ]; then
         echo -e "${YELLOW}⚠️  bun not found — skipping type check for assistant/${NC}"
     else
         echo "🔍 Type-checking assistant/..."


### PR DESCRIPTION
## Summary
- Skip tsc in pre-commit hook when running inside a git worktree
- The cold cache costs ~20s per worktree (seeded `.tsbuildinfo` can't be reused due to symlinked node_modules path mismatch) and CI catches type errors anyway
- Detection uses `git rev-parse --git-dir` vs `--git-common-dir` (they differ only in worktrees)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
