### PR TITLE
fix: backfill existing guardian contacts with assistant_id in migration

### DIFF
--- a/assistant/src/memory/migrations/132-contacts-assistant-id.ts
+++ b/assistant/src/memory/migrations/132-contacts-assistant-id.ts
@@ -11,4 +11,11 @@ export function migrateContactsAssistantId(database: DrizzleDb): void {
   } catch {
     /* already exists */
   }
+
+  // Backfill existing guardian contacts so they remain discoverable via
+  // queries that filter on assistant_id = 'self'.  Without this, NULL = 'self'
+  // evaluates to false in SQL and existing guardian bindings silently break.
+  database.run(
+    /*sql*/ `UPDATE contacts SET assistant_id = 'self' WHERE role = 'guardian' AND assistant_id IS NULL`,
+  );
 }


### PR DESCRIPTION
Address review feedback from PR #12200: backfill existing guardian contact rows with assistant_id='self' so they remain discoverable after the schema change. Without this, existing guardian bindings silently break on upgrade because NULL = 'self' is falsy in SQL.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
