### PR TITLE
M1: Live transcription overlays for PTT and wake word

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -2351,7 +2351,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 let quickInputActive = self?.quickInputWindow?.isVisible ?? false
                 let isDictation = self?.voiceInput?.currentMode == .dictation
                 if !mainWindowActive && !hasActiveConvo && !quickInputActive && !isDictation {
-                    let window = VoiceTranscriptionWindow()
+                    let window = VoiceTranscriptionWindow(
+                        voiceModeManager: self?.mainWindow?.voiceModeManager
+                    )
                     window.show()
                     self?.voiceTranscriptionWindow = window
                 }

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -573,6 +573,9 @@ final class VoiceInputManager {
                         self.stopRecording()
                     } else {
                         self.onPartialTranscription?(text)
+                        if self.currentMode == .dictation {
+                            self.overlayWindow.updatePartialTranscription(text)
+                        }
                     }
                 }
 

--- a/clients/macos/vellum-assistant/Features/Voice/DictationOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationOverlayWindow.swift
@@ -10,25 +10,37 @@ final class DictationOverlayWindow {
     private var panel: NSPanel?
     private var iconView: NSView?
     private var label: NSTextField?
+    private var transcriptionLabel: NSTextField?
     private var spinner: NSProgressIndicator?
+    private var currentState: DictationState?
 
-    private func panelWidth(for state: DictationState) -> CGFloat {
+    private static let baseHeight: CGFloat = 40
+    private static let expandedHeight: CGFloat = 58
+    private static let baseWidth: CGFloat = 160
+    private static let maxTranscriptionWidth: CGFloat = 400
+
+    private func panelWidth(for state: DictationState, hasTranscription: Bool = false) -> CGFloat {
+        if hasTranscription { return Self.maxTranscriptionWidth }
         switch state {
         case .transforming: return 280
-        default: return 160
+        default: return Self.baseWidth
         }
     }
 
     func show(state: DictationState) {
+        currentState = state
         let width = panelWidth(for: state)
+        let height = Self.baseHeight
 
         if let panel = panel {
             updateContent(state: state)
+            // Clear transcription when state changes (new recording cycle)
+            transcriptionLabel?.stringValue = ""
 
             if let screen = NSScreen.main {
                 let screenFrame = screen.visibleFrame
                 let x = screenFrame.midX - width / 2
-                let newFrame = NSRect(x: x, y: panel.frame.origin.y, width: width, height: 40)
+                let newFrame = NSRect(x: x, y: panel.frame.origin.y, width: width, height: height)
                 panel.setFrame(newFrame, display: true, animate: false)
             }
 
@@ -37,7 +49,7 @@ final class DictationOverlayWindow {
             let contentView = buildContentView(state: state)
 
             let newPanel = NSPanel(
-                contentRect: NSRect(x: 0, y: 0, width: width, height: 40),
+                contentRect: NSRect(x: 0, y: 0, width: width, height: height),
                 styleMask: [.borderless, .nonactivatingPanel],
                 backing: .buffered,
                 defer: false
@@ -64,13 +76,39 @@ final class DictationOverlayWindow {
         log.debug("Showing dictation overlay: \(String(describing: state))")
     }
 
+    /// Update the live transcription text shown below the status line.
+    /// Only takes effect while the overlay is in the `.recording` state.
+    func updatePartialTranscription(_ text: String) {
+        guard case .recording = currentState else { return }
+        guard let panel = panel else { return }
+
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        transcriptionLabel?.stringValue = trimmed
+
+        let hasText = !trimmed.isEmpty
+        let width = hasText ? Self.maxTranscriptionWidth : Self.baseWidth
+        let height = hasText ? Self.expandedHeight : Self.baseHeight
+        transcriptionLabel?.isHidden = !hasText
+
+        if let screen = NSScreen.main {
+            let screenFrame = screen.visibleFrame
+            let x = screenFrame.midX - width / 2
+            // Keep the top edge pinned by computing y from the top
+            let topY = panel.frame.origin.y + panel.frame.height
+            let newFrame = NSRect(x: x, y: topY - height, width: width, height: height)
+            panel.setFrame(newFrame, display: true, animate: false)
+        }
+    }
+
     func dismiss() {
         spinner?.stopAnimation(nil)
         panel?.orderOut(nil)
         panel = nil
         iconView = nil
         label = nil
+        transcriptionLabel = nil
         spinner = nil
+        currentState = nil
     }
 
     func showDoneAndDismiss() {
@@ -88,24 +126,32 @@ final class DictationOverlayWindow {
 
         let icon = makeIcon(for: state)
         let text = makeLabel(for: state)
+        let transcription = makeTranscriptionLabel()
 
         icon.translatesAutoresizingMaskIntoConstraints = false
         text.translatesAutoresizingMaskIntoConstraints = false
+        transcription.translatesAutoresizingMaskIntoConstraints = false
 
         container.addSubview(icon)
         container.addSubview(text)
+        container.addSubview(transcription)
 
         NSLayoutConstraint.activate([
             icon.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
-            icon.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            icon.topAnchor.constraint(equalTo: container.topAnchor, constant: 12),
 
             text.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 8),
             text.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -16),
-            text.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            text.centerYAnchor.constraint(equalTo: icon.centerYAnchor),
+
+            transcription.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            transcription.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -16),
+            transcription.topAnchor.constraint(equalTo: icon.bottomAnchor, constant: 4),
         ])
 
         self.iconView = icon
         self.label = text
+        self.transcriptionLabel = transcription
 
         return container
     }
@@ -119,10 +165,13 @@ final class DictationOverlayWindow {
             container.addSubview(newIcon)
             NSLayoutConstraint.activate([
                 newIcon.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
-                newIcon.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+                newIcon.topAnchor.constraint(equalTo: container.topAnchor, constant: 12),
             ])
             if let lbl = label {
                 lbl.leadingAnchor.constraint(equalTo: newIcon.trailingAnchor, constant: 8).isActive = true
+            }
+            if let transLbl = transcriptionLabel {
+                transLbl.topAnchor.constraint(equalTo: newIcon.bottomAnchor, constant: 4).isActive = true
             }
             oldSpinner?.stopAnimation(nil)
             oldIcon.removeFromSuperview()
@@ -203,6 +252,16 @@ final class DictationOverlayWindow {
         field.lineBreakMode = .byTruncatingTail
         field.maximumNumberOfLines = 1
         self.label = field
+        return field
+    }
+
+    private func makeTranscriptionLabel() -> NSTextField {
+        let field = NSTextField(labelWithString: "")
+        field.font = NSFont(name: "Inter", size: 10) ?? NSFont.systemFont(ofSize: 10)
+        field.textColor = NSColor(VColor.textMuted)
+        field.lineBreakMode = .byTruncatingTail
+        field.maximumNumberOfLines = 1
+        field.isHidden = true
         return field
     }
 }

--- a/clients/macos/vellum-assistant/Features/Voice/DictationOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationOverlayWindow.swift
@@ -169,6 +169,7 @@ final class DictationOverlayWindow {
             ])
             if let lbl = label {
                 lbl.leadingAnchor.constraint(equalTo: newIcon.trailingAnchor, constant: 8).isActive = true
+                lbl.centerYAnchor.constraint(equalTo: newIcon.centerYAnchor).isActive = true
             }
             if let transLbl = transcriptionLabel {
                 transLbl.topAnchor.constraint(equalTo: newIcon.bottomAnchor, constant: 4).isActive = true

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceTranscriptionWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceTranscriptionWindow.swift
@@ -22,7 +22,7 @@ struct VoiceTranscriptionView: View {
                     .clipShape(Circle())
             }
 
-            Text(voiceModeManager.stateLabel)
+            Text(voiceModeManager.stateLabel.isEmpty ? "Listening" : voiceModeManager.stateLabel)
                 .font(VFont.bodyMedium)
                 .foregroundColor(VColor.textPrimary)
 

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceTranscriptionWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceTranscriptionWindow.swift
@@ -4,11 +4,12 @@ import SwiftUI
 
 struct VoiceTranscriptionView: View {
     @State private var appearance = AvatarAppearanceManager.shared
+    @ObservedObject var voiceModeManager: VoiceModeManager
 
     private let circleSize: CGFloat = 80
 
     var body: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: 8) {
             ZStack {
                 Circle()
                     .stroke(VColor.accent, lineWidth: 2.5)
@@ -21,13 +22,22 @@ struct VoiceTranscriptionView: View {
                     .clipShape(Circle())
             }
 
-            Text("Listening")
+            Text(voiceModeManager.stateLabel)
                 .font(VFont.bodyMedium)
                 .foregroundColor(VColor.textPrimary)
+
+            if !voiceModeManager.liveTranscription.isEmpty {
+                Text(voiceModeManager.liveTranscription)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .lineLimit(3)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 260)
+            }
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 16)
-        .frame(width: 140)
+        .frame(minWidth: 140)
         .vPanelBackground()
     }
 }
@@ -35,16 +45,30 @@ struct VoiceTranscriptionView: View {
 @MainActor
 final class VoiceTranscriptionWindow {
     private var panel: NSPanel?
+    private weak var voiceModeManager: VoiceModeManager?
 
-    private let panelWidth: CGFloat = 140
-    private let panelHeight: CGFloat = 140
+    private let baseWidth: CGFloat = 140
+    private let baseHeight: CGFloat = 140
     private let margin: CGFloat = 16
 
+    init(voiceModeManager: VoiceModeManager? = nil) {
+        self.voiceModeManager = voiceModeManager
+    }
+
     func show() {
-        let hostingController = NSHostingController(rootView: VoiceTranscriptionView())
+        let rootView: AnyView
+        if let manager = voiceModeManager {
+            rootView = AnyView(VoiceTranscriptionView(voiceModeManager: manager))
+        } else {
+            // Fallback: create a dummy manager for backward compatibility
+            let fallback = VoiceModeManager()
+            rootView = AnyView(VoiceTranscriptionView(voiceModeManager: fallback))
+        }
+
+        let hostingController = NSHostingController(rootView: rootView)
 
         let panel = NSPanel(
-            contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: panelHeight),
+            contentRect: NSRect(x: 0, y: 0, width: baseWidth, height: baseHeight),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
@@ -62,9 +86,9 @@ final class VoiceTranscriptionWindow {
         // Position top-right corner of screen
         if let screen = NSScreen.main {
             let screenFrame = screen.visibleFrame
-            let x = screenFrame.maxX - panelWidth - margin
-            let y = screenFrame.maxY - panelHeight - margin
-            panel.setFrame(NSRect(x: x, y: y, width: panelWidth, height: panelHeight), display: false)
+            let x = screenFrame.maxX - baseWidth - margin
+            let y = screenFrame.maxY - baseHeight - margin
+            panel.setFrame(NSRect(x: x, y: y, width: baseWidth, height: baseHeight), display: false)
         }
 
         panel.orderFront(nil)


### PR DESCRIPTION
Adds live transcription text to both DictationOverlayWindow (PTT) and VoiceTranscriptionWindow (wake word) so users can see what's being recognized in real-time. Addresses Gap 1 and Gap 3 from #11260. Part of #12271.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
