### PR TITLE
fix: handle URIError from decodeURIComponent in http-router path params

### DIFF
--- a/assistant/src/runtime/http-router.ts
+++ b/assistant/src/runtime/http-router.ts
@@ -94,7 +94,17 @@ export class HttpRouter {
       // Extract named params
       const params: RouteParams = {};
       for (let i = 0; i < compiled.paramNames.length; i++) {
-        params[compiled.paramNames[i]] = decodeURIComponent(match[i + 1]);
+        try {
+          params[compiled.paramNames[i]] = decodeURIComponent(match[i + 1]);
+        } catch {
+          return new Response(
+            JSON.stringify({
+              error: "BAD_REQUEST",
+              message: "Malformed percent-encoding in URL path parameter",
+            }),
+            { status: 400, headers: { "Content-Type": "application/json" } },
+          );
+        }
       }
 
       // Enforce route-level scope/principal policy.


### PR DESCRIPTION
Wraps decodeURIComponent in try/catch to return 400 instead of unhandled 500 on malformed percent-encoded path params. Addresses review feedback from PR #12251.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
