### PR TITLE
fix: heartbeat Run Now bypasses disabled/active-hours guards

### DIFF
--- a/assistant/src/daemon/handlers/config-heartbeat.ts
+++ b/assistant/src/daemon/handlers/config-heartbeat.ts
@@ -210,7 +210,7 @@ export function handleHeartbeatRunNow(
     return;
   }
   heartbeatService
-    .runOnce()
+    .runOnce({ force: true })
     .then((didRun) => {
       if (didRun) {
         ctx.send(socket, { type: "heartbeat_run_now_response", success: true });
@@ -219,7 +219,7 @@ export function handleHeartbeatRunNow(
           type: "heartbeat_run_now_response",
           success: false,
           error:
-            "Heartbeat skipped (disabled, outside active hours, or already running)",
+            "Heartbeat skipped (a previous run is still active)",
         });
       }
     })

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -71,14 +71,15 @@ export class HeartbeatService {
     log.info("Heartbeat service stopped");
   }
 
-  /** Returns true if the heartbeat actually ran, false if skipped. */
-  async runOnce(): Promise<boolean> {
+  /** Returns true if the heartbeat actually ran, false if skipped.
+   *  When `force` is true (e.g. manual "Run Now"), skip enabled & active-hours guards. */
+  async runOnce({ force = false }: { force?: boolean } = {}): Promise<boolean> {
     const config = getConfig().heartbeat;
-    if (!config.enabled) return false;
+    if (!force && !config.enabled) return false;
 
     // Active hours guard — only applied when both bounds are set.
     // The schema rejects configs where only one bound is provided.
-    if (config.activeHoursStart != null && config.activeHoursEnd != null) {
+    if (!force && config.activeHoursStart != null && config.activeHoursEnd != null) {
       const hour = this.deps.getCurrentHour?.() ?? new Date().getHours();
       if (
         !isWithinActiveHours(


### PR DESCRIPTION
## Summary
- The heartbeat "Run Now" (play) button now always executes, bypassing the `enabled` and `activeHours` guards that only apply to automatic timer runs.
- The overlap guard (previous run still active) is still respected.
- Updated the skip error message to only mention the relevant reason.

## Test plan
- [ ] Click "Run Now" while heartbeat is disabled — should run successfully
- [ ] Click "Run Now" outside active hours — should run successfully
- [ ] Click "Run Now" while a run is already in progress — should show "a previous run is still active"
- [ ] Verify automatic timer runs still respect enabled/active-hours guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
