### PR TITLE
refactor: remove requestId ?? runId fallback coalescing in guardian approval interception

### DIFF
--- a/assistant/src/memory/guardian-approvals.ts
+++ b/assistant/src/memory/guardian-approvals.ts
@@ -27,7 +27,7 @@ export type ApprovalRequestStatus =
 export interface GuardianApprovalRequest {
   id: string;
   runId: string;
-  requestId: string | null;
+  requestId: string;
   conversationId: string;
   assistantId: string;
   channel: string;
@@ -55,7 +55,7 @@ function rowToApprovalRequest(
   return {
     id: row.id,
     runId: row.runId,
-    requestId: row.requestId ?? null,
+    requestId: row.requestId ?? row.runId,
     conversationId: row.conversationId,
     assistantId: row.assistantId,
     channel: row.channel,
@@ -129,6 +129,7 @@ export function createApprovalRequest(params: {
   return rowToApprovalRequest(row);
 }
 
+/** @deprecated Prefer `getPendingApprovalForRequest()` — runId-based lookup will be removed once all rows have requestId populated. */
 export function getPendingApprovalForRun(
   runId: string,
 ): GuardianApprovalRequest | null {
@@ -176,6 +177,8 @@ export function getPendingApprovalForRequest(
  * regardless of whether it has expired. Used by the non-guardian gate to
  * detect expired-but-unresolved approvals that should still block the
  * requester from self-approving.
+ *
+ * @deprecated Prefer `getUnresolvedApprovalForRequest()` — runId-based lookup will be removed once all rows have requestId populated.
  */
 export function getUnresolvedApprovalForRun(
   runId: string,

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -305,7 +305,7 @@ export async function handleApprovalInterception(
           allowedActions: guardianAllowedActions,
           role: "guardian",
           pendingApprovals: effectivePending.map((a) => ({
-            requestId: a.requestId ?? a.runId,
+            requestId: a.requestId!,
             toolName: a.toolName,
           })),
           userMessage: content,
@@ -355,7 +355,7 @@ export async function handleApprovalInterception(
         // provided, otherwise use the single guardian approval.
         const targetApproval = engineResult.targetRequestId
           ? (allGuardianPending.find(
-              (a) => (a.requestId ?? a.runId) === engineResult.targetRequestId,
+              (a) => a.requestId === engineResult.targetRequestId,
             ) ?? guardianApproval)
           : guardianApproval;
 


### PR DESCRIPTION
## Summary
- Removes `requestId ?? runId` fallback patterns from `guardian-approval-interception.ts`
- Makes `GuardianApprovalRequest.requestId` non-nullable (typed as `string`)
- Adds backward compat in data layer: `rowToApprovalRequest()` falls back to `runId` for legacy rows
- Deprecates `getPendingApprovalForRun()` and `getUnresolvedApprovalForRun()` in favor of `*ForRequest()` variants

Part of plan: CODE_QUALITY_REFACTORS.md (PR 3 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
