### PR TITLE
fix: restore discriminating delay in agent-loop abort test

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -329,8 +329,9 @@ describe("AgentLoop", () => {
     const toolExecutor = async () => {
       // Abort from a timer while this tool is "stuck"
       setTimeout(() => controller.abort(), 50);
-      // Simulate being stuck for a long time
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      // Simulate being stuck for a long time — must be well above the
+      // assertion threshold (2000ms) so the test catches abort regressions
+      await new Promise((resolve) => setTimeout(resolve, 10_000));
       return { content: "should never return", isError: false };
     };
 


### PR DESCRIPTION
Address review feedback from PR #12194: restore the stuck-tool delay to 10000ms (well above the 2000ms assertion threshold) so the abort test can actually detect regressions. With the previous 100ms delay, even a broken abort implementation would pass the test.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
