### PR TITLE
chore: remove unused recordInteraction, updateChannelLastSeenByExternalId, updateChannelLastSeenByExternalChatId

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -584,29 +584,6 @@ export function mergeContacts(
 }
 
 /**
- * Record an interaction with a contact — bumps count and updates timestamp.
- */
-export function recordInteraction(contactId: string): void {
-  const db = getDb();
-  const now = Date.now();
-  const existing = db
-    .select()
-    .from(contacts)
-    .where(eq(contacts.id, contactId))
-    .get();
-  if (!existing) return;
-
-  db.update(contacts)
-    .set({
-      lastInteraction: now,
-      interactionCount: existing.interactionCount + 1,
-      updatedAt: now,
-    })
-    .where(eq(contacts.id, contactId))
-    .run();
-}
-
-/**
  * Find a contact by a specific channel address. Returns null if not found.
  */
 export function findContactByAddress(
@@ -899,47 +876,5 @@ export function updateChannelLastSeenById(channelId: string): void {
   db.update(contactChannels)
     .set({ lastSeenAt: now, updatedAt: now })
     .where(eq(contactChannels.id, channelId))
-    .run();
-}
-
-/**
- * Update the lastSeenAt timestamp on a contact channel by (type, externalUserId).
- * Optimized for the hot path — single UPDATE with no prior SELECT.
- */
-export function updateChannelLastSeenByExternalId(
-  channelType: string,
-  externalUserId: string,
-): void {
-  const db = getDb();
-  const now = Date.now();
-  db.update(contactChannels)
-    .set({ lastSeenAt: now, updatedAt: now })
-    .where(
-      and(
-        eq(contactChannels.type, channelType),
-        eq(contactChannels.externalUserId, externalUserId),
-      ),
-    )
-    .run();
-}
-
-/**
- * Update the lastSeenAt timestamp on a contact channel by (type, externalChatId).
- * Fallback for members that only have a chat ID and no external user ID.
- */
-export function updateChannelLastSeenByExternalChatId(
-  channelType: string,
-  externalChatId: string,
-): void {
-  const db = getDb();
-  const now = Date.now();
-  db.update(contactChannels)
-    .set({ lastSeenAt: now, updatedAt: now })
-    .where(
-      and(
-        eq(contactChannels.type, channelType),
-        eq(contactChannels.externalChatId, externalChatId),
-      ),
-    )
     .run();
 }

--- a/assistant/src/contacts/index.ts
+++ b/assistant/src/contacts/index.ts
@@ -3,7 +3,6 @@ export {
   getContact,
   listContacts,
   mergeContacts,
-  recordInteraction,
   searchContacts,
   upsertContact,
 } from "./contact-store.js";

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -264,7 +264,7 @@ export function initializeDb(): void {
   // 33. Add verification and access-control columns to contact_channels
   migrateContactChannelsAccessFields(database);
 
-  // 34. Composite index on (type, external_chat_id) for updateChannelLastSeenByExternalChatId
+  // 34. Composite index on (type, external_chat_id) for contact channel lookups
   migrateContactChannelsTypeChatIdIndex(database);
 
   // 35. Safety-sync remaining legacy data then drop assistant_ingress_members and channel_guardian_bindings

--- a/assistant/src/memory/migrations/130-contact-channels-type-ext-chat-id-index.ts
+++ b/assistant/src/memory/migrations/130-contact-channels-type-ext-chat-id-index.ts
@@ -3,9 +3,8 @@ import type { DrizzleDb } from "../db-connection.js";
 /**
  * Add a composite index on (type, external_chat_id) for contact_channels.
  *
- * updateChannelLastSeenByExternalChatId filters on this column pair on every
- * inbound message for chat-id-only members; without the index each call
- * performs a table scan.
+ * findContactByChannelExternalChatId filters on this column pair; without the
+ * index each call performs a table scan.
  */
 export function migrateContactChannelsTypeChatIdIndex(
   database: DrizzleDb,


### PR DESCRIPTION
## Summary
- Delete 3 unused exported functions from contact-store.ts
- Remove re-exports from contacts/index.ts
- recordInteraction, updateChannelLastSeenByExternalId, updateChannelLastSeenByExternalChatId are all dead code

Part of plan: contacts-post-migration-cleanup.md (PR 2 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
