### PR TITLE
fix: ensure consistent composite member IDs across all ingress endpoints

### DIFF
--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -163,6 +163,7 @@ export function upsertMemberContactsFirst(params: {
     // No usable identity — return a minimal fallback record
     return {
       id: "",
+      contactId: null,
       assistantId: params.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
       sourceChannel: params.sourceChannel,
       externalUserId: params.externalUserId ?? null,
@@ -229,6 +230,7 @@ export function upsertMemberContactsFirst(params: {
   // Fallback: construct minimal IngressMember from params
   return {
     id: "",
+    contactId: null,
     assistantId: params.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
     sourceChannel: params.sourceChannel,
     externalUserId: params.externalUserId ?? null,
@@ -249,8 +251,8 @@ export function upsertMemberContactsFirst(params: {
 
 /**
  * Revoke an ingress member by updating the contacts channel status.
- * The memberId may be a channel ID (from contactChannelToMemberRecord shim)
- * or a composite contactId:channelId (from contactToMemberResponse in ingress-service).
+ * The memberId may be a plain channel ID (internal callers) or a composite
+ * contactId:channelId (from the API response format).
  */
 export function revokeMemberContactsFirst(
   memberId: string,
@@ -279,8 +281,8 @@ export function revokeMemberContactsFirst(
 
 /**
  * Block an ingress member by updating the contacts channel status.
- * The memberId may be a channel ID (from contactChannelToMemberRecord shim)
- * or a composite contactId:channelId (from contactToMemberResponse in ingress-service).
+ * The memberId may be a plain channel ID (internal callers) or a composite
+ * contactId:channelId (from the API response format).
  */
 export function blockMemberContactsFirst(
   memberId: string,
@@ -308,7 +310,7 @@ export function blockMemberContactsFirst(
 
 /**
  * Update the lastSeenAt timestamp on a contact channel by its ID.
- * The channelId comes from the contactChannelToMemberRecord shim (member.id = channel.id).
+ * Expects a plain channel UUID (IngressMember.id), not the composite API ID.
  */
 export function touchChannelLastSeen(channelId: string): void {
   try {

--- a/assistant/src/contacts/member-record-shim.ts
+++ b/assistant/src/contacts/member-record-shim.ts
@@ -18,6 +18,8 @@ export type MemberPolicy = "allow" | "deny" | "escalate";
 
 export interface IngressMember {
   id: string;
+  /** The owning contact's ID — used to build composite contactId:channelId API IDs. */
+  contactId: string | null;
   assistantId: string;
   sourceChannel: string;
   externalUserId: string | null;
@@ -41,6 +43,7 @@ export function contactChannelToMemberRecord(
 ): IngressMember {
   return {
     id: channel.id,
+    contactId: contact.id,
     assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     sourceChannel: channel.type,
     externalUserId: channel.externalUserId,

--- a/assistant/src/runtime/ingress-service.ts
+++ b/assistant/src/runtime/ingress-service.ts
@@ -134,7 +134,7 @@ function inviteToResponse(
 
 export function memberToResponse(m: IngressMember): MemberResponseData {
   return {
-    id: m.id,
+    id: m.contactId ? `${m.contactId}:${m.id}` : m.id,
     sourceChannel: m.sourceChannel,
     externalUserId: m.externalUserId ?? undefined,
     externalChatId: m.externalChatId ?? undefined,
@@ -151,7 +151,7 @@ function contactToMemberResponse(
   contact: ContactWithChannels,
 ): MemberResponseData[] {
   return contact.channels.map((ch) => ({
-    id: ch.id,
+    id: `${contact.id}:${ch.id}`,
     sourceChannel: ch.type,
     externalUserId: ch.externalUserId ?? undefined,
     externalChatId: ch.externalChatId ?? undefined,


### PR DESCRIPTION
Addresses review feedback from PR #12149. The list endpoint returned composite contactId:channelId IDs but upsert/revoke/block returned plain channel UUIDs. Updates all response paths to use the composite format consistently.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
