### PR TITLE
feat: daemon loading skeleton for sidebar threads and chat area

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DaemonLoadingOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DaemonLoadingOverlay.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Blank page with a centered loading spinner, shown over the chat area
+/// while waiting for the daemon to connect.
+struct DaemonLoadingChatSkeleton: View {
+    var body: some View {
+        ZStack {
+            VColor.backgroundSubtle
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+            VLoadingIndicator(size: 24, color: VColor.textMuted)
+        }
+        .accessibilityHidden(true)
+    }
+}
+
+/// Skeleton thread rows shown in the sidebar while threads are loading.
+/// Mimics 5 thread rows matching the height of nav items like "Things".
+struct DaemonLoadingThreadsSkeleton: View {
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(0..<5, id: \.self) { _ in
+                VSkeletonBone(height: 13)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, VSpacing.xs)
+                    .padding(.vertical, 11)
+                    .padding(.horizontal, VSpacing.sm)
+            }
+        }
+        .accessibilityHidden(true)
+    }
+}
+
+#if DEBUG
+#Preview("DaemonLoadingChatSkeleton") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        DaemonLoadingChatSkeleton()
+            .padding(VSpacing.lg)
+    }
+    .frame(width: 600, height: 500)
+}
+
+#Preview("DaemonLoadingThreadsSkeleton") {
+    ZStack {
+        adaptiveColor(light: Moss._50, dark: Moss._950).ignoresSafeArea()
+        DaemonLoadingThreadsSkeleton()
+    }
+    .frame(width: 240, height: 300)
+}
+#endif

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -111,6 +111,8 @@ struct MainWindowView: View {
     @State private var threadSwitcherDismissTimer: DispatchWorkItem?
     /// Whether the "coming alive" overlay is currently showing.
     @State private var showComingAlive: Bool
+    /// Whether the daemon-loading skeleton overlay is currently showing.
+    @State private var showDaemonLoading: Bool
 
     init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, conversationZoomManager: ConversationZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, onSendWakeUp: (() -> Void)? = nil) {
         self.threadManager = threadManager
@@ -129,6 +131,9 @@ struct MainWindowView: View {
         self.voiceModeManager = voiceModeManager
         self.onSendWakeUp = onSendWakeUp
         self._showComingAlive = State(initialValue: onSendWakeUp != nil)
+        // Show skeleton loading only for normal launches (not post-onboarding where
+        // ComingAliveOverlay handles the transition).
+        self._showDaemonLoading = State(initialValue: onSendWakeUp == nil)
     }
 
     // MARK: - Layout Constants
@@ -593,6 +598,12 @@ struct MainWindowView: View {
 
                         chatContentView(geometry: geometry)
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                            .overlay {
+                                if showDaemonLoading {
+                                    DaemonLoadingChatSkeleton()
+                                        .transition(.opacity)
+                                }
+                            }
                     }
                     .padding(16)
                     .animation(VAnimation.panel, value: sidebarExpanded)
@@ -695,8 +706,26 @@ struct MainWindowView: View {
         .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
             windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected)
         }
-        .onReceive(daemonClient.$isConnected) { _ in
-            windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected)
+        .onReceive(daemonClient.$isConnected) { connected in
+            windowState.refreshAPIKeyStatus(isConnected: connected)
+
+            // Fallback for fresh users with 0 threads: dismiss skeleton after a
+            // short delay once the daemon is connected. Only applies during initial load.
+            guard connected, showDaemonLoading else { return }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                guard showDaemonLoading else { return }
+                withAnimation(VAnimation.standard) {
+                    showDaemonLoading = false
+                }
+            }
+        }
+        .onChange(of: threadManager.threads.isEmpty) { _, isEmpty in
+            // Dismiss skeleton when threads arrive from daemon
+            if !isEmpty && showDaemonLoading {
+                withAnimation(VAnimation.standard) {
+                    showDaemonLoading = false
+                }
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             threadManager.markActiveThreadSeenIfNeeded()
@@ -1242,6 +1271,7 @@ struct MainWindowView: View {
             // MARK: Threads (scrollable)
             SidebarThreadsHeader(
                 hasUnseenThreads: threadManager.unseenVisibleConversationCount > 0,
+                isLoading: showDaemonLoading,
                 onMarkAllSeen: {
                     let markedIds = threadManager.markAllThreadsSeen()
                     guard !markedIds.isEmpty else { return }
@@ -1269,6 +1299,10 @@ struct MainWindowView: View {
 
             ScrollView {
                 VStack(spacing: 0) {
+                    if showDaemonLoading && displayedThreads.isEmpty {
+                        DaemonLoadingThreadsSkeleton()
+                    }
+
                     ForEach(displayedThreads) { thread in
                         threadItem(thread)
                             .padding(.bottom, VSpacing.xxs)
@@ -1762,6 +1796,7 @@ private typealias SidebarNavRow = SidebarPrimaryRow
 
 private struct SidebarThreadsHeader: View {
     let hasUnseenThreads: Bool
+    var isLoading: Bool = false
     let onMarkAllSeen: () -> Void
     let onNewThread: () -> Void
 
@@ -1779,8 +1814,11 @@ private struct SidebarThreadsHeader: View {
                     tooltip: "Mark all as seen",
                     action: onMarkAllSeen
                 )
+                .disabled(isLoading)
             }
             VIconButton(label: "New thread", icon: "plus", iconOnly: true, action: onNewThread)
+                .disabled(isLoading)
+                .opacity(isLoading ? 0.4 : 1)
         }
         .padding(.leading, 20)
         .padding(.trailing, VSpacing.md)

--- a/clients/shared/DesignSystem/Core/Feedback/VSkeletonBone.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VSkeletonBone.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Atomic skeleton placeholder — a rounded rectangle with shimmer animation.
+/// Use as a stand-in for text lines, avatars, or UI elements during loading.
+public struct VSkeletonBone: View {
+    public var width: CGFloat?
+    public var height: CGFloat
+    public var radius: CGFloat
+
+    public init(width: CGFloat? = nil, height: CGFloat = 14, radius: CGFloat = VRadius.sm) {
+        self.width = width
+        self.height = height
+        self.radius = radius
+    }
+
+    public var body: some View {
+        RoundedRectangle(cornerRadius: radius)
+            .fill(VColor.surfaceBorder.opacity(0.5))
+            .frame(width: width, height: height)
+            .vShimmer()
+    }
+}
+
+#Preview("VSkeletonBone") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            VSkeletonBone(width: 200, height: 14)
+            VSkeletonBone(width: 140, height: 14)
+            VSkeletonBone(width: 160, height: 10, radius: VRadius.xs)
+            HStack(spacing: VSpacing.sm) {
+                VSkeletonBone(width: 28, height: 28, radius: VRadius.md)
+                VSkeletonBone(width: 120, height: 14)
+            }
+        }
+        .padding()
+    }
+    .frame(width: 350, height: 200)
+}

--- a/clients/shared/DesignSystem/Modifiers/ShimmerEffect.swift
+++ b/clients/shared/DesignSystem/Modifiers/ShimmerEffect.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+/// Sweeps a translucent `LinearGradient` highlight left-to-right across the
+/// modified view, creating a "shimmer" skeleton-loading effect.
+///
+/// Respects `accessibilityReduceMotion` — falls back to a static appearance.
+public struct ShimmerEffectModifier: ViewModifier {
+    public var highlightColor: Color
+    public var duration: TimeInterval
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var phase: CGFloat = -1
+
+    public init(
+        highlightColor: Color = VColor.surface,
+        duration: TimeInterval = 1.5
+    ) {
+        self.highlightColor = highlightColor
+        self.duration = duration
+    }
+
+    public func body(content: Content) -> some View {
+        content
+            .overlay {
+                if !reduceMotion {
+                    GeometryReader { geometry in
+                        let width = geometry.size.width
+
+                        LinearGradient(
+                            colors: [
+                                .clear,
+                                highlightColor.opacity(0.4),
+                                highlightColor.opacity(0.7),
+                                highlightColor.opacity(0.4),
+                                .clear,
+                            ],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                        .frame(width: width * 0.6)
+                        .offset(x: phase * (width * 1.6))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .clipped()
+                }
+            }
+            .onAppear {
+                guard !reduceMotion else { return }
+                withAnimation(
+                    .linear(duration: duration)
+                        .repeatForever(autoreverses: false)
+                ) {
+                    phase = 1
+                }
+            }
+    }
+}
+
+public extension View {
+    func vShimmer(
+        highlightColor: Color = VColor.surface,
+        duration: TimeInterval = 1.5
+    ) -> some View {
+        modifier(ShimmerEffectModifier(
+            highlightColor: highlightColor,
+            duration: duration
+        ))
+    }
+}
+
+#Preview("ShimmerEffect") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VStack(spacing: VSpacing.lg) {
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .fill(VColor.surfaceBorder.opacity(0.5))
+                .frame(width: 200, height: 14)
+                .vShimmer()
+
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.surfaceBorder.opacity(0.5))
+                .frame(width: 300, height: 40)
+                .vShimmer()
+
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(VColor.surfaceBorder.opacity(0.5))
+                .frame(height: 80)
+                .vShimmer()
+        }
+        .padding()
+    }
+    .frame(width: 400, height: 250)
+}


### PR DESCRIPTION
## Summary
- Adds skeleton thread rows in the sidebar and a loading spinner over the chat area while the daemon connects on app launch
- Prevents the app from appearing empty during the initial load window — real nav items (Search, Intelligence, Things, Preferences) render normally while thread placeholders shimmer
- Auto-dismisses when threads arrive, or after 1.5s fallback once daemon connects; new-thread button is disabled during loading
- Adds reusable `.vShimmer()` ViewModifier and `VSkeletonBone` design system primitives
- Fixes pre-existing `nonisolated` build error in `AppDelegate+Notifications`

## Test plan
- [ ] Kill daemon (`vellum sleep`), launch app — skeleton thread rows + loading spinner appear
- [ ] Start daemon (`vellum wake`) — skeleton fades out when threads load
- [ ] Fresh user with 0 threads — skeleton dismisses after 1.5s once daemon connects
- [ ] Subsequent daemon restarts while app is running — skeleton does NOT reappear
- [ ] Post-onboarding flow (`showComingAlive`) — skeleton does NOT conflict with coming-alive animation
- [ ] Accessibility: enable Reduce Motion — shimmer animation falls back to static
- [ ] `./build.sh` from `clients/macos/` compiles without new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
