### PR TITLE
fix: use non-null assertion for writeResult in voice invite redemption path

### DIFF
--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -380,7 +380,7 @@ export function redeemVoiceInviteCode(params: {
           policy: "allow",
           inviteId: invite.id,
         });
-        memberId = writeResult?.channel.id;
+        memberId = writeResult!.channel.id;
 
         const recorded = recordInviteUse({
           inviteId: invite.id,


### PR DESCRIPTION
Fixes the optional chaining bug where writeResult?.channel.id silently produces undefined when upsertMemberContactsFirst returns null. Changes to non-null assertion (writeResult!) to match the other two redemption paths and fail fast instead of returning a corrupted success response.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
