### PR TITLE
fix: reword schema comment to avoid tripping assistant-id boundary guard

### DIFF
--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -416,7 +416,7 @@ export const contacts = sqliteTable("contacts", {
   updatedAt: integer("updated_at").notNull(),
   role: text("role").notNull().default("contact"), // 'guardian' | 'contact'
   principalId: text("principal_id"), // internal auth principal (nullable)
-  assistantId: text("assistant_id"), // which assistant this guardian is for (nullable, daemon default is 'self')
+  assistantId: text("assistant_id"), // which assistant this guardian is for (nullable, daemon default is DAEMON_INTERNAL_ASSISTANT_ID)
 });
 
 export const contactChannels = sqliteTable(


### PR DESCRIPTION
## Summary
- The `assistant-id-boundary-guard` test catches inline comments containing the literal string `'self'` in daemon source files
- Reworded the comment on `schema.ts:419` to reference `DAEMON_INTERNAL_ASSISTANT_ID` instead of the literal string

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22655359952/job/65663872904

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
