### PR TITLE
fix: use double quotes in guard test policy extraction regexes

### DIFF
--- a/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
+++ b/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
@@ -94,7 +94,7 @@ describe("route policy coverage", () => {
     // Match: `{ endpoint: 'foo' }` entries, `registerPolicy('foo', ...)`
     // calls, and bare string literals in arrays like INTERNAL_ENDPOINTS.
     const policyEndpointMatches = routePolicySrc.matchAll(
-      /endpoint:\s*'([^']+)'|registerPolicy\(\s*'([^']+)'/g,
+      /endpoint:\s*"([^"]+)"|registerPolicy\(\s*"([^"]+)"/g,
     );
     const registeredPolicies = new Set<string>();
     for (const m of policyEndpointMatches) {
@@ -107,7 +107,7 @@ describe("route policy coverage", () => {
       /INTERNAL_ENDPOINTS\s*=\s*\[([\s\S]*?)\]/,
     );
     if (internalArrayMatch) {
-      const arrayLiterals = internalArrayMatch[1].matchAll(/'([^']+)'/g);
+      const arrayLiterals = internalArrayMatch[1].matchAll(/"([^"]+)"/g);
       for (const m of arrayLiterals) {
         registeredPolicies.add(m[1]);
       }


### PR DESCRIPTION
Both Codex and Devin flagged that policy extraction regexes in guard-tests.test.ts use single quotes while route-policy.ts uses double quotes, making registeredPolicies always empty. Fixed all three regex patterns to match double-quoted strings. Addresses feedback from #12230.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
