### PR TITLE
chore: clean up stale migration comments in contacts code

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -86,7 +86,7 @@ interface SyncChannelData {
   isPrimary?: boolean;
   externalUserId?: string | null;
   externalChatId?: string | null;
-  /** Raw (pre-canonicalization) address used only for dedup fallback against legacy records. */
+  /** Raw (pre-canonicalization) address used for dedup fallback when matching contacts created before address normalization. */
   legacyAddress?: string;
   status?: ChannelStatus;
   policy?: ChannelPolicy;

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -1,9 +1,9 @@
 /**
- * Contacts-first write module.
+ * Contacts write module.
  *
- * All mutations write directly to the contacts table (the authoritative
- * source). The legacy ingress_members and guardian_bindings tables are
- * no longer written to.
+ * All mutations (member upserts, guardian bindings, revocations) write
+ * directly to the contacts table, the single authoritative source for
+ * identity and access-control state.
  */
 
 import type { ChannelId } from "../channels/types.js";


### PR DESCRIPTION
## Summary
- Update stale module-level JSDoc in contacts-write.ts to remove legacy table references
- Update legacyAddress field comment in contact-store.ts to remove migration-era wording

Part of plan: contacts-post-migration-cleanup.md (PR 7 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
