### PR TITLE
fix: use service-level revokeBinding in config-channels revoke path

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -2,10 +2,7 @@ import * as net from "node:net";
 
 import type { ChannelId } from "../../channels/types.js";
 import { findContactChannel } from "../../contacts/contact-store.js";
-import {
-  revokeGuardianBindingContactsFirst,
-  revokeMemberContactsFirst,
-} from "../../contacts/contacts-write.js";
+import { revokeMemberContactsFirst } from "../../contacts/contacts-write.js";
 import { contactChannelToMemberRecord } from "../../contacts/member-record-shim.js";
 import * as externalConversationStore from "../../memory/external-conversation-store.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
@@ -14,6 +11,7 @@ import {
   findActiveSession,
   getGuardianBinding,
   getPendingChallenge,
+  revokeBinding,
   revokePendingChallenges,
 } from "../../runtime/channel-guardian-service.js";
 import {
@@ -228,7 +226,7 @@ export function revokeGuardianForChannel(
     revokeMemberContactsFirst(member.id, "guardian_binding_revoked");
   }
 
-  revokeGuardianBindingContactsFirst(assistantId, resolvedChannel);
+  revokeBinding(assistantId, resolvedChannel);
 
   return {
     success: true,


### PR DESCRIPTION
Addresses review feedback from PR #12090 (via #12122).

## Summary
- Replace direct `revokeGuardianBindingContactsFirst()` call in `config-channels.ts` with the service-level `revokeBinding()` from `channel-guardian-service.ts`
- Remove now-unused `revokeGuardianBindingContactsFirst` import from `contacts-write.js`
- Ensures all revoke paths go through the service layer for proper encapsulation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
