### PR TITLE
test: add tests for heartbeat runOnce force option

### DIFF
--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -253,6 +253,49 @@ describe("HeartbeatService", () => {
     expect(processMessageCalls).toHaveLength(0);
   });
 
+  test("force bypasses disabled config", async () => {
+    mockConfig.heartbeat.enabled = false;
+    const service = createService();
+    await service.runOnce({ force: true });
+
+    expect(processMessageCalls).toHaveLength(1);
+  });
+
+  test("force bypasses active hours guard", async () => {
+    mockConfig.heartbeat.activeHoursStart = 9;
+    mockConfig.heartbeat.activeHoursEnd = 17;
+
+    const service = createService({ getCurrentHour: () => 3 });
+    await service.runOnce({ force: true });
+
+    expect(processMessageCalls).toHaveLength(1);
+  });
+
+  test("force does not bypass overlap prevention", async () => {
+    let resolveFirst: () => void;
+    const firstPromise = new Promise<void>((r) => {
+      resolveFirst = r;
+    });
+
+    const service = createService({
+      processMessage: async () => {
+        await firstPromise;
+        processMessageCalls.push({ conversationId: "slow", content: "slow" });
+        return { messageId: "msg-1" };
+      },
+    });
+
+    const run1 = service.runOnce({ force: true });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const didRun = await service.runOnce({ force: true });
+    expect(didRun).toBe(false);
+
+    resolveFirst!();
+    await run1;
+    expect(processMessageCalls).toHaveLength(1);
+  });
+
   test("alerts on processMessage failure", async () => {
     const service = createService({
       processMessage: async () => {


### PR DESCRIPTION
## Summary
- Add 3 tests for the `force` option on `runOnce()` (introduced in #12237):
  - `force` bypasses disabled config
  - `force` bypasses active hours guard
  - `force` does not bypass overlap prevention

## Test plan
- [ ] All heartbeat tests pass (`bun test heartbeat-service.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
