### PR TITLE
fix: hash migration files in DB template cache key and ensure data dir

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -1,9 +1,15 @@
 import { createHash } from "node:crypto";
-import { copyFileSync, existsSync, readFileSync, renameSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
-import { getDbPath } from "../util/platform.js";
+import { ensureDataDir, getDbPath } from "../util/platform.js";
 import { getDb, getSqlite } from "./db-connection.js";
 import {
   addCoreColumns,
@@ -65,15 +71,28 @@ import {
 // ---------------------------------------------------------------------------
 
 function getTemplateDbPath(): string {
-  // Hash this file's content so the template auto-invalidates when migrations change.
-  const content = readFileSync(new URL(import.meta.url).pathname, "utf-8");
-  const hash = createHash("md5").update(content).digest("hex").slice(0, 12);
-  return join(tmpdir(), `vellum-test-db-template-${hash}.db`);
+  // Hash this file + all migration files so the template auto-invalidates
+  // when any migration changes.
+  const thisFile = new URL(import.meta.url).pathname;
+  const hash = createHash("md5");
+  hash.update(readFileSync(thisFile, "utf-8"));
+  const migrationsDir = join(dirname(thisFile), "migrations");
+  for (const name of readdirSync(migrationsDir).sort()) {
+    if (name.endsWith(".ts")) {
+      hash.update(readFileSync(join(migrationsDir, name), "utf-8"));
+    }
+  }
+  return join(
+    tmpdir(),
+    `vellum-test-db-template-${hash.digest("hex").slice(0, 12)}.db`,
+  );
 }
 
 function tryRestoreTemplate(): boolean {
   const templatePath = getTemplateDbPath();
   if (!existsSync(templatePath)) return false;
+  // getDb() hasn't run yet, so the data directory may not exist.
+  ensureDataDir();
   copyFileSync(templatePath, getDbPath());
   // Open the pre-migrated copy — getDb() will set PRAGMAs but skip migrations.
   getDb();


### PR DESCRIPTION
Address review feedback from PR #12179: (1) hash all migration files in the template cache key so changes to any migration invalidate the cached template, (2) ensure the destination directory exists before copying the template DB.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
