### PR TITLE
fix: write test durations before exit on failure

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -189,6 +189,14 @@ if [[ ${xargs_exit} -ge 125 ]]; then
   exit 1
 fi
 
+# Write observed durations for longest-first scheduling in future CI runs.
+# This must happen before the failure exit so durations are persisted even when
+# tests fail, aligning with the `if: always()` cache save step in CI.
+if [[ -n "${TEST_DURATIONS_OUTPUT}" && -f "${results_dir}/durations" ]]; then
+  sort -t$'\t' -k1 -rn "${results_dir}/durations" > "${TEST_DURATIONS_OUTPUT}"
+  echo "Wrote test durations to ${TEST_DURATIONS_OUTPUT}"
+fi
+
 # Print output for any failed tests
 if [[ -f "${results_dir}/failures" ]]; then
   echo ""
@@ -378,12 +386,6 @@ if [[ "${COVERAGE}" == "true" ]]; then
   else
     echo "Warning: no coverage data was generated"
   fi
-fi
-
-# Write observed durations for longest-first scheduling in future CI runs
-if [[ -n "${TEST_DURATIONS_OUTPUT}" && -f "${results_dir}/durations" ]]; then
-  sort -t$'\t' -k1 -rn "${results_dir}/durations" > "${TEST_DURATIONS_OUTPUT}"
-  echo "Wrote test durations to ${TEST_DURATIONS_OUTPUT}"
 fi
 
 echo "All ${#test_files[@]} test files passed"


### PR DESCRIPTION
Address review feedback from PR #12190: move the durations-output block before the failure exit so test durations are persisted even when tests fail, aligning with the if: always() cache save step in CI.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
