### PR TITLE
fix: make assistantId required on listGuardianChannels and revokeGuardianChannel

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -2007,7 +2007,9 @@ export class RelayConnection {
     // Contacts-first: prefer the voice-bound guardian, then fall back to
     // any guardian channel (mirrors the voice-first pattern in the legacy path).
     const voiceGuardian = findGuardianForChannel("voice");
-    const guardianChannels = voiceGuardian ? null : listGuardianChannels();
+    const guardianChannels = voiceGuardian
+      ? null
+      : listGuardianChannels(assistantId);
     const guardianContact = voiceGuardian?.contact ?? guardianChannels?.contact;
     if (guardianContact) {
       const meta: Record<string, string> = {};

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -764,17 +764,15 @@ export function findGuardianForChannel(
  */
 export function revokeGuardianChannel(
   channelType: string,
-  assistantId?: string,
+  assistantId: string,
 ): boolean {
   const db = getDb();
   const conditions = [
     eq(contacts.role, "guardian"),
     eq(contactChannels.type, channelType),
     eq(contactChannels.status, "active"),
+    eq(contacts.assistantId, assistantId),
   ];
-  if (assistantId) {
-    conditions.push(eq(contacts.assistantId, assistantId));
-  }
   const rows = db
     .select({
       channelId: contactChannels.id,
@@ -808,7 +806,7 @@ export function revokeGuardianChannel(
  * pick a guardian that has no active channels.
  * Returns channels ordered by most-recently-verified first.
  */
-export function listGuardianChannels(): {
+export function listGuardianChannels(assistantId: string): {
   contact: Contact;
   channels: ContactChannel[];
 } | null {
@@ -821,7 +819,11 @@ export function listGuardianChannels(): {
     .from(contacts)
     .innerJoin(contactChannels, eq(contacts.id, contactChannels.contactId))
     .where(
-      and(eq(contacts.role, "guardian"), eq(contactChannels.status, "active")),
+      and(
+        eq(contacts.role, "guardian"),
+        eq(contactChannels.status, "active"),
+        eq(contacts.assistantId, assistantId),
+      ),
     )
     .orderBy(desc(contactChannels.verifiedAt))
     .all();

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -116,7 +116,7 @@ export function notifyGuardianOfAccessRequest(
     guardianResolutionSource = "contacts";
   } else {
     // Try contacts-first: any active guardian channel
-    const allGuardianChannels = listGuardianChannels();
+    const allGuardianChannels = listGuardianChannels(canonicalAssistantId);
     if (allGuardianChannels && allGuardianChannels.channels.length > 0) {
       const fallbackChannel = allGuardianChannels.channels[0];
       guardianExternalUserId = fallbackChannel.externalUserId;


### PR DESCRIPTION
## Summary
- Made `assistantId` a required parameter on `listGuardianChannels` and `revokeGuardianChannel` in contact-store.ts
- Added assistantId filtering to `listGuardianChannels` WHERE clause
- Removed conditional `if (assistantId)` guard from `revokeGuardianChannel`
- Updated 2 call sites of `listGuardianChannels` to pass assistantId

Part of plan: require-assistantid-guardian-queries.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
