### PR TITLE
fix: add updated_at to migration INSERT and use findByTokenHash for invite lookup

### DIFF
--- a/assistant/src/memory/migrations/131-drop-legacy-member-guardian-tables.ts
+++ b/assistant/src/memory/migrations/131-drop-legacy-member-guardian-tables.ts
@@ -27,7 +27,7 @@ export function migrateDropLegacyMemberGuardianTables(
     // Insert any active guardian bindings not already present in contacts.
     // We match on (type, external_user_id) to avoid duplicating existing rows.
     raw.exec(/*sql*/ `
-      INSERT INTO contacts (id, display_name, role, principal_id, created_at)
+      INSERT INTO contacts (id, display_name, role, principal_id, created_at, updated_at)
       SELECT
         'legacy-guardian-' || b.id,
         COALESCE(
@@ -36,6 +36,7 @@ export function migrateDropLegacyMemberGuardianTables(
         ),
         'guardian',
         b.guardian_principal_id,
+        b.created_at,
         b.created_at
       FROM channel_guardian_bindings b
       WHERE b.status = 'active'
@@ -79,11 +80,12 @@ export function migrateDropLegacyMemberGuardianTables(
   if (membersTableExists) {
     // Insert non-pending members not already present in contacts.
     raw.exec(/*sql*/ `
-      INSERT INTO contacts (id, display_name, created_at)
+      INSERT INTO contacts (id, display_name, created_at, updated_at)
       SELECT
         'legacy-member-' || m.id,
         COALESCE(m.display_name, m.username, m.external_user_id, 'Unknown'),
-        m.created_at
+        m.created_at,
+        COALESCE(m.updated_at, m.created_at)
       FROM assistant_ingress_members m
       WHERE m.status != 'pending'
         AND NOT EXISTS (

--- a/assistant/src/runtime/ingress-service.ts
+++ b/assistant/src/runtime/ingress-service.ts
@@ -307,9 +307,9 @@ export function redeemIngressInvite(params: {
     }
     return { ok: true, data: inviteToResponse(inv) };
   }
-  // Fetch the invite to build the response
-  const invites = listInvites({});
-  const inv = invites.find((i) => i.id === outcome.inviteId);
+  // Look up the invite by token hash — same approach as the already_member path
+  // above. Using findByTokenHash avoids the pagination limit of listInvites.
+  const inv = findByTokenHash(hashToken(params.token));
   if (!inv) {
     return { ok: false, error: "Invite not found after redemption" };
   }


### PR DESCRIPTION
Addresses review feedback from PR #12174. Fixes two bugs: (1) migration 131 INSERT into contacts was missing NOT NULL updated_at column, (2) redeemIngressInvite used paginated listInvites which could miss older invites — now uses findByTokenHash for reliable lookup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
