### PR TITLE
fix: restore 200ms delay for un-mocked notification pipeline in relay-server test

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -3562,7 +3562,7 @@ describe("relay-server", () => {
     // Simulate transport close while still in guardian wait
     relay.handleTransportClosed(1001, "Going away");
 
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await new Promise((resolve) => setTimeout(resolve, 200));
 
     const events = getCallEvents(session.id);
     const handoffEvents = events.filter(


### PR DESCRIPTION
Address review feedback from PR #12199: restore the 200ms delay for the callback handoff notification assertion that waits on an un-mocked emitNotificationSignal() fire-and-forget chain.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
