### PR TITLE
fix: decode URI-encoded path params in runtime HTTP router

### DIFF
--- a/assistant/src/runtime/http-router.ts
+++ b/assistant/src/runtime/http-router.ts
@@ -94,7 +94,7 @@ export class HttpRouter {
       // Extract named params
       const params: RouteParams = {};
       for (let i = 0; i < compiled.paramNames.length; i++) {
-        params[compiled.paramNames[i]] = match[i + 1];
+        params[compiled.paramNames[i]] = decodeURIComponent(match[i + 1]);
       }
 
       // Enforce route-level scope/principal policy.


### PR DESCRIPTION
Adds decodeURIComponent to route parameter extraction in http-router.ts so that composite member IDs (contactId:channelId) survive gateway URL encoding. Fixes revoke/block operations through the gateway.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
