### PR TITLE
test: pass assistantId to guardian query functions in test files

### DIFF
--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -214,7 +214,7 @@ describe("guardian vellum migration", () => {
     const principalId = ensureVellumGuardianBinding("self");
     expect(principalId).toMatch(/^vellum-principal-/);
 
-    const guardianResult = findGuardianForChannel("vellum");
+    const guardianResult = findGuardianForChannel("vellum", "self");
     expect(guardianResult).not.toBeNull();
     expect(guardianResult!.contact.principalId).toBe(principalId);
     expect(guardianResult!.channel.verifiedVia).toBe("startup-migration");
@@ -238,11 +238,11 @@ describe("guardian vellum migration", () => {
 
     ensureVellumGuardianBinding("self");
 
-    const tgGuardian = findGuardianForChannel("telegram");
+    const tgGuardian = findGuardianForChannel("telegram", "self");
     expect(tgGuardian).not.toBeNull();
     expect(tgGuardian!.channel.externalUserId).toBe("tg-user-123");
 
-    const vGuardian = findGuardianForChannel("vellum");
+    const vGuardian = findGuardianForChannel("vellum", "self");
     expect(vGuardian).not.toBeNull();
   });
 });
@@ -440,7 +440,7 @@ describe("resolveLocalIpcAuthContext", () => {
 
   test("enriches actorPrincipalId from vellum guardian binding when present", () => {
     ensureVellumGuardianBinding("self");
-    const guardianResult = findGuardianForChannel("vellum");
+    const guardianResult = findGuardianForChannel("vellum", "self");
     expect(guardianResult).toBeTruthy();
 
     const ctx = resolveLocalIpcAuthContext("session-123");

--- a/assistant/src/__tests__/emit-signal-routing-intent.test.ts
+++ b/assistant/src/__tests__/emit-signal-routing-intent.test.ts
@@ -21,7 +21,7 @@ mock.module("../channels/config.js", () => ({
 }));
 
 mock.module("../contacts/contact-store.js", () => ({
-  findGuardianForChannel: () => null,
+  findGuardianForChannel: (_channelType: string, _assistantId: string) => null,
 }));
 
 mock.module("../memory/channel-guardian-store.js", () => ({

--- a/assistant/src/__tests__/trusted-contact-verification.test.ts
+++ b/assistant/src/__tests__/trusted-contact-verification.test.ts
@@ -427,7 +427,7 @@ describe("trusted contact verification → member activation", () => {
     }
 
     // The original guardian binding should remain intact
-    const guardianResult = findGuardianForChannel("telegram");
+    const guardianResult = findGuardianForChannel("telegram", "self");
     expect(guardianResult).not.toBeNull();
     expect(guardianResult!.channel.externalUserId).toBe(
       "guardian-user-original",
@@ -455,7 +455,7 @@ describe("trusted contact verification → member activation", () => {
     }
 
     // Guardian binding should be created (in contacts table)
-    const guardianResult = findGuardianForChannel("telegram");
+    const guardianResult = findGuardianForChannel("telegram", "self");
     expect(guardianResult).not.toBeNull();
     expect(guardianResult!.channel.externalUserId).toBe("guardian-user");
   });


### PR DESCRIPTION
## Summary
- Updated all test files to pass required assistantId to findGuardianForChannel, listGuardianChannels, and revokeGuardianChannel
- Updated mock signatures to match new required parameter
- Grepped for any additional test files needing updates

Part of plan: require-assistantid-guardian-queries.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
