### PR TITLE
fix: update test files to use ContactWriteResult properties

### DIFF
--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -236,7 +236,7 @@ describe("invite-redemption-service", () => {
       externalUserId: "revoked-user",
       status: "revoked",
     });
-    expect(member.status).toBe("revoked");
+    expect(member!.channel.status).toBe("revoked");
 
     const outcome = redeemInvite({
       rawToken,

--- a/assistant/src/__tests__/trusted-contact-verification.test.ts
+++ b/assistant/src/__tests__/trusted-contact-verification.test.ts
@@ -333,9 +333,12 @@ describe("trusted contact verification → member activation", () => {
     });
 
     // Revoke the member
-    const revoked = revokeMemberContactsFirst(member.id, "testing revocation");
+    const revoked = revokeMemberContactsFirst(
+      member!.channel.id,
+      "testing revocation",
+    );
     expect(revoked).not.toBeNull();
-    expect(revoked!.status).toBe("revoked");
+    expect(revoked!.channel.status).toBe("revoked");
 
     // Verify the member is indeed revoked (ACL would reject)
     const revokedResult = findContactChannel({


### PR DESCRIPTION
## Summary
- Fix `invite-redemption-service.test.ts` to use `member!.channel.status` instead of `member.status`
- Fix `trusted-contact-verification.test.ts` to use `member!.channel.id` and `revoked!.channel.status` instead of `member.id` and `revoked!.status`
- These test files were missed when PR #12260 changed `upsertMemberContactsFirst`/`revokeMemberContactsFirst` return types from `IngressMember` to `ContactWriteResult | null`

## Original prompt
Help me fix the CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22670343072 (excluding benchmarks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
