### PR TITLE
refactor: replace contactChannelToMemberRecord calls with native Contact/ContactChannel usage

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -18,7 +18,6 @@ import {
   listGuardianChannels,
 } from "../contacts/contact-store.js";
 import { upsertMemberContactsFirst } from "../contacts/contacts-write.js";
-import { contactChannelToMemberRecord } from "../contacts/member-record-shim.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import { getCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
 import * as conversationStore from "../memory/conversation-store.js";
@@ -714,7 +713,7 @@ export class RelayConnection {
         // an explicit decision to block them. This must be checked before
         // invite redemption so a blocked caller cannot bypass the block by
         // redeeming an active invite.
-        if (actorTrust.memberRecord?.status === "blocked") {
+        if (actorTrust.memberRecord?.channel.status === "blocked") {
           log.info(
             {
               callSessionId: this.callSessionId,
@@ -792,12 +791,12 @@ export class RelayConnection {
       // Members with policy: 'deny' have status: 'active' so resolveActorTrust
       // classifies them as trusted_contact, but the guardian has explicitly
       // denied their access. Block them the same way the text-channel path does.
-      if (actorTrust.memberRecord?.policy === "deny") {
+      if (actorTrust.memberRecord?.channel.policy === "deny") {
         log.info(
           {
             callSessionId: this.callSessionId,
             from: msg.from,
-            memberId: actorTrust.memberRecord.id,
+            channelId: actorTrust.memberRecord.channel.id,
             trustClass: actorTrust.trustClass,
           },
           "Inbound voice ACL: member policy deny",
@@ -806,8 +805,8 @@ export class RelayConnection {
         recordCallEvent(this.callSessionId, "inbound_acl_denied", {
           from: msg.from,
           trustClass: actorTrust.trustClass,
-          memberId: actorTrust.memberRecord.id,
-          memberPolicy: actorTrust.memberRecord.policy,
+          channelId: actorTrust.memberRecord.channel.id,
+          memberPolicy: actorTrust.memberRecord.channel.policy,
         });
 
         this.sendTextToken(
@@ -832,12 +831,12 @@ export class RelayConnection {
       // Members with policy: 'escalate' require guardian approval, but a live
       // voice call cannot be paused for async approval. Fail-closed by denying
       // the call with an appropriate message — mirrors the deny block above.
-      if (actorTrust.memberRecord?.policy === "escalate") {
+      if (actorTrust.memberRecord?.channel.policy === "escalate") {
         log.info(
           {
             callSessionId: this.callSessionId,
             from: msg.from,
-            memberId: actorTrust.memberRecord.id,
+            channelId: actorTrust.memberRecord.channel.id,
             trustClass: actorTrust.trustClass,
           },
           "Inbound voice ACL: member policy escalate — cannot hold live call for guardian approval",
@@ -846,8 +845,8 @@ export class RelayConnection {
         recordCallEvent(this.callSessionId, "inbound_acl_denied", {
           from: msg.from,
           trustClass: actorTrust.trustClass,
-          memberId: actorTrust.memberRecord.id,
-          memberPolicy: actorTrust.memberRecord.policy,
+          channelId: actorTrust.memberRecord.channel.id,
+          memberPolicy: actorTrust.memberRecord.channel.policy,
         });
 
         this.sendTextToken(
@@ -1775,14 +1774,12 @@ export class RelayConnection {
           externalUserId: fromNumber,
           externalChatId: fromNumber,
         });
-        const member = contactResult
-          ? contactChannelToMemberRecord(
-              contactResult.contact,
-              contactResult.channel,
-            )
-          : null;
-        if (member && member.status === "active" && member.policy === "allow") {
-          requesterMemberId = member.id;
+        if (
+          contactResult &&
+          contactResult.channel.status === "active" &&
+          contactResult.channel.policy === "allow"
+        ) {
+          requesterMemberId = contactResult.channel.id;
         }
       } catch (err) {
         log.warn(

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -153,8 +153,8 @@ export function inboundActorContextFromTrust(
     actorMemberDisplayName: ctx.actorMetadata.memberDisplayName,
     trustClass: ctx.trustClass,
     guardianIdentity: ctx.guardianBindingMatch?.guardianExternalUserId,
-    memberStatus: ctx.memberRecord?.status ?? undefined,
-    memberPolicy: ctx.memberRecord?.policy ?? undefined,
+    memberStatus: ctx.memberRecord?.channel.status ?? undefined,
+    memberPolicy: ctx.memberRecord?.channel.policy ?? undefined,
     denialReason: ctx.denialReason,
   };
 }

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -16,8 +16,7 @@ import {
   findContactByChannelExternalId,
   findGuardianForChannel,
 } from "../contacts/contact-store.js";
-import type { IngressMember } from "../contacts/member-record-shim.js";
-import { contactChannelToMemberRecord } from "../contacts/member-record-shim.js";
+import type { ContactChannel, ContactWithChannels } from "../contacts/types.js";
 import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
 import { getLogger } from "../util/logger.js";
@@ -74,8 +73,11 @@ export interface ActorTrustContext {
   } | null;
   /** Canonical principal ID from the guardian binding. */
   guardianPrincipalId?: string;
-  /** Ingress member record, if any, for this sender. */
-  memberRecord: IngressMember | null;
+  /** Resolved contact + channel for this sender, if any. */
+  memberRecord: {
+    contact: ContactWithChannels;
+    channel: ContactChannel;
+  } | null;
   /** Trust classification. */
   trustClass: TrustClass;
   /** Assistant-facing metadata for downstream consumption. */
@@ -207,7 +209,7 @@ export function resolveActorTrust(
   );
 
   // --- Member lookup via contacts ---
-  let memberRecord: IngressMember | null = null;
+  let memberRecord: ActorTrustContext["memberRecord"] = null;
   const contactMatch = findContactByChannelExternalId(
     input.sourceChannel,
     canonicalSenderId,
@@ -219,10 +221,7 @@ export function resolveActorTrust(
         ch.externalUserId === canonicalSenderId,
     );
     if (matchingChannel) {
-      memberRecord = contactChannelToMemberRecord(
-        contactMatch,
-        matchingChannel,
-      );
+      memberRecord = { contact: contactMatch, channel: matchingChannel };
     }
   }
   log.debug(
@@ -238,24 +237,20 @@ export function resolveActorTrust(
   // current sender to avoid misidentification in group chats.
   // Canonicalize the stored member ID to handle formatting variance (e.g.
   // phone numbers stored without E.164 normalization).
-  const memberMatchesSender = memberRecord?.externalUserId
+  const memberMatchesSender = memberRecord?.channel.externalUserId
     ? canonicalizeInboundIdentity(
         input.sourceChannel,
-        memberRecord.externalUserId,
+        memberRecord.channel.externalUserId,
       ) === canonicalSenderId
     : false;
 
-  const memberUsername =
-    memberMatchesSender &&
-    typeof memberRecord?.username === "string" &&
-    memberRecord.username.trim().length > 0
-      ? memberRecord.username.trim()
-      : undefined;
+  // ContactChannel has no username field — the shim always set it to null.
+  const memberUsername = undefined;
   const memberDisplayName =
     memberMatchesSender &&
-    typeof memberRecord?.displayName === "string" &&
-    memberRecord.displayName.trim().length > 0
-      ? memberRecord.displayName.trim()
+    typeof memberRecord?.contact.displayName === "string" &&
+    memberRecord.contact.displayName.trim().length > 0
+      ? memberRecord.contact.displayName.trim()
       : undefined;
   // Prefer member profile metadata over transient sender metadata so guardian-
   // curated contact details are canonical for assistant-facing identity —
@@ -273,7 +268,7 @@ export function resolveActorTrust(
   } else if (
     memberMatchesSender &&
     memberRecord &&
-    memberRecord.status === "active"
+    memberRecord.channel.status === "active"
   ) {
     trustClass = "trusted_contact";
   } else {

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -10,7 +10,6 @@
 import type { ChannelId } from "../channels/types.js";
 import { findContactChannel } from "../contacts/contact-store.js";
 import { upsertMemberContactsFirst } from "../contacts/contacts-write.js";
-import { contactChannelToMemberRecord } from "../contacts/member-record-shim.js";
 import { getSqlite } from "../memory/db.js";
 import {
   findActiveVoiceInvites,
@@ -134,18 +133,17 @@ export function redeemInvite(params: {
     externalUserId: canonicalUserId,
     externalChatId: externalChatId,
   });
-  const existingMember = contactResult
-    ? contactChannelToMemberRecord(contactResult.contact, contactResult.channel)
-    : null;
+  const existingChannel = contactResult?.channel ?? null;
+  const existingContact = contactResult?.contact ?? null;
 
-  if (existingMember && existingMember.status === "active") {
-    return { ok: true, type: "already_member", memberId: existingMember.id };
+  if (existingChannel && existingChannel.status === "active") {
+    return { ok: true, type: "already_member", memberId: existingChannel.id };
   }
 
   // Blocked members cannot bypass the guardian's explicit block via invite
   // links. Return the same generic failure as an invalid token to avoid
   // leaking membership status to the caller.
-  if (existingMember && existingMember.status === "blocked") {
+  if (existingChannel && existingChannel.status === "blocked") {
     return { ok: false, reason: "invalid_token" };
   }
 
@@ -153,14 +151,14 @@ export function redeemInvite(params: {
   // in a non-active state (revoked/pending), reactivate it via upsertMember
   // and consume an invite use atomically. The fresh-member path below also
   // uses upsertMemberContactsFirst to keep contacts in sync.
-  if (existingMember) {
+  if (existingChannel) {
     // Sentinel error used to trigger a transaction rollback when the invite
     // was concurrently revoked/expired between pre-validation and write time.
     const STALE_INVITE = Symbol("stale_invite");
-    const canonicalMemberId = existingMember.externalUserId
+    const canonicalMemberId = existingChannel.externalUserId
       ? canonicalizeInboundIdentity(
           sourceChannel as ChannelId,
-          existingMember.externalUserId,
+          existingChannel.externalUserId,
         )
       : null;
     const canonicalCallerId = externalUserId
@@ -172,8 +170,8 @@ export function redeemInvite(params: {
       canonicalMemberId === canonicalCallerId
     );
     const preservedDisplayName =
-      memberMatchesSender && existingMember.displayName?.trim().length
-        ? existingMember.displayName
+      memberMatchesSender && existingContact?.displayName?.trim().length
+        ? existingContact.displayName
         : displayName;
 
     let reactivated: ReturnType<typeof upsertMemberContactsFirst> | undefined;
@@ -343,19 +341,18 @@ export function redeemVoiceInviteCode(params: {
     channelType: "voice",
     externalUserId: canonicalCallerId,
   });
-  const existingMember = voiceContactResult
-    ? contactChannelToMemberRecord(
-        voiceContactResult.contact,
-        voiceContactResult.channel,
-      )
-    : null;
+  const existingVoiceChannel = voiceContactResult?.channel ?? null;
 
-  if (existingMember && existingMember.status === "active") {
-    return { ok: true, type: "already_member", memberId: existingMember.id };
+  if (existingVoiceChannel && existingVoiceChannel.status === "active") {
+    return {
+      ok: true,
+      type: "already_member",
+      memberId: existingVoiceChannel.id,
+    };
   }
 
   // Blocked members cannot bypass the guardian's explicit block
-  if (existingMember && existingMember.status === "blocked") {
+  if (existingVoiceChannel && existingVoiceChannel.status === "blocked") {
     return { ok: false, reason: "invalid_or_expired" };
   }
 
@@ -365,8 +362,9 @@ export function redeemVoiceInviteCode(params: {
 
   // Reactivation should not overwrite a guardian-managed nickname (same
   // protection as the token-based redemption path above).
-  const preservedDisplayName = existingMember?.displayName?.trim().length
-    ? existingMember.displayName
+  const voiceContact = voiceContactResult?.contact ?? null;
+  const preservedDisplayName = voiceContact?.displayName?.trim().length
+    ? voiceContact.displayName
     : (invite.friendName ?? undefined);
 
   try {

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -9,8 +9,12 @@
 import type { ChannelId } from "../../../channels/types.js";
 import { findContactChannel } from "../../../contacts/contact-store.js";
 import { touchChannelLastSeen } from "../../../contacts/contacts-write.js";
-import type { IngressMember } from "../../../contacts/member-record-shim.js";
-import { contactChannelToMemberRecord } from "../../../contacts/member-record-shim.js";
+import type { MemberStatus } from "../../../contacts/member-record-shim.js";
+import type {
+  ChannelStatus,
+  ContactChannel,
+  ContactWithChannels,
+} from "../../../contacts/types.js";
 import * as channelDeliveryStore from "../../../memory/channel-delivery-store.js";
 import { getLogger } from "../../../util/logger.js";
 import { notifyGuardianOfAccessRequest } from "../../access-request-helper.js";
@@ -47,8 +51,14 @@ export interface AclEnforcementParams {
   externalMessageId: string;
 }
 
+/** Resolved contact + channel pair from ACL enforcement. */
+export type ResolvedMember = {
+  contact: ContactWithChannels;
+  channel: ContactChannel;
+};
+
 export interface AclResult {
-  resolvedMember: IngressMember | null;
+  resolvedMember: ResolvedMember | null;
   /** When set, the caller must return this response immediately. */
   earlyResponse?: Response;
   /**
@@ -70,6 +80,12 @@ function parseGuardianVerifyCode(content: string): string | undefined {
   if (bareMatch) return bareMatch[1];
 
   return undefined;
+}
+
+/** Map ChannelStatus to the legacy MemberStatus for API consumers. */
+function channelStatusToMemberStatus(status: ChannelStatus): MemberStatus {
+  if (status === "unverified") return "pending";
+  return status;
 }
 
 /**
@@ -97,7 +113,7 @@ export async function enforceIngressAcl(
     externalMessageId,
   } = params;
 
-  let resolvedMember: IngressMember | null = null;
+  let resolvedMember: ResolvedMember | null = null;
 
   // Verification codes must bypass the ACL membership check — users without a
   // member record need to verify before they can be recognized as members.
@@ -145,10 +161,10 @@ export async function enforceIngressAcl(
         externalChatId: conversationExternalId,
       });
       resolvedMember = contactResult
-        ? contactChannelToMemberRecord(
-            contactResult.contact,
-            contactResult.channel,
-          )
+        ? {
+            contact: contactResult.contact,
+            channel: contactResult.channel,
+          }
         : null;
     }
 
@@ -296,7 +312,7 @@ export async function enforceIngressAcl(
     }
 
     if (resolvedMember) {
-      if (resolvedMember.status !== "active") {
+      if (resolvedMember.channel.status !== "active") {
         // Same bypass logic as the no-member branch: verification codes and
         // bootstrap commands must pass through even when the member record is
         // revoked/blocked — otherwise the user can never re-verify.
@@ -316,7 +332,7 @@ export async function enforceIngressAcl(
             log.info(
               {
                 sourceChannel,
-                memberId: resolvedMember.id,
+                channelId: resolvedMember.channel.id,
                 hasPendingChallenge,
                 hasActiveOutboundSession,
               },
@@ -343,7 +359,7 @@ export async function enforceIngressAcl(
             log.info(
               {
                 sourceChannel,
-                memberId: resolvedMember.id,
+                channelId: resolvedMember.channel.id,
                 hasValidBootstrapSession: false,
               },
               "Ingress ACL: inactive member bootstrap bypass denied",
@@ -380,8 +396,8 @@ export async function enforceIngressAcl(
           log.info(
             {
               sourceChannel,
-              memberId: resolvedMember.id,
-              status: resolvedMember.status,
+              channelId: resolvedMember.channel.id,
+              status: resolvedMember.channel.status,
             },
             "Ingress ACL: member not active, denying",
           );
@@ -390,7 +406,7 @@ export async function enforceIngressAcl(
           // re-approve. Blocked members are intentionally excluded — the
           // guardian already made an explicit decision to block them.
           let guardianNotified = false;
-          if (resolvedMember.status !== "blocked") {
+          if (resolvedMember.channel.status !== "blocked") {
             try {
               const accessResult = notifyGuardianOfAccessRequest({
                 canonicalAssistantId,
@@ -399,7 +415,9 @@ export async function enforceIngressAcl(
                 actorExternalId: canonicalSenderId ?? rawSenderId,
                 actorDisplayName,
                 actorUsername,
-                previousMemberStatus: resolvedMember.status,
+                previousMemberStatus: channelStatusToMemberStatus(
+                  resolvedMember.channel.status,
+                ),
               });
               guardianNotified = accessResult.notified;
             } catch (err) {
@@ -436,16 +454,16 @@ export async function enforceIngressAcl(
             earlyResponse: Response.json({
               accepted: true,
               denied: true,
-              reason: `member_${resolvedMember.status}`,
+              reason: `member_${resolvedMember.channel.status}`,
             }),
             guardianVerifyCode,
           };
         }
       }
 
-      if (resolvedMember.policy === "deny") {
+      if (resolvedMember.channel.policy === "deny") {
         log.info(
-          { sourceChannel, memberId: resolvedMember.id },
+          { sourceChannel, channelId: resolvedMember.channel.id },
           "Ingress ACL: member policy deny",
         );
         if (replyCallbackUrl) {
@@ -478,7 +496,7 @@ export async function enforceIngressAcl(
       }
 
       // 'allow' or 'escalate' — update last seen and continue
-      touchChannelLastSeen(resolvedMember.id);
+      touchChannelLastSeen(resolvedMember.channel.id);
     }
   }
 

--- a/assistant/src/runtime/routes/inbound-stages/escalation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/escalation-intercept.ts
@@ -9,7 +9,7 @@
  */
 import type { ChannelId } from "../../../channels/types.js";
 import type { InterfaceId } from "../../../channels/types.js";
-import type { IngressMember } from "../../../contacts/member-record-shim.js";
+import type { ResolvedMember } from "./acl-enforcement.js";
 import { createCanonicalGuardianRequest } from "../../../memory/canonical-guardian-store.js";
 import * as channelDeliveryStore from "../../../memory/channel-delivery-store.js";
 import { emitNotificationSignal } from "../../../notifications/emit-signal.js";
@@ -24,7 +24,7 @@ const log = getLogger("runtime-http");
 // ---------------------------------------------------------------------------
 
 export interface EscalationInterceptParams {
-  resolvedMember: IngressMember | null;
+  resolvedMember: ResolvedMember | null;
   canonicalAssistantId: string;
   sourceChannel: ChannelId;
   sourceInterface: InterfaceId;
@@ -73,7 +73,7 @@ export function handleEscalationIntercept(
     rawSenderId,
   } = params;
 
-  if (resolvedMember?.policy !== "escalate") {
+  if (resolvedMember?.channel.policy !== "escalate") {
     return null;
   }
 
@@ -81,7 +81,7 @@ export function handleEscalationIntercept(
   if (!binding) {
     // Fail-closed: can't escalate without a guardian to route to
     log.info(
-      { sourceChannel, memberId: resolvedMember.id },
+      { sourceChannel, channelId: resolvedMember.channel.id },
       "Ingress ACL: escalate policy but no guardian binding, denying",
     );
     return Response.json({

--- a/assistant/src/runtime/routes/inbound-stages/verification-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/verification-intercept.ts
@@ -13,7 +13,6 @@
 import type { ChannelId } from "../../../channels/types.js";
 import { findContactChannel } from "../../../contacts/contact-store.js";
 import { upsertMemberContactsFirst } from "../../../contacts/contacts-write.js";
-import { contactChannelToMemberRecord } from "../../../contacts/member-record-shim.js";
 import * as channelDeliveryStore from "../../../memory/channel-delivery-store.js";
 import { emitNotificationSignal } from "../../../notifications/emit-signal.js";
 import { canonicalizeInboundIdentity } from "../../../util/canonicalize-identity.js";
@@ -123,21 +122,17 @@ export async function handleVerificationIntercept(
             externalChatId: conversationExternalId,
           })
         : null;
-    const existingMember = existingContactResult
-      ? contactChannelToMemberRecord(
-          existingContactResult.contact,
-          existingContactResult.channel,
-        )
-      : null;
-    const memberMatchesSender = existingMember?.externalUserId
+    const existingChannel = existingContactResult?.channel ?? null;
+    const existingContact = existingContactResult?.contact ?? null;
+    const memberMatchesSender = existingChannel?.externalUserId
       ? canonicalizeInboundIdentity(
           sourceChannel,
-          existingMember.externalUserId,
+          existingChannel.externalUserId,
         ) === (canonicalSenderId ?? rawSenderId)
       : false;
     const preservedDisplayName =
-      memberMatchesSender && existingMember?.displayName?.trim().length
-        ? existingMember.displayName
+      memberMatchesSender && existingContact?.displayName?.trim().length
+        ? existingContact.displayName
         : actorDisplayName;
 
     upsertMemberContactsFirst({


### PR DESCRIPTION
## Summary
- Replace all contactChannelToMemberRecord shim calls with direct Contact/ContactChannel usage
- Update ActorTrustContext.memberRecord and AclResult.resolvedMember types from IngressMember to native types
- Update all downstream consumers of these interfaces (trust resolution, ACL enforcement, escalation intercept)

Part of plan: contacts-post-migration-cleanup.md (PR 10 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
