### PR TITLE
fix: make assistantId required on findGuardianForChannel

### DIFF
--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -101,7 +101,7 @@ async function dispatchGuardianQuestionInner(
     // level guardian identity. Resolve the principal from the contacts table.
     let guardianPrincipalId: string | undefined;
 
-    const guardianResult = findGuardianForChannel("vellum");
+    const guardianResult = findGuardianForChannel("vellum", assistantId);
     if (guardianResult?.contact.principalId) {
       guardianPrincipalId = guardianResult.contact.principalId;
     }

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -2006,7 +2006,7 @@ export class RelayConnection {
     let metadataJson: string | null = null;
     // Contacts-first: prefer the voice-bound guardian, then fall back to
     // any guardian channel (mirrors the voice-first pattern in the legacy path).
-    const voiceGuardian = findGuardianForChannel("voice");
+    const voiceGuardian = findGuardianForChannel("voice", assistantId);
     const guardianChannels = voiceGuardian
       ? null
       : listGuardianChannels(assistantId);

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -723,17 +723,15 @@ export function findContactChannel(params: {
  */
 export function findGuardianForChannel(
   channelType: string,
-  assistantId?: string,
+  assistantId: string,
 ): { contact: Contact; channel: ContactChannel } | null {
   const db = getDb();
   const conditions = [
     eq(contacts.role, "guardian"),
     eq(contactChannels.type, channelType),
     eq(contactChannels.status, "active"),
+    eq(contacts.assistantId, assistantId),
   ];
-  if (assistantId) {
-    conditions.push(eq(contacts.assistantId, assistantId));
-  }
   const rows = db
     .select({
       contact: contacts,

--- a/assistant/src/notifications/destination-resolver.ts
+++ b/assistant/src/notifications/destination-resolver.ts
@@ -44,7 +44,7 @@ export function resolveDestinations(
         // Vellum delivery is local IPC — no external endpoint required.
         // Include the guardianPrincipalId so the adapter can annotate
         // guardian-sensitive notifications for scoped delivery.
-        const guardianResult = findGuardianForChannel("vellum");
+        const guardianResult = findGuardianForChannel("vellum", assistantId);
         const metadata: Record<string, unknown> = {};
         if (guardianResult) {
           metadata.guardianPrincipalId = guardianResult.contact.principalId;
@@ -65,7 +65,7 @@ export function resolveDestinations(
       }
       case "telegram":
       case "sms": {
-        const guardianResult = findGuardianForChannel(channel);
+        const guardianResult = findGuardianForChannel(channel, assistantId);
         if (guardianResult && guardianResult.channel.externalChatId) {
           result.set(channel as NotificationChannel, {
             channel: channel as NotificationChannel,

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -95,7 +95,7 @@ function getBroadcaster(): NotificationBroadcaster {
 
 // ── Connected channels resolution ──────────────────────────────────────
 
-function getConnectedChannels(_assistantId: string): NotificationChannel[] {
+function getConnectedChannels(assistantId: string): NotificationChannel[] {
   const channels: NotificationChannel[] = [];
 
   // getDeliverableChannels() returns ChannelId[] but every returned channel
@@ -115,7 +115,7 @@ function getConnectedChannels(_assistantId: string): NotificationChannel[] {
         // externalChatId check ensures we don't report a channel as
         // connected when the contacts record exists but lacks the
         // delivery address the destination-resolver needs.
-        const guardian = findGuardianForChannel(channel);
+        const guardian = findGuardianForChannel(channel, assistantId);
         if (guardian && guardian.channel.externalChatId) {
           channels.push(channel);
         }

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -108,7 +108,10 @@ export function notifyGuardianOfAccessRequest(
     "none";
 
   // Try contacts-first: source channel
-  const sourceGuardian = findGuardianForChannel(sourceChannel);
+  const sourceGuardian = findGuardianForChannel(
+    sourceChannel,
+    canonicalAssistantId,
+  );
   if (sourceGuardian) {
     guardianExternalUserId = sourceGuardian.channel.externalUserId;
     guardianPrincipalId = sourceGuardian.contact.principalId;
@@ -143,7 +146,10 @@ export function notifyGuardianOfAccessRequest(
       "No guardian principal for access request — self-healing vellum binding",
     );
     const healedPrincipalId = ensureVellumGuardianBinding(canonicalAssistantId);
-    const vellumGuardian = findGuardianForChannel("vellum");
+    const vellumGuardian = findGuardianForChannel(
+      "vellum",
+      canonicalAssistantId,
+    );
     if (vellumGuardian) {
       guardianExternalUserId =
         vellumGuardian.channel.externalUserId ?? guardianExternalUserId;

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -171,7 +171,10 @@ export function resolveActorTrust(
   }
 
   // --- Guardian lookup ---
-  const guardianResult = findGuardianForChannel(input.sourceChannel);
+  const guardianResult = findGuardianForChannel(
+    input.sourceChannel,
+    input.assistantId,
+  );
   let guardianBindingMatch: ActorTrustContext["guardianBindingMatch"] = null;
   let guardianPrincipalId: string | undefined;
   let isGuardian = false;

--- a/assistant/src/runtime/guardian-vellum-migration.ts
+++ b/assistant/src/runtime/guardian-vellum-migration.ts
@@ -29,7 +29,7 @@ const log = getLogger("guardian-vellum-migration");
 export function ensureVellumGuardianBinding(
   assistantId: string = DAEMON_INTERNAL_ASSISTANT_ID,
 ): string {
-  const guardianResult = findGuardianForChannel("vellum");
+  const guardianResult = findGuardianForChannel("vellum", assistantId);
   if (guardianResult && guardianResult.contact.principalId) {
     log.debug(
       { assistantId, guardianPrincipalId: guardianResult.contact.principalId },

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -41,7 +41,7 @@ export function resolveLocalIpcTrustContext(
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
 
   // Try contacts-first for the vellum guardian channel
-  const guardianResult = findGuardianForChannel("vellum");
+  const guardianResult = findGuardianForChannel("vellum", assistantId);
   if (guardianResult && guardianResult.contact.principalId) {
     const guardianPrincipalId = guardianResult.contact.principalId;
     const trustCtx = resolveTrustContext({
@@ -55,9 +55,7 @@ export function resolveLocalIpcTrustContext(
 
   // No guardian contact with a principalId — bootstrap via ensureVellumGuardianBinding
   // to self-heal (creates the binding + contact if missing).
-  log.debug(
-    "No vellum guardian contact found; bootstrapping binding for IPC",
-  );
+  log.debug("No vellum guardian contact found; bootstrapping binding for IPC");
   const principalId = ensureVellumGuardianBinding(assistantId);
   const trustCtx = resolveTrustContext({
     assistantId,
@@ -81,7 +79,10 @@ export function resolveLocalIpcAuthContext(sessionId: string): AuthContext {
   const authContext = buildIpcAuthContext(sessionId);
 
   // Enrich with the guardian principal ID from contacts-first path
-  const guardianResult = findGuardianForChannel("vellum");
+  const guardianResult = findGuardianForChannel(
+    "vellum",
+    authContext.assistantId,
+  );
   if (guardianResult && guardianResult.contact.principalId) {
     return {
       ...authContext,

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -38,7 +38,10 @@ function requireBoundGuardian(authContext: AuthContext): Response | null {
       403,
     );
   }
-  const guardianResult = findGuardianForChannel("vellum");
+  const guardianResult = findGuardianForChannel(
+    "vellum",
+    authContext.assistantId,
+  );
   if (!guardianResult) {
     // No guardian yet — in pre-bootstrap state, allow through
     return null;

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -80,7 +80,10 @@ function requireBoundGuardian(authContext: AuthContext): Response | null {
       403,
     );
   }
-  const guardianResult = findGuardianForChannel("vellum");
+  const guardianResult = findGuardianForChannel(
+    "vellum",
+    authContext.assistantId,
+  );
   if (!guardianResult) {
     // No guardian yet — in pre-bootstrap state, allow through
     return null;

--- a/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
+++ b/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
@@ -44,7 +44,7 @@ function ensureGuardianPrincipal(assistantId: string): {
   guardianPrincipalId: string;
   isNew: boolean;
 } {
-  const guardianResult = findGuardianForChannel("vellum");
+  const guardianResult = findGuardianForChannel("vellum", assistantId);
   if (guardianResult && guardianResult.contact.principalId) {
     return {
       guardianPrincipalId: guardianResult.contact.principalId,


### PR DESCRIPTION
## Summary
- Made `assistantId` a required parameter on `findGuardianForChannel` in contact-store.ts (was optional)
- Removed conditional `if (assistantId)` guard — WHERE clause now always filters by assistantId
- Updated all 14 production call sites across 11 files to pass assistantId

Part of plan: require-assistantid-guardian-queries.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
