### PR TITLE
fix: preserve existing contact fields in channel-matched upsert path

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -224,20 +224,16 @@ export function upsertContact(params: {
         contactId = existingChannel.contactId;
         const updateSet: Record<string, unknown> = {
           displayName: params.displayName,
-          relationship:
-            params.relationship !== undefined ? params.relationship : undefined,
-          importance:
-            params.importance !== undefined ? params.importance : undefined,
-          responseExpectation:
-            params.responseExpectation !== undefined
-              ? params.responseExpectation
-              : undefined,
-          preferredTone:
-            params.preferredTone !== undefined
-              ? params.preferredTone
-              : undefined,
           updatedAt: now,
         };
+        if (params.relationship !== undefined)
+          updateSet.relationship = params.relationship;
+        if (params.importance !== undefined)
+          updateSet.importance = params.importance;
+        if (params.responseExpectation !== undefined)
+          updateSet.responseExpectation = params.responseExpectation;
+        if (params.preferredTone !== undefined)
+          updateSet.preferredTone = params.preferredTone;
         if (params.role !== undefined) updateSet.role = params.role;
         if (params.principalId !== undefined)
           updateSet.principalId = params.principalId;


### PR DESCRIPTION
## Summary
- Fix upsertContact bug where channel-matched update path drops existing field values
- Only include optional fields in updateSet when explicitly provided in params
- Aligns channel-matched path with existing by-ID update path behavior

Part of plan: contacts-post-migration-cleanup.md (PR 1 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)