### PR TITLE
fix: map unverified channel status to pending in ACL reason and session context

### DIFF
--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -18,6 +18,7 @@ import {
 import { getAppsDir, listAppFiles } from "../memory/app-store.js";
 import type { Message } from "../providers/types.js";
 import type { ActorTrustContext } from "../runtime/actor-trust-resolver.js";
+import { channelStatusToMemberStatus } from "../runtime/routes/inbound-stages/acl-enforcement.js";
 
 /**
  * Describes the capabilities of the channel through which the user is
@@ -153,7 +154,9 @@ export function inboundActorContextFromTrust(
     actorMemberDisplayName: ctx.actorMetadata.memberDisplayName,
     trustClass: ctx.trustClass,
     guardianIdentity: ctx.guardianBindingMatch?.guardianExternalUserId,
-    memberStatus: ctx.memberRecord?.channel.status ?? undefined,
+    memberStatus: ctx.memberRecord
+      ? channelStatusToMemberStatus(ctx.memberRecord.channel.status)
+      : undefined,
     memberPolicy: ctx.memberRecord?.channel.policy ?? undefined,
     denialReason: ctx.denialReason,
   };

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -83,7 +83,9 @@ function parseGuardianVerifyCode(content: string): string | undefined {
 }
 
 /** Map ChannelStatus to the legacy MemberStatus for API consumers. */
-function channelStatusToMemberStatus(status: ChannelStatus): MemberStatus {
+export function channelStatusToMemberStatus(
+  status: ChannelStatus,
+): MemberStatus {
   if (status === "unverified") return "pending";
   return status;
 }
@@ -454,7 +456,7 @@ export async function enforceIngressAcl(
             earlyResponse: Response.json({
               accepted: true,
               denied: true,
-              reason: `member_${resolvedMember.channel.status}`,
+              reason: `member_${channelStatusToMemberStatus(resolvedMember.channel.status)}`,
             }),
             guardianVerifyCode,
           };


### PR DESCRIPTION
Fixes two callsites where raw 'unverified' channel status leaked through instead of being mapped to 'pending' via channelStatusToMemberStatus(). The ACL denial reason field and the session runtime assembly memberStatus field now correctly produce 'member_pending' matching the legacy API contract.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
