### PR TITLE
fix: scope resolveClientIp per-request to prevent cross-request IP attribution

### DIFF
--- a/gateway/src/http/router.ts
+++ b/gateway/src/http/router.ts
@@ -9,7 +9,7 @@ import {
 // Public types
 // ---------------------------------------------------------------------------
 
-type GetClientIp = () => string;
+export type GetClientIp = () => string;
 
 /**
  * Auth strategy for a route:
@@ -50,12 +50,15 @@ export interface RouteDefinition {
    */
   precondition?: () => Response | null;
   /** Route handler. Params are populated from regex capture groups. */
-  handler: (req: Request, params: RouteParams) => Promise<Response> | Response;
+  handler: (
+    req: Request,
+    params: RouteParams,
+    getClientIp: GetClientIp,
+  ) => Promise<Response> | Response;
 }
 
 export interface RouterDeps {
   authRateLimiter: AuthRateLimiter;
-  getClientIp: GetClientIp;
 }
 
 // ---------------------------------------------------------------------------
@@ -72,10 +75,14 @@ export interface RouterDeps {
 export function createRouter(
   routes: RouteDefinition[],
   deps: RouterDeps,
-): (req: Request, url: URL) => Promise<Response> | Response | null {
-  const { authRateLimiter, getClientIp } = deps;
+): (
+  req: Request,
+  url: URL,
+  getClientIp: GetClientIp,
+) => Promise<Response> | Response | null {
+  const { authRateLimiter } = deps;
 
-  return (req: Request, url: URL) => {
+  return (req: Request, url: URL, getClientIp: GetClientIp) => {
     for (const route of routes) {
       const matchResult = matchRoute(route, url.pathname, req.method);
       if (!matchResult) continue;
@@ -91,7 +98,7 @@ export function createRouter(
       switch (auth) {
         case "none":
         case "custom":
-          return route.handler(req, matchResult.params);
+          return route.handler(req, matchResult.params, getClientIp);
 
         case "edge": {
           const { requireEdgeAuth } = createAuthMiddleware(
@@ -100,7 +107,7 @@ export function createRouter(
           );
           const authError = requireEdgeAuth(req);
           if (authError) return authError;
-          return route.handler(req, matchResult.params);
+          return route.handler(req, matchResult.params, getClientIp);
         }
 
         case "edge-scoped": {
@@ -110,12 +117,12 @@ export function createRouter(
           );
           const authError = requireEdgeAuthWithScope(req, route.scope!);
           if (authError) return authError;
-          return route.handler(req, matchResult.params);
+          return route.handler(req, matchResult.params, getClientIp);
         }
 
         case "track-failures": {
           return wrapWithAuthFailureTracking(
-            (r) => route.handler(r, matchResult.params),
+            (r) => route.handler(r, matchResult.params, getClientIp),
             authRateLimiter,
             getClientIp,
             route.trackFailureStatuses,

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -53,7 +53,11 @@ import {
 } from "./slack/socket-mode.js";
 import { handleInbound } from "./handlers/handle-inbound.js";
 import { checkAuthRateLimit } from "./http/middleware/rate-limit.js";
-import { createRouter, type RouteDefinition } from "./http/router.js";
+import {
+  createRouter,
+  type RouteDefinition,
+  type GetClientIp,
+} from "./http/router.js";
 import { callTelegramApi } from "./telegram/api.js";
 import { reconcileTelegramWebhook } from "./telegram/webhook-manager.js";
 
@@ -454,16 +458,16 @@ function main() {
       path: "/v1/integrations/guardian/vellum/refresh",
       method: "POST",
       auth: "custom",
-      handler: (req) => {
+      handler: (req, _params, getClientIp) => {
         const authHeader = req.headers.get("authorization");
         if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
-          authRateLimiter.recordFailure(resolveClientIp());
+          authRateLimiter.recordFailure(getClientIp());
           return Response.json({ error: "Unauthorized" }, { status: 401 });
         }
         const token = authHeader.slice(7);
         const result = validateEdgeToken(token, { allowExpired: true });
         if (!result.ok) {
-          authRateLimiter.recordFailure(resolveClientIp());
+          authRateLimiter.recordFailure(getClientIp());
           return Response.json({ error: "Unauthorized" }, { status: 401 });
         }
         return guardianControlPlaneProxy.handleGuardianRefresh(req);
@@ -621,18 +625,13 @@ function main() {
     routes.push({
       path: /^\//, // match everything
       auth: "track-failures",
-      handler: (req) => handleRuntimeProxy(req, resolveClientIp()),
+      handler: (req, _params, getClientIp) =>
+        handleRuntimeProxy(req, getClientIp()),
     });
   }
 
-  // `resolveClientIp` is a lazy getter that is set per-request in the
-  // fetch handler. Declared here so that the guardian refresh custom
-  // auth handler and the runtime proxy catch-all can reference it.
-  let resolveClientIp: () => string;
-
   const router = createRouter(routes, {
     authRateLimiter,
-    getClientIp: () => resolveClientIp(),
   });
 
   const server = Bun.serve({
@@ -695,9 +694,10 @@ function main() {
         return Response.json({ status: "ok" });
       }
 
-      // Set the per-request IP resolver for use by auth middleware and
-      // custom auth handlers in the route table.
-      resolveClientIp = () => getClientIp(req, svr, config.trustProxy);
+      // Per-request IP resolver — scoped to this request so it remains
+      // correct across async yields under concurrent load.
+      const resolveClientIp: GetClientIp = () =>
+        getClientIp(req, svr, config.trustProxy);
 
       const rateLimitResponse = checkAuthRateLimit(
         url,
@@ -732,7 +732,7 @@ function main() {
       const tracedReq = new Request(req, { headers });
 
       // ── Route table dispatch ──
-      const response = router(tracedReq, url);
+      const response = router(tracedReq, url, resolveClientIp);
       if (response !== null) return response;
 
       return Response.json(


### PR DESCRIPTION
Both Codex and Devin flagged a concurrency bug introduced in #12211: resolveClientIp was hoisted to a shared let at main() scope. Under concurrent load, wrapWithAuthFailureTracking could record auth failures against the wrong client IP after async yields. This fix scopes the IP resolver per-request by passing it through the router dispatch call instead of capturing it via closure.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
