### PR TITLE
fix: use Bun end-of-run summary as completion marker in test.sh

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -159,14 +159,14 @@ printf '%s\n' "${test_files[@]}" | xargs -P "${WORKERS}" -I {} bash -c '
 
   if [[ -n "${timeout_cmd}" && ( ${exit_code} -eq 124 || ${exit_code} -eq 137 ) ]]; then
     # timeout killed the process — check if all tests actually passed.
-    # Bun test outputs "(fail)" for failed tests and a summary line like
-    # "X pass" when the run completes. Both conditions must hold: no failures
-    # AND a completion marker present. Without the completion marker, the
-    # process was killed mid-run before finishing all tests.
+    # Bun test outputs "(fail)" for failed tests and a final summary line
+    # "Ran X tests across Y files" when the run completes. Both conditions
+    # must hold: no failures AND the end-of-run summary present. Without
+    # the summary, the process was killed mid-run before finishing all tests.
     if grep -q "^(fail)" "${out_file}" 2>/dev/null; then
       echo "${test_file}" >> "${results_dir}/failures"
       echo "  ✗ ${base} (killed after ${per_test_timeout}s — tests failed and process hung)"
-    elif grep -qE "^[[:space:]]*[0-9]+ pass" "${out_file}" 2>/dev/null; then
+    elif grep -qE "^Ran [0-9]+ tests across" "${out_file}" 2>/dev/null; then
       echo "  ⚠ ${base} (tests passed but process hung after ${per_test_timeout}s — likely open handles)"
     else
       echo "${test_file}" >> "${results_dir}/failures"


### PR DESCRIPTION
Codex flagged that the 'N pass' grep pattern could match mid-output log lines. Replaced with Bun's 'Ran X tests across Y files' end-of-run summary marker for more robust completion detection. Addresses feedback from #12229.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
