### PR TITLE
fix: center command palette vertically on screen

### DIFF
--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteWindow.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteWindow.swift
@@ -157,8 +157,7 @@ final class CommandPaletteWindow {
             let width = max(fittingSize.width, 600)
             let height = fittingSize.height
             let x = screenFrame.midX - width / 2
-            // Position ~1/3 from top (Spotlight-style)
-            let y = screenFrame.midY + screenFrame.height * 0.15
+            let y = screenFrame.midY - height / 2
             panel.setFrame(
                 NSRect(x: x, y: y, width: width, height: height),
                 display: true


### PR DESCRIPTION
## Summary
- Command palette (Cmd+K) now appears at true center of screen instead of ~1/3 from the top

## Test plan
- [ ] Press Cmd+K — palette should appear centered both horizontally and vertically
- [ ] Test on multi-monitor setup — should center on the screen where the mouse cursor is

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
