### PR TITLE
fix: force-exit call-controller test process to prevent CI hang

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -168,6 +168,10 @@ afterAll(() => {
   } catch {
     /* best effort */
   }
+  // Force-exit to prevent open handles from fire-and-forget async
+  // operations (guardian dispatch, pointer writes) keeping the bun
+  // process alive past the CI per-file timeout.
+  process.exit(0);
 });
 
 // ── RelayConnection mock factory ────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `process.exit(0)` to `afterAll` in `call-controller.test.ts` to prevent open handles from fire-and-forget async operations (guardian dispatch, pointer writes) keeping the bun process alive past the CI 120s per-file timeout

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22655535426/job/65664400612

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
