### PR TITLE
fix: add missing loader exports to test mocks and improve call-controller exit

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -39,8 +39,8 @@ mock.module("../util/logger.js", () => ({
 
 // ── Config mock ─────────────────────────────────────────────────────
 
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({
+mock.module("../config/loader.js", () => {
+  const config = {
     ui: {},
 
     provider: "anthropic",
@@ -59,8 +59,20 @@ mock.module("../config/loader.js", () => ({
     },
     memory: { enabled: false },
     notifications: { decisionModelIntent: "latency-optimized" },
-  }),
-}));
+  };
+  return {
+    getConfig: () => config,
+    loadConfig: () => config,
+    loadRawConfig: () => ({}),
+    saveConfig: () => {},
+    saveRawConfig: () => {},
+    invalidateConfigCache: () => {},
+    applyNestedDefaults: (c: unknown) => c,
+    getNestedValue: () => undefined,
+    setNestedValue: () => {},
+    API_KEY_PROVIDERS: [],
+  };
+});
 
 // ── Call constants mock ──────────────────────────────────────────────
 
@@ -171,7 +183,9 @@ afterAll(() => {
   // Force-exit to prevent open handles from fire-and-forget async
   // operations (guardian dispatch, pointer writes) keeping the bun
   // process alive past the CI per-file timeout.
-  process.exit(0);
+  // Schedule on next tick — bun's test runner may intercept synchronous
+  // process.exit() calls during afterAll.
+  setTimeout(() => process.exit(0), 0);
 });
 
 // ── RelayConnection mock factory ────────────────────────────────────

--- a/assistant/src/__tests__/handle-user-message-secret-resume.test.ts
+++ b/assistant/src/__tests__/handle-user-message-secret-resume.test.ts
@@ -20,8 +20,8 @@ mock.module("../runtime/local-actor-identity.js", () => ({
   }),
 }));
 
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({
+mock.module("../config/loader.js", () => {
+  const config = {
     daemon: { standaloneRecording: false },
     secretDetection: {
       enabled: true,
@@ -29,8 +29,20 @@ mock.module("../config/loader.js", () => ({
       customPatterns: [],
       entropyThreshold: 3.5,
     },
-  }),
-}));
+  };
+  return {
+    getConfig: () => config,
+    loadConfig: () => config,
+    loadRawConfig: () => ({}),
+    saveConfig: () => {},
+    saveRawConfig: () => {},
+    invalidateConfigCache: () => {},
+    applyNestedDefaults: (c: unknown) => c,
+    getNestedValue: () => undefined,
+    setNestedValue: () => {},
+    API_KEY_PROVIDERS: [],
+  };
+});
 
 const { handleUserMessage } = await import("../daemon/handlers/sessions.js");
 

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -68,6 +68,15 @@ mock.module("../memory/conversation-store.js", () => ({
 
 mock.module("../config/loader.js", () => ({
   getConfig: getConfigMock,
+  loadConfig: getConfigMock,
+  loadRawConfig: () => ({}),
+  saveConfig: () => {},
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+  applyNestedDefaults: (c: unknown) => c,
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+  API_KEY_PROVIDERS: [],
 }));
 
 mock.module("../daemon/approval-generators.js", () => ({


### PR DESCRIPTION
## Summary
- Add all `config/loader` exports (`loadConfig`, `loadRawConfig`, `saveConfig`, etc.) to test mocks in `handle-user-message-secret-resume.test.ts`, `handlers-user-message-approval-consumption.test.ts`, and `call-controller.test.ts` to prevent `Export named 'X' not found` errors from transitive imports
- Schedule `process.exit(0)` via `setTimeout` in `call-controller.test.ts` `afterAll` to avoid bun's test runner intercepting synchronous exit calls, preventing CI timeout hangs

## Original prompt
fix this ci issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22655880593/job/65665439445

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
