### PR TITLE
fix: use canonical httpError envelope for malformed path params

### DIFF
--- a/assistant/src/runtime/http-router.ts
+++ b/assistant/src/runtime/http-router.ts
@@ -12,6 +12,7 @@
 
 import { enforcePolicy, getPolicy } from "./auth/route-policy.js";
 import type { AuthContext } from "./auth/types.js";
+import { httpError } from "./http-errors.js";
 import { withErrorHandling } from "./middleware/error-handler.js";
 
 // ---------------------------------------------------------------------------
@@ -97,12 +98,10 @@ export class HttpRouter {
         try {
           params[compiled.paramNames[i]] = decodeURIComponent(match[i + 1]);
         } catch {
-          return new Response(
-            JSON.stringify({
-              error: "BAD_REQUEST",
-              message: "Malformed percent-encoding in URL path parameter",
-            }),
-            { status: 400, headers: { "Content-Type": "application/json" } },
+          return httpError(
+            "BAD_REQUEST",
+            "Malformed percent-encoding in URL path parameter",
+            400,
           );
         }
       }


### PR DESCRIPTION
Use httpError() instead of a custom JSON payload for the BAD_REQUEST response when decodeURIComponent fails in http-router path param extraction. This ensures the error shape matches all other /v1/* failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
