### PR TITLE
fix: rename guardian test section header to channel-scoped

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -1243,10 +1243,10 @@ describe("guardian service rate limiting", () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// 8. Assistant-scoped guardian resolution
+// 8. Channel-scoped guardian resolution
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe("assistant-scoped guardian resolution", () => {
+describe("channel-scoped guardian resolution", () => {
   beforeEach(() => {
     resetTables();
   });


### PR DESCRIPTION
Address review feedback from PR #12197: update section 8 describe block and comment to say 'channel-scoped' instead of 'assistant-scoped' to match the test assertions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
