### PR TITLE
fix: mock local-actor-identity in handler tests to fix CI

### DIFF
--- a/assistant/src/__tests__/handle-user-message-secret-resume.test.ts
+++ b/assistant/src/__tests__/handle-user-message-secret-resume.test.ts
@@ -8,6 +8,30 @@ mock.module("../config/env.js", () => ({
   isMonitoringEnabled: () => false,
 }));
 
+mock.module("../runtime/local-actor-identity.js", () => ({
+  resolveLocalIpcTrustContext: () => ({
+    trustClass: "guardian",
+    sourceChannel: "vellum",
+    guardianPrincipalId: "local-principal",
+  }),
+  resolveLocalIpcAuthContext: () => ({
+    scope: "ipc_v1",
+    actorPrincipalId: "local-principal",
+  }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    daemon: { standaloneRecording: false },
+    secretDetection: {
+      enabled: true,
+      blockIngress: true,
+      customPatterns: [],
+      entropyThreshold: 3.5,
+    },
+  }),
+}));
+
 const { handleUserMessage } = await import("../daemon/handlers/sessions.js");
 
 describe("handleUserMessage secret redirect continuation", () => {
@@ -56,6 +80,8 @@ describe("handleUserMessage secret redirect continuation", () => {
       setCommandIntent: () => {},
       updateClient: () => {},
       emitActivityState: () => {},
+      hasAnyPendingConfirmation: () => false,
+      hasPendingConfirmation: () => false,
       processMessage: (
         content: string,
         _attachments: unknown[],

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -77,6 +77,18 @@ mock.module("../daemon/approval-generators.js", () => ({
   }),
 }));
 
+mock.module("../runtime/local-actor-identity.js", () => ({
+  resolveLocalIpcTrustContext: () => ({
+    trustClass: "guardian",
+    sourceChannel: "vellum",
+    guardianPrincipalId: "local-principal",
+  }),
+  resolveLocalIpcAuthContext: () => ({
+    scope: "ipc_v1",
+    actorPrincipalId: "local-principal",
+  }),
+}));
+
 mock.module("../util/logger.js", () => ({
   getLogger: () => ({
     info: () => {},


### PR DESCRIPTION
## Summary
- Add `mock.module('../runtime/local-actor-identity.js', ...)` to both `handlers-user-message-approval-consumption.test.ts` and `handle-user-message-secret-resume.test.ts` to prevent `SQLiteError: no such table: contacts`
- Add missing `hasAnyPendingConfirmation` and `hasPendingConfirmation` session mock methods in the secret-resume test
- Mock `getConfig` in the secret-resume test so secret detection behavior is consistent regardless of local config

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22655880593/job/65665439445#logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
