### PR TITLE
refactor: rename ContactsFirst functions now that legacy paths are gone

### DIFF
--- a/assistant/docs/trusted-contact-access.md
+++ b/assistant/docs/trusted-contact-access.md
@@ -92,11 +92,11 @@ Identity binding ensures the verification code can only be consumed by the inten
 
 ### Stage: `active` (code verified, trusted contact created)
 
-| Store                       | Table                                      | Record                                                                                                                                                                                                           |
-| --------------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `contacts-write.ts`         | `contacts` / `contact_channels`            | Upserted via `upsertMemberContactsFirst()`: creates a contact record and a `contact_channels` entry with `status: 'active'`, `policy: 'allow'`, channel type, `externalUserId`, `externalChatId`, `displayName`. |
-| `channel-guardian-store.ts` | `channel_guardian_verification_challenges` | Updated to `status: 'consumed'`, `consumedByExternalUserId`, `consumedByChatId` set.                                                                                                                             |
-| `channel-guardian-store.ts` | `channel_guardian_rate_limits`             | Reset via `resetRateLimit()` on successful verification.                                                                                                                                                         |
+| Store                       | Table                                      | Record                                                                                                                                                                                              |
+| --------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `contacts-write.ts`         | `contacts` / `contact_channels`            | Upserted via `upsertMember()`: creates a contact record and a `contact_channels` entry with `status: 'active'`, `policy: 'allow'`, channel type, `externalUserId`, `externalChatId`, `displayName`. |
+| `channel-guardian-store.ts` | `channel_guardian_verification_challenges` | Updated to `status: 'consumed'`, `consumedByExternalUserId`, `consumedByChatId` set.                                                                                                                |
+| `channel-guardian-store.ts` | `channel_guardian_rate_limits`             | Reset via `resetRateLimit()` on successful verification.                                                                                                                                            |
 
 ### Stage: `denied` (guardian rejected)
 
@@ -137,10 +137,10 @@ Voice calls have a dedicated in-call guardian approval flow that differs from th
 
 **Key difference from text-channel flow:** Voice approvals skip the verification session step because the caller's phone identity is already known from the active call. Text-channel approvals still mint a 6-digit verification code for out-of-band identity confirmation.
 
-| Store                         | Table                           | Record                                                                                             |
-| ----------------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `canonical-guardian-store.ts` | `canonical_guardian_requests`   | `kind: 'access_request'`, `status: 'pending'` -> `'approved'` or `'denied'`                        |
-| `contacts-write.ts`           | `contacts` / `contact_channels` | On approval: upserted via `upsertMemberContactsFirst()` with `status: 'active'`, `policy: 'allow'` |
+| Store                         | Table                           | Record                                                                                |
+| ----------------------------- | ------------------------------- | ------------------------------------------------------------------------------------- |
+| `canonical-guardian-store.ts` | `canonical_guardian_requests`   | `kind: 'access_request'`, `status: 'pending'` -> `'approved'` or `'denied'`           |
+| `contacts-write.ts`           | `contacts` / `contact_channels` | On approval: upserted via `upsertMember()` with `status: 'active'`, `policy: 'allow'` |
 
 ## Sequence Diagram
 

--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -48,7 +48,7 @@ mock.module("../config/env.js", () => ({
 }));
 
 import { findGuardianForChannel } from "../contacts/contact-store.js";
-import { createGuardianBindingContactsFirst } from "../contacts/contacts-write.js";
+import { createGuardianBinding } from "../contacts/contacts-write.js";
 import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
 import {
   createActorTokenRecord,
@@ -227,7 +227,7 @@ describe("guardian vellum migration", () => {
   });
 
   test("ensureVellumGuardianBinding preserves existing bindings for other channels", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "tg-user-123",

--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -52,7 +52,7 @@ mock.module("../daemon/handlers.js", () => ({
 }));
 
 import { upsertContact } from "../contacts/contact-store.js";
-import { createGuardianBindingContactsFirst } from "../contacts/contacts-write.js";
+import { createGuardianBinding } from "../contacts/contacts-write.js";
 import type { Session } from "../daemon/session.js";
 import {
   createCanonicalGuardianDelivery,
@@ -266,7 +266,7 @@ describe("stale callback handling without matching pending approval", () => {
 
 describe("inbound callback metadata triggers decision handling", () => {
   beforeEach(() => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "telegram-user-default",
@@ -360,7 +360,7 @@ describe("inbound callback metadata triggers decision handling", () => {
 
 describe("inbound text matching approval phrases triggers decision handling", () => {
   beforeEach(() => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "telegram-user-default",
@@ -442,7 +442,7 @@ describe("inbound text matching approval phrases triggers decision handling", ()
 
 describe("non-decision messages during pending approval (legacy fallback)", () => {
   beforeEach(() => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "telegram-user-default",
@@ -524,7 +524,7 @@ describe("messages without pending approval proceed normally", () => {
 
 describe("empty content with callbackData bypasses validation", () => {
   beforeEach(() => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "telegram-user-default",
@@ -637,7 +637,7 @@ describe("empty content with callbackData bypasses validation", () => {
 
 describe("callback requestId validation", () => {
   beforeEach(() => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "telegram-user-default",
@@ -765,7 +765,7 @@ describe("callback requestId validation", () => {
 
 describe("no immediate reply after approval decision", () => {
   beforeEach(() => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "telegram-user-default",
@@ -898,7 +898,7 @@ describe("stale callback handling", () => {
 
 describe("SMS channel approval decisions", () => {
   beforeEach(() => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "sms",
       guardianExternalUserId: "sms-user-default",
@@ -1190,7 +1190,7 @@ describe("SMS guardian verify intercept", () => {
 
 describe("guardian decision scoping — multiple pending approvals", () => {
   test("callback for older request resolves to the correct approval request", async () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-scope-user",
@@ -1275,7 +1275,7 @@ describe("guardian decision scoping — multiple pending approvals", () => {
 
 describe("ambiguous plain-text decision with multiple pending requests", () => {
   test("does not apply plain-text decision to wrong request when multiple pending", async () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-ambig-user",
@@ -1662,7 +1662,7 @@ describe("assistant-scoped guardian verification via handleChannelInbound", () =
 
 describe("conversational approval engine — standard path", () => {
   beforeEach(() => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "telegram-user-default",
@@ -1883,7 +1883,7 @@ describe("conversational approval engine — standard path", () => {
 
 describe("guardian conversational approval via conversation engine", () => {
   test("guardian follow-up clarification: engine returns keep_pending", async () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-conv-user",
@@ -1965,7 +1965,7 @@ describe("guardian conversational approval via conversation engine", () => {
   });
 
   test("guardian natural-language approval: engine returns approve_once", async () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-nlp-user",
@@ -2045,7 +2045,7 @@ describe("guardian conversational approval via conversation engine", () => {
   });
 
   test("guardian callback button approve_always is downgraded to approve_once", async () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-dg-user",
@@ -2100,7 +2100,7 @@ describe("guardian conversational approval via conversation engine", () => {
   });
 
   test("multi-pending guardian disambiguation: engine requests clarification", async () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-multi-user",
@@ -2203,7 +2203,7 @@ describe("guardian conversational approval via conversation engine", () => {
 
 describe("keep_pending remains conversational — standard path", () => {
   beforeEach(() => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "telegram-user-default",
@@ -2264,7 +2264,7 @@ describe("keep_pending remains conversational — standard path", () => {
 
 describe("keep_pending remains conversational — guardian path", () => {
   test('guardian explicit "yes" with keep_pending returns assistant_turn without applying a decision', async () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-user-fb",
@@ -2339,7 +2339,7 @@ describe("keep_pending remains conversational — guardian path", () => {
 
 describe("requester cancel of guardian-gated pending request", () => {
   beforeEach(() => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-cancel",
@@ -2653,7 +2653,7 @@ describe("requester cancel of guardian-gated pending request", () => {
 
 describe("engine decision race condition — standard path", () => {
   beforeEach(() => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "telegram-user-default",
@@ -2723,7 +2723,7 @@ describe("engine decision race condition — standard path", () => {
 
 describe("engine decision race condition — guardian path", () => {
   test("returns stale_ignored when guardian engine approves but interaction was already resolved", async () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-race-user",
@@ -2805,14 +2805,14 @@ describe("engine decision race condition — guardian path", () => {
 
 describe("non-decision status reply for different channels", () => {
   beforeEach(() => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "telegram-user-default",
       guardianDeliveryChatId: "chat-123",
       guardianPrincipalId: "telegram-user-default",
     });
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "sms",
       guardianExternalUserId: "telegram-user-default",
@@ -2923,7 +2923,7 @@ describe("non-decision status reply for different channels", () => {
 describe("background channel processing approval prompts", () => {
   test("marks guardian channel turns interactive and delivers approval prompt when confirmation is pending", async () => {
     // Set up a guardian binding so the sender is recognized as a guardian
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "telegram-user-default",
@@ -2987,7 +2987,7 @@ describe("background channel processing approval prompts", () => {
   test("guardian prompt delivery still works when binding ID formatting differs from sender ID", async () => {
     // Guardian binding includes extra whitespace; trust resolution canonicalizes
     // identity and prompt delivery should still treat this sender as the guardian.
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "  telegram-user-default  ",
@@ -3052,7 +3052,7 @@ describe("background channel processing approval prompts", () => {
     // Set up a guardian binding for a DIFFERENT user so the sender is a
     // trusted contact (not the guardian). The guardian route is resolvable
     // because the binding exists — approval notifications can be delivered.
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-user-other",
@@ -3174,7 +3174,7 @@ describe("NL approval routing via destination-scoped canonical requests", () => 
     ensureConversation("conv-voice-nl-1");
 
     // Create guardian binding for Telegram
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: guardianUserId,
@@ -3232,7 +3232,7 @@ describe("NL approval routing via destination-scoped canonical requests", () => 
     const differentChatId = "different-chat-999";
 
     // Create guardian binding for the guardian user on the different chat
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: guardianUserId,
@@ -3289,7 +3289,7 @@ describe("NL approval routing via destination-scoped canonical requests", () => 
 describe("trusted-contact self-approval blocked before guardian approval row exists", () => {
   beforeEach(() => {
     // Create a guardian binding so the requester resolves as trusted_contact
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-tc-selfapproval",

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -113,7 +113,7 @@ globalThis.fetch = (async (
 }) as unknown as typeof fetch;
 import { eq } from "drizzle-orm";
 
-import { createGuardianBindingContactsFirst } from "../contacts/contacts-write.js";
+import { createGuardianBinding } from "../contacts/contacts-write.js";
 import {
   handleGuardianVerification,
   MAX_SENDS_PER_SESSION,
@@ -551,7 +551,7 @@ describe("guardian service challenge validation", () => {
 
   test("validateAndConsumeChallenge revokes existing binding before creating new one", () => {
     // Create initial guardian binding
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "asst-1",
       channel: "telegram",
       guardianExternalUserId: "old-user",
@@ -594,7 +594,7 @@ describe("guardian identity check", () => {
   });
 
   test("isGuardian returns true for matching user", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "asst-1",
       channel: "telegram",
       guardianExternalUserId: "user-42",
@@ -606,7 +606,7 @@ describe("guardian identity check", () => {
   });
 
   test("isGuardian returns false for non-matching user", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "asst-1",
       channel: "telegram",
       guardianExternalUserId: "user-42",
@@ -622,7 +622,7 @@ describe("guardian identity check", () => {
   });
 
   test("isGuardian returns false after binding is revoked", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "asst-1",
       channel: "telegram",
       guardianExternalUserId: "user-42",
@@ -636,7 +636,7 @@ describe("guardian identity check", () => {
   });
 
   test("getGuardianBinding returns the active binding", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "asst-1",
       channel: "telegram",
       guardianExternalUserId: "user-42",
@@ -655,7 +655,7 @@ describe("guardian identity check", () => {
   });
 
   test("isGuardian works for sms channel", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "asst-1",
       channel: "sms",
       guardianExternalUserId: "phone-user-1",
@@ -670,7 +670,7 @@ describe("guardian identity check", () => {
   });
 
   test("serviceRevokeBinding revokes the active binding", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "asst-1",
       channel: "telegram",
       guardianExternalUserId: "user-42",
@@ -1253,7 +1253,7 @@ describe("channel-scoped guardian resolution", () => {
 
   test("isGuardian resolves independently per channel", () => {
     // Create guardian binding on telegram
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "user-alpha",
@@ -1261,7 +1261,7 @@ describe("channel-scoped guardian resolution", () => {
       guardianDeliveryChatId: "chat-alpha",
     });
     // Create guardian binding on sms with a different user
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "sms",
       guardianExternalUserId: "user-beta",
@@ -1279,14 +1279,14 @@ describe("channel-scoped guardian resolution", () => {
   });
 
   test("getGuardianBinding returns different bindings for different channels", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "user-alpha",
       guardianPrincipalId: "user-alpha",
       guardianDeliveryChatId: "chat-alpha",
     });
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "sms",
       guardianExternalUserId: "user-beta",
@@ -1304,14 +1304,14 @@ describe("channel-scoped guardian resolution", () => {
   });
 
   test("revoking binding for one channel does not affect another", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "user-alpha",
       guardianPrincipalId: "user-alpha",
       guardianDeliveryChatId: "chat-alpha",
     });
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "sms",
       guardianExternalUserId: "user-beta",
@@ -1533,7 +1533,7 @@ describe("IPC handler channel-aware guardian status", () => {
   });
 
   test("status action returns guardianDeliveryChatId when bound", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "user-42",
@@ -1561,7 +1561,7 @@ describe("IPC handler channel-aware guardian status", () => {
   });
 
   test("status action returns guardian username/displayName from binding metadata", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "user-43",
@@ -1871,7 +1871,7 @@ describe("voice guardian challenge validation", () => {
   });
 
   test("validateAndConsumeChallenge revokes existing voice binding before creating new one", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "asst-1",
       channel: "voice",
       guardianExternalUserId: "old-voice-user",
@@ -1913,7 +1913,7 @@ describe("voice guardian identity and revocation", () => {
   });
 
   test("isGuardian works for voice channel", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "asst-1",
       channel: "voice",
       guardianExternalUserId: "voice-user-1",
@@ -1928,7 +1928,7 @@ describe("voice guardian identity and revocation", () => {
   });
 
   test("getGuardianBinding returns voice binding", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "asst-1",
       channel: "voice",
       guardianExternalUserId: "voice-user-1",
@@ -1943,7 +1943,7 @@ describe("voice guardian identity and revocation", () => {
   });
 
   test("revokeBinding clears active voice guardian binding", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "asst-1",
       channel: "voice",
       guardianExternalUserId: "voice-user-1",
@@ -1957,14 +1957,14 @@ describe("voice guardian identity and revocation", () => {
   });
 
   test("revokeBinding for voice does not affect telegram binding", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "asst-1",
       channel: "voice",
       guardianExternalUserId: "voice-user-1",
       guardianPrincipalId: "voice-user-1",
       guardianDeliveryChatId: "voice-chat-1",
     });
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "asst-1",
       channel: "telegram",
       guardianExternalUserId: "tg-user-1",
@@ -2192,7 +2192,7 @@ describe("IPC handler voice guardian verification", () => {
   });
 
   test("status for voice reflects bound state", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "voice",
       guardianExternalUserId: "voice-user-1",
@@ -2219,7 +2219,7 @@ describe("IPC handler voice guardian verification", () => {
   });
 
   test("revoke for voice clears active binding", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "voice",
       guardianExternalUserId: "voice-user-1",
@@ -2246,14 +2246,14 @@ describe("IPC handler voice guardian verification", () => {
   });
 
   test("revoke for voice does not affect telegram binding", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "voice",
       guardianExternalUserId: "voice-user-1",
       guardianPrincipalId: "voice-user-1",
       guardianDeliveryChatId: "voice-chat-1",
     });
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "tg-user-1",
@@ -2812,7 +2812,7 @@ describe("outbound SMS verification", () => {
 
   test("start_outbound rejects when active binding exists (rebind=false)", () => {
     // Create an existing guardian binding
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "sms",
       guardianExternalUserId: "+15551234567",
@@ -2839,7 +2839,7 @@ describe("outbound SMS verification", () => {
 
   test("start_outbound allows rebind when rebind=true", () => {
     // Create an existing guardian binding
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "sms",
       guardianExternalUserId: "+15551234567",
@@ -3352,7 +3352,7 @@ describe("outbound Telegram verification", () => {
   });
 
   test("start_outbound for telegram rejects when active binding exists (rebind=false)", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "user-42",
@@ -3876,7 +3876,7 @@ describe("outbound voice verification", () => {
   });
 
   test("start_outbound for voice rejects when binding exists (rebind=false)", () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "voice",
       guardianExternalUserId: "+15551234567",

--- a/assistant/src/__tests__/conversation-attention-telegram.test.ts
+++ b/assistant/src/__tests__/conversation-attention-telegram.test.ts
@@ -293,9 +293,9 @@ describe("Telegram callback seen signals", () => {
     });
 
     // Create a guardian binding (via contacts) so approval can be handled
-    const { createGuardianBindingContactsFirst } =
+    const { createGuardianBinding } =
       await import("../contacts/contacts-write.js");
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "telegram-user-default",

--- a/assistant/src/__tests__/guardian-routing-state.test.ts
+++ b/assistant/src/__tests__/guardian-routing-state.test.ts
@@ -38,7 +38,7 @@ mock.module("../security/secret-ingress.js", () => ({
 }));
 
 import { upsertContact } from "../contacts/contact-store.js";
-import { createGuardianBindingContactsFirst } from "../contacts/contacts-write.js";
+import { createGuardianBinding } from "../contacts/contacts-write.js";
 import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import * as channelDeliveryStore from "../memory/channel-delivery-store.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
@@ -223,7 +223,7 @@ describe("inbound-message-handler trusted-contact interactivity", () => {
 
   test("trusted contact with guardian binding gets interactive turn", async () => {
     // Create guardian binding in contacts table so the trust resolver finds it
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-user-for-tc",
@@ -324,7 +324,7 @@ describe("inbound-message-handler trusted-contact interactivity", () => {
 
   test("guardian actors remain interactive regardless", async () => {
     // Guardian binding matches the sender — use contacts-first so trust resolver finds it
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "telegram-user-default",

--- a/assistant/src/__tests__/inbound-invite-redemption.test.ts
+++ b/assistant/src/__tests__/inbound-invite-redemption.test.ts
@@ -88,7 +88,7 @@ mock.module("../runtime/approval-message-composer.js", () => ({
 }));
 
 import { findContactChannel } from "../contacts/contact-store.js";
-import { upsertMemberContactsFirst } from "../contacts/contacts-write.js";
+import { upsertMember } from "../contacts/contacts-write.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { createInvite, revokeInvite } from "../memory/ingress-invite-store.js";
 import { handleChannelInbound } from "../runtime/routes/channel-routes.js";
@@ -331,7 +331,7 @@ describe("inbound invite redemption intercept", () => {
 
   test("existing active member sending normal message is unaffected", async () => {
     // Pre-create an active member
-    upsertMemberContactsFirst({
+    upsertMember({
       assistantId: "self",
       sourceChannel: "telegram",
       externalUserId: "user-active-member",
@@ -381,7 +381,7 @@ describe("inbound invite redemption intercept", () => {
     });
 
     // Pre-create an active member that will click the invite link
-    upsertMemberContactsFirst({
+    upsertMember({
       assistantId: "self",
       sourceChannel: "telegram",
       externalUserId: "user-already-active",
@@ -408,7 +408,7 @@ describe("inbound invite redemption intercept", () => {
       maxUses: 5,
     });
 
-    upsertMemberContactsFirst({
+    upsertMember({
       assistantId: "self",
       sourceChannel: "telegram",
       externalUserId: "user-invite-123",

--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -24,7 +24,7 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import { upsertMemberContactsFirst } from "../contacts/contacts-write.js";
+import { upsertMember } from "../contacts/contacts-write.js";
 import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
 import {
   createInvite,
@@ -179,7 +179,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Pre-create an active member
-    upsertMemberContactsFirst({
+    upsertMember({
       sourceChannel: "telegram",
       externalUserId: "existing-user",
       status: "active",
@@ -209,7 +209,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Pre-create a blocked member — simulates a guardian-initiated block
-    upsertMemberContactsFirst({
+    upsertMember({
       sourceChannel: "telegram",
       externalUserId: "blocked-user",
       status: "blocked",
@@ -231,7 +231,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Pre-create a revoked member
-    const member = upsertMemberContactsFirst({
+    const member = upsertMember({
       sourceChannel: "telegram",
       externalUserId: "revoked-user",
       status: "revoked",
@@ -282,7 +282,7 @@ describe("invite-redemption-service", () => {
 
   test("returns invalid_token for an active member with a bogus token (no membership probing)", () => {
     // Pre-create an active member
-    upsertMemberContactsFirst({
+    upsertMember({
       sourceChannel: "telegram",
       externalUserId: "probed-user",
       status: "active",
@@ -307,7 +307,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Pre-create an active member
-    upsertMemberContactsFirst({
+    upsertMember({
       sourceChannel: "telegram",
       externalUserId: "expired-token-user",
       status: "active",
@@ -331,7 +331,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Pre-create an active member on telegram
-    upsertMemberContactsFirst({
+    upsertMember({
       sourceChannel: "telegram",
       externalUserId: "cross-channel-user",
       status: "active",

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -85,7 +85,7 @@ mock.module("../runtime/gateway-client.js", () => ({
   },
 }));
 
-import { createGuardianBindingContactsFirst } from "../contacts/contacts-write.js";
+import { createGuardianBinding } from "../contacts/contacts-write.js";
 import {
   listCanonicalGuardianDeliveries,
   listCanonicalGuardianRequests,
@@ -189,7 +189,7 @@ describe("non-member access request notification", () => {
 
   test("guardian is notified when a non-member messages and a guardian binding exists", async () => {
     // Set up a guardian binding for this channel
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-user-789",
@@ -235,7 +235,7 @@ describe("non-member access request notification", () => {
   });
 
   test("no duplicate approval requests for repeated messages from same non-member", async () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-user-789",
@@ -306,7 +306,7 @@ describe("non-member access request notification", () => {
 
   test("cross-channel fallback: SMS guardian binding resolves for Telegram access request", async () => {
     // Only an SMS guardian binding exists — no Telegram binding
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "sms",
       guardianExternalUserId: "guardian-sms-user",
@@ -342,7 +342,7 @@ describe("non-member access request notification", () => {
   });
 
   test("no notification when actorExternalId is absent", async () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-user-789",
@@ -419,7 +419,7 @@ describe("access-request-helper unit tests", () => {
 
   test("notifyGuardianOfAccessRequest uses cross-channel binding when source-channel binding is missing", () => {
     // Only SMS binding exists
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "sms",
       guardianExternalUserId: "guardian-sms",
@@ -455,7 +455,7 @@ describe("access-request-helper unit tests", () => {
 
   test("notifyGuardianOfAccessRequest prefers source-channel binding over cross-channel fallback", () => {
     // Both Telegram and SMS bindings exist
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-tg",
@@ -463,7 +463,7 @@ describe("access-request-helper unit tests", () => {
       guardianPrincipalId: "test-principal-tg",
       verifiedVia: "test",
     });
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "sms",
       guardianExternalUserId: "guardian-sms",

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -173,8 +173,8 @@ import {
 } from "../calls/relay-server.js";
 import { setVoiceBridgeDeps } from "../calls/voice-session-bridge.js";
 import {
-  createGuardianBindingContactsFirst,
-  upsertMemberContactsFirst,
+  createGuardianBinding,
+  upsertMember,
 } from "../contacts/contacts-write.js";
 import {
   listCanonicalGuardianRequests,
@@ -276,7 +276,7 @@ function addTrustedVoiceContact(
   phoneNumber: string,
   assistantId: string = "self",
 ): void {
-  upsertMemberContactsFirst({
+  upsertMember({
     assistantId,
     sourceChannel: "voice",
     externalUserId: phoneNumber,
@@ -1466,7 +1466,7 @@ describe("relay-server", () => {
       assistantId: "self",
     });
 
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "voice",
       guardianExternalUserId: "+15550001111",
@@ -1516,7 +1516,7 @@ describe("relay-server", () => {
       assistantId: "self",
     });
 
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "voice",
       guardianExternalUserId: "+15550009999",
@@ -1571,7 +1571,7 @@ describe("relay-server", () => {
       initiatedFromConversationId: "conv-guardian-outbound-voice-origin",
     });
 
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "voice",
       guardianExternalUserId: "+15550001111",
@@ -1623,7 +1623,7 @@ describe("relay-server", () => {
       initiatedFromConversationId: "conv-guardian-outbound-strict-origin",
     });
 
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "tg-guardian-user",
@@ -2473,7 +2473,7 @@ describe("relay-server", () => {
     });
 
     // Create a blocked member
-    upsertMemberContactsFirst({
+    upsertMember({
       assistantId: "self",
       sourceChannel: "voice",
       externalUserId: "+15558881111",

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -13,7 +13,7 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
 
-import { createGuardianBindingContactsFirst } from "../contacts/contacts-write.js";
+import { createGuardianBinding } from "../contacts/contacts-write.js";
 import type { ServerMessage } from "../daemon/ipc-protocol.js";
 import type { Session } from "../daemon/session.js";
 import { createCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
@@ -294,7 +294,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
     db.run("DELETE FROM contacts");
     pendingInteractions.clear();
 
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "vellum",
       guardianExternalUserId: "dev-bypass",

--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -91,8 +91,8 @@ mock.module("../runtime/approval-message-composer.js", () => ({
 import { getResolver } from "../approvals/guardian-request-resolvers.js";
 import { findContactChannel } from "../contacts/contact-store.js";
 import {
-  createGuardianBindingContactsFirst,
-  upsertMemberContactsFirst,
+  createGuardianBinding,
+  upsertMember,
 } from "../contacts/contacts-write.js";
 import { createApprovalRequest } from "../memory/channel-guardian-store.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
@@ -168,7 +168,7 @@ describe("trusted contact lifecycle notification signals", () => {
 
   test("guardian deny emits guardian_decision and denied signals", async () => {
     // Set up guardian binding and member record (guardians must pass ACL)
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-user-789",
@@ -176,7 +176,7 @@ describe("trusted contact lifecycle notification signals", () => {
       guardianPrincipalId: "guardian-user-789",
       verifiedVia: "test",
     });
-    upsertMemberContactsFirst({
+    upsertMember({
       assistantId: "self",
       sourceChannel: "telegram",
       externalUserId: "guardian-user-789",
@@ -250,7 +250,7 @@ describe("trusted contact lifecycle notification signals", () => {
 
   test("guardian approve emits guardian_decision and verification_sent signals", async () => {
     // Set up guardian binding and member record (guardians must pass ACL)
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-user-789",
@@ -258,7 +258,7 @@ describe("trusted contact lifecycle notification signals", () => {
       guardianPrincipalId: "guardian-user-789",
       verifiedVia: "test",
     });
-    upsertMemberContactsFirst({
+    upsertMember({
       assistantId: "self",
       sourceChannel: "telegram",
       externalUserId: "guardian-user-789",
@@ -328,7 +328,7 @@ describe("trusted contact lifecycle notification signals", () => {
 
   test("deduplication keys prevent duplicate signals", async () => {
     // Set up guardian binding and member record (guardians must pass ACL)
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-user-789",
@@ -336,7 +336,7 @@ describe("trusted contact lifecycle notification signals", () => {
       guardianPrincipalId: "guardian-user-789",
       verifiedVia: "test",
     });
-    upsertMemberContactsFirst({
+    upsertMember({
       assistantId: "self",
       sourceChannel: "telegram",
       externalUserId: "guardian-user-789",
@@ -395,7 +395,7 @@ describe("trusted contact activated notification signal", () => {
 
   test("successful trusted contact verification emits activated signal", async () => {
     // Set up a guardian binding so the verification path allows bypass
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-user-789",
@@ -452,7 +452,7 @@ describe("trusted contact activated notification signal", () => {
   });
 
   test("re-verification preserves an existing guardian-managed member display name", async () => {
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-user-789",
@@ -461,7 +461,7 @@ describe("trusted contact activated notification signal", () => {
       verifiedVia: "test",
     });
 
-    upsertMemberContactsFirst({
+    upsertMember({
       assistantId: "self",
       sourceChannel: "telegram",
       externalUserId: "requester-user-456",
@@ -533,7 +533,7 @@ describe("trusted contact activated notification signal", () => {
 
   test("member is persisted BEFORE activated signal is emitted", async () => {
     // Set up a guardian binding
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-user-789",
@@ -566,7 +566,7 @@ describe("trusted contact activated notification signal", () => {
     );
     expect(activatedSignals.length).toBe(1);
 
-    // Verify the member was already persisted (the signal fires after upsertMemberContactsFirst)
+    // Verify the member was already persisted (the signal fires after upsertMember)
     const result = findContactChannel({
       channelType: "telegram",
       externalUserId: "requester-user-456",

--- a/assistant/src/__tests__/trusted-contact-multichannel.test.ts
+++ b/assistant/src/__tests__/trusted-contact-multichannel.test.ts
@@ -98,8 +98,8 @@ mock.module("../runtime/approval-message-composer.js", () => ({
 
 import { findContactChannel } from "../contacts/contact-store.js";
 import {
-  createGuardianBindingContactsFirst,
-  upsertMemberContactsFirst,
+  createGuardianBinding,
+  upsertMember,
 } from "../contacts/contacts-write.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import {
@@ -230,7 +230,7 @@ for (const config of CHANNEL_CONFIGS) {
     });
 
     test("guardian is notified when a non-member messages", async () => {
-      createGuardianBindingContactsFirst({
+      createGuardianBinding({
         assistantId: "self",
         channel: config.channel,
         guardianExternalUserId: config.guardianExternalUserId,
@@ -283,7 +283,7 @@ for (const config of CHANNEL_CONFIGS) {
         expect(challengeResult.verificationType).toBe("trusted_contact");
       }
 
-      upsertMemberContactsFirst({
+      upsertMember({
         assistantId: "self",
         sourceChannel: config.channel,
         externalUserId: config.senderExternalUserId,
@@ -307,7 +307,7 @@ for (const config of CHANNEL_CONFIGS) {
 
     test("no cross-channel leakage between member records", () => {
       // Create a member for this channel
-      upsertMemberContactsFirst({
+      upsertMember({
         assistantId: "self",
         sourceChannel: config.channel,
         externalUserId: config.senderExternalUserId,

--- a/assistant/src/__tests__/trusted-contact-verification.test.ts
+++ b/assistant/src/__tests__/trusted-contact-verification.test.ts
@@ -46,9 +46,9 @@ import {
   findGuardianForChannel,
 } from "../contacts/contact-store.js";
 import {
-  createGuardianBindingContactsFirst,
-  revokeMemberContactsFirst,
-  upsertMemberContactsFirst,
+  createGuardianBinding,
+  revokeMember,
+  upsertMember,
 } from "../contacts/contacts-write.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { resolveActorTrust } from "../runtime/actor-trust-resolver.js";
@@ -118,7 +118,7 @@ describe("trusted contact verification → member activation", () => {
     }
 
     // Simulate the member upsert that inbound-message-handler performs on success
-    upsertMemberContactsFirst({
+    upsertMember({
       sourceChannel: "telegram",
       externalUserId: "requester-user-123",
       externalChatId: "requester-chat-123",
@@ -144,7 +144,7 @@ describe("trusted contact verification → member activation", () => {
   });
 
   test("resolveActorTrust surfaces member displayName when sender displayName is missing", () => {
-    upsertMemberContactsFirst({
+    upsertMember({
       sourceChannel: "telegram",
       externalUserId: "requester-user-jeff",
       externalChatId: "requester-chat-jeff",
@@ -172,7 +172,7 @@ describe("trusted contact verification → member activation", () => {
   });
 
   test("resolveActorTrust prioritizes member displayName over sender displayName", () => {
-    upsertMemberContactsFirst({
+    upsertMember({
       sourceChannel: "telegram",
       externalUserId: "requester-user-jeff-priority",
       externalChatId: "requester-chat-jeff-priority",
@@ -204,7 +204,7 @@ describe("trusted contact verification → member activation", () => {
   test("resolveActorTrust falls back to sender metadata when member record matches chat but not sender (group chat)", () => {
     // Simulate a group chat: member record exists for a different user who
     // shares the same externalChatId (e.g., Telegram group).
-    upsertMemberContactsFirst({
+    upsertMember({
       sourceChannel: "telegram",
       externalUserId: "other-user-in-group",
       externalChatId: "shared-group-chat",
@@ -256,7 +256,7 @@ describe("trusted contact verification → member activation", () => {
     );
 
     // Simulate member upsert on verification success
-    upsertMemberContactsFirst({
+    upsertMember({
       sourceChannel: "telegram",
       externalUserId: "requester-user-456",
       externalChatId: "requester-chat-456",
@@ -296,7 +296,7 @@ describe("trusted contact verification → member activation", () => {
       "chat-cross-test",
     );
 
-    upsertMemberContactsFirst({
+    upsertMember({
       sourceChannel: "telegram",
       externalUserId: "user-cross-test",
       externalChatId: "chat-cross-test",
@@ -322,7 +322,7 @@ describe("trusted contact verification → member activation", () => {
 
   test("re-verification of previously revoked member reactivates them", () => {
     // Create and activate a member
-    const member = upsertMemberContactsFirst({
+    const member = upsertMember({
       sourceChannel: "telegram",
       externalUserId: "user-revoked",
       externalChatId: "chat-revoked",
@@ -332,7 +332,7 @@ describe("trusted contact verification → member activation", () => {
     });
 
     // Revoke the member
-    const revoked = revokeMemberContactsFirst(
+    const revoked = revokeMember(
       member!.channel.id,
       "testing revocation",
     );
@@ -371,8 +371,8 @@ describe("trusted contact verification → member activation", () => {
       expect(result.verificationType).toBe("trusted_contact");
     }
 
-    // upsertMemberContactsFirst reactivates the existing record
-    upsertMemberContactsFirst({
+    // upsertMember reactivates the existing record
+    upsertMember({
       sourceChannel: "telegram",
       externalUserId: "user-revoked",
       externalChatId: "chat-revoked",
@@ -392,7 +392,7 @@ describe("trusted contact verification → member activation", () => {
 
   test("trusted contact verification does NOT create a guardian binding", () => {
     // Ensure there's an existing guardian binding we want to preserve
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "telegram",
       guardianExternalUserId: "guardian-user-original",

--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -24,7 +24,7 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import { upsertMemberContactsFirst } from "../contacts/contacts-write.js";
+import { upsertMember } from "../contacts/contacts-write.js";
 import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
 import { createInvite, revokeInvite } from "../memory/ingress-invite-store.js";
 import { redeemVoiceInviteCode } from "../runtime/invite-redemption-service.js";
@@ -282,7 +282,7 @@ describe("redeemVoiceInviteCode", () => {
     const { code } = createVoiceInvite({ callerPhone: phone });
 
     // Pre-create an active member for this phone on voice channel
-    upsertMemberContactsFirst({
+    upsertMember({
       sourceChannel: "voice",
       externalUserId: phone,
       status: "active",
@@ -307,7 +307,7 @@ describe("redeemVoiceInviteCode", () => {
     const phone = "+15551234567";
     const { code } = createVoiceInvite({ callerPhone: phone });
 
-    upsertMemberContactsFirst({
+    upsertMember({
       sourceChannel: "voice",
       externalUserId: phone,
       status: "blocked",

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -13,7 +13,7 @@
 
 import { answerCall } from "../calls/call-domain.js";
 import { getGatewayInternalBaseUrl } from "../config/env.js";
-import { upsertMemberContactsFirst } from "../contacts/contacts-write.js";
+import { upsertMember } from "../contacts/contacts-write.js";
 import {
   type CanonicalGuardianRequest,
   getCanonicalGuardianRequest,
@@ -451,7 +451,7 @@ const accessRequestResolver: GuardianRequestResolver = {
     // relay server's in-call wait loop will detect the approved status.
     if (channel === "voice") {
       try {
-        upsertMemberContactsFirst({
+        upsertMember({
           assistantId,
           sourceChannel: "voice",
           externalUserId: requesterExternalUserId,

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -17,7 +17,7 @@ import {
   findGuardianForChannel,
   listGuardianChannels,
 } from "../contacts/contact-store.js";
-import { upsertMemberContactsFirst } from "../contacts/contacts-write.js";
+import { upsertMember } from "../contacts/contacts-write.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import { getCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
 import * as conversationStore from "../memory/conversation-store.js";
@@ -983,7 +983,7 @@ export class RelayConnection {
 
     if (!params.skipMemberActivation) {
       try {
-        upsertMemberContactsFirst({
+        upsertMember({
           assistantId,
           sourceChannel: "voice",
           externalUserId: fromNumber,

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -55,7 +55,7 @@ function parseDisplayNameFromMetadata(
  * Returns a GuardianBinding-compatible object synthesized from the input params
  * (so callers expecting binding.id still work).
  */
-export function createGuardianBindingContactsFirst(params: {
+export function createGuardianBinding(params: {
   assistantId: string;
   channel: string;
   guardianExternalUserId: string;
@@ -116,7 +116,7 @@ export function createGuardianBindingContactsFirst(params: {
  * Revoke a guardian binding by updating the contacts table.
  * Returns true when a guardian channel was found and revoked, false otherwise.
  */
-export function revokeGuardianBindingContactsFirst(
+export function revokeGuardianBinding(
   assistantId: string,
   channel: string,
 ): boolean {
@@ -138,7 +138,7 @@ export function revokeGuardianBindingContactsFirst(
  * Returns the native Contact + ContactChannel, or null if no usable
  * identity was provided or the lookup failed after upsert.
  */
-export function upsertMemberContactsFirst(params: {
+export function upsertMember(params: {
   sourceChannel: string;
   externalUserId?: string;
   externalChatId?: string;
@@ -216,7 +216,7 @@ export function upsertMemberContactsFirst(params: {
  * The memberId may be a plain channel ID (internal callers) or a composite
  * contactId:channelId (from the API response format).
  */
-export function revokeMemberContactsFirst(
+export function revokeMember(
   memberId: string,
   reason?: string,
 ): ContactWriteResult | null {
@@ -246,7 +246,7 @@ export function revokeMemberContactsFirst(
  * The memberId may be a plain channel ID (internal callers) or a composite
  * contactId:channelId (from the API response format).
  */
-export function blockMemberContactsFirst(
+export function blockMember(
   memberId: string,
   reason?: string,
 ): ContactWriteResult | null {

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -2,7 +2,7 @@ import * as net from "node:net";
 
 import type { ChannelId } from "../../channels/types.js";
 import { findContactChannel } from "../../contacts/contact-store.js";
-import { revokeMemberContactsFirst } from "../../contacts/contacts-write.js";
+import { revokeMember } from "../../contacts/contacts-write.js";
 import type { ChannelStatus } from "../../contacts/types.js";
 import * as externalConversationStore from "../../memory/external-conversation-store.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
@@ -209,7 +209,7 @@ export function revokeGuardianForChannel(
   }
 
   // Revoke the member BEFORE the guardian binding so that
-  // revokeMemberContactsFirst sees the channel as active/pending and sets the
+  // revokeMember sees the channel as active/pending and sets the
   // correct revokedReason ("guardian_binding_revoked"). If the guardian binding
   // is revoked first, the channel is already marked revoked and the member
   // revocation becomes a no-op (wrong reason or skipped entirely).
@@ -226,7 +226,7 @@ export function revokeGuardianForChannel(
       channelStatus === "pending" ||
       channelStatus === "unverified"
     ) {
-      revokeMemberContactsFirst(
+      revokeMember(
         contactResult.channel.id,
         "guardian_binding_revoked",
       );

--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -11,8 +11,8 @@ import { v4 as uuid } from "uuid";
 
 import { findGuardianForChannel } from "../contacts/contact-store.js";
 import {
-  createGuardianBindingContactsFirst,
-  revokeGuardianBindingContactsFirst,
+  createGuardianBinding,
+  revokeGuardianBinding,
 } from "../contacts/contacts-write.js";
 import type {
   GuardianBinding,
@@ -345,7 +345,7 @@ export function validateAndConsumeChallenge(
   }
 
   // Revoke any existing active binding before creating a new one (same-user re-verification)
-  revokeGuardianBindingContactsFirst(assistantId, channel);
+  revokeGuardianBinding(assistantId, channel);
 
   const metadata: Record<string, string> = {};
   if (actorUsername && actorUsername.trim().length > 0) {
@@ -362,7 +362,7 @@ export function validateAndConsumeChallenge(
     vellumBinding?.guardianPrincipalId ?? actorExternalUserId;
 
   // Create the new guardian binding
-  const binding = createGuardianBindingContactsFirst({
+  const binding = createGuardianBinding({
     assistantId,
     channel,
     guardianExternalUserId: actorExternalUserId,
@@ -430,7 +430,7 @@ export function isGuardian(
  * Revoke the active guardian binding for a given assistant and channel.
  */
 export function revokeBinding(assistantId: string, channel: string): boolean {
-  return revokeGuardianBindingContactsFirst(assistantId, channel);
+  return revokeGuardianBinding(assistantId, channel);
 }
 
 /**

--- a/assistant/src/runtime/guardian-vellum-migration.ts
+++ b/assistant/src/runtime/guardian-vellum-migration.ts
@@ -13,7 +13,7 @@
 import { v4 as uuid } from "uuid";
 
 import { findGuardianForChannel } from "../contacts/contact-store.js";
-import { createGuardianBindingContactsFirst } from "../contacts/contacts-write.js";
+import { createGuardianBinding } from "../contacts/contacts-write.js";
 import { getLogger } from "../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
 
@@ -40,7 +40,7 @@ export function ensureVellumGuardianBinding(
 
   const guardianPrincipalId = `vellum-principal-${uuid()}`;
 
-  createGuardianBindingContactsFirst({
+  createGuardianBinding({
     assistantId,
     channel: "vellum",
     guardianExternalUserId: guardianPrincipalId,

--- a/assistant/src/runtime/ingress-service.ts
+++ b/assistant/src/runtime/ingress-service.ts
@@ -8,9 +8,9 @@
 import { isChannelId } from "../channels/types.js";
 import { listContacts } from "../contacts/contact-store.js";
 import {
-  blockMemberContactsFirst,
-  revokeMemberContactsFirst,
-  upsertMemberContactsFirst,
+  blockMember,
+  revokeMember,
+  upsertMember,
 } from "../contacts/contacts-write.js";
 import type {
   ContactWithChannels,
@@ -394,7 +394,7 @@ export function upsertIngressMember(params: {
         "At least one of externalUserId or externalChatId is required for upsert",
     };
   }
-  const result = upsertMemberContactsFirst({
+  const result = upsertMember({
     assistantId: params.assistantId,
     sourceChannel: params.sourceChannel,
     externalUserId: params.externalUserId,
@@ -417,7 +417,7 @@ export function revokeIngressMember(
   if (!memberId) {
     return { ok: false, error: "memberId is required for revoke" };
   }
-  const result = revokeMemberContactsFirst(memberId, reason);
+  const result = revokeMember(memberId, reason);
   if (!result) {
     return { ok: false, error: "Member not found or cannot be revoked" };
   }
@@ -431,7 +431,7 @@ export function blockIngressMember(
   if (!memberId) {
     return { ok: false, error: "memberId is required for block" };
   }
-  const result = blockMemberContactsFirst(memberId, reason);
+  const result = blockMember(memberId, reason);
   if (!result) {
     return { ok: false, error: "Member not found or already blocked" };
   }

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -9,7 +9,7 @@
 
 import type { ChannelId } from "../channels/types.js";
 import { findContactChannel } from "../contacts/contact-store.js";
-import { upsertMemberContactsFirst } from "../contacts/contacts-write.js";
+import { upsertMember } from "../contacts/contacts-write.js";
 import { getSqlite } from "../memory/db.js";
 import {
   findActiveVoiceInvites,
@@ -150,7 +150,7 @@ export function redeemInvite(params: {
   // Inactive member reactivation: when the user already has a member record
   // in a non-active state (revoked/pending), reactivate it via upsertMember
   // and consume an invite use atomically. The fresh-member path below also
-  // uses upsertMemberContactsFirst to keep contacts in sync.
+  // uses upsertMember to keep contacts in sync.
   if (existingChannel) {
     // Sentinel error used to trigger a transaction rollback when the invite
     // was concurrently revoked/expired between pre-validation and write time.
@@ -174,11 +174,11 @@ export function redeemInvite(params: {
         ? existingContact.displayName
         : displayName;
 
-    let reactivated: ReturnType<typeof upsertMemberContactsFirst> | undefined;
+    let reactivated: ReturnType<typeof upsertMember> | undefined;
     try {
       getSqlite()
         .transaction(() => {
-          reactivated = upsertMemberContactsFirst({
+          reactivated = upsertMember({
             assistantId: assistantId ?? invite.assistantId,
             sourceChannel,
             externalUserId,
@@ -221,11 +221,11 @@ export function redeemInvite(params: {
   // Fresh member creation: upsert into contacts tables and consume an invite
   // use atomically, mirroring the reactivation path above.
   const STALE_INVITE_FRESH = Symbol("stale_invite_fresh");
-  let freshResult: ReturnType<typeof upsertMemberContactsFirst> | undefined;
+  let freshResult: ReturnType<typeof upsertMember> | undefined;
   try {
     getSqlite()
       .transaction(() => {
-        freshResult = upsertMemberContactsFirst({
+        freshResult = upsertMember({
           assistantId: assistantId ?? invite.assistantId,
           sourceChannel,
           externalUserId,
@@ -370,7 +370,7 @@ export function redeemVoiceInviteCode(params: {
   try {
     getSqlite()
       .transaction(() => {
-        const writeResult = upsertMemberContactsFirst({
+        const writeResult = upsertMember({
           assistantId: invite.assistantId,
           sourceChannel: "voice",
           externalUserId: callerExternalUserId,

--- a/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
+++ b/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
@@ -14,7 +14,7 @@ import { createHash } from "node:crypto";
 import { v4 as uuid } from "uuid";
 
 import { findGuardianForChannel } from "../../contacts/contact-store.js";
-import { createGuardianBindingContactsFirst } from "../../contacts/contacts-write.js";
+import { createGuardianBinding } from "../../contacts/contacts-write.js";
 import { getLogger } from "../../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { mintCredentialPair } from "../auth/credential-service.js";
@@ -55,7 +55,7 @@ function ensureGuardianPrincipal(assistantId: string): {
   // Mint a new principal ID for the vellum channel
   const guardianPrincipalId = `vellum-principal-${uuid()}`;
 
-  createGuardianBindingContactsFirst({
+  createGuardianBinding({
     assistantId,
     channel: "vellum",
     guardianExternalUserId: guardianPrincipalId,

--- a/assistant/src/runtime/routes/inbound-stages/verification-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/verification-intercept.ts
@@ -12,7 +12,7 @@
  */
 import type { ChannelId } from "../../../channels/types.js";
 import { findContactChannel } from "../../../contacts/contact-store.js";
-import { upsertMemberContactsFirst } from "../../../contacts/contacts-write.js";
+import { upsertMember } from "../../../contacts/contacts-write.js";
 import * as channelDeliveryStore from "../../../memory/channel-delivery-store.js";
 import { emitNotificationSignal } from "../../../notifications/emit-signal.js";
 import { canonicalizeInboundIdentity } from "../../../util/canonicalize-identity.js";
@@ -135,7 +135,7 @@ export async function handleVerificationIntercept(
         ? existingContact.displayName
         : actorDisplayName;
 
-    upsertMemberContactsFirst({
+    upsertMember({
       assistantId: canonicalAssistantId,
       sourceChannel,
       externalUserId: canonicalSenderId ?? rawSenderId,


### PR DESCRIPTION
## Summary
- Rename 5 ContactsFirst functions to drop the stale suffix
- createGuardianBindingContactsFirst → createGuardianBinding, etc.
- Update all ~23 importing files across production and test code

Part of plan: contacts-post-migration-cleanup.md (PR 13 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
