### PR TITLE
fix: update callers of contacts-write to handle ContactWriteResult return type

### DIFF
--- a/assistant/src/runtime/ingress-service.ts
+++ b/assistant/src/runtime/ingress-service.ts
@@ -12,10 +12,11 @@ import {
   revokeMemberContactsFirst,
   upsertMemberContactsFirst,
 } from "../contacts/contacts-write.js";
-import type {
-  IngressMember,
-  MemberPolicy,
-  MemberStatus,
+import {
+  contactChannelToMemberRecord,
+  type IngressMember,
+  type MemberPolicy,
+  type MemberStatus,
 } from "../contacts/member-record-shim.js";
 import type { ContactWithChannels } from "../contacts/types.js";
 import {
@@ -391,7 +392,7 @@ export function upsertIngressMember(params: {
         "At least one of externalUserId or externalChatId is required for upsert",
     };
   }
-  const member = upsertMemberContactsFirst({
+  const result = upsertMemberContactsFirst({
     assistantId: params.assistantId,
     sourceChannel: params.sourceChannel,
     externalUserId: params.externalUserId,
@@ -401,6 +402,10 @@ export function upsertIngressMember(params: {
     policy: params.policy as MemberPolicy | undefined,
     status: params.status as MemberStatus | undefined,
   });
+  if (!result) {
+    return { ok: false, error: "Failed to upsert member" };
+  }
+  const member = contactChannelToMemberRecord(result.contact, result.channel);
   return { ok: true, data: memberToResponse(member) };
 }
 
@@ -411,10 +416,14 @@ export function revokeIngressMember(
   if (!memberId) {
     return { ok: false, error: "memberId is required for revoke" };
   }
-  const revoked = revokeMemberContactsFirst(memberId, reason);
-  if (!revoked) {
+  const revokedResult = revokeMemberContactsFirst(memberId, reason);
+  if (!revokedResult) {
     return { ok: false, error: "Member not found or cannot be revoked" };
   }
+  const revoked = contactChannelToMemberRecord(
+    revokedResult.contact,
+    revokedResult.channel,
+  );
   return { ok: true, data: memberToResponse(revoked) };
 }
 
@@ -425,9 +434,13 @@ export function blockIngressMember(
   if (!memberId) {
     return { ok: false, error: "memberId is required for block" };
   }
-  const blocked = blockMemberContactsFirst(memberId, reason);
-  if (!blocked) {
+  const blockedResult = blockMemberContactsFirst(memberId, reason);
+  if (!blockedResult) {
     return { ok: false, error: "Member not found or already blocked" };
   }
+  const blocked = contactChannelToMemberRecord(
+    blockedResult.contact,
+    blockedResult.channel,
+  );
   return { ok: true, data: memberToResponse(blocked) };
 }

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -215,7 +215,7 @@ export function redeemInvite(params: {
     return {
       ok: true,
       type: "redeemed",
-      memberId: reactivated!.id,
+      memberId: reactivated!.channel.id,
       inviteId: invite.id,
     };
   }
@@ -258,7 +258,7 @@ export function redeemInvite(params: {
   return {
     ok: true,
     type: "redeemed",
-    memberId: freshMember!.id,
+    memberId: freshMember!.channel.id,
     inviteId: invite.id,
   };
 }
@@ -372,7 +372,7 @@ export function redeemVoiceInviteCode(params: {
   try {
     getSqlite()
       .transaction(() => {
-        const member = upsertMemberContactsFirst({
+        const memberResult = upsertMemberContactsFirst({
           assistantId: invite.assistantId,
           sourceChannel: "voice",
           externalUserId: callerExternalUserId,
@@ -382,7 +382,7 @@ export function redeemVoiceInviteCode(params: {
           policy: "allow",
           inviteId: invite.id,
         });
-        memberId = member.id;
+        memberId = memberResult?.channel.id;
 
         const recorded = recordInviteUse({
           inviteId: invite.id,


### PR DESCRIPTION
Update ingress-service.ts, invite-redemption-service.ts, and verification-intercept.ts to handle the new ContactWriteResult return type from upsertMemberContactsFirst, revokeMemberContactsFirst, and blockMemberContactsFirst after PR #12260 changed the return contract.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
