### PR TITLE
fix: merge duplicate type imports in escalation-intercept.ts

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/escalation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/escalation-intercept.ts
@@ -7,15 +7,14 @@
  * Extracted from inbound-message-handler.ts to keep the top-level handler
  * focused on orchestration.
  */
-import type { ChannelId } from "../../../channels/types.js";
-import type { InterfaceId } from "../../../channels/types.js";
-import type { ResolvedMember } from "./acl-enforcement.js";
+import type { ChannelId, InterfaceId } from "../../../channels/types.js";
 import { createCanonicalGuardianRequest } from "../../../memory/canonical-guardian-store.js";
 import * as channelDeliveryStore from "../../../memory/channel-delivery-store.js";
 import { emitNotificationSignal } from "../../../notifications/emit-signal.js";
 import { getLogger } from "../../../util/logger.js";
 import { getGuardianBinding } from "../../channel-guardian-service.js";
 import { GUARDIAN_APPROVAL_TTL_MS } from "../channel-route-shared.js";
+import type { ResolvedMember } from "./acl-enforcement.js";
 
 const log = getLogger("runtime-http");
 


### PR DESCRIPTION
## Summary
- Merge two separate `import type` statements from `../../../channels/types.js` into a single import to satisfy `simple-import-sort/imports` lint rule
- Move `ResolvedMember` type import to correct position after `../` imports

## Original prompt
fix the CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22670521775

🤖 Generated with [Claude Code](https://claude.com/claude-code)