### PR TITLE
fix: remove command palette border artifact at corners

### DIFF
--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteView.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteView.swift
@@ -120,10 +120,6 @@ struct CommandPaletteView: View {
         }
         .background(VColor.surface)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .stroke(VColor.surfaceBorder, lineWidth: 1)
-        )
         .shadow(color: .black.opacity(0.3), radius: 20, y: 10)
         .frame(width: 600)
         .onAppear {

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteWindow.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteWindow.swift
@@ -67,6 +67,9 @@ final class CommandPaletteWindow {
 
         let hostingController = NSHostingController(rootView: view)
         hostingController.sizingOptions = [.intrinsicContentSize]
+        hostingController.view.wantsLayer = true
+        hostingController.view.layer?.cornerRadius = VRadius.lg
+        hostingController.view.layer?.masksToBounds = true
 
         let newPanel = CommandPalettePanel(
             contentRect: NSRect(x: 0, y: 0, width: 600, height: 120),


### PR DESCRIPTION
## Summary
- Remove the SwiftUI overlay stroke border that was causing a visible outline around the command palette
- Set `cornerRadius` + `masksToBounds` on the hosting view's layer to cleanly clip corners without artifacts

## Test plan
- [ ] Open command palette (Cmd+K) — no visible border/outline at the corners
- [ ] Corners should be cleanly rounded with no artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
